### PR TITLE
fix: brew install in OS X

### DIFF
--- a/content/doc/book/getting-started/installing.adoc
+++ b/content/doc/book/getting-started/installing.adoc
@@ -110,9 +110,16 @@ To install from the website, using a package:
 
 Jenkins can also be installed using `brew`:
 
+* Install the latest release version
 [source,bash]
 ----
 brew install jenkins
+----
+
+* Install the LTS version
+[source,bash]
+----
+brew install jenkins-lts
 ----
 
 

--- a/content/doc/book/getting-started/installing.adoc
+++ b/content/doc/book/getting-started/installing.adoc
@@ -112,7 +112,7 @@ Jenkins can also be installed using `brew`:
 
 [source,bash]
 ----
-brew cask install jenkins
+brew install jenkins
 ----
 
 


### PR DESCRIPTION
We should use `brew install jenkins` instead of `brew cask install jenkins`. Jenkins is installed by `brew` not `brew cask`.