### PR TITLE
Add link to plugins affected by SECURITY-170

### DIFF
--- a/content/2.0.html.haml
+++ b/content/2.0.html.haml
@@ -245,7 +245,16 @@ title: "Jenkins 2 Overview"
         %td.content
           Jenkins 2 no longer supports AJP with the embedded Winstone-Jetty container, so if you're using Jenkins with a reverse proxy, please make sure it uses HTTP before upgrading.
 
-
+%div.admonitionblock.important
+  %table
+    %tbody
+      %tr
+        %td.icon
+          %i.fa.icon-important{:title => 'important'}
+        %td.content
+          Jenkins 2 includes several security updates that affects a number of plugins. Make sure to check 
+          %a{:href => 'https://wiki.jenkins-ci.org/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170'}
+            here to see if a plugin you are using was affected.
 
 %a{:name => 'feedback'}
 


### PR DESCRIPTION
The page [here ](https://jenkins.io/2.0/#compat ) is currently misleading and says "Jenkins 2 is a drop-in replacement of the Jenkins 1.x series of releases and fully backward compatible." However, if users are coming from certain version of Jenkins 1.x, they will have issues regarding the plugins on https://wiki.jenkins-ci.org/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170. Adding this link will help users out when debugging issues related to their Jenkins upgrade.