### PR TITLE
WEBSITE-129 - Add pipeline steps reference documentation.

### DIFF
--- a/content/doc/index.html.haml
+++ b/content/doc/index.html.haml
@@ -35,6 +35,8 @@ title: Jenkins Documentation
       %a{ href: "pipeline/jenkinsfile"}Getting Started with Jenkinsfile?
     %li
       %a{ href: "pipleine/cookbook"}Pipeline Cookbook?
+    %li
+      %a{ href: "pipeline/steps"}Pipeline Steps Reference
 
 %hr/
 

--- a/content/doc/pipeline/steps/ansible.adoc
+++ b/content/doc/pipeline/steps/ansible.adoc
@@ -1,0 +1,75 @@
+---
+layout: simplepage
+title: "ansible"
+---
+:doctitle: ansible
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== ansible
+
+=== +ansiblePlaybook+: Invoke an ansible playbook
+
+====
+Execute an Ansible playbook. Only the playbook parameter is mandatory.
+====
++playbook+::
++
+*Type:* String
+
+
++credentialsId+ (optional)::
++
+*Type:* String
+
+
++extras+ (optional)::
++
+*Type:* String
+
+
++installation+ (optional)::
++
+*Type:* String
+
+
++inventory+ (optional)::
++
+*Type:* String
+
+
++limit+ (optional)::
++
+*Type:* String
+
+
++skippedTags+ (optional)::
++
+*Type:* String
+
+
++startAtTask+ (optional)::
++
+*Type:* String
+
+
++sudo+ (optional)::
++
+*Type:* boolean
+
+
++sudoUser+ (optional)::
++
+*Type:* String
+
+
++tags+ (optional)::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/credentials-binding.adoc
+++ b/content/doc/pipeline/steps/credentials-binding.adoc
@@ -1,0 +1,92 @@
+---
+layout: simplepage
+title: "credentials-binding"
+---
+:doctitle: credentials-binding
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== credentials-binding
+
+=== +withCredentials+: Bind credentials to variables
+====
+Allows various kinds of credentials (secrets) to be used in idiosyncratic ways.
+    Each binding will define an environment variable active within the scope of the step.
+    You can then use them directly from any other steps that expect environment variables to be set:
+
+[source,java]
+----
+node {
+  withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'mylogin',
+                    usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+    sh '''
+      set +x
+      curl -u $USERNAME:$PASSWORD https://private.server/ > output
+    '''
+  }
+}
+----
+    or retrieve values from Groovy code via the env magic variable:
+
+[source,java]
+----
+def password = env.PASSWORD
+----
+
+    Note that some steps explicitly ask for credentials of a particular kind,
+    usually as a credentialsId parameter,
+    in which case this step is unnecessary.
+
+
+    For bindings which store a secret file, beware that
+
+[source,java]
+----
+node {
+  dir('subdir') {
+    withCredentials([[$class: 'FileBinding', credentialsId: 'secret', variable: 'FILE']]) {
+      sh 'use $FILE'
+    }
+  }
+}
+----
+
+    is not safe, as $FILE might be inside the workspace (in subdir@tmp/secretFiles/),
+    and thus visible to anyone able to browse the job’s workspace.
+    If you need to run steps in a different directory than the usual workspace, you should instead use
+
+[source,java]
+----
+node {
+  withCredentials([[$class: 'FileBinding', credentialsId: 'secret', variable: 'FILE']]) {
+    dir('subdir') {
+      sh 'use $FILE'
+    }
+  }
+}
+----
+
+    to ensure that the secrets are outside the workspace; or choose a different workspace entirely:
+
+[source,java]
+----
+node {
+  ws {
+    withCredentials([[$class: 'FileBinding', credentialsId: 'secret', variable: 'FILE']]) {
+      sh 'use $FILE'
+    }
+  }
+}
+----
+====
++bindings+::
++
+*Array/List*
+Nested Choice of Objects
+
+
+

