### PR TITLE
Revert "OMG Whitespace"

### DIFF
--- a/content/_partials/downloadlist.html.haml
+++ b/content/_partials/downloadlist.html.haml
@@ -21,7 +21,8 @@
       .btn-group
         %a.btn.btn-primary.chromeOnly{:href=>'http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war'}
           %i.icon-box-add
-          #{ site.jenkins.stable }.war
+          = site.jenkins.stable
+          \.war
         %button.btn.btn-primary.dropdown-toggle{'data-toggle' => 'dropdown', 'data-trigger' => 'hover', 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
         .dropdown-menu
           %a.dropdown-item{:href=>'https://registry.hub.docker.com/u/jenkinsci/jenkins/'}
@@ -69,7 +70,8 @@
       .btn-group
         %a.btn.btn-primary.chromeOnly{:href=>'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
           %i.icon-box-add
-          #{ site.jenkins.latest }.war
+          = site.jenkins.latest
+          \.war
         %button.btn.btn-primary.dropdown-toggle{'data-toggle' => 'dropdown', 'data-trigger' => 'hover', 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
         .dropdown-menu
           %a.dropdown-item{:href=>'https://registry.hub.docker.com/u/jenkinsci/jenkins/'}


### PR DESCRIPTION
This reverts commit bff124d4cdd3f8598ca584411c1e37518a6739a6 from #233.

As explained there:

> That space was actually important, because it's not referring to the file name. Just the version of Jenkins, and the way it's packaged. Think *2.0 rpm*. `.war` doesn't lend itself to leaving off the leading period, unfortunately.


CC @rtyler @bwalding 