### PR TITLE
Keep more builds, and use development profile again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 #!/usr/bin/env groovy
 
-/* Only keep the 10 most recent builds. */
+/* Keep 50 builds but only 5 artifacts. */
 def projectProperties = [
-    [$class: 'BuildDiscarderProperty',strategy: [$class: 'LogRotator', numToKeepStr: '5']],
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '5', daysToKeepStr: '', numToKeepStr: '50')),
 ]
 
 if (!env.CHANGE_ID) {

--- a/content/_config/site.yml
+++ b/content/_config/site.yml
@@ -34,11 +34,11 @@ asciidoctor:
     notitle: ''
 profiles:
   production:
+  development:
+    base_url: http://localhost:4242/
     # Don't log to GA while working on the site
     google_analytics:
       account: UA-000000-0
-  local:
-    base_url: http://localhost:4242/
   hrmpw:
     base_url: https://hrmpw.github.io/jenkins.io/
     deploy:


### PR DESCRIPTION
PR build should ideally be `production` profile to demonstrate this doesn't break things again.

More build logs can't really hurt. 50 builds is one day.