--- a/content/doc/pipeline/steps/deployment-notification.adoc
+++ b/content/doc/pipeline/steps/deployment-notification.adoc
@@ -1,0 +1,31 @@
+---
+layout: simplepage
+title: "deployment-notification"
+---
+:doctitle: deployment-notification
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== deployment-notification
+
+=== +awaitDeployment+: Awaiting for deployment
+====
+Pauses a Workflow job until artifacts are deployed to servers via configuration management tools
+    like Chef/Puppet/etc. For this feature to work, you must also install a plugin that's specific to the configuration
+    management tool you are using, such as the puppet plugin.
+====
++threshold+::
++
+*Type:* int
+
+
++env+::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/docker-workflow.adoc
+++ b/content/doc/pipeline/steps/docker-workflow.adoc
@@ -1,0 +1,78 @@
+---
+layout: simplepage
+title: "docker-workflow"
+---
+:doctitle: docker-workflow
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== docker-workflow
+
+=== +dockerFingerprintFrom+: Record trace of a Docker image used in FROM
+====
+Normally used implicitly by method calls on the docker global variable.
+    Records the fact that a Docker image was built from another.
+====
++dockerfile+::
++
+Workspace-relative path of a Dockerfile which will be parsed for its FROM instruction.
+*Type:* String
+
+
++image+::
++
+ID or tag of the image which was just built, like --tag of docker build.
+*Type:* String
+
+
++toolName+ (optional)::
++
+*Type:* String
+
+
+
+=== +dockerFingerprintRun+: Record trace of a Docker image run in a container
+====
+Normally used implicitly by method calls on the docker global variable.
+    Records the fact that a Docker image was used by this build.
+====
++containerId+::
++
+*Type:* String
+
+
++toolName+ (optional)::
++
+*Type:* String
+
+
+
+=== +withDockerContainer+: Run build steps inside a Docker container
+====
+Normally used implicitly by method calls on the docker global variable.
+    Takes an image ID or symbolic name which must already have been pulled locally
+    and starts a container based on that image.
+    Runs all nested sh steps inside that container.
+    The workspace is mounted read-write into the container.
+====
++image+::
++
+*Type:* String
+
+
++args+ (optional)::
++
+Any other arguments to pass to docker run.
+*Type:* String
+
+
++toolName+ (optional)::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/email-ext.adoc
+++ b/content/doc/pipeline/steps/email-ext.adoc
@@ -1,0 +1,59 @@
+---
+layout: simplepage
+title: "email-ext"
+---
+:doctitle: email-ext
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== email-ext
+
+=== +emailext+: Extended Email
+====
+Step for sending email via the email-ext plugin.
+====
++subject+::
++
+*Type:* String
+
+
++body+::
++
+*Type:* String
+
+
++attachLog+ (optional)::
++
+*Type:* boolean
+
+
++attachmentsPattern+ (optional)::
++
+*Type:* String
+
+
++compressLog+ (optional)::
++
+*Type:* boolean
+
+
++mimeType+ (optional)::
++
+*Type:* String
+
+
++replyTo+ (optional)::
++
+*Type:* String
+
+
++to+ (optional)::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/hipchat.adoc
+++ b/content/doc/pipeline/steps/hipchat.adoc
@@ -1,0 +1,106 @@
+---
+layout: simplepage
+title: "hipchat"
+---
+:doctitle: hipchat
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== hipchat
+
+=== +hipchatSend+: Send HipChat Message
+====
+Simple step for sending a HipChat message to designated room.
+    Use the advanced settings to override the HipChat Plugin global configuration to include: HipChat Server, API Token, API Version (1 or 2) and Send As (v1 API only).
+    Please see the HipChat Plugin global configuration for more details on the fields.
+
+    Usage Example:
+    
+        hipchatSend "Build Started - ${env.JOB_NAME} ${env.BUILD_NUMBER} (Open)"
+====
++message+::
++
+REQUIRED The message body
+    Valid length range: 1 - 10000.
+    Message may include global variables, for example environment and currentBuild variables:
+    
+        hipchatSend "${env.JOB_NAME} ${env.BUILD_NUMBER} status: ${currentBuild.result} (Open)"
+
+        *Type:* String
+
+
++color+ (optional)::
++
+OPTIONAL Background color for message.
+    Valid values: YELLOW, GREEN, RED, PURPLE, GRAY, RANDOM.
+    Defaults to 'GRAY'.
+    hipchatSend color: "YELLOW", message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
++
+*Values:*
+
+* +YELLOW+
+* +GREEN+
+* +RED+
+* +PURPLE+
+* +GRAY+
+* +RANDOM+
+
+
++failOnError+ (optional)::
++
+If set to true, then the step will abort the Workflow run as a failure if there is an error sending message.
+    hipchatSend failOnError: true, message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
+*Type:* boolean
+
+
++notify+ (optional)::
++
+OPTIONAL Whether this message should trigger a user notification (change the tab color, play a sound, notify mobile phones, etc). Each recipient's notification preferences are taken into account.
+    Defaults to false.
+    hipchatSend notify: true, message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
+*Type:* boolean
+
+
++room+ (optional)::
++
+Allows overriding the HipChat Plugin default room.
+    hipchatSend room: "room-name", message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
+*Type:* String
+
+
++sendAs+ (optional)::
++
+Allows overriding the HipChat Plugin default Send As value (v1 API only).
+*Type:* String
+
+
++server+ (optional)::
++
+Allows overriding the HipChat Plugin default HipChat Server.
+*Type:* String
+
+
++textFormat+ (optional)::
++
+Enable this setting to send the notification in text format.
+*Type:* boolean
+
+
++token+ (optional)::
++
+Allows overriding the HipChat Plugin default API Token.
+*Type:* String
+
+
++v2enabled+ (optional)::
++
+Allows overriding the HipChat Plugin default API Version to use - v1 or v2.
+    hipchatSend Workflow step defaults to v2 API
+*Type:* boolean
+
+
+

--- a/content/doc/pipeline/steps/htmlpublisher.adoc
+++ b/content/doc/pipeline/steps/htmlpublisher.adoc
@@ -1,0 +1,54 @@
+---
+layout: simplepage
+title: "htmlpublisher"
+---
+:doctitle: htmlpublisher
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== htmlpublisher
+
+=== +publishHTML+: Publish HTML reports
++target+::
++
+Nested Object
+
++reportName+:::
++
+The name of the report to display for the build/project, such as &quot;Code Coverage&quot;
+*Type:* String
+
++reportDir+:::
++
+The path to the HTML report directory relative to the workspace.
+*Type:* String
+
++reportFiles+:::
++
+The file(s) to provide links inside the report directory
+*Type:* String
+
++keepAll+:::
++
+If checked, archive reports for all successful builds, otherwise only the most recent
+*Type:* boolean
+
++alwaysLinkToLastBuild+:::
++
+If this control and &quot;Keep past HTML reports&quot; are checked, 
+  publish the link on project level even if build failed.
+*Type:* boolean
+
++allowMissing+:::
++
+If checked, will allow report to be missing and build will not fail on missing report
+*Type:* boolean
+
+
+
+
+

--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -1,0 +1,21 @@
+---
+layout: simplepage
+title: "Pipeline Steps Reference"
+---
+
+- steps_dir = File.expand_path(File.dirname(__FILE__))
+%p
+  The following plugins offer Pipeline-compatible steps.  Each plugin link 
+  offers more information about the parameters for each step.
+
+%div.toc
+  %ul
+    - sections_from(steps_dir).each do |section, file, url, children|
+      %li
+        %a{:href => url}
+          = section
+        %ul
+          - children.each do |section, file, sect_url, sect_children|
+            %li
+              %a{:href => "#{url}##{sect_url}"}
+                = section

