### PR TITLE
Added "Page history" links to pages containing GitHub link

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -38,6 +38,15 @@
     %div#github
       %a{:href => "https://github.com/jenkins-infra/jenkins.io/edit/master/content/#{page.relative_source_path}",
           :title => "Edit #{page.relative_source_path} on GitHub"}
-        Improve this page
+        :escaped
+          [Improve this page]
+      
+      :plain
+        &nbsp;
+      
+      %a{:href => "https://github.com/jenkins-infra/jenkins.io/commits/master/content/#{page.relative_source_path}",
+          :title => "View #{page.relative_source_path} history on GitHub"}
+        :escaped
+          [Page history]
 
       = google_analytics_universal

--- a/content/blogs.html.haml
+++ b/content/blogs.html.haml
@@ -25,8 +25,17 @@
     = partial('footer.html.haml')
 
     %div#github
-      %a{:href => "https://github.com/rtyler/jenkins.io/edit/master/content/#{page.relative_source_path}",
+      %a{:href => "https://github.com/jenkins-infra/jenkins.io/edit/master/content/#{page.relative_source_path}",
           :title => "Edit #{page.relative_source_path} on GitHub"}
-        Improve this page
+        :escaped
+          [Improve this page]
+      
+      :plain
+        &nbsp;
+      
+      %a{:href => "https://github.com/jenkins-infra/jenkins.io/commits/master/content/#{page.relative_source_path}",
+          :title => "View #{page.relative_source_path} history on GitHub"}
+        :escaped
+          [Page history]
 
     = google_analytics_universal


### PR DESCRIPTION
Now it's easy to open GitHub and to see latest changes in the page.

Example:
<img width="689" alt="screen shot 2016-01-10 at 03 04 37" src="https://cloud.githubusercontent.com/assets/3000480/12219136/f2683ecc-b746-11e5-8fae-9eb0067d2340.png">

@reviewbybees @rtyler 