### PR TITLE
Add mention of StringBinding to use secret text

### DIFF
--- a/content/doc/pipeline/steps/credentials-binding.adoc
+++ b/content/doc/pipeline/steps/credentials-binding.adoc
@@ -82,6 +82,18 @@ node {
   }
 }
 ----
+
+    You can also access secret text credentials:
+    
+[source,java]
+----
+node {
+  withCredentials([[$class: 'StringBinding', credentialsId: 'mytoken', variable: 'TOKEN' ]]) {
+    sh 'use $TOKEN'
+  }
+}
+----
+
 ====
 +bindings+::
 +


### PR DESCRIPTION
The docs only mentioned how to load username and password or secret files and completely omitted secret text. This adds a small section mentioning how to use secret text.