--- a/content/doc/pipeline/steps/integrity-plugin.adoc
+++ b/content/doc/pipeline/steps/integrity-plugin.adoc
@@ -1,0 +1,119 @@
+---
+layout: simplepage
+title: "integrity-plugin"
+---
+:doctitle: integrity-plugin
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== integrity-plugin
+
+=== +siaddprojectlabel+: Integrity SCM Label
++serverConfig+::
++
+*Type:* String
+
+
++checkpointLabel+ (optional)::
++
+A valid Integrity Checkpoint label string.  No groovy pre-processing is applied.
+*Type:* String
+
+
++configPath+ (optional)::
++
+*Type:* String
+
+
++password+ (optional)::
++
+*Type:* String
+
+
++userName+ (optional)::
++
+*Type:* String
+
+
+
+=== +sicheckpoint+: Integrity SCM Checkpoint
++serverConfig+::
++
+*Type:* String
+
+
++checkpointDesc+ (optional)::
++
+*Type:* String
+
+
++checkpointLabel+ (optional)::
++
+A valid Integrity Checkpoint label string.  No groovy pre-processing is applied.
+*Type:* String
+
+
++configPath+ (optional)::
++
+*Type:* String
+
+
++password+ (optional)::
++
+*Type:* String
+
+
++userName+ (optional)::
++
+*Type:* String
+
+
+
+=== +sici+: Integrity SCM Checkin
++serverConfig+::
++
+*Type:* String
+
+
++configPath+ (optional)::
++
+*Type:* String
+
+
++excludes+ (optional)::
++
+Ant-style filter for an excludes pattern.  Example: **/*.class
+*Type:* String
+
+
++includes+ (optional)::
++
+Ant-style filter for an includes pattern.  Example: **/*.java
+*Type:* String
+
+
++itemID+ (optional)::
++
+Integrity Lifecycle Manager Item ID designation.  Acceptable values include:
+	&nbsp;&nbsp;:none    // Indicates no change packages are used for check in
+	&nbsp;&nbsp;:bypass  // Assumes that the user has administrative privileges to bypass change package policies configured for the Integrity Project
+	&nbsp;&nbsp;0        // Same as :none above
+	&nbsp;&nbsp;12345    // An actual valid Integrity Item ID that the plugin will use to create a change package
+*Type:* String
+
+
++password+ (optional)::
++
+*Type:* String
+
+
++userName+ (optional)::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/jira.adoc
+++ b/content/doc/pipeline/steps/jira.adoc
@@ -1,0 +1,40 @@
+---
+layout: simplepage
+title: "jira"
+---
+:doctitle: jira
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== jira
+
+=== +jiraComment+: JIRA: Add comment to the issue
++issueKey+::
++
+*Type:* String
+
+
++body+::
++
+*Type:* String
+
+
+
+=== +jiraIssueSelector+: JIRA: Issue selector
++issueSelector+ (optional)::
++
+Nested Choice of Objects
+
+
+
+=== +jiraSearch+: JIRA: Search issues
++jql+::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/p4.adoc
+++ b/content/doc/pipeline/steps/p4.adoc
@@ -1,0 +1,55 @@
+---
+layout: simplepage
+title: "p4"
+---
+:doctitle: p4
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== p4
+
+=== +p4publish+: P4 Publish
++credential+::
++
+*Type:* String
+
+
++workspace+::
++
+Nested Choice of Objects
+
+
++publish+::
++
+Nested Choice of Objects
+
+
+
+=== +p4tag+: P4 Tag
++rawLabelName+::
++
+*Type:* String
+
+
++rawLabelDesc+::
++
+*Type:* String
+
+
+
+=== +p4unshelve+: P4 Unshelve
++shelf+::
++
+*Type:* String
+
+
++resolve+::
++
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/parallel-test-executor.adoc
+++ b/content/doc/pipeline/steps/parallel-test-executor.adoc
@@ -1,0 +1,34 @@
+---
+layout: simplepage
+title: "parallel-test-executor"
+---
+:doctitle: parallel-test-executor
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== parallel-test-executor
+
+=== +splitTests+: Split Test Runs
++parallelism+::
++
+Nested Choice of Objects
+
+
++generateInclusions+ (optional)::
++
+If disabled, the splitStep call will return a List&lt;List&lt;String&gt;&gt; containing the exclusion patterns for the different buckets.
+
+If enabled, the splitStep call won't return a List&lt;List&lt;String&gt;&gt;.
+Instead it will return a List of a structure with :
+
+    boolean includes whether the following list is an inclusion or an exclusion list
+    List&lt;String&gt; list the list of patterns
+
+*Type:* boolean
+
+
+

--- a/content/doc/pipeline/steps/pipeline-utility-steps.adoc
+++ b/content/doc/pipeline/steps/pipeline-utility-steps.adoc
@@ -1,0 +1,263 @@
+---
+layout: simplepage
+title: "pipeline-utility-steps"
+---
+:doctitle: pipeline-utility-steps
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== pipeline-utility-steps
+
+=== +findFiles+: Find files in the workspace
+====
+Find files in the current working directory.
+    The step returns an array of file info objects who's properties you can see in the below example.
+    Ex: 
+    
+        def files = findFiles(glob: '**/TEST-*.xml')
+        echo """${files[0].name}
+                ${files[0].path}
+                ${files[0].directory}
+                ${files[0].length}
+                ${files[0].lastModified}"""
+====
++glob+ (optional)::
++
+Ant style pattern
+    of file paths that should match. If this property is set all descendants of the
+    current working directory will be searched for a match and returned,
+    if it is omitted only the direct descendants of the directory will be returned.
+*Type:* String
+
+
+
+=== +readManifest+: Read a Jar Manifest
+====
+Reads a
+    Jar Manifest
+    file or text and parses it into a set of Maps.
+    The returned data structure has two properties: main for the main attributes,
+    and entries containing each individual section (except for main).
+
+
+    Example:
+    
+        
+            def man = readManifest file: 'target/my.jar'
+            assert man.main['Version'] == '6.15.8'
+            assert man.main['Application-Name'] == 'My App'
+            assert man.entries['Section1']['Key1'] == 'value1-1'
+            assert man.entries['Section2']['Key2'] == 'value2-2'
+====
++file+ (optional)::
++
+Optional path to a file to read.
+  It could be a plain text, .jar, .war or .ear.
+  In the latter cases the manifest will be extracted from the archive and then read.
+
+
+  You can only specify file or text, not both in the same invocation.
+*Type:* String
+
+
++text+ (optional)::
++
+Optional text containing the manifest data.
+
+
+  You can only specify file or text, not both in the same invocation.
+*Type:* String
+
+
+
+=== +readProperties+: Read properties from files in the workspace or text.
+====
+Reads a file in the current working directory or a String as a plain text
+    Java Properties
+    file.
+    The returned object is a normal Map with String keys.
+    The map can also be pre loaded with default values before reading/parsing the data.
+
+Fields:
+
+    
+        file:
+        Optional path to a file in the workspace to read the properties from.
+        These are added to the resulting map after the defaults and so will overwrite any key/value pairs already present.
+    
+    
+        text:
+        An Optional String containing properties formatted data.
+        These are added to the resulting map after file and so will overwrite any key/value pairs already present.
+    
+    
+        defaults:
+        An Optional Map containing default key/values.
+        These are added to the resulting map first.
+    
+
+
+    Example:
+    
+        
+        def d = [test: 'Default', something: 'Default', other: 'Default']
+        def props = readProperties defaults: d, file: 'dir/my.properties', text: 'other=Override'
+        assert props['test'] == 'One'
+        assert props['something'] == 'Default'
+        assert props.something == 'Default'
+        assert props.other == 'Override'
+====
++defaults+ (optional)::
++
+*Type:* Map
+
+
++file+ (optional)::
++
+*Type:* String
+
+
++text+ (optional)::
++
+*Type:* String
+
+
+
+=== +touch+: Create a file (if not already exist) in the workspace, and set the timestamp
+====
+Creates a file (if not already exist) and sets the timestamp.
+====
++file+::
++
+The path to the file to touch.
+*Type:* String
+
+
++timestamp+ (optional)::
++
+The timestamp to set (number of ms since the epoc), leave empty for current system time.
+*Type:* long
+
+
+
+=== +unzip+: Extract Zip file
+====
+Extract a zip file in the workspace.
+====
++zipFile+::
++
+The name/path of the zip file to extract.
+*Type:* String
+
+
++dir+ (optional)::
++
+The path of the base directory to create the zip from.
+    Leave empty to create from the current working directory.
+*Type:* String
+
+
++glob+ (optional)::
++
+Ant style pattern
+    of files to extract from the zip.
+    Leave empty to include all files and directories.
+*Type:* String
+
+
++read+ (optional)::
++
+Read the content of the files into a Map instead of writing them to the workspace.
+    The keys of the map will be the path of the files read.
+    E.g.
+    
+      def v = unzip zipFile: 'example.zip', glob: '*.txt', read: true
+      String version = v['version.txt']
+*Type:* boolean
+
+
++test+ (optional)::
++
+Test the integrity of the archive instead of extracting it.
+  When this parameter is enabled, all other parameters (except for zipFile) will be ignored.
+  The step will return true or false depending on the result
+  instead of throwing an exception.
+*Type:* boolean
+
+
+
+=== +writeMavenPom+: Write a maven project file.
+====
+Writes a
+    Maven project
+    file. That for example was previously read by readMavenPom.
+
+Fields:
+
+    
+        model:
+        The Model
+        object to write.
+    
+    
+        file:
+        Optional path to a file in the workspace to write to.
+        If left empty the step will write to pom.xml in the current working directory.
+    
+
+
+    Example:
+    
+        
+        def pom = readMavenPom file: 'pom.xml'
+        //Do some manipulation
+        writeMavenPom model: pom
+====
++model+::
++
++org.kohsuke.stapler.NoStaplerConstructorException: There's no @DataBoundConstructor on any constructor of class org.apache.maven.model.Model+
+
+
++file+ (optional)::
++
+*Type:* String
+
+
+
+=== +zip+: Create Zip file
+====
+Create a zip file of content in the workspace.
+====
++zipFile+::
++
+The name/path of the zip file to create.
+*Type:* String
+
+
++archive+ (optional)::
++
+If the zip file should be archived as an artifact of the current build.
+    The file will still be kept in the workspace after archiving.
+*Type:* boolean
+
+
++dir+ (optional)::
++
+The path of the base directory to create the zip from.
+    Leave empty to create from the current working directory.
+*Type:* String
+
+
++glob+ (optional)::
++
+Ant style pattern
+    of files to include in the zip.
+    Leave empty to include all files and directories.
+*Type:* String
+
+
+

