### PR TITLE
Correct Jenkinsfile to lowercase j

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -47,7 +47,7 @@ code" via the <<pipeline/syntax#,Pipeline DSL>>.
 footnoteref:[dsl,link:https://en.wikipedia.org/wiki/Domain-specific_language[Domain-Specific Language]]
 
 Typically, this "Pipeline as Code" would be written to a
-<<pipeline/Jenkinsfile#,`Jenkinsfile`>> and checked into a project's source control
+<<pipeline/jenkinsfile#,`Jenkinsfile`>> and checked into a project's source control
 repository, for example:
 
 [pipeline]


### PR DESCRIPTION
I meant to catch this in 602, but my eyes were playing tricks on me. The Jenkinsfile link is pointing to https://jenkins.io/doc/book/pipeline/Jenkinsfile/ . Note the uppercase J - that breaks the link. Changing it to a lowercase j fixes it.

![image](https://cloud.githubusercontent.com/assets/21689198/22714246/9bf63fc2-ed59-11e6-9dda-5a5f52432a52.png)