### PR TITLE
Updating landing page to move the Pipeline banner up

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -6,6 +6,12 @@ homepage: true
 ---
 
 = partial('downloadbanner.html.haml')
+= partial('jumbotron.html.haml',
+  :href => '/doc/book/pipeline',
+  :title => 'Pipeline as Code',
+  :intro => 'Pipeline provides an extensible set of tools for modeling simple-to-complex delivery pipelines "as code". Create your first Pipeline and "Jenkinsfile" using the new Declarative Pipeline syntax.',
+  :image => site.solutions[:pipeline].jumbotron.image,
+  :call_to_action => {:text => 'Get Started', :href => '/doc/pipeline/tour/hello-world/'})
 = partial('projectjumbotron.html.haml',
   :href => '/projects/blueocean',
   :title => 'Blue Ocean beta',
@@ -14,12 +20,7 @@ homepage: true
   :call_to_action => {:text => 'Learn more', :href => '/projects/blueocean'})
 = partial('featurelist.html.haml')
 = partial('steps.html.haml', site.steps[:firststart])
-= partial('jumbotron.html.haml',
-  :href => '/doc/book/pipeline',
-  :title => 'Pipeline as Code',
-  :intro => 'Use the Pipeline plugin to describe your continuous delivery pipeline with its flexible domain-specific language',
-  :image => site.solutions[:pipeline].jumbotron.image,
-  :call_to_action => {:text => 'Learn more', :href => '/doc/pipeline/tour/hello-world/'})
+
 
 %div
   .section.events.fff

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -9,7 +9,7 @@ homepage: true
 = partial('jumbotron.html.haml',
   :href => '/doc/book/pipeline',
   :title => 'Pipeline as Code',
-  :intro => 'Pipeline provides an extensible set of tools for modeling simple-to-complex delivery pipelines "as code". Create your first Pipeline and "Jenkinsfile" using the new Declarative Pipeline syntax.',
+  :intro => 'Pipeline provides an extensible set of tools for modeling simple-to-complex continous delivery (CD) pipelines "as code". Create your first Pipeline and "Jenkinsfile" using the new Declarative Pipeline syntax.',
   :image => site.solutions[:pipeline].jumbotron.image,
   :call_to_action => {:text => 'Get Started', :href => '/doc/pipeline/tour/hello-world/'})
 = partial('projectjumbotron.html.haml',


### PR DESCRIPTION
Given the interest in the topic currently, let's move the Pipeline jumbotron banner up to the top and land people on the new docs quicker.

@rtyler 