### PR TITLE
Require American English, mention sentence case for titles

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -128,11 +128,11 @@ structuring can help readers compare and contrast the various options to make
 an informed decision on which path is suitable for them.
 
 
-* Titles should only have the first letter intentionally capitalized. This
-  ensures that casing of articles and prepositions, mixed with proper nouns,
-  doesn't get too confusing. For example:  "Starting a JNLP Agent on Windows"
-  versus "Starting A JNLP Agent On Windows" versus "Starting a JNLP agent on
-  Windows". The latter will result in the most consistent titles
+* Titles should only have the first letter intentionally capitalized ("sentence case").
+  This ensures that casing of articles and prepositions, mixed with proper nouns, doesn't get too confusing.
+  For example: "Starting a JNLP Agent on Windows" versus "Starting A JNLP Agent On Windows" versus "Starting a JNLP agent on Windows".
+  The latter will result in the most consistent titles.
+* Use American English
 * Only proper nouns should be capitalized, for example "Windows." But not
   "Windows Server" unless, of course, you're referring to a product named
   "Windows Server."


### PR DESCRIPTION
And this is why hard line wraps at a specific line length are stupid. It makes additions impossible to diff. Let's please not do that anymore.