### PR TITLE
Update the handbook navigation to make the "next" link point to the next section or chapter

### DIFF
--- a/content/_layouts/chapter.html.haml
+++ b/content/_layouts/chapter.html.haml
@@ -9,12 +9,16 @@ layout: default
 
   previous_chapter = nil
   next_chapter = nil
+  next_is_section = false
 
   if index > 0
     previous_chapter = site.handbook.chapters[index - 1]
   end
 
-  if index < site.handbook.chapters.size
+  if chapter.sections && chapter.sections.size > 0
+    next_chapter = chapter.sections.first
+    next_is_section = true
+  elsif index < site.handbook.chapters.size
     next_chapter = site.handbook.chapters[index + 1]
   end
 
@@ -31,8 +35,13 @@ layout: default
         Index
 
       - if next_chapter
-        %a.next.page-link{:href =>  File.join('..', next_chapter.key)}
-          #{next_chapter.title} ⇒
+        - if next_is_section
+          %a.next.page-link{:href =>  next_chapter.key}
+            #{next_chapter.title} ⇒
+        - else
+          %a.next.page-link{:href =>  File.join('..', next_chapter.key)}
+            #{next_chapter.title} ⇒
+
 
 
 

--- a/content/_layouts/section.html.haml
+++ b/content/_layouts/section.html.haml
@@ -5,39 +5,51 @@ layout: default
 :ruby
   section_key = File.basename(page.source_path, File.extname(page.source_path))
   chapter_key = File.basename(File.dirname(page.source_path))
-  chapter = site.handbook.chapters.find { |c| c.key == chapter_key }
+  index = site.handbook.chapters.index { |c| c.key == chapter_key }
+  chapter = site.handbook.chapters[index]
 
   our_index = chapter.sections.find_index { |s| s.key == section_key }
   total = chapter.sections.size
+  next_is_chapter = false
 
   # We need to do all this silly arithmetic in order to determine what the
   # indices for the previous and/or next sections in this chapter would be
   prev_section = nil
   if our_index > 0
-    prev_section = our_index - 1
+    prev_section = chapter.sections[our_index - 1]
   end
 
   next_section = nil
   if our_index < (total - 1)
-    next_section = our_index + 1
+    next_section = chapter.sections[our_index + 1]
   end
+
+  # If we're at the end of the chapter, and there's another chapter after us,
+  # let's make the next section the next chapter's index page
+  if next_section.nil? && (index < site.handbook.chapters.size)
+    next_is_chapter = true
+    next_section = site.handbook.chapters[index + 1]
+  end
+
 
 .container
   .row.body
 
     .section_nav.pagination-links
       - unless prev_section.nil?
-        - section = chapter.sections[prev_section]
-        %a.prev.page-link{:href => File.join('..', section.key)}
-          ⇐ #{section.title}
+        %a.prev.page-link{:href => File.join('..', prev_section.key)}
+          ⇐ #{prev_section.title}
 
       %a.up.page-link{:href => '../'}
         ⇑ "#{chapter.title}
 
       - unless next_section.nil?
-        - section = chapter.sections[next_section]
-        %a.next.page-link{:href => File.join('..', section.key)}
-          #{section.title} ⇒
+        - if next_is_chapter
+          %a.next.page-link{:href => File.join('../../', next_section.key)}
+            #{next_section.title} ⇒
+        - else
+          %a.next.page-link{:href => File.join('..', next_section.key)}
+            #{next_section.title} ⇒
 
       %br/
 
@@ -54,17 +66,15 @@ layout: default
 
     .section_nav.pagination-links
       - unless prev_section.nil?
-        - section = chapter.sections[prev_section]
-        %a.prev.page-link{:href => File.join('..', section.key)}
-          ⇐ #{section.title}
+        %a.prev.page-link{:href => File.join('..', prev_section.key)}
+          ⇐ #{prev_section.title}
 
       %a.up.page-link{:href => '../'}
         ⇑ "#{chapter.title}
 
       - unless next_section.nil?
-        - section = chapter.sections[next_section]
-        %a.next.page-link{:href => File.join('..', section.key)}
-          #{section.title} ⇒
+        %a.next.page-link{:href => File.join('..', next_section.key)}
+          #{next_section.title} ⇒
 
       %br/
 


### PR DESCRIPTION
I find it a bit confusing to be on a chapter "index" page and have the
right-arrow navigation link take me to the next chapter. This change makes the
right-arrow link take the reader to the first section.

On the last section in the chapter, the right-arrow becomes the next chapter.

The left-arrow link will always be the previous section (if in the sections) or
the previous chapter (if in the chapter).

This should make it clearer how a reader should navigate through chapters and
sections by just clicking right-arrow, right-arrow, right-arrow


![book-nav](https://cloud.githubusercontent.com/assets/26594/20852835/eaf2feb8-b89c-11e6-8e79-4bf2a9bcfe80.png)
