### PR TITLE
[WEBSITE-275] Fix LTS docker link to point to the LTS docker image

### DIFF
--- a/content/_partials/downloadlist.html.haml
+++ b/content/_partials/downloadlist.html.haml
@@ -25,7 +25,7 @@
           \.war
         %button.btn.btn-primary.dropdown-toggle{'data-toggle' => 'dropdown', 'data-trigger' => 'hover', 'aria-haspopup'=>"true", 'aria-expanded'=>"false"}
         .dropdown-menu
-          %a.dropdown-item{:href=>'https://registry.hub.docker.com/u/jenkinsci/jenkins/'}
+          %a.dropdown-item{:href=>'https://registry.hub.docker.com/_/jenkins/'}
             %span.icon
             %span.title
               Docker


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>