### PR TITLE
Link the feedburner-based RSS feed

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -15,6 +15,7 @@ layout: default
       = display_author_for(page)
 
     = partial('tweetbutton.html.haml')
+    = partial('feedburner.html.haml')
 
     %div.content
       = content

--- a/content/_partials/feedburner.html.haml
+++ b/content/_partials/feedburner.html.haml
@@ -1,0 +1,8 @@
+%div{:style => 'float: right; margin-right: 5px; clear: all;'}
+  %a{:href => "http://feeds.feedburner.com/ContinuousBlog",
+    :title => "Subscribe to my feed",
+    :rel => "alternate",
+    :type => "application/rss+xml"}
+    %img{:src => "//feedburner.google.com/fb/images/pub/feed-icon16x16.png",
+      :alt => "RSS feed",
+      :style => "border:0"}/


### PR DESCRIPTION
When I brought this over from Drupal, I had omitted any references to the feed;
time to bring it back