### PR TITLE
Implement a simple JAM topic suggestion page

### DIFF
--- a/content/projects/jam/suggest.html.haml
+++ b/content/projects/jam/suggest.html.haml
@@ -1,0 +1,82 @@
+---
+layout: simplepage
+title: Suggest a presentation
+---
+
+:css
+  .row.body {
+    padding-top: 0px;
+  }
+
+:markdown
+  Around the world there are lots of Jenkins Area Meetups which would be
+  interested in hearing your Jenkins story.
+
+  Submit the form below to let various JAM organizers know you are interested!"
+
+%hr/
+
+.input-group-lg
+  %form{:action => 'https://formspree.io/jenkinsci-jam@googlegroups.com',
+        :method => 'POST'}
+
+    .row
+      .col-lg-4
+        .input-group
+          %label{:for => 'Name'}
+            %h4
+              Your name
+          %input.form-control{:type => :text, :name => 'Name',
+            :required => true,
+            :placeholder => 'Mr. Jenkins'}/
+
+      .col-lg-4
+        .input-group
+          %label{:for => 'Reply-To'}
+            %h4
+              Your email
+          %input.form-control{:type => :email, :name => 'Reply-To',
+            :required => true, :placeholder => 'jenkins@example.com'}/
+
+      .col-lg-4
+        .input-group
+          %label{:for => 'Location'}
+            %h4
+              Location
+          %input.form-control{:type => :email, :name => 'Location',
+            :required => true, :placeholder => 'Berlin, Germany'}/
+
+    .row
+      &nbsp;
+
+    .row
+      .col-lg-10
+        .input-group
+          %label{:for => 'Suggested Topic'}
+            %h4
+              Topic suggestion
+          %input.form-control{:type => :text, :name => 'Suggested Topic',
+            :required => true, :placeholder => 'Using Jenkins with This Cool Tech'}/
+
+    .row
+      &nbsp;
+
+
+    .row
+      .col-lg-10
+        .input-group
+          %label{:for => 'Abstract'}
+            %h5
+              Abstract &amp; Bio
+          %textarea.form-control{:name => 'Abstract', :cols => 40, :rows => 6}
+
+    .row
+      &nbsp;
+
+
+    .row
+      .col-lg-8
+        .input-group.input-group-btn
+          %input.btn{:type => :submit, :value => 'Suggest topic'}
+
+%hr/


### PR DESCRIPTION
This was requested by our Events Officer (@alyssat) and I finally got around to
it :)

It's pretty basic for a first revision, depending on how JAM organizers feel
about the page we may see additional changes in short order

![jam-topic-prettier](https://cloud.githubusercontent.com/assets/26594/20851994/5e4826ae-b898-11e6-964e-e02250c90736.png)
