### PR TITLE
Cookbook cleanup: Architecting for Manageability and Architecting for Scale

### DIFF
--- a/content/doc/book/architecting-for-manageability.adoc
+++ b/content/doc/book/architecting-for-manageability.adoc
@@ -24,17 +24,9 @@ Upgrading or downgrading either the Jenkins core or any plugins can sometimes ha
 Test masters should have identical configurations, jobs, and plugins as the production master so that test upgrades  will most closely resemble the outcomes of a similar change on your production master. For example, installing the Folders plugin while running a version of the Jenkins core older than 1.554.1 will cause the instance crash and be inaccessible until the plugin is manually uninstalled from the _plugin_ folder.
 
 ==== Setting up a test instance
-There are many methods for setting up a test instance, but the commonality between them all is that the _$JENKINS_HOME_ between them is nearly identical. Whether this means that most all of the production masters’ _$JENKINS_HOME_ folder is version controlled in a service like GitHub and mounted manually or programmatically to a test server or Docker container, or whether the settings are auto-pushed or the test instance automatically created by CloudBees Jenkins Operations Center, the result is nearly the same.
+There are many methods for setting up a test instance, but the commonality between them all is that the _$JENKINS_HOME_ between them is nearly identical. Whether this means that most all of the production masters’ _$JENKINS_HOME_ folder is version controlled in a service like GitHub and mounted manually or programmatically to a test server or Docker container, the result is nearly the same.
 
 It is ideal to first ensure sure the master is idle (no running or queued jobs) before attempting to create a test master.
-
-If you are running CloudBees Jenkins Enterprise, there are also a few files specific to CJE which you should not copy over into your alternate installation:
-
-* _identity.key_ should not be copied to the test master, as this identifies the installation generally. For the new installation you will need a distinct test license. 
-
-* The _jgroups_ subdirectory should not be copied. Otherwise the new installation may attempt to join an HA cluster with the old installation.
-
-* _cluster-identity.txt_, if present (only created if you have a custom jgroups.xml), should not be copied.
 
 *With GitHub + manual commands*
 
@@ -167,38 +159,11 @@ docker run -d --dns=172.17.42.1 --name joc-1 --volumes-from storage -e JENKINS_H
 
 Note that Docker only supports one mounted volume at a time, so if you are planning on running multiple test instances on Docker, all of their _$JENKINS_HOME_s will need to be version controlled in the same GitHub repo.
 
-*With Jenkins Operations Center*
-
-CloudBees Jenkins Operations Center  can push plugins, core Jenkins versions, and security configurations to any Jenkins master that is managed by it. This makes it possible to attach a test server instance  (whether that be a Docker container, EC2 instance, vSphere VM, etc) and CJOC will automatically push to the master those pre-configured settings once a connection is established. 
-
-To keep both masters in sync plugin/core-wise, 3 Custom Update Centers would need to be set up using the Custom Update Center plugin by CloudBees. The update center would need to be hosted on CloudBees Jenkins Operations Center and maintained by the Jenkins administrator.
-
-Update centers can take several different upstream resources:
-
-1. The *open source update center* - https://updates.jenkins-ci.org/current/update-center.json - this is the default update center that ships with open-source Jenkins instances. 
-2. The *experimental open source update center* - http://updates.jenkins-ci.org/experimental/update-center.json - this update center only contains experimental plugins which are not yet stable or ready for production, but which represent the most cutting edge version of Jenkins’ feature set.
-3. The *CloudBees update center* - http://jenkins-updates.cloudbees.com/updateCenter/WwwvhPlQ/update-center.json - this update center includes CloudBees’ proprietary plugins and their dependencies.
-4. The *CloudBees experimental update center* - http://jenkins-updates.cloudbees.com/updateCenter/HcEXz-Ow/update-center.json - like its open source equivalent, this update center contains the most experimental and cutting edge versions of the CloudBees plugin set, but which are not necessarily ready for production.
-5. The *CloudBees Jenkins Operations Center update center* - http://jenkins-updates.cloudbees.com/update-center/operations-center/update-center.json - This update center only contains plugins for the CloudBees Jenkins Operations Center product.
-6. The *CloudBees Jenkins Operations Center experimental update center* - http://jenkins-updates.cloudbees.com/updateCenter/xcdPj_ZA/update-center.json - Like the previous experimental update centers, this UC contains the most cutting edge versions of the CloudBees Jenkins Operations Center product’s feature set.
-
-With this in mind, here is how a test instance could be set up with a combination of the above update centers:
-
-* *Main update center* - This custom update center would only take the OSS plugins as its upstream plugins. The administrator would need to select which plugins to store and which versions to push to any downstream update center. This update center should be configured to automatically promote the latest plugin.
-
-* *Production update center* - This custom update center would need to take the main update center as its upstream and be configured to *not* automatically take the latest version. This allows the administrator more control over what plugins will be available to the downstream master, in this case the production master. This will in turn prevent users of the downstream master from being able to upgrade beyond an approved version of a plugin of the Jenkins core.
-
-* *Test update center* - This customer update center would need to take the main update center as its upstream and be configured to automatically take the latest version of its plugins. This allows the test environment to always have access to the latest plugins to be tested against your environment. The test master will be the downstream master for this update center.
-
-The only further configuration that would need to be duplicated would be the jobs, which can be accomplished by copy/pasting the jobs folder from the production master to the target test master or by a script that is run by a Cluster Operation on CJOC. Such a custom script can be configured to run after certain triggers or at certain intervals.
-
 .Test master slaves
 
 Test masters can be connected to test slaves, but this will require further configurations. Depending on your implementation of a test instance, you will either need to create a Jenkins Docker slave image or a slave VM. Of course, open-source plugins like the EC2 plugin also the option of spinning up new slaves on-demand.
 
