### PR TITLE
Fix typos

### DIFF
--- a/content/doc/pipeline/jenkinsfile.adoc
+++ b/content/doc/pipeline/jenkinsfile.adoc
@@ -9,11 +9,11 @@ title: "Getting Started with Jenkinsfile"
 
 == Audience and Purpose
 
-This document is intended for novice Jenkins users who want to leverage the power of pipeline functionality. Extending the reach of what was learned from a "Hello World" example in link:http://jenkins.io/doc/pipeline/[Getting Started with Pipelines], this document explains how to use a Jenkinsfile to perform a simple checkout and build for the contents of a repository. 
+This document is intended for novice Jenkins users who want to leverage the power of pipeline functionality. Extending the reach of what was learned from a "Hello World" example in link:http://jenkins.io/doc/pipeline/[Getting Started with Pipelines], this document explains how to use a Jenkinsfile to perform a simple checkout and build for the contents of a repository.
 
 == Creating a Jenkinsfile
 
-A Jenkinsfile is a container for your pipeline (or other) script, which details what specific steps are needed to perform a job for which you want to use Jenkins. You create a Jenkinsfile with your preferred Groovy editor, or through the configuration page on the web interface of your Jenkins instance. 
+A Jenkinsfile is a container for your pipeline (or other) script, which details what specific steps are needed to perform a job for which you want to use Jenkins. You create a Jenkinsfile with your preferred Groovy editor, or through the configuration page on the web interface of your Jenkins instance.
 
 Using a Groovy editor to code a Jenkinsfile gives you more flexibility for building complex single or multi-branch pipelines, but whether you use an editor or the Jenkins interface does not matter if what you want to do is get familiar with basic Jenkinsfile content.
 
@@ -23,7 +23,7 @@ Using a Groovy editor to code a Jenkinsfile gives you more flexibility for build
 . Use standard Jenkins syntax.
 . Save your file.
 
-The following example shows a basic Jenkinsfile made to build and test code for a Maven project. "Node" is the step that schedules tasks in the following block to run on the machine (usually an agent) that matches the label specified in the step argument (in this case, a node called "linux"). Code between the braces ( { and } ) is the body of the node step. The *checkout scm* command indicates that this Jenkinsfile was created with an eye toward multi-branch support: 
+The following example shows a basic Jenkinsfile made to build and test code for a Maven project. "Node" is the step that schedules tasks in the following block to run on the machine (usually an agent) that matches the label specified in the step argument (in this case, a node called "linux"). Code between the braces ( { and } ) is the body of the node step. The *checkout scm* command indicates that this Jenkinsfile was created with an eye toward multi-branch support:
 
 ____
  node (‘linux’){
@@ -34,9 +34,9 @@ ____
  }
 ____
 
-In single-branch contexts, you could replace *checkout scm* with a source code checkout step that calls a particular repository, such as: 
+In single-branch contexts, you could replace *checkout scm* with a source code checkout step that calls a particular repository, such as:
 ____
-git url: 'https://github.com/[my-repository]/simple-maven-project-with-tests.git'.
+git url: "https://github.com/my-organization/simple-maven-project-with-tests.git"
 ____
 
 == Making Pull Requests
@@ -50,9 +50,9 @@ A pull reqeust to a repository included in or monitored by an Organization Folde
 
 == Using Organization Folders
 
-Organization folders enable Jenkins to automatically detect and include any new repositories within them as resources. 
+Organization folders enable Jenkins to automatically detect and include any new repositories within them as resources.
 
-When you create a new repository (as might be the case for a new project), that repository has a Jenkinsfile. If you also configure one or more organization folders, Jenkins automatically detects any repository in an organization folder, scans the contents of that repository at either default or configurable intervals, and creates a Multi-branch Pipeline project for what it finds in the scan. Organzation folders and multi-branch pipelines 
+When you create a new repository (as might be the case for a new project), that repository has a Jenkinsfile. If you also configure one or more organization folders, Jenkins automatically detects any repository in an organization folder, scans the contents of that repository at either default or configurable intervals, and creates a Multi-branch Pipeline project for what it finds in the scan. Organzation folders and multi-branch pipelines
 
 Organization folders alleviate the need for administrators or developers to manually create projects for new repositories. When organization folders are in use, Jenkins views your repositories as a hierarchy, and each repository may optionally have child elements such as branches and pull requests.
 
@@ -76,7 +76,6 @@ Multi-branch Pipeline projects and Organization Folders are examples of "compute
 
 == Basic Checkout and Build
 
-Checkout and build command examples are shown in the code example used by the introduction this document. This document assumes Jenkins is running on Linux or another Unix-like operating system. 
+Checkout and build command examples are shown in the code example used by the introduction this document. This document assumes Jenkins is running on Linux or another Unix-like operating system.
 
 If your Jenkins server or agent is running on Windows, you are less likely to be using the Bourne shell (*sh*) or link:http://www.computerhope.com/unix/ubash.htm[Bourne-Again shell] (*bash*) as a command language interpreter for starting software builds. In Windows environments, use *bat* in place of *sh*, and backslashes ( \ ) rather than slashes as file separators in pathnames.
-


### PR DESCRIPTION
Foreword: sorry for all the formatting changes, I only want to change line 39. Even "vi" did reformat the other lines.

1. fix missing quotes in html rendering: the single quotes (') disappear in html. Escaping single quotes doesn't work so I used double quotes.
2. don't use square brackets that are rendered in html as an hyperlink
3. use "my-organization" instead of "my-repository"