### PR TITLE
Change Mercurial version from 2.0.0 to 1.58

### DIFF
--- a/content/blog/2017/2017-02-06-scm-api-2-take2.adoc
+++ b/content/blog/2017/2017-02-06-scm-api-2-take2.adoc
@@ -35,7 +35,7 @@ Git Plugin:: This depends on the exact release line of the Git plugin that you a
 * Following the 2.6.x release line: *2.6.4* or newer
 * Following the 3.0.x release line (_recommended_): *3.0.4* or newer
 
-Mercurial Plugin:: 2.0.0 or newer
+Mercurial Plugin:: 1.58 or newer
 GitHub Branch Source Plugin:: *2.0.1* or newer
 BitBucket Branch Source Plugin:: *2.0.2* or newer
 GitHub Organization Folders Plugin:: 1.6


### PR DESCRIPTION
The post currently shows Mercurial 2.0.0 as the recommended version of Mercurial. The newest available version is 1.58, so maybe we should change to reflect that.