-If you are not using CloudBees Jenkins Operations Center, the slave connection information will then need to be edited in the config.xml located in your test master’s _$JENKINS_HOME_. 
-
-If using Jenkins Operations Center, no further configuration is required so long as the test master has been added as a client master to CJOC.
+The slave connection information will also need to be edited in the config.xml located in your test master’s _$JENKINS_HOME_. 
 
 .Rolling back plugins that cause failures
 
@@ -218,7 +183,7 @@ The https://wiki.jenkins-ci.org/display/JENKINS/Metrics+Plugin[Jenkins Metrics P
 
 .Metrics exposed
 
-The exact list of exposed metrics varies depending on your installed plugins. For example, on a CloudBees Jenkins Operations Center master, metrics regarding shared slaves and the number of managed masters will be available via the Dropwizard Metrics API. To get a full list of available metrics for your own master, run the following script on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Script+Console[your master’s script console]:
+The exact list of exposed metrics varies depending on your installed plugins. To get a full list of available metrics for your own master, run the following script on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Script+Console[your master’s script console]:
 
 [source]
 for (j in Jenkins.instance.getExtensionList(jenkins.metrics.api.MetricProvider.class)) {

--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -115,21 +115,11 @@ One best practice to avoid this failure is to configure a job with the assumptio
 
 ==== Define a policy to share slave machines
 
-As mentioned previously, slaves should be interchangeable and standardized in order to make them sharable and to optimize resource usage.  Slaves should not be customized for a particular set of jobs, nor for a particular team. CloudBees' recommendation is always to make slaves general enough to be shared among jobs and teams, but there are exceptions.
+As mentioned previously, slaves should be interchangeable and standardized in order to make them sharable and to optimize resource usage.  Slaves should not be customized for a particular set of jobs, nor for a particular team. 
 
 Lately Jenkins has become more and more popular not only in CI but also in CD, which means that it must orchestrate jobs and pipelines which involve different teams and technical profiles: developers, QA people and Dev-Ops people.
 
 In such a scenario, it might make sense to create customized and dedicated slaves: different tools are usually required by different teams (i.e. Puppet/Chef for the Ops team) and teams’ credentials are usually stored on the slave in order to ensure their protection and privacy. 
-
-////
-CloudBees Jenkins Enterprise offers plugins that make this possible, allowing a Jenkins administrator to tie a specific slave to a specific folder (Folder Plus plugin) and to create security strategies at folder level (RBAC).
-
-In details, the combination of Role Based Access Control Enterprise Plugin with the Folder Plus Enterprise Plugin allows the isolation among teams in terms of slaves, so that: 
-
-* Teams which are not allowed to access a specific folder, won’t be able to access the slaves tied to that folder, ensuring protection of team-specific data (i.e. credentials).
-
-* Slaves attached to a folder will be protected from being used by jobs which are not in the same folder.
-////
 
 In order to ensure the execution of a job on a single/group of slaves only (i.e. iOS builds on OSX slaves only), it is possible to tie the job to the slave by specifying the slave's label in the job configuration page. Note that the restriction has to be replicated in every single job to be tied and that the slave won’t be protected from being used by other teams.
 
@@ -186,23 +176,6 @@ When evaluating these strategies, it is important to weigh them against the vert
 
 Another note is that a smaller number of jobs translates to faster recovery from failures and more importantly a higher mean time between failures.
 
-//// 
-
-*Commenting out pending Tiger release*
-
-==== Jenkins-as-a-Service sizing strategies
-
-In the age of software being delivered as internal services in an organization, master/slave configurations can also be viewed as a combined unit when their provisioning is configured to occur in tandem, either as a script or within a tool. Instead of masters being provisioned separately from slaves, organizations which deliver Jenkins-as-a-service to internal teams can thereby provision both a master and a cluster of slaves as a single unit to their end-users.
-
-*Some Tiger provisioning details here* 
-
-*Eng recs here*
-
-////
-
-////
-
-*Commenting out pending updated data*
 ==== Calculating how many jobs, masters, and executors are needed
 
 Having the best possible estimate of necessary configurations for a Jenkins installation allows an organization to get started on the right foot with Jenkins and reduces the number of configuration iterations needed to achieve an optimal installation. The challenge for Jenkins architects is that true limit of vertical scaling on a Jenkins master is constrained by whatever hardware is in place for the master, as well as harder to quantify pieces like the types of builds and tests that will be run on the build nodes. 
@@ -211,8 +184,6 @@ There is a way to estimate roughly how many masters, jobs and executors will be 
 
 If you have information on the actual number of available cores on your planned master, you can make adjustments to the 
 “number of masters” equations accordingly. 
-
-NOTE: Enterprise topology is unique and this equation is known to underestimate a larger organization’s executor counts.
 
 The equation for *estimating the number of masters and executors needed* when the number of configured jobs is known is as follows:
 
@@ -228,7 +199,6 @@ number of masters = number of jobs/500
 number of executors = number of jobs * 0.03
 
 These numbers will provide a good starting point for a Jenkins installation, but adjustments to actual installation size may be needed based on the types of builds and tests that an installation runs.
-////
 
 ==== Scalable storage for masters
 
@@ -250,8 +220,6 @@ Additionally, to easily prevent a _$JENKINS_HOME_ folder from becoming bloated, 
 === Setting up a backup policy
 
 It is a best practice to take regular backups of your $JENKINS_HOME. A backup ensures that your Jenkins instance can be restored despite a misconfiguration, accidental job deletion, or data corruption.  
-
-CloudBees offers a plugin that allows backups to be taken using a Jenkins job, which you can read more about http://jenkins-cookbook.cloudbees.com/docs/jenkins-cookbook/_backing_up_with_cloudbees_backup_plugin.html[here] 
 
 ==== Finding your $JENKINS_HOME
  
@@ -446,13 +414,13 @@ Ideally, masters will be set up to automatically recover from failures without h
 
 .Step 1: Make each master highly available
 
-Each Jenkins master needs to be set up such that it is part of a Jenkins cluster. One way to do this is to upgrade the master to run CloudBees Jenkins Enterprise, which includes a http://jenkins-cookbook.cloudbees.com/docs/jenkins-cookbook/_setting_up_high_availability_with_cloudbees_high_availability_plugin.html[High Availability plugin] that allows for an automatic failover when a master goes down and to notify other nodes in the cluster of the failure.
+Each Jenkins master needs to be set up such that it is part of a Jenkins cluster.
 
 A proxy (typically HAProxy or F5) then fronts the primary master. The proxy’s job is to continuously monitor the primary master and route requests to the backup if the primary goes down. To make the infrastructure more resilient, you can have multiple backup masters configured.
 
 .Step 2: Enable security
 
-Set up an authentication realm that Jenkins will use for its user database. If using CloudBees Jenkins Enterprise, enable the Role-based Access Control plugin that comes bundled with it.
+Set up an authentication realm that Jenkins will use for its user database.
 
 TIP: If you are trying to set up a proof-of-concept, it is recommended to use the https://wiki.jenkins-ci.org/display/JENKINS/Mock+Security+Realm+Plugin[Mock Security Realm plugin] for authentication.
 
@@ -460,6 +428,6 @@ TIP: If you are trying to set up a proof-of-concept, it is recommended to use th
 
 Add build servers to your master to ensure you are conducting actual build execution off of the master, which is meant to be an orchestration hub, and onto a “dumb” machine with sufficient memory and I/O for a given job or test.
 
-.Step 4: Setup a http://jenkins-cookbook.apps.cloudbees.com/docs/jenkins-cookbook/_test_instances.html[test instance]
+.Step 4: Setup a test instance
 
 A test instance is typically used to test new plugin updates. When a plugin is ready to be used, it should be installed into the main production update center.


### PR DESCRIPTION
2 links still included whose content needs to be migrated to jenkins.io:

* Full list of exposed metrics by the Metrics Plugin - https://documentation.cloudbees.com/docs/cje-user-guide/monitoring-sect-reference.html#monitoring-sect-reference-metrics 
* Basic and advanced usages of Metrics Plugin metrics: https://documentation.cloudbees.com/docs/cje-user-guide/monitoring-sect-getting-started.html[here].