### PR TITLE
Fix URLs on the site to facilitate local development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,9 +273,6 @@ def defineDevTask(name, body) {
         scriptArgs '--dev',
                    '--source-dir', "${projectDir}/${contentDir}",
                    '--output-dir', project.ext.siteOutputDir
-        if (hasProperty('profile')) {
-            scriptArgs '--profile', profile
-        }
         configuration 'asciidoctor'
         body.delegate = delegate
         body()

--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,9 @@ task compileContent(type: JRubyExec) {
                 '--output-dir', project.ext.siteOutputDir
     /* without the --force option, awestruct is not smart enough to regenerate
      * files based on includes */
+    if (hasProperty('profile')) {
+        scriptArgs '--profile', profile
+    }
     configuration 'asciidoctor'
     inputs.source fileTree(projectDir)
                     .include("${contentDir}/**/*.adoc")

--- a/build.gradle
+++ b/build.gradle
@@ -166,11 +166,11 @@ task compileContent(type: JRubyExec) {
                 '--url', 'https://jenkins.io',
                 '--source-dir', "${projectDir}/${contentDir}",
                 '--output-dir', project.ext.siteOutputDir
-    /* without the --force option, awestruct is not smart enough to regenerate
-     * files based on includes */
     if (hasProperty('profile')) {
         scriptArgs '--profile', profile
     }
+    /* without the --force option, awestruct is not smart enough to regenerate
+     * files based on includes */
     configuration 'asciidoctor'
     inputs.source fileTree(projectDir)
                     .include("${contentDir}/**/*.adoc")
@@ -273,6 +273,9 @@ def defineDevTask(name, body) {
         scriptArgs '--dev',
                    '--source-dir', "${projectDir}/${contentDir}",
                    '--output-dir', project.ext.siteOutputDir
+        if (hasProperty('profile')) {
+            scriptArgs '--profile', profile
+        }
         configuration 'asciidoctor'
         body.delegate = delegate
         body()

--- a/content/_config/site.yml
+++ b/content/_config/site.yml
@@ -34,6 +34,7 @@ asciidoctor:
     notitle: ''
 profiles:
   development:
+    base_url: http://localhost:4242/
     # Don't log to GA while working on the site
     google_analytics:
       account: UA-000000-0
@@ -47,5 +48,3 @@ profiles:
     deploy:
       host: github_pages
       branch: gh-pages
-  local:
-    base_url: http://localhost:4242/

--- a/content/_config/site.yml
+++ b/content/_config/site.yml
@@ -47,3 +47,5 @@ profiles:
     deploy:
       host: github_pages
       branch: gh-pages
+  local:
+    base_url: http://localhost:4242/

--- a/content/blog/2016/2016-04-11-run-your-api-tests-continuously-with-jenkins-and-dhc.adoc
+++ b/content/blog/2016/2016-04-11-run-your-api-tests-continuously-with-jenkins-and-dhc.adoc
@@ -82,7 +82,7 @@ link:http://insomnia.rest/[Insomnia].
 But in this article, I'll offer a quick look at link:https://restlet.com/products/dhc/[DHC],
 a handy visual tool, that you can use both manually to craft your tests and assertions,
 and whose test scenarios you can export and integrate in your build and continuous integration pipeline,
-thanks to link:http://maven.apache.org/[Maven] and link:https://jenkins.io/[Jenkins].
+thanks to link:http://maven.apache.org/[Maven] and Jenkins.
 
 At the end of this post, you should be able to see the following reporting in your Jenkins dashboard,
 when visualising the resulting API test execution:

--- a/content/blog/2016/2016-04-26-jenkins-20-is-here.adoc
+++ b/content/blog/2016/2016-04-26-jenkins-20-is-here.adoc
@@ -13,7 +13,7 @@ software development and beyond.  It is quite remarkable for a project that
 originally started as a hobby project under a different name. I'm very proud.
 
 Around this time last year,
-link:https://jenkins.io/blog/2015/02/09/jenkins-celebration-day-is-february-26/[we've]
+link:/blog/2015/02/09/jenkins-celebration-day-is-february-26/[we've]
 celebrated 10 years, 1000 plugins, and 100K installations. That was a good time
 to retrospect, and we started thinking about the next 10 years of Jenkins and
 what's necessary to meet that challenge.  This project has long been on a

--- a/content/blog/2016/2016-05-25-update-plugin-for-pipeline.adoc
+++ b/content/blog/2016/2016-05-25-update-plugin-for-pipeline.adoc
@@ -367,7 +367,7 @@ awesome plugin for Jenkins Pipeline jobs!
 
 === Links
 
-* link:https://jenkins.io/solutions/pipeline/[Jenkins Pipeline Overview]
+* link:/solutions/pipeline/[Jenkins Pipeline Overview]
 * link:https://github.com/jenkinsci/pipeline-plugin/blob/master/DEVGUIDE.md[Pipeline Plugin Developer Guide]
 * link:https://github.com/jenkinsci/jenkins[Jenkins Source Code]
 * link:https://github.com/jenkinsci/workflow-step-api-plugin[Workflow Step API Plugin]

--- a/content/blog/2016/2016-06-30-ewm-alpha-version.adoc
+++ b/content/blog/2016/2016-06-30-ewm-alpha-version.adoc
@@ -61,4 +61,4 @@ link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=sh
 * link:https://youtu.be/u4zhxfUT8P4?t=22m7s[Mid-term presentation]
 * link:/blog/2016/05/23/external-workspace-manager-plugin/[Project intro blog post]
 * link:https://summerofcode.withgoogle.com/[GSoC page]
-* link:https://jenkins.io/projects/gsoc/[Jenkins GSoC Page]
+* link:/projects/gsoc/[Jenkins GSoC Page]

--- a/content/blog/2016/2016-07-07-jenkins-2.7.1.adoc
+++ b/content/blog/2016/2016-07-07-jenkins-2.7.1.adoc
@@ -7,7 +7,7 @@ tags:
 author: kohsuke
 ---
 
-It’s been almost three months since we’ve released link:https://jenkins.io/2.0/[Jenkins 2.0], the first ever major version upgrade for this 10 year old project. The 2.x versions since then has been adopted by more than 20% of the users, but one segment of users who haven’t seen the benefits of Jenkins 2 is those who has been running LTS releases.
+It’s been almost three months since we’ve released link:/2.0/[Jenkins 2.0], the first ever major version upgrade for this 10 year old project. The 2.x versions since then has been adopted by more than 20% of the users, but one segment of users who haven’t seen the benefits of Jenkins 2 is those who has been running LTS releases.
 
 But that is no more! The new version of Jenkins LTS release we just released is 2.7.1, and now LTS users get to finally enjoy Jenkins 2.
 

--- a/content/blog/2016/2016-08-03-st-petersburg-jam-3-4-report.adoc
+++ b/content/blog/2016/2016-08-03-st-petersburg-jam-3-4-report.adoc
@@ -45,7 +45,7 @@ Talks:
  ** link:https://speakerdeck.com/onenashev/itgm8-o-jenkins-2-i-planakh-na-budushchieie[Presentation] (rus)
 * *Aleksandr Tarasov*, Alfa-Laboratory, "Continuous Delivery with Jenkins: Lessons learned"
  ** Aleksandr summarized AlfaLab's experience of Jenkins usage for Continuous Delivery in their environment.
-   He talked about the flow based on link:https://jenkins.io/doc/pipeline/[Jenkins Pipeline], link:https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin[JobDSL] and link:https://jenkins.io/projects/blueocean/[BlueOcean] prototype.
+   He talked about the flow based on link:/doc/pipeline/[Jenkins Pipeline], link:https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin[JobDSL] and link:/projects/blueocean/[BlueOcean] prototype.
  ** link:http://www.slideshare.net/aatarasoff/continuous-delivery-with-jenkins-lessons-learned[Presentation] (rus)
   
 After the talks we had a roundtable about Jenkins (~10 Jenkins experts).

--- a/content/blog/2016/2016-08-09-ewm-beta-version.adoc
+++ b/content/blog/2016/2016-08-09-ewm-beta-version.adoc
@@ -168,6 +168,6 @@ link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=sh
 
 * link:https://github.com/jenkinsci/external-workspace-manager-plugin[Project repository]
 * link:/blog/2016/05/23/external-workspace-manager-plugin/[Project intro blog post]
-* link:https://jenkins.io/blog/2016/06/30/ewm-alpha-version/[Alpha version announcement]
+* link:/blog/2016/06/30/ewm-alpha-version/[Alpha version announcement]
 * link:https://summerofcode.withgoogle.com/[GSoC page]
-* link:https://jenkins.io/projects/gsoc/[Jenkins GSoC Page]
+* link:/projects/gsoc/[Jenkins GSoC Page]

--- a/content/blog/2016/2016-09-09-take-the-2016-jenkins-survey-blog.adoc
+++ b/content/blog/2016/2016-09-09-take-the-2016-jenkins-survey-blog.adoc
@@ -29,8 +29,8 @@ All participants will be able to access reports summarizing survey results. If
 you’re curious about what insights your input will provide, see the results of
 last year’s 2015 survey:
 
-- link:https://jenkins.io/files/2015-Jenkins-Community-Survey-Results.pdf[2015 Community Survey Results (PDF)]
-- link:https://jenkins.io/files/State-of-Jenkins-Infographic-2015.pdf[State of Jenkins Infographic (PDF)]
+- link:/files/2015-Jenkins-Community-Survey-Results.pdf[2015 Community Survey Results (PDF)]
+- link:/files/State-of-Jenkins-Infographic-2015.pdf[State of Jenkins Infographic (PDF)]
 
 Your feedback helps capture a bigger picture of
 community trends and needs. There are laws that govern prize giveaways and

--- a/content/blog/2016/2016-09-20-jom-plugin-development.adoc
+++ b/content/blog/2016/2016-09-20-jom-plugin-development.adoc
@@ -39,7 +39,7 @@ Node.js,
 ReactJS,
 link:https://www.npmjs.com/package/jenkins-js-builder[Jenkins JS Builder],
 link:https://github.com/jenkinsci/jenkins-design-language[Jenkins Design Language],
-link:https://jenkins.io/projects/blueocean/[Blue Ocean]
+link:/projects/blueocean/[Blue Ocean]
 
 === Links
 

--- a/content/blog/2016/2016-09-29-jenkins-world-2016-wrap-up-experts-demos.adoc
+++ b/content/blog/2016/2016-09-29-jenkins-world-2016-wrap-up-experts-demos.adoc
@@ -101,8 +101,8 @@ Thank you to everyone who staffed the booth and gave demos.
 Also, thanks to everyone who attended the demos and came by to ask questions.
 If you have more questions, you don't have to wait until next year's Jenkins World.
 Join the
-link:https://jenkins.io/content/mailing-lists/[jenkinsci-users] mailing list or the
-link:https://jenkins.io/content/chat/[#jenkins IRC channel] to
+link:/content/mailing-lists/[jenkinsci-users] mailing list or the
+link:/chat/[#jenkins IRC channel] to
 get help from experts around the world.
 
 And finally, a special thanks to the Jenkins Events officer, link:https://github.com/alyssat[Alyssa Tong],

--- a/content/blog/2016/2016-09-30-jenkins-world-2016-wrap-up-complete.adoc
+++ b/content/blog/2016/2016-09-30-jenkins-world-2016-wrap-up-complete.adoc
@@ -34,7 +34,7 @@ link:/projects/jam/[Jenkins Area Meetups], today there are 37 around the
 world, with ~7000 members.
 * *Security* - Daniel Beck has done a great job a "Security Officer" for the project over the last year.
 Jenkins 2 includes tighter security out of the box, 9 security alerts have been addressed, and the
-link:https://jenkins.io/security/[Security Team] is continuing to evaluate threats as they are reported.
+link:/security/[Security Team] is continuing to evaluate threats as they are reported.
 * *Pipeline* - Pipeline has been a success and there many improvements on the way, including better
 Pipeline Library support, a UI-based Pipeline Editor, and Declarative Pipeline syntax.
 * *Blue Ocean* - Blue Ocean announced their "1.0 Beta" release and discussed their roadmap.

--- a/content/blog/2016/2016-10-16-stage-lock-milestone.adoc
+++ b/content/blog/2016/2016-10-16-stage-lock-milestone.adoc
@@ -22,7 +22,7 @@ Separating these concerns into explicit, independent steps allows for much great
 
 === Stage
 
-The `stage` step is a primary building block in Pipeline, dividing the steps of a Pipeline into explicit units and helping to visualize the progress using the "Stage View" plugin or link:https://jenkins.io/projects/blueocean/["Blue Ocean"]. Beginning with version 2.2 of "Pipeline Stage Step" plugin, the `stage` step now requires a block argument, wrapping all steps within the defined stage. This makes the boundaries of where each `stage` begins and ends obvious and predictable. In addition, the concurrency argument of `stage` has now been removed to make this step more concise; responsibility for concurrency control has been delegated to the `lock` step.
+The `stage` step is a primary building block in Pipeline, dividing the steps of a Pipeline into explicit units and helping to visualize the progress using the "Stage View" plugin or link:/projects/blueocean/["Blue Ocean"]. Beginning with version 2.2 of "Pipeline Stage Step" plugin, the `stage` step now requires a block argument, wrapping all steps within the defined stage. This makes the boundaries of where each `stage` begins and ends obvious and predictable. In addition, the concurrency argument of `stage` has now been removed to make this step more concise; responsibility for concurrency control has been delegated to the `lock` step.
 
 [source, groovy]
 ----

--- a/content/blog/2017/2017-01-17-scm-api-2.0-release.adoc
+++ b/content/blog/2017/2017-01-17-scm-api-2.0-release.adoc
@@ -12,7 +12,7 @@
 The link:https://issues.jenkins-ci.org/browse/JENKINS-41121[regressions
 discovered after release] have now been resolved and this post has been updated with the correct plugin version numbers.
 
-See link:https://jenkins.io/blog/2017/02/06/scm-api-2-take2/[this post] for more details.
+See link:/blog/2017/02/06/scm-api-2-take2/[this post] for more details.
 ====
 
 We are announcing the
@@ -61,7 +61,7 @@ If you don't care about the hows and whys, you can just skip down to <<tldr,this
 == The back-story
 
 Way back in September 2013 we announced the
-link:https://jenkins.io/blog/2013/09/23/literate-builds-wtf/[Literate plugin],
+link:/blog/2013/09/23/literate-builds-wtf/[Literate plugin],
 as an experimental new way of modeling branch development in Jenkins.
 
 When you are performing an experiment, the recommendation is to do just enough work to let you perform the test.

--- a/content/blog/2017/2017-01-19-converting-conditional-to-pipeline.adoc
+++ b/content/blog/2017/2017-01-19-converting-conditional-to-pipeline.adoc
@@ -16,8 +16,8 @@ Technical Evangelist at link:https://cloudbees.com[CloudBees].
 == Introduction
 
 With all the new developments in
-link:https://jenkins.io/doc/book/pipeline/[Jenkins Pipeline] (and
-link:https://jenkins.io/blog/2017/01/12/declarative-pipeline-beta-2/[Declarative Pipeline on the horizon]),
+link:/doc/book/pipeline/[Jenkins Pipeline] (and
+link:/blog/2017/01/12/declarative-pipeline-beta-2/[Declarative Pipeline on the horizon]),
 it's easy to forget what we did to create "pipelines" before
 *Pipeline*.
 There are number of plugins, some that have been around since the very beginning,
@@ -504,7 +504,7 @@ I found scenarios which could not easily be migrated to Pipeline, but even those
 are only more difficult, rather than impossible.
 
 The next thing to do is add a section to the
-link:https://jenkins.io/doc/book/[Jenkins Handbook] documenting the Pipeline
+link:/doc/book/[Jenkins Handbook] documenting the Pipeline
 equivalent of all of the Conditions and the most commonly used Tokens.
 Look for it soon!
 

--- a/content/blog/2017/2017-02-01-security-updates.md
+++ b/content/blog/2017/2017-02-01-security-updates.md
@@ -9,7 +9,7 @@
 We just released security updates to Jenkins, versions 2.44 and 2.32.2, that fix a high severity and several medium and low severity issues.
 
 For an overview of what was fixed, see the [security advisory](https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01).
-For an overview on the possible impact of these changes on upgrading Jenkins LTS, see our [LTS upgrade guide](https://jenkins.io/doc/upgrade-guide/2.32/#upgrading-to-jenkins-lts-2-32-2).
+For an overview on the possible impact of these changes on upgrading Jenkins LTS, see our [LTS upgrade guide](/doc/upgrade-guide/2.32/#upgrading-to-jenkins-lts-2-32-2).
 I strongly recommend you read these documents, as there are a few possible side effects of these fixes.
 
 Subscribe to the [jenkinsci-advisories mailing list](/content/mailing-lists) to receive important notifications related to Jenkins security.

--- a/content/blog/2017/2017-02-10-blueocean-devlog-feb2.adoc
+++ b/content/blog/2017/2017-02-10-blueocean-devlog-feb2.adoc
@@ -34,7 +34,7 @@ Some development highlights:
   your room)
 - Some new refinements to the design merged to the master branch (see images below).
 - Beta 22 featured the 1.0 version of
-  link:https://jenkins.io/blog/2017/02/03/declarative-pipeline-ga/[Declarative Pipeline]
+  link:/blog/2017/02/03/declarative-pipeline-ga/[Declarative Pipeline]
 - An
   link:https://github.com/jenkinsci/blueocean-plugin/commit/99524c36afedfb11150ac20d26c6b1d4e01b714a[Australian translation]
   was added; really critical stuff, I know..

--- a/content/changelog-stable/index.html
+++ b/content/changelog-stable/index.html
@@ -210,7 +210,7 @@ View ratings below, and click one of the icons next to your version to provide y
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36539">issue 36539</a>)
   <li class="bug">
     Add missing internationalization support to <code>ResourceBundleUtil</code>.
-    It fixes internationalization in <a href="https://jenkins.io/projects/blueocean/">Blue Ocean</a> 
+    It fixes internationalization in <a href="/projects/blueocean/">Blue Ocean</a> 
     and <a href="http://jenkinsci.github.io/jenkins-design-language/">Jenkins Design Language</a>. 
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-35845">issue 35845</a>)
   <li class="bug">
@@ -237,7 +237,7 @@ View ratings below, and click one of the icons next to your version to provide y
 <h3><a name=v2.19.3>What's new in 2.19.3</a> (2016-11-16)</h3>
 
 <div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
-  This is an out-of-schedule release addressing <a href="https://jenkins.io/blog/2016/11/12/addressing-remote-vulnerabilities-in-cli/">the zero day vulnerability published on November 11, 2016</a>. It does not contain the usual LTS bug fixes, but only addresses the security vulnerability. There will be another LTS release in the 2.19.x line containing bug fixes as regularly scheduled.
+  This is an out-of-schedule release addressing <a href="/blog/2016/11/12/addressing-remote-vulnerabilities-in-cli/">the zero day vulnerability published on November 11, 2016</a>. It does not contain the usual LTS bug fixes, but only addresses the security vulnerability. There will be another LTS release in the 2.19.x line containing bug fixes as regularly scheduled.
 </div>
 
 <ul class=image>

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -230,8 +230,8 @@ Jenkins Pipelines.
 
 === Additional Resources
 
-* link:https://jenkins.io/doc/pipeline/steps[Pipeline Steps Reference],
+* link:/doc/pipeline/steps[Pipeline Steps Reference],
   encompassing all steps provided by plugins distributed in the Jenkins Update
   Center.
-* link:https://jenkins.io/doc/pipeline/examples[Pipeline Examples], a
+* link:/doc/pipeline/examples[Pipeline Examples], a
   community-curated collection of copyable Pipeline examples.

--- a/content/doc/upgrade-guide/2.32.adoc
+++ b/content/doc/upgrade-guide/2.32.adoc
@@ -51,7 +51,7 @@ The remoting blacklist of classes prohibited from being used in XStream and Java
    ^java[.]util[.]ServiceLoader$
    ^java[.]net[.]URLClassLoader$
 
-No legitimate use of these types is expected, but possible. Previous advice in the link:https://jenkins.io/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[upgrade guide for Jenkins 2.19.3] still applies.
+No legitimate use of these types is expected, but possible. Previous advice in the link:/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[upgrade guide for Jenkins 2.19.3] still applies.
 
 ==== User creation via GET no longer possible
 

--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -135,7 +135,7 @@ section: participate
         %a{:href => 'https://groups.google.com/forum/#!forum/jenkinsci-docs'}
           jenkinsci-docs
         mailing list and the
-        %a{:href => 'https://jenkins.io/content/chat/'}
+        %a{:href => '/chat/'}
           \#jenkins-community IRC channel.
       %li
         %a{:href => 'https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-documentation'}

--- a/content/security/advisory/2014-10-30.adoc
+++ b/content/security/advisory/2014-10-30.adoc
@@ -12,7 +12,7 @@ Historically, Jenkins master and slaves behaved as if they altogether form a sin
 
 This has increasingly become problematic, as larger enterprise deployments have developed more sophisticated trust separation model, where the administators of a master might take slaves owned by other teams. In such an environment, slaves are less trusted than the master. Yet the "single distributed process" assumption was not communicated well to the users, resulting in vulnerabilities in some deployments.
 
-SECURITY-144 (CVE-2014-3665) introduces a new subsystem to address this problem. This feature is off by default for compatibility reasons. See link:https://jenkins.io/redirect/security-144/[Wiki] for more details, who should turn this on, and implications.
+SECURITY-144 (CVE-2014-3665) introduces a new subsystem to address this problem. This feature is off by default for compatibility reasons. See link:/redirect/security-144/[Wiki] for more details, who should turn this on, and implications.
 
 
 == Severity

--- a/content/security/advisory/2015-11-11.adoc
+++ b/content/security/advisory/2015-11-11.adoc
@@ -103,7 +103,7 @@ These versions include fixes to all the vulnerabilities described above. All pri
 
 == Credit
 
-The Jenkins project would like to thank the following people for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the following people for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Akshay Dayal (from Google)* for SECURITY-184
 * *Ari Rubinstein* for SECURITY-195

--- a/content/security/advisory/2015-12-09.adoc
+++ b/content/security/advisory/2015-12-09.adoc
@@ -56,7 +56,7 @@ These versions include fixes to all the vulnerabilities described above. All pri
 
 == Credit
 
-The Jenkins project would like to thank the following people for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the following people for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Alex Soto Bueno, CloudBees, Inc.* for SECURITY-234
 * *Antoine Musso and Timo Tijhof* for SECURITY-95

--- a/content/security/advisory/2016-02-24.adoc
+++ b/content/security/advisory/2016-02-24.adoc
@@ -63,7 +63,7 @@ These versions include fixes to all the vulnerabilities described above. All pri
 
 == Credit
 
-The Jenkins project would like to thank the following people for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the following people for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Moritz Bechler* for SECURITY-232
 * *Seung-Hyun Cho* for SECURITY-238

--- a/content/security/advisory/2016-04-11.adoc
+++ b/content/security/advisory/2016-04-11.adoc
@@ -46,7 +46,7 @@ These versions include fixes to the vulnerabilities described above. All prior v
 
 == Credit
 
-The Jenkins project would like to thank the following people for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the following people for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Daniel Beck, CloudBees, Inc.* for SECURITY-136
 * *Jesse Glick, CloudBees, Inc.* for SECURITY-258

--- a/content/security/advisory/2016-05-11.adoc
+++ b/content/security/advisory/2016-05-11.adoc
@@ -96,7 +96,7 @@ These versions include fixes to all the vulnerabilities described above. All pri
 
 == Credit
 
-The Jenkins project would like to thank the following people for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the following people for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Adam Cazzolla and Ben Bleiberg, Sonatype Inc.* for SECURITY-276
 * *Charles Nelson* for SECURITY-250
@@ -107,5 +107,5 @@ The Jenkins project would like to thank the following people for discovering and
 
 == Other Resources
 
-* link:https://jenkins.io/blog/2016/05/11/security-update/[Announcement blog post]
+* link:/blog/2016/05/11/security-update/[Announcement blog post]
 * link:https://www.cloudbees.com/jenkins-security-advisory-2016-05-11[Corresponding security advisory for CloudBees Jenkins Enterprise and CloudBees Jenkins Operations Center]

--- a/content/security/advisory/2016-06-20.adoc
+++ b/content/security/advisory/2016-06-20.adoc
@@ -67,7 +67,7 @@ These versions include fixes to the vulnerabilities described above. All prior v
 
 == Credit
 
-The Jenkins project would like to thank the following people for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the following people for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Ben Walding, CloudBees, Inc.* for SECURITY-278
 * *Jason Marzan* for SECURITY-290

--- a/content/security/advisory/2016-11-16.adoc
+++ b/content/security/advisory/2016-11-16.adoc
@@ -37,7 +37,7 @@ As part of this fix, a number of other so-called "gadgets" were reviewed and are
 
 == Other resources
 
-* link:https://jenkins.io/blog/2016/11/16/security-updates-addressing-zero-day/[November 16 blog post announcing the fixes]
-* link:https://jenkins.io/blog/2016/11/12/addressing-remote-vulnerabilities-in-cli/[November 11 blog post with workaround after public disclosure of the vulnerability]
-* link:https://jenkins.io/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[LTS 2.19.3 upgrade guide for Jenkins administrators]
+* link:/blog/2016/11/16/security-updates-addressing-zero-day/[November 16 blog post announcing the fixes]
+* link:/blog/2016/11/12/addressing-remote-vulnerabilities-in-cli/[November 11 blog post with workaround after public disclosure of the vulnerability]
+* link:/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[LTS 2.19.3 upgrade guide for Jenkins administrators]
 * link:https://www.cloudbees.com/jenkins-security-advisory-2016-11-16[Corresponding security advisory for CloudBees Jenkins Enterprise and CloudBees Jenkins Operations Center]

--- a/content/security/advisory/2017-02-01.adoc
+++ b/content/security/advisory/2017-02-01.adoc
@@ -92,7 +92,7 @@ To prevent this, console notes are now signed by Jenkins when created, and Jenki
 
 XStream-based APIs in Jenkins (e.g. +/createItem+ URLs, or +POST config.xml+ remote API) were vulnerable to a remote code execution vulnerability involving the deserialization of various types in +javax.imageio+.
 
-In case this extension of the blacklist results in regressions, the blacklist can be customized as described link:https://jenkins.io/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[in the Jenkins LTS upgrade guide for Jenkins 2.19.3].
+In case this extension of the blacklist results in regressions, the blacklist can be customized as described link:/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[in the Jenkins LTS upgrade guide for Jenkins 2.19.3].
 
 
 === Information disclosure vulnerability in search suggestions
@@ -169,7 +169,7 @@ These versions include fixes to all the vulnerabilities described above. All pri
 
 == Credit
 
-The Jenkins project would like to thank the reporters for discovering and link:https://jenkins.io/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
+The Jenkins project would like to thank the reporters for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
 
 * *Ben Walding, CloudBees, Inc.* for SECURITY-304
 * *Daniel Beck, CloudBees, Inc.* for SECURITY-343, SECURITY-371, SECURITY-385, and SECURITY-392
@@ -185,5 +185,5 @@ The Jenkins project would like to thank the reporters for discovering and link:h
 
 == Other Resources
 
-* https://jenkins.io/blog/2017/02/01/security-updates/[Announcement blog post]
+* /blog/2017/02/01/security-updates/[Announcement blog post]
 * https://www.cloudbees.com/cloudbees-security-advisory-2017-02-01[Corresponding advisory from CloudBees for CloudBees Jenkins Platform]

--- a/content/solutions/pipeline.adoc
+++ b/content/solutions/pipeline.adoc
@@ -29,7 +29,7 @@ features like:
 * checking the pipeline definition into source control (`Jenkinsfile`)
 * support for extending the domain specific language with additional,
   organization specific steps, via the
-  "link:https://jenkins.io/doc/book/pipeline/shared-libraries/[Shared Libraries]" feature.
+  "link:/doc/book/pipeline/shared-libraries/[Shared Libraries]" feature.
 
 In an adjacent space is the
 link:https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin[Job DSL plugin]


### PR DESCRIPTION
- allow setting an Awestruct profile in Gradle
- Change existing links to be host relative

With these changes, the site can be generated using `./gradlew -Pprofile=development …` and run statically on a local system. Otherwise, many links would point to jenkins.io.