### PR TITLE
Fix syntax in Declarative `docker` examples.

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -253,14 +253,14 @@ dynamically provisioned on a <<../glossary#node, node>> pre-configured to
 accept Docker-based Pipelines, or on a node matching the optionally defined
 `label` parameter.  `docker` also optionally accepts an `args` parameter
 which may contain arguments to pass directly to a `docker run` invocation.
- For example: `agent { docker: 'maven:3-alpine' }` or
+ For example: `agent { docker 'maven:3-alpine' }` or
 [source,groovy]
 ----
 agent {
     docker {
-        image: 'maven:3-alpine'
-        label: 'my-defined-label'
-        args:  '-v /tmp:/tmp'
+        image 'maven:3-alpine'
+        label 'my-defined-label'
+        args  '-v /tmp:/tmp'
     }
 }
 ----
@@ -306,15 +306,17 @@ pipeline {
     agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker: 'maven:3-alpine' } // <2>
+            agent { docker 'maven:3-alpine' } // <2>
             steps {
-                sh 'mvn -B clean verify'
+                echo 'Hello, Maven'
+                sh 'mvn --version'
             }
         }
         stage('Example Test') {
-            agent { docker: 'openjdk:8-jre' } // <3>
+            agent { docker 'openjdk:8-jre' } // <3>
             steps {
-                echo 'Hello JRE'
+                echo 'Hello, JDK'
+                sh 'java -version'
             }
         }
     }


### PR DESCRIPTION
Using `:` after the key in both forms of the `docker` block are incorrect.

I copy-pasted the fixed versions into Jenkins and they worked as expected.