### PR TITLE
Remove Jenkins World jumbotron from the home page.

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -6,12 +6,6 @@ homepage: true
 ---
 
 = partial('downloadbanner.html.haml')
-= partial('jumbotron.html.haml',
-  :href => 'http://jenkinsworld.com',
-  :title => 'Register for Jenkins World',
-  :intro => "Join the Jenkins community at \"Jenkins World\" in Santa Clara, California from September 13th - 15th for workshops, presentations and all things Jenkins.",
-  :image => '/images/conferences/jenkinsworld_jumbotron_faded.png',
-  :call_to_action => {:text => 'Learn more', :href => 'http://jenkinsworld.com'})
 = partial('featurelist.html.haml')
 = partial('steps.html.haml', site.steps[:firststart])
 = partial('jumbotron.html.haml',


### PR DESCRIPTION
Jenkins World is over, and the previous jumbotron was "2.0 is here" which is a bit outdated.  So we can live without it until the next special event comes along.

![image](https://cloud.githubusercontent.com/assets/138615/18612058/9ca35804-7d03-11e6-8ede-6d0a88783275.png)
