### PR TITLE
Introduce code and content licensing for the site

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,0 +1,42 @@
+= License
+
+== Code
+
+This license applies code contributed to this repository which is generally
+used in the construction of the Jenkins website
+
+.MIT License
+""
+Copyright (c) 2015-2016 CloudBees, Inc, and respective contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+""
+
+== Content
+
+
+The link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons
+Atribution-ShareAlike 4.0] license applies, unless otherwise stated to the
+content created as part of this website, such as the Asciidoc or Markdown files
+inside of `content/`.
+
+image:::https://licensebuttons.net/l/by-sa/4.0/88x31.png[Attribution/Share-a-like]
+
+* link:https://creativecommons.org/licenses/by-sa/4.0/[Human-readable license text]
+* link:https://creativecommons.org/licenses/by-sa/4.0/legalcode[Full legal license text]

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -50,3 +50,7 @@
           [Page history]
 
       = google_analytics_universal
+
+    #creativecommons
+      %a{:href => 'https://creativecommons.org/licenses/by-sa/4.0/'}
+        %img{:src => 'https://licensebuttons.net/l/by-sa/4.0/88x31.png'}/

--- a/content/css/style.css
+++ b/content/css/style.css
@@ -759,3 +759,11 @@ blockquote {
 .block .pager li {
   float:left;
 }
+
+
+/* Ensure the license shows at the far right so as not to interfere with our
+ * "improve this page" link
+ */
+#creativecommons {
+    float: right;
+}


### PR DESCRIPTION
I completely forgot about this until now. MIT license is the license of the
Jenkins core repo, so I believe that to be sufficient. Whereas CC-BY-SA 4.0 I
believe is the appropriate content license