### PR TITLE
Add governance document

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -4,31 +4,31 @@ title:  Project Governance Document
 section: project
 ---
 
-h2. Who we are
+== Who we are
 
 The Jenkins project as a community revolves around Jenkins as a piece of software. We are a group of open-source developers and users who develop, use, promote Jenkins, software around Jenkins, and other related activities for our mutual benefit.
 
-The project is affiliated with [Software in the Public Interest|http://www.spi-inc.org/] (SPI), a non-profit organization that provides legal representation and other necessities for running an open-source software project. SPI also acts as our treasury, and legally owns the project assets.
+The project is affiliated with link:http://www.spi-inc.org/[Software in the Public Interest] (SPI), a non-profit organization that provides legal representation and other necessities for running an open-source software project. SPI also acts as our treasury, and legally owns the project assets.
 
-h2. Our Philosophy
+== Our Philosophy
 
-h3. Lower barrier of entry
+=== Lower barrier of entry
 
 We strive for lower barrier of entry to the project. This is partly achieved by not requiring new contributors to “prove themselves” before they are admitted to the committership. Instead, we assume they are good until proven otherwise, and this principle applies to anybody without arbitrary discrimination. We recognize that every contribution is precious, and we recognize that every added process turn away some potential contributors.
 
-The lower barrier of entry is partly achieved by structuring the project to [core|#core], [plugins|#plugins], [modules|#modules], and other independent pieces, thereby reducing the need for collaboration and communication. We try to let everyone have their own turf where they can work efficiently without bogged down by discussions and compromises. We believe everyone has the right to express their idea in their own plugins.
+The lower barrier of entry is partly achieved by structuring the project to core, plugins, modules, and other independent pieces, thereby reducing the need for collaboration and communication. We try to let everyone have their own turf where they can work efficiently without bogged down by discussions and compromises. We believe everyone has the right to express their idea in their own plugins.
 
 The lower barrier of entry is also partly achieved by recognizing that people move on. Lots of code in the project is maintained by people other than the original author. We encourage new contributors to take over existing projects that aren’t actively maintained. We believe that “old” contributors deserve respect from “new” contributors, but the inaction on the part of the original contributors shall not block new contributors from making changes.
 
-h3. Meritocracy
+=== Meritocracy
 
-Our striving to lower barrier of entry doesn’t mean everyone has the equal voice. We value those who contribute more to the project, namely [Meritocracy|https://en.wikipedia.org/wiki/Meritocracy]. Contribution shouldn’t be narrowly interpreted just to code changes, but rather it includes such activities as helping others in the community, doing PR, running infrastructure, and so on.
+Our striving to lower barrier of entry doesn’t mean everyone has the equal voice. We value those who contribute more to the project, namely link:https://en.wikipedia.org/wiki/Meritocracy[Meritocracy]. Contribution shouldn’t be narrowly interpreted just to code changes, but rather it includes such activities as helping others in the community, doing PR, running infrastructure, and so on.
 
-h3. Transparency
+=== Transparency
 
 We believe in running the project transparently. This includes everything from decision-making to defects in the code.
 
-h3. Compatibility matters
+=== Compatibility matters
 
 We recognize that users expect their existing data, accumulated under past versions (including Hudson up to 1.395) to continue working under future versions of Jenkins. This includes jobs configurations, build records, and plugin binaries that they are using. The Jenkins project places high value on maintaining this compatibility, and will be very careful in removing functionality.
 
@@ -36,201 +36,195 @@ To enable the above goal, we also recognize that plugin developers expect APIs a
 
 Because one plugin can depend on another, we expect the same principle from plugins that many other plugins depend on.
 
-h3. Automation
+=== Automation
 
 One of the goals of the Jenkins project is to enable more automation, and we apply the same principle in developing Jenkins. Accordingly, we develop and use a number of daemons, bots, and scripts to perform house-keeping activities and day-to-day operations, we use Jenkins ourselves to run many of those.
 
 This not only frees our time to do more creative work, but it also helps reduce the barrier to entry by reducing the blockage of one developer by another. Plus it has the added benefit of eating our own dogfood.
 
-h2. License
+== License
 
-The Jenkins project uses the [MIT License|http://opensource.org/licenses/MIT] as the primary license of choice, for the code that we develop. Unless otherwise stated, all the code is under the MIT license.
+The Jenkins project uses the link:http://opensource.org/licenses/MIT[MIT License] as the primary license of choice, for the code that we develop. Unless otherwise stated, all the code is under the MIT license.
 
-The [core of Jenkins|https://github.com/jenkinsci/jenkins] is entirely under the MIT license, as is the majority of our [infrastructure code|https://github.com/jenkins-infra] (that runs the project itself), as well as many plugins. We encourage hosted plugins to use the same MIT license, to simplify the story for users, but plugins are free to choose their own licenses, so long as it’s an OSI-approved open-source license.
+The link:https://github.com/jenkinsci/jenkins[core of Jenkins] is entirely under the MIT license, as is the majority of our link:https://github.com/jenkins-infra[infrastructure code] (that runs the project itself), as well as many plugins. We encourage hosted plugins to use the same MIT license, to simplify the story for users, but plugins are free to choose their own licenses, so long as it’s an OSI-approved open-source license.
 
 This is not to be confused with proprietary plugins --- we recognize and encourage plugins that people write on their own for their internal use, without necessarily making the source code available. But no such plugins will be hosted by the Jenkins project.
 
-{anchor:cla}
+[[cla]]
 
-h3. Contributor License Agreement (CLA)
+=== Contributor License Agreement (CLA)
 
 To further clarify the intellectual property rights around the project, we require that core committers sign a contributor agreement. This CLA is the same as Apache's CLA with "Apache" replaced by "SPI". This agreement explicitly assigns a set of rights to SPI, such as the effective joint copyright ownership, patent grant, as well as acknowledging that you have the necessary rights to contribute changes.
 
 The assignment of these rights to SPI helps Jenkins being neutral to any particular vendor, and it'll also make legal departments happy especially in large organizations who want to use Jenkins.
 
-CLAs come in two flavors. Every core contributor needs to sign an Individual CLA (ICLA), and in cases where you as an individual do not own the work you are contributing (such as when your company assigns you to work on Jenkins and therefore your company owns the hard work you produced), the corporation also needs to sign a Corporate CLA (CCLA). See [the discussion in Apache for more details|https://www.apache.org/licenses/#clas]. The CLA forms can be obtained from the following URLs:
+CLAs come in two flavors. Every core contributor needs to sign an Individual CLA (ICLA), and in cases where you as an individual do not own the work you are contributing (such as when your company assigns you to work on Jenkins and therefore your company owns the hard work you produced), the corporation also needs to sign a Corporate CLA (CCLA). See link:https://www.apache.org/licenses/#clas[the discussion in Apache for more details]. The CLA forms can be obtained from the following URLs:
 
-* [ICLA|https://raw.github.com/jenkinsci/infra-cla/approved/icla.txt]
-* [CCLA|https://raw.github.com/jenkinsci/infra-cla/approved/ccla.txt]
+* link:https://raw.github.com/jenkinsci/infra-cla/approved/icla.txt[ICLA]
+* link:https://raw.github.com/jenkinsci/infra-cla/approved/ccla.txt[CCLA]
 
 To balance the additional overhead with the lower barrier to entry, this policy only applies to the core, although we welcome anyone who's willing to submit a CLA for their work on plugins.
 
-Details to submit CLAs are documented in [infra-cla README|https://github.com/jenkinsci/infra-cla/blob/master/README.md].
+Details to submit CLAs are documented in link:https://github.com/jenkinsci/infra-cla/blob/master/README.md[infra-cla README].
 
-h3. 3rd party library licenses in the core
+=== 3rd party library licenses in the core
 
 The Jenkins project depends heavily on 3rd party libraries. We believe it's better to reuse what we can than to reinvent, so that our precious resources can be spent elsewhere.
 
-Jenkins as a whole needs to be an open-source project, so we've been restricting ourselves to only use 3rd party libraries that are [OSI-approved open-source licenses|http://www.opensource.org/] (such as Apache Software License, BSD license, MIT license, Eclipse Public License, and Lesser GNU Public License.) In addition, to keep the core reusable for the widest possible use cases, we refuse so-called [copyleft licenses|http://en.wikipedia.org/wiki/Copyleft] that restrict the overall license to a specific license (such as GNU Public License.) To that end, we designated the following licenses as approved licenses that we can depend on. Additional licenses are subject to the approval by the board:
+Jenkins as a whole needs to be an open-source project, so we've been restricting ourselves to only use 3rd party libraries that are link:http://www.opensource.org/[OSI-approved open-source licenses] (such as Apache Software License, BSD license, MIT license, Eclipse Public License, and Lesser GNU Public License.) In addition, to keep the core reusable for the widest possible use cases, we refuse so-called link:http://en.wikipedia.org/wiki/Copyleft[copyleft licenses] that restrict the overall license to a specific license (such as GNU Public License.) To that end, we designated the following licenses as approved licenses that we can depend on. Additional licenses are subject to the approval by the board:
 
-* [Apache Software License|http://www.apache.org/licenses/]
-* [BSD license|http://opensource.org/licenses/bsd-license.php], [MIT license|http://opensource.org/licenses/mit-license.php]
-* [W3C software license|http://opensource.org/licenses/W3C.php]
-* [CDDL|http://opensource.org/licenses/cddl1.php], [CPL|http://opensource.org/licenses/cpl1.0.php], [EPL|http://opensource.org/licenses/eclipse-1.0.php], and [MPL|http://opensource.org/licenses/mozilla1.0.php], and [LGPL|http://opensource.org/licenses/lgpl-license.php] (these licenses require that derivative works to be under the same license as the original license, so the source code needs to be separated into its own repository, but binaries can be used as dependencies to the core.)
+* link:http://www.apache.org/licenses/[Apache Software License]
+* link:http://opensource.org/licenses/bsd-license.php[BSD license], link:http://opensource.org/licenses/mit-license.php[MIT license]
+* link:http://opensource.org/licenses/W3C.php[W3C software license]
+* link:http://opensource.org/licenses/cddl1.php[CDDL], link:http://opensource.org/licenses/cpl1.0.php[CPL], link:http://opensource.org/licenses/eclipse-1.0.php[EPL], and link:http://opensource.org/licenses/mozilla1.0.php[MPL], and link:http://opensource.org/licenses/lgpl-license.php[LGPL] (these licenses require that derivative works to be under the same license as the original license, so the source code needs to be separated into its own repository, but binaries can be used as dependencies to the core.)
 
-In core, the build process ensure that all the licenses of the dependency libraries are accounted for. In other words, we require that dependency POMs declare their own licenses in the Maven way, or use [the license completion script|https://github.com/jenkinsci/jenkins/blob/master/licenseCompleter.groovy] to supply one where the POM is missing that information. The completion script is also used in case the library is dual-licensed to pick a specific license. This is done so that the summary list of the 3rd party library licenses do not include copy-left licenses.
+In core, the build process ensure that all the licenses of the dependency libraries are accounted for. In other words, we require that dependency POMs declare their own licenses in the Maven way, or use link:https://github.com/jenkinsci/jenkins/blob/master/licenseCompleter.groovy[the license completion script] to supply one where the POM is missing that information. The completion script is also used in case the library is dual-licensed to pick a specific license. This is done so that the summary list of the 3rd party library licenses do not include copy-left licenses.
 
-The result is packaged into the core and is visible from [within the application itself|https://ci.jenkins-ci.org/about]. It is also available in the XML format inside the war file.
+The result is packaged into the core and is visible from link:https://ci.jenkins-ci.org/about[within the application itself]. It is also available in the XML format inside the war file.
 
-h3. 3rd party library licenses in the plugins
+=== 3rd party library licenses in the plugins
 
 Plugins do not necessarily follow the same formality when it comes to the 3rd party license policy. They obviously need to honor the licenses of the libraries they use, but for example they need not run the same license completion scheme that the core uses.
 
-We encourage plugins to follow the same 3rd party license policy as the core. You may vary from it at your own risk. For example, see [FSF's opinion about GPL plugins with a non-GPL core|https://www.gnu.org/licenses/gpl-faq.html#NFUseGPLPlugins].
+We encourage plugins to follow the same 3rd party license policy as the core. You may vary from it at your own risk. For example, see link:https://www.gnu.org/licenses/gpl-faq.html#NFUseGPLPlugins[FSF's opinion about GPL plugins with a non-GPL core].
 
-h2. Trademark
+== Trademark
 
-The name "Jenkins" is a registered trademark in the USA ([\#4664929|https://trademarks.justia.com/854/47/jenkins-85447465.html], held by SPI) in order to protect the project and users from confusing use of the term. To reduce the process overhead and uphold our open-source spirit, we adopt the Linux kernel policy on trademark usage.
+The name "Jenkins" is a registered trademark in the USA (link:https://trademarks.justia.com/854/47/jenkins-85447465.html[#4664929], held by SPI) in order to protect the project and users from confusing use of the term. To reduce the process overhead and uphold our open-source spirit, we adopt the Linux kernel policy on trademark usage.
 
-You need to apply for a [sublicense|Trademark Sublicense] if you are using the term "Jenkins" as part of your own trademark or brand identifier for Jenkins-based software goods or services. It doesn’t matter if your trademark is unregistered, or if you do not plan to make any money using the mark.
+You need to apply for a link:https://wiki.jenkins-ci.org/display/JENKINS/Trademark+Sublicense[sublicense] if you are using the term "Jenkins" as part of your own trademark or brand identifier for Jenkins-based software goods or services. It doesn’t matter if your trademark is unregistered, or if you do not plan to make any money using the mark.
 
 Answering the following questions (which break out each of the key issues) may help you determine if you need a sublicense. If you are still in doubt, please contact the board and we will work with you to determine whether you need to apply for a sublicense.
 
 If the answer to all three of the following questions is "yes," then you need to apply for a sublicense. If the answer to any of these questions is "no," then you do not need to apply for a sublicense.
 
-# Is my mark a trademark (see how Linux Foundation define "trademark" in [FAQ|http://www.linuxfoundation.org/programs/legal/trademark/faq])?
-# Does my mark contain the following string of adjacent letters, in this order: "Jenkins"? These letters may or may not be capitalized, and in the case of foreign characters, phonetic translations also apply.
-# Do I use my mark to identify software-related goods or services (see how that phrase is [defined|http://www.linuxfoundation.org/programs/legal/trademark/faq] again in LF)?
+- Is my mark a trademark (see how Linux Foundation define "trademark" in link:http://www.linuxfoundation.org/programs/legal/trademark/faq[FAQ])?
+- Does my mark contain the following string of adjacent letters, in this order: "Jenkins"? These letters may or may not be capitalized, and in the case of foreign characters, phonetic translations also apply.
+- Do I use my mark to identify software-related goods or services (see how that phrase is link:http://www.linuxfoundation.org/programs/legal/trademark/faq[defined] again in LF)?
 
-A list of trademark usages approved by the project can be found on the [Approved Trademark Usage] page.
+A list of trademark usages approved by the project can be found on the link:https://wiki.jenkins-ci.org/display/JENKINS/Approved+Trademark+Usage[Approved Trademark Usage] page.
 
-h2. Project roles/stakeholders
+== Project roles/stakeholders
 
-{anchor:board}
-
-h3. Governance board
+=== Governance board
 
 The governance board consists of three people who act as public representatives of the project, when such representation is necessary, for example to interface external entities such as SPI.
 
 The board also acts as the ultimate decision-making authority in case disputes cannot be resolved via the regular project community meeting. The decision-making ability of the board is more symbolic and honorific, and it “rules” like British queens rather than a dictatorship.
 
-The [Governance Board] page provides further information, including a list of current board members, and how to contact the board.
+The link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance Board] page provides further information, including a list of current board members, and how to contact the board.
 
-The process by which the [Governance Board] is elected can be reviewed in the [Board Election Process]
+The process by which the Governance Board is elected can be reviewed in the link:https://wiki.jenkins-ci.org/display/JENKINS/Board+Election+Process[Board Election Process]
 
 
-h3. Infrastructure admins
+=== Infrastructure admins
 
-Infrastructure administrators have root access to the various servers and build slaves that run {{jenkins-ci.org}} and other sub-domains. They keep those servers up and running, installing new software, coordinating mirrors, handling keys and certificates, and making sure that we can keep churning out code.
+Infrastructure administrators have root access to the various servers and build slaves that run +jenkins-ci.org+ and other sub-domains. They keep those servers up and running, installing new software, coordinating mirrors, handling keys and certificates, and making sure that we can keep churning out code.
 
 Because of the sensitive nature of this work, infrastructure admins are by invitation only, and some of the activity happen behind closed doors. Infrastructure admins often appoint others to delegate some partial access to the system to complete some tasks.
 
-A list of admins of some of the public infrastructure components can be found here: [Infrastructure Admins]
+A list of admins of some of the public infrastructure components can be found here: link:https://wiki.jenkins-ci.org/display/JENKINS/Infrastructure+Admins[Infrastructure Admins]
 
 
-h3. Core committers
+=== Core committers
 
-Core committers are those who have push access to [the main Jenkins repository|https://github.com/jenkinsci/jenkins] that produces {{jenkins.war}}. To become a core committer, one needs to sign the [contributor license agreement|#cla]. One is not required to have a proven history of contributions before being granted commit access, but that doesn’t mean other core committers will never revert your changes.
+Core committers are those who have push access to link:https://github.com/jenkinsci/jenkins[the main Jenkins repository] that produces +jenkins.war+. To become a core committer, one needs to sign the <<cla,contributor license agreement>>. One is not required to have a proven history of contributions before being granted commit access, but that doesn’t mean other core committers will never revert your changes.
 
-The list of CLA signers is be maintained here: [https://github.com/jenkinsci/infra-cla]
+The list of CLA signers is be maintained here: https://github.com/jenkinsci/infra-cla
 
 
-h3. Plugin committers
+=== Plugin committers
 
 Plugin committers are those who have push access to specific plugin repositories hosted under the jenkinsci GitHub organization. One is not required to have a proven history of contributions before being granted commit access. All you have to do is to ask. But that doesn’t mean other existing committers will never revert your changes.
 
-h3. Localization contributors
+=== Localization contributors
 
 Localization contributors have push access to both the core and hosted plugins. They make localization/internationalization related changes to the code and resources, and they push those changes without seeking approval from the core/plugin committers.
 
-h3. Users
+=== Users
 
 Users use Jenkins and its plugins. They contribute to the project by providing feedback, filing bug reports, prioritizing features and fixes for developers, helping other users, and making committers feel like their work is worth while.
 
-h2. Communication
+== Communication
 
 The communication among people in the community is crucial to the oneness of the project. People in the Jenkins project communicates with each other in several different places.
 
-h3. Mailing lists
+=== Mailing lists
 
-We encourage mailing lists as the primary means of developer & user discussion, because of their asynchrony and ability to search the archive. The project website lists [the active mailing lists and their purposes|https://jenkins-ci.org/content/mailing-lists].
+We encourage mailing lists as the primary means of developer & user discussion, because of their asynchrony and ability to search the archive. The project website lists link:https://jenkins-ci.org/content/mailing-lists[the active mailing lists and their purposes].
 
-h3. IRC
+=== IRC
 
-Jenkins project uses [an IRC channel|https://jenkins-ci.org/content/chat] for real time interactive communications. This is also the place where active members bond with each other.
+Jenkins project uses link:https://jenkins-ci.org/content/chat[an IRC channel] for real time interactive communications. This is also the place where active members bond with each other.
 
-h3. Twitter
+=== Twitter
 
-[@jenkinsci|https://twitter.com/jenkinsci] is the official Twitter account of the Jenkins project, run by the infrastructure admins.
+link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account of the Jenkins project, run by the infrastructure admins.
 
-h2. Infrastructure
+== Infrastructure
 
-h3. Source code
+=== Source code
 
-The [GitHub JenkinsCI organization|https://github.com/jenkinsci/] is where we host most of our code (see [the list of repositories|https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have [the subversion repository|https://svn.jenkins-ci.org/] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
+The link:https://github.com/jenkinsci/[GitHub JenkinsCI organization] is where we host most of our code (see link:https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Repositories[the list of repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have link:https://svn.jenkins-ci.org/[the subversion repository] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
 
-To aid classifying our 1000\+ Git repositories, some naming conventions have been adopted:
+To aid classifying our 1000+ Git repositories, some naming conventions have been adopted:
 
 * plugins are named "*-plugin"
 * libraries are named "lib-*"
 * backend infrastructure programs are named "backend-*"
 
-To encourage migration of plugins from Subversion to Git, a daemon is used to mirror plugins individually to GitHub. See [this page|Moving from Subversion (svn) to Github] for more about how to migrate your plugin to GitHub.
+To encourage migration of plugins from Subversion to Git, a daemon is used to mirror plugins individually to GitHub. See link:https://wiki.jenkins-ci.org/display/JENKINS/Moving+from+Subversion+%28svn%29+to+Github[this page] for more about how to migrate your plugin to GitHub.
 
-h3. User Accounts
+=== User Accounts
 
-The infrastructure admins run an LDAP server and [a small frontend program|https://jenkins-ci.org/account] to let users create accounts on jenkins-ci.org. This account is used for all the software that we run ourselves.
+The infrastructure admins run an LDAP server and link:https://jenkins-ci.org/account[a small frontend program] to let users create accounts on jenkins-ci.org. This account is used for all the software that we run ourselves.
 
-h3. Wiki
+=== Wiki
 
 This wiki that you are reading is our primary collaboration mechanism for documentation. This uses the LDAP server described above for access.
 
-h3. Bug tracker
+=== Bug tracker
 
-[Our primary bug tracker|https://issues.jenkins-ci.org/] is maintained by the infra admins. This uses the LDAP server described above for access.
+link:https://issues.jenkins-ci.org/[Our primary bug tracker] is maintained by the infra admins. This uses the LDAP server described above for access.
 
-h3. Jenkins on Jenkins
+=== Jenkins on Jenkins
 
-We [run Jenkins for our own development|https://ci.jenkins-ci.org/] and to automate various infrastructure tasks. Because of the sensitive nature of setting up jobs, only the infra admins have full write access.
+We link:https://ci.jenkins-ci.org/[run Jenkins for our own development] and to automate various infrastructure tasks. Because of the sensitive nature of setting up jobs, only the infra admins have full write access.
 
-h2. Decision making
+== Decision making
 
-Jenkins project uses [biweekly project meetings|Governance Meeting Agenda] as the primary forum of decision making for matters that need consensus. The meeting is open to anyone, and the [minutes are public|http://meetings.jenkins-ci.org/jenkins/]. Agenda items can be added by anyone by simply updating the Wiki page with your name.
+Jenkins project uses link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda[biweekly project meetings] as the primary forum of decision making for matters that need consensus. The meeting is open to anyone, and the link:http://meetings.jenkins-ci.org/jenkins/[minutes are public]. Agenda items can be added by anyone by simply updating the Wiki page with your name.
 
 The board serves as the ultimate decision-making body in case the project meeting fails to reach a consensus on a particular topic.
 
-h2. How we develop code
+== How we develop code
 
-{anchor:core}
+=== Core
 
-h3. Core
-
-The core refers to a set of code and libraries that result in the {{jenkins.war}} binary. [The official core repository|https://github.com/jenkinsci/jenkins] is hosted on GitHub.
+The core refers to a set of code and libraries that result in the +jenkins.war+ binary. link:https://github.com/jenkinsci/jenkins[The official core repository] is hosted on GitHub.
 
 Long time committers push changes directly into this repository, although other core committers can still revert their changes and discuss them when they feel that is necessary. New committers can also do the same when they feel good about their changes, or if the changes are trivial.
 
-Committers old and new who feel their changes need review use [GitHub pull requests|https://github.com/jenkinsci/jenkins/pulls] as a way to solicit feedback. People without commit access also use pull requests to get their changes into the core. Core committers are expected to be attentive to pending pull requests, and try to act on them quickly.
+Committers old and new who feel their changes need review use link:https://github.com/jenkinsci/jenkins/pulls[GitHub pull requests] as a way to solicit feedback. People without commit access also use pull requests to get their changes into the core. Core committers are expected to be attentive to pending pull requests, and try to act on them quickly.
 
 Core committers generally use their own judgement to decide what to work on.
 
-h3. Releases
+=== Releases
 
-Every weekend a new release is built from the master branch and released, in various forms, including {{jenkins.war}} and native packages. This allows us to get new features and bug fixes into the hands of users relatively quickly.
+Every weekend a new release is built from the master branch and released, in various forms, including +jenkins.war+ and native packages. This allows us to get new features and bug fixes into the hands of users relatively quickly.
 
-h3. LTS Releases
+=== LTS Releases
 
-Every three months or so we pick a prior release as the new long-term support (LTS) release and then create the ‘stable’ branch, from that release point. This branch gets important bug fixes backported from the master branch, and further patch releases are built roughly every two weeks until the next LTS baseline is chosen. See [LTS Release Line] for more details.
+Every three months or so we pick a prior release as the new long-term support (LTS) release and then create the ‘stable’ branch, from that release point. This branch gets important bug fixes backported from the master branch, and further patch releases are built roughly every two weeks until the next LTS baseline is chosen. See link:https://wiki.jenkins-ci.org/JENKINS/LTS+Release+Line[LTS Release Line] for more details.
 
-h3. Core Coding Convention
+=== Core Coding Convention
 
-We roughly follow [Sun coding convention|http://www.oracle.com/technetwork/java/codeconvtoc-136057.html] in the source code, and we use 4 space indentation and don’t use tabs. It's generally more practical and appreciated if you submit changes that don't change the code format too much as it eases the coding review job. Try submitting formatting changes and functional changes in separate commits.
+We roughly follow link:http://www.oracle.com/technetwork/java/codeconvtoc-136057.html[Sun coding convention] in the source code, and we use 4 space indentation and don’t use tabs. It's generally more practical and appreciated if you submit changes that don't change the code format too much as it eases the coding review job. Try submitting formatting changes and functional changes in separate commits.
 
 With that said, we do not believe in rigorously enforcing coding convention, and we don’t want to turn down contributions because their code format doesn’t match what we use. So consider this informational.
 
 
-{anchor:plugins}
-
-h3. Plugins
+=== Plugins
 
 Plugins are developed autonomously by the people working on the plugin. Each gets its own repository, its own Jenkins-on-Jenkins job, its own bug tracker component, and maintain their own release schedules.
 
@@ -240,25 +234,23 @@ Since much of such local culture is implicit, it's often difficult to tell from 
 
 Maintainer information should be listed in the info box of the plugin's wiki page. If you have trouble figuring out who to contact, the good fallback option is the developers' mailing list.
 
-h3. Plugin Wiki Page
+=== Plugin Wiki Page
 
-Each plugin has its own Wiki page in {{[https://wiki.jenkins-ci.org/]}}, such as [this|Git plugin]. Plugin wiki pages should the macro that produces the stock header table, describing what the plugin does, along with the release history / changelog. Take a look at some plugin wiki pages as a guideline of what you should do.
+Each plugin has its own Wiki page in https://wiki.jenkins-ci.org/, such as link:https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin[this]. Plugin wiki pages should the macro that produces the stock header table, describing what the plugin does, along with the release history / changelog. Take a look at some plugin wiki pages as a guideline of what you should do.
 
 These wiki pages are referenced from the update center built in to Jenkins, and they are the primary means through which users discover information about plugins.
 
-{anchor:modules}
+=== Modules
 
-h3. Modules
-
-Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in {{WEB-INF/lib}} and therefore it behaves as if it's a part of the core from the users' point of view. Modules can be thought of as something in between a library and a plugin. It has its own POM, a set of source code, and built separately, like a library, but it gets the same compile-time processing as plugins do.
+Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in +WEB-INF/lib+ and therefore it behaves as if it's a part of the core from the users' point of view. Modules can be thought of as something in between a library and a plugin. It has its own POM, a set of source code, and built separately, like a library, but it gets the same compile-time processing as plugins do.
 
 This assists splitting a big hair ball (that is the core) into more manageable smaller pieces, and allow OEMs to add/remove functionalities separately.
 
-h3. Commit guidelines
+=== Commit guidelines
 
-See [the pull request checklist|#pull-request] for guidelines on submitting code to Jenkins.
+See <<pull-request,the pull request checklist>> for guidelines on submitting code to Jenkins.
 
-h3. Copying code from elsewhere
+=== Copying code from elsewhere
 
 When you have a license to do so, and when that license is compatible with the MIT license, you can copy the code from elsewhere into Jenkins.
 
@@ -268,7 +260,7 @@ The code to be copied must be clearly marked with the license it is under, and w
 
 In particular, this means we can copy Oracle Hudson's source code under the MIT license, but not Eclipse Hudson's source code under EPL.
 
-h3. Locally patching dependencies
+=== Locally patching dependencies
 
 Sometimes, it is necessary to make bug fixes and changes in the libraries that we use. Where the library is significant to Jenkins and the impact is considerable to our users, we choose to maintain local patch sets to upstream libraries, just like Linux distributions maintain such patches for its packages.
 
@@ -276,19 +268,19 @@ We normally intend such local patches to be integrated into upstream, so we file
 
 In some cases, the supposed "temporary" patch sets became more permanent for various reasons beyond our control, such as the ceased development in the upstream, but that's only because that's how it turned out, not because we intended it at the outset. With the distributed version control system, maintaining parallel patch release for Jenkins isn't as hard as it used to be.
 
-h2. How to join the project
+== How to join the project
 
-h3. Bringing in new plugins/tools/libraries
+=== Bringing in new plugins/tools/libraries
 
-If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See [Hosting Plugins] for more details.
+If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See link:https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins[Hosting Plugins] for more details.
 
-h3. Making changes to existing plugins
+=== Making changes to existing plugins
 
-If you are interested in just making a small number of changes without an intent to stay. It’s the easiest to send in pull requests through GitHub. See [using pull requests|#pull-request] for more details. If your pull requests are not getting timely attention, please ping us via the developers' mailing list, so that we can resolve that.
+If you are interested in just making a small number of changes without an intent to stay. It’s the easiest to send in pull requests through GitHub. See <<pull-request,using pull requests>> for more details. If your pull requests are not getting timely attention, please ping us via the developers' mailing list, so that we can resolve that.
 
 If you’d like to be involved more seriously, in addition to the pull request, we encourage you to consider becoming a committer. Drop us a note in the IRC channel or the dev list, and we’ll set you up with commit access. Try to be courteous to existing developers by sending them heads-up and coordinating with them, but if they aren’t responding, don’t let that block your progress. The seniority of the developers are earned through on-going participation.
 
-h3. Helping and taking over dormant plugins
+=== Helping and taking over dormant plugins
 
 It is often the case that the original developer moves onto other things once the plugin becomes good enough for them (or if the original author changes the job and no longer has incentive to work on the technology.) So we encourage new developers or developers of different plugin to pitch in on other plugins’ pending pull requests or work on issues filed against them.
 
@@ -296,33 +288,33 @@ To that end, we also encourage people to pick up dormant plugins and consider th
 
 Many less active plugins do not really have any obvious owner, and they are collaboratively maintained by people making small changes and releasing them whenever the need arises. If in doubt, ask on the dev list.
 
-h3. Making changes to core
+=== Making changes to core
 
-If you are interested in just making small changes without an intent to stay, the same process applies as plugins, described above. However, because core changes affect larger number of people, we’d be grateful if you’d try to go extra distance on the notes described in [using pull requests|#pull-request].
+If you are interested in just making small changes without an intent to stay, the same process applies as plugins, described above. However, because core changes affect larger number of people, we’d be grateful if you’d try to go extra distance on the notes described in <<pull-request,using pull requests>>.
 
-If you’d like to be involved more seriously, consider getting commit access. See the section about becoming a plugin developer for how to get this. In addition, we need to ask you to [sign the contributor license agreement|#cla] (CLA).
+If you’d like to be involved more seriously, consider getting commit access. See the section about becoming a plugin developer for how to get this. In addition, we need to ask you to <<cla,sign the contributor license agreement>> (CLA).
 
 When making changes, use your common sense. For example, if you are thinking about making a big change, it is recommended that you discuss your changes with the developers upfront. Or if you see that the part you’d like to work on has been actively modified by others, give them a heads-up.
 
-h3. Contributing localizations
+=== Contributing localizations
 
-We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see [Internationalization] for the details of how to make changes.
+We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see link:https://wiki.jenkins-ci.org/display/JENKINS/Internationalization[Internationalization] for the details of how to make changes.
 
-{anchor:pull-request}
+[[pull-request]]
 
-h3. Using pull requests
+=== Using pull requests
 
 As discussed above, Jenkins project uses pull requests as one of the main workflow to get the changes in. When you prepare your pull request, consider the following checklist as the best practice.
 
-* See [the github online help|https://help.github.com/articles/creating-a-pull-request/] for how to create a pull request
-* We encourage you to file a ticket in [the issue tracker|https://issues.jenkins-ci.org/] to describe the bug that you are fixing or the feature you are implementing. This creates a permanent record on our system that allows future developers to understand how the code came into the current shape. This is not a requirement (especially for small changes), but we appreciate if you do that.
-* Refer to the ticket in your commit message by using the notation {{\[JENKINS-1234\]}} where JENKINS-1234 is the ticket ID. This allows our scripts to understand the history and generate changelogs without human help. If you use the notation {{\[FIX JENKINS-1234\]}}, our bot will close the ticket automatically when the change is merged into the repository, and when the change is tested in our CI server. These notations create useful cross-references across systems, and are therefore highly recommended.
-* We encourage you to have a test case for the code you added to avoid future regressions. See [Unit Test] for more details about how to write tests.
+* See link:https://help.github.com/articles/creating-a-pull-request/[the github online help] for how to create a pull request
+* We encourage you to file a ticket in link:https://issues.jenkins-ci.org/[the issue tracker] to describe the bug that you are fixing or the feature you are implementing. This creates a permanent record on our system that allows future developers to understand how the code came into the current shape. This is not a requirement (especially for small changes), but we appreciate if you do that.
+* Refer to the ticket in your commit message by using the notation +[JENKINS-1234]+ where _JENKINS-1234_ is the ticket ID. This allows our scripts to understand the history and generate changelogs without human help. If you use the notation +[FIX JENKINS-1234]+, our bot will close the ticket automatically when the change is merged into the repository, and when the change is tested in our CI server. These notations create useful cross-references across systems, and are therefore highly recommended.
+* We encourage you to have a test case for the code you added to avoid future regressions. See link:https://wiki.jenkins-ci.org/display/JENKINS/Unit+Test[Unit Test] for more details about how to write tests.
 * Try to describe your changes so that other people understand what you did.
 * Make sure you didn’t modify portions that aren’t related to your changes (most often caused by IDE auto-fixing import statements and other code formats.)
 
-We do try to be attentive to inbound pull requests, but as you can see [here|Pending Pull Requests], unfortunately we can fail to resolve some of them in a timely fashion. If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list, and please consider becoming a committer and push the changes directly. See [Pull Request to Repositories] for more.
+We do try to be attentive to inbound pull requests, but as you can see link:https://wiki.jenkins-ci.org/display/JENKINS/Pending+Pull+Requests[here], unfortunately we can fail to resolve some of them in a timely fashion. If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list, and please consider becoming a committer and push the changes directly. See link:https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories[Pull Request to Repositories] for more.
 
-h2. This document
+== This document
 
-This document is owned by the community and substantial changes are approved via the project meeting. Send your questions to the dev list, or add an item to the [next meeting's agenda|Governance Meeting Agenda].
+This document is owned by the community and substantial changes are approved via the project meeting. Send your questions to the dev list, or add an item to the link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda[next meeting's agenda].

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -1,0 +1,328 @@
+---
+layout: simplepage
+title:  Project Governance Document
+section: project
+---
+
+h2. Who we are
+
+The Jenkins project as a community revolves around Jenkins as a piece of software. We are a group of open-source developers and users who develop, use, promote Jenkins, software around Jenkins, and other related activities for our mutual benefit.
+
+The project is affiliated with [Software in the Public Interest|http://www.spi-inc.org/] (SPI), a non-profit organization that provides legal representation and other necessities for running an open-source software project. SPI also acts as our treasury, and legally owns the project assets.
+
+h2. Our Philosophy
+
+h3. Lower barrier of entry
+
+We strive for lower barrier of entry to the project. This is partly achieved by not requiring new contributors to “prove themselves” before they are admitted to the committership. Instead, we assume they are good until proven otherwise, and this principle applies to anybody without arbitrary discrimination. We recognize that every contribution is precious, and we recognize that every added process turn away some potential contributors.
+
+The lower barrier of entry is partly achieved by structuring the project to [core|#core], [plugins|#plugins], [modules|#modules], and other independent pieces, thereby reducing the need for collaboration and communication. We try to let everyone have their own turf where they can work efficiently without bogged down by discussions and compromises. We believe everyone has the right to express their idea in their own plugins.
+
+The lower barrier of entry is also partly achieved by recognizing that people move on. Lots of code in the project is maintained by people other than the original author. We encourage new contributors to take over existing projects that aren’t actively maintained. We believe that “old” contributors deserve respect from “new” contributors, but the inaction on the part of the original contributors shall not block new contributors from making changes.
+
+h3. Meritocracy
+
+Our striving to lower barrier of entry doesn’t mean everyone has the equal voice. We value those who contribute more to the project, namely [Meritocracy|https://en.wikipedia.org/wiki/Meritocracy]. Contribution shouldn’t be narrowly interpreted just to code changes, but rather it includes such activities as helping others in the community, doing PR, running infrastructure, and so on.
+
+h3. Transparency
+
+We believe in running the project transparently. This includes everything from decision-making to defects in the code.
+
+h3. Compatibility matters
+
+We recognize that users expect their existing data, accumulated under past versions (including Hudson up to 1.395) to continue working under future versions of Jenkins. This includes jobs configurations, build records, and plugin binaries that they are using. The Jenkins project places high value on maintaining this compatibility, and will be very careful in removing functionality.
+
+To enable the above goal, we also recognize that plugin developers expect APIs and other code that they depend on to remain available in future versions of Jenkins. This is not to say we don’t ever remove anything, but we do it very carefully.
+
+Because one plugin can depend on another, we expect the same principle from plugins that many other plugins depend on.
+
+h3. Automation
+
+One of the goals of the Jenkins project is to enable more automation, and we apply the same principle in developing Jenkins. Accordingly, we develop and use a number of daemons, bots, and scripts to perform house-keeping activities and day-to-day operations, we use Jenkins ourselves to run many of those.
+
+This not only frees our time to do more creative work, but it also helps reduce the barrier to entry by reducing the blockage of one developer by another. Plus it has the added benefit of eating our own dogfood.
+
+h2. License
+
+The Jenkins project uses the [MIT License|http://opensource.org/licenses/MIT] as the primary license of choice, for the code that we develop. Unless otherwise stated, all the code is under the MIT license.
+
+The [core of Jenkins|https://github.com/jenkinsci/jenkins] is entirely under the MIT license, as is the majority of our [infrastructure code|https://github.com/jenkins-infra] (that runs the project itself), as well as many plugins. We encourage hosted plugins to use the same MIT license, to simplify the story for users, but plugins are free to choose their own licenses, so long as it’s an OSI-approved open-source license.
+
+This is not to be confused with proprietary plugins --- we recognize and encourage plugins that people write on their own for their internal use, without necessarily making the source code available. But no such plugins will be hosted by the Jenkins project.
+
+{anchor:cla}
+
+h3. Contributor License Agreement (CLA)
+
+To further clarify the intellectual property rights around the project, we require that core committers sign a contributor agreement. This CLA is the same as Apache's CLA with "Apache" replaced by "SPI". This agreement explicitly assigns a set of rights to SPI, such as the effective joint copyright ownership, patent grant, as well as acknowledging that you have the necessary rights to contribute changes.
+
+The assignment of these rights to SPI helps Jenkins being neutral to any particular vendor, and it'll also make legal departments happy especially in large organizations who want to use Jenkins.
+
+CLAs come in two flavors. Every core contributor needs to sign an Individual CLA (ICLA), and in cases where you as an individual do not own the work you are contributing (such as when your company assigns you to work on Jenkins and therefore your company owns the hard work you produced), the corporation also needs to sign a Corporate CLA (CCLA). See [the discussion in Apache for more details|https://www.apache.org/licenses/#clas]. The CLA forms can be obtained from the following URLs:
+
+* [ICLA|https://raw.github.com/jenkinsci/infra-cla/approved/icla.txt]
+* [CCLA|https://raw.github.com/jenkinsci/infra-cla/approved/ccla.txt]
+
+To balance the additional overhead with the lower barrier to entry, this policy only applies to the core, although we welcome anyone who's willing to submit a CLA for their work on plugins.
+
+Details to submit CLAs are documented in [infra-cla README|https://github.com/jenkinsci/infra-cla/blob/master/README.md].
+
+h3. 3rd party library licenses in the core
+
+The Jenkins project depends heavily on 3rd party libraries. We believe it's better to reuse what we can than to reinvent, so that our precious resources can be spent elsewhere.
+
+Jenkins as a whole needs to be an open-source project, so we've been restricting ourselves to only use 3rd party libraries that are [OSI-approved open-source licenses|http://www.opensource.org/] (such as Apache Software License, BSD license, MIT license, Eclipse Public License, and Lesser GNU Public License.) In addition, to keep the core reusable for the widest possible use cases, we refuse so-called [copyleft licenses|http://en.wikipedia.org/wiki/Copyleft] that restrict the overall license to a specific license (such as GNU Public License.) To that end, we designated the following licenses as approved licenses that we can depend on. Additional licenses are subject to the approval by the board:
+
+* [Apache Software License|http://www.apache.org/licenses/]
+* [BSD license|http://opensource.org/licenses/bsd-license.php], [MIT license|http://opensource.org/licenses/mit-license.php]
+* [W3C software license|http://opensource.org/licenses/W3C.php]
+* [CDDL|http://opensource.org/licenses/cddl1.php], [CPL|http://opensource.org/licenses/cpl1.0.php], [EPL|http://opensource.org/licenses/eclipse-1.0.php], and [MPL|http://opensource.org/licenses/mozilla1.0.php], and [LGPL|http://opensource.org/licenses/lgpl-license.php] (these licenses require that derivative works to be under the same license as the original license, so the source code needs to be separated into its own repository, but binaries can be used as dependencies to the core.)
+
+In core, the build process ensure that all the licenses of the dependency libraries are accounted for. In other words, we require that dependency POMs declare their own licenses in the Maven way, or use [the license completion script|https://github.com/jenkinsci/jenkins/blob/master/licenseCompleter.groovy] to supply one where the POM is missing that information. The completion script is also used in case the library is dual-licensed to pick a specific license. This is done so that the summary list of the 3rd party library licenses do not include copy-left licenses.
+
+The result is packaged into the core and is visible from [within the application itself|https://ci.jenkins-ci.org/about]. It is also available in the XML format inside the war file.
+
+h3. 3rd party library licenses in the plugins
+
+Plugins do not necessarily follow the same formality when it comes to the 3rd party license policy. They obviously need to honor the licenses of the libraries they use, but for example they need not run the same license completion scheme that the core uses.
+
+We encourage plugins to follow the same 3rd party license policy as the core. You may vary from it at your own risk. For example, see [FSF's opinion about GPL plugins with a non-GPL core|https://www.gnu.org/licenses/gpl-faq.html#NFUseGPLPlugins].
+
+h2. Trademark
+
+The name "Jenkins" is a registered trademark in the USA ([\#4664929|https://trademarks.justia.com/854/47/jenkins-85447465.html], held by SPI) in order to protect the project and users from confusing use of the term. To reduce the process overhead and uphold our open-source spirit, we adopt the Linux kernel policy on trademark usage.
+
+You need to apply for a [sublicense|Trademark Sublicense] if you are using the term "Jenkins" as part of your own trademark or brand identifier for Jenkins-based software goods or services. It doesn’t matter if your trademark is unregistered, or if you do not plan to make any money using the mark.
+
+Answering the following questions (which break out each of the key issues) may help you determine if you need a sublicense. If you are still in doubt, please contact the board and we will work with you to determine whether you need to apply for a sublicense.
+
+If the answer to all three of the following questions is "yes," then you need to apply for a sublicense. If the answer to any of these questions is "no," then you do not need to apply for a sublicense.
+
+# Is my mark a trademark (see how Linux Foundation define "trademark" in [FAQ|http://www.linuxfoundation.org/programs/legal/trademark/faq])?
+# Does my mark contain the following string of adjacent letters, in this order: "Jenkins"? These letters may or may not be capitalized, and in the case of foreign characters, phonetic translations also apply.
+# Do I use my mark to identify software-related goods or services (see how that phrase is [defined|http://www.linuxfoundation.org/programs/legal/trademark/faq] again in LF)?
+
+A list of trademark usages approved by the project can be found on the [Approved Trademark Usage] page.
+
+h2. Project roles/stakeholders
+
+{anchor:board}
+
+h3. Governance board
+
+The governance board consists of three people who act as public representatives of the project, when such representation is necessary, for example to interface external entities such as SPI.
+
+The board also acts as the ultimate decision-making authority in case disputes cannot be resolved via the regular project community meeting. The decision-making ability of the board is more symbolic and honorific, and it “rules” like British queens rather than a dictatorship.
+
+The [Governance Board] page provides further information, including a list of current board members, and how to contact the board.
+
+The process by which the [Governance Board] is elected can be reviewed in the [Board Election Process]
+
+
+h3. Infrastructure admins
+
+Infrastructure administrators have root access to the various servers and build slaves that run {{jenkins-ci.org}} and other sub-domains. They keep those servers up and running, installing new software, coordinating mirrors, handling keys and certificates, and making sure that we can keep churning out code.
+
+Because of the sensitive nature of this work, infrastructure admins are by invitation only, and some of the activity happen behind closed doors. Infrastructure admins often appoint others to delegate some partial access to the system to complete some tasks.
+
+A list of admins of some of the public infrastructure components can be found here: [Infrastructure Admins]
+
+
+h3. Core committers
+
+Core committers are those who have push access to [the main Jenkins repository|https://github.com/jenkinsci/jenkins] that produces {{jenkins.war}}. To become a core committer, one needs to sign the [contributor license agreement|#cla]. One is not required to have a proven history of contributions before being granted commit access, but that doesn’t mean other core committers will never revert your changes.
+
+The list of CLA signers is be maintained here: [https://github.com/jenkinsci/infra-cla]
+
+
+h3. Plugin committers
+
+Plugin committers are those who have push access to specific plugin repositories hosted under the jenkinsci GitHub organization. One is not required to have a proven history of contributions before being granted commit access. All you have to do is to ask. But that doesn’t mean other existing committers will never revert your changes.
+
+h3. Localization contributors
+
+Localization contributors have push access to both the core and hosted plugins. They make localization/internationalization related changes to the code and resources, and they push those changes without seeking approval from the core/plugin committers.
+
+h3. Users
+
+Users use Jenkins and its plugins. They contribute to the project by providing feedback, filing bug reports, prioritizing features and fixes for developers, helping other users, and making committers feel like their work is worth while.
+
+h2. Communication
+
+The communication among people in the community is crucial to the oneness of the project. People in the Jenkins project communicates with each other in several different places.
+
+h3. Mailing lists
+
+We encourage mailing lists as the primary means of developer & user discussion, because of their asynchrony and ability to search the archive. The project website lists [the active mailing lists and their purposes|https://jenkins-ci.org/content/mailing-lists].
+
+h3. IRC
+
+Jenkins project uses [an IRC channel|https://jenkins-ci.org/content/chat] for real time interactive communications. This is also the place where active members bond with each other.
+
+h3. Twitter
+
+[@jenkinsci|https://twitter.com/jenkinsci] is the official Twitter account of the Jenkins project, run by the infrastructure admins.
+
+h2. Infrastructure
+
+h3. Source code
+
+The [GitHub JenkinsCI organization|https://github.com/jenkinsci/] is where we host most of our code (see [the list of repositories|https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have [the subversion repository|https://svn.jenkins-ci.org/] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
+
+To aid classifying our 1000\+ Git repositories, some naming conventions have been adopted:
+
+* plugins are named "*-plugin"
+* libraries are named "lib-*"
+* backend infrastructure programs are named "backend-*"
+
+To encourage migration of plugins from Subversion to Git, a daemon is used to mirror plugins individually to GitHub. See [this page|Moving from Subversion (svn) to Github] for more about how to migrate your plugin to GitHub.
+
+h3. User Accounts
+
+The infrastructure admins run an LDAP server and [a small frontend program|https://jenkins-ci.org/account] to let users create accounts on jenkins-ci.org. This account is used for all the software that we run ourselves.
+
+h3. Wiki
+
+This wiki that you are reading is our primary collaboration mechanism for documentation. This uses the LDAP server described above for access.
+
+h3. Bug tracker
+
+[Our primary bug tracker|https://issues.jenkins-ci.org/] is maintained by the infra admins. This uses the LDAP server described above for access.
+
+h3. Jenkins on Jenkins
+
+We [run Jenkins for our own development|https://ci.jenkins-ci.org/] and to automate various infrastructure tasks. Because of the sensitive nature of setting up jobs, only the infra admins have full write access.
+
+h2. Decision making
+
+Jenkins project uses [biweekly project meetings|Governance Meeting Agenda] as the primary forum of decision making for matters that need consensus. The meeting is open to anyone, and the [minutes are public|http://meetings.jenkins-ci.org/jenkins/]. Agenda items can be added by anyone by simply updating the Wiki page with your name.
+
+The board serves as the ultimate decision-making body in case the project meeting fails to reach a consensus on a particular topic.
+
+h2. How we develop code
+
+{anchor:core}
+
+h3. Core
+
+The core refers to a set of code and libraries that result in the {{jenkins.war}} binary. [The official core repository|https://github.com/jenkinsci/jenkins] is hosted on GitHub.
+
+Long time committers push changes directly into this repository, although other core committers can still revert their changes and discuss them when they feel that is necessary. New committers can also do the same when they feel good about their changes, or if the changes are trivial.
+
+Committers old and new who feel their changes need review use [GitHub pull requests|https://github.com/jenkinsci/jenkins/pulls] as a way to solicit feedback. People without commit access also use pull requests to get their changes into the core. Core committers are expected to be attentive to pending pull requests, and try to act on them quickly.
+
+Core committers generally use their own judgement to decide what to work on.
+
+h3. Releases
+
+Every weekend a new release is built from the master branch and released, in various forms, including {{jenkins.war}} and native packages. This allows us to get new features and bug fixes into the hands of users relatively quickly.
+
+h3. LTS Releases
+
+Every three months or so we pick a prior release as the new long-term support (LTS) release and then create the ‘stable’ branch, from that release point. This branch gets important bug fixes backported from the master branch, and further patch releases are built roughly every two weeks until the next LTS baseline is chosen. See [LTS Release Line] for more details.
+
+h3. Core Coding Convention
+
+We roughly follow [Sun coding convention|http://www.oracle.com/technetwork/java/codeconvtoc-136057.html] in the source code, and we use 4 space indentation and don’t use tabs. It's generally more practical and appreciated if you submit changes that don't change the code format too much as it eases the coding review job. Try submitting formatting changes and functional changes in separate commits.
+
+With that said, we do not believe in rigorously enforcing coding convention, and we don’t want to turn down contributions because their code format doesn’t match what we use. So consider this informational.
+
+
+{anchor:plugins}
+
+h3. Plugins
+
+Plugins are developed autonomously by the people working on the plugin. Each gets its own repository, its own Jenkins-on-Jenkins job, its own bug tracker component, and maintain their own release schedules.
+
+Some plugins are actively maintained by a small number of people and they may have their own local culture, such as different coding convention, additional commit policies. We do this so that people can feel ownership and attachment to their effort, and so that they won’t feel like they have to follow externally decided rules.
+
+Since much of such local culture is implicit, it's often difficult to tell from outside the operating culture of a given plugin. The safe rule of thumb is to contact existing developers upfront before doing any commit (but if there's no timely response in a week so, you should feel free to commit.) Less actively maintained plugins tend not to have such local culture, so in those cases, if you feel lucky you can commit changes ahead and send a heads-up simultaneously, (and accept the possibility that the changes get reverted.)
+
+Maintainer information should be listed in the info box of the plugin's wiki page. If you have trouble figuring out who to contact, the good fallback option is the developers' mailing list.
+
+h3. Plugin Wiki Page
+
+Each plugin has its own Wiki page in {{[https://wiki.jenkins-ci.org/]}}, such as [this|Git plugin]. Plugin wiki pages should the macro that produces the stock header table, describing what the plugin does, along with the release history / changelog. Take a look at some plugin wiki pages as a guideline of what you should do.
+
+These wiki pages are referenced from the update center built in to Jenkins, and they are the primary means through which users discover information about plugins.
+
+{anchor:modules}
+
+h3. Modules
+
+Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in {{WEB-INF/lib}} and therefore it behaves as if it's a part of the core from the users' point of view. Modules can be thought of as something in between a library and a plugin. It has its own POM, a set of source code, and built separately, like a library, but it gets the same compile-time processing as plugins do.
+
+This assists splitting a big hair ball (that is the core) into more manageable smaller pieces, and allow OEMs to add/remove functionalities separately.
+
+h3. Commit guidelines
+
+See [the pull request checklist|#pull-request] for guidelines on submitting code to Jenkins.
+
+h3. Copying code from elsewhere
+
+When you have a license to do so, and when that license is compatible with the MIT license, you can copy the code from elsewhere into Jenkins.
+
+The most typical case of this is that the original code is licensed under a certain subset of the open-source licenses, such as ASL, BSD, and MIT license. Copyleft licenses, even though they are open-sourced, cannot be copied, such as EPL and GPL.
+
+The code to be copied must be clearly marked with the license it is under, and when copying, you need to maintain the copyright/license attribution in the header. Please also indicate the origin of the copy as a part of the commit message.
+
+In particular, this means we can copy Oracle Hudson's source code under the MIT license, but not Eclipse Hudson's source code under EPL.
+
+h3. Locally patching dependencies
+
+Sometimes, it is necessary to make bug fixes and changes in the libraries that we use. Where the library is significant to Jenkins and the impact is considerable to our users, we choose to maintain local patch sets to upstream libraries, just like Linux distributions maintain such patches for its packages.
+
+We normally intend such local patches to be integrated into upstream, so we file tickets upstream and provide our diff. When this works, this allows us to go back to the pristine upstream release at some point in the future. Those patch sets are maintained in our git repositories as a parallel branch.
+
+In some cases, the supposed "temporary" patch sets became more permanent for various reasons beyond our control, such as the ceased development in the upstream, but that's only because that's how it turned out, not because we intended it at the outset. With the distributed version control system, maintaining parallel patch release for Jenkins isn't as hard as it used to be.
+
+h2. How to join the project
+
+h3. Bringing in new plugins/tools/libraries
+
+If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See [Hosting Plugins] for more details.
+
+h3. Making changes to existing plugins
+
+If you are interested in just making a small number of changes without an intent to stay. It’s the easiest to send in pull requests through GitHub. See [using pull requests|#pull-request] for more details. If your pull requests are not getting timely attention, please ping us via the developers' mailing list, so that we can resolve that.
+
+If you’d like to be involved more seriously, in addition to the pull request, we encourage you to consider becoming a committer. Drop us a note in the IRC channel or the dev list, and we’ll set you up with commit access. Try to be courteous to existing developers by sending them heads-up and coordinating with them, but if they aren’t responding, don’t let that block your progress. The seniority of the developers are earned through on-going participation.
+
+h3. Helping and taking over dormant plugins
+
+It is often the case that the original developer moves onto other things once the plugin becomes good enough for them (or if the original author changes the job and no longer has incentive to work on the technology.) So we encourage new developers or developers of different plugin to pitch in on other plugins’ pending pull requests or work on issues filed against them.
+
+To that end, we also encourage people to pick up dormant plugins and consider them theirs. To do this, drop us a note at the dev list, and try to contact the previous maintainer to find out if they are still interested in driving the plugin. Trying insistently to contact the latest apparently inactive maintainer(s) before taking over is is an important practice to us. The practice is generally to add them in CC on your maintainership requests to the dev ML.
+
+Many less active plugins do not really have any obvious owner, and they are collaboratively maintained by people making small changes and releasing them whenever the need arises. If in doubt, ask on the dev list.
+
+h3. Making changes to core
+
+If you are interested in just making small changes without an intent to stay, the same process applies as plugins, described above. However, because core changes affect larger number of people, we’d be grateful if you’d try to go extra distance on the notes described in [using pull requests|#pull-request].
+
+If you’d like to be involved more seriously, consider getting commit access. See the section about becoming a plugin developer for how to get this. In addition, we need to ask you to [sign the contributor license agreement|#cla] (CLA).
+
+When making changes, use your common sense. For example, if you are thinking about making a big change, it is recommended that you discuss your changes with the developers upfront. Or if you see that the part you’d like to work on has been actively modified by others, give them a heads-up.
+
+h3. Contributing localizations
+
+We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see [Internationalization] for the details of how to make changes.
+
+{anchor:pull-request}
+
+h3. Using pull requests
+
+As discussed above, Jenkins project uses pull requests as one of the main workflow to get the changes in. When you prepare your pull request, consider the following checklist as the best practice.
+
+* See [the github online help|https://help.github.com/articles/creating-a-pull-request/] for how to create a pull request
+* We encourage you to file a ticket in [the issue tracker|https://issues.jenkins-ci.org/] to describe the bug that you are fixing or the feature you are implementing. This creates a permanent record on our system that allows future developers to understand how the code came into the current shape. This is not a requirement (especially for small changes), but we appreciate if you do that.
+* Refer to the ticket in your commit message by using the notation {{\[JENKINS-1234\]}} where JENKINS-1234 is the ticket ID. This allows our scripts to understand the history and generate changelogs without human help. If you use the notation {{\[FIX JENKINS-1234\]}}, our bot will close the ticket automatically when the change is merged into the repository, and when the change is tested in our CI server. These notations create useful cross-references across systems, and are therefore highly recommended.
+* We encourage you to have a test case for the code you added to avoid future regressions. See [Unit Test] for more details about how to write tests.
+* Try to describe your changes so that other people understand what you did.
+* Make sure you didn’t modify portions that aren’t related to your changes (most often caused by IDE auto-fixing import statements and other code formats.)
+
+We do try to be attentive to inbound pull requests, but as you can see [here|Pending Pull Requests], unfortunately we can fail to resolve some of them in a timely fashion. If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list, and please consider becoming a committer and push the changes directly. See [Pull Request to Repositories] for more.
+
+h2. This document
+
+This document is owned by the community and substantial changes are approved via the project meeting. Send your questions to the dev list, or add an item to the [next meeting's agenda|Governance Meeting Agenda].


### PR DESCRIPTION
Preparation to migrate https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document to the site. (Not yet linked from any footer/menu items.)

This change (and the corresponding removal of the wiki page's contents) may be subject to approval by the governance meeting, not sure.