### PR TITLE
Changed tools to support jdk instead of java

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -620,7 +620,7 @@ if `agent none` is specified.
 ===== Supported Tools
 
 maven::
-java::
+jdk::
 gradle::
 
 [[tools-example]]


### PR DESCRIPTION
The tools section doesn't support `java`, it supports `jdk`.
@abayer