### PR TITLE
Introduce an awestruct extension for generation of tables of contents

### DIFF
--- a/content/_ext/adoctoc.rb
+++ b/content/_ext/adoctoc.rb
@@ -32,7 +32,7 @@ module DirectoryTOC
     pages_by_path = awestruct_pages.map { |p| [p.source_path, p] }.to_h
     toc = []
 
-    Dir[File.join(directory, '*.adoc')].each do |adoc|
+    Dir[File.join(directory, '*.adoc')].sort.each do |adoc|
       page = pages_by_path[adoc]
       # Since all our documents are going to have front-matter so they render
       # properly, we need to look first at the Awestruct::Page and then

--- a/content/_ext/adoctoc.rb
+++ b/content/_ext/adoctoc.rb
@@ -1,0 +1,49 @@
+require 'asciidoctor'
+
+
+# The DirectoryTOC module helps provide the ability to generate a nested
+# datastructure based on the asciidoc files inserted into a directory. Instead
+# of requiring the user to create one large monolithic `.adoc` file, this
+# allows individual sections to be defined and managed as separate files
+module DirectoryTOC
+  def compute_section_link(document, title)
+    prefix = document.attributes['idprefix'] || ''
+    separator = document.attributes['idseparator'] || '-'
+    title = title.downcase.gsub(Asciidoctor::InvalidSectionIdCharsRx, separator)
+
+    return [
+      prefix,
+      title.tr_s(separator, separator).chomp(separator),
+    ].join('')
+  end
+
+  def find_all_sections(section, document)
+    children = []
+    section.sections.each do |sub|
+      children << [sub.title,
+                   document.file,
+                   compute_section_link(document, sub.title),
+                   find_all_sections(sub, document)]
+    end
+    return children
+  end
+
+  def adoc_toc_for(directory, awestruct_pages)
+    pages_by_path = awestruct_pages.map { |p| [p.source_path, p] }.to_h
+    toc = []
+
+    Dir[File.join(directory, '*.adoc')].each do |adoc|
+      page = pages_by_path[adoc]
+      # Since all our documents are going to have front-matter so they render
+      # properly, we need to look first at the Awestruct::Page and then
+      # re-render to grab the sections from the asciidoc
+      document = Asciidoctor.load(page.raw_content)
+
+      document.sections.each do |section|
+        children = find_all_sections(section, document)
+        toc << [section.title, adoc, page.url, children]
+      end
+    end
+    return toc
+  end
+end

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -1,22 +1,14 @@
-require 'authorship'
-require 'debuggable-partial'
-require 'legacy'
-require 'releases'
-require 'solutionpage'
-require 'versionswitcher'
-require 'yearposts'
-require 'betterdatadir'
+Dir[File.join(File.dirname(__FILE__), '*.rb')].each do |extension|
+  next if extension == __FILE__
+  require extension
+end
 
 Awestruct::Extensions::Pipeline.new do
   # Register all our blog content under the `site.posts` variable
   extension YearPosts.new('/blog', :posts)
-
   extension Awestruct::Extensions::Indexifier.new
   extension Awestruct::Extensions::Sitemap.new
   extension BetterDataDir.new
-
-  #extension Awestruct::Extensions::Tagger.new(:posts,
-  #                                             '/blog')
 
   extension Awestruct::Extensions::Paginator.new(:posts,
                                                   '/node/index',


### PR DESCRIPTION
Instead of requiring one big giant document, this allows us to create a series of chapters inside a single directory and then still have a cohesive table of contents on a "summary" page.