### PR TITLE
Add redirects for Jenkins

### DIFF
--- a/content/_layouts/redirect.html.haml
+++ b/content/_layouts/redirect.html.haml
@@ -1,0 +1,37 @@
+- # Define a redirect elsewhere with optional support for browser language detection
+- # Configuration is via front matter, one URL is the non-JS default, others are redirected to via JS if language matches
+- #
+- # ---
+- # layout: redirect
+- # redirect_url: "https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API"
+- # localized_urls:
+- #   ja: "https://wiki.jenkins-ci.org/display/JA/Remote+access+API"
+- #   de: "https://wiki.jenkins-ci.org/display/DE/Remote+access+API"
+- # ---
+
+
+:ruby
+  single_url = if page.localized_urls then false else true end
+
+
+%html
+  %head
+    %meta{:'http-equiv' => 'content-type', :content => 'text/html; charset=utf-8'}/
+    - if single_url
+      %meta{:'http-equiv' => 'refresh', :content => "0;URL=#{page.redirect_url}"}/
+    - else
+      %noscript
+        %meta{:'http-equiv' => 'refresh', :content => "0;URL=#{page.redirect_url}"}/
+  %body
+    %center
+      This content has moved to
+      %a{:href => page.redirect_url}
+        = page.redirect_url
+    %script
+      var language = window.navigator.userLanguage || window.navigator.language;
+      - unless single_url
+        - page.localized_urls.each do |lang, url|
+          if (language == "#{lang}" || language.length > 2 && language.substring(0, #{1 + lang.length}) == "#{lang}-") {
+          window.location = "#{url}";
+          } else
+      window.location = "#{page.redirect_url}";

--- a/content/redirect/api-token.adoc
+++ b/content/redirect/api-token.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Remote+access+API
+---

--- a/content/redirect/build-record-migration.adoc
+++ b/content/redirect/build-record-migration.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/JENKINS-24380+Migration
+---

--- a/content/redirect/cli-https-proxy-tunnel.adoc
+++ b/content/redirect/cli-https-proxy-tunnel.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Jenkins+CLI
+---

--- a/content/redirect/cli.adoc
+++ b/content/redirect/cli.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Jenkins+CLI
+---

--- a/content/redirect/configuring-servlet-containers.adoc
+++ b/content/redirect/configuring-servlet-containers.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Containers
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Containers
+---

--- a/content/redirect/contribute.adoc
+++ b/content/redirect/contribute.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://jenkins.io/participate/
+---

--- a/content/redirect/developer/class-is-missing-descriptor.adoc
+++ b/content/redirect/developer/class-is-missing-descriptor.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/My+class+is+missing+descriptor
+---

--- a/content/redirect/developer/extension-points.adoc
+++ b/content/redirect/developer/extension-points.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Extension+points
+---

--- a/content/redirect/developer/index.adoc
+++ b/content/redirect/developer/index.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Extend+Jenkins
+---

--- a/content/redirect/developer/structured-form-submission.adoc
+++ b/content/redirect/developer/structured-form-submission.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Structured+Form+Submission
+---

--- a/content/redirect/fingerprint.adoc
+++ b/content/redirect/fingerprint.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Fingerprint
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Fingerprint
+---

--- a/content/redirect/hangout.adoc
+++ b/content/redirect/hangout.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: 'https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38'
+layout: redirect
+redirect_url: https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38
 ---

--- a/content/redirect/installation-wizard.adoc
+++ b/content/redirect/installation-wizard.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins#InstallingJenkins-InstallationWizard
+---

--- a/content/redirect/issue-tracker.adoc
+++ b/content/redirect/issue-tracker.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://issues.jenkins-ci.org
+---

--- a/content/redirect/logging.adoc
+++ b/content/redirect/logging.adoc
@@ -1,4 +1,6 @@
 ---
 layout: redirect
 redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Logging
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Logger+Configuration
 ---

--- a/content/redirect/mailing-lists.adoc
+++ b/content/redirect/mailing-lists.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://jenkins-ci.org/content/mailing-lists
+---

--- a/content/redirect/migrate-jenkins-home.adoc
+++ b/content/redirect/migrate-jenkins-home.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Administering+Jenkins
+---

--- a/content/redirect/offline-installation.adoc
+++ b/content/redirect/offline-installation.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Offline+Jenkins+Installation
+---

--- a/content/redirect/oracle-account-signup.adoc
+++ b/content/redirect/oracle-account-signup.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://jenkins-ci.org/oracleAccountSignup # TODO get rid of double redirect
+---

--- a/content/redirect/parameterized-builds.adoc
+++ b/content/redirect/parameterized-builds.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Build
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Parameterized+Build
+---

--- a/content/redirect/rekey.adoc
+++ b/content/redirect/rekey.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2013-01-04
+---

--- a/content/redirect/remote-api.adoc
+++ b/content/redirect/remote-api.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Remote+access+API
+---

--- a/content/redirect/report-an-issue.adoc
+++ b/content/redirect/report-an-issue.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/How+to+report+an+issue
+---

--- a/content/redirect/scm-change-trigger.adoc
+++ b/content/redirect/scm-change-trigger.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project
+---

--- a/content/redirect/search-box.adoc
+++ b/content/redirect/search-box.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Search+Box
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Search+Box
+---

--- a/content/redirect/securing-jenkins.adoc
+++ b/content/redirect/securing-jenkins.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: 'https://wiki.jenkins-ci.org/display/JENKINS/Securing+Jenkins'
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Securing+Jenkins
 ---

--- a/content/redirect/security-144.adoc
+++ b/content/redirect/security-144.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: 'https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control/'
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control
 ---

--- a/content/redirect/setting-system-properties.adoc
+++ b/content/redirect/setting-system-properties.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+---

--- a/content/redirect/troubleshooting/darwin-failed-to-parse-arguments.adoc
+++ b/content/redirect/troubleshooting/darwin-failed-to-parse-arguments.adoc
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_url: https://issues.jenkins-ci.org/browse/JENKINS-9634
+# TODO Write documentation for this request to provide information
+---

--- a/content/redirect/troubleshooting/disable-security-manager.adoc
+++ b/content/redirect/troubleshooting/disable-security-manager.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Containers
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Containers
+---

--- a/content/redirect/troubleshooting/executor-starvation.adoc
+++ b/content/redirect/troubleshooting/executor-starvation.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Executor+Starvation
+---

--- a/content/redirect/troubleshooting/initialization-not-completed.adoc
+++ b/content/redirect/troubleshooting/initialization-not-completed.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://issues.jenkins-ci.org/browse/JENKINS-37759 # TODO better URL
+---

--- a/content/redirect/troubleshooting/java.awt.headless.adoc
+++ b/content/redirect/troubleshooting/java.awt.headless.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+got+java.awt.headless+problem
+---

--- a/content/redirect/troubleshooting/jna-already-loaded.adoc
+++ b/content/redirect/troubleshooting/jna-already-loaded.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/JNA+is+already+loaded
+---

--- a/content/redirect/troubleshooting/process-leaked-file-descriptors.adoc
+++ b/content/redirect/troubleshooting/process-leaked-file-descriptors.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build
+---

--- a/content/redirect/troubleshooting/utf8-url-decoding.adoc
+++ b/content/redirect/troubleshooting/utf8-url-decoding.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Tomcat#Tomcat-i18n
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Tomcat#Tomcat-i18n
+---

--- a/content/redirect/troubleshooting/windows-agent-restart.adoc
+++ b/content/redirect/troubleshooting/windows-agent-restart.adoc
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Windowsslaveserviceupgrades
+# This page exists in the Japanese wiki, but is missing the referenced section
+---

--- a/content/redirect/troubleshooting/windows-service-fails-to-start.adoc
+++ b/content/redirect/troubleshooting/windows-service-fails-to-start.adoc
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+windows+service+fails+to+start
+localized_urls:
+  ja: https://wiki.jenkins-ci.org/display/JA/Jenkins+windows+service+fails+to+start
+---

--- a/content/redirect/user-content-directory.adoc
+++ b/content/redirect/user-content-directory.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/User+Content
+---

--- a/content/redirect/users-mailing-list.adoc
+++ b/content/redirect/users-mailing-list.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://jenkins-ci.org/content/mailing-lists
+---


### PR DESCRIPTION
This builds on top of #670 to provide redirects from Jenkins in preparation of https://github.com/jenkinsci/jenkins/pull/2756, mostly to the wiki (sometimes either JENKINS or JA depending on browser language).

I also rewrote existing redirects to use the new layout for consistency.