### PR TITLE
Missing quotes around title containing :

### DIFF
--- a/content/blog/2016/2016-03-02-toulousejam-hackergarten.adoc
+++ b/content/blog/2016/2016-03-02-toulousejam-hackergarten.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Jenkins Hackergarten : mercredi 9 mars 2016 à Toulouse
+title: "Jenkins Hackergarten : mercredi 9 mars 2016 à Toulouse"
 tags:
 - hackergarten
 - jam


### PR DESCRIPTION
```
could not parse /blog/2016/2016-03-02-toulousejam-hackergarten.adoc
While processing file
An error occurred: (<unknown>): mapping values are not allowed here at
line 3 column 29
```