### PR TITLE
Add many more terms to the glossary for reference by other chapters in the user handbook

### DIFF
--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -5,15 +5,119 @@ layout: chapter
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
-:toc: left
-:notitle:
+:toc:
+
+////
+XXX: Pages to mark as deprecated by this document:
+      * https://wiki.jenkins-ci.org/display/JENKINS/Terminology
+////
 
 [glossary]
 = Glossary
 
+////
+NOTE: The [glossary] delimiter in AsciiDoctor doesn't autogenerate anchors for
+each of the terms below. Which means that if we want to cross-reference terms
+directly from other documents we need to include an inline anchor.
+
+Additionally, because these inline anchors don't attach to section headings,
+cross referencing must include the appropriate display text, for example:
+
+  MyTerm:: [[myterm]] this is the definition of MyTerm
+
+Should be cross-referenced with:
+
+  <<myterm,MyTerm>>
+
+To ensure it is rendered appropriately.
+////
+
+== General Terms
 
 [glossary]
+Agent::  [[agent]]
+    An agent is typically a machine, or container, which connects to a Jenkins
+    master and executes tasks when directed by the master.
+Artifact:: [[artifact]]
+    An immutable file generated during a <<build,Build>> or <<pipeline,Pipeline>>
+    run which is *archived* onto the Jenkins <<master,Master>> for
+    later retrieval by users.
+Build:: [[build]]
+    Result of a single execution of a <<project,Project>>
+Cloud:: [[cloud]]
+    A System Configuration which provides dynamic <<agent,Agent>>
+    provisioning and allocation, such as that provided by the
+    link:https://plugins.jenkins.io/azure-vm-agents[Azure VM Agents]
+    or
+    link:https://plugins.jenkins.io/ec2[Amazon EC2] plugins.
+Core:: [[core]]
+    The primary Jenkins application (`jenkins.war`) which provides
+    the basic web UI, configuration, and foundation upon which <<plugin, Plugins>>
+    can be built.
+Downstream:: [[downstream]]
+    A configured <<pipeline,Pipeline>> or <<project,Project>> which is triggered
+    as part of the execution of a separate Pipeline or Project.
+Executor:: [[executor]]
+    A slot for execution of work defined by a <<pipeline,Pipeline>> or
+    <<project,Project>> on a <<node, Node>>. A Node may have zero or more
+    Executors configured which corresponds to how many concurrent Projects or
+    Pipelines are able to execute on that Node.
+Fingerprint:: [[fingerprint]]
+    A hash considered globally unique to track the usage of an
+    <<artifact,Artifact>> or other entity across multiple
+    <<pipeline,Pipelines>> or <<project,Projects>>.
+Folder:: [[folder]]
+    An organizational container for <<pipeline,Pipelines>> and/or
+    <<project,Projects>>, similar to folders on a file system.
+Item:: [[item]]
+    An entity in the web UI corresponding to either a:
+    <<folder,Folder>>, <<pipeline,Pipeline>>, or <<project,Project>>.
+Job:: [[job]]
+    A deprecated term, synonymous with <<project,Project>>.
+Master:: [[master]]
+    The central, coordinating process which stores configuration, loads plugins,
+    and renders the various user interfaces for Jenkins.
+Node:: [[node]]
+    A machine which is part of the Jenkins environment and capable
+    of executing <<pipeline,Pipelines>> or <<project,Projects>>. Both the
+    <<master,Master>> and <<agent,Agents>> are considered to be Nodes.
+Project:: [[project]]
+    A user-configured description of work which Jenkins should perform, such as
+    building a piece of software, etc.
+Pipeline:: [[pipeline]]
+    A user-defined model of a continuous delivery pipeline, for more read the
+    <<pipeline#,Pipeline chapter>> in this handbook.
+Plugin:: [[plugin]]
+    An extension to Jenkins functionality provided separately
+    from Jenkins <<core,Core>>.
+Publisher:: [[publisher]]
+    Part of a <<build,Build>> after the completion of all configured
+    <<step,Steps>> which publishes reports, sends notifications, etc.
+Step:: [[step]]
+    A single task; fundamentally steps tell Jenkins _what_ to do inside of a
+    <<pipeline,Pipeline>> or <<project,Project>>.
+Trigger:: [[trigger]]
+    A criteria for triggering a new <<pipeline,Pipeline>> run or
+    <<build,Build>>.
+Upstream:: [[upstream]]
+    A configured <<pipeline,Pipeline>> or <<project,Project>> which triggers a
+    separate Pipeline or Project as part of its execution.
+Workspace:: [[workspace]]
+    A disposable directory on the file system of a <<node,Node>>
+    where work can be done by a <<pipeline,Pipeline>> or <<project,Project>>.
+    Workspaces are typically left in place after a <<build,Build>> or
+    <<pipeline,Pipeline>> run completes unless specific Workspace cleanup policies
+    have been put in place on the Jenkins <<master,Master>>.
 
-Freestyle Job::
-    A Freestyle Job
 
+////
+XXX: It's currently unclear to me (rtyler) whether these merit definition
+
+== Project/Pipeline Status
+
+Aborted:: [[aborted]]
+Failed:: [[failed]]
+Stable:: [[stable]]
+Successful:: [[successful]]
+Unstable:: [[unstable]]
+////


### PR DESCRIPTION
For reference, some of these terms were cleared up (but not all) during the
Jenkins 2 preparation by @orrc:

 * jenkinsci/jenkins#2101
 * jenkinsci/jenkins#2137

I don't expect this to be the complete glossary, but enough to make it easy to
refer to common terms from other chapters