### PR TITLE
Support solution page short-links for anything not .html.haml

### DIFF
--- a/content/_ext/solutionpage.rb
+++ b/content/_ext/solutionpage.rb
@@ -11,7 +11,7 @@ class SolutionPage
 
     solutions.each do |solution|
       page = site.engine.load_page(solution.source_path)
-      page.output_path = "/s/#{File.basename(solution.source_path, '.html.haml')}/index.html"
+      page.output_path = "/s/#{File.basename(solution.source_path, File.extname(solution.source_path))}/index.html"
       puts " = Imported solution #{solution.source_path} as #{page.output_path}"
       site.pages << page
     end


### PR DESCRIPTION
This fixes an issue @alyssat noticed with our /s/ruby type URLs no longer
working (404)