### PR TITLE
Add link to upgrade guide from changelog.

### DIFF
--- a/content/changelog-stable/index.html
+++ b/content/changelog-stable/index.html
@@ -47,9 +47,11 @@ Legend: <br>
 View ratings below, and click one of the icons next to your version to provide your input.
 </div>
 
-<a href="" onClick="document.getElementById('rc').style.display='block';return false">
-Upcoming changes</a>
 <a href="" style="padding-left:3em" onClick="return loaddata(this)">Community ratings</a>
+
+<div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
+  See our new <a href="/doc/upgrade-guide/">LTS upgrade guide</a> for advice on upgrading Jenkins.
+</div>
 
 
   <div id="rc" style="display:none;">


### PR DESCRIPTION
Style is annoying but intended to be temporary to inform those who
may directly access the changelog and not see the link in the popup.

---

I also removed the 'upcoming changes' link (but kept the hidden div, IIRC the JavaScript needs it to not mess up displaying votes), since we're never populating that for LTS.

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/19063472/7b793628-8a03-11e6-9947-c26fea2bd1c3.png)

@oleg-nenashev @olivergondza @rtyler Please review.
