### PR TITLE
Add the [pipeline] block for nicely enumerating either/or/both Declarative and Pipeline Script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ source 'https://rubygems.org'
 # See this section for more:
 #   <https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#advanced-building>
 
+gem 'colorize'
 gem 'awestruct', '~> 0.5.7'
 gem 'awestruct-ibeams', '~> 0.3'
 gem 'asciidoctor', '~> 1.5.5'

--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -32,17 +32,17 @@ Add the following snippet to the `Jenkinsfile` in the project's root directory
 
 === Source code
 
-All source code should use the `[source]` block macro, with the language
-specified in order ensure the code block has its syntax highlighted
-appropriately:
+All source code *except Pipeline source code* should use the `[source]` block
+macro, with the language specified in order ensure the code block has its
+syntax highlighted appropriately:
 
-[source, asciidoc, indent=0]
+[source, asciidoc]
+--
+[source, groovy]
 ----
-    [source, groovy]
-    ----
-    [1, 2, 3].each { println it }
-    ----
+[1, 2, 3].each { println it }
 ----
+--
 
 Becomes:
 
@@ -52,6 +52,46 @@ Becomes:
 ----
 
 
+==== Pipeline code
+
+There is a special AsciiDoctor extension located in
+`lib/asciidoctor/extensions` which adds the `[pipeline]` block for including
+Pipeline code. This block supports both *Declarative Pipeline* and *Pipeline
+Script* syntax. For example:
+
+
+[source, asciidoc]
+--
+[pipeline]
+----
+// Script //
+node {
+    stage('Build') {
+      checkout scm
+      // Install dependencies
+      sh 'npm install'
+    }
+}
+
+// Declarative //
+pipeline {
+    agent docker: 'node:6.3'
+    stages {
+        stage('Build') {
+            sh 'npm install'
+        }
+    }
+}
+----
+--
+
+This `pipeline` block will _prefer_ the Declarative Pipeline syntax when
+rendering, and provide a link for toggling the Pipeline Script.
+
+
+The `// Declarative //` or `// Script //` delimiters are *MANDATORY*, even when
+defining a `[pipeline]` block with only one syntax supported. These delimiters
+instruct the extension on how to render the given code.
 
 == Assorted comments
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ configurations {
 }
 
 dependencies {
+    /* For rendering colored output for warnings/etc */
+    asciidoctor 'rubygems:colorize:[0.8.1,1.0)'
     /* used for primary site generation */
     asciidoctor 'rubygems:awestruct:[0.5.7,0.6)'
     /* ensure we pull in a more recent version of asciidoctor */

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -7,6 +7,11 @@ Dir[File.join(File.dirname(__FILE__), '*.rb')].each do |extension|
   require extension
 end
 
+Dir[File.join(File.dirname(__FILE__), '/../../lib/**/*.rb')].each do |extension|
+  require extension
+end
+
+
 Awestruct::Extensions::Pipeline.new do
   # Register all our blog content under the `site.posts` variable
   extension YearPosts.new('/blog', :posts)

--- a/content/blog/2016/2016-09-19-blueocean-beta-declarative-pipeline-pipeline-editor.adoc
+++ b/content/blog/2016/2016-09-19-blueocean-beta-declarative-pipeline-pipeline-editor.adoc
@@ -50,7 +50,10 @@ you declare how you want your Pipeline to look rather than using Pipeline Script
 
 Here's a small example of a Declarative Pipeline for nodejs that runs the whole
 Pipeline inside a Docker container:
-```
+
+[pipeline]
+----
+// Declarative //
 pipeline {
   agent docker:'node:6.3'
   stages {
@@ -63,7 +66,21 @@ pipeline {
     }
   }
 }
-```
+
+// Script //
+node('docker') {
+  docker.image('node:6.3').inside {
+    stage('build') {
+      sh 'npm --version'
+      sh 'npm install'
+    }
+
+    stage('test') {
+      sh 'npm test'
+    }
+  }
+}
+----
 
 Docker support in Declarative Pipeline allows you to version your application code,
 Jenkins Pipeline configuration, and the environment where your pipeline will run,
@@ -73,7 +90,10 @@ Declarative Pipeline introduces the `postBuild` section that makes it
 easy to run things conditionally at the end of your Pipeline without the
 complexity of the `try... catch` of Pipeline script.
 
-```
+
+[pipeline]
+----
+// Declarative //
 postBuild {
   always {
     sh 'echo "This will always run"'
@@ -93,7 +113,33 @@ postBuild {
     sh 'echo "... or the other way around :)"'
   }
 }
-```
+
+
+// Script //
+node('docker') {
+  try {
+    stage('build') {
+      /* .. snip .. */
+    }
+    stage('test') {
+      /* .. snip .. */
+    }
+
+    sh 'echo "This will run only if successful"'
+  }
+  catch (exc) {
+    if (currentBuild.result == 'UNSTABLE') {
+      sh 'echo "This will run only if the run was marked as unstable"'
+    }
+    if (currentBuild.result == 'FAILURE') {
+      sh 'echo "This will run only if failed"'
+    }
+  }
+  finally {
+    sh 'echo "This will always run"'
+  }
+}
+----
 
 And there is so much more!
 

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1586,3 +1586,12 @@ table {
     height: 4rem;
     text-align: center;
 }
+
+
+.pipeline-block {
+  margin-bottom: 1rem;
+}
+
+.pipeline-script-expand {
+  font-size: 0.7rem;
+}

--- a/lib/asciidoctor/extensions/pipeline-block.rb
+++ b/lib/asciidoctor/extensions/pipeline-block.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+
+require 'asciidoctor/extensions'
+require 'coderay'
+
+Asciidoctor::Extensions.register do
+  block do
+    named :pipeline
+    on_context :listing
+    name_positional_attributes 'format'
+
+    process do |parent, reader, attrs|
+      format = (attrs.delete('format') || '')
+      codelines = reader.lines()
+      script = nil
+      declarative = nil
+
+      # Find where our "// Script" comment is for highlighting the Pipeline
+      # Script syntax
+      script_index = codelines.find_index { |c| c.match(/\/\/ (script) \/\//i) } || -1
+      decl_index = codelines.find_index { |c| c.match(/\/\/ (declarative) \/\//i) } || -1
+
+      # It would be great to re-use the [source] block styling, but it turns
+      # out that our parser is going to delete WHATEVER style attribute we
+      # would give the block if we used #create_listing_block()
+      #
+      # Ouch: <https://github.com/asciidoctor/asciidoctor/blob/master/lib/asciidoctor/parser.rb#L1086-L1087>
+      snippet = ['<div class="pipeline-block">']
+
+      if decl_index >= 0
+        # Default to reading until the end of codelines
+        last_line = -1
+
+        if script_index > decl_index
+          last_line = script_index - 1
+        end
+        declarative = codelines[(decl_index + 1) .. last_line].join("\n").chomp
+        declarative = CodeRay::Duo[:groovy, :html, {:css => :style}].highlight(declarative)
+        snippet << <<-EOF
+<div class="listingblock pipeline-declarative">
+  <div class="title">Jenkinsfile (Declarative Pipeline)</div>
+  <div class="content">
+EOF
+        snippet << <<-EOF
+<pre class="CodeRay highlight nowrap"><code class="language-groovy" data-lang="groovy">#{declarative}</code></pre>
+EOF
+        snippet << '</div></div>'
+      end
+
+      if script_index >= 0
+        # Default to reading until the end of codelines
+        last_line = -1
+
+        # If our decl_index is lower than script_index, that means Declarative
+        # was listed first, so we need to stop short of it
+        if decl_index > script_index
+          last_line = decl_index - 1
+        end
+
+        # Since we have a declarative block, let's show that by default and
+        # hide this but leave a bread-crumb
+        unless declarative.nil?
+          snippet << <<-EOF
+<div class="pipeline-script-expand">
+  <a href="#" onclick="javascript:$(this).parent().siblings('.pipeline-script').toggle(); return false;">Toggle Pipeline Script</a>
+  <em>(Advanced)</em>
+</div>
+EOF
+        end
+
+        script = codelines[(script_index + 1) .. last_line].join("\n").chomp
+        script = CodeRay::Duo[:groovy, :html, {:css => :style}].highlight(script)
+        snippet << <<-EOF
+<div class="listingblock pipeline-script"
+      style="display: #{(declarative.nil? or 'none') or 'inherit'}">
+  <div class="title">Jenkinsfile (Pipeline Script)</div>
+  <div class="content">
+EOF
+        snippet << <<-EOF
+<pre class="CodeRay highlight nowrap"><code class="language-groovy" data-lang="groovy">#{script}</code></pre>
+EOF
+        snippet << '</div></div>'
+      end
+
+      snippet << '</div>'
+
+      create_pass_block(parent, snippet.join(''), attrs)
+    end
+  end
+end

--- a/lib/asciidoctor/extensions/pipeline-block.rb
+++ b/lib/asciidoctor/extensions/pipeline-block.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'colorize'
 require 'asciidoctor/extensions'
 require 'coderay'
 
@@ -83,6 +84,18 @@ EOF
       end
 
       snippet << '</div>'
+
+      # Fortunately Awestruct sets a handy docfile attribute so we can print a
+      # useful warning
+      docfile = parent.document.attributes['docfile']
+
+      if script_index < 0
+        puts "WARNING: [pipeline] block lacks `// Script //` section in #{docfile}".red
+      end
+
+      if decl_index < 0
+        puts "WARNING: [pipeline] block lacks `// Declarative //` section in #{docfile}".red
+      end
 
       create_pass_block(parent, snippet.join(''), attrs)
     end


### PR DESCRIPTION
In use, a documentation and/or blog post author might write:

```asciidoc
[pipeline]
----
// Script //
node {
    stage('Build') {
    checkout scm
    // Install dependencies
    sh 'npm install'
    }
}

// Declarative //
pipeline {
    agent docker: 'node:6.3'
    stages {
        stage('Build') {
            sh 'npm install'
        }
    }
}
----
````


In practice, this renders with preference to Declarative Pipeline, such as this example from @i386's most recent Declarative Pipeline blog post:

![post-build-default](https://cloud.githubusercontent.com/assets/26594/20693449/54c52efe-b593-11e6-9433-6936488c658f.png)

![post-build](https://cloud.githubusercontent.com/assets/26594/20693453/58149874-b593-11e6-8203-f6779be0309b.png)


In the case when only Declarative or Script is available, that will be shown by default.