### PR TITLE
Limit eventmachine to 1.0.x series

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,9 @@ dependencies {
     asciidoctor 'rubygems:kramdown:[1.9.0,2.0)'
     /* contains a number of useful awestruct extensions */
     asciidoctor 'rubygems:awestruct-ibeams:[0.2.1,1.0)'
-
+    /* 1.2.0 causes 'C extensions are not supported' error. It's known that
+        JRuby's C extensions are deprecated */
+    asciidoctor 'rubygems:eventmachine:[1.0, 1.2)'
 
     /* used for processing haml templates (haml.info) */
     asciidoctor 'rubygems:haml:[4.0.7,5.0)'


### PR DESCRIPTION
I'm not sure yet why this happens but on OS X 10.10+ with homebrew
eventmachine 1.2.0 consistently produces:

```
Building native extensions.  This could take a while...
ERROR:  Error installing
/Users/mmccaskill/.gradle/caches/modules-2/files-2.1/rubygems/eventmachine/1.2.0/66dac1bde48b857e23888a487fbbe452ebfd87b5/eventmachine-1.2.0.gem:
    ERROR: Failed to build gem native extension.

    java -cp
:/Users/mmccaskill/.gradle/caches/modules-2/files-2.1/org.jruby/jruby-complete/9.0.5.0/a5f1d5e8945a08ac9da8f7f528c513c60445eaeb/jruby-complete-9.0.5.0.jar
org.jruby.Main -r ./siteconf20160315-27388-17mrn1t.rb extconf.rb
NotImplementedError: C extensions are not supported
    <top> at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:1
  require at org/jruby/RubyKernel.java:937
   (root) at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
    <top> at extconf.rb:2

extconf failed, exit code 1

Gem files will remain installed in
/Users/mmccaskill/Development/Code/CloudBees/jenkins.io/build/tmp/asciidoctor/gems/eventmachine-1.2.0
for inspection.
```