### PR TITLE
[WEBSTITE-306] - Restructure the page

### DIFF
--- a/content/projects/gsoc.adoc
+++ b/content/projects/gsoc.adoc
@@ -7,8 +7,20 @@ tags:
 - gsoc2017
 ---
 
-The link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
-(GSoC) project is an annual, international, program which encourages
+[NOTE]
+====
+This page is about Google Summer of Code (GSoC) 2017.
+Information about the previous year is archived and referenced below.
+
+Preparation is still underway for GSoC 2017; the project has not been accepted yet.
+The list of accepted organizations will be published on **Feb 27**.
+All students are welcome to start project discussions before this date.
+====
+
+== About GSoC
+
+link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
+(GSoC) is an annual, international, program which encourages
 college-aged students to participate with open source projects during the summer
 break between classes. 
 
@@ -19,67 +31,11 @@ In exchange, numerous Jenkins community members volunteer as "mentors"
 for students to help integrate them into the open source community and succeed
 in completing their summer projects.
 
-== 2017 Student Projects
+== Student Application process
 
-[NOTE]
-====
-Preparation is still underway for Google Summer of Code 2017
+=== Application steps
 
-The project has not been accepted to GSoC 2017 yet;
-the list of accepted organizations will be published on **Feb 27**.
-All students are welcome to start project discussions before this date.
-====
-
-=== Project ideas
-
-NOTE: The table below lists the well-defined project ideas, which already have potential mentors.
-Students are eligible to submit any other Jenkins-related ideas though it may be hard to find mentors in particular cases.
-
-.Project Ideas with Mentors
-[frame="topbot",options="header,footer",cols="asciidoc,literal,asciidoc,literal"]
-|======================
-|Title |Area | Description | Potential Mentors
-
-| EDA tool integration plugin
-| Plugins, Hardware Design
-| The idea is to create a Jenkins plugin for one of the widely used Electronic Design Automation (EDA) tools. 
-
-Tools from both ASIC or FPGA design flow are acceptable. 
-We are ready to consider conditionally-free and open-source tools, which would be available to the student and his mentors. 
-
-Prerequisites:
-
-* Basic knowledge of the hardware engineering area
-* Basic knowledge of Java programming language
-* Hands-on experience with the selected EDA tool. 
-In the case of FPGA flows it would be useful to have a prototyping board as well.
-| link:https://github.com/martinda[Martin d'Anjou], link:https://github.com/oleg-nenashev[Oleg Nenashev]
-
-| link:https://wiki.jenkins-ci.org/display/JENKINS/Support+Core+Plugin[Support core plugin] improvements 
-| Plugins
-| It is often difficult for plugins developers to diagnose issues and analyse the user environment.
-
-The link:https://wiki.jenkins-ci.org/display/JENKINS/Support+Core+Plugin[Support Core plugin] allows users to generate a bundle to help on this but it is nowadays rarely used because it is isn't user friendly.
-Various fixes and improvements may help our community a lot. 
-
-Few ideas of new features to add:
-
-* Ease the management of bundles (UI to list, delete, browse, download bundles) - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
-* Bundles will have to be stored in our public JIRA thus it is critical to provide anonymisation of the content by default - link:https://issues.jenkins-ci.org/browse/JENKINS-21670[JENKINS-21670]
-* Submission of bundles in link:https://issues.jenkins-ci.org[our bug tracker] - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
-* etc.
-
-Prerequisites:
-
-* Basic knowledge of Jenkins (as a user)
-* Basic knowledge of Java programming language
-
-| link:https://github.com/alecharp[Adrien Lecharpentier], link:https://github.com/christ66[Steven Christou]
-|======================
-
-=== Application process
-
-1. Check out the project ideas (see above).
+1. Check out the project ideas (see below).
 2. Select an interesting project idea or draft your own proposal.
 3. If you are not familiar with Jenkins, read the introductory info on the website and trying it out with one of your previous projects.
 4. Join the _jenkinsci-dev_ and _jenkinsci-gsoc-all-public_ mailing lists
@@ -104,6 +60,49 @@ It is required for the initial review and feedback collection.
 NOTE: In GSoC we do not hire you in the common sense.
 Please do not **just** send us your CVs or universal cover letters.
 We are mostly interested to understand your interests and your motivation to work in the project.
+
+== Project ideas
+
+Below you can find project ideas proposed by potential mentors.
+Students are eligible to submit any other Jenkins-related ideas though it may be hard to find mentors in particular cases.
+
+=== EDA tool integration plugin
+
+The idea is to create a Jenkins plugin for one of the widely used Electronic Design Automation (EDA) tools. 
+
+Tools from both ASIC or FPGA design flow are acceptable. 
+We are ready to consider conditionally-free and open-source tools, which would be available to the student and his mentors. 
+
+Prerequisites:
+
+* Basic knowledge of the hardware engineering area
+* Basic knowledge of Java programming language
+* Hands-on experience with the selected EDA tool. 
+* In the case of FPGA flows it would be useful to have a prototyping board as well.
+
+Potential mentors: link:https://github.com/martinda[Martin d'Anjou], link:https://github.com/oleg-nenashev[Oleg Nenashev]
+
+=== Support core plugin improvements 
+
+It is often difficult for plugins developers to diagnose issues and analyse the user environment.
+
+The link:https://wiki.jenkins-ci.org/display/JENKINS/Support+Core+Plugin[Support Core plugin] allows users to generate a bundle to help on this but it is nowadays rarely used because it is isn't user friendly.
+Various fixes and improvements may help our community a lot. 
+
+Few ideas of new features to add:
+
+* Ease the management of bundles (UI to list, delete, browse, download bundles) - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
+* Bundles will have to be stored in our public JIRA thus it is critical to provide anonymisation of the content by default - link:https://issues.jenkins-ci.org/browse/JENKINS-21670[JENKINS-21670]
+* Submission of bundles in link:https://issues.jenkins-ci.org[our bug tracker] - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
+* etc.
+
+Prerequisites:
+
+* Basic knowledge of Jenkins (as a user)
+* Basic knowledge of Java programming language
+
+Potential mentors: link:https://github.com/alecharp[Adrien Lecharpentier], link:https://github.com/christ66[Steven Christou]
+
 
 == Getting in touch
 
@@ -169,7 +168,7 @@ Students are expected to...
 0. Produce the good quality code with reasonable amount of testing and documentation
 0. Have a finalized deliverable at the end of the project
 
-Students are not expected to...
+Students are **not** expected to...
 
 0. Strictly follow the originally submitted mini-design and the project proposal
 * The world is not ideal, and there may be unexpected obstacles or shortcuts


### PR DESCRIPTION
The restructuring is required to simplify the layout and to allow referencing particular projects. Tables are also PITA. The new structure also seems to be better:

<img width="333" alt="screen shot 2017-02-06 at 16 29 43" src="https://cloud.githubusercontent.com/assets/3000480/22653416/909c3a44-ec89-11e6-9203-469c9624430a.png">
