### PR TITLE
Add option to not offer link to edit page on GitHub

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -82,14 +82,15 @@
                         Reddit
 
           .col-lg-4.col-md-12.col-sm-12.col-xs-12.footer-left
-            %p.box
-              %a{:href => "https://github.com/jenkins-infra/jenkins.io/edit/master/content/#{page.relative_source_path}",
-              :title => "Edit #{page.relative_source_path} on GitHub"}
-                Improve this page
-              |
-              %a{:href => "https://github.com/jenkins-infra/jenkins.io/commits/master/content/#{page.relative_source_path}",
-              :title => "View #{page.relative_source_path} history on GitHub"}
-                Page history
+            - unless page.uneditable
+              %p.box
+                %a{:href => "https://github.com/jenkins-infra/jenkins.io/edit/master/content/#{page.relative_source_path}",
+                :title => "Edit #{page.relative_source_path} on GitHub"}
+                  Improve this page
+                |
+                %a{:href => "https://github.com/jenkins-infra/jenkins.io/commits/master/content/#{page.relative_source_path}",
+                :title => "View #{page.relative_source_path} history on GitHub"}
+                  Page history
 
             .license-box
               #creativecommons

--- a/content/_layouts/pipelinesteps.html.haml
+++ b/content/_layouts/pipelinesteps.html.haml
@@ -1,0 +1,7 @@
+---
+layout: documentation
+uneditable: true
+notitle: true
+---
+
+= content

--- a/content/changelog-stable/index.html
+++ b/content/changelog-stable/index.html
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: simplepage
 title: LTS Changelog
 ---
 

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -16,7 +16,8 @@ RESOURCES = [
     'https://raw.githubusercontent.com/jenkinsci/jenkins/master/changelog.html',
     'content/changelog/index.html',
     {
-      :layout => 'post',
+      :layout => 'simplepage',
+      :uneditable => 'true',
       :title => 'Changelog',
     },
     nil


### PR DESCRIPTION
* `changelog` is now uneditable, as it's sourced from jenkinsci/jenkins
  * `changelog-stable` is still editable, as it's stored in this repo
* Generated Pipeline steps are uneditable
* New layout for generated Pipeline steps to centralize their styling.

Somewhat unrelated:

* Make changelogs from `post` into `simplepage`, no need to tweet or left-align those