### PR TITLE
Remove errant quotation mark in section navigation.

### DIFF
--- a/content/_layouts/section.html.haml
+++ b/content/_layouts/section.html.haml
@@ -42,7 +42,7 @@ notitle: true
           ⇐ #{prev_section.title}
 
       %a.up.page-link{:href => '../'}
-        ⇑ "#{chapter.title}
+        ⇑ #{chapter.title}
 
       - unless next_section.nil?
         - if next_is_chapter
@@ -71,7 +71,7 @@ notitle: true
           ⇐ #{prev_section.title}
 
       %a.up.page-link{:href => '../'}
-        ⇑ "#{chapter.title}
+        ⇑ #{chapter.title}
 
       - unless next_section.nil?
         - if next_is_chapter


### PR DESCRIPTION
After/before:
![image](https://cloud.githubusercontent.com/assets/138615/22625480/714dd360-eb98-11e6-816a-276453fb7fce.png)
