### PR TITLE
img links should be fixed in docs

### DIFF
--- a/content/doc/book/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline-as-code.adoc
@@ -333,6 +333,7 @@ to be broken.
 
 [[throttled-concurrent]]
 .Throttled stage concurrency with Pipeline
+//fix the link please
 image::ch13/stage-concurrency.png[scaledwidth=“90%”]
 
 Consider a simple pipeline with three stages. A naive implementation of this
@@ -423,6 +424,7 @@ helpful metrics like average run time by stage and by build, and a user-friendly
 interface for interacting with input steps.
 
 .Pipeline Stage View plugin
+//fix the link please
 image::ch13/workflow-big-responsive.png[scaledwidth=“90%”]
 
 The only prerequisite for this plugin is a pipeline with defined stages in the
@@ -454,6 +456,7 @@ artifacts in a build will then be available in the left-hand menu of Jenkins:
 
 [[fingerprint-workflow]]
 .List of fingerprinted files
+//fix the link please
 image::ch13/workflow-fingerprint.png[scaledwidth=“90%”]
 
 To find where an artifact is used and deployed to, simply follow the “more
@@ -462,6 +465,7 @@ in its “Usage” list.
 
 [[fingerprinting]]
 .Fingerprint of a WAR
+//fix the link please
 image::ch13/fingerprinting.png[scaledwidth=“90%”]
 
 For more information, visit the


### PR DESCRIPTION
Some images below the of the mid articles are broken.

https://jenkins.io/doc/book/resources/pipeline-as-code/ch13/fingerprinting.png
https://jenkins.io/doc/book/resources/pipeline-as-code/ch13/stage-concurrency.png
https://jenkins.io/doc/book/resources/pipeline-as-code/ch13/workflow-big-responsive.png
https://jenkins.io/doc/book/resources/pipeline-as-code/ch13/workflow-fingerprint.png