### PR TITLE
Fix ToC for project pages

### DIFF
--- a/content/_layouts/project.html.haml
+++ b/content/_layouts/project.html.haml
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+
+.container
+  .row
+    .col-lg-9
+      %h1
+        = page.title
+      = content
+    .col-lg-3
+      .sidebar-nav
+        %h4 On this page
+        =document.converter.convert document, 'outline'

--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -2,19 +2,13 @@
 layout: default
 ---
 
-:css
-  .row {
-    margin-right: 5em;
-    margin-left: 5em;
-  }
-  .toc {
-      float: right;
-  }
-
-
 .container
-  .row.body
-    %h1
-      = page.title
-
-    = content
+  .row
+    .col-lg-9
+      %h1
+        = page.title
+      = content
+    .col-lg-3
+      .sidebar-nav
+        %h4 On this page
+        =document.converter.convert document, 'outline'

--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -2,13 +2,17 @@
 layout: default
 ---
 
+:css
+  .row {
+    margin-right: 5em;
+    margin-left: 5em;
+  }
+  .toc {
+      float: right;
+  }
 .container
-  .row
-    .col-lg-9
-      %h1
-        = page.title
-      = content
-    .col-lg-3
-      .sidebar-nav
-        %h4 On this page
-        =document.converter.convert document, 'outline'
+  .row.body
+    %h1
+      = page.title
+
+    = content

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1,3 +1,7 @@
+body > .container {
+  margin-top: 60px;
+}
+
 .container.page {
   position: relative
 }
@@ -1546,3 +1550,8 @@ table {
     margin-bottom: 1.25rem;
 }
 
+/** Project page **/
+
+.sidebar-nav h4 {
+  margin-bottom: 1.5rem;
+}

--- a/content/projects/blueocean.adoc
+++ b/content/projects/blueocean.adoc
@@ -1,5 +1,5 @@
 ---
-layout: simplepage
+layout: project
 title: "Blue Ocean"
 section: projects
 ---

--- a/content/projects/blueocean.adoc
+++ b/content/projects/blueocean.adoc
@@ -3,9 +3,6 @@ layout: simplepage
 title: "Blue Ocean"
 section: projects
 ---
-
-:toc:
-
 ++++
 <style>
 .jumbotron.featured {
@@ -18,7 +15,6 @@ section: projects
 }
 </style>
 ++++
-
 TIP: Blue Ocean is now in the Experimental Update Center.
 To install, enable the link:https://jenkins.io/blog/2013/09/23/experimental-plugins-update-center/[experimental update center] and search for "BlueOcean :: UX". Note it is still Alpha.
 Keep an eye out for blogs.
@@ -85,12 +81,12 @@ inviting someone else – in closed source – to do it.
 
 == Exploring the Blue Ocean
 
-Here is a quick tour of Blue Ocean. 
+Here is a quick tour of Blue Ocean.
 
 image:/images/post-images/blueocean/pipeline-activity.png[Pipeline activity, role=center]
 
-Blue Ocean is under heavy development. Watch the mailing lists and repos to keep on top of the latest activity. 
-Some parts you will see are in stages of design, others are already implemented. 
+Blue Ocean is under heavy development. Watch the mailing lists and repos to keep on top of the latest activity.
+Some parts you will see are in stages of design, others are already implemented.
 
 
 === Pipelines
@@ -173,7 +169,7 @@ The source code can be found on Github:
 === How can I try it on my instance?
 
 Blue Ocean is now in the Experimental Update Center.
-To install, enable the link:https://jenkins.io/blog/2013/09/23/experimental-plugins-update-center/[experimental update center] and search for "BlueOcean :: UX". 
+To install, enable the link:https://jenkins.io/blog/2013/09/23/experimental-plugins-update-center/[experimental update center] and search for "BlueOcean :: UX".
 Note it is still Alpha.
 
 === How will Jenkins users consume the Blue Ocean UI?

--- a/content/projects/gsoc.adoc
+++ b/content/projects/gsoc.adoc
@@ -4,8 +4,6 @@ title: "Google Summer of Code"
 section: projects
 ---
 
-:toc:
-
 The link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
 (GSoC) project is an annual, international, program which encourages
 college-aged students to participate with open source projects during the summer

--- a/content/projects/gsoc.adoc
+++ b/content/projects/gsoc.adoc
@@ -1,5 +1,5 @@
 ---
-layout: simplepage
+layout: project
 title: "Google Summer of Code"
 section: projects
 ---

--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -1,5 +1,5 @@
 ---
-layout: simplepage
+layout: project
 title: "Jenkins Sub-projects"
 section: projects
 ---

--- a/content/projects/jam.adoc
+++ b/content/projects/jam.adoc
@@ -1,5 +1,5 @@
 ---
-layout: simplepage
+layout: project
 title: "Jenkins Area Meetups"
 section: projects
 ---

--- a/content/projects/jam.adoc
+++ b/content/projects/jam.adoc
@@ -4,8 +4,6 @@ title: "Jenkins Area Meetups"
 section: projects
 ---
 
-:toc:
-
 Jenkins Area Meetups (JAMs) are local meetups intended to bring Jenkins users
 and contributors together for socializing and learning.
 JAMs are organized by local Jenkins community members who have a passion for
@@ -121,7 +119,7 @@ We also have the link:http://www.meetup.com/Jenkins-online-meetup/[Jenkins Onlin
 * Bangalore, India
 * link:http://www.meetup.com/Delhi-Jenkins-Meetup/[Delhi, India]
 * Hyderabad, India
-* Singapore, Singapore 
+* Singapore, Singapore
 * link:http://www.meetup.com/Tel-Aviv-Jenkins-Area-Meetup/[Tel Aviv, Israel]
 
 === South America
@@ -129,4 +127,3 @@ We also have the link:http://www.meetup.com/Jenkins-online-meetup/[Jenkins Onlin
 * link:http://www.meetup.com/Lima-Jenkins-Area-Meetup/[Lima, Perú]
 
 == Resources
-


### PR DESCRIPTION
This change relies on a release of asciidoctor that contains https://github.com/awestruct/awestruct/pull/517 

Project pages ToCs were screwed up:
![blue ocean 2016-08-30 16-08-11](https://cloud.githubusercontent.com/assets/50156/18077914/f684f7a6-6ecb-11e6-86e3-434573945568.png)

Fixed it by adding a ToC sidebar to `simplepage` templates
![blue ocean 2016-08-30 16-04-12](https://cloud.githubusercontent.com/assets/50156/18077898/e1799470-6ecb-11e6-8517-03f71ef13c6a.png)