### PR TITLE
Add inline macro for Javadoc links

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -93,6 +93,23 @@ The `// Declarative //` or `// Script //` delimiters are *MANDATORY*, even when
 defining a `[pipeline]` block with only one syntax supported. These delimiters
 instruct the extension on how to render the given code.
 
+=== Javadoc links
+
+The `javadoc` inline macro can be used to link to the Jenkins Javadoc at http://javadoc.jenkins-ci.org/.
+
+It supports a variety of different syntaxes:
+
+* `javadoc:hudson.scm.SCM[]` links to the full URL for the class.
+* `javadoc:hudson.scm.SCM#all()[]` links to the full URL for the class, and includes a fragment.
+* `javadoc:SCM[]` links to the `/byShortName` URL for the class. Due to the redirect, fragments won't work here.
+
+By default, all of these use the class name as label, but that can be customized if necessary by providing an alternative label between the square brackets.
+
+[source, asciidoc]
+----
+javadoc:hudson.scm.SCM#all()[a list of all known SCM implementations]
+----
+
 == Assorted comments
 
 * Prefer "for example" over "e.g." which can be more clear to non-native english

--- a/lib/asciidoctor/extensions/javadoc-link.rb
+++ b/lib/asciidoctor/extensions/javadoc-link.rb
@@ -1,0 +1,39 @@
+require 'asciidoctor'
+require 'asciidoctor/extensions'
+
+#
+# Usage:
+# javadoc:SCM[]
+# javadoc:SCM[some label]
+# javadoc:hudson.scm.SCM[]
+# javadoc:hudson.scm.SCM[some label]
+# javadoc:hudson.scm.SCM#anchor[]
+# javadoc:hudson.scm.SCM#anchor[some label]
+#
+Asciidoctor::Extensions.register do
+  inline_macro do
+    named :javadoc
+    name_positional_attributes 'label'
+
+    process do |parent, target, attrs|
+
+      classname = label = title = target
+
+      if classname.include? "."
+        classname = classname.gsub(/#.*/, '')
+        classurl = classname.gsub(/\./, '/') + ".html"
+
+        classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '') : ''
+        label = (attrs.has_key? 'label') ? attrs['label'] : classname
+        target = %(http://javadoc.jenkins-ci.org/#{classurl}#{classfrag})
+      else
+        label = (attrs.has_key? 'label') ? attrs['label'] : classname
+        target = %(http://javadoc.jenkins-ci.org/byShortName/#{classname}) 
+      end
+
+      title = %(Javadoc for #{classname})
+
+      (create_anchor parent, label, type: :link, target: target, attributes: {'title' => title}).render
+    end
+  end
+end


### PR DESCRIPTION
- support for short name and full name
- for full names, supports anchors