### PR TITLE
Fail the build if illegal .htaccess content was found

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,13 @@ try {
                                 echo "Failing build due to warnings in log output" >&2
                                 exit 1
                             fi
+
+                            illegal_htaccess_content="$( find content -name '.htaccess' -type f -exec grep --extended-regexp --invert-match '^(#|ErrorDocument)' {} \\; )"                            
+                            if [[ -n "$illegal_htaccess_content" ]] ; then
+                                echo "Failing build due to illegal content in .htaccess files, only ErrorDocument is allowed:" >&2
+                                echo "$illegal_htaccess_content" >&2
+                                exit 1
+                            fi
                            '''
                     }
                 }


### PR DESCRIPTION
Supports https://github.com/jenkins-infra/jenkins-infra/pull/688 to prevent problems like https://github.com/jenkins-infra/jenkins.io/pull/664 which caused Internal Server Errors