### PR TITLE
Add security team to 'Code' section on /participate

### DIFF
--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -111,6 +111,11 @@ section: participate
       Do you enjoy writing code? There are numerous plugins and components for you to contribute to.
       %a{:href => 'code'}
         Learn more.
+    %p
+      Are you an established contributor to Jenkins and looking for a new challenge?
+      The Jenkins Security Team is looking for members willing to help improve Jenkins security.
+      %a{:href => '/security#team'}
+        Learn more.
 
     %h3
       Translate


### PR DESCRIPTION
Link anchor depends on #631.