### PR TITLE
Add ability to define summaries for handbook chapters and sections

### DIFF
--- a/content/_ext/handbook.rb
+++ b/content/_ext/handbook.rb
@@ -5,12 +5,12 @@ module Awestruct
   module IBeams
 
     class Section
-      attr_accessor :title, :file, :asciidoc, :key
+      attr_accessor :title, :file, :asciidoc, :key, :summary
     end
 
     class Chapter
       attr_accessor :sections, :title,
-                    :file, :asciidoc, :key
+                    :file, :asciidoc, :key, :summary
 
       def initialize
         @sections = []
@@ -63,6 +63,7 @@ module Awestruct
           chapter = Chapter.new
           chapter.key = c
           chapter.title = pagemap[overview].title
+          chapter.summary = pagemap[overview].summary
 
           if sections = yaml['sections']
             sections.each do |s|
@@ -70,6 +71,7 @@ module Awestruct
               section.key = s
               full_path = File.join(dir, "#{s}.adoc")
               section.title = pagemap[full_path].title
+              section.summary = pagemap[full_path].summary
               chapter.sections << section
             end
           end

--- a/content/doc/book/index.html.haml
+++ b/content/doc/book/index.html.haml
@@ -9,11 +9,17 @@ title: "Jenkins Handbook"
     %li{:style => 'font-size: 24px;'}
       %a{:href => chapter.key}
         = chapter.title
+      - if chapter.summary
+        %p{:style => 'font-size: 14px;'}
+          = chapter.summary
       %ol
         - chapter.sections.each do |section|
-          %li{:style => 'font-size: 16px;'}
+          %li{:style => 'font-size: 20px;'}
             %a{:href => File.join(chapter.key, section.key)}
               = section.title
+            - if section.summary
+              %p{:style => 'font-size: 14px;'}
+                = section.summary
 
 .page-link
   %a{:href => '/doc'}


### PR DESCRIPTION
Usage:

Add `summary` to the front matter of a chapter or section for the handbook.

Looks like this (content change is not part of the PR -- except the font size change, nothing should change in presentation in this PR):

> ![screen shot 2016-12-05 at 16 57 55](https://cloud.githubusercontent.com/assets/1831569/20891780/1796bc36-bb0c-11e6-85f3-82523b2c2405.png)
