### PR TITLE
Add an official-ish version of the approved Code of Conduct

### DIFF
--- a/content/_partials/navbar.html.haml
+++ b/content/_partials/navbar.html.haml
@@ -36,5 +36,8 @@
         %a{:href => "https://ci.jenkins-ci.org/", :title => "Jenkins own Jenkins install"}
           CI
       %li.leaf
+        %a{:href => "/conduct", :title => "Jenkins project Code of Conduct"}
+          Conduct
+      %li.leaf
         %a{:href => "/donate", :title => "Donate to Jenkins"}
           Donation

--- a/content/conduct.adoc
+++ b/content/conduct.adoc
@@ -1,0 +1,186 @@
+---
+layout: default
+title: "Jenkins Code of Conduct"
+---
+
+:toc:
+
+
+This document only defines the Code of Conduct and Reporting/Handling processes
+for the Jenkins project/community. For more details about our cultural values,
+goals, philosophies, structure and so on, please consult our
+link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document[Governance Document]. 
+
+
+== Code of Conduct
+
+As contributors and maintainers of this project (defined under <<Community Spaces>>
+and the
+link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document[Governance
+Document]), and in the interest of fostering an open and welcoming community,
+we pledge to respect all people who contribute through reporting issues,
+posting feature requests, updating documentation, submitting pull requests or
+patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+The Jenkins board has the right and responsibility to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful. Plugin and other maintainers also have the
+right and responsibility to remove, edit, or reject comments, commits, code,
+wiki edits, issues, and other contributions that are not aligned to this Code
+of Conduct.
+
+By adopting this Code of Conduct, the Jenkins board commits themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the
+link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Jenkins
+board] at jenkinsci-board@googlegroups.com.  All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The board is obligated to maintain
+confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the
+link:http://contributor-covenant.org/[Contributor Covenant], version 1.3.0,
+available from link:http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+
+
+=== Community Spaces
+
+==== Source Control
+
+* GitHub
+** Organizations
+*** link:https://github.com/jenkinsci[jenkinsci]
+*** link:https://github.com/jenkinsci-cert[jenkinsci-cert]
+*** link:https://github.com/jenkins-infra[jenkins-infra]
+** Commits
+** Pull requests
+** Issues
+** Wikis
+* Subversion
+
+Technical criticism is always appreciated, but avoid destructive behavior such as unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
+
+(courtesy of the link:https://golang.org/conduct#values[Go Lang Code of Conduct])
+
+==== Websites
+
+Everything hosted under link:https://jenkins-ci.org/[jenkins-ci.org] and its sub-domains such as:
+
+* link:https://issues.jenkins-ci.org/[issues.jenkins-ci.org]
+* link:https://wiki.jenkins-ci.org/[wiki.jenkins-ci.org]
+* link:http://lists.jenkins-ci.org/mailman/listinfo[lists.jenkins-ci.org]
+
+==== Mailing lists
+
+Those hosted on Google Groups (see
+link:https://jenkins-ci.org/content/mailing-lists[here]) and those self-hosted
+on link:http://lists.jenkins-ci.org/mailman/listinfo[lists.jenkins-ci.org].
+
+==== IRC Channels
+
+Documented in the
+link:https://wiki.jenkins-ci.org/display/JENKINS/IRC+Channel[IRC Channel] wiki
+page, e.g.
+
+* `#jenkins`
+* `#jenkins-meeting`
+* `#jenkins-infra`
+* `#jenkins-community`
+
+==== Events
+
+* link:https://wiki.jenkins-ci.org/display/JENKINS/Office+Hours[Office Hours]\
+* link:https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Area+Meetup[Jenkins
+  Area Meetup]
+* Events where Jenkins is officially being represented (e.g.
+  link:https://fosdem.org[FOSDEM] , link:https://socallinuxexpo.org/[SCaLE])
+* Other Jenkins groups (such as conferences, meetups, and other unofficial
+  forums) are encouraged to adopt this Code of Conduct. Those groups must
+  provide their own moderators and/or reporting system.
+
+
+== Reporting
+
+If you feel somebody has breached this code, please send an email with the
+relevant information (links, etc) to jenkinsci-board@googlegroups.com. This
+email list is only readable by the
+link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance
+Board] members.
+
+Please understand that the board may not have all of the necessary context and
+history, so it's better to be more verbose than less verbose about such
+matters.
+
+If you believe one of the members of the board has violated the code of conduct
+above, please email one of the other members of the Governance Board with the
+details (their emails are visible on the
+link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance
+Board] page).
+
+== Handling of violations
+
+Depending on the severity of the violations the board may elect to take one of the following paths. The resolution of violations will be done in private, and the affected people will be notified but there will not be a public announcement. We aim to prevent mud-slinging and unnecessary further personal attacks/etc.
+
+=== Reprimand
+
+If the severity of the violation is mild enough, the board will notify the
+community member that his or her conduct is not acceptable and needs to change.
+
+=== Probation
+
+If the severity of the violation is serious or reprimands are not effective,
+the board will ask the community member to "take a break." Meaning, to step
+away from the project for a period of time. This means no participating in:
+
+* The link:https://wiki.jenkins-ci.org/display/JENKINS/IRC+Channel[IRC Channels]
+* Mailing lists
+* Pull requests
+* Events
+* etc
+
+The intent of this is to send a clear signal to the community member that their
+conduct is unacceptable, de-escalate the situation for everyone who are
+affected, and ask the community member to reflect on their behaviors.
+
+=== Expulsion
+
+If probation clearly doesn't address the issue, or the issue is of high
+severity to warrant an expulsion, the contributor will be expelled from the
+Jenkins community for a period of 12 months. After which they may appeal to the
+board for the ban to be lifted.
+
+The ban will include but is not limited to:
+
+*  Bans from Jenkins community IRC Channels
+*  Deletion of their LDAP account
+*  Blocking their GitHub username from the jenkinsci github organization
+*  Banning their email address from jenkins mailing lists
+
+
+
+NOTE: This page has been imported from the
+link:https://wiki.jenkins-ci.org/display/JENKINS/Code+of+Conduct[Code of
+Conduct] wiki page, which, as of `v15`, was approved by the project governance
+meeting on
+link:http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[2016-01-09]


### PR DESCRIPTION
This is taken from this wiki page
(https://wiki.jenkins-ci.org/display/JENKINS/Code+of+Conduct) and was approved
in today's project meeting
(http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html)

This being added to the site should make it easier to find, and make it more
clearly an official policy for the project

![coc](https://cloud.githubusercontent.com/assets/26594/12158912/05013f7c-b493-11e5-893f-95e21b900d87.png)