### PR TITLE
Introduce /projects/ pages to give a more discoverable home to some of our projects

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -25,6 +25,26 @@
           %a.btn.btn-primary.dropdown-toggle{'data-toggle'=>"dropdown", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
             Downloads
           = partial('downloadlist.html.haml')
+      %li.nav-item{:class => active_link?('blog')}
+        %a.nav-link{:href => '/node'}
+          Blog
+      %li.nav-item{:class => active_link?('doc')}
+        %a.nav-link{:href => '/doc'}
+          Documentation
+      %li.nav-item
+        %a.nav-link{:href => 'https://wiki.jenkins-ci.org/display/JENKINS/Plugins'}
+          Plugins
+      - # Can't use active_link? here because our section is going to be the actual solution page itself
+      - # but we still want to highlight the active link on the Use-cases dropdown
+      %li.nav-item.dropdown{:class => ('active' if (page.section && site.solutions.keys.include?(page.section.to_sym)))}
+        %a.nav-link.dropdown-toggle{'data-toggle' => 'dropdown',
+            :href=> "#", :role=>"button", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
+          Use-cases
+        %div.dropdown-menu
+          - site.solutions.keys.sort.each do |key|
+            - link = "/solutions/#{key}"
+            %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
+              = site.solutions[key].usecase
       %li.nav-item.dropdown
         %a.nav-link.dropdown-toggle{'data-toggle' => 'dropdown',
             :href=> "#", :role=>"button", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
@@ -37,41 +57,33 @@
           %a.dropdown-item{:href => "https://twitter.com/jenkinsci", :title => "Check out @jenkinsci on Twitter"}
             Twitter
           %a.dropdown-item{:href => "/content/event-calendar", :title => "Calendar for Jenkins events"}
-            Event Calendar
+            Events
           %a.dropdown-item{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Office+Hours", :title => "Hangouts-based online meeting"}
             Office Hours
-          %a.dropdown-item{:href => "http://jenkins.meetup.com/", :title => "Meetups"}
-            Meetups
           %a.dropdown-item{:href => "https://reddit.com/r/jenkinsci", :title => "Latest Jenkins related news on /r/jenkinsci"}
             \/r/jenkinsci
-          %a.dropdown-item{:href =>"https://wiki.jenkins-ci.org/display/JENKINS/Google+Summer+Of+Code+2016", :title => "Google Summer of Code"}
-            Google Summer of Code
-      - # Can't use active_link? here because our section is going to be the actual solution page itself
-      - # but we still want to highlight the active link on the Use-cases dropdown
-      %li.nav-item.dropdown{:class => ('active' if (page.section && site.solutions.keys.include?(page.section.to_sym)))}
+      %li.nav-item.dropdown{:class => ('active' if (page.section == 'projects'))}
         %a.nav-link.dropdown-toggle{'data-toggle' => 'dropdown',
-            :href=> "#", :role=>"button", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
-          Use-cases
+            :href=> "/projects", :role=>"button", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
+          Sub-projects
         %div.dropdown-menu
-          - site.solutions.keys.sort.each do |key|
-            - link = "/solutions/#{key}"
-            %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
-              = site.solutions[key].usecase
-      %li.nav-item{:class => active_link?('blog')}
-        %a.nav-link{:href => '/node'}
-          Blog
-      %li.nav-item{:class => active_link?('doc')}
-        %a.nav-link{:href => '/doc'}
-          Documentation
-      %li.nav-item
-        %a.nav-link{:href => 'https://wiki.jenkins-ci.org/display/JENKINS/Plugins'}
-          Plugins
-      %li.nav-item
-        %a.nav-link{:href => 'https://wiki.jenkins-ci.org/'}
-          Wiki
-      %li.nav-item
-        %a.nav-link{:href => 'https://issues.jenkins-ci.org/'}
-          Issues
+          %a.dropdown-item.feature{:href => '/projects/'}
+            Overview
+          - site.pages.map do |page|
+            - next unless page.url.match(/\/projects\/(\w)/)
+            %a.dropdown-item.feature{:href => page.url}
+              = page.title
+      %li.nav-item.dropdown
+        %a.nav-link.dropdown-toggle{'data-toggle' => 'dropdown',
+            :href=> "/projects", :role=>"button", 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
+          Resources
+        %div.dropdown-menu
+          %a.dropdown-item.feature{:href => 'https://accounts.jenkins.io/', :title => 'Create/manage your account for accessing wiki, issue tracker, etc'}
+            Account Management
+          %a.dropdown-item.feature{:href => 'https://issues.jenkins-ci.org/'}
+            Issue Tracker
+          %a.dropdown-item.feature{:href => 'https://wiki.jenkins-ci.org/'}
+            Wiki
       %li.nav-item{:class => active_link?('security')}
         %a.nav-link{:href => '/security'}
           Security
@@ -81,9 +93,6 @@
       %li.nav-item{:class => active_link?('conduct')}
         %a.nav-link{:href => '/conduct'}
           Conduct
-      %li.nav-item
-        %a.nav-link{:href => 'https://accounts.jenkins.io/', :title => "Create/manage your account for accessing the Wiki, Issue Tracker, etc"}
-          Account
 
 #ji-top-peg
   %a#ji-fork-tag{:href => 'https://github.com/jenkinsci'}

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1479,6 +1479,11 @@ p.details {
 @media screen and (max-width: 991px){
   .footer-left{
     margin-top: 1rem;
-  }    
+  }
+}
 
+/* keep our bulleted lists tight */
+li>p {
+  padding: 0;
+  margin: 0;
 }

--- a/content/projects/gsoc.adoc
+++ b/content/projects/gsoc.adoc
@@ -1,0 +1,109 @@
+---
+layout: simplepage
+title: "Jenkins Google Summer of Code"
+section: projects
+---
+
+:toc:
+
+The link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
+(GSoC) project is an annual, international, program which encourages
+college-aged students to participate with open source projects during the summer
+break between classes. Students accepted into the program receive a stipend,
+paid by Google, to work well-defined projects to improve or enhance the Jenkins
+project.  In exchange, numerous Jenkins community members volunteer as "mentors"
+for students to help integrate them into the open source community and succeed
+in completing their summer projects.
+
+== 2016 Student Projects
+
+The Jenkins project is participating in the Google Summer of Code 2016 with
+link:https://summerofcode.withgoogle.com/organizations/5668199471251456/[five
+student projects].
+
+
+=== Support-core plugin improvements
+
+The objective of this project is to make improvements for support-core plugin by
+implementing the following three features and functionalities which have been
+requested in issue tracker. JENKINS-33090 JENKINS-33091 JENKINS-21670
+
+==== Mentors
+
+* link:https://github.com/aheritier[Arnaud Heritier]
+* link:https://github.com/christ66[Steven Christou]
+
+=== Automatic Plugin Documentation Publishing
+
+Currently Jenkins has plugin documentation is being stored in Confluence.
+Sometimes the documentation is scattered and outdated. In order to improve the
+situation we would like to follow the documentation-as-code approach and to put
+docs to plugin repositories and then publish them on the project website using
+the awestruct engine. The project aims an implementation of a documentation
+continuous deployment flow powered by Jenkins and Pipeline Plugin.
+
+==== Mentors
+
+* link:https://github.com/rtyler[R Tyler Croy]
+* link:https://github.com/batmat[Baptiste Mathaus]
+
+=== External Workspace Manager Plugin
+
+Currently, Jenkins’ build workspace may become very large in size due to the
+fact that some compilers generate very large volumes of data. The existing
+plugins that share the workspace across builds are able to do this by copying
+the files from one workspace to another, process which is inefficient.
+
+A solution for this problem is to create the
+link:https://github.com/jenkinsci/external-workspace-manager-plugin[External
+Workspace Manager Plugin].
+
+==== Mentors
+
+* link:https://github.com/oleg-nenashev[Oleg Nenashev]
+* link:https://github.com/martinda[Martin d'Anjou]
+
+=== Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration
+
+Although powerful, Jenkins new job creation and configuration process may be non
+obvious and time consuming. This can be improved by making UI more intuitive,
+concise, and functional. I plan to achieve this by creating a simpler new job
+creation, configuration process focused on essential elements, and embedding new
+functionality.
+
+==== Mentors
+
+* link:https://github.com/michaelneale[Michael Neale]
+* link:https://github.com/lanwen[Merkushev Kirill]
+
+=== Jenkins Usage Statistics Analysis
+
+Jenkins is a powerful application that allows continuous integration and
+delivery of products. It has collected anonymous usage informations of more than
+100,000 installations. Our goal is to perform various analysis and studies over
+this dataset to discover trend in resource utilisation for example plugins
+utilisation, spotting downgrades etc. This project covers a wide range of high
+priority problems which need to be solved. Problem such as how quickly users are
+upgrading Jenkins and its plugin, will give us the insight of popularity &
+unpopularity of the releases. Spotting downgrades will warn that something is
+wrong with the version. Correlating what users are saying(community rating) with
+what users are doing (upgrades/downgrades). Finding set of the plugins which are
+most likely to be used together will setup the pillars for development of plugin
+recommendation system. These were the few set of the problems that will give
+better insights of Jenkins utilization with some of the basic data mining
+studies like latest trend in the installation size, pie charts for platforms in
+use and ranking the users.
+
+==== Mentors
+
+* link:https://github.com/daniel-beck[Daniel Beck]
+* link:https://github.com/kohsuke[Kohsuke Kawaguchi]
+
+---
+
+== Resources
+
+* link:https://summerofcode.withgoogle.com/organizations/5668199471251456/[Jenkins GSoC organization profile]
+* link:https://groups.google.com/forum/#!forum/jenkinsci-dev[jenkinsci-dev@ mailing list]
+* link:https://wiki.jenkins-ci.org/display/JENKINS/Google+Summer+Of+Code+2016[GSoC
+  wiki page] with more organizational information.

--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -1,0 +1,52 @@
+---
+layout: simplepage
+title: "Jenkins Sub-projects"
+section: projects
+---
+
+At the heart of the Jenkins project exists the automation engine's
+link:https://github.com/jenkinsci/jenkins[core] and hundreds of
+link:https://wiki.jenkins-ci.org/display/JENKINS/Plugins[plugins]. There are
+however other collaborative initiatives going on under the umbrella of the
+Jenkins project which grow or expand the project in new ways.
+
+== Google Summer of Code
+
+image:/images/plugin.png["Summer of Code", role=left]
+
+The link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
+(GSoC) project is an annual, international, program which encourages
+college-aged students to participate with open source projects during the summer
+break between classes. Students accepted into the program receive a stipend,
+paid by Google, to work well-defined projects to improve or enhance the Jenkins
+project.  In exchange, numerous Jenkins community members volunteer as "mentors"
+for students to help integrate them into the open source community and succeed
+in completing their summer projects.
+
+The Jenkins project is participating in the Google Summer of Code 2016 with
+link:https://summerofcode.withgoogle.com/organizations/5668199471251456/[five
+student projects].
+
+link:/projects/gsoc[*Learn more*]
+
+---
+
+
+== Jenkins Area Meetups
+
+image:/images/user.gif["Social Jenkins events", role=left]
+
+Jenkins Area Meetups (JAMs) are local meetups intended to bring Jenkins users
+and contributors together for socializing and learning.
+JAMs are organized by local Jenkins community members who have a passion for
+sharing new Jenkins concepts, patterns and tools. JAMs can be found
+link:http://www.meetup.com/pro/jenkins/[around the world], and if there isn't a
+JAM in your city, you could be the one to start it!
+
+Jenkins Area Meetups are driven by local organizers but receive support from
+the Jenkins project via swag (stickers, etc), promotion, and help bootstrapping
+and operating the meetup group.
+
+link:/projects/jam[*Learn more*]
+
+---

--- a/content/projects/jam.adoc
+++ b/content/projects/jam.adoc
@@ -1,0 +1,132 @@
+---
+layout: simplepage
+title: "Jenkins Area Meetups"
+section: projects
+---
+
+:toc:
+
+Jenkins Area Meetups (JAMs) are local meetups intended to bring Jenkins users
+and contributors together for socializing and learning.
+JAMs are organized by local Jenkins community members who have a passion for
+sharing new Jenkins concepts, patterns and tools. JAMs can be found
+link:http://www.meetup.com/pro/jenkins/[around the world], and if there isn't a
+JAM in your city, you could be the one to start it!
+
+Jenkins Area Meetups are driven by local organizers but receive support from
+the Jenkins project via swag (stickers, etc), promotion, and help bootstrapping
+and operating the meetup group.
+
+== Getting Started
+
+Send us an email jenkinsci-jam@googlegroups.com to get started. Let us know the
+city in which you’d like to host the JAM. Our team will create a meetup page on
+meetup.com and we will work with you to organize your JAM.
+
+*JAM Support*
+
+* Swag - We will send you cool swags (stickers, t-shirts, Jenkins bobble-heads, etc) to share with members
+* Promote - We give every JAM continuous social media love via Twitter, blog posts, Facebook, newsletter, and post on the jenkinsci.org events calendar.
+* Jenkins Expertise - We will help you to schedule a Jenkins expert as the key speaker at your JAM, or provide you with presentation materials.
+* Outreach - We will assist in reaching out to your local community for food/venue sponsorship.
+
+=== Best Practices
+
+* Attend existing meetup groups to gauge Jenkins interest/market within your area.
+* Reach out to existing JAM organizer(s) to learn best practices and time commitment.
+* Set up a Twitter account (for example, #JenkinsNYC). Email your group’s Twitter ID to jenkinsci-jam@googlegroups.com so we can help to promote your JAM.
+* Promote, tweet and post your JAM in advance.
+* Avoid product pitches. Keep it real, it’s not about promotions. This is about - and for - learning opportunities for the community.
+* Shake up the format. Have presentations, panel discussions, roundtables, workshops, hackathons, etc.
+* Set a consistent date, time and location so members will plan for it. Avoid cancelling your meeting as people will lose faith and stop RSVPing for your JAM.
+
+=== Stepping Down
+
+In the event you can no longer be a JAM organizer, we ask that you nominate a
+replacement organizer in your place. If this is not possible please send email
+to jenkinsci-jam@googlegroups.com, we will work with you to find a replacement.
+
+== Supporting a JAM
+
+If you are not able to be a JAM organizer, food or venue, or recording sponsors are always needed. If your company is interested in sponsoring any of these items pls email jenkinsci-jam@googlegroups.com or reach out to the local JAM organizer via meetup.com.
+
+*Benefits of Being a Food or Venue or Recording Sponsor:*
+
+* Logo and link on the meetup page.
+* Verbal acknowledgement at the opening/closing remark by the host.
+* Sponsor table at the meeting to display collaterals, signage, swag.
+* Opportunity to host a drawing.
+* Mention in social media.
+* A two minute talk to address the attendees.
+
+*Food Sponsor:*
+
+Sponsor food and beverages for the specific month's meetup. The cost is about
+$200 to $600 depending on the number of attendees. The money is used to
+purchase pizza, soft drinks and paperware. One sponsor is needed for each
+monthly meeting.
+
+*Venue Sponsor:*
+
+Venue sponsors provide the facility to host the meeting for free. One venue sponsor is needed per meeting. A meeting room with chairs and a couple of six feet tables with open space for food/beverages and mingling would be sufficient. Access to a public bathroom would be needed as well. A meetup will need such equipments as projection and screen. In the event where a meeting has more than 50 attendees an audio system will be needed.
+
+*Recording Sponsor:*
+
+Recording sponsor volunteer his/her recording equipments and time to record a
+meeting and make it public after the meeting.
+
+
+== JAMs Around the World
+
+The list below is manually curated, for the most up-to-date information,
+consult this link:https://www.meetup.com/pro/jenkins/[meetup.com page].
+
+We also have the link:http://www.meetup.com/Jenkins-online-meetup/[Jenkins Online Meetup].
+
+=== North America
+
+* link:http://www.meetup.com/Atlanta-Jenkins-Meetup/[Atlanta, GA]
+* link:http://www.meetup.com/Austin-Jenkins-Area-Meetup/[Austin, TX]
+* link:http://www.meetup.com/Boston-Jenkins-Area-Meetup/[Boston, MA]
+* link:http://www.meetup.com/Boulder-Jenkins-Area-Meetup/[Boulder, CO]
+* link:http://www.meetup.com/DFW-Jenkins-Area-Meetup/[Dallas/Fort Worth, TX]
+* link:http://www.meetup.com/Guadalajara-Jenkins-Area-Meetup/[Guadalajara, Mexico]
+* link:http://www.meetup.com/Los-Angeles-Jenkins-Area-Meetup/[Los Angeles, CA]
+* link:http://www.meetup.com/NYC-Jenkins-Meetup/[New York, NY]
+* link:http://www.meetup.com/Raleigh-Jenkins-Area-Meetup/[Raleigh, NC]
+* link:http://www.meetup.com/San-Francisco-Jenkins-Area-Meetup/[San Francisco, CA]
+* link:http://www.meetup.com/Seattle-Jenkins-Area-Meetup/[Seattle, WA]
+* link:http://www.meetup.com/Washington-DC-Jenkins-Area-Meetup/[Washington, DC]
+
+=== Europe
+
+* link:http://www.meetup.com/Amsterdam-Jenkins-Area-Meetup/[Amsterdam, Netherlands]
+* link:http://www.meetup.com/Barcelona-Jenkins-Area-Meetup/[Barcelona, Spain]
+* link:http://www.meetup.com/Brno-Jenkins-Area-Meetup/[Brno, Czech Republic]
+* link:http://www.meetup.com/Budapest-JenkinsCI-Users/[Budapest, Hungary]
+* link:http://www.meetup.com/Jenkins-Copenhagen-JAM/[Copenhagen, Denmark]
+* link:http://www.meetup.com/Dublin-Jenkins-Meetup/[Dublin, Ireland]
+* Hamburg, Germany
+* London, UK
+* Moscow, Russia
+* link:http://www.meetup.com/Rennes-Jenkins-Area-Meetup/[Rennes, France]
+* link:http://www.meetup.com/Seville-Jenkins-Area-Meetup/[Seville, Spain] - link:http://seville-jam.es/[website]
+* link:http://www.meetup.com/St-Petersburg-Jenkins-Meetup/[St. Petersburg, Russia]
+* link:http://www.meetup.com/Stockholm-Jenkins-Meetup/[Stockholm, Sweden]
+* link:http://www.meetup.com/Toulouse-Jenkins-Area-Meetup/[Toulouse, France]
+* Zurich, Switzerland
+
+=== Asia
+
+* Bangalore, India
+* link:http://www.meetup.com/Delhi-Jenkins-Meetup/[Delhi, India]
+* Hyderabad, India
+* Singapore, Singapore 
+* link:http://www.meetup.com/Tel-Aviv-Jenkins-Area-Meetup/[Tel Aviv, Israel]
+
+=== South America
+
+* link:http://www.meetup.com/Lima-Jenkins-Area-Meetup/[Lima, Perú]
+
+== Resources
+


### PR DESCRIPTION
There are a couple initiatives within the Jenkins project which are are not
quite "core" or "plugins" in the traditional sense that we have had in the
project. These projects generally expand the horizons of Jenkins in a social or
technology aspect and as such I think require some escalated visibility inside
of the jenkins.io site structure.

![sub-projects](https://cloud.githubusercontent.com/assets/26594/15514360/9fc1467a-219d-11e6-909c-f35e31ef7475.png)
