### PR TITLE
Remove dead and outdated images from the "Scale" chapter.

### DIFF
--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -80,13 +80,6 @@ whose integrity and privacy could not be, thus,  guaranteed.
 For all these reasons Jenkins supports the "master/agent" mode, where the
 workload of building projects are delegated to multiple agents.
 
-[[agent_arch]]
-.Master/agent architecture
-image::master-slave.png[scaledwidth="30%"]
-
-NOTE: An architecture with 1 Jenkins master connected to 1 agent over a TCP/IP
-socket. The agent has 4 execution slots and is building 3 of the configured jobs.
-
 An agent is a machine set up to offload projects from the master. The method
 with which builds are scheduled depends on the configuration given to each
 project. For example, some projects may be configured to "restrict where this
@@ -106,10 +99,6 @@ In order for a machine to be recognized an agent, it needs to run a specific
 agent program to establish bi-directional communication with the master.
 
 There are different ways to establish a connection between master and agent:
-
-[[node_config]]
-.New node configuration screen
-image::newNodeConfigPage.png[scaledwidth=90%]
 
 ////
 TODO: The terminology used in these two bullet points needs to be sychronised


### PR DESCRIPTION
These images use deprecated terminology and it is better to just omit them for
now.

In general, we will need to find a better way to manage and update images than
what we have right now.

Fixes WEBSITE-131