### PR TITLE
Sort pipeline steps documentation case-insensitively

### DIFF
--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -10,7 +10,7 @@ title: "Pipeline Steps Reference"
 
 %div
   %ul
-    - sections_from(steps_dir).each do |section, file, url, children|
+    - sections_from(steps_dir).sort_by { |it| it[0].downcase }.each do |section, file, url, children|
       %li
         %a{:href => url}
           = section


### PR DESCRIPTION
Because this sort order makes no sense:

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/22913902/e71b35fc-f26d-11e6-811d-4b2f61d73700.png)

Even better with all the https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/5 goodness.
