### PR TITLE
add missing word in tests-and-artifacts.adoc

### DIFF
--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -55,7 +55,7 @@ trends and report on them. A Pipeline that has failing tests will be marked as
 "UNSTABLE", denoted by yellow in the web UI. That is distinct from the "FAILED"
 state, denoted by red.
 
-When there test failures, it is often useful to grab built artifacts from
+When there are test failures, it is often useful to grab built artifacts from
 Jenkins to local analysis and investigation. This is made practical by
 Jenkins's built-in support for storing "artifacts", files generated during the
 execution of the Pipeline.


### PR DESCRIPTION
Added a missing 'are' into tests-and-artifacts.adoc.