--- a/content/doc/pipeline/steps/ssh-agent.adoc
+++ b/content/doc/pipeline/steps/ssh-agent.adoc
@@ -1,0 +1,38 @@
+---
+layout: simplepage
+title: "ssh-agent"
+---
+:doctitle: simplepage
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== ssh-agent
+
+=== +sshagent+: SSH Agent
+====
+----
+node {
+  sshagent (credentials: ['deploy-dev']) {
+    sh 'ssh -o StrictHostKeyChecking=no -l cloudbees 192.168.1.106 uname -a'
+  }
+}
+----
+
+Multiple credentials could be passed in the array but it is not supported using Snippet Generator.
+====
++credentials+::
++
+*Array/List*
+*Type:* String
+
+
++ignoreMissing+ (optional)::
++
+*Type:* boolean
+
+
+

--- a/content/doc/pipeline/steps/teamconcert.adoc
+++ b/content/doc/pipeline/steps/teamconcert.adoc
@@ -1,0 +1,83 @@
+---
+layout: simplepage
+title: "teamconcert"
+---
+:doctitle: teamconcert
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== teamconcert
+
+=== +teamconcert+: Team Concert
++buildType+::
++
+Nested Object
+
++value+:::
++
+*Type:* String
+
+
++buildDefinition+:::
++
+*Type:* String
+
+
++buildWorkspace+:::
++
+*Type:* String
+
+
+
+
++changelog+ (optional)::
++
+*Type:* boolean
+
+
++overrideConfig+ (optional)::
++
+Nested Object
+
++serverURI+:::
++
+*Type:* String
+
+
++credentialsId+:::
++
+*Type:* String
+
+
++buildTool+:::
++
+*Type:* String
+
+
++avoidUsingToolkit+ (optional):::
++
+*Type:* boolean
+
+
++serverUri+ (optional):::
++
+*Type:* String
+
+
++timeout+ (optional):::
++
+*Type:* int
+
+
+
+
++poll+ (optional)::
++
+*Type:* boolean
+
+
+

