### PR TITLE
[FIX WEBSITE-312] Callouts for [pipeline] blocks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ try {
                             set -o pipefail
                             set -o xtrace
                             ./gradlew --quiet --console=plain --no-daemon --info --stacktrace | tee build.log
-                            if [[ -n "$( grep --fixed-strings WARNING build.log | grep --invert-match --fixed-strings "no callouts refer to list item" | grep --invert-match --fixed-strings "skipping reference to missing attribute" )" ]] ; then
+                            if [[ -n "$( grep --fixed-strings WARNING build.log | grep --invert-match --fixed-strings "skipping reference to missing attribute" )" ]] ; then
                                 echo "Failing build due to warnings in log output" >&2
                                 exit 1
                             fi

--- a/content/blog/2017/2017-02-07-declarative-maven-project.adoc
+++ b/content/blog/2017/2017-02-07-declarative-maven-project.adoc
@@ -56,7 +56,7 @@ Declarative Pipeline and adding it to my branch.  Below is a minimal Pipeline
 ----
 // Declarative //
 pipeline { // <1>
-    agent any // <2> <3>
+    agent any // <2> // <3>
     stages { // <4>
         stage('Build') { // <5>
             steps { // <6>

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -372,12 +372,12 @@ directive, whereas users of Scripted Pipeline must use the `withEnv` step.
 // Declarative //
 pipeline {
     agent any
-    environment { /* <1> */
+    environment { // <1>
         CC = 'clang'
     }
     stages {
         stage('Example') {
-            environment { /* <2> */
+            environment { // <2>
                 DEBUG_FLAGS = '-g'
             }
             steps {

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -117,8 +117,8 @@ pipeline {
             }
         }
     }
-    post { /* <1> */
-        always { /* <2> */
+    post { // <1>
+        always { // <2>
             echo 'I will always say Hello again!'
         }
     }
@@ -158,7 +158,7 @@ Deploy.
 // Declarative //
 pipeline {
     agent any
-    stages { /* <1> */
+    stages { // <1>
         stage('Example') {
             steps {
                 echo 'Hello World'
@@ -197,7 +197,7 @@ pipeline {
     agent any
     stages {
         stage('Example') {
-            steps { /* <1> */
+            steps { // <1>
                 echo 'Hello World'
             }
         }
@@ -283,7 +283,7 @@ dockerfile:: Execute the Pipeline, or stage, with a container built from a
 ----
 // Declarative //
 pipeline {
-    agent { docker 'maven:3-alpine' } /* <1> */
+    agent { docker 'maven:3-alpine' } // <1>
     stages {
         stage('Example Build') {
             steps {
@@ -303,16 +303,16 @@ of the given name and tag (`maven:3-alpine`).
 ----
 // Declarative //
 pipeline {
-    agent none /* <1> */
+    agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker: 'maven:3-alpine' } /* <2> */
+            agent { docker: 'maven:3-alpine' } // <2>
             steps {
                 sh 'mvn -B clean verify'
             }
         }
         stage('Example Test') {
-            agent { docker: 'openjdk:8-jre' } /* <3> */
+            agent { docker: 'openjdk:8-jre' } // <3>
             steps {
                 echo 'Hello JRE'
             }
@@ -365,13 +365,13 @@ automatically be defined: `MYVARNAME_USR` and `MYVARNAME_PSW` respective.
 // Declarative //
 pipeline {
     agent any
-    environment { /* <1> */
+    environment { // <1>
         CC = 'clang'
     }
     stages {
         stage('Example') {
-            environment { /* <2> */
-                AN_ACCESS_KEY = credentials('my-prefined-secret-text') /* <3> */
+            environment { // <2>
+                AN_ACCESS_KEY = credentials('my-prefined-secret-text') // <3>
             }
             steps {
                 sh 'printenv'
@@ -439,7 +439,7 @@ time at which the line was emitted. For example: `options { timestamps() }`
 pipeline {
     agent any
     options {
-        timeout(time: 1, unit: 'HOUR') /* <1> */
+        timeout(time: 1, unit: 'HOUR') // <1>
     }
     stages {
         stage('Example') {
@@ -642,7 +642,7 @@ gradle::
 pipeline {
     agent any
     tools {
-        maven 'apache-maven-3.0.1' /* <1> */
+        maven 'apache-maven-3.0.1' // <1>
     }
     stages {
         stage('Example') {

--- a/lib/asciidoctor/extensions/pipeline-block.rb
+++ b/lib/asciidoctor/extensions/pipeline-block.rb
@@ -44,6 +44,12 @@ Asciidoctor::Extensions.register do
           declarative = nil
         else
           declarative = CodeRay::Duo[:groovy, :html, {:css => :style}].highlight(declarative)
+          declarative = declarative.gsub(/\/\/ +&lt;(\d+)&gt;/) {
+            m = $~
+            parent.document.callouts.register(m[1])
+            create_inline(parent, :callout, m[1], :id => parent.document.callouts.read_next_id).convert
+          }
+
           snippet << <<-EOF
   <div class="listingblock pipeline-declarative">
     <div class="title">Jenkinsfile (Declarative Pipeline)</div>
@@ -84,6 +90,12 @@ Asciidoctor::Extensions.register do
           end
 
           script = CodeRay::Duo[:groovy, :html, {:css => :style}].highlight(script)
+          script = script.gsub(/\/\/ +&lt;(\d+)&gt;/) {
+            m = $~
+            parent.document.callouts.register(m[1])
+            create_inline(parent, :callout, m[1], :id => parent.document.callouts.read_next_id).convert
+          }
+
           snippet << <<-EOF
   <div class="listingblock pipeline-script"
         style="display: #{(declarative.nil? or 'none') or 'inherit'}">


### PR DESCRIPTION
> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/22809145/7f2adf96-ef30-11e6-81ba-674916ac0379.png)

The regex pattern is a bit limited in what it can recognize, hence weirdness like `// <1> // <2>`, but I didn't want take the time to understand https://github.com/asciidoctor/asciidoctor/blob/76ac457a1d777d7186db624cad67f2366c2186ee/lib/asciidoctor.rb#L747...L748 and we don't need most of the supported syntaxes anyway.

`/* <1> */` isn't even supported by real AsciiDoctor, so I just rewrote those.

As callouts are now being registered correctly, these warnings are no longer excluded from failing the build.