### PR TITLE
Importing the top-level security content in jenkins.io

### DIFF
--- a/content/doc/book/securing-jenkins.adoc
+++ b/content/doc/book/securing-jenkins.adoc
@@ -1,0 +1,50 @@
+---
+layout: simplepage
+---
+:doctitle: Securing Jenkins
+:notitle:
+:description:
+:email: jenkinsci-users@googlegroups.com
+:imagesdir: /doc/book/resources/securing-jenkins
+:toc: left
+
+== Securing Jenkins
+In the default configuration, Jenkins does not perform any security checks. This means the ability of Jenkins to
+launch processes and access local files are available to anyone who can access Jenkins web UI and some more.
+
+Securing Jenkins has two aspects to it.
+
+* Access control, which ensures users are authenticated when accessing Jenkins and their activities are authorized.
+* Protecting Jenkins against external threats
+
+== Access Control
+You should lock down the access to Jenkins UI so that users are authenticated and appropriate set of permissions are given to them. This setting is controlled mainly by two axes:
+
+* *Security Realm*, which determines users and their passwords, as well as what groups the users belong to.
+* *Authorization Strategy*, which determines who has access to what.
+
+These two axes are orthogonal, and need to be individually configured. For example, you might choose to use external LDAP or Active Directory as the security realm, and you might choose "everyone full access once logged in" mode for authorization strategy. Or you might choose to let Jenkins run its own user database, and perform access control based on the permission/user matrix.
+
+The following pages discuss various aspects of this feature in details:
+
+* https://wiki.jenkins-ci.org/display/JENKINS/Quick+and+Simple+Security[Quick and Simple Security] --- if you are running Jenkins like `java -jar jenkins.war` and only need a very simple set up
+* https://wiki.jenkins-ci.org/display/JENKINS/Standard+Security+Setup[Standard Security Setup] --- discusses the most common set up of letting Jenkins run its own user database and do finer-grained access control
+* https://wiki.jenkins-ci.org/display/JENKINS/Apache+frontend+for+security[Apache frontend for security] --- run Jenkins behind Apache and perform access control in Apache instead of Jenkins
+* https://wiki.jenkins-ci.org/display/JENKINS/Authenticating+scripted+clients[Authenticating scripted clients] --- if you need to programatically access security-enabled Jenkins web UI, use BASIC auth
+* https://wiki.jenkins-ci.org/display/JENKINS/Disable+security[Help\! I locked myself out\!|Disable security] --- if something goes really wrong and you can't get full access anymore
+* https://wiki.jenkins-ci.org/display/JENKINS/Matrix-based+security[Matrix-based security|Matrix-based security] --- Granting and denying finer-grained permissions
+
+
+== Protect users of Jenkins from other threats
+There are additional security subsystems in Jenkins that protect Jenkins and users of Jenkins from indirect attacks.
+
+The following topics discuss features that are *off by default*. We recommend you read them first and act on them.
+
+* https://wiki.jenkins-ci.org/display/JENKINS/CSRF+Protection[CSRF Protection] --- prevent a remote attack against Jenkins running inside your firewall
+* https://wiki.jenkins-ci.org/display/JENKINS/Security+implication+of+building+on+master[Security implication of building on master] --- protect Jenkins master from malicious builds
+* https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control[Slave To Master Access Control] --- protect Jenkins master from malicious build agents
+
+The following topics discuss other security features that are on by default. You'll only need to look at them when they are causing problems.
+
+* https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] --- protect users of Jenkins from malicious builds
+* https://wiki.jenkins-ci.org/display/JENKINS/Markup+formatting[Markup formatting] --- protect users of Jenkins from malicious users of Jenkins

--- a/content/doc/book/securing-jenkins.adoc
+++ b/content/doc/book/securing-jenkins.adoc
@@ -9,7 +9,7 @@ layout: simplepage
 :toc: left
 
 == Securing Jenkins
-In the default configuration, Jenkins does not perform any security checks. This means the ability of Jenkins to
+In the default configuration of Jenkins 1.x, Jenkins does not perform any security checks. This means the ability of Jenkins to
 launch processes and access local files are available to anyone who can access Jenkins web UI and some more.
 
 Securing Jenkins has two aspects to it.


### PR DESCRIPTION
... to at least provide a navigability from http://jenkins.io/

More fuller treatment of the content requires a bigger work and it
shouldn't be on the critical path for communication.