### PR TITLE
Switch to https for issues / feedburner links on security page

### DIFF
--- a/content/security.adoc
+++ b/content/security.adoc
@@ -28,7 +28,7 @@ Jenkins. You can receive notifications for such advisories in one of the
 following ways:
 
 . jenkinsci-advisories@googlegroups.com (_read-only_) mailing list (link:https://groups.google.com/forum/#!forum/jenkinsci-advisories[list archive])
-. link:http://feeds.feedburner.com/jenkins-security-advisories[jenkins-security-advisories RSS feed]
+. link:https://feeds.feedburner.com/jenkins-security-advisories[jenkins-security-advisories RSS feed]
 
 === Archived Advisories
 
@@ -40,7 +40,7 @@ link:https://wiki.jenkins-ci.org/display/SECURITY/Home[wiki page].
 == Reporting vulnerabilities
 
 If you find a vulnerability in Jenkins, please report it in the issue tracker
-under the link:http://issues.jenkins-ci.org/browse/SECURITY[SECURITY project].
+under the link:https://issues.jenkins-ci.org/browse/SECURITY[SECURITY project].
 This project is configured in such a way that only the reporter and the core
 Jenkins developers can see the details.
 


### PR DESCRIPTION
Security page should be using https for everything it can.

There is an argument for updating all the old blogs / changelogs etc, but that is a bigger PR (mechanical work though).