### PR TITLE
Get rid of the space between the version and the .war

### DIFF
--- a/content/_partials/downloadlist.html.haml
+++ b/content/_partials/downloadlist.html.haml
@@ -21,8 +21,7 @@
       .btn-group
         %a.btn.btn-primary.chromeOnly{:href=>'http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war'}
           %i.icon-box-add
-          = site.jenkins.stable
-          \.war
+          #{ site.jenkins.stable }.war
         %button.btn.btn-primary.dropdown-toggle{'data-toggle' => 'dropdown', 'data-trigger' => 'hover', 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
         .dropdown-menu
           %a.dropdown-item{:href=>'https://registry.hub.docker.com/u/jenkinsci/jenkins/'}
@@ -70,8 +69,7 @@
       .btn-group
         %a.btn.btn-primary.chromeOnly{:href=>'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
           %i.icon-box-add
-          = site.jenkins.latest
-          \.war
+          #{ site.jenkins.latest }.war
         %button.btn.btn-primary.dropdown-toggle{'data-toggle' => 'dropdown', 'data-trigger' => 'hover', 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
         .dropdown-menu
           %a.dropdown-item{:href=>'https://registry.hub.docker.com/u/jenkinsci/jenkins/'}


### PR DESCRIPTION
I'll be truthful - I didn't test this - I ran the gradle assembly job a few times and it aborted every time with nonsensical errors.

I assume there is a test deployment somewhere - but I wasn't able to find it.