### PR TITLE
When describing classes in a Pipeline Shared Library that have "data" they must be serializable

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -229,7 +229,7 @@ constructor, or just one method:
 [source,groovy]
 ----
 package org.foo
-class Utilities {
+class Utilities implements Serializable {
   def steps
   Utilities(steps) {this.steps = steps}
   def mvn(args) {
@@ -238,7 +238,9 @@ class Utilities {
 }
 ----
 
-Which would be access from Pipeline with:
+When saving state on classes, such as above, the class *must* impmlement the
+`Serializable` interface. This ensures that a Pipeline using the class, as seen
+in the example below, can properly suspend and resume in Jenkins.
 
 [source,groovy]
 ----


### PR DESCRIPTION
Fixes [JENKINS-38868](https://issues.jenkins-ci.org/browse/JENKINS-38868)