### PR TITLE
Remove poorly implemented center-popup-dialog button in favor of a static one

### DIFF
--- a/content/_partials/downloadbanner.html.haml
+++ b/content/_partials/downloadbanner.html.haml
@@ -34,14 +34,6 @@
   })
 
 %div#ji-home-carousel.carousel.slide{'data-ride' => 'carousel',:class => page.topic}
-  #ji-download
-    %button#download-banner-btn.btn-lg.btn.btn-primary{'data-toggle'=>"popover", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
-      %span.brick-tops
-      Download Jenkins
-    = partial('downloadlist.html.haml')
-    .br
-      .carousel-caption.secondary
-        Get #{site.jenkins.stable} LTS .war or the latest #{site.jenkins.latest} weekly release
   %ol.carousel-indicators.hidden
     %li.active{'data-target' => '#ji-home-carousel', 'data-slide-to' => 0}
     %li{'data-target' => '#ji-home-carousel', 'data-slide-to' => 1}
@@ -61,6 +53,8 @@
         %p
           The leading open source automation server, Jenkins provides hundreds
           of plugins to support building, deploying and automating any project.
+        %a.btn-lg.btn.btn-primary{:href => '/download'}
+          Download
 
   %a.left.carousel-control{:href=>"#ji-home-carousel",:role=>"button",'data-slide'=>"prev"}
     %span.icon-prev{"aria-hidden"=>"true"}

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -123,7 +123,7 @@ nav form.search .input-group>input.form-control:focus{opacity:1; width:12rem}
 }
 
 .carousel-item {
-  min-height: 27rem;
+  min-height: 20rem;
   background: #fff;
 }
 


### PR DESCRIPTION
The previous button was absolutely positioned on the page, leading to issues
like [WEBSITE-139](https://issues.jenkins-ci.org/browse/WEBSITE-139). I do not have the CSS abilities to make this work properly, so I'm simplifying by removing the unnecessary functionality.

![139-fix](https://cloud.githubusercontent.com/assets/26594/13975224/59002e76-f070-11e5-96a3-c3b9a225f913.png)
