### PR TITLE
Update /donate page so it can replace the Donation wiki page

### DIFF
--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -1,37 +1,25 @@
 ---
-layout: default
+layout: simplepage
 title: "Donate to Jenkins"
 ---
 
-NOTE: You can donate directly through the
-link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[SPI donation
-page] (donation in US dollars) or via the
-link:http://www.ffis.de/Verein/donations.html[ffis.de donation page] (donation
-in Euros) if you do not need the context below
+NOTE: You can donate directly through the link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[SPI donation page] (donation in USD)
+or via the link:http://www.ffis.de/Verein/donations.html[ffis.de donation page] (donation in EUR) if you do not need the context below
+
+The Jenkins project is affiliated with link:http://www.spi-inc.org[Software in the Public Interest], a non-profit organization.
+Via SPI we can accept link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[donations online] in USD.
+For other ways to donate, refer to the link:http://spi-inc.org/donations[donations page on the SPI website].
 
 
+For European residents, we can also accept donations through link:http://www.ffis.de/Verein/donations.html[ffis.de] via bank transfer in EUR.
+As ffis.de is a charitable association, this donation is tax deductible in Germany.
 
-The Jenkins project is affiliated with link:http://www.spi-inc.org[Software in
-the Public Interest], a non-profit organization. Via SPI we can accept
-link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[donations
-online] in US dollars. For other ways to donate, refer to the
-link:http://spi-inc.org/donations[donations page on the SPI website].
-
-
-For European residents, we can also accept donations through
-link:http://www.ffis.de/Verein/donations.html[ffis.de] via bank transfer in
-Euro.
-As ffis.de is a charitable association, this donation is tax deductible under
-in Germany.
-
-NOTE: If you donate via ffis.de, please write to `donation[at]ffis.de` to
-ensure that your donation will be earmarked for the Jenkins project.
+NOTE: If you donate via ffis.de, please write to `donation[at]ffis.de` to ensure that your donation will be earmarked for the Jenkins project.
 
 
 == Why donate?
 
-Your contributions help us keep Jenkins going by paying project expenses, such
-as:
+Your contributions help us keep Jenkins going by paying project expenses, such as:
 
 *Operating expenses:*
 
@@ -39,7 +27,12 @@ as:
 * Covering network transit costs (not including that incurred by mirrors)
 * Equipment/replacement hardware
 
-A portion of contributions help fund SPI, Inc, which acts as the legal umbrella
-organization for holding copyrights, etc.
+A portion of contributions help fund SPI, Inc, which acts as the legal umbrella organization for holding copyrights, etc.
 
 Your contribution is *not* used for paying personnel.
+
+== Friend of Jenkins
+
+In showing our appreciation, we'll send out a special "friend of Jenkins" plugin to those who have donated at least 25 USD / 25 EUR.
+This plugin adds a little icon in the footer section, telling that you are a friend of Jenkins.
+You can install this to your Jenkins to show off that you've helped us.


### PR DESCRIPTION
Incorporate a few minor changes from https://wiki.jenkins-ci.org/display/JENKINS/Donation (notably, those pages appear to have never had identical content…) in preparation for removal of the wiki page.