### PR TITLE
Remove unnecessary ToC layout for the pipeline steps index.

### DIFF
--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -8,7 +8,7 @@ title: "Pipeline Steps Reference"
   The following plugins offer Pipeline-compatible steps.  Each plugin link 
   offers more information about the parameters for each step.
 
-%div.toc
+%div
   %ul
     - sections_from(steps_dir).each do |section, file, url, children|
       %li


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/138615/22048594/4be28f1c-dd2e-11e6-9b3d-51c5277e61de.png)

After:
![image](https://cloud.githubusercontent.com/assets/138615/22048584/3e61e982-dd2e-11e6-9ccf-1819d6c6d96f.png)
