### PR TITLE
Fix broken Gradle dev task for on-the-fly page generation

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -13,7 +13,19 @@ Ensure you have the latest python and ruby installed using link:http://brew.sh[H
 === Instructions
 
 This project uses link:http://gradle.org[Gradle] to build, so as long as you
-have JDK7 or later in your path, you should be able to build the site with:
+have JDK7 or later in your path, you should be able to run the commands below.
+
+If you're working on content and want to test the site, the easiest way is:
+
+    % ./gradlew dev
+
+This will start the awestruct dev server, which will be available at
+link:localhost:4242[http://localhost:4242].  This generates each page on the fly
+the first time you access it, or after you make a change.  Compilation will take
+a second or two, but this is a lot faster than having to generate the entire
+static site up front.
+
+If you do want to generate the entire site, you can run:
 
     % ./gradlew assemble
 
@@ -22,13 +34,13 @@ link:https://docs.gradle.org/current/userguide/continuous_build.html[continuous
 build] mode, where it will regenerate the site whenever a `.adoc`, `.haml` or
 `.md` file is changed.
 
-
-The easiest way to run the site is with the run task:
+Once you've built the site, the easiest way to test it is with the run task:
 
     % ./gradlew run
 
 This will host the statically generated site at
-link:localhost:4242[http://localhost:4242]
+link:localhost:4242[http://localhost:4242], without any automated re-compilation
+of content.
 
 == Editing content
 
@@ -251,7 +263,3 @@ This requires adding a
 link:http://awestruct.org/profiles/[profile]
  to `content/_config/site.yml` for your fork, and manually operating
  `awestruct`
-
-
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -264,10 +264,13 @@ task run(type:Exec) {
 }
 
 def defineDevTask(name, body) {
-    task(name, type: Exec) {
+    task(name, type: JRubyExec) {
         description "Run in the development mode with live reloading. Point your browser to http://localhost:4242/"
-        workingDir 'content'
-        commandLine 'awestruct', '--dev', '--output-dir', '../build/_site'
+        script 'awestruct'
+        scriptArgs '--dev',
+                   '--source-dir', "${projectDir}/${contentDir}",
+                   '--output-dir', project.ext.siteOutputDir
+        configuration 'asciidoctor'
         body.delegate = delegate
         body()
     }

--- a/content/_config/site.yml
+++ b/content/_config/site.yml
@@ -33,6 +33,10 @@ asciidoctor:
     fragment: ''
     notitle: ''
 profiles:
+  development:
+    # Don't log to GA while working on the site
+    google_analytics:
+      account: UA-000000-0
   hrmpw:
     base_url: https://hrmpw.github.io/jenkins.io/
     deploy:


### PR DESCRIPTION
Running `./gradlew assemble` takes ~forever, so it's nice to run in awestruct dev mode, which will only compile pages that you access (and re-compile if they're changed).