### PR TITLE
Link fix for https://issues.jenkins-ci.org/browse/WEBSITE-310

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -43,11 +43,11 @@ If you are not yet familiar with basic Jenkins terminology and features, start w
 Jenkins Pipeline is a suite of plugins which supports implementing and
 integrating continuous delivery pipelines into Jenkins. Pipeline provides an
 extensible set of tools for modeling simple-to-complex delivery pipelines "as
-code" via the <<syntax#,Pipeline DSL>>.
+code" via the <<pipeline/syntax#,Pipeline DSL>>.
 footnoteref:[dsl,link:https://en.wikipedia.org/wiki/Domain-specific_language[Domain-Specific Language]]
 
 Typically, this "Pipeline as Code" would be written to a
-<<Jenkinsfile#,`Jenkinsfile`>> and checked into a project's source control
+<<pipeline/Jenkinsfile#,`Jenkinsfile`>> and checked into a project's source control
 repository, for example:
 
 [pipeline]


### PR DESCRIPTION
There are two links in this page which are broken in the same way. They're both missing pipeline in their paths. 

https://jenkins.io/doc/book/syntax/
https://jenkins.io/doc/book/Jenkinsfile/

These should both get changed to 

https://jenkins.io/doc/book/pipeline/syntax/
https://jenkins.io/doc/book/pipeline/Jenkinsfile/
