### PR TITLE
Fix minor typo

### DIFF
--- a/content/doc/book/managing/security.adoc
+++ b/content/doc/book/managing/security.adoc
@@ -315,7 +315,7 @@ Jenkins also manages a file named `gui.conf`, in the `whitelisted-callables.d`
 directory, where commands added via the web UI are written. In order to disable
 the ability of administrators to change whitelisted commands from the web UI,
 place an empty `gui.conf` file in the directory and change its permissions such
-that is is not writeable by the operating system user Jenkins run as.
+that is not writeable by the operating system user Jenkins run as.
 
 ==== File Access Rules
 
@@ -386,7 +386,7 @@ Jenkins also manages `50-gui.conf`, in the `filepath-filters/` directory, where
 File Access Rules added via the web UI are written. In order to disable the
 ability of administrators to change the File Access Rules from the web UI,
 place an empty `50-gui.conf` file in the directory and change its permissions
-such that is is not writeable by the operating system user Jenkins run as.
+such that is not writeable by the operating system user Jenkins run as.
 
 === Disabling
 


### PR DESCRIPTION
duplicate `is` used in security doc.