### PR TITLE
Get rid of obsolete .htaccess with illegal rules

### DIFF
--- a/content/sites/default/files/.htaccess
+++ b/content/sites/default/files/.htaccess
@@ -1,3 +1,0 @@
-SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
-Options None
-Options +FollowSymLinks


### PR DESCRIPTION
First line is Drupal-specific: https://www.drupal.org/files/sa-2006-006/advisory.txt

The rest is useless as well I think.