### PR TITLE
Move the donation page from the wiki into the static site

### DIFF
--- a/content/_partials/navbar.html.haml
+++ b/content/_partials/navbar.html.haml
@@ -2,7 +2,7 @@
   %div#page-bar
     %ul.menu
       %li.leaf.first
-        %a{:href => "/node", :title => "Blog landing page"}
+        %a{:href => "/node", :title => "Blog"}
           Blog
       %li.expanded
         %a{:href => "/", :title => ""}
@@ -15,26 +15,26 @@
             %a{:href => "/content/chat", :title => "Chat with the rest of the Jenkins community on IRC"}
               Chat
           %li.leaf
-            %a{:href => "http://twitter.com/jenkinsci", :title => "Check out @jenkinsci on Twitter"}
+            %a{:href => "https://twitter.com/jenkinsci", :title => "Check out @jenkinsci on Twitter"}
               Twitter
           %li.leaf
             %a{:href => "/content/event-calendar", :title => "Calendar for Jenkins events"}
               Event Calendar
           %li.leaf
-            %a{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Office+Hours", :title => "WebEx-based online meeting"}
+            %a{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Office+Hours", :title => "Hangouts-based online meeting"}
               Office Hours
           %li.leaf.last
-            %a{:href => "https://reddit.com/r/jenkinsci", :title => "Check out the latest links and news on jenkinsci.reddit.com!"}
+            %a{:href => "https://reddit.com/r/jenkinsci", :title => "Latest Jenkins related news on /r/jenkinsci"}
               reddit
       %li.leaf
         %a{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Issue+Tracking", :title => "JIRA for Jenkins"}
           Bug Tracker
       %li.leaf
-        %a{:href => "http://wiki.jenkins-ci.org/", :title => "Main documentation of Jenkins"}
+        %a{:href => "https://wiki.jenkins-ci.org/", :title => "Jenkins Wiki"}
           Wiki
       %li.leaf
-        %a{:href => "http://ci.jenkins-ci.org/", :title => "Jenkins and plugins built on Jenkins"}
+        %a{:href => "https://ci.jenkins-ci.org/", :title => "Jenkins own Jenkins install"}
           CI
       %li.leaf
-        %a{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Donation", :title => ""}
+        %a{:href => "/donate", :title => "Donate to Jenkins"}
           Donation

--- a/content/css/style.css
+++ b/content/css/style.css
@@ -48,7 +48,7 @@ legend {
 }
 
 p {
-	margin: 15px 0;
+	margin: 10px 0;
 }
 
 a:link, a:visited {

--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -1,0 +1,45 @@
+---
+layout: default
+title: "Donate to Jenkins"
+---
+
+NOTE: You can donate directly through the
+link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[SPI donation
+page] (donation in US dollars) or via the
+link:http://www.ffis.de/Verein/donations.html[ffis.de donation page] (donation
+in Euros) if you do not need the context below
+
+
+
+The Jenkins project is affiliated with link:http://www.spi-inc.org[Software in
+the Public Interest], a non-profit organization. Via SPI we can accept
+link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[donations
+online] in US dollars. For other ways to donate, refer to the
+link:http://spi-inc.org/donations[donations page on the SPI website].
+
+
+For European residents, we can also accept donations through
+link:http://www.ffis.de/Verein/donations.html[ffis.de] via bank transfer in
+Euro.
+As ffis.de is a charitable association, this donation is tax deductible under
+in Germany.
+
+NOTE: If you donate via ffis.de, please write to `donation[at]ffis.de` to
+ensure that your donation will be earmarked for the Jenkins project.
+
+
+== Why donate?
+
+Your contributions help us keep Jenkins going by paying project expenses, such
+as:
+
+*Operating expenses:*
+
+* SSL certificates on our websites
+* Covering network transit costs (not including that incurred by mirrors)
+* Equipment/replacement hardware
+
+A portion of contributions help fund SPI, Inc, which acts as the legal umbrella
+organization for holding copyrights, etc.
+
+Your contribution is *not* used for paying personnel.


### PR DESCRIPTION
Realistically this page should have always been on the website, but I believe
that it was added to the wiki due to the painful editing/authorship experience
we previously experienced with the site

Fixes WEBSITE-59