### PR TITLE
Remove last remnants of php

### DIFF
--- a/content/content/event-calendar/index.html
+++ b/content/content/event-calendar/index.html
@@ -20,7 +20,7 @@ TimeZone:
 </div>
 </div>
 
-<iframe src="https://www.google.com/calendar/b/0/embed?showTitle=0&amp;showCalendars=0&amp;height=590&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=4ss12f0mqr3tbp1t2fe369slf4%40group.calendar.google.com&amp;color=%2329527A&amp;ctz=<?php echo $_GET['timeZone'] ?>" style=" border-width:0 " width="590" height="590" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://www.google.com/calendar/b/0/embed?showTitle=0&amp;showCalendars=0&amp;height=590&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=4ss12f0mqr3tbp1t2fe369slf4%40group.calendar.google.com&amp;color=%2329527A" style=" border-width:0 " width="590" height="590" frameborder="0" scrolling="no"></iframe>
 
 <div>
 <a href="https://www.google.com/calendar/feeds/4ss12f0mqr3tbp1t2fe369slf4%40group.calendar.google.com/public/basic"><img src="https://www.google.com/calendar/images/xml.gif"></a>

--- a/content/stable-rc/index.html
+++ b/content/stable-rc/index.html
@@ -10,8 +10,6 @@
 <p>
 LTS Release candidate is the build intended for the upcoming LTS release of Jenkins. <a href="https://wiki.jenkins-ci.org/display/JENKINS/Release+Process">See Wiki for more about what it means.</a>
 </p>
-<p>Upcoming version: <b><?php include "/srv/releases/jenkins/version-stable-rc.txt"?></b></p>
-
 
   <style>
     #download DT {

--- a/content/welcome/index.html
+++ b/content/welcome/index.html
@@ -71,7 +71,7 @@ Jenkins is an open-source continuous integration server with 300+ plugins to sup
 			<td><a href="https://wiki.jenkins-ci.org/display/JENKINS/Plugins"><img src="/sites/default/files/images/plugin.png" class=logo></a></td> 
 			<td><a href="https://wiki.jenkins-ci.org/display/JENKINS/Plugins"> 
 			<div class=title>Customize Jenkins</div> 
-			<div class=description>Choose from <strong><?php include "/var/www/updates2.jenkins-ci.org/pluginCount.txt"?></strong> plugins to customize Jenkins exactly to your needs.</div> 
+			<div class=description>Choose from <strong>hundreds</strong> of plugins to customize Jenkins exactly to your needs.</div>
 			</a></td> 
 		</tr> 
 		<tr> 


### PR DESCRIPTION
None of these are interpreted any more and in fact they leek to the http response as is.

`content/welcome/index.html` seems outright unused on the first glance. I am not sure how `content/content/event-calendar/index.html` was supposed to work but it looks like XSS vulnerability back in PHP days.