### PR TITLE
Incorporate LTS Upgrade Guides back into the documentation structure

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -55,6 +55,8 @@ section: doc
             = active_href('doc/book/pipeline/syntax', 'Pipeline Syntax reference')
           %li
             = active_href('doc/pipeline/steps', 'Pipeline Steps reference')
+          %li
+            = active_href('doc/upgrade-guide', 'LTS Upgrade Guide', :fuzzy => true)
 
         %h5
           Recent Tutorials

--- a/content/doc/upgrade-guide.html.haml
+++ b/content/doc/upgrade-guide.html.haml
@@ -1,7 +1,6 @@
 ---
-layout: simplepage
+layout: documentation
 title: "Jenkins LTS Upgrade Guide"
-section: doc
 ---
 
 %p

--- a/content/doc/upgrade-guide/2.19.adoc
+++ b/content/doc/upgrade-guide/2.19.adoc
@@ -1,7 +1,7 @@
 ---
-layout: simplepage
+layout: documentation
 title:  Jenkins Upgrade Guide
-section: doc
+notitle: true
 ---
 
 == Upgrading to Jenkins LTS 2.19.x

--- a/content/doc/upgrade-guide/2.32.adoc
+++ b/content/doc/upgrade-guide/2.32.adoc
@@ -1,7 +1,7 @@
 ---
-layout: simplepage
+layout: documentation
 title:  Jenkins Upgrade Guide
-section: doc
+notitle: true
 ---
 
 == Upgrading to Jenkins LTS 2.32.x

--- a/content/doc/upgrade-guide/2.7.adoc
+++ b/content/doc/upgrade-guide/2.7.adoc
@@ -1,7 +1,7 @@
 ---
-layout: simplepage
+layout: documentation
 title:  Jenkins Upgrade Guide
-section: doc
+notitle: true
 ---
 
 == Upgrading to Jenkins LTS 2.7.x


### PR DESCRIPTION
This getting hidden was an omission. This commit also changes the Upgrade
Guides's layout to be documentation for better navigation in and out of the
upgrade guides

Fixes WEBSITE-305