--- a/content/doc/pipeline/steps/workflow-basic-steps.adoc
+++ b/content/doc/pipeline/steps/workflow-basic-steps.adoc
@@ -1,0 +1,502 @@
+---
+layout: simplepage
+title: "workflow-basic-steps"
+---
+:doctitle: workflow-basic-steps
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== workflow-basic-steps
+
+=== +archive+: Archive artifacts
+====
+Archives build output artifacts for later use.
+====
++includes+::
++
+Include artifacts matching this Ant style pattern.
+Use a comma separated list to add more than one expression.
+*Type:* String
+
+
++excludes+ (optional)::
++
+Exclude artifacts matching this Ant-style pattern.
+Use a comma-separated list to add more than one expression.
+*Type:* String
+
+
+
+=== +deleteDir+: Recursively delete the current directory from the workspace
+====
+Recursively deletes the current directory and its contents.
+    Symbolic links and junctions will not be followed but will be removed.
+    To delete a specific directory of a workspace wrap the deleteDir
+    step in a dir step.
+====
+
+=== +dir+: Change current directory
+====
+Change current directory. Any step inside the dir block will 
+    use this directory as current and any relative path will use it as base path.
+====
++path+::
++
+*Type:* String
+
+
+
+=== +echo+: Print Message
++message+::
++
+*Type:* String
+
+
+
+=== +error+: Error signal
+====
+Signals an error.
+    Useful if you want to conditionally abort some part of your program.
+    You can also just throw new Exception(),
+    but this step will avoid printing a stack trace.
+====
++message+::
++
+*Type:* String
+
+
+
+=== +fileExists+: Verify if file exists in workspace
+====
+Checks if the given file (as relative path to current directory) exists.
+    Returns true | false.
+====
++file+::
++
+Relative (/-separated) path to file within a workspace to verify its existence.
+*Type:* String
+
+
+
+=== +isUnix+: Checks if running on a Unix-like node
+====
+Returns true if enclosing node is running on a Unix-like system (such as Linux or Mac OS X), false if Windows.
+====
+
+=== +mail+: Mail
+====
+Simple step for sending email.
+====
++subject+::
++
+Email subject line.
+*Type:* String
+
+
++body+::
++
+Email body.
+*Type:* String
+
+
++bcc+ (optional)::
++
+BCC email address list. Comma separated list of email addresses.
+*Type:* String
+
+
++cc+ (optional)::
++
+CC email address list. Comma separated list of email addresses.
+*Type:* String
+
+
++charset+ (optional)::
++
+Email body character encoding. Defaults to UTF-8
+*Type:* String
+
+
++from+ (optional)::
++
+From email address. Defaults to the admin address globally configured for the Jenkins instance.
+*Type:* String
+
+
++mimeType+ (optional)::
++
+Email body MIME type. Defaults to text/plain.
+*Type:* String
+
+
++replyTo+ (optional)::
++
+Reploy-To email address. Defaults to the admin address globally configured for the Jenkins instance.
+*Type:* String
+
+
++to+ (optional)::
++
+To email address list. Comma separated list of email addresses.
+*Type:* String
+
+
+
+=== +pwd+: Determine current directory
+====
+Returns the current directory path as a string.
+====
++tmp+ (optional)::
++
+If selected, return a temporary directory associated with the workspace rather than the workspace itself.
+    This is an appropriate place to put temporary files which should not clutter a source checkout;
+    local repositories or caches; etc.
+*Type:* boolean
+
+
+
+=== +readFile+: Read file from workspace
+====
+Reads a file from a relative path (with root in current directory, usually workspace) and returns its content as a plain string.
+====
++file+::
++
+Relative (/-separated) path to file within a workspace to read.
+*Type:* String
+
+
++encoding+ (optional)::
++
+*Type:* String
+
+
+
+=== +retry+: Retry the body up to N times
+====
+Retry the block (up to N times) if any exception happens during its body execution.
+====
++count+::
++
+*Type:* int
+
+
+
+=== +sleep+: Sleep
+====
+Simply pauses the Pipeline build until the given amount of time has expired.
+    Equivalent to (on Unix) sh 'sleep …'.
+    May be used to pause one branch of parallel while another proceeds.
+====
++time+::
++
+*Type:* int
+
+
++unit+ (optional)::
++
+*Values:*
+
+* +NANOSECONDS+
+* +MICROSECONDS+
+* +MILLISECONDS+
+* +SECONDS+
+* +MINUTES+
+* +HOURS+
+* +DAYS+
+
+
+
+=== +step+: General Build Step
+====
+This is a special step that allows to call builders or post-build actions (as in freestyle or similar projects), in general "build steps".
+    Just select the build step to call from the dropdown list and configure it as needed.
+    
+    
+    Note that only Pipeline-compatible steps will be shown in the list.
+====
++delegate+::
++
+Nested Choice of Objects
++$class: 'ArtifactArchiver'+
+====
+Archives the build artifacts (for example, distribution zip files or jar files)
+  so that they can be downloaded later.
+  Archived files will be accessible from the Jenkins webpage.
+
+
+Normally, Jenkins keeps artifacts for a build as long as a build log itself is kept,
+but if you don't need old artifacts and would rather save disk space, you can do so.
+
+
+
+Note that the Maven job type automatically archives any produced Maven artifacts.
+Any artifacts configured here will be archived on top of that.
+Automatic artifact archiving can be disabled under the advanced Maven options.
+====
++artifacts+:::
++
+You can use wildcards like 'module/dist/**/*.zip'.
+   See 
+   the includes attribute of Ant fileset for the exact format.
+   The base directory is the workspace.
+   You can only archive files that are located in your workspace.
+*Type:* String
+
+
++allowEmptyArchive+ (optional):::
++
+Normally, a build fails if archiving returns zero artifacts.
+    This option allows the archiving process to return nothing without failing the build.
+    Instead, the build will simply throw a warning.
+*Type:* boolean
+
+
++caseSensitive+ (optional):::
++
+Artifact archiver uses Ant org.apache.tools.ant.DirectoryScanner which by default is case sensitive.
+    For instance, if the job produces *.hpi files, pattern "**/*.HPI" will fail to find them.
+    This option can be used to disable case sensitivity. When it's unchecked, pattern "/**/*.HPI" will match any *.hpi files, or pattern "**/cAsEsEnSiTiVe.jar" will match a file called caseSensitive.jar.
+*Type:* boolean
+
+
++defaultExcludes+ (optional):::
++
+*Type:* boolean
+
+
++excludes+ (optional):::
++
+Optionally specify the 'excludes' pattern,
+  such as "foo/bar/**/*". A file that matches this mask will not be archived even if it matches the
+  mask specified in 'files to archive' section.
+*Type:* String
+
+
++fingerprint+ (optional):::
++
+*Type:* boolean
+
+
++onlyIfSuccessful+ (optional):::
++
+*Type:* boolean
+
+
++$class: 'Fingerprinter'+
+====
+Jenkins can record the 'fingerprint' of files (most often jar files) to keep track
+  of where/when those files are produced and used. When you have inter-dependent
+  projects on Jenkins, this allows you to quickly find out answers to questions like:
+
+  
+    
+      I have foo.jar on my HDD but which build number of FOO did it come from?
+    
+    
+      My BAR project depends on foo.jar from the FOO project.
+    
+    
+      
+        Which build of foo.jar is used in BAR #51?
+      
+      
+        Which build of BAR contains my bug fix to foo.jar #32?
+      
+    
+  
+
+  
+To use this feature, all of the involved projects (not just the project
+in which a file is produced, but also the projects in which the file
+is used) need to use this and record fingerprints.
+
+
+See this document
+for more details.
+====
++targets+:::
++
+Can use wildcards like module/dist/**/*.zip
+    (see the @includes of Ant fileset for the exact format).
+    The base directory is the workspace.
+*Type:* String
+
+
+
+
+
+=== +timeout+: Enforce time limit
+====
+Executes the code inside the block with a determined time out limit.
+    If the time limit is reached, an exception is thrown, which leads in aborting 
+    the build (unless it is catched and processed somehow).
+====
++time+::
++
+*Type:* int
+
+
++unit+ (optional)::
++
+*Values:*
+* +NANOSECONDS+
+* +MICROSECONDS+
+* +MILLISECONDS+
+* +SECONDS+
+* +MINUTES+
+* +HOURS+
+* +DAYS+
+
+
+
+=== +tool+: Use a tool from a predefined Tool Installation
+====
+Binds a tool installation to a variable (the tool home directory is returned).
+    Only tools already configured in Configure System are available here. If the original tool installer
+    has the auto-provision feature, then the tool will be installed as required.
+====
++name+::
++
+*Type:* String
+
+
++type+ (optional)::
++
+*Type:* String
+
+
+
+=== +waitUntil+: Wait for condition
+====
+Runs its body repeatedly until it returns true.
+    If it returns false, waits a while and tries again.
+    (Subsequent failures will slow down the delay between attempts.)
+    There is no limit to the number of retries,
+    but if the body throws an error that is thrown up immediately.
+====
+
+=== +withEnv+: Set environment variables
+====
+Sets one or more environment variables within a block.
+These are available to any external processes spawned within that scope.
+For example:
+
+----
+    node {
+      withEnv(['MYTOOL_HOME=/usr/local/mytool']) {
+        sh '$MYTOOL_HOME/bin/start'
+      }
+    }
+----
+
+(Note that here we are using single quotes in Groovy, so the variable expansion is being done by the Bourne shell, not Jenkins.)
+See the documentation for the env singleton for more information on environment variables.
+====
++overrides+::
++
+A list of environment variables to set, each in the form VARIABLE=value
+    or VARIABLE= to unset variables otherwise defined.
+    You may also use the syntax PATH+WHATEVER=/something
+    to prepend /something to $PATH.
+*Array/List*
+*Type:* String
+
+
+
+=== +wrap+: General Build Wrapper
+====
+This is a special step that allows to call build wrappers (also called "Environment Configuration" in freestyle or similar projects).
+    Just select the wrapper to use from the dropdown list and configure it as needed. Everything inside the wrapper block is under its effect.
+    
+    
+    Note that only Pipeline-compatible wrappers will be shown in the list.
+====
++delegate+::
++
+Nested Choice of Objects
+
+
+
+=== +writeFile+: Write file to workspace
+====
+Write the given content to a named file in the current directory.
+====
++file+::
++
+*Type:* String
+
+
++text+::
++
+*Type:* String
+
+
++encoding+ (optional)::
++
+*Type:* String
+
+
+
+
+=== +catchError+: Catch error and set build result
+====
+If the body throws an exception, mark the build as a failure, but nonetheless
+    continue to execute the Pipeline from the statement following the catchError step.
+    This is only necessary when using certain post-build actions (notifiers)
+    originally defined for freestyle projects which pay attention to the result of the ongoing build.
+----
+node {
+    catchError {
+        sh 'might fail'
+    }
+    step([$class: 'Mailer', recipients: 'admin@somewhere'])
+}
+----
+
+If the shell step fails, the Pipeline build’s status will be set to failed, so that the subsequent mail step will see that this build is failed.
+In the case of the mail sender, this means that it will send mail.
+(It may also send mail if this build succeeded but previous ones failed, and so on.)
+Even in that case, this step can be replaced by the following idiom:
+
+node {
+    try {
+        sh 'might fail'
+    } catch (err) {
+        echo "Caught: ${err}"
+        currentBuild.result = 'FAILURE'
+    }
+    step([$class: 'Mailer', recipients: 'admin@somewhere'])
+}
+
+For all other cases, use plain try-catch(-finally) blocks:
+
+----
+node {
+    sh './set-up.sh'
+    try {
+        sh 'might fail'
+        echo 'Succeeded!'
+    } catch (err) {
+        echo "Failed: ${err}"
+    } finally {
+        sh './tear-down.sh'
+    }
+    echo 'Printed whether above succeeded or failed.'
+}
+// …and the pipeline as a whole succeeds
+----
+
+See this document for background.
+====
+
+=== +unarchive+: Copy archived artifacts into the workspace
++mapping+ (optional)::
++
+Type: Map
+
+
+

