### PR TITLE
Correct misspelling in "Pipeline" book topic

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -151,6 +151,6 @@ for more information.
 [[stage]]
 Stage::
     `stage` is a step for defining a conceptually distinct subset of the
-    entire Pipeline, for example: "Build", "Test", and "Deploy", which is tused by many.
+    entire Pipeline, for example: "Build", "Test", and "Deploy", which is used by many
     plugins to visualize or present Jenkins Pipeline status/progress.
     footnoteref:[blueocean,link:/projects/blueocean[Blue Ocean], link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin[Pipeline Stage View plugin]]


### PR DESCRIPTION
Corrected misspelling of "used" and remove oddly placed full stop from the "Stage" term definition of https://jenkins.io/doc/book/pipeline/.

Minor corrections, but given they were featured on a prominent page from jenkins.io, I thought it worth adding this fairly small PR - let me know if you don't normally accept single edits like this.