### PR TITLE
[JENKINS-29922] Documentation update

### DIFF
--- a/content/doc/pipeline/index.adoc
+++ b/content/doc/pipeline/index.adoc
@@ -599,13 +599,16 @@ a build tool):
 [source, groovy]
 ----
  node {
-   git url: 'https://github.com/joe_user/simple-maven-project-with-tests.git'
+   git 'https://github.com/joe_user/simple-maven-project-with-tests.git'
    def mvnHome = tool 'M3'
    sh "${mvnHome}/bin/mvn -B -Dmaven.test.failure.ignore verify"
-   step([$class: 'ArtifactArchiver', artifacts: '**/target/*.jar', fingerprint: true])
-   step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+   archiveArtifacts artifacts: '**/target/*.jar', fingerprint: true
+   junit '**/target/surefire-reports/TEST-*.xml'
  }
 ----
+
+(Older versions of Pipeline require a slightly more verbose syntax.
+The “snippet generator” can be used to see the exact format.)
 
 * If tests fail, the Pipeline is marked unstable (as denoted by a yellow ball in
   the Jenkins UI), and you can browse "Test Result Trend" to see the relevant history.


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-cps-plugin/pull/35. Similar to https://github.com/jenkinsci/pipeline-plugin/issues/401; someone seems to have copied & pasted a bunch of documentation, so now we have two copies to maintain.

@reviewbybees esp. @kohsuke, @abayer