--- a/content/doc/pipeline/steps/workflow-cps.adoc
+++ b/content/doc/pipeline/steps/workflow-cps.adoc
@@ -1,0 +1,41 @@
+---
+layout: simplepage
+title: "workflow-cps"
+---
+:doctitle: workflow-cps
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== workflow-cps
+
+=== +load+: Evaluate a Groovy source file into the Pipeline script
+====
+Takes a filename in the workspace and runs it as Groovy source text.
+    
+        The loaded file can contain statements at top level or just load and run a closure. For example:
+    
+    
+    def pipeline
+    node('slave') {
+        pipeline = load 'pipeline.groovy'
+        pipeline.functionA()
+    }
+    pipeline.functionB()
+    
+    
+    Where pipeline.groovy defines functionA and functionB functions (among others) before ending with return this;
+====
++path+::
++
+Current directory (pwd()) relative path to the Groovy file to load.
+*Type:* String
+
+
+
+=== +parallel+: Execute in parallel
+*Type:* List of steps
+

--- a/content/doc/pipeline/steps/workflow-multibranch.adoc
+++ b/content/doc/pipeline/steps/workflow-multibranch.adoc
@@ -1,0 +1,220 @@
+---
+layout: simplepage
+title: "workflow-multibranch"
+---
+:doctitle: workflow-multibranch
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== workflow-multibranch
+
+=== +properties+: Set job properties
+====
+Updates the properties of the job which runs this step.
+    Mainly useful from multibranch Pipelines, so that Jenkinsfile itself can encode what would otherwise be static job configuration.
+====
++properties+::
++
+*Array/List*
+Nested Choice of Objects
+
++$class: 'BuildDiscarderProperty'+
+====
+This controls the disk consumption of Jenkins by managing how long you'd like to keep
+  records of the builds (such as console output, build artifacts, and so on.)
+  Jenkins offers two criteria:
+
+  
+    
+      Driven by age. You can have Jenkins delete a record if it reaches a certain age
+      (for example, 7 days old.)
+    
+      Driven by number. You can have Jenkins make sure that it only maintains up to
+      N build records. If a new build is started, the oldest record will
+      be simply removed.
+  
+
+Jenkins also allows you to mark an individual build as 'Keep this log forever', to
+exclude certain important builds from being discarded automatically.
+The last stable and last successful build are always kept as well.
+====
++strategy+:::
++
+Nested Choice of Objects
+
++$class: 'LogRotator'+
++daysToKeepStr+::::
++
+*Type:* String
+
+
++numToKeepStr+::::
++
+*Type:* String
+
+
++artifactDaysToKeepStr+::::
++
+*Type:* String
+
+
++artifactNumToKeepStr+::::
++
+*Type:* String
+
+
+
+
++$class: 'ParametersDefinitionProperty'+
+====
+When you are using Jenkins for various automations, it's sometimes convenient
+    to be able to "parameterize" a build, by requiring a set of user inputs to
+    be made available to the build process. For example, you might be setting up
+    an on-demand test job, where the user can submit a zip file of the binaries to be tested.
+
+    
+This section configures what parameters your build takes. Parameters are distinguished
+by their names, and so you can have multiple parameters provided that they have different names.
+
+
+See the Wiki topic
+for more discussions about this feature.
+====
++parameterDefinitions+:::
++
+*Array/List*
+Nested Choice of Objects
+
++$class: 'BooleanParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++defaultValue+::::
++
+*Type:* boolean
+
+
++description+::::
++
+*Type:* String
+
+
++$class: 'ChoiceParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++choices+::::
++
+*Type:* String
+
+
++description+::::
++
+*Type:* String
+
+
++$class: 'FileParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++description+::::
++
+*Type:* String
+
+
++$class: 'PasswordParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++defaultValue+::::
++
+*Type:* String
+
+
++description+::::
++
+*Type:* String
+
+
++$class: 'RunParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++projectName+::::
++
+*Type:* String
+
+
++description+::::
++
+*Type:* String
+
+
++filter+::::
++
+*Values:*
+
+* +ALL+
+* +STABLE+
+* +SUCCESSFUL+
+* +COMPLETED+
+
+
++$class: 'StringParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++defaultValue+::::
++
+*Type:* String
+
+
++description+::::
++
+*Type:* String
+
+
++$class: 'TextParameterDefinition'+
+
++name+::::
++
+*Type:* String
+
+
++defaultValue+::::
++
+*Type:* String
+
+
++description+::::
++
+*Type:* String
+
+
+
+
+
+
+

