### PR TITLE
Fix broken link

### DIFF
--- a/content/doc/book/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline-as-code.adoc
@@ -258,7 +258,7 @@ Jenkins experience increases, organizations inevitably want to move beyond
 simple pipelines and create complex flows specific to their delivery process.
 
 These Jenkins users require a feature that treats complex pipelines as a
-first-class object, and so the link::https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin[Pipeline
+first-class object, and so the link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin[Pipeline
 plugin] was developed .
 
 ==== Pre-requisites


### PR DESCRIPTION
Link to "Pipeline plugin" had an extra colon that was causing it to 404 to the user