### PR TITLE
Don't use headers for the outline

### DIFF
--- a/content/doc/book/index.html.haml
+++ b/content/doc/book/index.html.haml
@@ -6,16 +6,14 @@ title: "Jenkins Handbook"
 
 %ol
   - site.handbook.chapters.each do |chapter|
-    %li
+    %li{:style => 'font-size: 24px;'}
       %a{:href => chapter.key}
-        %h4
-          = chapter.title
+        = chapter.title
       %ol
         - chapter.sections.each do |section|
-          %li
+          %li{:style => 'font-size: 16px;'}
             %a{:href => File.join(chapter.key, section.key)}
-              %h6
-                = section.title
+              = section.title
 
 .page-link
   %a{:href => '/doc'}


### PR DESCRIPTION
The current outline looks just ridiculously bad, and it also wastes a lot of vertical space. This fixes that.
![before](https://cloud.githubusercontent.com/assets/1831569/20767574/1161b5e8-b73b-11e6-87ee-ee8eb5156fd0.png)
![after](https://cloud.githubusercontent.com/assets/1831569/20767576/14a9bc82-b73b-11e6-9849-5386537e411d.png)

