### PR TITLE
Link in the Pipeline Use-case is fixed

### DIFF
--- a/content/solutions/pipeline.adoc
+++ b/content/solutions/pipeline.adoc
@@ -45,7 +45,7 @@ which is worth mentioning as well.
   has a fairly comprehensive
   link:https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md[tutorial]
   checked into its source tree too.
-* link:http://documentation.cloudbees.com/docs/cookbook/_continuous_delivery_with_jenkins_workflow.html[Overview of Continuous Delivery with Workflow]
+* link:https://go.cloudbees.com/docs/cloudbees-documentation/cookbook/ch13.html#ch13__continuous_delivery_with_jenkins_pipeline[Overview of Continuous Delivery with Pipeline]
 * link:https://dzone.com/refcardz/continuous-delivery-with-jenkins-workflow[DZone Refcard]
 
 == Demos


### PR DESCRIPTION
Old CloudBees documentation link is replaced with new CloudBees Network link.
The old link was still working but it was leading to the first chapter of the Cookbook.
The new link leads directly to the "Continuous Delivery with Jenkins Pipeline" chapter.