### PR TITLE
Reference ci.jenkins.io rather than ci.jenkins-ci.org

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -97,7 +97,7 @@
                         %a{:href => 'https://github.com/jenkinsci'}
                           GitHub
                       %li
-                        %a{:href => 'https://ci.jenkins-ci.org'}
+                        %a{:href => 'https://ci.jenkins.io'}
                           Jenkins on Jenkins
 
                 %li.area.multi.col-md-3.col-sm-6.col-xs-6

--- a/content/_partials/legacy/navbar.html.haml
+++ b/content/_partials/legacy/navbar.html.haml
@@ -58,7 +58,7 @@
             %a{:href => "https://wiki.jenkins-ci.org/", :title => "Jenkins Wiki"}
               Wiki
           %li.leaf.last
-            %a{:href => "https://ci.jenkins-ci.org/", :title => "Jenkins own Jenkins install"}
+            %a{:href => "https://ci.jenkins.io/", :title => "Jenkins own Jenkins install"}
               CI
 
       %li.leaf

--- a/content/changelog-stable/index.html
+++ b/content/changelog-stable/index.html
@@ -38,11 +38,11 @@ Some tips:
 Help other Jenkins users by letting the community know which releases you've used,
 and whether they had any significant issues. <br>
 Legend: <br>
- <img src="//ci.jenkins-ci.org/images/16x16/health-80plus.gif" width="16" height="16"
+ <img src="//ci.jenkins.io/images/16x16/health-80plus.gif" width="16" height="16"
   alt="Sunny"> = I use it on my production site without major issues. <br>
- <img src="//ci.jenkins-ci.org/images/16x16/health-40to59.gif" width="16" height="16"
+ <img src="//ci.jenkins.io/images/16x16/health-40to59.gif" width="16" height="16"
   alt="Cloudy"> = I don't recommend it. <br>
- <img src="//ci.jenkins-ci.org/images/16x16/health-00to19.gif" width="16" height="16"
+ <img src="//ci.jenkins.io/images/16x16/health-00to19.gif" width="16" height="16"
   alt="Lightning"> = I tried it but rolled back to a previous version. <br>
 View ratings below, and click one of the icons next to your version to provide your input.
 </div>


### PR DESCRIPTION
See also https://github.com/jenkins-infra/rating/pull/8