### PR TITLE
Make it more clear/obvious to the browser which page in the topnav they're on

### DIFF
--- a/content/_ext/activenav.rb
+++ b/content/_ext/activenav.rb
@@ -1,0 +1,6 @@
+
+module ActiveNav
+  def active_link?(section_name, options={:css_class => 'active'})
+    return options[:css_class] if page.section == section_name
+  end
+end

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -31,6 +31,7 @@ Awestruct::Extensions::Pipeline.new do
 
   transformer VersionSwitcher.new
 
+  helper ActiveNav
   helper Authorship
   helper Legacy
 

--- a/content/_layouts/default.html.haml
+++ b/content/_layouts/default.html.haml
@@ -22,7 +22,9 @@ layout: frame
       %div#content-bottom/
 
 - else
-  = partial('toptoolbar.html.haml')
+  - # We need to propogate the page.section into the partial since inside the partial
+  - # this template (default.html.haml) is scoped as `poge`
+  = partial('toptoolbar.html.haml', :section => page.section)
 
   - if page.precontent
     - page.precontent.each do |pre|

--- a/content/_layouts/solution.html.haml
+++ b/content/_layouts/solution.html.haml
@@ -1,5 +1,6 @@
 ---
 layout: frame
+section: solutions
 ---
 - key = page.simple_name.to_sym
 - data = site.solutions[key]
@@ -37,7 +38,7 @@ layout: frame
 
       %div#content-bottom/
 - else
-  = partial('toptoolbar.html.haml')
+  = partial('toptoolbar.html.haml', :section => page.simple_name)
 
   = partial('jumbotron.html.haml',
       :href => "/solutions/#{page.simple_name}",

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -6,8 +6,6 @@
     });
   })
 
-
-
 #ji-hover-layer
 
 - if (page.section == 'doc')
@@ -48,37 +46,39 @@
             \/r/jenkinsci
           %a.dropdown-item{:href =>"https://wiki.jenkins-ci.org/display/JENKINS/Google+Summer+Of+Code+2016", :title => "Google Summer of Code"}
             Google Summer of Code
-      %li.nav-item.dropdown{:class => ('active' if page.section == 'solutions' )}
+      - # Can't use active_link? here because our section is going to be the actual solution page itself
+      - # but we still want to highlight the active link on the Use-cases dropdown
+      %li.nav-item.dropdown{:class => ('active' if (page.section && site.solutions.keys.include?(page.section.to_sym)))}
         %a.nav-link.dropdown-toggle{'data-toggle' => 'dropdown',
             :href=> "#", :role=>"button", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
           Use-cases
         %div.dropdown-menu
           - site.solutions.keys.sort.each do |key|
             - link = "/solutions/#{key}"
-            %a.dropdown-item.feature{:href => link}
+            %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
               = site.solutions[key].usecase
-      %li.nav-item{:class => ('active' if page.section == 'blog' )}
+      %li.nav-item{:class => active_link?('blog')}
         %a.nav-link{:href => '/node'}
           Blog
-      %li.nav-item{:class => ('active' if page.section == 'doc' )}
+      %li.nav-item{:class => active_link?('doc')}
         %a.nav-link{:href => '/doc'}
           Documentation
       %li.nav-item
         %a.nav-link{:href => 'https://wiki.jenkins-ci.org/display/JENKINS/Plugins'}
           Plugins
-      %li.nav-item{:class => ('active' if page.section == 'issues' )}
+      %li.nav-item
         %a.nav-link{:href => 'https://wiki.jenkins-ci.org/'}
           Wiki
-      %li.nav-item{:class => ('active' if page.section == 'issues' )}
+      %li.nav-item
         %a.nav-link{:href => 'https://issues.jenkins-ci.org/'}
           Issues
-      %li.nav-item
+      %li.nav-item{:class => active_link?('security')}
         %a.nav-link{:href => '/security'}
           Security
-      %li.nav-item{:class => ('active' if page.section == 'press' )}
+      %li.nav-item{:class => active_link?('press')}
         %a.nav-link{:href => '/press'}
           Press
-      %li.nav-item{:class => ('active' if page.section == 'conduct' )}
+      %li.nav-item{:class => active_link?('conduct')}
         %a.nav-link{:href => '/conduct'}
           Conduct
 

--- a/content/conduct.adoc
+++ b/content/conduct.adoc
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 title: "Jenkins Code of Conduct"
+section: conduct
 ---
 
 :toc:

--- a/content/doc/index.html.haml
+++ b/content/doc/index.html.haml
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 title: Jenkins Documentation
+section: doc
 ---
 
 - book_dir = File.expand_path(File.dirname(__FILE__) + '/book')

--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: 'Jenkins Community Blog'
+section: blog
 ---
 
 - if legacy?

--- a/content/press.adoc
+++ b/content/press.adoc
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 title: "Jenkins Press Information"
+section: press
 ---
 
 

--- a/content/security.adoc
+++ b/content/security.adoc
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 title: "Jenkins Security"
+section: security
 ---
 
 


### PR DESCRIPTION
This has been annoying me, so I fixed it over the weekend.

![obvious-nav-doc](https://cloud.githubusercontent.com/assets/26594/14085930/737c12f4-f4d7-11e5-91e9-c84b002f5406.png)


![obvious-nav-subnav](https://cloud.githubusercontent.com/assets/26594/14085933/75f9c8dc-f4d7-11e5-952f-ba748d74c273.png)
