### PR TITLE
[INFRA-607] Pipeline steps documentation update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath "org.ajoberstar:gradle-git:1.2.0"
-        classpath "com.github.jruby-gradle:jruby-gradle-plugin:[1.1.4,2.0)"
+        classpath "com.github.jruby-gradle:jruby-gradle-plugin:[1.3.0,2.0)"
         /*
          * not available on jcenter, only the Gradle plugins portal, this
          * plugin also wasn't published with the proper maven metadata so we
@@ -46,7 +46,7 @@ dependencies {
     /* used for legacy markdown template processing via tilt */
     asciidoctor 'rubygems:kramdown:[1.9.0,2.0)'
     /* contains a number of useful awestruct extensions */
-    asciidoctor 'rubygems:awestruct-ibeams:[0.2.1,1.0)'
+    asciidoctor 'rubygems:awestruct-ibeams:[0.2.1,0.3.0)'
     /* 1.2.0 causes 'C extensions are not supported' error. It's known that
         JRuby's C extensions are deprecated */
     asciidoctor 'rubygems:eventmachine:[1.0, 1.2)'
@@ -55,6 +55,11 @@ dependencies {
      * <https://github.com/guard/listen/pull/377#issuecomment-216241081>
      */
     asciidoctor 'rubygems:listen:3.1.1'
+
+    /* ffi-1.9.13 doesn't seem to like embedded JRuby sub-process invocations
+     * <https://gist.github.com/rtyler/87644f89da7c828c3be2e3b2400c9edb>
+     */
+    asciidoctor 'rubygems:ffi:1.9.10'
 
     /* used for processing haml templates (haml.info) */
     asciidoctor 'rubygems:haml:[4.0.7,5.0)'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath "org.ajoberstar:gradle-git:1.2.0"
-        classpath "com.github.jruby-gradle:jruby-gradle-plugin:[1.3.0,2.0)"
+        classpath "com.github.jruby-gradle:jruby-gradle-plugin:[1.1.4,2.0)"
         /*
          * not available on jcenter, only the Gradle plugins portal, this
          * plugin also wasn't published with the proper maven metadata so we
@@ -32,6 +32,7 @@ description = 'Build for generating jenkins.io'
 version = "2.0.${System.env.BUILD_NUMBER ?: '0'}+${ext.gitRef}"
 defaultTasks 'assemble', 'archive'
 
+
 configurations {
     asciidoctor
     externalFetcher
@@ -45,7 +46,7 @@ dependencies {
     /* used for legacy markdown template processing via tilt */
     asciidoctor 'rubygems:kramdown:[1.9.0,2.0)'
     /* contains a number of useful awestruct extensions */
-    asciidoctor 'rubygems:awestruct-ibeams:[0.2.1,0.3.0)'
+    asciidoctor 'rubygems:awestruct-ibeams:[0.2.1,1.0)'
     /* 1.2.0 causes 'C extensions are not supported' error. It's known that
         JRuby's C extensions are deprecated */
     asciidoctor 'rubygems:eventmachine:[1.0, 1.2)'
@@ -54,11 +55,6 @@ dependencies {
      * <https://github.com/guard/listen/pull/377#issuecomment-216241081>
      */
     asciidoctor 'rubygems:listen:3.1.1'
-
-    /* ffi-1.9.13 doesn't seem to like embedded JRuby sub-process invocations
-     * <https://gist.github.com/rtyler/87644f89da7c828c3be2e3b2400c9edb>
-     */
-    asciidoctor 'rubygems:ffi:1.9.10'
 
     /* used for processing haml templates (haml.info) */
     asciidoctor 'rubygems:haml:[4.0.7,5.0)'
@@ -71,6 +67,10 @@ dependencies {
     /* needed for clean HTTP accesses */
     externalFetcher 'rubygems:faraday:[0.9.2,1.0)'
     externalFetcher 'rubygems:faraday_middleware:[0.9.2,1.0)'
+
+    /* needed for unzipping external resources */
+    externalFetcher 'rubygems:rubyzip:1.2.0'
+
     /* used for running release.rss.groovy */
     externalFetcher localGroovy()
 }

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -8,6 +8,7 @@ require 'faraday'
 require 'faraday_middleware'
 require 'uri'
 require 'yaml'
+require 'zip'
 
 
 RESOURCES = [
@@ -17,17 +18,26 @@ RESOURCES = [
     {
       :layout => 'post',
       :title => 'Changelog',
-    }
+    },
+    nil
   ],
   [
     'https://updates.jenkins.io/latestCore.txt',
     'content/_tmp/latestCore.txt',
+    nil,
     nil
   ],
   [
     'https://updates.jenkins.io/stable/latestCore.txt',
     'content/_tmp/latestLTSCore.txt',
+    nil,
     nil
+  ],
+  [
+    'https://jenkins.ci.cloudbees.com/job/infra/job/PipelineStepsDoc/lastSuccessfulBuild/artifact/allAscii.zip',
+    'content/_tmp/allAscii.zip',
+    nil,
+    'content/doc/pipeline/steps'
   ],
 ]
 
@@ -49,7 +59,7 @@ class Fetcher
   def process(resources)
     failures = []
 
-    resources.each do |origin, destination, frontmatter|
+    resources.each do |origin, destination, frontmatter, zip_dest|
       response = fetch_resource(origin)
 
       unless response.success?
@@ -63,6 +73,17 @@ class Fetcher
           f.write("---\n")
         end
         f.write(response.body)
+      end
+
+      #if downloading a zip file, extract it
+      if origin.include? ".zip"
+        Zip.on_exists_proc = true
+        Zip::File.open(destination) do |zip_file|
+          zip_file.each do |f|
+            fpath = File.join(zip_dest, f.name)
+            zip_file.extract(f, fpath)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Automatically create pipeline step documentation.  This goes out to the PipelineStepsDoc job, and grabs the last successful build artifact for use in the documentation section of the website.  This contains the most recent pipeline step information for the plugins in the Jenkins maven repository.