### PR TITLE
Fix broken wiki link on the 2.0 landing page.

### DIFF
--- a/content/2.0.html.haml
+++ b/content/2.0.html.haml
@@ -148,7 +148,7 @@ title: Jenkins 2.0
 
 %p
   We have more details of
-  %a{:href => "wiki.jenkins-ci.org/display/JENKINS/Jenkins+2.0"}
+  %a{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+2.0"}
     the 2.0 plan
   on our wiki!
 


### PR DESCRIPTION
As reported by a few people on Twitter.

Ping @daniel-beck
Ping @jenkinsci/eastern-hemisphere :)