--- a/content/doc/pipeline/steps/workflow-scm-step.adoc
+++ b/content/doc/pipeline/steps/workflow-scm-step.adoc
@@ -1,0 +1,103 @@
+---
+layout: simplepage
+title: "workflow-scm-step"
+---
+:doctitle: workflow-scm-step
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== workflow-scm-step
+
+=== +checkout+: General SCM
+====
+This is a special step that allows to run checkouts using any configuration
+    options offered by any Pipeline-compatible SCM plugin.
+    To use a concrete SCM implementations, just install the corresponding plugin 
+    and check if it is shown in the list below.
+    Then select the SCM to use from the dropdown list and configure it as needed.
+    
+    
+Any other specific step to run checkouts (like svn or git)
+are simplistic options of this step.
+====
++scm+::
++
+Nested Choice of Objects
+
+
++changelog+ (optional)::
++
+*Type:* boolean
+
+
++poll+ (optional)::
++
+*Type:* boolean
+
+
+
+=== +git+: Git
+====
+Git step. It performs a clone from the specified repository.
+    
+    
+Note that this step is shorthand for the generic SCM step:
+
+    checkout([$class: 'GitSCM', branches: [[name: '*/master']], userRemoteConfigs: [[url: 'http://git-server/user/repository.git']]])
+
+====
++url+::
++
+*Type:* String
+
+
++branch+ (optional)::
++
+*Type:* String
+
+
++changelog+ (optional)::
++
+*Type:* boolean
+
+
++credentialsId+ (optional)::
++
+*Type:* String
+
+
++poll+ (optional)::
++
+*Type:* boolean
+
+
+
+=== +svn+: Subversion
+====
+SVN step. It performs a checkout from the specified repository.
+    
+    
+Note that this step is shorthand for the generic SCM step:
+
+    checkout([$class: 'SubversionSCM', remote: 'http://sv-server/repository/trunk']]])
+====
++url+::
++
+*Type:* String
+
+
++changelog+ (optional)::
++
+*Type:* boolean
+
+
++poll+ (optional)::
++
+*Type:* boolean
+
+
+

