### PR TITLE
Add localized redirect capability

### DIFF
--- a/content/_layouts/redirect.html.haml
+++ b/content/_layouts/redirect.html.haml
@@ -1,0 +1,37 @@
+- # Define a redirect elsewhere with optional support for browser language detection
+- # Configuration is via front matter, one URL is the non-JS default, others are redirected to via JS if language matches
+- #
+- # ---
+- # layout: redirect
+- # redirect_url: "https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API"
+- # localized_urls:
+- #   ja: "https://wiki.jenkins-ci.org/display/JA/Remote+access+API"
+- #   de: "https://wiki.jenkins-ci.org/display/DE/Remote+access+API"
+- # ---
+
+
+:ruby
+  single_url = if page.localized_urls then false else true end
+
+
+%html
+  %head
+    %meta{:'http-equiv' => 'content-type', :content => 'text/html; charset=utf-8'}/
+    - if single_url
+      %meta{:'http-equiv' => 'refresh', :content => "0;URL=#{page.redirect_url}"}/
+    - else
+      %noscript
+        %meta{:'http-equiv' => 'refresh', :content => "0;URL=#{page.redirect_url}"}/
+  %body
+    %center
+      This content has moved to
+      %a{:href => page.redirect_url}
+        = page.redirect_url
+    %script
+      var language = window.navigator.userLanguage || window.navigator.language;
+      - unless single_url
+        - page.localized_urls.each do |lang, url|
+          if (language == "#{lang}" || language.length > 2 && language.substring(0, #{1 + lang.length}) == "#{lang}-") {
+          window.location = "#{url}";
+          } else
+      window.location = "#{page.redirect_url}";


### PR DESCRIPTION
Add infrastructure for localizable redirects based on browser language. Can be used to implement en/ja wiki switch in redirect URLs for https://github.com/jenkinsci/jenkins/pull/2756

One minor issue: The clickable link and its label are not localized, only the JS redirect is. I just didn't care enough to clean this up.