### PR TITLE
Add a jenkins.io/hangout redirect URL

### DIFF
--- a/content/hangout.adoc
+++ b/content/hangout.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+refresh_to_post_id: "https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38"
+---

--- a/content/redirect/hangout.adoc
+++ b/content/redirect/hangout.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+refresh_to_post_id: "https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38"
+---


### PR DESCRIPTION
This commit also adds a redirect permalink under jenkins.io/redirect/hangout
which can/should use more in the future.

[WEBSITE-167](https://issues.jenkins-ci.org/browse/WEBSITE-167)