--- a/content/doc/pipeline/steps/workflow-support.adoc
+++ b/content/doc/pipeline/steps/workflow-support.adoc
@@ -1,0 +1,463 @@
+---
+layout: simplepage
+title: "workflow-support"
+---
+:doctitle: workflow-support
+:notitle:
+:description:
+:author: 
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+
+== workflow-support
+
+=== +build+: Build a job
+====
+Triggers a new build for a given job.
+====
++job+::
++
+Name of a downstream job to build.
+    May be another Pipeline job, but more commonly a freestyle or other project.
+    Use a simple name if the job is in the same folder as this upstream Pipeline job;
+    otherwise can use relative paths like ../sister-folder/downstream
+    or absolute paths like /top-level-folder/nested-folder/downstream.
+*Type:* String
+
+
++parameters+ (optional)::
++
+*Array/List*
+Nested Choice of Objects
+
++$class: 'BooleanParameterValue'+
+
++name+:::
++
+*Type:* String
+
+
++value+:::
++
+*Type:* boolean
+
+
++$class: 'FileParameterValue'+
+
++name+:::
++
+*Type:* String
+
+
++file+:::
++
+Nested Choice of Objects
+
+
++$class: 'PasswordParameterValue'+
+
++name+:::
++
+*Type:* String
+
+
++value+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'RunParameterValue'+
+
++name+:::
++
+*Type:* String
+
+
++runId+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'StringParameterValue'+
+
++name+:::
++
+*Type:* String
+
+
++value+:::
++
+*Type:* String
+
+
++$class: 'TextParameterValue'+
+
++name+:::
++
+*Type:* String
+
+
++value+:::
++
+*Type:* String
+
+
+
+
++propagate+ (optional)::
++
+If set, then if the downstream build is anything but successful (blue ball), this step fails.
+    If disabled, then this step succeeds even if the downstream build is unstable, failed, etc.;
+    use the result property of the return value as needed.
+*Type:* boolean
+
+
++quietPeriod+ (optional)::
++
+Optional alternate quiet period (in seconds) before building.
+    If unset, defaults to the quiet period defined by the downstream project
+    (or finally to the system-wide default quiet period).
+*Type:* int
+
+
++wait+ (optional)::
++
+You may ask that this Pipeline build wait for completion of the downstream build.
+    In that case the return value of the step is an object on which you can obtain the following read-only properties:
+    so you can inspect its result and so on.
+
+
+    number
+    result (typically SUCCESS, UNSTABLE, or FAILED)
+    displayName
+    description
+    id
+    timeInMillis
+    startTimeInMillis
+    duration
+    building
+    inProgress
+    previousBuild (another similar object)
+    nextBuild
+    absoluteUrl
+
+
+For a non-Pipeline downstream build, the buildVariables property offers access to a map of defined build variables.
+For a Pipeline downstream build, this property gives access to any variables set globally on env.
+
+
+Administrator-approved scripts outside the sandbox can use the rawBuild property to get access to a hudson.model.Run with further APIs.
+You will generally need to do so inside a method marked @NonCPS to avoid storing intermediate values.
+
+
+If you do not wait, this step succeeds so long as the downstream build can be added to the queue (it will not even have been started).
+In that case there is currently no return value.
+
+*Type:* boolean
+
+
+
+=== +input+: Wait for interactive input
+====
+This step pauses Pipeline execution and allows the user to interact and control the flow of the build.
+    Only a basic "process" or "abort" option is provided in the stage view.
+    
+    
+You can optionally request information back, hence the name of the step. 
+The parameter entry screen can be accessed via a link at the bottom of the build console log or
+via link in the sidebar for a build.
+====
++message+::
++
+This parameter gives a prompt which will be shown to a human:
+        Ready to go?
+    Proceed or Abort
+    
+
+
+If you click "Proceed" the build will proceed to the next step, if you click "Abort" the build will be aborted.
+*Type:* String
+
+
++id+ (optional)::
++
+Every input step has an unique ID. It is used in the generated URL to proceed or abort.
+
+A specific ID could be used, for example, to mechanically respond to the input from some external process/tool.
+*Type:* String
+
+
++ok+ (optional)::
++
+*Type:* String
+
+
++parameters+ (optional)::
++
+Request that the submitter specify one or more parameter values when approving.
+    If just one parameter is listed, its value will become the value of the input step.
+    If multiple parameters are listed, the return value will be a map keyed by the parameter names.
+    If parameters are not requested, the step returns nothing if approved.
++
+On the parameter entry screen you are able to enter values for parameters that are defined in this field.
+
+*Array/List*
+Nested Choice of Objects
+
++$class: 'BooleanParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++defaultValue+:::
++
+*Type:* boolean
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'ChoiceParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++choices+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'FileParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'PasswordParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++defaultValue+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'RunParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++projectName+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++filter+:::
++
+*Values:*
+
+* +ALL+
+* +STABLE+
+* +SUCCESSFUL+
+* +COMPLETED+
+
+
++$class: 'StringParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++defaultValue+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
++$class: 'TextParameterDefinition'+
+
++name+:::
++
+*Type:* String
+
+
++defaultValue+:::
++
+*Type:* String
+
+
++description+:::
++
+*Type:* String
+
+
+
+
++submitter+ (optional)::
++
+User ID or external group name of person or people permitted to respond to the input.
+*Type:* String
+
+
+
+=== +node+: Allocate node
+====
+Allocates an executor on a node (typically a slave) and runs further code in the context of a workspace on that slave.
+====
++label+::
++
+Computer name, label name, or any other label expression like linux && 64bit to restrict where this step builds.
+    May be left blank, in which case any available executor is taken.
+*Type:* String
+
+
+
+=== +stage+: Stage
+====
+By default, Pipeline builds can run concurrently. 
+    The stage command lets you mark certain sections of a build as being constrained by limited concurrency.
+    Newer builds are always given priority when entering such a throttled stage; older builds will simply exit early if 
+    they are preëmpted.
+====
++name+::
++
+*Type:* String
+
+
++concurrency+ (optional)::
++
+Concurrency level.
++
+A concurrency of one is useful to let you lock a singleton resource, such as deployment to a single target server. 
+Only one build will deploy at a given time: the newest which passed all previous stages
+*Type:* int
+
+
+
+=== +stash+: Stash some files to be used later in the build
+====
+Saves a set of files for use later in the same build, generally on another node/workspace.
+    Stashed files are not otherwise available and are generally discarded at the end of the build.
+====
++name+::
++
+Name of a stash.
+    Should be a simple identifier akin to a job name.
+*Type:* String
+
+
++excludes+ (optional)::
++
+Optional set of "Ant-style exclude patterns.
+    Use a comma separated list to add more than one expression.
+    If blank, no file will be excluded.
+*Type:* String
+
+
++includes+ (optional)::
++
+Optional set of "Ant-style include patterns.
+    Use a comma separated list to add more than one expression.
+    If blank, treated like \**: all files.
+    The current working directory is the base directory for the saved files,
+    which will later be restored in the same relative locations,
+    so if you want to use a subdirectory wrap this in dir.
+
+*Type:* String
+
+
++useDefaultExcludes+ (optional)::
++
+If selected, use the default excludes from Ant - see
+    here for the list.
+*Type:* boolean
+
+
+
+=== +unstash+: Restore files previously stashed
+====
+Restores a set of files previously stashed into the current workspace.
+====
++name+::
++
+Name of a previously saved stash.
+*Type:* String
+
+
+
+=== +ws+: Allocate workspace
+====
+Allocates a workspace.
+    Note that a workspace is automatically allocated for you with the node step.
+====
++dir+::
++
+A workspace is automatically allocated for you with the node step,
+    or you can get an alternate workspace with this ws step,
+    but by default the location is chosen automatically.
+    (Something like SLAVE_ROOT/workspace/JOB_NAME@2.)
++
+You can instead specify a path here and that workspace will be locked instead.
+(The path may be relative to the slave root, or absolute.)
+
+
+If concurrent builds ask for the same workspace, a directory with a suffix such as @2 may be locked instead.
+Currently there is no option to wait to lock the exact directory requested;
+if you need to enforce that behavior, you can either fail (error) when pwd indicates that you got a different directory,
+or you may enforce serial execution of this part of the build by some other means such as stage name: '…', concurrency: 1.
+
+
+If you do not care about locking, just use the dir step to change current directory.
+
+*Type:* String
+
+
+


### PR DESCRIPTION
Static files for the pipeline-compatible steps.  They've been slightly tweaked so there's at least a better description for each of the steps.  These are all the plugins that I know are pipeline compatible at the moment.  More can be added as they're found.

The index page is a listing of all the plugins with their steps & a short description.  This way, the user will know what plugin they'll have to install.