### PR TITLE
Reset changelog style reset

### DIFF
--- a/content/changelog.css
+++ b/content/changelog.css
@@ -1,7 +1,4 @@
 /* icons taken from http://www.image-seed.com/archives/cat_10007473.html */
-BODY, TH, TD, P, LI {
-  font-size: 100%;
-}
 
 /* cancel out the CSS style definition in the Drupal theme */
 #content .content UL.image LI {


### PR DESCRIPTION
This messed up the title bar on the changelog pages compared to other URLs:

Compare:

https://jenkins.io/changelog/
https://jenkins.io/events/