### PR TITLE
Parse Gradle build log for warnings and fail if found

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,13 @@ try {
                         */
                         'HOME=.',
                         ]) {
-                        sh './gradlew --quiet --console=plain --no-daemon --info --stacktrace'
+                        sh '''
+                            ./gradlew --quiet --console=plain --no-daemon --info --stacktrace | tee build.log
+                            if [[ -n "$( grep --fixed-strings WARNING build.log | grep --invert-match --fixed-strings "no callouts refer to list item" | grep --invert-match --fixed-strings "skipping reference to missing attribute" )" ]] ; then
+                                echo "Failing build due to warnings in log output" >&2
+                                exit 1
+                            fi
+                           '''
                     }
                 }
             }


### PR DESCRIPTION
The following warnings are still in the build and I'm not sure how to fix them:

* `no callouts refer to list item`
* `skipping reference to missing attribute`

So these are excluded (for now).

All other warnings, Both asciidoctor and awestruct, will fail the build.

Depends on #614, #618, #620.