### PR TITLE
Pin to awestruct 0.5.6 since 0.5.7 introduces a Ruby 2.0 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ configurations {
 
 dependencies {
     /* used for primary site generation */
-    asciidoctor 'rubygems:awestruct:[0.5.6,0.6)'
+    asciidoctor 'rubygems:awestruct:0.5.6'
     /* ensure we pull in a more recent version of asciidoctor */
     asciidoctor 'rubygems:asciidoctor:[1.5.3,2.0)'
     /* used for legacy markdown template processing via tilt */


### PR DESCRIPTION
Womp womp

    Starting process 'command '/usr/lib/jvm/java-7-openjdk-amd64/bin/java''. Working directory: /home/tyler/source/github/jenkins-infra/jenkins.io Command: /usr/lib/jvm/java-7-openjdk-amd64/bin/java -Dfile.encoding=utf-8 -Duser.country=US -Duser.language=en -Duser.variant -cp /home/tyler/.gradle/caches/modules-2/files-2.1/org.jruby/jruby-complete/1.7.23/98150edb47ccc36917c1ef475d694b91a3356245/jruby-complete-1.7.23.jar org.jruby.Main -S gem install /home/tyler/.gradle/caches/modules-2/files-2.1/rubygems/awestruct/0.5.7/c443be2604157f2cb542caaa158a2015618cabd8/awestruct-0.5.7.gem --ignore-dependencies --install-dir=/home/tyler/source/github/jenkins-infra/jenkins.io/build/tmp/asciidoctor --no-user-install --wrappers --no-document --local
    Successfully started process 'command '/usr/lib/jvm/java-7-openjdk-amd64/bin/java''
    ERROR:  Error installing /home/tyler/.gradle/caches/modules-2/files-2.1/rubygems/awestruct/0.5.7/c443be2604157f2cb542caaa158a2015618cabd8/awestruct-0.5.7.gem:
        awestruct requires Ruby version >= 2.0.
    :compileContent FAILED
    :compileContent (Thread[main,5,main]) completed. Took 35.224 secs.