### PR TITLE
Add the /redirect/ URL namespace for providing permanent links we can embed them

### DIFF
--- a/content/redirect/find-jenkins-logs.adoc
+++ b/content/redirect/find-jenkins-logs.adoc
@@ -1,0 +1,4 @@
+---
+layout: refresh
+refresh_to_post_id: 'https://wiki.jenkins-ci.org/display/JENKINS/Logging'
+---


### PR DESCRIPTION
This is the first such redirect which can be used in the the security token
screen in Jenkins 2.0 to help users find the security token

See also jenkinsci/jenkins#2115