### PR TITLE
credentials-binding step's formatting is changed

### DIFF
--- a/content/doc/pipeline/steps/credentials-binding.adoc
+++ b/content/doc/pipeline/steps/credentials-binding.adoc
@@ -15,8 +15,8 @@ title: "credentials-binding"
 === +withCredentials+: Bind credentials to variables
 ====
 Allows various kinds of credentials (secrets) to be used in idiosyncratic ways.
-    Each binding will define an environment variable active within the scope of the step.
-    You can then use them directly from any other steps that expect environment variables to be set:
+Each binding will define an environment variable active within the scope of the step.
+You can then use them directly from any other steps that expect environment variables to be set:
 
 [source,java]
 ----
@@ -30,19 +30,19 @@ node {
   }
 }
 ----
-    or retrieve values from Groovy code via the env magic variable:
+
+or retrieve values from Groovy code via the env magic variable:
 
 [source,java]
 ----
 def password = env.PASSWORD
 ----
 
-    Note that some steps explicitly ask for credentials of a particular kind,
-    usually as a credentialsId parameter,
-    in which case this step is unnecessary.
+Note that some steps explicitly ask for credentials of a particular kind,
+usually as a credentialsId parameter,
+in which case this step is unnecessary.
 
-
-    For bindings which store a secret file, beware that
+For bindings which store a secret file, beware that
 
 [source,java]
 ----
@@ -55,9 +55,9 @@ node {
 }
 ----
 
-    is not safe, as $FILE might be inside the workspace (in subdir@tmp/secretFiles/),
-    and thus visible to anyone able to browse the job’s workspace.
-    If you need to run steps in a different directory than the usual workspace, you should instead use
+is not safe, as $FILE might be inside the workspace (in subdir@tmp/secretFiles/),
+and thus visible to anyone able to browse the job’s workspace.
+If you need to run steps in a different directory than the usual workspace, you should instead use
 
 [source,java]
 ----
@@ -70,7 +70,7 @@ node {
 }
 ----
 
-    to ensure that the secrets are outside the workspace; or choose a different workspace entirely:
+to ensure that the secrets are outside the workspace; or choose a different workspace entirely:
 
 [source,java]
 ----


### PR DESCRIPTION
Indentation is removed to make text in between code blocks into the Paragraphs instead of the Literal blocks.