### PR TITLE
hello-world: fix syntax for docker agents

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -36,7 +36,7 @@ various languages.
 ----
 // Declarative //
 pipeline {
-    agent { docker:'maven:3.3.3' }
+    agent { docker 'maven:3.3.3' }
     stages {
         stage('build') {
             steps {
@@ -63,7 +63,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker:'node:6.3' }
+    agent { docker 'node:6.3' }
     stages {
         stage('build') {
             steps {
@@ -90,7 +90,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker: 'ruby' }
+    agent { docker 'ruby' }
     stages {
         stage('build') {
             steps {
@@ -117,7 +117,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker:'python:3.5.1' }
+    agent { docker 'python:3.5.1' }
     stages {
         stage('build') {
             steps {
@@ -144,7 +144,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker: 'php' }
+    agent { docker 'php' }
     stages {
         stage('build') {
             steps {


### PR DESCRIPTION
With the previous version, you get a syntax error when starting the build:

```
WorkflowScript: 2: Expected an agent @ line 2, column 5.
       agent { docker:'maven:3.3.3' }
       ^

WorkflowScript: 2: No agent type specified. Must be one of [docker, dockerfile, label, any, none] @ line 2, column 5.
       agent { docker:'maven:3.3.3' }
       ^

2 errors
```
