### PR TITLE
Kill the unnecessary margin in our lists

### DIFF
--- a/content/css/style.css
+++ b/content/css/style.css
@@ -75,8 +75,11 @@ acronym, abbr {
 	border-bottom: 1px dashed #999;
 }
 
-li{
+li {
 	margin-left:30px;
+}
+li p {
+    margin: 0;
 }
 
 .tabs li {


### PR DESCRIPTION
This was driving me nuts, every list was being spaced out way too far as a
result of the `p` element's styling

The image below, left is production and right is with this change

![fecking-lists](https://cloud.githubusercontent.com/assets/26594/12158919/175020a8-b493-11e5-88d1-d20bc680e866.png)
