### PR TITLE
Adding info on referencing other vars in environment directive

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -379,6 +379,7 @@ pipeline {
         stage('Example') {
             environment { /* <2> */
                 DEBUG_FLAGS = '-g'
+                FULL_CC_CMD = '${CC} ${DEBUG_FLAGS}' /* <3> */
             }
             steps {
                 sh 'printenv'
@@ -398,6 +399,9 @@ node {
 apply to all steps within the Pipeline.
 <2> An `environment` directive defined within a `stage` will only apply the
 given environment variables to steps within the `stage`.
+<3> An `environment` directive can contain environment variables referring to
+other environment variables. When doing so, be sure to use single-quotes or
+escape the dollar signs referring to the other variable.
 
 === Parameters
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -372,6 +372,7 @@ pipeline {
         stage('Example') {
             environment { /* <2> */
                 AN_ACCESS_KEY = credentials('my-prefined-secret-text') /* <3> */
+                FULL_CC_CMD = '${CC} -g' /* <4> */
             }
             steps {
                 sh 'printenv'
@@ -388,6 +389,9 @@ given environment variables to steps within the `stage`.
 <3> The `environment` block has a helper method `credentials()` defined which
 can be used to access pre-defined Credentials by their identifier in the
 Jenkins environment.
+<4> An `environment` directive can contain environment variables referring to
+other environment variables. When doing so, be sure to use single-quotes or
+escape the dollar signs referring to the other variable.
 
 ==== options
 


### PR DESCRIPTION
See https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/110, which fixes [JENKINS-41748](https://issues.jenkins-ci.org/browse/JENKINS-41748)

cc @rtyler @bitwiseman 