### PR TITLE
Reference security advisories in LTS changelog

### DIFF
--- a/content/changelog-stable/index.html
+++ b/content/changelog-stable/index.html
@@ -64,7 +64,7 @@ View ratings below, and click one of the icons next to your version to provide y
 <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
-    (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01">security advisory</a>)
+    (<a href="https://jenkins.io/security/advisory/2017-02-01/">security advisory</a>)
   <li class="major rfe">
     Support displaying of warnings from the update site in the plugin manager and in administrative monitors.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-40494">issue 40494</a>,
@@ -243,7 +243,7 @@ View ratings below, and click one of the icons next to your version to provide y
 <ul class=image>
    <li class="major bug">
      <strong>Important security fixes</strong>
-     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-11-16">security advisory</a>)
+     (<a href="https://jenkins.io/security/advisory/2016-11-16/">security advisory</a>)
   <li class="rfe">
     Allow disabling the Jenkins CLI over HTTP and JNLP agent port by setting the System property <tt>jenkins.CLI.disabled</tt> to <tt>true</tt>.
 </ul>
@@ -639,7 +639,7 @@ View ratings below, and click one of the icons next to your version to provide y
 <ul class=image>
    <li class="major bug">
      <strong>Important security fixes</strong>
-     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-05-11">security advisory</a>)
+     (<a href="https://jenkins.io/security/advisory/2016-05-11/">security advisory</a>)
 
   <li class="rfe">
     Update remoting to 2.57.
@@ -771,7 +771,7 @@ View ratings below, and click one of the icons next to your version to provide y
     <ul class=image>
        <li class="major bug">
          <strong>Important security fixes</strong>
-         (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-02-24">security advisory</a>)
+         (<a href="https://jenkins.io/security/advisory/2016-02-24/">security advisory</a>)
       <li class="bug">
         Don't submit usage statistics while Jenkins hasn't finished loading.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-32190">issue 32190</a>)
@@ -845,7 +845,7 @@ View ratings below, and click one of the icons next to your version to provide y
     <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
-    (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-12-09">security advisory</a>)
+    (<a href="https://jenkins.io/security/advisory/2015-12-09/">security advisory</a>)
         <li class='bug'>
     SECURITY-186 regression: non-item tasks hidden
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-31649'>issue 31649</a>)
@@ -863,7 +863,7 @@ View ratings below, and click one of the icons next to your version to provide y
     <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
-    (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11">security advisory</a>)
+    (<a href="https://jenkins.io/security/advisory/2015-11-11/">security advisory</a>)
   <li class='bug'>
     AbstractBuildExecution#reportError should work will any kind of Build Step
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-30730'>issue 30730</a>)
@@ -876,13 +876,6 @@ View ratings below, and click one of the icons next to your version to provide y
   <li class='bug'>
     FlyWeightTasks tied to a label will not cause node provisioning and will be blocked forever.
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-30084'>issue 30084</a>)
-  <li class='bug'>
-    People with Jenkins.ADMINISTER are always able to see API tokens of all users
-    (SECURITY-200)
-  <li class='bug'>
-    CLI (/cli) exposes instance information via left sidebar
-    (SECURITY-192)
-
     </ul>
 
 
@@ -1103,6 +1096,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.596.2>What's new in 1.596.2</a> (2015/03/23)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2015-03-23/">security advisory</a>)
         <li class='bug'>
     JDK9 with jigsaw file layer is not detected as valid JDK
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-25601'>issue 25601</a>)
@@ -1113,30 +1109,23 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     Animated ball in job's build history widget won't open Console Output
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-26365'>issue 26365</a>)
   <li class='bug'>
-    Reflected XSS (affects IE all versions and Safari)
-    (SECURITY-177)
-  <li class='bug'>
     Large number of build parameters for pending jobs (e.g.gerrit triggered job) can cause unwieldy build history
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-22311'>issue 22311</a>)
   <li class='bug'>
     Infinite loop with crontab "H H(19-24) * * *"
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-25897'>issue 25897</a>)
   <li class='bug'>
-    XSS in FormValidation._error(..., Throwable, ...)
-    (SECURITY-171)
-  <li class='bug'>
     Run parameters should display in human readable form rather than build numbers
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-25174'>issue 25174</a>)
-  <li class='bug'>
-    arbitrary API Token change/leak via changeToken
-    (SECURITY-180)
-
     </ul>
 
 
 
     <h3><a name=v1.596.1>What's new in 1.596.1</a> (2015/02/28)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2015-02-27/">security advisory</a>)
         <li class='bug'>
     Job failure on remote node running JDK1.8 - java.lang.NoSuchMethodException: java.lang.UNIXProcess.destroyProcess(int)
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-21341'>issue 21341</a>)
@@ -1224,6 +1213,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.580.1>What's new in 1.580.1</a> (2014/10/29)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2014-10-30/">security advisory</a>)
         <li class='rfe'>
     Jetty should be used rather than Winstone for embedded deployments
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-18366'>issue 18366</a>)
@@ -1236,40 +1228,18 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
   <li class='bug'>
     Wrong EOL (UNIX type: LF) in Windows batch files executed for build steps of type "Execute Windows batch command"
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-7478'>issue 7478</a>)
-  <li class='bug'>
-    hudson.cli.util.ScriptLoader lets you read any file from the master with a variant of SECURITY-145
-    (SECURITY-147)
-  <li class='bug'>
-    RemotingDiagnostics based variant of SECURITY-145
-    (SECURITY-146)
-
     </ul>
 
 
 
     <h3><a name=v1.565.3>What's new in 1.565.3</a> (2014/10/01)</h3>
     <ul class=image>
-        <li class='bug'>
-    Plugin code can be downloaded by anyone with Overall/Read
-    (SECURITY-155)
-  <li class='bug'>
-    Stored passwords can be read out from build with parameters page
-    (SECURITY-138)
-  <li class='bug'>
-    Multiple cross-site scripting (XSS) vulnerabilities in ZeroClipboard.swf in ZeroClipboard before 1.3.2 as included with Jenkins
-    (SECURITY-149)
-  <li class='bug'>
-    Unauthenticated users can make Jenkins behind Apache unresponsive
-    (SECURITY-87)
-  <li class='bug'>
-    Users with limited Job/Configure can replace other jobs they have no access to (if they know the name)
-    (SECURITY-128)
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2014-10-01/">security advisory</a>)
   <li class='bug'>
     CLI calls are causing file descriptor leaks.
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-23248'>issue 23248</a>)
-  <li class='bug'>
-    Users with limited Job/Configure can change the kind of job via CLI, getting access to denied job types
-    (SECURITY-127)
   <li class='bug'>
     Test result trend breaks lazy-loading
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-23945'>issue 23945</a>)
@@ -1277,39 +1247,17 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     Unable to kill a job which is running
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-17667'>issue 17667</a>)
   <li class='bug'>
-    XSS weakness in load-statistics
-    (SECURITY-143)
-  <li class='bug'>
     Job is removed from ListView after rename
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-23893'>issue 23893</a>)
   <li class='bug'>
     set-build-result and set-build-parameter do insufficient checks
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-24080'>issue 24080</a>)
   <li class='bug'>
-    Missing no-sniff header
-    (SECURITY-122)
-  <li class='bug'>
-    Directory traversal
-    (SECURITY-131)
-  <li class='bug'>
     "incompatible InnerClasses attribute" error in IBM J9 VM
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-22525'>issue 22525</a>)
   <li class='bug'>
-    Arbitrary file system write via DiskFileItem deserialization
-    (SECURITY-159)
-  <li class='bug'>
-    Missing SecureFlag cookie
-    (SECURITY-120)
-  <li class='bug'>
-    Prevent (private security realm) usernames from being guessed (SECURITY-79 redux!)
-    (SECURITY-110)
-  <li class='bug'>
     Deadlock in OldDataMonitor
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-24358'>issue 24358</a>)
-  <li class='bug'>
-    RemoteInvocationHandler.RPCRequest allows invoking any method on an exported object event those not exposed by the exported interface
-    (SECURITY-150)
-
     </ul>
 
 
@@ -1538,18 +1486,15 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.532.2>What's new in 1.532.2</a> (2014/02/14)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2014-02-14/">security advisory</a>)
         <li class='bug'>
     CannotResolveClassException breaks loading of entire containing folder, not just one job
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-20951'>issue 20951</a>)
   <li class='bug'>
-    Default markup formatter permits offsite-bound forms
-    (SECURITY-88)
-  <li class='bug'>
     Using jenkins-cli connecting to HTTPS port fails due to hostname mismatch in certificate
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-12629'>issue 12629</a>)
-  <li class='bug'>
-    ApiTokenFilter does not check that the user actually exists
-    (SECURITY-89)
   <li class='bug'>
     HTTP two-way remoting does not work (jenkins-cli.jar without JNLP)
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-20128'>issue 20128</a>)
@@ -1559,9 +1504,6 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
   <li class='bug'>
     StreamCorruptedException
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-8856'>issue 8856</a>)
-  <li class='bug'>
-    UI Redressing/ClickJacking
-    (SECURITY-80)
   <li class='bug'>
     Fail to run 'groovysh' in CLI due to insufficient permission
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-17929'>issue 17929</a>)
@@ -1578,35 +1520,14 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     ListView.expand throws ClassCastException: … cannot be cast to hudson.model.TopLevelItem
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-20415'>issue 20415</a>)
   <li class='bug'>
-    Stored XSS
-    (SECURITY-74)
-  <li class='bug'>
-    Session Fixation
-    (SECURITY-75)
-  <li class='bug'>
-    /heapDump offered to anyone with ADMINISTER
-    (SECURITY-73)
-  <li class='bug'>
-    Username Guessing/Enumeration
-    (SECURITY-79)
-  <li class='bug'>
     RingBufferLogHandler throws ArrayIndexOutOfBoundsException after int-overflow
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-9120'>issue 9120</a>)
-  <li class='bug'>
-    Iframe Injection
-    (SECURITY-76)
-  <li class='bug'>
-    Reflected XSS in Cookie
-    (SECURITY-77)
   <li class='bug'>
     l:breakable mishandles HTML metacharacters
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-20928'>issue 20928</a>)
   <li class='bug'>
     Start JNLP slave ignores jar-cache flag
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-20093'>issue 20093</a>)
-  <li class='bug'>
-    Stored passwords can be read out from UIs with password fields
-    (SECURITY-93)
   <li class='bug'>
     Too many open files upon HTTP listener init or shutdown
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-14336'>issue 14336</a>)
@@ -1619,15 +1540,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
   <li class='bug'>
     Workspaces seem to be removed prematurely on concurrent jobs
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-10615'>issue 10615</a>)
-  <li class='bug'>
-    Job creators are able to edit or destroy the system configuration via the CLI
-    (SECURITY-108)
   <li class='rfe'>
     Disable\Delete "Remember me on this computer" check box in login screen
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-15757'>issue 15757</a>)
-  <li class='bug'>
-    SECURITY-55 fails if downstream project not visible
-    (SECURITY-109)
   <li class='bug'>
     Builds disappear some time after renaming job
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-18678'>issue 18678</a>)
@@ -1637,15 +1552,6 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
   <li class='bug'>
     java.lang.NoClassDefFoundError: sun/net/www/protocol/jar/JarURLConnection
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-20163'>issue 20163</a>)
-  <li class='bug'>
-    Remote code execution via xstream deserialization in XML API
-    (SECURITY-105)
-  <li class='bug'>
-    Jenkins on winstone vulnerable to session hijacking
-    (SECURITY-106)
-  <li class='bug'>
-    Jenkins allows anonymous access if the Authorization Strategy can't be loaded
-    (SECURITY-107)
   <li class='bug'>
     you cannot use the cli without giving Overall read to Anonymous
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-8815'>issue 8815</a>)
@@ -1930,6 +1836,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.509.1>What's new in 1.509.1</a> (2013/05/01)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2013-05-02/">security advisory</a>)
         <li class='bug'>
     FilePath.installIfNecessaryFrom routes download over remoting channel
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-17330'>issue 17330</a>)
@@ -1937,20 +1846,8 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     Add 'Are you sure' on Reload configuration from disk
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-15340'>issue 15340</a>)
   <li class='bug'>
-    MavenAbstractArtifactRecord.doRedeploy should require POST
-    (SECURITY-69)
-  <li class='bug'>
     Hover-over "Build Now" broken for parameterized jobs: "This page expects a form submission"
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-17110'>issue 17110</a>)
-  <li class='bug'>
-    XSS issue, where an internal attacker can cause a remote stylesheet to be loaded and containing scripts executed.
-    (SECURITY-67)
-  <li class='bug'>
-    CVE-2013-1808 stapler-adjunct-zeroclipboard: XSS via copying XSS payload into buffer
-    (SECURITY-71)
-  <li class='bug'>
-    Jenkins.doEval checks ADMINISTER rather than RUN_SCRIPTS; doScript CSRF
-    (SECURITY-63)
   <li class='bug'>
     Jenkins is no more WinXP compliant :  CreateSymbolicLinkW is not available
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-17343'>issue 17343</a>)
@@ -1961,6 +1858,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.480.3>What's new in 1.480.3</a> (2013/02/15)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2013-02-16/">security advisory</a>)
         <li class='bug'>
     "Remember me on this computer" does not work, cookie is not accepted in new session
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-16278'>issue 16278</a>)
@@ -1983,9 +1883,6 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     View.hasPeople too slow to use in sidepanel.jelly
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-16244'>issue 16244</a>)
   <li class='bug'>
-    XSS
-    (SECURITY-46)
-  <li class='bug'>
     File parameter causing data lost after Jenkins restart
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-13536'>issue 13536</a>)
 
@@ -1997,14 +1894,16 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     <ul class=image>
        <li class='major bug'>
     The master key that was protecting all the sensitive data in <tt>$JENKINS_HOME</tt> was vulnerable.
-    (SECURITY-49)
-
+      (<a href="https://jenkins.io/security/advisory/2013-01-04/">security advisory</a>)
     </ul>
 
 
 
     <h3><a name=v1.480.1>What's new in 1.480.1</a> (2012/11/17)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2012-11-20/">security advisory</a>)
         <li class='bug'>
     FilePath.validateAntFileMask too slow for /configure
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-7214'>issue 7214</a>)
@@ -2018,24 +1917,17 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
     Invalid JSON is produced during remote api operations when a changeSet contains duplicate keys.
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-13336'>issue 13336</a>)
   <li class='bug'>
-    Header manipulation (CrLf) – open redirect vulnerability in "j_acegi_security_check"
-    (SECURITY-44)
-  <li class='bug'>
     Memory exhaustion parsing large test stdio from Surefire
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-15382'>issue 15382</a>)
-  <li class='bug'>
-    Persistence XSS vulnerability in build's decription
-    (SECURITY-43)
-  <li class='bug'>
-    Header manipulation (CrLf) – open redirect vulnerability in Work Space
-    (SECURITY-45)
-
     </ul>
 
 
 
     <h3><a name=v1.466.2>What's new in 1.466.2</a> (2012/09/13)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2012-09-17/">security advisory</a>)
 
     </ul>
 
@@ -2106,7 +1998,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.424.6>What's new in 1.424.6</a> (2012/03/06)</h3>
     <ul class=image>
-
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2012-03-05/">security advisory</a>)
     </ul>
 
 
@@ -2149,6 +2043,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.424.2>What's new in 1.424.2</a> (2012/01/10)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2012-01-12/">security advisory</a>)
         <li class='bug'>
     Viewing large console logs with timestamper plugin cause Jenkins to crash
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-9349'>issue 9349</a>)
@@ -2158,22 +2055,18 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
   <li class='bug'>
      Jenkins PID changes after restart
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-11742'>issue 11742</a>)
-  <li class='bug'>
-    Running Jenkins with the bundeled Winstone is succeptible to the hash table attack http://www.ocert.org/advisories/ocert-2011-003.html
-    (SECURITY-22)
-
     </ul>
 
 
 
     <h3><a name=v1.424.1>What's new in 1.424.1</a> (2011/11/30)</h3>
     <ul class=image>
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2011-11-08/">security advisory</a>)
         <li class='bug'>
     JDKInstaller fails with OutOfMemory exception
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-10689'>issue 10689</a>)
-  <li class='bug'>
-    XSS in Winstone
-    (SECURITY-17)
   <li class='bug'>
     Tools download does not appear to respect proxy settings
     (<a href='https://issues.jenkins-ci.org/browse/JENKINS-5271'>issue 5271</a>)
@@ -2208,10 +2101,9 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3><a name=v1.409.3>What's new in 1.409.3</a> (2011/11/08)</h3>
     <ul class=image>
-        <li class='bug'>
-    XSS in Winstone
-    (SECURITY-17)
-
+      <li class="major bug">
+        <strong>Important security fixes</strong>
+        (<a href="https://jenkins.io/security/advisory/2011-11-08/">security advisory</a>)
     </ul>
 
 


### PR DESCRIPTION
* Switch from wiki to site URL when reference to security advisory is present
* Add reference to advisory (on the site, obviously) when it was missing
* Remove individual list entries for security fixes, those were often incomplete anyway

I also checked that all (core) security advisories are now referenced -- the old changelog process (autogenerated and stored on cucumber) resulted in versions with no listed security fixes, and no reference to the advisory. So while these old changelogs are probably frequently incomplete, at least we now reference all the advisories.