### PR TITLE
BlueOcean - fix wording in the "Is this a CloudBees project?" section

### DIFF
--- a/content/projects/blueocean.adoc
+++ b/content/projects/blueocean.adoc
@@ -201,22 +201,23 @@ community to extend it for other job types in the future.
 
 === Is this a CloudBees project?
 
-While the project's inception has happened within CloudBees we see this project
-being one owned by the community.
+The short answer is *"no"*. 
+The project has been originated and sponsored by CloudBees, but it's being considered as a *100% open project* (including sources, roadmaps, public discussions, etc.).
+Everybody is invited to contribute to it.
 
+Here is a cite from link:https://github.com/i386[James Dumay] (Blue Ocean product manager at CloudBees): 
+_"
+While the project’s inception has happened within CloudBees we see this project
+being one owned by the community.
 At CloudBees we recognize the importance of a vibrant and healthy Jenkins
 community, we see the company and community working in symbiosis: a thriving
 developer community is good for CloudBees and CloudBees provides time and money
 back into the community to make it stronger.
-
-Blue Ocean is our way of giving back and strengthening. To that effect we've
+Blue Ocean is our way of giving back and strengthening. To that effect we’ve
 put together a new a team of product, UX, frontend and backend developers (some
 old faces and a lot of new ones!) that will be working on this project with the
 community full time.
-
-And I think it goes without saying but here it is anyway: any and all
-development, discussion, bikeshedding ;) - you name it - will be happening on
-the public Jenkins mailing lists and IRC room.
+"_
 
 === What does this mean for my plugins?
 


### PR DESCRIPTION
Now this section distinguishes "we" as a Jenkins project and "we" as CloudBees used by James.

CC @i386 @michaelneale 