### PR TITLE
Correct Haml indentation error

### DIFF
--- a/content/_partials/carousel.html.haml
+++ b/content/_partials/carousel.html.haml
@@ -22,13 +22,13 @@
 
 %div#ji-home-carousel.carousel.slide{'data-ride' => 'carousel',:class => page.topic}
 #ji-download
-          .btn-group
-            %button.btn-lg.btn.btn-primary{'data-toggle'=>"popover", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
-              Download Jenkins
-            = partial('downloadlist.html.haml')
-          .br
-            .carousel-caption.secondary
-              Get 1.625.3 LTS .war or the latest 1.644 weekly or choose other options
+  .btn-group
+    %button.btn-lg.btn.btn-primary{'data-toggle'=>"popover", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
+      Download Jenkins
+    = partial('downloadlist.html.haml')
+  .br
+    .carousel-caption.secondary
+      Get #{site.jenkins.stable} LTS .war or the latest #{site.jenkins.latest} weekly
   %ol.carousel-indicators.hidden
     %li.active{'data-target' => '#ji-home-carousel', 'data-slide-to' => 0}
     %li{'data-target' => '#ji-home-carousel', 'data-slide-to' => 1}


### PR DESCRIPTION
This commit also brings back the dynamic versions to the carousel


This fixes a small regression introduced in #156 