### PR TITLE
Redundant "the" in first para of tour section

### DIFF
--- a/content/projects/blueocean.adoc
+++ b/content/projects/blueocean.adoc
@@ -85,7 +85,7 @@ Here is a quick tour of Blue Ocean.
 
 image:/images/post-images/blueocean/pipeline-activity.png[Pipeline activity, role=center]
 
-Blue Ocean is under heavy development. Watch the the mailing lists and repos to keep on top of the latest activity. 
+Blue Ocean is under heavy development. Watch the mailing lists and repos to keep on top of the latest activity. 
 Some parts you will see are in stages of design, others are already implemented. 
 
 


### PR DESCRIPTION
Text had said "Watch the the mailing lists and repos to keep on top of the latest activity. 
Some parts you will see are in stages of design, others are already implemented." Proposal is to remove redundant "the"