### PR TITLE
Allow simplepage to have notitle

### DIFF
--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -12,7 +12,8 @@ layout: default
   }
 .container
   .row.body
-    %h1
-      = page.title
+    - unless page.notitle
+      %h1
+        = page.title
 
     = content


### PR DESCRIPTION
Example use case: `sections_from` and `simplepage` are weird to combine when it's only one section per document, e.g. in https://jenkins.io/doc/upgrade-guide/2.19/ where I had to improvise with a general title to not have redundancy.

Some documents may not even be able to not have weird redundancy there, as the actual page title is also needed in the `sections_from` list. Looking at you, all Pipeline step pages.

(FWIW I needed to put `notitle: whatever` into the front matter for this to work, `:notitle:` didn't, including on at least some pages that already set that -- what's up with that?)