### PR TITLE
fix "Seven Habits of ..." link text due to line wrap in source

### DIFF
--- a/content/doc/book/hardware-recommendations.adoc
+++ b/content/doc/book/hardware-recommendations.adoc
@@ -81,9 +81,7 @@ generic the agents, the more easily they are interchanged, which in turn
 allows for a better use of resources and a reduced impact on productivity if
 some agents suffer an outage. Andrew Bayer introduced this concept of
 "fungibility" as applied to agents during his presentation
-http://www.slideshare.net/andrewbayer/seven-habits-of-highly-effective-jenkins-users-2014-edition["Seven
-Habits of Highly Effective Jenkins Users" at the Jenkins User Conference
-(Europe, 2014)].
+http://www.slideshare.net/andrewbayer/seven-habits-of-highly-effective-jenkins-users-2014-edition["Seven Habits of Highly Effective Jenkins Users" at the Jenkins User Conference (Europe, 2014)].
 
 The more automated the environment configuration is, the easier it is to
 replicate a configuration onto a new agent machine. Tools for configuration


### PR DESCRIPTION
I put the really long url and [link text] on a single line so that they would render correctly. Don't know if adoc has a way to do this on multiple lines.