### PR TITLE
Fix a few minor syntax and formatting errors in 'Using a Jenkinsfile'.

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -51,7 +51,7 @@ pipeline {
                 echo 'Building..'
             }
         }
-        stage('Test'){
+        stage('Test') {
             steps {
                 echo 'Testing..'
             }
@@ -153,7 +153,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'make' /* <1> */
+                sh 'make' // <1>
                 archiveArtifacts artifacts: '**/target/*.jar', fingerprint: true // <2>
             }
         }
@@ -528,7 +528,9 @@ pipeline {
             }
         }
         stage('Test on Linux') {
-            agent label 'linux' // <2>
+            agent { // <2>
+                label 'linux'
+            }
             steps {
                 unstash 'app' // <3>
                 sh 'make check'
@@ -540,7 +542,9 @@ pipeline {
             }
         }
         stage('Test on Windows') {
-            agent label 'linux'
+            agent {
+                label 'windows'
+            }
             steps {
                 unstash 'app'
                 bat 'make check' // <4>
@@ -588,7 +592,7 @@ stage('Test') {
 <1> The `stash` step allows capturing files matching an inclusion pattern
 (`**/target/*.jar`) for reuse within the _same_ Pipeline. Once the Pipeline has
 completed its execution, stashed files are deleted from the Jenkins master.
-<2> The optional parameter to `agent`/`node` allows for any valid Jenkins label
+<2> The parameter in `agent`/`node` allows for any valid Jenkins label
 expression. Consult the <<syntax#, Pipeline Syntax>> section for more details.
 <3> `unstash` will retrieve the named "stash" from the Jenkins master into the
 Pipeline's current workspace.


### PR DESCRIPTION
As reported by a user on IRC.