### PR TITLE
Only show date (in ISO-8601), only show author if date is set

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -8,11 +8,12 @@ layout: default
       %a{:href => page.url, :title => page.title}
         = page.title
 
-    %span.submitted
-      Published on
-      = page.date
-      by
-      = display_author_for(page)
+    - if page.date
+      %span.submitted
+        Published on
+        = page.date.strftime('%Y-%m-%d')
+        by
+        = display_author_for(page)
 
     = partial('tweetbutton.html.haml')
     = partial('legacy/feedburner.html.haml')
@@ -33,11 +34,12 @@ layout: default
 
           = partial('tweetbutton.html.haml')
 
-          %span.submitted
-            Published on
-            = page.date
-            by
-            = display_author_for(page)
+          - if page.date
+            %span.submitted
+              Published on
+              = page.date.strftime('%Y-%m-%d')
+              by
+              = display_author_for(page)
 
         = content
 


### PR DESCRIPTION
Posts only have a date, not a time, so show only the former. Keeps the unambiguous ISO 8601 format.

---

This also gets rid of some weirdness on pages like the changelog:

> Published on by kohsuke

If there's no date, it's likely there's no need for displaying the author either.