### PR TITLE
Update overview.adoc

### DIFF
--- a/content/doc/book/pipeline/overview.adoc
+++ b/content/doc/book/pipeline/overview.adoc
@@ -431,8 +431,9 @@ the following, substituting your own name for "joe-user":
   }
 ----
 
-In Windows environments, use `bat` in place of `sh` and use backslashes as the
-file separator where needed (backslashes need to be escaped inside strings).
+In Windows environments, you would use `bat` in place of `sh` and you might
+use backslashes as the file separator where needed (backslashes need to be
+escaped inside strings).
 
 For example, rather than:
 
@@ -447,6 +448,10 @@ you would use:
 ----
 bat "${mvnHome}\\bin\\mvn -B verify"
 ----
+
+However, it's really only DOS that requires backslashes as path separators.  Windows
+can work with backslashes, but it does not require them.  Therefore, the same paths
+using forward slashes should work fine on Windows using the `bat` function.
 
 Your Groovy pipeline script can include functions, conditional tests, loops,
 try/catch/finally blocks, and so on.


### PR DESCRIPTION
Add simpler alternative to escaped backslashes in `bat` description.

Note that I haven't tested this on a Jenkins instance running on Windows, but I know that Java running on Windows is perfectly happy with path references using forward slashes (in properties files, for instance).