### PR TITLE
Add preview download link

### DIFF
--- a/content/_partials/downloadlist.html.haml
+++ b/content/_partials/downloadlist.html.haml
@@ -116,7 +116,7 @@
   
     .col-md-6.text-xs-center
       %h3
-        Preview
+        Preview (Not recommeded for production use)
 
       %p
         This is 2.0 beta
@@ -157,7 +157,3 @@
               %span.icon
               %span.title
                 Windows
-      %p.details
-        %a.item{:href=>'/changelog'} Changelog
-        |
-        %a.item{:href=>'http://mirrors.jenkins-ci.org/war/'} Past Releases

--- a/content/_partials/downloadlist.html.haml
+++ b/content/_partials/downloadlist.html.haml
@@ -113,3 +113,51 @@
         %a.item{:href=>'/changelog'} Changelog
         |
         %a.item{:href=>'http://mirrors.jenkins-ci.org/war/'} Past Releases
+  
+    .col-md-6.text-xs-center
+      %h3
+        Preview
+
+      %p
+        This is 2.0 beta
+
+      %p
+        .btn-group{:style=>'margin-top: 1.3125rem;'}
+          %a.btn.btn-primary.chromeOnly{:href=>'http://mirrors.jenkins-ci.org/war-rc/2.0/jenkins.war'}
+            %i.icon-box-add
+            = site.jenkins.latest
+            \.war
+          %button.btn.btn-primary.dropdown-toggle{'data-toggle' => 'dropdown', 'data-trigger' => 'hover', 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
+          .dropdown-menu
+            %a.dropdown-item{:href=>'https://hub.docker.com/r/jenkinsci/jenkins/'}
+              %span.icon
+              %span.title
+                Docker
+            %a.dropdown-item{:href=>'http://www.freshports.org/devel/jenkins'}
+              %span.icon
+              %span.title
+                FreeBSD
+            %a.dropdown-item{:href=>'http://mirrors.jenkins-ci.org/osx-rc/jenkins-2.0.pkg'}
+              %span.icon
+              %span.title
+                Mac OS X
+            %a.dropdown-item{:href=>'http://pkg.jenkins-ci.org/opensuse-rc/jenkins-2.0-1.2.noarch.rpm'}
+              %span.icon
+              %span.title
+                openSUSE
+            %a.dropdown-item{:href=>'http://pkg.jenkins-ci.org/redhat-rc/jenkins-2.0-1.1.noarch.rpm'}
+              %span.icon
+              %span.title
+                Red Hat/Fedora/CentOS
+            %a.dropdown-item{:href=>'http://pkg.jenkins-ci.org/debian-rc/binary/jenkins_2.0_all.deb'}
+              %span.icon
+              %span.title
+                Ubuntu/Debian
+            %a.dropdown-item{:href=>'http://mirrors.jenkins-ci.org/windows-rc/jenkins-2.0.zip'}
+              %span.icon
+              %span.title
+                Windows
+      %p.details
+        %a.item{:href=>'/changelog'} Changelog
+        |
+        %a.item{:href=>'http://mirrors.jenkins-ci.org/war/'} Past Releases


### PR DESCRIPTION
This adds the 2.0 preview of jenkins to downloads.

The reason I add this functionality is because some users like trying out new software. This makes it easer to try out new software.

Plus it is encouraging users try 2.0 here  https://jenkins.io/2.0/

