### PR TITLE
corrects the port used in the gradle run task description

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -28,7 +28,7 @@ The easiest way to run the site is with the run task:
     % ./gradlew run
 
 This will host the statically generated site at
-link:localhost:8000[http://localhost:8000]
+link:localhost:4242[http://localhost:4242]
 
 == Editing content
 


### PR DESCRIPTION
CONTRIBUTING.adoc linked to localhost:8000 when describing where the site is hosted, but the gradle run task starts it on 4242