### PR TITLE
Upgrade to Java 8 - announce the plan

### DIFF
--- a/content/blog/2017/2017-01-17-Jenkins-is-upgrading-to-Java-8.adoc
+++ b/content/blog/2017/2017-01-17-Jenkins-is-upgrading-to-Java-8.adoc
@@ -1,0 +1,41 @@
+---
+layout: post
+title: "Jenkins Upgrades To Java 8"
+tags:
+- java8
+- upgrade
+author: batmat
+---
+
+**In the next few months, Jenkins will require Java 8 as its runtime.**
+
+Back in link:/blog/2016/11/03/2016-11-22-what-jvm-versions-are-running-jenkins-the-return/[last November, we discussed interesting statistics showing that Jenkins was now running Java 8 on a majority of its running instances].
+This was _52.8%_ back then, and now reaching link:http://stats.jenkins.io/plugin-installation-trend/jvms.json[_58%_ two months later].
+If we only look at Jenkins 2.x, then we reach _72%_.
+
+== Timeline
+
+Here is how we plan to roll that baseline upgrade in the next few months.
+
+* Now: Announce the intention publicly.
+* April, 2017: Drop support for Java 7 in Jenkins weekly.
+   With the current rhythm, that means _2.52_ will most likely be the first weekly to require Java 8.
+* June 2017: First LTS version requiring Java 8 is published.
+   This should be something around _2.60.1_.
+
+
+CAUTION: If you are still running Java 7, you will not be able to upgrade to the latest LTS version after some date probably around May 2017.
+
+== Why Upgrade to Java 8
+
+Balancing those numbers with many other criteria:
+
+* Java 7 has been now end-of-lifed for 18+ months
+* People are already moving away from Java 7, as show the numbers
+* Java 8 runtime is known from the field to be more stable
+* Many developers have been wanting to be allowed to leverage the improvements that Java 8 provides to the language and platform
+  (lambdas, Date/Time API... just to name a few).
+  Being also a developer community, we want Jenkins to be appealing to contributors.
+
+
+If you have questions or feedback about this announcement, please feel free to post it to the Jenkins developers mailing list.

--- a/content/blog/2017/2017-01-17-Jenkins-is-upgrading-to-Java-8.adoc
+++ b/content/blog/2017/2017-01-17-Jenkins-is-upgrading-to-Java-8.adoc
@@ -10,8 +10,6 @@ author: batmat
 **In the next few months, Jenkins will require Java 8 as its runtime.**
 
 Back in link:/blog/2016/11/03/2016-11-22-what-jvm-versions-are-running-jenkins-the-return/[last November, we discussed interesting statistics showing that Jenkins was now running Java 8 on a majority of its running instances].
-This was _52.8%_ back then, and now reaching link:http://stats.jenkins.io/plugin-installation-trend/jvms.json[_58%_ two months later].
-If we only look at Jenkins 2.x, then we reach _72%_.
 
 == Timeline
 
@@ -32,6 +30,8 @@ Balancing those numbers with many other criteria:
 
 * Java 7 has been now end-of-lifed for 18+ months
 * People are already moving away from Java 7, as show the numbers
+** _52.8%_ of instances were already running Java 8 back in last November, and now reaching link:http://stats.jenkins.io/plugin-installation-trend/jvms.json[_58%_ two months later].
+** If we only look at Jenkins 2.x, then we reach _72%_.
 * Java 8 runtime is known from the field to be more stable
 * Many developers have been wanting to be allowed to leverage the improvements that Java 8 provides to the language and platform
   (lambdas, Date/Time API... just to name a few).


### PR DESCRIPTION
Now the CI build does run on Windows too, and is back to green, it's time to act on the plan I think.

@olivergondza @kohsuke @daniel-beck @oleg-nenashev @rtyler @slide @orrc @jtnord @jglick 