### PR TITLE
Do not show changelog entries for unreleased versions

### DIFF
--- a/content/changelog-stable/index.html.haml
+++ b/content/changelog-stable/index.html.haml
@@ -13,21 +13,22 @@ title: LTS Changelog
 
 .ratings
   - site.changelogs[:lts].reverse_each do | release |
-    %h3
-      %a{:name => "v#{release.version}" }
-        What's new in
-        = release.version
-      = "(#{release.date})"
-    -if release.changes and release.lts_changes and release.lts_baseline
-      %div
-        %strong
-          = "Changes since #{release.lts_baseline}:"
-    %ul.image
-      = partial('changes.html.haml', :changes => release.changes)
-    -if release.changes and release.lts_changes
-      %div
-        %strong
-          = "Notable changes since #{release.lts_predecessor}:"
+    - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.stable)
+      %h3
+        %a{:name => "v#{release.version}" }
+          What's new in
+          = release.version
+        = "(#{release.date})"
+      -if release.changes and release.lts_changes and release.lts_baseline
+        %div
+          %strong
+            = "Changes since #{release.lts_baseline}:"
       %ul.image
-        = partial('changes.html.haml', :changes => release.lts_changes)
+        = partial('changes.html.haml', :changes => release.changes)
+      -if release.changes and release.lts_changes
+        %div
+          %strong
+            = "Notable changes since #{release.lts_predecessor}:"
+        %ul.image
+          = partial('changes.html.haml', :changes => release.lts_changes)
   = partial('changelog-stable.html')

--- a/content/changelog/index.html.haml
+++ b/content/changelog/index.html.haml
@@ -7,13 +7,14 @@ title: Changelog
 
 .ratings
   - site.changelogs[:weekly].reverse_each do | release |
-    %h3
-      %a{:name => "v#{release.version}" }
-        What's new in
-        = release.version
-      = "(#{release.date})"
-    %ul.image
-      = partial('changes.html.haml', :changes => release.changes)
+    - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
+      %h3
+        %a{:name => "v#{release.version}" }
+          What's new in
+          = release.version
+        = "(#{release.date})"
+      %ul.image
+        = partial('changes.html.haml', :changes => release.changes)
   = partial('changelog-weekly.html')
 
 


### PR DESCRIPTION
Now we can amend the changelog whenever we like (Saturdays? Monday before LTS release? \*gasp\*) and don't have to care about when the actual release happens.

Actual diff: https://github.com/jenkins-infra/jenkins.io/pull/673/files?w=1

CC @oleg-nenashev @olivergondza 