### PR TITLE
Add support for multiple handbook type structures on `site`

### DIFF
--- a/content/_ext/handbook.rb
+++ b/content/_ext/handbook.rb
@@ -28,13 +28,16 @@ module Awestruct
     end
 
     class HandbookExtension
-      def initialize(book_dir)
+      attr_accessor :name
+
+      def initialize(name, book_dir)
+        @name = name
         @book_dir = book_dir
       end
 
       def execute(site)
-        unless site.handbook
-          site.handbook = Handbook.new(@book_dir)
+        unless site[@name]
+          site[@name] = Handbook.new(@book_dir)
         end
         # We need a map of source files to their Awestruct::Page to avoid
         # re-rendering things too much in the process of generating this page
@@ -71,7 +74,7 @@ module Awestruct
             end
           end
 
-          site.handbook.chapters << chapter
+          site[@name].chapters << chapter
         end
       end
     end

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -34,7 +34,8 @@ Awestruct::Extensions::Pipeline.new do
   extension SolutionPage.new
   extension Releases.new
 
-  extension Awestruct::IBeams::HandbookExtension.new(File.expand_path(File.dirname(__FILE__) + '/../doc/book'))
+  extension Awestruct::IBeams::HandbookExtension.new(:handbook,
+                                                     File.expand_path(File.dirname(__FILE__) + '/../doc/book'))
 
   transformer VersionSwitcher.new
 


### PR DESCRIPTION
To create a new structure, add another extension instance in
`content/_ext/pipeline.rb`, e.g.:

    extension Awestruct::IBeams::HandbookExtension(:devbook, full_path_to_book_dir)