### PR TITLE
Add a Solutions page for Pipeline as Code

### DIFF
--- a/content/solutions/pipeline.html.haml
+++ b/content/solutions/pipeline.html.haml
@@ -1,0 +1,140 @@
+---
+layout: frame
+title: "Pipeline as Code with Jenkins"
+articles:
+-
+  - http://udaypal.com/jenkins-workflow-getting-started/
+  - "Getting started with Jenkins Workflow"
+-
+  - https://jenkins-ci.org/content/pipeline-code-multibranch-workflows-jenkins
+  - "Multibranch Workflows in Jenkins"
+plugins:
+-
+  - "https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin"
+  - "Workflow plugin"
+  - "allows creating Workflow scripts for defining a pipeline of build/test/deploy steps"
+-
+  - "https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin"
+  - "Job DSL plugin"
+  - "allows the programmatic creation of projects using a DSL"
+-
+  - "https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin"
+  - "Build Flow plugin"
+  - "allows managing Jenkins jobs orchestration using a dedicated DSL, extracting the flow logic from jobs."
+---
+
+- # ensure we have URI in scope since we'll need it later
+- require 'uri'
+
+- if legacy?
+  - # Since we have an old version of the Docker solution page, this will have to do
+  %div#page{:class => 'clearfloat'}
+    %div#top{:class => 'clearfloat'}/
+    %div#sidebar
+      .block
+        .content
+          %h2
+            Pipeline as Code Articles
+
+          %p
+            Here's a collection of articles about implementing "Pipeline as
+            Code" with Jenkins from around the web
+
+          %ul
+          - page.articles.each do |link, title|
+            %li
+              %a{:href => link}
+                = title
+              (
+              %code>
+                = URI.parse(link).host
+              )
+
+      .block
+        .content
+          %h2
+            Plugins for Jenkins
+
+          %p
+            Implementing a pipeline in Jenkins with code is possible via a
+            number of different plugins, each of which has taken a different
+            approach to solving the problem.
+
+          %ul
+            - page.plugins.each do |link, title, description|
+              %li
+                %a{:href => link}
+                  = title
+                \-
+                = description
+
+      = partial('download.html.haml')
+
+
+    %div#content{:class => 'main-content with-sidebar'}
+      %div#content-top/
+
+      :markdown
+        The default interaction model with Jenkins, historically, has been very web UI
+        driven, requiring users to manually create jobs, then manually fill in the
+        details through a web browser. This requires additional effort to create and
+        manage jobs to test and build multiple projects, it also keeps the
+        configuration of a job to build/test/deploy separate from the actual code being
+        built/tested/deployed. This prevents users from applying their existing CI/CD
+        best practices to the job configurations themselves.
+
+
+        # Workflow
+
+        With the introduction of the [Workflow
+        plugin](https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin),
+        users now can implement a project's entire build/test/deploy pipeline
+        in a `Jenkinsfile` and store that alongside their code, treating their
+        pipeline as another piece of code checked into source control.
+
+        The Workflow plugin itself is inspired by the [Build Flow
+        plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin)
+        but aims to improve upon some concepts explored by Build Flow with
+        features like the ability to suspend/resume of executing jobs.
+
+        In an adjacent space is the [Job DSL
+        plugin](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin)
+        which is worth checking out depending on your use-case as well.
+
+
+        ## Getting Started
+
+        * The [Workflow
+          plugin](https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin)
+          has a fairly comprehensive
+          [tutorial](https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md)
+          checked into its source tree.
+        * [Overview of Continuous Delivery with Workflow](http://documentation.cloudbees.com/docs/cookbook/_continuous_delivery_with_jenkins_workflow.html)
+        * [DZone Refcard](https://dzone.com/refcardz/continuous-delivery-with-jenkins-workflow)
+        * [Pipeline as code "cook book"](http://documentation.cloudbees.com/docs/cookbook/pipeline-as-code.html)
+
+        ## Additional resources
+
+        * [Workflow Plugin page](https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin)
+        * [Plugins compatible with Workflow](https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md)
+        * [Stack Overflow "jenkins-workflow" tag](http://stackoverflow.com/questions/tagged/jenkins-workflow)
+        * [Examples repository](/content/workflow-best-practices-and-examples-repo-github)
+
+
+        ## Presentations
+
+        The presentations below were given by [Jesse Glick](https://github.com/jglick), author of the [Workflow Plugin page](https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin)
+
+        <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/VkIzoU7zYzE" frameborder="0" allowfullscreen></iframe>
+
+        * [2014 presentation](https://www.youtube.com/watch?v=gpaV6x9QwDo) (with [slides](https://www.cloudbees.com/sites/default/files/2014-0618-Boston-Jesse_Glick-Workflow.pdf))
+
+        Other presentations:
+
+        * [Pimp your Continuous Delivery Pipeline with Jenkins workflow (W-JAX 14)](http://www.slideshare.net/cloudbees/pimp-your-continuous-delivery-pipeline-with-jenkins-workflow-wjax-14) by [Cyrille Le Clerc](https://github.com/cyrille-leclerc)
+
+      %div#content-bottom/
+
+- else
+  - # New and improved version of the Pipeline solution page
+  = partial('toptoolbar.html.haml')


### PR DESCRIPTION
This is still a bit basic, and mostly riffed from
https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+as+Code but I'm starting
to see commonalities in Solutions pages.


![pac-solution-page](https://cloud.githubusercontent.com/assets/26594/12103699/59babf52-b2f9-11e5-9746-83ddc429365c.png)