### PR TITLE
Offset the header height for anchor elements

### DIFF
--- a/content/_partials/changelog-stable.html
+++ b/content/_partials/changelog-stable.html
@@ -5,7 +5,7 @@ title: LTS Changelog
 
 <!-- this document archives change logs of LTS releases 2.19.4 and earlier in HTML. It has since been replaced by YAML based changelogs. -->
 
-<h3><a name=v2.19.4>What's new in 2.19.4</a> (2016-11-23)</h3>
+<h3 id=v2.19.4>What's new in 2.19.4 (2016-11-23)</h3>
 <ul class=image>
 
   <li class="bug">
@@ -76,7 +76,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10912">issue 10912</a>)
 </ul>
 
-<h3><a name=v2.19.3>What's new in 2.19.3</a> (2016-11-16)</h3>
+<h3 id=v2.19.3>What's new in 2.19.3 (2016-11-16)</h3>
 
 <div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
   This is an out-of-schedule release addressing <a href="/blog/2016/11/12/addressing-remote-vulnerabilities-in-cli/">the zero day vulnerability published on November 11, 2016</a>. It does not contain the usual LTS bug fixes, but only addresses the security vulnerability. There will be another LTS release in the 2.19.x line containing bug fixes as regularly scheduled.
@@ -90,7 +90,7 @@ title: LTS Changelog
     Allow disabling the Jenkins CLI over HTTP and JNLP agent port by setting the System property <tt>jenkins.CLI.disabled</tt> to <tt>true</tt>.
 </ul>
 
-<h3><a name=v2.19.2>What's new in 2.19.2</a> (2016-11-01)</h3>
+<h3 id=v2.19.2>What's new in 2.19.2 (2016-11-01)</h3>
 <ul class=image>
 
   <li class="bug">
@@ -131,7 +131,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18114">issue 18114</a>)
 </ul>
 
-<h3><a name=v2.19.1>What's new in 2.19.1</a> (2016-10-03)</h3>
+<h3 id=v2.19.1>What's new in 2.19.1 (2016-10-03)</h3>
 
 <div><strong>Changes from 2.19:</strong></div>
 
@@ -194,7 +194,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36476">issue 36476</a>)
 </ul>
 
-<h3><a name=v2.7.4>What's new in 2.7.4</a> (2016-09-08)</h3>
+<h3 id=v2.7.4>What's new in 2.7.4 (2016-09-08)</h3>
 <ul class=image>
   <li class="major bug">
     Prevent File descriptor leaks when reading plugin manifests.
@@ -202,7 +202,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-37332">issue 37332</a>)
 </ul>
 
-<h3><a name=v2.7.3>What's new in 2.7.3</a> (2016/08/31)</h3>
+<h3 id=v2.7.3>What's new in 2.7.3 (2016/08/31)</h3>
 <ul class=image>
 
   <li class="major bug">
@@ -249,7 +249,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34882">issue 34882</a>)
 </ul>
 
-<h3><a name=v2.7.2>What's new in 2.7.2</a> (2016/08/03)</h3>
+<h3 id=v2.7.2>What's new in 2.7.2 (2016/08/03)</h3>
 <ul class=image>
 
   <li class=bug>
@@ -281,7 +281,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22722">issue 22722</a>)
 </ul>
 
-<h3><a name=v2.7.1>What's new in 2.7.1</a> (2016/07/06)</h3>
+<h3 id=v2.7.1>What's new in 2.7.1 (2016/07/06)</h3>
 
 <div><strong>Changes from 2.7:</strong></div>
 
@@ -440,7 +440,7 @@ title: LTS Changelog
 </ul>
 
 
-<h3><a name=v1.651.3>What's new in 1.651.3</a> (2016/06/08)</h3>
+<h3 id=v1.651.3>What's new in 1.651.3 (2016/06/08)</h3>
 <ul class=image>
 
   <li class='bug'>
@@ -477,7 +477,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34819">issue 34819</a>)
 </ul>
 
-<h3><a name=v1.651.2>What's new in 1.651.2</a> (2016/05/11)</h3>
+<h3 id=v1.651.2>What's new in 1.651.2 (2016/05/11)</h3>
 <ul class=image>
    <li class="major bug">
      <strong>Important security fixes</strong>
@@ -505,7 +505,7 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18032">issue 18032</a>)
 </ul>
 
-<h3><a name=v1.651.1>What's new in 1.651.1</a> (2016/04/14)</h3>
+<h3 id=v1.651.1>What's new in 1.651.1 (2016/04/14)</h3>
 
 <div><strong>Changes from 1.651:</strong></div>
 
@@ -592,14 +592,14 @@ title: LTS Changelog
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19565">issue 19565</a>)
 </ul>
 
-    <h3><a name=v1.642.4>What's new in 1.642.4</a> (2016/03/31)</h3>
+    <h3 id=v1.642.4>What's new in 1.642.4 (2016/03/31)</h3>
     <ul class=image>
        <li class="major bug">
          Honor the option to opt out of usage statistics submission.
         (<a href="https://wiki.jenkins-ci.org/display/JENKINS/Usage+Statistics+Privacy+Advisory+2016-03-30">advisory</a>)
     </ul>
 
-    <h3><a name=v1.642.3>What's new in 1.642.3</a> (2016/03/16)</h3>
+    <h3 id=v1.642.3>What's new in 1.642.3 (2016/03/16)</h3>
     <ul class=image>
        <li class=bug>
          Fields on the parameters page are no longer aligned at the bottom.
@@ -609,7 +609,7 @@ title: LTS Changelog
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22767">issue 22767</a>)
     </ul>
 
-    <h3><a name=v1.642.2>What's new in 1.642.2</a> (2016/02/24)</h3>
+    <h3 id=v1.642.2>What's new in 1.642.2 (2016/02/24)</h3>
     <ul class=image>
        <li class="major bug">
          <strong>Important security fixes</strong>
@@ -634,7 +634,7 @@ title: LTS Changelog
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-32567">issue 32567</a>)
     </ul>
 
-    <h3><a name=v1.642.1>What's new in 1.642.1</a> (2016/01/20)</h3>
+    <h3 id=v1.642.1>What's new in 1.642.1 (2016/01/20)</h3>
     <div><strong>No changes compared to 1.642</strong>. Notable changes since 1.625.3:</div>
     <ul class=image>
       <li class="major rfe">
@@ -683,7 +683,7 @@ title: LTS Changelog
 
 
 
-    <h3><a name=v1.625.3>What's new in 1.625.3</a> (2015/12/09)</h3>
+    <h3 id=v1.625.3>What's new in 1.625.3 (2015/12/09)</h3>
     <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
@@ -701,7 +701,7 @@ title: LTS Changelog
 
 
 
-    <h3><a name=v1.625.2>What's new in 1.625.2</a> (2015/11/11)</h3>
+    <h3 id=v1.625.2>What's new in 1.625.2 (2015/11/11)</h3>
     <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
@@ -722,7 +722,7 @@ title: LTS Changelog
 
 
 
-    <h3><a name=v1.625.1>What's new in 1.625.1</a> (2015/10/14)</h3>
+    <h3 id=v1.625.1>What's new in 1.625.1 (2015/10/14)</h3>
 
 <div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
 <strong>1.625.1 is the first Jenkins LTS release that requires Java 7 to run.</strong>
@@ -830,7 +830,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.609.3>What's new in 1.609.3</a> (2015/09/02)</h3>
+    <h3 id=v1.609.3>What's new in 1.609.3 (2015/09/02)</h3>
     <ul class=image>
         <li class='bug'>
     When NodeProvisioner processes planned nodes, it must always call spent()
@@ -852,7 +852,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.609.2>What's new in 1.609.2</a> (2015/07/28)</h3>
+    <h3 id=v1.609.2>What's new in 1.609.2 (2015/07/28)</h3>
     <ul class=image>
         <li class='bug'>
     NPE may happen if somebody tries to drop the e-mail JenkinsLocationConfiguration:setAdminAddress()
@@ -883,7 +883,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.609.1>What's new in 1.609.1</a> (2015/05/29)</h3>
+    <h3 id=v1.609.1>What's new in 1.609.1 (2015/05/29)</h3>
     <ul class=image>
         <li class='bug'>
     Concurrent build limits not honored on Jenkins 1.607
@@ -920,7 +920,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.596.3>What's new in 1.596.3</a> (2015/05/20)</h3>
+    <h3 id=v1.596.3>What's new in 1.596.3 (2015/05/20)</h3>
     <ul class=image>
         <li class='bug'>
     Build history text field wrap fails when containing markup
@@ -936,7 +936,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.596.2>What's new in 1.596.2</a> (2015/03/23)</h3>
+    <h3 id=v1.596.2>What's new in 1.596.2 (2015/03/23)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -963,7 +963,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.596.1>What's new in 1.596.1</a> (2015/02/28)</h3>
+    <h3 id=v1.596.1>What's new in 1.596.1 (2015/02/28)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -988,7 +988,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.580.3>What's new in 1.580.3</a> (2015/01/27)</h3>
+    <h3 id=v1.580.3>What's new in 1.580.3 (2015/01/27)</h3>
     <ul class=image>
         <li class='bug'>
     Basic Authentication in combination with Session is broken
@@ -1019,7 +1019,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.580.2>What's new in 1.580.2</a> (2014/12/15)</h3>
+    <h3 id=v1.580.2>What's new in 1.580.2 (2014/12/15)</h3>
     <ul class=image>
         <li class='bug'>
     Job owned by SYSTEM instead of creator when 'Setup after creation' used
@@ -1053,7 +1053,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.580.1>What's new in 1.580.1</a> (2014/10/29)</h3>
+    <h3 id=v1.580.1>What's new in 1.580.1 (2014/10/29)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1074,7 +1074,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.565.3>What's new in 1.565.3</a> (2014/10/01)</h3>
+    <h3 id=v1.565.3>What's new in 1.565.3 (2014/10/01)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1104,7 +1104,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.565.2>What's new in 1.565.2</a> (2014/09/03)</h3>
+    <h3 id=v1.565.2>What's new in 1.565.2 (2014/09/03)</h3>
     <ul class=image>
         <li class='bug'>
     Jenkins needs to check whether the war's directory is writeable before offering to upgrade
@@ -1132,7 +1132,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.565.1>What's new in 1.565.1</a> (2014/07/30)</h3>
+    <h3 id=v1.565.1>What's new in 1.565.1 (2014/07/30)</h3>
     <ul class=image>
         <li class='bug'>
     Queue.maintain does disk I/O via PeepholePermalink.resolve
@@ -1187,7 +1187,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.554.3>What's new in 1.554.3</a> (2014/06/30)</h3>
+    <h3 id=v1.554.3>What's new in 1.554.3 (2014/06/30)</h3>
     <ul class=image>
         <li class='bug'>
     Queue.maintain does disk I/O via PeepholePermalink.resolve
@@ -1206,7 +1206,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.554.2>What's new in 1.554.2</a> (2014/05/30)</h3>
+    <h3 id=v1.554.2>What's new in 1.554.2 (2014/05/30)</h3>
     <ul class=image>
         <li class='bug'>
     Don't ask for confirmation when it doesn't make any sense
@@ -1246,7 +1246,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.554.1>What's new in 1.554.1</a> (2014/04/30)</h3>
+    <h3 id=v1.554.1>What's new in 1.554.1 (2014/04/30)</h3>
     <ul class=image>
         <li class='bug'>
     NPE if trying to install a plugin from the update center and either the update source or the plugin contains a '.' in its name
@@ -1283,7 +1283,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.532.3>What's new in 1.532.3</a> (2014/04/11)</h3>
+    <h3 id=v1.532.3>What's new in 1.532.3 (2014/04/11)</h3>
     <ul class=image>
         <li class='bug'>
     Replace description in error dialog instead of appending
@@ -1326,7 +1326,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.532.2>What's new in 1.532.2</a> (2014/02/14)</h3>
+    <h3 id=v1.532.2>What's new in 1.532.2 (2014/02/14)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1402,7 +1402,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.532.1>What's new in 1.532.1</a> (2013/11/25)</h3>
+    <h3 id=v1.532.1>What's new in 1.532.1 (2013/11/25)</h3>
     <ul class=image>
         <li class='bug'>
     Collecting findbugs analysis results occasionally causes ssh slave to go offline causing job to abort
@@ -1460,7 +1460,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.509.4>What's new in 1.509.4</a> (2013/10/09)</h3>
+    <h3 id=v1.509.4>What's new in 1.509.4 (2013/10/09)</h3>
     <ul class=image>
         <li class='rfe'>
     Configurable loggers should capture messages on slaves
@@ -1566,7 +1566,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.509.3>What's new in 1.509.3</a> (2013/09/09)</h3>
+    <h3 id=v1.509.3>What's new in 1.509.3 (2013/09/09)</h3>
     <ul class=image>
         <li class='bug'>
     Standalone install does not work with Apache + mod_proxy_ajp + SSL
@@ -1651,7 +1651,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.509.2>What's new in 1.509.2</a> (2013/06/27)</h3>
+    <h3 id=v1.509.2>What's new in 1.509.2 (2013/06/27)</h3>
     <ul class=image>
         <li class='bug'>
     Quoting Issue with JDK Installer with Windows Slave
@@ -1676,7 +1676,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.509.1>What's new in 1.509.1</a> (2013/05/01)</h3>
+    <h3 id=v1.509.1>What's new in 1.509.1 (2013/05/01)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1698,7 +1698,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.480.3>What's new in 1.480.3</a> (2013/02/15)</h3>
+    <h3 id=v1.480.3>What's new in 1.480.3 (2013/02/15)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1732,7 +1732,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.480.2>What's new in 1.480.2</a> (2013/01/06)</h3>
+    <h3 id=v1.480.2>What's new in 1.480.2 (2013/01/06)</h3>
     <ul class=image>
        <li class='major bug'>
     The master key that was protecting all the sensitive data in <tt>$JENKINS_HOME</tt> was vulnerable.
@@ -1741,7 +1741,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.480.1>What's new in 1.480.1</a> (2012/11/17)</h3>
+    <h3 id=v1.480.1>What's new in 1.480.1 (2012/11/17)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1765,7 +1765,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.466.2>What's new in 1.466.2</a> (2012/09/13)</h3>
+    <h3 id=v1.466.2>What's new in 1.466.2 (2012/09/13)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1775,7 +1775,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.466.1>What's new in 1.466.1</a> (2012/07/23)</h3>
+    <h3 id=v1.466.1>What's new in 1.466.1 (2012/07/23)</h3>
     <ul class=image>
         <li class='bug'>
     A current active build in the build history is lost if the job configuration XML uploaded
@@ -1794,7 +1794,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.447.2>What's new in 1.447.2</a> (2012/06/11)</h3>
+    <h3 id=v1.447.2>What's new in 1.447.2 (2012/06/11)</h3>
     <ul class=image>
         <li class='bug'>
     Guice injector failure can cause failure of whole Jenkins
@@ -1813,7 +1813,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.447.1>What's new in 1.447.1</a> (2012/03/28)</h3>
+    <h3 id=v1.447.1>What's new in 1.447.1 (2012/03/28)</h3>
     <ul class=image>
         <li class='bug'>
     File handle leak in serving static files
@@ -1838,7 +1838,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.424.6>What's new in 1.424.6</a> (2012/03/06)</h3>
+    <h3 id=v1.424.6>What's new in 1.424.6 (2012/03/06)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1847,21 +1847,21 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.424.5>What's new in 1.424.5</a> (2012/03/05)</h3>
+    <h3 id=v1.424.5>What's new in 1.424.5 (2012/03/05)</h3>
     <ul class=image>
 
     </ul>
 
 
 
-    <h3><a name=v1.424.4>What's new in 1.424.4</a> (2012/03/05)</h3>
+    <h3 id=v1.424.4>What's new in 1.424.4 (2012/03/05)</h3>
     <ul class=image>
 
     </ul>
 
 
 
-    <h3><a name=v1.424.3>What's new in 1.424.3</a> (2012/02/27)</h3>
+    <h3 id=v1.424.3>What's new in 1.424.3 (2012/02/27)</h3>
     <ul class=image>
         <li class='rfe'>
     upgrade Apache Maven Wagon to 2.0
@@ -1883,7 +1883,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.424.2>What's new in 1.424.2</a> (2012/01/10)</h3>
+    <h3 id=v1.424.2>What's new in 1.424.2 (2012/01/10)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1901,7 +1901,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.424.1>What's new in 1.424.1</a> (2011/11/30)</h3>
+    <h3 id=v1.424.1>What's new in 1.424.1 (2011/11/30)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1941,7 +1941,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.409.3>What's new in 1.409.3</a> (2011/11/08)</h3>
+    <h3 id=v1.409.3>What's new in 1.409.3 (2011/11/08)</h3>
     <ul class=image>
       <li class="major bug">
         <strong>Important security fixes</strong>
@@ -1950,7 +1950,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.409.2>What's new in 1.409.2</a> (2011/09/12)</h3>
+    <h3 id=v1.409.2>What's new in 1.409.2 (2011/09/12)</h3>
     <ul class=image>
         <li class=bug>
     Failure in test class constructor or @Before method is not reported (was: Maven plugin doesn't set build to unstable on SurefireExecutionException)
@@ -1975,7 +1975,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
 
 
-    <h3><a name=v1.409.1>What's new in 1.409.1</a> (2011/06/06)</h3>
+    <h3 id=v1.409.1>What's new in 1.409.1 (2011/06/06)</h3>
     <ul class=image>
         <li class=bug>
     Deadlock when upstream and downstream jobs are blocked on each other

--- a/content/_partials/changelog-weekly.html
+++ b/content/_partials/changelog-weekly.html
@@ -1,4 +1,4 @@
-<h3><a name=v2.46>What's new in 2.46</a> (2017/02/13)</h3>
+<h3 id=v2.46>What's new in 2.46 (2017/02/13)</h3>
 <ul class=image>
     <li class=bug>
         Failure to serialize a single <code>Action</code> could cause an entire REST export response to fail.
@@ -30,7 +30,7 @@
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-41765">issue 41765</a>)
 
 </ul>
-<h3><a name=v2.45>What's new in 2.45</a> (2017/02/06)</h3>
+<h3 id=v2.45>What's new in 2.45 (2017/02/06)</h3>
 <ul class=image>
     <li class=bug>
         Delete obsolete pinning UI.
@@ -45,25 +45,25 @@
         Fix completely wrong Basque translation.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2731">pull 2731</a>)
 </ul>
-<h3><a name=v2.44>What's new in 2.44</a> (2017/02/01)</h3>
+<h3 id=v2.44>What's new in 2.44 (2017/02/01)</h3>
 <ul class=image>
     <li class="major bug">
         <strong>Important security fixes</strong>
         (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01">security advisory</a>)
 </ul>
-<h3><a name=v2.43>What's new in 2.43</a> (2017/01/29)</h3>
+<h3 id=v2.43>What's new in 2.43 (2017/01/29)</h3>
 <ul class=image>
     <li class=rfe>
         Print stack traces in logical order, with the most important part on top.
         (<a href="https://github.com/jenkinsci/jenkins/pull/1485">pull 1485</a>)
 </ul>
-<h3><a name=v2.42>What's new in 2.42</a> (2017/01/22)</h3>
+<h3 id=v2.42>What's new in 2.42 (2017/01/22)</h3>
 <ul class=image>
     <li class=bug>
         <code>IllegalStateException</code> from Winstone when making certain requests with access logging enabled.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-37625">issue 37625</a>)
 </ul>
-<h3><a name=v2.41>What's new in 2.41</a> (2017/01/15)</h3>
+<h3 id=v2.41>What's new in 2.41 (2017/01/15)</h3>
 <ul class=image>
     <li class=bug>
         Restore option value for setting build result to unstable when loading shell and batch build steps from disk.
@@ -81,7 +81,7 @@
         Enable the JNLP4 agent protocol by default.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-40886">issue 40886</a>)
 </ul>
-<h3><a name=v2.40>What's new in 2.40</a> (2017/01/08)</h3>
+<h3 id=v2.40>What's new in 2.40 (2017/01/08)</h3>
 <ul class=image>
     <li class="major rfe">
         Support displaying of warnings from the Update Site in the Plugin Manager
@@ -113,7 +113,7 @@
         Require POST in the <code>Reload from disk</code> management link.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2692">pull 2692</a>)
 </ul>
-<h3><a name=v2.39>What's new in 2.39</a> (2017/01/02)</h3>
+<h3 id=v2.39>What's new in 2.39 (2017/01/02)</h3>
 <ul class=image>
     <li class=bug>
         Properties were not passed to Maven command by Maven build step when the <code>Inject Build Variables</code> flag was not set.
@@ -126,7 +126,7 @@
         (<a href="https://github.com/jenkinsci/jenkins/pull/2688">pull 2688</a> and
         <a href="https://github.com/jenkinsci/jenkins/pull/2686">pull 2686</a>)
 </ul>
-<h3><a name=v2.38>What's new in 2.38</a> (2016/12/25)</h3>
+<h3 id=v2.38>What's new in 2.38 (2016/12/25)</h3>
 <ul class=image>
     <li class=rfe>
         Update to Winstone 3.2 to support ad-hoc certificate generation on Java 8 (using unsupported APIs).
@@ -140,7 +140,7 @@
         Correctly state that Jenkins will refuse to load plugins whose dependencies are not satisfied in plugin manager.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-40666">issue 40666</a>)
 </ul>
-<h3><a name=v2.37>What's new in 2.37</a> (2016/12/18)</h3>
+<h3 id=v2.37>What's new in 2.37 (2016/12/18)</h3>
 <ul class=image>
     <li class="rfe">
         Allow defining agent ping interval and ping timeout in seconds.
@@ -218,7 +218,7 @@
         Improved Polish translation.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2643">pull 2643</a>)
 </ul>
-<h3><a name=v2.36>What's new in 2.36</a> (2016/12/11)</h3>
+<h3 id=v2.36>What's new in 2.36 (2016/12/11)</h3>
 <ul class=image>
     <li class="bug">
         Several badges were missing in builds flagged as <code>KeepBuildForever</code>.
@@ -235,7 +235,7 @@
         These message classes are not guaranteed to be binary compatible.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2656">pull 2656</a>)
 </ul>
-<h3><a name=v2.35>What's new in 2.35</a> (2016/12/04)</h3>
+<h3 id=v2.35>What's new in 2.35 (2016/12/04)</h3>
 <ul class=image>
     <li class="rfe">
         Add display name and full display name of items to the remote API.
@@ -247,7 +247,7 @@
         Followup fix for JENKINS-23271 in 2.34 addressing plugin implementations not using <tt>ProcStarter</tt>.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2653">pull 2653</a>)
 </ul>
-<h3><a name=v2.34>What's new in 2.34</a> (2016/11/27)</h3>
+<h3 id=v2.34>What's new in 2.34 (2016/11/27)</h3>
 <ul class=image>
     <li class="rfe">
         Improve performance of <code>Action</code> retrieval methods.
@@ -269,7 +269,7 @@
         It was likely impacting process termination on Windows agents.
         (<a href="https://github.com/kohsuke/winp/issues/22">WinP Issue #22</a>)
 </ul>
-<h3><a name=v2.33>What's new in 2.33</a> (2016/11/20)</h3>
+<h3 id=v2.33>What's new in 2.33 (2016/11/20)</h3>
 <ul class=image>
     <li class="rfe">
         Reduce size of Jenkins WAR file by not storing identical copies of <code>remoting.jar</code>/<code>slave.jar</code> there.
@@ -292,7 +292,7 @@
         Improved Polish translation.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2640">pull 2640</a>)
 </ul>
-<h3><a name=v2.32>What's new in 2.32</a> (2016/11/16)</h3>
+<h3 id=v2.32>What's new in 2.32 (2016/11/16)</h3>
 <ul class=image>
     <li class="major bug">
         <strong>Important security fixes</strong>
@@ -300,7 +300,7 @@
     <li class="rfe">
         Allow disabling the Jenkins CLI over HTTP and JNLP agent port by setting the System property <tt>jenkins.CLI.disabled</tt> to <tt>true</tt>.
 </ul>
-<h3><a name=v2.31>What's new in 2.31</a> (2016/11/13)</h3>
+<h3 id=v2.31>What's new in 2.31 (2016/11/13)</h3>
 <ul class=image>
     <li class="rfe">
         Performance: Improve responsiveness of Jenkins web UI on mobile devices.
@@ -346,7 +346,7 @@
         Improved Polish translation.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2631">pull 2631</a>)
 </ul>
-<h3><a name=v2.30>What's new in 2.30</a> (2016/11/07)</h3>
+<h3 id=v2.30>What's new in 2.30 (2016/11/07)</h3>
 <ul class=image>
     <li class="major bug">
         Adjust incompatible <code>Actionable</code> initialization changes made for <a href="https://issues.jenkins-ci.org/browse/JENKINS-39404">issue 39404</a>).
@@ -361,7 +361,7 @@
         If the option has been configured in Jenkins starting from <code>2.16</code>, a reconfiguration may be required.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-39465">issue 39465</a>)
 </ul>
-<h3><a name=v2.29>What's new in 2.29</a> (2016/11/06)</h3>
+<h3 id=v2.29>What's new in 2.29 (2016/11/06)</h3>
 <p>
     <b class="color:red">Warning!</b> This release is not recommended for use due to
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-39555">issue 39555</a>
@@ -392,7 +392,7 @@
         Internal: Jelly attribute documentation now supports the <code>since</code> tag.
         (<a href="https://github.com/stapler/stapler/pull/84">Stapler pull #84</code>)
 </ul>
-<h3><a name=v2.28>What's new in 2.28</a> (2016/10/30)</h3>
+<h3 id=v2.28>What's new in 2.28 (2016/10/30)</h3>
 <ul class=image>
     <li class="rfe">
         Performance: Improve responsiveness of Jenkins web UI on mobile devices.
@@ -434,7 +434,7 @@
         This change required upgrade of detached plugins (see above).
         (<a href="https://github.com/jenkinsci/jenkins/pull/2568">pull 2568</a>)
 </ul>
-<h3><a name=v2.27>What's new in 2.27</a> (2016/10/23)</h3>
+<h3 id=v2.27>What's new in 2.27 (2016/10/23)</h3>
 <ul class=image>
     <li class="major rfe">
         Upgrade to the Remoting 3 baseline. Compatibility notes are available
@@ -464,7 +464,7 @@
         Deprecate <code>TopLevelItemDescriptor#getIconFilePathPattern()</code> and switch to <code>IconSpec</code>.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-38960">issue 38960</a>)
 </ul>
-<h3><a name=v2.26>What's new in 2.26</a> (2016/10/17)</h3>
+<h3 id=v2.26>What's new in 2.26 (2016/10/17)</h3>
 <ul class=image>
     <li class="rfe">
         Allow <code>CommandInterpreter</code> build steps to set a build result as <code>Unstable</code> via the return code.
@@ -515,7 +515,7 @@
         Internal: Bulk cleanup of <code>@since</code> definitions in Javadoc.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2578">pull 2578</a>)
 </ul>
-<h3><a name=v2.25>What's new in 2.25</a> (2016/10/09)</h3>
+<h3 id=v2.25>What's new in 2.25 (2016/10/09)</h3>
 <ul class=image>
     <li class="bug">
         Display transient actions for labels.
@@ -527,7 +527,7 @@
         Internal: Code modernization: Use try-with-resources a lot more
         (<a href="https://github.com/jenkinsci/jenkins/pull/2570">pull 2570</a>)
 </ul>
-<h3><a name=v2.24>What's new in 2.24</a> (2016/10/02)</h3>
+<h3 id=v2.24>What's new in 2.24 (2016/10/02)</h3>
 <ul class=image>
     <li class="major rfe">
         Show notification with popup on most pages when administrative monitors are active.
@@ -567,7 +567,7 @@
         CLI: Connection over HTTP was not working correctly.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34287">issue 34287</a>, regression in 2.0)
 </ul>
-<h3><a name=v2.23>What's new in 2.23</a> (2016/09/18)</h3>
+<h3 id=v2.23>What's new in 2.23 (2016/09/18)</h3>
 <ul class=image>
     <li class="bug">
         Fix JS/browser memory leak on Jenkins dashboard.
@@ -579,7 +579,7 @@
         Properly enable submit button on New Item page when choosing item type first.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36539">issue 36539</a>)
 </ul>
-<h3><a name=v2.22>What's new in 2.22</a> (2016/09/11)</h3>
+<h3 id=v2.22>What's new in 2.22 (2016/09/11)</h3>
 <ul class=image>
     <li class="rfe">
         Change symbol and constructor for SCMTrigger to <tt>pollScm</tt> to make it usable in Pipeline scripts.
@@ -601,7 +601,7 @@
         Use the correct 'gear' icon for Manage Jenkins in Plugin Manager.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34250">issue 34250</a>)
 </ul>
-<h3><a name=v2.21>What's new in 2.21</a> (2016/09/04)</h3>
+<h3 id=v2.21>What's new in 2.21 (2016/09/04)</h3>
 <ul class=image>
     <li class="rfe">
         Ask for confirmation before canceling/aborting runs.
@@ -622,7 +622,7 @@
         overridden and used in plugins.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2532">PR #2532</a>)
 </ul>
-<h3><a name=v2.20>What's new in 2.20</a> (2016/08/28)</h3>
+<h3 id=v2.20>What's new in 2.20 (2016/08/28)</h3>
 <ul class=image>
     <li class="rfe">
         Make <code>Cloud.PROVISION</code> permission independent from <code>Jenkins.ADMINISTER</code>.
@@ -650,7 +650,7 @@
         Fixed process tree management logic on Solaris with 64-bit JVMs.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-37559">issue 37559</a>)
 </ul>
-<h3><a name=v2.19>What's new in 2.19</a> (2016/08/21)</h3>
+<h3 id=v2.19>What's new in 2.19 (2016/08/21)</h3>
 <ul class=image>
     <li class="major bug">
         Prevent File descriptor leaks when reading plugin manifests.
@@ -678,7 +678,7 @@
         from <code>INFO</code> to <code>FINE</code>.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2510">PR #2510</a>)
 </ul>
-<h3><a name=v2.18>What's new in 2.18</a> (2016/08/15)</h3>
+<h3 id=v2.18>What's new in 2.18 (2016/08/15)</h3>
 <ul class=image>
     <li class="rfe">
         Better diagnostics and robustness against old <code>ChangeLogAnnotator</code> API usage in plugins.
@@ -732,7 +732,7 @@
         <a href="https://github.com/jenkinsci/jenkins/pull/2498">PR #2498</a>
         )
 </ul>
-<h3><a name=v2.17>What's new in 2.17</a> (2016/08/05)</h3>
+<h3 id=v2.17>What's new in 2.17 (2016/08/05)</h3>
 <ul class=image>
     <li class="major bug">
         Don't load all builds to display the paginated build history widget.
@@ -744,7 +744,7 @@
         Internal: Invoke FindBugs during core build.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36715">issue 36715</a>)
 </ul>
-<h3><a name=v2.16>What's new in 2.16</a> (2016/07/31)</h3>
+<h3 id=v2.16>What's new in 2.16 (2016/07/31)</h3>
 <ul class=image>
     <li class="major bug">
         Fix plugin dependency resolution. Jenkins will now refuse to load plugins with unsatisfied dependencies, which resulted in difficult to diagnose problems. <strong>This may result in errors on startup if your instance has an invalid plugin configuration.</strong>, check the Jenkins log for details.
@@ -789,7 +789,7 @@
         Internal: Fix the default value handling of <tt>ArtifactArchiver.excludes</tt>.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29922">issue 29922</a>)
 </ul>
-<h3><a name=v2.15>What's new in 2.15</a> (2016/07/24)</h3>
+<h3 id=v2.15>What's new in 2.15 (2016/07/24)</h3>
 <ul class=image>
     <li class="major bug">
         Tell browsers not to cache or try to autocomplete forms in Jenkins to prevent problems due to invalid data in form submissions.
@@ -811,7 +811,7 @@
         Internal: Extract the CLI command <tt>offline-node</tt> from core.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34468">issue 34468</a>)
 </ul>
-<h3><a name=v2.14>What's new in 2.14</a> (2016/07/17)</h3>
+<h3 id=v2.14>What's new in 2.14 (2016/07/17)</h3>
 <ul class=image>
     <li class=rfe>
         Minor optimization in calculation of recent build stability health report.
@@ -844,7 +844,7 @@
         Developer API: Usage of <code>ItemCategory#MIN_TOSHOW</code> in external plugins is now restricted.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36593">issue 36593</a>)
 </ul>
-<h3><a name=v2.13>What's new in 2.13</a> (2016/07/10)</h3>
+<h3 id=v2.13>What's new in 2.13 (2016/07/10)</h3>
 <ul class=image>
     <li class=bug>
         <code>IllegalStateException</code> under certain conditions when reloading configuration from disk while jobs are in the queue.
@@ -856,7 +856,7 @@
         Make setup wizard installation panel usable on small screens.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34668">issue 34668</a>)
 </ul>
-<h3><a name=v2.12>What's new in 2.12</a> (2016/07/05)</h3>
+<h3 id=v2.12>What's new in 2.12 (2016/07/05)</h3>
 <ul class=image>
     <li class=rfe>
         Enable the <code>DescriptorVisibilityFilter</code>s for ComputerLauncher, RetentionStrategy and NodeProperty.
@@ -893,14 +893,14 @@
         Internal API: Make <code>BulkChange</code> auto-closeable.
         (<a href="https://github.com/jenkinsci/jenkins/pull/2428">PR #2428</a>)
 </ul>
-<h3><a name=v2.11>What's new in 2.11</a> (2016/06/26)</h3>
+<h3 id=v2.11>What's new in 2.11 (2016/06/26)</h3>
 <ul class=image>
     <li class=rfe>
         Provide an extension point for SCM decisions such as whether to poll a specific job's backing
         repository for changes.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36123">issue 36123</a>)
 </ul>
-<h3><a name=v2.10>What's new in 2.10</a> (2016/06/19)</h3>
+<h3 id=v2.10>What's new in 2.10 (2016/06/19)</h3>
 <ul class=image>
     <li class=rfe>
         Better exception message if a <code>SecurityRealm</code> returns null when loading a user.
@@ -912,7 +912,7 @@
         Internal: It was impossible to build Jenkins on 32-bit Linux machine.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36052">issue 36052, regression from 2.0</a>)
 </ul>
-<h3><a name=v2.9>What's new in 2.9</a> (2016/06/13)</h3>
+<h3 id=v2.9>What's new in 2.9 (2016/06/13)</h3>
 <ul class=image>
     <li class=bug>
         Always send usage statistics over HTTPs to the new usage.jenkins.io hostname.
@@ -948,7 +948,7 @@
         API: Make it easier for <code>UpdateSite</code>s to tweak the </code>InstallationJob</code>.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-35402">issue 35402</a>)
 </ul>
-<h3><a name=v2.8>What's new in 2.8</a> (2016/06/05)</h3>
+<h3 id=v2.8>What's new in 2.8 (2016/06/05)</h3>
 <ul class=image>
     <li class=bug>
         Explicitly declare compatibility of Windows build agent service with .NET Framework 4.
@@ -977,7 +977,7 @@
         to the proxy validation logic.
         (<a href="https://github.com/jenkinsci/jenkins/pull/1955">PR #1955</a>)
 </ul>
-<h3><a name=v2.7>What's new in 2.7</a> (2016/05/29)</h3>
+<h3 id=v2.7>What's new in 2.7 (2016/05/29)</h3>
 <ul class=image>
 
     <li class="bug">
@@ -1009,7 +1009,7 @@
         Internal: NodeJS build was malfunctioning on Win x64.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-35201">issue 35201</a>)
 </ul>
-<h3><a name=v2.6>What's new in 2.6</a> (2016/05/22)</h3>
+<h3 id=v2.6>What's new in 2.6 (2016/05/22)</h3>
 <ul class=image>
     <li class="major rfe">
         Adapt the Setup Wizard GUI to provide a similar user experience when upgrading Jenkins.
@@ -1056,7 +1056,7 @@
         Internal: CLI command <code>connect-node</code> was extracted from the core to CLI.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31417">issue 31417</a>)
 </ul>
-<h3><a name=v2.5>What's new in 2.5</a> (2016/05/16)</h3>
+<h3 id=v2.5>What's new in 2.5 (2016/05/16)</h3>
 <ul class=image>
     <li class="major bug">
         Do not throw exceptions if <code>Jenkins.getInstance()</code> returns <code>null</code> instance.
@@ -1068,7 +1068,7 @@
         behavior change.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34857">issue 34857</a>)
 </ul>
-<h3><a name=v2.4>What's new in 2.4</a> (2016/05/15)</h3>
+<h3 id=v2.4>What's new in 2.4 (2016/05/15)</h3>
 <ul class=image>
     <li class=rfe>
         Internal/build: <code>jenkins-ui</code> (NPM module) is private, used only internally.
@@ -1180,13 +1180,13 @@
         (Controlled by <a href="https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties">PROTOCOL_CLASS_NAME.disabled</a>)
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34819">issue 34819</a>)
 </ul>
-<h3><a name=v2.3>What's new in 2.3</a> (2016/05/11)</h3>
+<h3 id=v2.3>What's new in 2.3 (2016/05/11)</h3>
 <ul class=image>
     <li class="major bug">
         <strong>Important security fixes</strong>
         (see the <a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-05-11">security advisory</a> for details and plugin compatibility issues)
 </ul>
-<h3><a name=v2.2>What's new in 2.2</a> (2016/05/08)</h3>
+<h3 id=v2.2>What's new in 2.2 (2016/05/08)</h3>
 <ul class=image>
     <li class="rfe">
         Add symbol annotations on core.
@@ -1223,7 +1223,7 @@
         Fix inline help for node name field.
         (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34601">issue 34601</a>)
 </ul>
-<h3><a name=v2.1>What's new in 2.1</a> (2016/05/01)</h3>
+<h3 id=v2.1>What's new in 2.1 (2016/05/01)</h3>
 <ul class=image>
     <li class="major bug">
         Enable disabled dependencies during plugin installations.
@@ -1297,7 +1297,7 @@
 </ul>
 
 
-<h3><a name=v2.0>What's new in 2.0</a> (2016/04/20)</h3>
+<h3 id=v2.0>What's new in 2.0 (2016/04/20)</h3>
 <div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
     <strong>More detailed information about the new features in Jenkins 2.0 <a href="/2.0/">on the overview page</a>.</strong>
 </div>

--- a/content/changelog-old.html
+++ b/content/changelog-old.html
@@ -8,7 +8,7 @@ title: Changelog Archives
 </p>
 
 
-<h3><a name=v1.656>What's new in 1.656</a> (2016/04/03)</h3>
+<h3 id=v1.656>What's new in 1.656 (2016/04/03)</h3>
 <ul class=image>
   <li class="bug">
     Advertise the correct JNLP port when using the system property override.
@@ -29,7 +29,7 @@ title: Changelog Archives
     Core development: Prevent leaking threads due to <tt>NioChannelSelector</tt>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2176">pull 2176</a>)
 </ul>
-<h3><a name=v1.655>What's new in 1.655</a> (2016/03/27)</h3>
+<h3 id=v1.655>What's new in 1.655 (2016/03/27)</h3>
 <ul class=image>
   <li class="major bug">
     Downgrade Stapler to 1.239 to fix remote API issues.
@@ -54,7 +54,7 @@ title: Changelog Archives
     Core Development:  Add the <tt>.mvn</tt> directory and set default <tt>-Xmx</tt> value.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2162">pull 2162</a>)
 </ul>
-<h3><a name=v1.654>What's new in 1.654</a> (2016/03/21)</h3>
+<h3 id=v1.654>What's new in 1.654 (2016/03/21)</h3>
 <ul class=image>
   <li class="bug">
     Improve logging and error message when JNLP is already in use.
@@ -81,7 +81,7 @@ title: Changelog Archives
     Do not specifically require .NET framework 2.0 since 4.0 will do as well.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21484">issue 21484</a>)
 </ul>
-<h3><a name=v1.653>What's new in 1.653</a> (2016/03/13)</h3>
+<h3 id=v1.653>What's new in 1.653 (2016/03/13)</h3>
 <ul class=image>
   <li class="major rfe">
     Support encrypted communication between master and JNLP slaves.
@@ -95,7 +95,7 @@ title: Changelog Archives
   <li class="rfe">
     Developer API: <tt>Jenkins.getInstance()</tt> cannot be <tt>null</tt> anymore. Introduced <tt>Jenkins.getInstanceOrNull()</tt>.
 </ul>
-<h3><a name=v1.652>What's new in 1.652</a> (2016/03/06)</h3>
+<h3 id=v1.652>What's new in 1.652 (2016/03/06)</h3>
 <ul class=image>
   <li class="bug">
     Under some conditions Jenkins startup could fail because of incorrectly linked extensions; now recovering more gracefully.
@@ -104,7 +104,7 @@ title: Changelog Archives
     Developer API: Add <tt>WorkspaceList.tempDir(…)</tt>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27152">issue 27152</a>)
 </ul>
-<h3><a name=v1.651>What's new in 1.651</a> (2016/02/28)</h3>
+<h3 id=v1.651>What's new in 1.651 (2016/02/28)</h3>
 <ul class=image>
   <li class="rfe">
     Move periodic task log files from <code>JENKINS_HOME/*.log</code> to <code>JENKINS_HOME/logs/tasks/*.log</code> and rotate them periodically rather than overwrite every execution.
@@ -113,13 +113,13 @@ title: Changelog Archives
     Fix documentation of proxy configuration.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2060">pull 2060</a>)
 </ul>
-<h3><a name=v1.650>What's new in 1.650</a> (2016/02/24)</h3>
+<h3 id=v1.650>What's new in 1.650 (2016/02/24)</h3>
 <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-02-24">security advisory</a>)
 </ul>
-<h3><a name=v1.649>What's new in 1.649</a> (2016/02/21)</h3>
+<h3 id=v1.649>What's new in 1.649 (2016/02/21)</h3>
 <ul class=image>
   <li class="rfe">
     Allow changing the directory used for the extraction of plugin archives via the <code>--pluginroot</code> CLI option (also controllable via the <code>hudson.PluginManager.workDir</code> system property / context parameter. Also document the <code>--webroot</code> CLI parameter in <code>java -jar jenkins.war --help</code>
@@ -135,7 +135,7 @@ title: Changelog Archives
     (<a href="https://github.com/jenkinsci/jenkins/pull/2041">pull 2041</a>,
     <a href="https://github.com/jenkinsci/jenkins/pull/2044">pull 2044</a>)
 </ul>
-<h3><a name=v1.648>What's new in 1.648</a> (2016/02/17)</h3>
+<h3 id=v1.648>What's new in 1.648 (2016/02/17)</h3>
 <ul class=image>
   <li class="rfe">
     Improved Czech and Polish translation.
@@ -146,13 +146,13 @@ title: Changelog Archives
     Generate new instance identity file when the existing one is found to be corrupt.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29240">issue 29240</a>)
 </ul>
-<h3><a name=v1.647>What's new in 1.647</a> (2016/02/04)</h3>
+<h3 id=v1.647>What's new in 1.647 (2016/02/04)</h3>
 <ul class=image>
   <li class="bug">
     Retrieve tool installer metadata from all update sites.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-32328">issue 32328</a>)
 </ul>
-<h3><a name=v1.646>What's new in 1.646</a> (2016/01/25)</h3>
+<h3 id=v1.646>What's new in 1.646 (2016/01/25)</h3>
 <ul class=image>
   <li class="major rfe">
     The official parent POM for plugins is now hosted in the <code>plugin-pom</code> repository, starting with version 2.0.
@@ -167,7 +167,7 @@ title: Changelog Archives
     Added missing translations for Polish language.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1986">pull 1986</a>)
 </ul>
-<h3><a name=v1.645>What's new in 1.645</a> (2016/01/18)</h3>
+<h3 id=v1.645>What's new in 1.645 (2016/01/18)</h3>
 <ul class=image>
   <li class="bug">
     Cleanup of CLI error handling and return codes.
@@ -191,7 +191,7 @@ title: Changelog Archives
     Pass <tt>$it</tt> to contents of <tt>dropdownDescriptorSelector</tt>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19565">issue 19565</a>)
 </ul>
-<h3><a name=v1.644>What's new in 1.644</a> (2016/01/10)</h3>
+<h3 id=v1.644>What's new in 1.644 (2016/01/10)</h3>
 <ul class=image>
   <li class="rfe">
     API changes: Add a reusable implementation of <code>IdleOfflineCause</code> class.
@@ -209,7 +209,7 @@ title: Changelog Archives
     The Windows service wrapper now specifies the <code>--webroot</code> argument to extract the war file into <code>%BASE%</code>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1951">pull 1951</a>)
 </ul>
-<h3><a name=v1.643>What's new in 1.643</a> (2015/12/20)</h3>
+<h3 id=v1.643>What's new in 1.643 (2015/12/20)</h3>
 <ul class=image>
   <li class="bug">
     Fix when multiple clouds are set up and provisioning of a node is denied.
@@ -221,19 +221,19 @@ title: Changelog Archives
     Allow specifying the default TCP slave agent listener port via system property.
     (<a href="https://github.com/jenkinsci/jenkins/commit/653fbdb65024b1b528e21f682172885f7111bba9">commit 653fbdb</a>)
 </ul>
-<h3><a name=v1.642>What's new in 1.642</a> (2015/12/13)</h3>
+<h3 id=v1.642>What's new in 1.642 (2015/12/13)</h3>
 <ul class=image>
   <li class="major bug">
     Various kinds of settings could not be saved since 1.640.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31954">issue 31954</a>)
 </ul>
-<h3><a name=v1.641>What's new in 1.641</a> (2015/12/09)</h3>
+<h3 id=v1.641>What's new in 1.641 (2015/12/09)</h3>
 <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-12-09">security advisory</a>)
 </ul>
-<h3><a name=v1.640>What's new in 1.640</a> (2015/12/07)</h3>
+<h3 id=v1.640>What's new in 1.640 (2015/12/07)</h3>
 <ul class=image>
   <li class="rfe">
     Added support of default values in the <code>enum.jelly</code> form element.
@@ -259,7 +259,7 @@ title: Changelog Archives
     API changes: Deprecate subclassing of <code>hudson.Plugin</code>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1940">PR 1940</a>)
 </ul>
-<h3><a name=v1.639>What's new in 1.639</a> (2015/11/29)</h3>
+<h3 id=v1.639>What's new in 1.639 (2015/11/29)</h3>
 <ul class=image>
   <li class="major bug">
     “Discard old builds” setting would be lost if resaving job configuration as of 1.637 without rechecking the box.
@@ -271,13 +271,13 @@ title: Changelog Archives
     Multiple workspace browser features broken on Windows masters since 1.634.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31015">issue 31015</a>)
 </ul>
-<h3><a name=v1.638>What's new in 1.638</a> (2015/11/11)</h3>
+<h3 id=v1.638>What's new in 1.638 (2015/11/11)</h3>
 <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11">security advisory</a>)
 </ul>
-<h3><a name=v1.637>What's new in 1.637</a> (2015/11/08)</h3>
+<h3 id=v1.637>What's new in 1.637 (2015/11/08)</h3>
 <ul class=image>
   <li class="bug">
     Remove useless warnings about a JDK named <em>null</em>.
@@ -286,13 +286,13 @@ title: Changelog Archives
     New <tt>OptionalJobProperty</tt> class to simplify <tt>JobProperty</tt> creation.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1888">pull 1888</a>)
 </ul>
-<h3><a name=v1.636>What's new in 1.636</a> (2015/11/01)</h3>
+<h3 id=v1.636>What's new in 1.636 (2015/11/01)</h3>
 <ul class=image>
   <li class="rfe">
     Add "lastCompletedBuild" job permalink.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26270">issue 26270</a>)
 </ul>
-<h3><a name=v1.635>What's new in 1.635</a> (2015/10/25)</h3>
+<h3 id=v1.635>What's new in 1.635 (2015/10/25)</h3>
 <ul class=image>
   <li class="rfe">
     Make Node implement Saveable.
@@ -314,7 +314,7 @@ title: Changelog Archives
     Update JNA library to 4.2.1 in order to integrate fixes for linux-ppc64 and linux-arm platforms.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15792">issue 15792</a>)
 </ul>
-<h3><a name=v1.634>What's new in 1.634</a> (2015/10/18)</h3>
+<h3 id=v1.634>What's new in 1.634 (2015/10/18)</h3>
 <ul class=image>
   <li class="major bug">
     Fix order of builds in new builds history widget introduced in 1.633.
@@ -347,7 +347,7 @@ title: Changelog Archives
     Let a combobox display its drop-down when focused, so users can see candidates without entering a letter.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26278">issue 26278</a>)
 </ul>
-<h3><a name=v1.633>What's new in 1.633</a> (2015/10/11)</h3>
+<h3 id=v1.633>What's new in 1.633 (2015/10/11)</h3>
 <ul class=image>
   <li class="rfe">
     Added safari pinned tab icon.
@@ -378,7 +378,7 @@ title: Changelog Archives
     Build history pagination and search.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26445">issue 26445</a>)
 </ul>
-<h3><a name=v1.632>What's new in 1.632</a> (2015/10/05)</h3>
+<h3 id=v1.632>What's new in 1.632 (2015/10/05)</h3>
 <ul class=image>
   <li class="bug">
     Optimize TagCloud size calculation.
@@ -399,25 +399,25 @@ title: Changelog Archives
     Sidepanel controls with confirmation (<code>lib/layout/task</code>) did not assign the proper CSS style.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-30787">issue 30787</a>)
 </ul>
-<h3><a name=v1.631>What's new in 1.631</a> (2015/09/27)</h3>
+<h3 id=v1.631>What's new in 1.631 (2015/09/27)</h3>
 <ul class=image>
   <li class=rfe>
     Add proper labels for plugin categories assigned to some plugins.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1758">PR 1758</a>)
 </ul>
-<h3><a name=v1.630>What's new in 1.630</a> (2015/09/20)</h3>
+<h3 id=v1.630>What's new in 1.630 (2015/09/20)</h3>
 <ul class=image>
   <li class="bug">
     Make <tt>JenkinsRule</tt> useable on systems which don't support JNA
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29507">issue 29507</a>)
 </ul>
-<h3><a name=v1.629>What's new in 1.629</a> (2015/09/15)</h3>
+<h3 id=v1.629>What's new in 1.629 (2015/09/15)</h3>
 <ul class=image>
   <li class="rfe">
     Old data monitor made Jenkins single-threaded for all saves.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-30139">issue 30139</a>)
 </ul>
-<h3><a name=v1.628>What's new in 1.628</a> (2015/09/06)</h3>
+<h3 id=v1.628>What's new in 1.628 (2015/09/06)</h3>
 <ul class=image>
   <li class="rfe">
     Replaced all non java.util.logging logging libraries with slf4j interceptors.
@@ -426,7 +426,7 @@ title: Changelog Archives
     Document <tt>allBuilds</tt> subtree in remote API for jobs.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1817">PR 1817</a>)
 </ul>
-<h3><a name=v1.627>What's new in 1.627</a> (2015/08/30)</h3>
+<h3 id=v1.627>What's new in 1.627 (2015/08/30)</h3>
 <ul class=image>
   <li class="major bug">
     Race condition in triggers could cause various <code>NullPointerException</code>s.
@@ -438,7 +438,7 @@ title: Changelog Archives
     Allow plugins to augment or replace the plugin manager UI.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1788">PR 1788</a>)
 </ul>
-<h3><a name=v1.626>What's new in 1.626</a> (2015/08/23)</h3>
+<h3 id=v1.626>What's new in 1.626 (2015/08/23)</h3>
 <ul class=image>
   <li class="bug">
     RunIdMigrator fails to revert Matrix and Maven jobs.
@@ -448,7 +448,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29798">issue 29798</a>)
   <li class=>
 </ul>
-<h3><a name=v1.625>What's new in 1.625</a> (2015/08/17)</h3>
+<h3 id=v1.625>What's new in 1.625 (2015/08/17)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a deadlock between the old data monitor and authorization strategies.
@@ -460,15 +460,15 @@ title: Changelog Archives
     Do not display <em>No changes</em> if changelog is still being computed.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-2327">issue 2327</a>)
 </ul>
-<h3><a name=v1.624>What's new in 1.624</a> (2015/08/09)</h3>
+<h3 id=v1.624>What's new in 1.624 (2015/08/09)</h3>
 <ul class=image>
   <li class=rfe>
     Allow more job types to use a custom &quot;Build Now&quot; text.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26147">issue 26147</a>)
 </ul>
-<h3><a name=v1.623>What's new in 1.623</a> (2015/08/02)</h3>
+<h3 id=v1.623>What's new in 1.623 (2015/08/02)</h3>
 <p><em>No notable changes in this release.</em></p>
-<h3><a name=v1.622>What's new in 1.622</a> (2015/07/27)</h3>
+<h3 id=v1.622>What's new in 1.622 (2015/07/27)</h3>
 <ul class=image>
   <li class=rfe>
     Jenkins now support self-restart and daemonization in FreeBSD
@@ -477,7 +477,7 @@ title: Changelog Archives
     Node provisioner may fail to correctly indicate that provisioning was finished.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29568">issue 29568</a>)
 </ul>
-<h3><a name=v1.621>What's new in 1.621</a> (2015/07/19)</h3>
+<h3 id=v1.621>What's new in 1.621 (2015/07/19)</h3>
 <ul class=image>
   <li class=bug>
     Sort by 'Free Disk Space' is incorrect.
@@ -492,13 +492,13 @@ title: Changelog Archives
     Don't run trigger for disabled/copied projects.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1617">PR 1617</a>)
 </ul>
-<h3><a name=v1.620>What's new in 1.620</a> (2015/07/12)</h3>
+<h3 id=v1.620>What's new in 1.620 (2015/07/12)</h3>
 <ul class=image>
   <li class=bug>
     Display system info even when slave is temporarily offline.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29300">issue 29300</a>)
 </ul>
-<h3><a name=v1.619>What's new in 1.619</a> (2015/07/05)</h3>
+<h3 id=v1.619>What's new in 1.619 (2015/07/05)</h3>
 <ul class=image>
   <li class=bug>
     Update auto-installer metadata for newly installed plugins.
@@ -507,7 +507,7 @@ title: Changelog Archives
     Allow plugins to veto process killing.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9104">issue 9104</a>)
 </ul>
-<h3><a name=v1.618>What's new in 1.618</a> (2015/06/29)</h3>
+<h3 id=v1.618>What's new in 1.618 (2015/06/29)</h3>
 <ul class=image>
   <li class=bug>
     Fix deadlock in hudson.model.Executor.
@@ -541,7 +541,7 @@ title: Changelog Archives
     Always use earlier start time when merging two equivalent queue items.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-2180">issue 2180</a>)
 </ul>
-<h3><a name=v1.617>What's new in 1.617</a> (2015/06/07)</h3>
+<h3 id=v1.617>What's new in 1.617 (2015/06/07)</h3>
 <ul class=image>
   <li class=bug>
     Regression in build-history causing ball to not open console
@@ -554,13 +554,13 @@ title: Changelog Archives
     if Jenkins nodes has not been loaded yet
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28654">issue 28654</a>)
 </ul>
-<h3><a name=v1.616>What's new in 1.616</a> (2015/05/31)</h3>
+<h3 id=v1.616>What's new in 1.616 (2015/05/31)</h3>
 <ul class=image>
   <li class=bug>
     Job loading can be broken by <code>NullPointerException</code> in a build trigger
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27549">issue 27549</a>)
 </ul>
-<h3><a name=v1.615>What's new in 1.615</a> (2015/05/25)</h3>
+<h3 id=v1.615>What's new in 1.615 (2015/05/25)</h3>
 <ul class=image>
   <li class=bug>
     Improper calculation of queue length in <code>UnlabeledLoadStatistics</code>
@@ -585,7 +585,7 @@ title: Changelog Archives
     Build History badges don't wrap
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28455">issue 28455</a>)
 </ul>
-<h3><a name=v1.614>What's new in 1.614</a> (2015/05/17)</h3>
+<h3 id=v1.614>What's new in 1.614 (2015/05/17)</h3>
 <ul class=image>
   <li class=rfe>
     ExtensionList even listener.
@@ -603,7 +603,7 @@ title: Changelog Archives
     Do not follow href after sending POST via l:task
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28437">issue 28437</a>)
 </ul>
-<h3><a name=v1.613>What's new in 1.613</a> (2015/05/10)</h3>
+<h3 id=v1.613>What's new in 1.613 (2015/05/10)</h3>
 <ul class=image>
   <li class=bug>
     Update bundled LDAP plugin in order to restore missing help files
@@ -612,7 +612,7 @@ title: Changelog Archives
     hudson.model.Run.getLog() throws IndexOutOfBoundsException when called with maxLines=0
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27441">issue 27441</a>)
 </ul>
-<h3><a name=v1.612>What's new in 1.612</a> (2015/05/03)</h3>
+<h3 id=v1.612>What's new in 1.612 (2015/05/03)</h3>
 <ul class=image>
   <li class=rfe>
     <strong>Jenkins now requires Java 7</strong>.
@@ -641,7 +641,7 @@ title: Changelog Archives
     configured JVM options.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28111">issue 28111</a>)
 </ul>
-<h3><a name=v1.611>What's new in 1.611</a> (2015/04/26)</h3>
+<h3 id=v1.611>What's new in 1.611 (2015/04/26)</h3>
 <ul class=image>
   <li class=bug>
     <code>Descriptor.getId</code> fix in 1.610 introduced a regression affecting at least the Copy Artifacts plugin.
@@ -661,7 +661,7 @@ title: Changelog Archives
     Correctly identify Channel listener onClose propagated exceptions
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28062">issue 28062</a>
 </ul>
-<h3><a name=v1.610>What's new in 1.610</a> (2015/04/19)</h3>
+<h3 id=v1.610>What's new in 1.610 (2015/04/19)</h3>
 <ul class=image>
   <li class=bug>
     Since 1.598 overrides of <code>Descriptor.getId</code> were not correctly handled by form binding, breaking at least the CloudBees Templates plugin.
@@ -674,7 +674,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27708">issue 27708</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-27871">issue 27871</a>)
 </ul>
-<h3><a name=v1.609>What's new in 1.609</a> (2015/04/12)</h3>
+<h3 id=v1.609>What's new in 1.609 (2015/04/12)</h3>
 <ul class=image>
   <li class=bug>
     When concurrent builds are enabled, artifact retention policy may delete artifact being
@@ -684,7 +684,7 @@ title: Changelog Archives
     Documentation for $BUILD_ID did not reflect current reality
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26520">issue 26520</a>)
 </ul>
-<h3><a name=v1.608>What's new in 1.608</a> (2015/04/05)</h3>
+<h3 id=v1.608>What's new in 1.608 (2015/04/05)</h3>
 <ul class=image>
   <li class=bug>
     PeepholePermalink RunListenerImpl oncompleted should be triggered before downstream builds are triggered.
@@ -705,7 +705,7 @@ title: Changelog Archives
     Starting this version, native packages are produced from <a href="https://github.com/jenkinsci/packaging">the new repository</a>.
     File issues related to installers and packages in the <code>packaging</code> component.
 </ul>
-<h3><a name=v1.607>What's new in 1.607</a> (2015/03/30)</h3>
+<h3 id=v1.607>What's new in 1.607 (2015/03/30)</h3>
 <ul class=image>
   <li class=bug>
     JSONP served with the wrong MIME type and rejected by Chrome.
@@ -752,7 +752,7 @@ title: Changelog Archives
     Build reports to be running for 45 yr and counting.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26777">issue 26777</a>)
 </ul>
-<h3><a name=v1.606>What's new in 1.606</a> (2015/03/23)</h3>
+<h3 id=v1.606>What's new in 1.606 (2015/03/23)</h3>
 <ul class=image>
   <li class=bug>
     Jenkins CLI doesn't handle arguments with equal signs
@@ -767,13 +767,13 @@ title: Changelog Archives
     Fixes to several security vulnerabilities.
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-03-23">advisory</a>)
 </ul>
-<h3><a name=v1.605>What's new in 1.605</a> (2015/03/16)</h3>
+<h3 id=v1.605>What's new in 1.605 (2015/03/16)</h3>
 <ul class=image>
   <li class=bug>
     Integrate Stapler fix for queue item API always returning 404 Not Found since 1.601.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27256">issue 27256</a>)
 </ul>
-<h3><a name=v1.604>What's new in 1.604</a> (2015/03/15)</h3>
+<h3 id=v1.604>What's new in 1.604 (2015/03/15)</h3>
 <ul class=image>
   <li class=rfe>
     Added a switch (<tt>-Dhudson.model.User.allowNonExistentUserToLogin=true</tt>) to let users login even when the record is not found in the backend security realm.
@@ -788,13 +788,13 @@ title: Changelog Archives
     Show displayName in build remote API.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26723">issue 26723</a>)
 </ul>
-<h3><a name=v1.602>What's new in 1.602</a> (2015/03/08)</h3>
+<h3 id=v1.602>What's new in 1.602 (2015/03/08)</h3>
 <ul class=image>
   <li class="rfe">
     Show Check Now button also on Available and Updates tabs of plugin manager.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1593">PR 1593</a>)
 </ul>
-<h3><a name=v1.601>What's new in 1.601</a> (2015/03/03)</h3>
+<h3 id=v1.601>What's new in 1.601 (2015/03/03)</h3>
 <ul class=image>
   <li class="major bug">
     Regression with environment variables in 1.600.
@@ -812,7 +812,7 @@ title: Changelog Archives
     Map Queue.Item.id onto Run
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27096">issue 27096</a>)
 </ul>
-<h3><a name=v1.600>What's new in 1.600</a> (2015/02/28)</h3>
+<h3 id=v1.600>What's new in 1.600 (2015/02/28)</h3>
 <ul class=image>
   <li class="major bug">
     Fixes to multiple security vulnerabilities.
@@ -832,7 +832,7 @@ title: Changelog Archives
     Maven build step fail to launch mvn process when special chars are present in build variables.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26684">issue 26684</a>)
 </ul>
-<h3><a name=v1.599>What's new in 1.599</a> (2015/02/16)</h3>
+<h3 id=v1.599>What's new in 1.599 (2015/02/16)</h3>
 <ul class=image>
   <li class=bug>
     Errors in some Maven builds since 1.598.
@@ -856,7 +856,7 @@ title: Changelog Archives
     Allow OldDataMonitor to discard promoted-build-plugin Promotions
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26718">issue 26718</a>)
 </ul>
-<h3><a name=v1.598>What's new in 1.598</a> (2015/01/25)</h3>
+<h3 id=v1.598>What's new in 1.598 (2015/01/25)</h3>
 <ul class=image>
   <li class=bug>
     FutureImpl does not cancel its start future.
@@ -902,7 +902,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25455">issue 25455</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-23151">issue 23151</a>)
 </ul>
-<h3><a name=v1.597>What's new in 1.597</a> (2015/01/19)</h3>
+<h3 id=v1.597>What's new in 1.597 (2015/01/19)</h3>
 <ul class=image>
   <li class='major rfe'>
     <b><tt>JENKINS_HOME</tt> layout change</b>: builds are now keyed by build numbers and not timestamps.
@@ -931,7 +931,7 @@ title: Changelog Archives
     Add range check for H(X-Y) syntax.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25897">issue 25897</a>)
 </ul>
-<h3><a name=v1.596>What's new in 1.596</a> (2015/01/04)</h3>
+<h3 id=v1.596>What's new in 1.596 (2015/01/04)</h3>
 <ul class=image>
   <li class=bug>
     Build page was broken in Hungarian localization while building.
@@ -940,7 +940,7 @@ title: Changelog Archives
     Allow breaking label and node lists.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25989">issue 25989</a>)
 </ul>
-<h3><a name=v1.595>What's new in 1.595</a> (2014/12/21)</h3>
+<h3 id=v1.595>What's new in 1.595 (2014/12/21)</h3>
 <ul class=image>
   <li class=bug>
     Spurious warnings in the log after deleting builds.
@@ -953,7 +953,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25499">issue 25499</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-25498">issue 25498</a>)
 </ul>
-<h3><a name=v1.594>What's new in 1.594</a> (2014/12/14)</h3>
+<h3 id=v1.594>What's new in 1.594 (2014/12/14)</h3>
 <ul class=image>
   <li class=bug>
     After recent Java security updates, Jenkins would not gracefully recover from a deleted <code>secrets/master.key</code>.
@@ -962,7 +962,7 @@ title: Changelog Archives
     <i>Restrict where this project can be run</i> regressed in 1.589 when using the ClearCase plugin.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25533">issue 25533</a>)
 </ul>
-<h3><a name=v1.593>What's new in 1.593</a> (2014/12/07)</h3>
+<h3 id=v1.593>What's new in 1.593 (2014/12/07)</h3>
 <ul class=image>
   <li class=rfe>
     Dynamic Single/Multi line Build History layout.
@@ -971,19 +971,19 @@ title: Changelog Archives
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-24687">issue 24687</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-24589">issue 24589</a>)
 </ul>
-<h3><a name=v1.592>What's new in 1.592</a> (2014/11/30)</h3>
+<h3 id=v1.592>What's new in 1.592 (2014/11/30)</h3>
 <ul class=image>
   <li class=bug>
     Performance problems on large workspaces associated with validating file include patterns.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25759">issue 25759</a>)
 </ul>
-<h3><a name=v1.591>What's new in 1.591</a> (2014/11/25)</h3>
+<h3 id=v1.591>What's new in 1.591 (2014/11/25)</h3>
 <ul class=image>
   <li class=bug>
     Always use forward slashes in path separators during in ZIP archives generated by Directory Browser
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22514">issue 22514</a>)
 </ul>
-<h3><a name=v1.590>What's new in 1.590</a> (2014/11/16)</h3>
+<h3 id=v1.590>What's new in 1.590 (2014/11/16)</h3>
 <ul class=image>
   <li class=bug>
     Basic Authentication in combination with Session is broken
@@ -1004,7 +1004,7 @@ title: Changelog Archives
     API method to get non-null <code>Jenkins</code> instance with internal validation
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23339">issue 23339</a>)
 </ul>
-<h3><a name=v1.589>What's new in 1.589</a> (2014/11/09)</h3>
+<h3 id=v1.589>What's new in 1.589 (2014/11/09)</h3>
 <ul class=image>
   <li class=bug>
     JNA error in <code>WindowsInstallerLink.doDoInstall</code>.
@@ -1013,7 +1013,7 @@ title: Changelog Archives
     Restore compatibility of label assignment for some plugins.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25372">issue 25372</a>)
 </ul>
-<h3><a name=v1.588>What's new in 1.588</a> (2014/11/02)</h3>
+<h3 id=v1.588>What's new in 1.588 (2014/11/02)</h3>
 <ul class=image>
   <li class=bug>
     Unnecessarily slow startup time with a massive number of jobs.
@@ -1022,7 +1022,7 @@ title: Changelog Archives
     Custom workspace option did not work under some conditions.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25221">issue 25221</a>)
 </ul>
-<h3><a name=v1.587>What's new in 1.587</a> (2014/10/29)</h3>
+<h3 id=v1.587>What's new in 1.587 (2014/10/29)</h3>
 <ul class=image>
   <li class=bug>
     Queue didn't always leave a trail for cancelled items properly
@@ -1034,7 +1034,7 @@ title: Changelog Archives
     Introduced slave-to-master security mechanism to defend a master from slaves.
     (<a href="http://jenkins-ci.org/security-144">SECURITY-144</a>)
 </ul>
-<h3><a name=v1.586>What's new in 1.586</a> (2014/10/26)</h3>
+<h3 id=v1.586>What's new in 1.586 (2014/10/26)</h3>
 <ul class=image>
   <li class=rfe>
     Bumping up JNA to 4.10. This is potentially a breaking change for plugins that depend on JNA 3.x
@@ -1050,7 +1050,7 @@ title: Changelog Archives
     Existing <code>FileParameter</code>s should be handled as different values to avoid merging of queued builds
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19017">issue 19017</a>)
 </ul>
-<h3><a name=v1.585>What's new in 1.585</a> (2014/10/19)</h3>
+<h3 id=v1.585>What's new in 1.585 (2014/10/19)</h3>
 <ul class=image>
   <li class=bug>
     Build health computed repeatedly for a single Weather column cell.
@@ -1091,7 +1091,7 @@ title: Changelog Archives
     Incorporated a fix for "Poodle" (CVE-2014-3566) vulnerability in the HTTPS connector of "java -jar jenkins.war"
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25169">issue 25169</a>)
 </ul>
-<h3><a name=v1.584>What's new in 1.584</a> (2014/10/12)</h3>
+<h3 id=v1.584>What's new in 1.584 (2014/10/12)</h3>
 <ul class=image>
   <li class=rfe>
     Diagnostic thread names are now available while requests are still in filters
@@ -1109,13 +1109,13 @@ title: Changelog Archives
     Do not consider port in use error to be a successful start of Jenkins on Debian.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24966">issue 24966</a>)
 </ul>
-<h3><a name=v1.583>What's new in 1.583</a> (2014/10/01)</h3>
+<h3 id=v1.583>What's new in 1.583 (2014/10/01)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixes to multiple security vulnerabilities.
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2014-10-01">security advisory</a>)
 </ul>
-<h3><a name=v1.582>What's new in 1.582</a> (2014/09/28)</h3>
+<h3 id=v1.582>What's new in 1.582 (2014/09/28)</h3>
 <ul class=image>
   <li class=bug>
     Channel reader thread can end up consuming 100% CPU.
@@ -1147,7 +1147,7 @@ title: Changelog Archives
     handle job move when buildDir is configured to a custom location.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24825">issue 24825</a>)
 </ul>
-<h3><a name=v1.581>What's new in 1.581</a> (2014/09/21)</h3>
+<h3 id=v1.581>What's new in 1.581 (2014/09/21)</h3>
 <ul class=image>
   <li class=rfe>
     Use slightly larger Jenkins head icon.
@@ -1162,7 +1162,7 @@ title: Changelog Archives
     Wrong Hebrew localization resulted in broken console output since 1.539.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24614">issue 24614</a>)
 </ul>
-<h3><a name=v1.580>What's new in 1.580</a> (2014/09/14)</h3>
+<h3 id=v1.580>What's new in 1.580 (2014/09/14)</h3>
 <ul class=image>
   <li class=bug>
     Health reports saved to disk before 1.576 showed no weather icon since that version.
@@ -1174,7 +1174,7 @@ title: Changelog Archives
     Add editable descriptions for label atoms.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-6153">issue 6153</a>)
 </ul>
-<h3><a name=v1.579>What's new in 1.579</a> (2014/09/06)</h3>
+<h3 id=v1.579>What's new in 1.579 (2014/09/06)</h3>
 <ul class=image>
   <li class=bug>
     <code>ConcurrentModificationException</code> in <code>RunListProgressiveRendering</code>.
@@ -1195,7 +1195,7 @@ title: Changelog Archives
     Debian package now sets umask to 027 by default for better default privacy. See <tt>/etc/default/jenkins</tt> to change this.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24514">issue 24514</a>)
 </ul>
-<h3><a name=v1.578>What's new in 1.578</a> (2014/08/31)</h3>
+<h3 id=v1.578>What's new in 1.578 (2014/08/31)</h3>
 <ul class=image>
   <li class=rfe>
     Added 'no-store' to the 'Cache-Control' header to avoid accidental information leak through local cache backup
@@ -1207,7 +1207,7 @@ title: Changelog Archives
     Use absolute links for computer sidepanel items so they don't break as easily.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23963">issue 23963</a>)
 </ul>
-<h3><a name=v1.577>What's new in 1.577</a> (2014/08/24)</h3>
+<h3 id=v1.577>What's new in 1.577 (2014/08/24)</h3>
 <ul class=image>
   <li class="major bug">
     Failure to migrate legacy user records in 1.576 properly broke Jenkins, resulted in NullPointerExceptions.
@@ -1248,7 +1248,7 @@ title: Changelog Archives
     Properly consider busy executors when reducing a node's executor count.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24095">issue 24095</a>)
 </ul>
-<h3><a name=v1.576>What's new in 1.576</a> (2014/08/18)</h3>
+<h3 id=v1.576>What's new in 1.576 (2014/08/18)</h3>
 <ul class=image>
   <li class="bug">
     Worked around "incompatible InnerClasses attribute" bug in IBM J9 VM
@@ -1288,7 +1288,7 @@ title: Changelog Archives
     Modernize tabBar and bigtable.  Makes the project view look better.  Same for Plugin Manager.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24030">issue 24030</a>)
 </ul>
-<h3><a name=v1.575>What's new in 1.575</a> (2014/08/10)</h3>
+<h3 id=v1.575>What's new in 1.575 (2014/08/10)</h3>
 <ul class=image>
   <li class="rfe">
     Move option to fingerprint artifacts to Archive the Artifacts, Advanced options.
@@ -1333,7 +1333,7 @@ title: Changelog Archives
     Restrict access to SCM trigger status page to administrators.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1327">pull 1282</a>)
 </ul>
-<h3><a name=v1.574>What's new in 1.574</a> (2014/07/27)</h3>
+<h3 id=v1.574>What's new in 1.574 (2014/07/27)</h3>
 <ul class=image>
   <li class="rfe">
     UI redesign: Use Helvetica as default font
@@ -1346,7 +1346,7 @@ title: Changelog Archives
     Use native encoding for filenames in downloaded ZIPs.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20663">issue 20663</a>)
 </ul>
-<h3><a name=v1.573>What's new in 1.573</a> (2014/07/20)</h3>
+<h3 id=v1.573>What's new in 1.573 (2014/07/20)</h3>
 <ul class=image>
   <li class="rfe">
     UI redesign: Changed element alignment, removed sidebar link underlines
@@ -1362,7 +1362,7 @@ title: Changelog Archives
     Fixed unnecessary eager loading of build records in certain code path.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18065">issue 18065</a>)
 </ul>
-<h3><a name=v1.572>What's new in 1.572</a> (2014/07/13)</h3>
+<h3 id=v1.572>What's new in 1.572 (2014/07/13)</h3>
 <ul class=image>
   <li class="major rfe">
     UI redesign: Changed header, made layout &lt;div&gt;-based and responsive
@@ -1374,7 +1374,7 @@ title: Changelog Archives
     Do not offer automatic upgrade if war parent directory is not writable
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23683">issue 23683</a>)
 </ul>
-<h3><a name=v1.571>What's new in 1.571</a> (2014/07/07)</h3>
+<h3 id=v1.571>What's new in 1.571 (2014/07/07)</h3>
 <ul class=image>
   <li class=bug>
     <code>IllegalArgumentException</code> from <code>AbstractProject.getEnvironment</code> when trying to get environment variables from an offline slave.
@@ -1386,7 +1386,7 @@ title: Changelog Archives
     Master computer is not notified using ComputerListener
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23481">issue 23481</a>)
 </ul>
-<h3><a name=v1.570>What's new in 1.570</a> (2014/06/29)</h3>
+<h3 id=v1.570>What's new in 1.570 (2014/06/29)</h3>
 <ul class=image>
   <li class=rfe>
     Add CLI commands to add jobs to and remove jobs from views (add-job-to-view, remove-job-from-view).
@@ -1416,7 +1416,7 @@ title: Changelog Archives
     Fixed <code>NullPointerException</code> when &quot;properties&quot; element is missing in a job's configuration submission by JSON
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23437">issue 23437</a>)
 </ul>
-<h3><a name=v1.569>What's new in 1.569</a> (2014/06/23)</h3>
+<h3 id=v1.569>What's new in 1.569 (2014/06/23)</h3>
 <ul class=image>
   <li class=rfe>
     Jenkins can now kill Win32 processes from Win64 JVMs.
@@ -1434,7 +1434,7 @@ title: Changelog Archives
     When Jenkins had a lot of jobs, submitting a view configuration change could overload the web server, even if few of the jobs were selected.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20327">issue 20327</a>)
 </ul>
-<h3><a name=v1.568>What's new in 1.568</a> (2014/06/15)</h3>
+<h3 id=v1.568>What's new in 1.568 (2014/06/15)</h3>
 <ul class=image>
   <li class=bug>
     Fixed JNLP connection handling problem
@@ -1458,7 +1458,7 @@ title: Changelog Archives
     API changes allowing to create nested launchers (<code>DecoratedLauncher</code>)
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19454">issue 19454</a>)
 </ul>
-<h3><a name=v1.567>What's new in 1.567</a> (2014/06/09)</h3>
+<h3 id=v1.567>What's new in 1.567 (2014/06/09)</h3>
 <ul class=image>
   <li class="bug">
     Fixed a reference counting bug in the remoting layer.
@@ -1522,7 +1522,7 @@ title: Changelog Archives
     Added an option to archive artifacts only when the build is successful
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22699">issue 22699</a>)
 </ul>
-<h3><a name=v1.566>What's new in 1.566</a> (2014/06/01)</h3>
+<h3 id=v1.566>What's new in 1.566 (2014/06/01)</h3>
 <ul class=image>
   <li class="rfe">
     Configurable case sensitivity mode for user IDs.
@@ -1537,7 +1537,7 @@ title: Changelog Archives
     Jenkins cannot restart Windows service
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22685">issue 22685</a>)
 </ul>
-<h3><a name=v1.565>What's new in 1.565</a> (2014/05/26)</h3>
+<h3 id=v1.565>What's new in 1.565 (2014/05/26)</h3>
 <ul class=image>
   <li class="bug">
     Misleading error message trying to dynamically update a plugin (which is impossible) on an NFS filesystem.
@@ -1557,7 +1557,7 @@ title: Changelog Archives
     Fixed localization of build environment variable help.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22867">issue 22867</a>)
 </ul>
-<h3><a name=v1.564>What's new in 1.564</a> (2014/05/19)</h3>
+<h3 id=v1.564>What's new in 1.564 (2014/05/19)</h3>
 <ul class=image>
   <li class="rfe">
     Improve list view performance on large instances with folders.
@@ -1570,7 +1570,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22879">issue 22879</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-22798">issue 22798</a>)
 </ul>
-<h3><a name=v1.563>What's new in 1.563</a> (2014/05/11)</h3>
+<h3 id=v1.563>What's new in 1.563 (2014/05/11)</h3>
 <ul class=image>
   <li class="major bug">
     Memory exhaustion in remoting channel since 1.560.
@@ -1591,7 +1591,7 @@ title: Changelog Archives
     Again show proper display names for build parameters.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22755">issue 22755</a>)
 </ul>
-<h3><a name=v1.562>What's new in 1.562</a> (2014/05/03)</h3>
+<h3 id=v1.562>What's new in 1.562 (2014/05/03)</h3>
 <ul class=image>
   <li class=bug>
     Next build link was not reliably available from a previous build after starting a new one.
@@ -1612,7 +1612,7 @@ title: Changelog Archives
     Add links to nodes on thread dump page for easier navigation.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22672">issue 22672</a>)
 </ul>
-<h3><a name=v1.561>What's new in 1.561</a> (2014/04/27)</h3>
+<h3 id=v1.561>What's new in 1.561 (2014/04/27)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a corner case handling of tool installation.
@@ -1691,7 +1691,7 @@ title: Changelog Archives
     Return queue item location when triggering buildWithParameters.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13546">issue 13546</a>)
 </ul>
-<h3><a name=v1.560>What's new in 1.560</a> (2014/04/20)</h3>
+<h3 id=v1.560>What's new in 1.560 (2014/04/20)</h3>
 <ul class=image>
   <li class='major rfe'>
     Enforcing build trigger authentication at runtime by checking authentication associated with a build, rather than at configuration time.
@@ -1734,7 +1734,7 @@ title: Changelog Archives
     Remotely triggered builds now show correct IP address through proxy.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18008">issue 18008</a>)
 </ul>
-<h3><a name=v1.559>What's new in 1.559</a> (2014/04/13)</h3>
+<h3 id=v1.559>What's new in 1.559 (2014/04/13)</h3>
 <ul class=image>
   <li class=rfe>
     Slaves connected via Java Web Start now restart themselves when a connection to Jenkins is lost.
@@ -1746,7 +1746,7 @@ title: Changelog Archives
     Faster rendering of views containing many items.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18364">issue 18364</a>)
 </ul>
-<h3><a name=v1.558>What's new in 1.558</a> (2014/04/06)</h3>
+<h3 id=v1.558>What's new in 1.558 (2014/04/06)</h3>
 <ul class=image>
   <li class=rfe>
     Cron-style trigger configuration will now display expected prior and subsequent run times.
@@ -1778,7 +1778,7 @@ title: Changelog Archives
     Fixed NPE executing <tt>Pipe.EOF</tt> with <tt>ProxyWriter</tt>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20769">issue 20769</a>)
 </ul>
-<h3><a name=v1.557>What's new in 1.557</a> (2014/03/31)</h3>
+<h3 id=v1.557>What's new in 1.557 (2014/03/31)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>ArrayIndexOutOfBoundsException</tt> in XStream with Oracle JDK8 release version
@@ -1805,7 +1805,7 @@ title: Changelog Archives
     Allow JDK8 (and other versions) to be downloaded by JDKInstaller correctly.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22347">issue 22347</a>)
 </ul>
-<h3><a name=v1.556>What's new in 1.556</a> (2014/03/23)</h3>
+<h3 id=v1.556>What's new in 1.556 (2014/03/23)</h3>
 <ul class=image>
   <li class=rfe>
     Access through API token and SSH key login now fully retains group memberships.
@@ -1816,7 +1816,7 @@ title: Changelog Archives
   <li class=rfe>
     Job can be reloaded individually from disk with "job/FOO/reload" URL or "reload-job" CLI command
 </ul>
-<h3><a name=v1.555>What's new in 1.555</a> (2014/03/16)</h3>
+<h3 id=v1.555>What's new in 1.555 (2014/03/16)</h3>
 <ul class=image>
   <li class=bug>
     Jenkins should recover gracefully from a failure to process "remember me" cookie
@@ -1825,7 +1825,7 @@ title: Changelog Archives
     Fixed Up link in matrix projects
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21773">issue 21773</a>)
 </ul>
-<h3><a name=v1.554>What's new in 1.554</a> (2014/03/09)</h3>
+<h3 id=v1.554>What's new in 1.554 (2014/03/09)</h3>
 <ul class=image>
   <li class=bug>
     Archiving of symlinks as artifacts did not work in some cases.
@@ -1834,7 +1834,7 @@ title: Changelog Archives
     Slow rendering of directories with many entries in remote workspaces.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21780">issue 21780</a>)
 </ul>
-<h3><a name=v1.553>What's new in 1.553</a> (2014/03/02)</h3>
+<h3 id=v1.553>What's new in 1.553 (2014/03/02)</h3>
 <ul class=image>
   <li class=bug>
     Build history widget only showed the last day of builds.
@@ -1860,7 +1860,7 @@ title: Changelog Archives
     Fix autocompletion for items in folders.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1124">pull request 1124</a>)
 </ul>
-<h3><a name=v1.552>What's new in 1.552</a> (2014/02/24)</h3>
+<h3 id=v1.552>What's new in 1.552 (2014/02/24)</h3>
 <ul class=image>
   <li class=bug>
     Fixed handling of default JENKINS_HOME when storing CLI credentials
@@ -1877,7 +1877,7 @@ title: Changelog Archives
   <li class=rfe>
     Improve detection of broken reverse proxy setups.
 </ul>
-<h3><a name=v1.551>What's new in 1.551</a> (2014/02/14)</h3>
+<h3 id=v1.551>What's new in 1.551 (2014/02/14)</h3>
 <ul class=image>
   <li class='major bug'>
     Valentine's day security release that contains more than a dozen security fixes.
@@ -1921,7 +1921,7 @@ title: Changelog Archives
   <li class=bug>
     "java -jar jenkins.war" should use unique session cookie for users who run multiple Jenkins on the same host.
 </ul>
-<h3><a name=v1.550>What's new in 1.550</a> (2014/02/09)</h3>
+<h3 id=v1.550>What's new in 1.550 (2014/02/09)</h3>
 <ul class=image>
   <li class=bug>
     Report number of all jobs as part of usage statistics
@@ -1930,7 +1930,7 @@ title: Changelog Archives
     Replace description in error dialog instead of appending
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21457">issue 21457</a>)
 </ul>
-<h3><a name=v1.549>What's new in 1.549</a> (2014/01/25)</h3>
+<h3 id=v1.549>What's new in 1.549 (2014/01/25)</h3>
 <ul class=image>
   <li class=bug>
     Removing the "keep this build forever" lock on a build should require the DELETE permission.
@@ -1948,7 +1948,7 @@ title: Changelog Archives
     Allow more specific loggers to reduce log level.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21386">issue 21386</a>)
 </ul>
-<h3><a name=v1.548>What's new in 1.548</a> (2014/01/20)</h3>
+<h3 id=v1.548>What's new in 1.548 (2014/01/20)</h3>
 <ul class=image>
   <li class=rfe>
     API for adding actions to a wide class of model objects at once.
@@ -1974,7 +1974,7 @@ title: Changelog Archives
     Option to hold lazy-loaded build references strongly, weakly, and more.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19400">issue 19400</a>)
 </ul>
-<h3><a name=v1.547>What's new in 1.547</a> (2014/01/12)</h3>
+<h3 id=v1.547>What's new in 1.547 (2014/01/12)</h3>
 <ul class=image>
   <li class=rfe>
     Split Windows slave functionality into its own plugin.
@@ -1985,7 +1985,7 @@ title: Changelog Archives
     Fixed Trend Graph NPE when there isn't any builds
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21239">issue 21239</a>)
 </ul>
-<h3><a name=v1.546>What's new in 1.546</a> (2014/01/06)</h3>
+<h3 id=v1.546>What's new in 1.546 (2014/01/06)</h3>
 <ul class=image>
   <li class="major bug">
     Builds disappear after renaming a job.
@@ -2000,7 +2000,7 @@ title: Changelog Archives
     When clicking <i>Apply</i> results in an exception (error page), show it, rather than creating an empty dialog.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20772">issue 20772</a>)
 </ul>
-<h3><a name=v1.545>What's new in 1.545</a> (2013/12/31)</h3>
+<h3 id=v1.545>What's new in 1.545 (2013/12/31)</h3>
 <ul class=image>
   <li class=bug>
       <code>CannotResolveClassException</code> breaks loading of entire containing folder, not just one job.
@@ -2015,7 +2015,7 @@ title: Changelog Archives
     Avoiding serializing the owning build as part of a test result action, as this can lead to errors later.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18410">issue 18410</a>)
 </ul>
-<h3><a name=v1.544>What's new in 1.544</a> (2013/12/15)</h3>
+<h3 id=v1.544>What's new in 1.544 (2013/12/15)</h3>
 <ul class=image>
   <li class=bug>
     RingBufferLogHandler throws ArrayIndexOutOfBoundsException after int-overflow.
@@ -2042,13 +2042,13 @@ title: Changelog Archives
     Fixed a possible dead lock problem in deleting projects.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19446">issue 19446</a>)
 </ul>
-<h3><a name=v1.543>What's new in 1.543</a> (2013/12/10)</h3>
+<h3 id=v1.543>What's new in 1.543 (2013/12/10)</h3>
 <ul class=image>
   <li class=bug>
     HTML metacharacters not escaped in log messages.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20800">issue 20800</a>)
 </ul>
-<h3><a name=v1.542>What's new in 1.542</a> (2013/12/02)</h3>
+<h3 id=v1.542>What's new in 1.542 (2013/12/02)</h3>
 <ul class=image>
   <li class=bug>
     Improved error diagnosis for jzlib deflate problem.
@@ -2066,7 +2066,7 @@ title: Changelog Archives
     Jenkins 1.540 just doesn't boot on Windows at all.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20630">issue 20630</a>)
 </ul>
-<h3><a name=v1.541>What's new in 1.541</a> (2013/11/24)</h3>
+<h3 id=v1.541>What's new in 1.541 (2013/11/24)</h3>
 <ul class=image>
   <li class=rfe>
     Add option to create view by copying an existing one.
@@ -2087,7 +2087,7 @@ title: Changelog Archives
     Fixed failed tests displaying as Yellow in JUnit history plot
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7866">issue 7866</a>)
 </ul>
-<h3><a name=v1.540>What's new in 1.540</a> (2013/11/17)</h3>
+<h3 id=v1.540>What's new in 1.540 (2013/11/17)</h3>
 <ul class=image>
   <li class=bug>
     CLI over HTTP was not working since 1.535.
@@ -2141,7 +2141,7 @@ title: Changelog Archives
     Better diagnosability for remoting <tt>StreamCorruptedException</tt>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-8856">issue 8856</a>)
 </ul>
-<h3><a name=v1.539>What's new in 1.539</a> (2013/11/11)</h3>
+<h3 id=v1.539>What's new in 1.539 (2013/11/11)</h3>
 <ul class=image>
   <li class=rfe>
     Core started relying on Java6 API, completing Java5 -&gt; Java6 migration.
@@ -2149,7 +2149,7 @@ title: Changelog Archives
   <li class=rfe>
     Adding a batch of contributed localization from the community.
 </ul>
-<h3><a name=v1.538>What's new in 1.538</a> (2013/11/03)</h3>
+<h3 id=v1.538>What's new in 1.538 (2013/11/03)</h3>
 <ul class=image>
   <li class=rfe>
     Disabled, aborted, and not-build status now has different image names to allow
@@ -2190,7 +2190,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19173">issue 19173</a>)
   </li>
 </ul>
-<h3><a name=v1.537>What's new in 1.537</a> (2013/10/27)</h3>
+<h3 id=v1.537>What's new in 1.537 (2013/10/27)</h3>
 <ul class=image>
   <li class='rfe'>
     Upgrade bundled plugin versions: ssh-slaves to 1.5, and credentials to 1.9.1
@@ -2213,7 +2213,7 @@ title: Changelog Archives
     Reverted the JENKINS-18629 fix in 1.536 as it causes various regressions in plugins.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20262">issue 20262</a>)
 </ul>
-<h3><a name=v1.536>What's new in 1.536</a> (2013/10/20)</h3>
+<h3 id=v1.536>What's new in 1.536 (2013/10/20)</h3>
 <ul class=image>
   <li class=bug>
     Fixed two file descriptor leaks.
@@ -2241,7 +2241,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Executor threads are now created only on demand.
 </ul>
-<h3><a name=v1.535>What's new in 1.535</a> (2013/10/14)</h3>
+<h3 id=v1.535>What's new in 1.535 (2013/10/14)</h3>
 <ul class=image>
   <li class=bug>
     Windows JDK installer failed in a path with spaces.
@@ -2277,7 +2277,7 @@ title: Changelog Archives
     Visualize queued jobs in view.
     (<a href="https://github.com/jenkinsci/jenkins/pull/531">pull request 531</a>)
 </ul>
-<h3><a name=v1.534>What's new in 1.534</a> (2013/10/07)</h3>
+<h3 id=v1.534>What's new in 1.534 (2013/10/07)</h3>
 <ul class=image>
   <li class='major bug'>
     Default crumb issuer configurations saved in older releases did not load as of Jenkins 1.531.
@@ -2295,13 +2295,13 @@ title: Changelog Archives
     Added postCheckout method for SCMs
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19740">issue 19740</a>)
 </ul>
-<h3><a name=v1.533>What's new in 1.533</a> (2013/09/29)</h3>
+<h3 id=v1.533>What's new in 1.533 (2013/09/29)</h3>
 <ul class=image>
   <li class=rfe>
     Offer alternate error message for pattern-based project naming strategy.
     (<a href="https://github.com/jenkinsci/jenkins/pull/914">pull request 914</a>)
 </ul>
-<h3><a name=v1.532>What's new in 1.532</a> (2013/09/23)</h3>
+<h3 id=v1.532>What's new in 1.532 (2013/09/23)</h3>
 <ul class=image>
   <li class='major bug'>
     Working around a GZip compression bug in jzlib affecting transfer of certain large, repetitive artifacts.
@@ -2325,7 +2325,7 @@ title: Changelog Archives
     Make the link to the aggregated test result from the project page work.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9637">issue 9637</a>)
 </ul>
-<h3><a name=v1.531>What's new in 1.531</a> (2013/09/16)</h3>
+<h3 id=v1.531>What's new in 1.531 (2013/09/16)</h3>
 <ul class=image>
   <li class=bug>
     Deleting an external run did not immediately remove it from build list, leading to errors from log rotation.
@@ -2352,7 +2352,7 @@ title: Changelog Archives
     No events fired when project is enable/disable or the description is changed
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17108">issue 17108</a>)
 </ul>
-<h3><a name=v1.530>What's new in 1.530</a> (2013/09/09)</h3>
+<h3 id=v1.530>What's new in 1.530 (2013/09/09)</h3>
 <ul class=image>
   <li class=bug>
     Send Maven agent JARs to slaves on demand, not unconditionally upon connection.
@@ -2370,7 +2370,7 @@ title: Changelog Archives
     Build number symlinks and permalinks not updated for Maven module builds.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18846">issue 18846</a>)
 </ul>
-<h3><a name=v1.529>What's new in 1.529</a> (2013/08/26)</h3>
+<h3 id=v1.529>What's new in 1.529 (2013/08/26)</h3>
 <ul class=image>
   <li class=rfe>
       With Apache Maven 3.1 build, logging configuration from the Apache Maven distribution is not used.
@@ -2391,7 +2391,7 @@ title: Changelog Archives
     Build for $username now shows also build scheduled by user
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16178">issue 16178</a>)
 </ul>
-<h3><a name=v1.528>What's new in 1.528</a> (2013/08/18)</h3>
+<h3 id=v1.528>What's new in 1.528 (2013/08/18)</h3>
 <ul class=image>
   <li class=rfe>
     Command line now supports "--sessionTimeout" option for controlling session timeout
@@ -2410,7 +2410,7 @@ title: Changelog Archives
     Jenkins does not invoke ProcessKillers for Windows
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19156">issue 19156</a>)
 </ul>
-<h3><a name=v1.527>What's new in 1.527</a> (2013/08/12)</h3>
+<h3 id=v1.527>What's new in 1.527 (2013/08/12)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>NoSuchFieldError: triggers</tt> with older Maven plugin
@@ -2429,7 +2429,7 @@ title: Changelog Archives
     Improved <tt>EnvironmentContributor</tt> to support project-level insertion.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19042">issue 19042</a>)
 </ul>
-<h3><a name=v1.526>What's new in 1.526</a> (2013/08/05)</h3>
+<h3 id=v1.526>What's new in 1.526 (2013/08/05)</h3>
 <ul class=image>
   <li class=bug>
     HudsonAuthenticationEntryPoint can break CLI support, because the port isn't exposed properly.
@@ -2491,9 +2491,9 @@ title: Changelog Archives
     People View does Not Populate if JQuery plugin enabled.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18641">issue 18641</a>)
 </ul>
-<h3><a name=v1.525>What's new in 1.525</a> (2013/07/29)</h3>
+<h3 id=v1.525>What's new in 1.525 (2013/07/29)</h3>
 <p>Same as 1.524; botched release.</p>
-<h3><a name=v1.524>What's new in 1.524</a> (2013/07/23)</h3>
+<h3 id=v1.524>What's new in 1.524 (2013/07/23)</h3>
 <ul class=image>
   <li class=bug>
     Clock Difference broken on Manage Nodes page
@@ -2510,13 +2510,13 @@ title: Changelog Archives
     Do not load disabled plugins as dependencies for other plugins.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18654">issue 18654</a>)
 </ul>
-<h3><a name=v1.523>What's new in 1.523</a> (2013/07/14)</h3>
+<h3 id=v1.523>What's new in 1.523 (2013/07/14)</h3>
 <ul class=image>
   <li class=bug>
     Fixed: claiming of tests doesn't work in Maven jobs (claim-plugin)
      (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14585">issue 14585</a>)
 </ul>
-<h3><a name=v1.522>What's new in 1.522</a> (2013/07/06)</h3>
+<h3 id=v1.522>What's new in 1.522 (2013/07/06)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a regression in the config form with some plugins
@@ -2536,7 +2536,7 @@ title: Changelog Archives
   <li class=bug>
     If every node is restricted to tied jobs only, Matrix build jobs can never start.
 </ul>
-<h3><a name=v1.521>What's new in 1.521</a> (2013/07/02)</h3>
+<h3 id=v1.521>What's new in 1.521 (2013/07/02)</h3>
 <ul class=image>
   <li class=bug>
     Build with parameters returns empty web page
@@ -2568,7 +2568,7 @@ title: Changelog Archives
   <li class=rfe>
     Revisited the extension point added in 1.519 that adds custom plexus components.
 </ul>
-<h3><a name=v1.520>What's new in 1.520</a> (2013/06/25)</h3>
+<h3 id=v1.520>What's new in 1.520 (2013/06/25)</h3>
 <ul class=image>
   <li class=bug>
     Slave launch thread should have the background activity credential.
@@ -2626,7 +2626,7 @@ title: Changelog Archives
     100% CPU pegging in <tt>Deflator.deflateBytes</tt>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14362">issue 14362</a>)
 </ul>
-<h3><a name=v1.519>What's new in 1.519</a> (2013/06/17)</h3>
+<h3 id=v1.519>What's new in 1.519 (2013/06/17)</h3>
 <ul class=image>
   <li class='major bug'>
     Log cluttered with irrelevant warnings about build timestamps when running on Windows on Java 6.
@@ -2648,7 +2648,7 @@ title: Changelog Archives
     Remoting classloader performance improvement upon reconnection to the same slave.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15120">issue 15120</a>)
 </ul>
-<h3><a name=v1.518>What's new in 1.518</a> (2013/06/11)</h3>
+<h3 id=v1.518>What's new in 1.518 (2013/06/11)</h3>
 <ul class=image>
   <li class=bug>
     NPE in <code>DefaultMatrixExecutionStrategyImpl.waitForCompletion</code>.
@@ -2677,7 +2677,7 @@ title: Changelog Archives
     Progress bar sometimes broken in People.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18119">issue 18119</a>)
 </ul>
-<h3><a name=v1.517>What's new in 1.517</a> (2013/06/02)</h3>
+<h3 id=v1.517>What's new in 1.517 (2013/06/02)</h3>
 <ul class=image>
   <li class=rfe>
     Enable word breaking in potentially long strings like job names.
@@ -2702,7 +2702,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18427">issue 18427</a>)
   </li>
 </ul>
-<h3><a name=v1.516>What's new in 1.516</a> (2013/05/27)</h3>
+<h3 id=v1.516>What's new in 1.516 (2013/05/27)</h3>
 <ul class=image>
   <li class=bug>
     NPE from <code>Run.getDynamic</code>.
@@ -2717,7 +2717,7 @@ title: Changelog Archives
     Errors in <code>init.groovy</code> halted startup; changed to just log a warning.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17933">issue 17933</a>)
 </ul>
-<h3><a name=v1.515>What's new in 1.515</a> (2013/05/18)</h3>
+<h3 id=v1.515>What's new in 1.515 (2013/05/18)</h3>
 <ul class=image>
   <li class=rfe>
     Windows services now auto-restart in case of abnormal process termination.
@@ -2749,7 +2749,7 @@ title: Changelog Archives
     Extension point to transform test names (for use with alternative JVM languages).
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17478">issue 17478</a>)
 </ul>
-<h3><a name=v1.514>What's new in 1.514</a> (2013/05/01)</h3>
+<h3 id=v1.514>What's new in 1.514 (2013/05/01)</h3>
 <ul class=image>
   <li class=rfe>
     Added a new <tt>set-build-parameter</tt> command that can update a build variable from within a build.
@@ -2775,7 +2775,7 @@ title: Changelog Archives
   <li class=rfe>
     Updated bundled plugins.
 </ul>
-<h3><a name=v1.513>What's new in 1.513</a> (2013/04/28)</h3>
+<h3 id=v1.513>What's new in 1.513 (2013/04/28)</h3>
 <ul class=image>
   <li class=rfe>
     Slave status monitor page shows when the data is last obtained
@@ -2800,7 +2800,7 @@ title: Changelog Archives
     Fixed an XSS vulnerability to copy arbitrary text into clipboard
     (SECURITY-71/CVE-2013-1808)
 </ul>
-<h3><a name=v1.512>What's new in 1.512</a> (2013/04/21)</h3>
+<h3 id=v1.512>What's new in 1.512 (2013/04/21)</h3>
 <ul class=image>
   <li class=rfe>
     Views can now include jobs located within folders.
@@ -2834,7 +2834,7 @@ title: Changelog Archives
     Fixed a bug in the logic that hides context menu anchor 'v'
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13995">issue 13995</a>)
 </ul>
-<h3><a name=v1.511>What's new in 1.511</a> (2013/04/14)</h3>
+<h3 id=v1.511>What's new in 1.511 (2013/04/14)</h3>
 <ul class=image>
   <li class=bug>
     JUnit result archiver should only fail builds if there are really no results - i.e. also no skipped tests.
@@ -2849,7 +2849,7 @@ title: Changelog Archives
     sort order of plugin list is not working by default.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17039">issue 17039</a>)
 </ul>
-<h3><a name=v1.510>What's new in 1.510</a> (2013/04/06)</h3>
+<h3 id=v1.510>What's new in 1.510 (2013/04/06)</h3>
 <ul class=image>
   <li class=bug>
     <tt>UnsatisfiedLinkError</tt> on <tt>CreateSymbolicLinkw</tt> on Windows XP.
@@ -2874,7 +2874,7 @@ title: Changelog Archives
     Context menu no longer automatically pops up
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13995">issue 13995</a>)
 </ul>
-<h3><a name=v1.509>What's new in 1.509</a> (2013/04/02)</h3>
+<h3 id=v1.509>What's new in 1.509 (2013/04/02)</h3>
 <ul class=image>
   <li class='major bug'>
     Heavy thread congestion saving fingerprints.
@@ -2904,13 +2904,13 @@ title: Changelog Archives
     View name should not allow "..".
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16608">issue 16608</a>)
 </ul>
-<h3><a name=v1.508>What's new in 1.508</a> (2013/03/25)</h3>
+<h3 id=v1.508>What's new in 1.508 (2013/03/25)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixing a regression in 1.507 that causes a failure to load matrix jobs.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17337">issue 17337</a>)
 </ul>
-<h3><a name=v1.507>What's new in 1.507</a> (2013/03/24)</h3>
+<h3 id=v1.507>What's new in 1.507 (2013/03/24)</h3>
 <ul class=image>
   <li class=rfe>
       Show the reason for a skipped test if the test result contains one
@@ -2935,7 +2935,7 @@ title: Changelog Archives
     Wrong build result in post build steps after failed pre build step in maven projects.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17177">issue 17177</a>)
 </ul>
-<h3><a name=v1.506>What's new in 1.506</a> (2013/03/17)</h3>
+<h3 id=v1.506>What's new in 1.506 (2013/03/17)</h3>
 <ul class=image>
   <li class='major bug'>
     Saving Global Jenkins Global Config wipes out the crumb issuer settings in the Global Security Config.
@@ -2966,7 +2966,7 @@ title: Changelog Archives
   <li class=rfe>
     Improved the duration browsers cache static resources.
 </ul>
-<h3><a name=v1.505>What's new in 1.505</a> (2013/03/10)</h3>
+<h3 id=v1.505>What's new in 1.505 (2013/03/10)</h3>
 <ul class=image>
   <li class='major bug'>
     Exception in flyweight tasks when checking if an executor is interrupted.
@@ -2996,7 +2996,7 @@ title: Changelog Archives
     Disabled Authenticode verification for Windows services.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15596">issue 15596</a>)
 </ul>
-<h3><a name=v1.504>What's new in 1.504</a> (2013/03/03)</h3>
+<h3 id=v1.504>What's new in 1.504 (2013/03/03)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in the "discard old builds" in 1.503.
@@ -3026,7 +3026,7 @@ title: Changelog Archives
     Significant improvement in Traditional Chinese localizations.
     (<a href="https://github.com/jenkinsci/jenkins/pull/716">pull 716</a>)
 </ul>
-<h3><a name=v1.503>What's new in 1.503</a> (2013/02/26)</h3>
+<h3 id=v1.503>What's new in 1.503 (2013/02/26)</h3>
 <ul class=image>
   <li class=bug>
     ${ITEM_FULLNAME} variable was not working for Maven projects on Windows,
@@ -3068,7 +3068,7 @@ title: Changelog Archives
   <li class=rfe>
     "Discard old build records" behavior is now pluggable, allowing plugins to define custom logic.
 </ul>
-<h3><a name=v1.502>What's new in 1.502</a> (2013/02/16)</h3>
+<h3 id=v1.502>What's new in 1.502 (2013/02/16)</h3>
 <ul class=image>
   <li class='major bug'>
     Miscellaneous security vulnerability fixes. See the advisory for more details.
@@ -3088,7 +3088,7 @@ title: Changelog Archives
   <li class=rfe>
     Extension point to listen BuildStep execution
 </ul>
-<h3><a name=v1.501>What's new in 1.501</a> (2013/02/10)</h3>
+<h3 id=v1.501>What's new in 1.501 (2013/02/10)</h3>
 <ul class=image>
   <li class='major bug'>
     Reverted change in 1.500 causing serious regression in HTTPS reverse proxy setups.
@@ -3124,7 +3124,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16499">issue 16499</a>)
 
 </ul>
-<h3><a name=v1.500>What's new in 1.500</a> (2013/01/26)</h3>
+<h3 id=v1.500>What's new in 1.500 (2013/01/26)</h3>
 <ul class=image>
   <li class=bug>
     Since 1.494, when signing up as a new user in the private security realm the email address was left unconfigured and a stack trace printed.
@@ -3172,25 +3172,25 @@ title: Changelog Archives
       Avoid unnecessary downloads if automatically installed tools are up-to-date
       (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16215">issue 16215</a>)
 </ul>
-<h3><a name=v1.499>What's new in 1.499</a> (2013/01/13)</h3>
+<h3 id=v1.499>What's new in 1.499 (2013/01/13)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>NoClassDefFoundError: Base64</tt> with the <tt>-jnlpCredentials</tt> option.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9679">issue 9679</a>)
 </ul>
-<h3><a name=v1.498>What's new in 1.498</a> (2013/01/07)</h3>
+<h3 id=v1.498>What's new in 1.498 (2013/01/07)</h3>
 <ul class=image>
   <li class='major bug'>
     The master key that was protecting all the sensitive data in <tt>$JENKINS_HOME</tt> was vulnerable.
     (SECURITY-49)
 </ul>
-<h3><a name=v1.497>What's new in 1.497</a> (2013/01/06)</h3>
+<h3 id=v1.497>What's new in 1.497 (2013/01/06)</h3>
 <ul class=image>
   <li class=bug>
     Delete the oldest build but it still come up on HistoryWidget
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16194">issue 16194</a>)
 </ul>
-<h3><a name=v1.496>What's new in 1.496</a> (2012/12/30)</h3>
+<h3 id=v1.496>What's new in 1.496 (2012/12/30)</h3>
 <ul class=image>
   <li class=bug>
     Aborting download of workspace files make Jenkins unstable
@@ -3202,7 +3202,7 @@ title: Changelog Archives
      Channel is already closed exception during threadDump
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16193">issue 16193</a>)
 </ul>
-<h3><a name=v1.495>What's new in 1.495</a> (2012/12/24)</h3>
+<h3 id=v1.495>What's new in 1.495 (2012/12/24)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>java.lang.NoSuchMethodError: hudson.model.RunMap.put(Lhudson/model/Run;)Lhudson/model/Run;</tt>
@@ -3220,7 +3220,7 @@ title: Changelog Archives
   <li class=rfe>
     Added <tt>console</tt> CLI command that dumps console output from a build.
 </ul>
-<h3><a name=v1.494>What's new in 1.494</a> (2012/12/16)</h3>
+<h3 id=v1.494>What's new in 1.494 (2012/12/16)</h3>
 <ul class=image>
   <li class=bug>
     Using file parameters could cause build records to not load.
@@ -3248,7 +3248,7 @@ title: Changelog Archives
     Separated global security configuration into its own view.
     (<a href="https://github.com/jenkinsci/jenkins/pull/628">pull 628</a>)
 </ul>
-<h3><a name=v1.493>What's new in 1.493</a> (2012/12/09)</h3>
+<h3 id=v1.493>What's new in 1.493 (2012/12/09)</h3>
 <ul class=image>
   <li class=bug>
     Slave's Name should be trimmed of spaces at the beginning and end of the Name on Save.
@@ -3259,7 +3259,7 @@ title: Changelog Archives
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-6846">issue 6846</a>)
 
 </ul>
-<h3><a name=v1.492>What's new in 1.492</a> (2012/11/25)</h3>
+<h3 id=v1.492>What's new in 1.492 (2012/11/25)</h3>
 <ul class=image>
   <li class=rfe>
     XStream form of projects excessively strict about null fields.
@@ -3293,7 +3293,7 @@ title: Changelog Archives
     "Disable Project" button breaks Free style project pages.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15887">issue 15887</a>)
 </ul>
-<h3><a name=v1.491>What's new in 1.491</a> (2012/11/18)</h3>
+<h3 id=v1.491>What's new in 1.491 (2012/11/18)</h3>
 <ul class=image>
   <li class='major bug'>
     HistoryWidget/entry.jelly throws NullPointerException
@@ -3311,7 +3311,7 @@ title: Changelog Archives
     Invert dependency of maven-plugin and config-file-provider plugin (if config-file-provider is installed, this change requires an update of the config-file-provider to >= 2.3)
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14914">issue 14914</a>)
 </ul>
-<h3><a name=v1.490>What's new in 1.490</a> (2012/11/12)</h3>
+<h3 id=v1.490>What's new in 1.490 (2012/11/12)</h3>
 <ul class=image>
   <li class=bug>
     Fixed the redirect handling in IPv6 literal address.
@@ -3328,7 +3328,7 @@ title: Changelog Archives
   <li class=rfe>
     Disable Nagle's algorithm for TCP/IP slave connection
 </ul>
-<h3><a name=v1.489>What's new in 1.489</a> (2012/11/04)</h3>
+<h3 id=v1.489>What's new in 1.489 (2012/11/04)</h3>
 <ul class=image>
   <li class=bug>
     JENKINS_HOME can be now on UNC path (like \\server\mount\dir)
@@ -3339,13 +3339,13 @@ title: Changelog Archives
   <li class=rfe>
     Improved the auto-completion of job names to support hierarchy better.
 </ul>
-<h3><a name=v1.488>What's new in 1.488</a> (2012/10/28)</h3>
+<h3 id=v1.488>What's new in 1.488 (2012/10/28)</h3>
 <ul class=image>
   <li class=bug>
     Harmless but noisy exception running builds on some Windows systems in non-English locale.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15316">issue 15316</a>)
 </ul>
-<h3><a name=v1.487>What's new in 1.487</a> (2012/10/23)</h3>
+<h3 id=v1.487>What's new in 1.487 (2012/10/23)</h3>
 <ul class=image>
   <li class=rfe>
     JNLP Slave agent on OS X can install itself as a launchd service.
@@ -3368,7 +3368,7 @@ title: Changelog Archives
     Plugin manager now supports uninstallation.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-3070">issue 3070</a>)
 </ul>
-<h3><a name=v1.486>What's new in 1.486</a> (2012/10/14)</h3>
+<h3 id=v1.486>What's new in 1.486 (2012/10/14)</h3>
 <ul class=image>
   <li class=bug>
     NullPointerException in various parts of the core due to <tt>RunList</tt> returning null.
@@ -3386,7 +3386,7 @@ title: Changelog Archives
     Memory exhaustion parsing large test stdio from Surefire.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15382">issue 15382</a>)
 </ul>
-<h3><a name=v1.485>What's new in 1.485</a> (2012/10/07)</h3>
+<h3 id=v1.485>What's new in 1.485 (2012/10/07)</h3>
 <ul class=image>
   <li class=bug>
     NPE deleting a slave.
@@ -3404,7 +3404,7 @@ title: Changelog Archives
     Build records are now lazy loaded, resulting in a reduced startup time
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-8754">issue 8754</a>)
 </ul>
-<h3><a name=v1.484>What's new in 1.484</a> (2012/09/30)</h3>
+<h3 id=v1.484>What's new in 1.484 (2012/09/30)</h3>
 <ul class=image>
   <li class=bug>
     Check view permissions before showing config page
@@ -3425,7 +3425,7 @@ title: Changelog Archives
     Mac OS X installer now sends log to <tt>/var/log/jenkins/jenkins.log</tt>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15178">issue 15178</a>)
 </ul>
-<h3><a name=v1.483>What's new in 1.483</a> (2012/09/23)</h3>
+<h3 id=v1.483>What's new in 1.483 (2012/09/23)</h3>
 <ul class=image>
   <li class=bug>
     Invalid warning message when the config-file-provider plugin is not installed
@@ -3458,7 +3458,7 @@ title: Changelog Archives
     Track and verify plugins used in configuration XML
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15003">issue 15003</a>)
 </ul>
-<h3><a name=v1.482>What's new in 1.482</a> (2012/09/16)</h3>
+<h3 id=v1.482>What's new in 1.482 (2012/09/16)</h3>
 <ul class=image>
   <li class=bug>
     Job created by posting <code>config.xml</code> to <code>/createItem</code> does not set GitHub webhook.
@@ -3469,7 +3469,7 @@ title: Changelog Archives
   <li class=rfe>
     Report root causes of UpstreamCause in log and status pages.
 </ul>
-<h3><a name=v1.481>What's new in 1.481</a> (2012/09/09)</h3>
+<h3 id=v1.481>What's new in 1.481 (2012/09/09)</h3>
 <ul class=image>
   <li class=bug>
     Matrix jobs are kept forever even if it's not needed
@@ -3490,7 +3490,7 @@ title: Changelog Archives
     Parameters defined in matrix projects are now available in configuration builds.
     (<a href="https://github.com/jenkinsci/jenkins/pull/543">pull 543</a>)
 </ul>
-<h3><a name=v1.480>What's new in 1.480</a> (2012/09/03)</h3>
+<h3 id=v1.480>What's new in 1.480 (2012/09/03)</h3>
 <ul class=image>
   <li class=bug>
     Refactored <code>behavior.js</code> to run more predictably.
@@ -3511,7 +3511,7 @@ title: Changelog Archives
     <code>hpi:run</code> failed due to <code>IllegalAccessError</code>s.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14983">issue 14983</a>)
 </ul>
-<h3><a name=v1.479>What's new in 1.479</a> (2012/08/29)</h3>
+<h3 id=v1.479>What's new in 1.479 (2012/08/29)</h3>
 <ul class=image>
   <li class=bug>
     "Ping-pong" builds store excessively large <code>CauseAction</code>.
@@ -3534,7 +3534,7 @@ title: Changelog Archives
     Parameter values disappear if user is not logged in
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7894">issue 7894</a>)
 </ul>
-<h3><a name=v1.478>What's new in 1.478</a> (2012/08/20)</h3>
+<h3 id=v1.478>What's new in 1.478 (2012/08/20)</h3>
 <ul class=image>
   <li class='major bug'>
     "Monitor External Job" broken since 1.468.
@@ -3543,7 +3543,7 @@ title: Changelog Archives
     Matrix configuration axes are no longer automatically re-ordered to alphanumeric order on reload.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14696">issue 14696</a>)
 </ul>
-<h3><a name=v1.477>What's new in 1.477</a> (2012/08/08)</h3>
+<h3 id=v1.477>What's new in 1.477 (2012/08/08)</h3>
 <ul class=image>
   <li class=bug>
     Annotation processor bugs in Stapler affecting plugin compilation.
@@ -3596,13 +3596,13 @@ title: Changelog Archives
   <li class=rfe>
     Added new extension point for transient user actions, and displays user properties if they are also Actions.
 </ul>
-<h3><a name=v1.476>What's new in 1.476</a> (2012/07/31)</h3>
+<h3 id=v1.476>What's new in 1.476 (2012/07/31)</h3>
 <ul class=image>
   <li class=bug>
     <code>NullPointerException</code> from <code>JUnitParser.parse</code>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14507">issue 14507</a>)
 </ul>
-<h3><a name=v1.475>What's new in 1.475</a> (2012/07/22)</h3>
+<h3 id=v1.475>What's new in 1.475 (2012/07/22)</h3>
 <ul class=image>
   <li class=bug>
     Enable/disable GUI for jobs either did not appear, or threw exceptions, for jobs inside folders
@@ -3614,7 +3614,7 @@ title: Changelog Archives
       Incorrect display of list items in project changes for SCMs such as Mercurial.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14365">issue 14365</a>)
 </ul>
-<h3><a name=v1.474>What's new in 1.474</a> (2012/07/09)</h3>
+<h3 id=v1.474>What's new in 1.474 (2012/07/09)</h3>
 <ul class=image>
   <li class=bug>
     Fix French translation
@@ -3626,7 +3626,7 @@ title: Changelog Archives
     Added a new extension point to listen to polling activities.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-14178">issue 14178</a>)
 </ul>
-<h3><a name=v1.473>What's new in 1.473</a> (2012/07/01)</h3>
+<h3 id=v1.473>What's new in 1.473 (2012/07/01)</h3>
 <ul class=image>
   <li class=bug>
     Updating job config.xml shouldn't clobber in-progress builds.
@@ -3638,7 +3638,7 @@ title: Changelog Archives
     Updated typo in Serbian translation.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13695">issue 13695</a>)
 </ul>
-<h3><a name=v1.472>What's new in 1.472</a> (2012/06/24)</h3>
+<h3 id=v1.472>What's new in 1.472 (2012/06/24)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a synchronization problem between master/slave data communication.
@@ -3655,7 +3655,7 @@ title: Changelog Archives
     Added a new hook to enable matrix project axes to change its values per build.
     (<a href="https://github.com/jenkinsci/jenkins/pull/449">pull 449</a>)
 </ul>
-<h3><a name=v1.471>What's new in 1.471</a> (2012/06/18)</h3>
+<h3 id=v1.471>What's new in 1.471 (2012/06/18)</h3>
 <ul class=image>
   <li class=bug>
     JSON MIME type should be "application/json"
@@ -3675,17 +3675,17 @@ title: Changelog Archives
   <li class=rfe>
     The CLI <tt>build</tt> command can now wait until the start of the build.
 </ul>
-<h3><a name=v1.470>What's new in 1.470</a> (2012/06/13)</h3>
+<h3 id=v1.470>What's new in 1.470 (2012/06/13)</h3>
 <ul class=image>
   <li class=bug>
     Problem in syncing mirrors with native packages. Re-releasing the same bits as 1.469 as 1.470.
 </ul>
-<h3><a name=v1.469>What's new in 1.469</a> (2012/06/11)</h3>
+<h3 id=v1.469>What's new in 1.469 (2012/06/11)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a regression in 1.468 that broke LDAP
 </ul>
-<h3><a name=v1.468>What's new in 1.468</a> (2012/06/11)</h3>
+<h3 id=v1.468>What's new in 1.468 (2012/06/11)</h3>
 <ul class=image>
   <li class=bug>
     Added more MIME type mapping for Winstone.
@@ -3709,7 +3709,7 @@ title: Changelog Archives
   <li class=rfe>
     Improved the background transparency of the animating ball icon
 </ul>
-<h3><a name=v1.467>What's new in 1.467</a> (2012/06/04)</h3>
+<h3 id=v1.467>What's new in 1.467 (2012/06/04)</h3>
 <ul class=image>
   <li class=bug>
     When accessing a page that requires authentication, redirection to start authentication results in a content decoding failure.
@@ -3748,20 +3748,20 @@ title: Changelog Archives
     Maven plugin: expand variables in "Room POM" field
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13822">issue 13822</a>)
 </ul>
-<h3><a name=v1.466>What's new in 1.466</a> (2012/05/28)</h3>
+<h3 id=v1.466>What's new in 1.466 (2012/05/28)</h3>
 <ul class=image>
   <li class=rfe>
     Exposed plugin manager and update center to the REST API
   <li class=rfe>
     Enabled concurrent build support for matrix projects
 </ul>
-<h3><a name=v1.465>What's new in 1.465</a> (2012/05/21)</h3>
+<h3 id=v1.465>What's new in 1.465 (2012/05/21)</h3>
 <ul class=image>
   <li class=bug>
     Artifact archiving from an ssh slave fails if symlinks are present
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13202">issue 13202</a>)
 </ul>
-<h3><a name=v1.464>What's new in 1.464</a> (2012/05/14)</h3>
+<h3 id=v1.464>What's new in 1.464 (2012/05/14)</h3>
 <ul class=image>
   <li class=bug>
     Don't try to set cookies on cachable requests.
@@ -3774,7 +3774,7 @@ title: Changelog Archives
   <li class=bug>
     missing search image on plugin manager.
 </ul>
-<h3><a name=v1.463>What's new in 1.463</a> (2012/05/07)</h3>
+<h3 id=v1.463>What's new in 1.463 (2012/05/07)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the Content-Range header handling.
@@ -3804,7 +3804,7 @@ title: Changelog Archives
     Publishers can be now reordered by the user.
     (<a href="https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/UQLvxQclyb4">discussion</a>)
 </ul>
-<h3><a name=v1.462>What's new in 1.462</a> (2012/04/30)</h3>
+<h3 id=v1.462>What's new in 1.462 (2012/04/30)</h3>
 <ul class=image>
   <li class=bug>
     API token authentication was broken in 1.461
@@ -3822,7 +3822,7 @@ title: Changelog Archives
     Validate project naming regex immediately.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13524">issue 13524</a>)
 </ul>
-<h3><a name=v1.461>What's new in 1.461</a> (2012/04/23)</h3>
+<h3 id=v1.461>What's new in 1.461 (2012/04/23)</h3>
 <ul class=image>
   <li class=bug>
     Flag -U is not used during the parsing step of a Maven Job
@@ -3834,7 +3834,7 @@ title: Changelog Archives
     allow j/k navigation for search results
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13105">issue 13105</a>)
 </ul>
-<h3><a name=v1.460>What's new in 1.460</a> (2012/04/14)</h3>
+<h3 id=v1.460>What's new in 1.460 (2012/04/14)</h3>
 <ul class=image>
   <li class=bug>
     Fixed: tests with the same name are no longer counted correctly.
@@ -3846,7 +3846,7 @@ title: Changelog Archives
   <li class=rfe>
     Supported hash token in the crontab syntax to distribute workload and avoid spikes.
 </ul>
-<h3><a name=v1.459>What's new in 1.459</a> (2012/04/09)</h3>
+<h3 id=v1.459>What's new in 1.459 (2012/04/09)</h3>
 <ul class=image>
   <li class=bug>
     CLI - I/O error in channel Chunked connection/Unexpected termination of the channel - still occuring in Jenkins 1.449.
@@ -3864,7 +3864,7 @@ title: Changelog Archives
     Added new extension point for transient build actions.
     (<a href="https://github.com/jenkinsci/jenkins/pull/421">pull 421</a>)
 </ul>
-<h3><a name=v1.458>What's new in 1.458</a> (2012/04/02)</h3>
+<h3 id=v1.458>What's new in 1.458 (2012/04/02)</h3>
 <ul class=image>
   <li class=bug>
     Build Status page continues to show flashing "building" icons after build completion.
@@ -3888,7 +3888,7 @@ title: Changelog Archives
   <li class=bug>
     Resolve dependency issue between 'maven-plugin' and 'config-file-provider' plugin. If you are using the 'config-file-provider' plugin, you have to upgrade to version 1.9.1!
 </ul>
-<h3><a name=v1.457>What's new in 1.457</a> (2012/03/26)</h3>
+<h3 id=v1.457>What's new in 1.457 (2012/03/26)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a thread leak in the embedded servlet container.
@@ -3912,7 +3912,7 @@ title: Changelog Archives
   <li class="rfe">
     Jenkins uses correct port in mDNS advertisement and shows up in Safari Bonjour bookmarks.
 </ul>
-<h3><a name=v1.456>What's new in 1.456</a> (2012/03/19)</h3>
+<h3 id=v1.456>What's new in 1.456 (2012/03/19)</h3>
 <ul class=image>
   <li class=bug>
     After renaming a job, the redirect goes to a wrong view.
@@ -3949,7 +3949,7 @@ title: Changelog Archives
     Matrix project execution order is made pluggable.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-12778">issue 12778</a>)
 </ul>
-<h3><a name=v1.455>What's new in 1.455</a> (2012/03/12)</h3>
+<h3 id=v1.455>What's new in 1.455 (2012/03/12)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a regression in 1.453 with IE9
@@ -3982,12 +3982,12 @@ title: Changelog Archives
   <li class=rfe>
     <tt>java -jar jenkins.war</tt> now uses the HTTP only session cookie that's more robust against XSS vulnerability.
 </ul>
-<h3><a name=v1.454>What's new in 1.454</a> (2012/03/05)</h3>
+<h3 id=v1.454>What's new in 1.454 (2012/03/05)</h3>
 <ul class=image>
   <li class=bug>
     Adjusted the HTML sanitization rules as they were too restrictive.
 </ul>
-<h3><a name=v1.453>What's new in 1.453</a> (2012/03/05)</h3>
+<h3 id=v1.453>What's new in 1.453 (2012/03/05)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a XSS vulnerability.
@@ -4023,7 +4023,7 @@ title: Changelog Archives
   <li class=rfe>
     update to guava 11.0.1
 </ul>
-<h3><a name=v1.452>What's new in 1.452</a> (2012/02/27)</h3>
+<h3 id=v1.452>What's new in 1.452 (2012/02/27)</h3>
 <ul class=image>
   <li class=bug>
     Infinite loop or invalid next execution with crontab DoW=7
@@ -4046,7 +4046,7 @@ title: Changelog Archives
     Misc performance improvements
     (<a href="https://github.com/jenkinsci/jenkins/pull/342">pull 342</a>)
 </ul>
-<h3><a name=v1.451>What's new in 1.451</a> (2012/02/13)</h3>
+<h3 id=v1.451>What's new in 1.451 (2012/02/13)</h3>
 <ul class=image>
   <li class=bug>
     The <tt>-c</tt> option in the <tt>build</tt> command wasn't working for some SCM.
@@ -4073,7 +4073,7 @@ title: Changelog Archives
     Recognize test results from eviware:maven-soapui-plugin.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11353">issue 11353</a>)
 </ul>
-<h3><a name=v1.450>What's new in 1.450</a> (2012/01/30)</h3>
+<h3 id=v1.450>What's new in 1.450 (2012/01/30)</h3>
 <ul class=image>
   <li class=bug>
     <tt>install-plugin</tt> CLI command fails to put a file in the right location when installing from URL.
@@ -4092,7 +4092,7 @@ title: Changelog Archives
   <li class=rfe>
     Running build via CLI now records actual user who started the build
 </ul>
-<h3><a name=v1.449>What's new in 1.449</a> (2012/01/23)</h3>
+<h3 id=v1.449>What's new in 1.449 (2012/01/23)</h3>
 <ul class=image>
   <li class=bug>
     Build fails on "Deploy artifacts to Maven repository" due to trying to upload parent POM twice for release artifacts.
@@ -4113,7 +4113,7 @@ title: Changelog Archives
   <li class=rfe>
     When run in terminal, warning/error messages are colored.
 </ul>
-<h3><a name=v1.448>What's new in 1.448</a> (2012/01/17)</h3>
+<h3 id=v1.448>What's new in 1.448 (2012/01/17)</h3>
 <ul class=image>
   <li class=bug>
     Location of the temporary file "Maven Global Settings" incompatible with release:prepare
@@ -4159,7 +4159,7 @@ title: Changelog Archives
     Jobs now support display name separate from its unique name
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-11762">issue 11762</a>
 </ul>
-<h3><a name=v1.447>What's new in 1.447</a> (2012/01/09)</h3>
+<h3 id=v1.447>What's new in 1.447 (2012/01/09)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a hash DoS vulnerability.
@@ -4177,7 +4177,7 @@ title: Changelog Archives
     Copy artifacts fails on windows slaves due to failing to set a timestamp.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11073">issue 11073</a>)
 </ul>
-<h3><a name=v1.446>What's new in 1.446</a> (2012/01/02)</h3>
+<h3 id=v1.446>What's new in 1.446 (2012/01/02)</h3>
 <ul class=image>
   <li class='major rfe'>
     Jenkins now acts as an SSH daemon
@@ -4192,7 +4192,7 @@ title: Changelog Archives
     Sort workspace file list based on request locale.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-12139">issue 12139</a>)
 </ul>
-<h3><a name=v1.445>What's new in 1.445</a> (2011/12/26)</h3>
+<h3 id=v1.445>What's new in 1.445 (2011/12/26)</h3>
 <ul class=image>
   <li class=rfe>
     CLI now supports using HTTP proxy for tunneling its TCP/IP connection.
@@ -4213,7 +4213,7 @@ title: Changelog Archives
   <li class=bug>
     Fixed prematurely re-drawn matrix test result graph.
 </ul>
-<h3><a name=v1.444>What's new in 1.444</a> (2011/12/19)</h3>
+<h3 id=v1.444>What's new in 1.444 (2011/12/19)</h3>
 <ul class=image>
   <li class=rfe>
     Make the matrix configuration table looks like the rest of Jenkins tables.
@@ -4224,7 +4224,7 @@ title: Changelog Archives
     Fixed the incorrect table border cropping
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-12061">issue 12061</a>)
 </ul>
-<h3><a name=v1.443>What's new in 1.443</a> (2011/12/12)</h3>
+<h3 id=v1.443>What's new in 1.443 (2011/12/12)</h3>
 <ul class=image>
   <li class=bug>
     Wagon 2.0 upgrade broke the Redeploy task for webdav repositories
@@ -4270,7 +4270,7 @@ title: Changelog Archives
   <li class=rfe>
     Added/improved localization to Arabic, Bulgarian, Catalan, Czech, Danish, German, Greek, Esperanto, Spanish, Estonian, Basque, Finnish, French, Hebrew, Hindi, Hungarian, Indonesian, Icelandic, Italian, Kannada, Korean, Lithuanian, Latvian, Marathi, Norwegian, Dutch, Polish, Portugeese, Romanian, Russian, Slovak, Slovenian, Serbian, Swedish, Telgu, Turkish, Ukrainian, and Chinese. Thanks everyone!
 </ul>
-<h3><a name=v1.442>What's new in 1.442</a> (2011/12/05)</h3>
+<h3 id=v1.442>What's new in 1.442 (2011/12/05)</h3>
 <ul class=image>
   <li class=bug>
     Workspaces mixed when launching multiple concurrent builds.
@@ -4288,7 +4288,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Plugins can be now installed without taking Jenkins offline.
 </ul>
-<h3><a name=v1.441>What's new in 1.441</a> (2011/11/27)</h3>
+<h3 id=v1.441>What's new in 1.441 (2011/11/27)</h3>
 <ul class=image>
   <li class=bug>
     If running as a daemon, don't daemonize one more time during restart.
@@ -4299,7 +4299,7 @@ title: Changelog Archives
   <li class=rfe>
     CLI jar now has the version number in the manifest as well as the "-version" option.
 </ul>
-<h3><a name=v1.440>What's new in 1.440</a> (2011/11/17)</h3>
+<h3 id=v1.440>What's new in 1.440 (2011/11/17)</h3>
 <ul class=image>
   <li class=bug>
     Sorting "diff" in test result requires 2 clicks
@@ -4331,7 +4331,7 @@ title: Changelog Archives
   <li class=rfe>
     Maven mojo records can be now sorted
 </ul>
-<h3><a name=v1.439>What's new in 1.439</a> (2011/11/14)</h3>
+<h3 id=v1.439>What's new in 1.439 (2011/11/14)</h3>
 <ul class=image>
   <li class=bug>
     Fixed random OutOfMemoryError with console annotations
@@ -4346,7 +4346,7 @@ title: Changelog Archives
     Added an extension point to sort matrix configuration builds when executing them sequentially
     (<a href="https://github.com/jenkinsci/jenkins/pull/301">pull #301</a>)
 </ul>
-<h3><a name=v1.438>What's new in 1.438</a> (2011/11/07)</h3>
+<h3 id=v1.438>What's new in 1.438 (2011/11/07)</h3>
 <ul class=image>
   <li class='major bug'>
     Thanks to Luca De Fulgentis, fixed XSS vulnerability with the built-in servlet container.
@@ -4367,7 +4367,7 @@ title: Changelog Archives
     Rewrote the JDK installer to remove problematic HtmlUnit dependencies.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11420">issue 11420</a>)
 </ul>
-<h3><a name=v1.437>What's new in 1.437</a> (2011/10/31)</h3>
+<h3 id=v1.437>What's new in 1.437 (2011/10/31)</h3>
 <ul class=image>
   <li class=rfe>
     Added MIME headers with job name and build result to notification emails.
@@ -4383,7 +4383,7 @@ title: Changelog Archives
   <li class=rfe>
     Allow update center CA certificates to be placed in $JENKINS_HOME/update-center-rootCAs
 </ul>
-<h3><a name=v1.436>What's new in 1.436</a> (2011/10/23)</h3>
+<h3 id=v1.436>What's new in 1.436 (2011/10/23)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a plugin boot problem that causes Jenkins to startup gracefully when some optional plugin dependencies aren't met (such as ivy to nant)
@@ -4406,7 +4406,7 @@ title: Changelog Archives
     Added hyperlinks to build trigger console messages.
     (<a href="https://github.com/jenkinsci/jenkins/pull/291">pull #291</a>)
 </ul>
-<h3><a name=v1.435>What's new in 1.435</a> (2011/10/17)</h3>
+<h3 id=v1.435>What's new in 1.435 (2011/10/17)</h3>
 <ul class=image>
   <li class=bug>
     Fixed the XML encoding sniffing problem in environments that have old JAXP
@@ -4418,7 +4418,7 @@ title: Changelog Archives
     "System Admin E-mail Address" is confusing label for notification mail "from"
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11209">issue 11209</a>)
 </ul>
-<h3><a name=v1.434>What's new in 1.434</a> (2011/10/09)</h3>
+<h3 id=v1.434>What's new in 1.434 (2011/10/09)</h3>
 <ul class=image>
   <li class=bug>
     Add support for android-maven-plugin integration test reports and fix an error with 2.x maven-android-plugin
@@ -4441,7 +4441,7 @@ title: Changelog Archives
     Added a way to show avatar images on user pages.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7494">issue 7494</a>)
 </ul>
-<h3><a name=v1.433>What's new in 1.433</a> (2011/10/01)</h3>
+<h3 id=v1.433>What's new in 1.433 (2011/10/01)</h3>
 <ul class=image>
   <li class=bug>
     Port on HTTP Proxy Configure accepts characters except the digits
@@ -4480,7 +4480,7 @@ title: Changelog Archives
     Jenkins internally started using Guice for loading extensions
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-8751">issue 8751</a>)
 </ul>
-<h3><a name=v1.432>What's new in 1.432</a> (2011/09/25)</h3>
+<h3 id=v1.432>What's new in 1.432 (2011/09/25)</h3>
 <ul class=image>
   <li class=bug>
     JDK auto-installation does not respect proxy settings
@@ -4503,7 +4503,7 @@ title: Changelog Archives
     Remember sortable table state into local storage
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-203">issue 203</a>)
 </ul>
-<h3><a name=v1.431>What's new in 1.431</a> (2011/09/19)</h3>
+<h3 id=v1.431>What's new in 1.431 (2011/09/19)</h3>
 <ul class=image>
   <li class=bug>
     Jenkins unable to start if the /tmp/jna catalogue exists and is owned by a different user
@@ -4518,7 +4518,7 @@ title: Changelog Archives
     Add "un/check all" buttons on matrix-based security.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7565">issue 7565</a>)
 </ul>
-<h3><a name=v1.430>What's new in 1.430</a> (2011/09/11)</h3>
+<h3 id=v1.430>What's new in 1.430 (2011/09/11)</h3>
 <ul class=image>
   <li class=bug>
     Added way to mark all plugins to be updated at once
@@ -4539,7 +4539,7 @@ title: Changelog Archives
     Add support for maven-android-plugin integration test reports
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10913">issue 10913</a>)
 </ul>
-<h3><a name=v1.429>What's new in 1.429</a> (2011/09/06)</h3>
+<h3 id=v1.429>What's new in 1.429 (2011/09/06)</h3>
 <ul class=image>
   <li class=bug>
     maven submodule build fails doing mkdir on master.
@@ -4569,7 +4569,7 @@ title: Changelog Archives
     External job submision now supports &lt;displayName&gt; and &lt;description&gt; elements
     (<a href="https://github.com/jenkinsci/jenkins/pull/215">pull 215</a>)
 </ul>
-<h3><a name=v1.428>What's new in 1.428</a> (2011/08/29)</h3>
+<h3 id=v1.428>What's new in 1.428 (2011/08/29)</h3>
 <ul class=image>
   <li class=bug>
     CLI jar download was making the browser prefer a wrong file name.
@@ -4589,7 +4589,7 @@ title: Changelog Archives
     (<a href="https://groups.google.com/forum/#!searchin/jenkinsci-users/timp/jenkinsci-users/YThhsdGBVwM/7_7GMYIYiRIJ">report</a>)
 
 </ul>
-<h3><a name=v1.427>What's new in 1.427</a> (2011/08/19)</h3>
+<h3 id=v1.427>What's new in 1.427 (2011/08/19)</h3>
 <ul class=image>
   <li class='major bug'>
     Builds failing while archiving test result if build is running in different VM (e.g. IBM J9) than Jenkins is
@@ -4647,7 +4647,7 @@ title: Changelog Archives
     Fixed unclear text for Tabs with no jobs
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9330">issue 9330</a>)
 </ul>
-<h3><a name=v1.426>What's new in 1.426</a> (2011/08/15)</h3>
+<h3 id=v1.426>What's new in 1.426 (2011/08/15)</h3>
 <ul class=image>
   <li class=bug>
     Auto Install JDK asks for Oracle account, but the link goes 404.
@@ -4664,7 +4664,7 @@ title: Changelog Archives
     Fixed background of title image
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9571">issue 9571</a>)
 </ul>
-<h3><a name=v1.425>What's new in 1.425</a> (2011/08/08)</h3>
+<h3 id=v1.425>What's new in 1.425 (2011/08/08)</h3>
 <ul class=image>
   <li class=rfe>
     Make syntax highlighting optional
@@ -4678,7 +4678,7 @@ title: Changelog Archives
   <li class=bug>
     MAVEN_OPTS configuration wasn't expanding environment variables.
 </ul>
-<h3><a name=v1.424>What's new in 1.424</a> (2011/08/01)</h3>
+<h3 id=v1.424>What's new in 1.424 (2011/08/01)</h3>
 <ul class=image>
   <li class='major bug'>
     Java Web Start binaries weren't signed.
@@ -4713,12 +4713,12 @@ title: Changelog Archives
   <li class='bug'>
     Fixed a problem in the core that prevents CLI users from authenticating with Crowd plugin (and others like it.)
 </ul>
-<h3><a name=v1.423>What's new in 1.423</a> (2011/07/25)</h3>
+<h3 id=v1.423>What's new in 1.423 (2011/07/25)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a boot problem in 1.422.
 </ul>
-<h3><a name=v1.422>What's new in 1.422</a> (2011/07/25)</h3>
+<h3 id=v1.422>What's new in 1.422 (2011/07/25)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in 1.421 that broke CentOS installations.
@@ -4734,7 +4734,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a new hudson.model.Computer.CREATE permission to limit who can create new slaves.
 </ul>
-<h3><a name=v1.421>What's new in 1.421</a> (2011/07/17)</h3>
+<h3 id=v1.421>What's new in 1.421 (2011/07/17)</h3>
 <ul class=image>
   <li class=bug>
     NPE when requesting http://server/job/TEST-START/description and the description is empty
@@ -4779,7 +4779,7 @@ title: Changelog Archives
     Maven build script to produce the binary was significantly modified.
     (<a href="https://github.com/jenkinsci/jenkins/pull/193">pull request 193</a>)
 </ul>
-<h3><a name=v1.420>What's new in 1.420</a> (2011/07/11)</h3>
+<h3 id=v1.420>What's new in 1.420 (2011/07/11)</h3>
 <ul class=image>
   <li class=bug>
     Fix: jenkins did not record test results generated by the GWT maven plugin
@@ -4815,7 +4815,7 @@ title: Changelog Archives
     Don't recalculate internal dependency graph if Maven dependencies haven't changed
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9301">issue 9301</a>)
 </ul>
-<h3><a name=v1.419>What's new in 1.419</a> (2011/07/05)</h3>
+<h3 id=v1.419>What's new in 1.419 (2011/07/05)</h3>
 <ul class=image>
   <li class=bug>
     "Ant Version" field in "Invoke Ant" Build step missing in 1.416
@@ -4854,7 +4854,7 @@ title: Changelog Archives
     Managed Windows slave launcher now lets you define a host name separately from the slave name.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10099">issue 10099</a>)
 </ul>
-<h3><a name=v1.418>What's new in 1.418</a> (2011/06/27)</h3>
+<h3 id=v1.418>What's new in 1.418 (2011/06/27)</h3>
 <ul class=image>
   <li class='major bug'>
     Permissions from LDAP groups weren't working properly since 1.416
@@ -4882,12 +4882,12 @@ title: Changelog Archives
     Added a new hudson.security.WipeOutPermission system property to enable a
     new WipeOut permission controlling the "Wipe Out Workspace" action.
 </ul>
-<h3><a name=v1.417>What's new in 1.417</a> (2011/06/20)</h3>
+<h3 id=v1.417>What's new in 1.417 (2011/06/20)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in 1.416 that broke cloud plugins like libvirt and EC2.
 </ul>
-<h3><a name=v1.416>What's new in 1.416</a> (2011/06/18)</h3>
+<h3 id=v1.416>What's new in 1.416 (2011/06/18)</h3>
 <ul class=image>
   <li class=rfe>
     Make captcha support optional; remove LGPL jcaptcha
@@ -4943,7 +4943,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Added a mechanism to write views in Groovy. The interface isn't committed yet. We are looking for feedback.
 </ul>
-<h3><a name=v1.415>What's new in 1.415</a> (2011/06/12)</h3>
+<h3 id=v1.415>What's new in 1.415 (2011/06/12)</h3>
 <ul class=image>
   <li class=bug>
     Output correct version from java -jar jenkins.war --version (broken since 1.410)
@@ -4979,7 +4979,7 @@ title: Changelog Archives
     When there are absolutely no executors for a specific label, there was an unnecessary delay in provisioning the
     first node for that label.
 </ul>
-<h3><a name=v1.414>What's new in 1.414</a> (2011/06/04)</h3>
+<h3 id=v1.414>What's new in 1.414 (2011/06/04)</h3>
 <ul class=image>
   <li class=bug>
     Fixed the concurrent modification exception in classloading during startup
@@ -5010,7 +5010,7 @@ title: Changelog Archives
     Log which build steps have changed the build result to build console.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9687">issue 9687</a>)
 </ul>
-<h3><a name=v1.413>What's new in 1.413</a> (2011/05/22)</h3>
+<h3 id=v1.413>What's new in 1.413 (2011/05/22)</h3>
 <ul class=image>
   <li class=bug>
     Fixed extra ' character in french translation.
@@ -5043,13 +5043,13 @@ title: Changelog Archives
     Boldify names of executed mojos for Freestyle and Maven2/3 jobs using Maven3 in console output.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9691">issue 9691</a>)
 </ul>
-<h3><a name=v1.412>What's new in 1.412</a> (2011/05/16)</h3>
+<h3 id=v1.412>What's new in 1.412 (2011/05/16)</h3>
 <ul class=image>
   <li class=rfe>
     Wait until updates are successfully installed before restarting Jenkins
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5047">issue 5047</a>)
 </ul>
-<h3><a name=v1.411>What's new in 1.411</a> (2011/05/09)</h3>
+<h3 id=v1.411>What's new in 1.411 (2011/05/09)</h3>
 <ul class=image>
   <li class=bug>
     Allow blank rootDN in LDAPSecurityRealm.
@@ -5078,7 +5078,7 @@ title: Changelog Archives
   <li class=rfe>
     Order of extension implementations is made bit more deterministic
 </ul>
-<h3><a name=v1.410>What's new in 1.410</a> (2011/05/01)</h3>
+<h3 id=v1.410>What's new in 1.410 (2011/05/01)</h3>
 <ul class=image>
   <li class=bug>
     Maven3 with multiple threads does not work in Jenkins.
@@ -5108,7 +5108,7 @@ title: Changelog Archives
     Memory space monitor now works for Mac OS X Snow Leopard
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9374">issue 9374</a>)
 </ul>
-<h3><a name=v1.409>What's new in 1.409</a> (2011/04/25)</h3>
+<h3 id=v1.409>What's new in 1.409 (2011/04/25)</h3>
 <ul class=image>
   <li class=bug>
     Some french strings are incorrect after renaming to Jenkins
@@ -5138,7 +5138,7 @@ title: Changelog Archives
   <li class=rfe>
     Added "about Jenkins" screen that shows the 3rd party license acknowledgement.
 </ul>
-<h3><a name=v1.408>What's new in 1.408</a> (2011/04/18)</h3>
+<h3 id=v1.408>What's new in 1.408 (2011/04/18)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression that resulted in too much escaping
@@ -5147,7 +5147,7 @@ title: Changelog Archives
     Fixed a persistence problem in <tt>View$PropertyList</tt>
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9367">issue 9367</a>)
 </ul>
-<h3><a name=v1.407>What's new in 1.407</a> (2011/04/15)</h3>
+<h3 id=v1.407>What's new in 1.407 (2011/04/15)</h3>
 <ul class=image>
   <li class='major bug'>
     Implemented comprehensive preventive measure against cross-site scripting.
@@ -5173,7 +5173,7 @@ title: Changelog Archives
   <li class=rfe>
     Jenkins has a new logo, thanks to Charles Lowell at The Frontside
 </ul>
-<h3><a name=v1.406>What's new in 1.406</a> (2011/04/11)</h3>
+<h3 id=v1.406>What's new in 1.406 (2011/04/11)</h3>
 <ul class=image>
   <li class=bug>
     Default viewport of the Timeline widgets were off by one day.
@@ -5210,7 +5210,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a mechanism for plugins to write an invisible node property
 </ul>
-<h3><a name=v1.405>What's new in 1.405</a> (2011/04/04)</h3>
+<h3 id=v1.405>What's new in 1.405 (2011/04/04)</h3>
 <ul class=image>
   <li class=bug>
     Fixed link to javadoc in maven modules and add link to generated test javadoc
@@ -5244,7 +5244,7 @@ title: Changelog Archives
   <li class=rfe>
     Added an extension point to allow adding transient actions to computers.
 </ul>
-<h3><a name=v1.404>What's new in 1.404</a> (2011/03/27)</h3>
+<h3 id=v1.404>What's new in 1.404 (2011/03/27)</h3>
 <ul class=image>
   <li class=bug>
     Regression in jenkins .401 maven plugin - deploy to repository post-task
@@ -5305,7 +5305,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a new extension point to contribute build variables.
 </ul>
-<h3><a name=v1.403>What's new in 1.403</a> (2011/03/20)</h3>
+<h3 id=v1.403>What's new in 1.403 (2011/03/20)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a race condition in the remote data transfer that results in silent file copy failures.
@@ -5348,12 +5348,12 @@ title: Changelog Archives
       Include OS type and version of slave in the system information page.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8996">issue 8996</a>)
 </ul>
-<h3><a name=v1.402>What's new in 1.402</a> (2011/03/20)</h3>
+<h3 id=v1.402>What's new in 1.402 (2011/03/20)</h3>
 <ul class=image>
   <li class=bug>
     Botched release. It doesn't exist.
 </ul>
-<h3><a name=v1.401>What's new in 1.401</a> (2011/03/13)</h3>
+<h3 id=v1.401>What's new in 1.401 (2011/03/13)</h3>
 <ul class=image>
   <li class=bug>
     Fix for JENKINS-8711 breaks deployments with credentials
@@ -5379,7 +5379,7 @@ title: Changelog Archives
     Defined a mechanism to replace some of the key UI text.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8579">issue 8579</a>)
 </ul>
-<h3><a name=v1.400>What's new in 1.400</a> (2011/03/06)</h3>
+<h3 id=v1.400>What's new in 1.400 (2011/03/06)</h3>
 <ul class=image>
   <li class=bug>
     NPE during in parsing POMs for Multi Module Build
@@ -5399,7 +5399,7 @@ title: Changelog Archives
     Configure the environment for Maven job type builds
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8092">issue 8902</a>)
 </ul>
-<h3><a name=v1.399>What's new in 1.399</a> (2011/02/27)</h3>
+<h3 id=v1.399>What's new in 1.399 (2011/02/27)</h3>
 <ul class=image>
   <li class='major bug'>
     On IBM JDKs, Jenkins incorrectly ended up closing stdout to read from forked processes.
@@ -5439,7 +5439,7 @@ title: Changelog Archives
     Improved the process forking abstractions so that plugins can more easily read from child processes.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-7809">issue 7809</a>)
 </ul>
-<h3><a name=v1.398>What's new in 1.398</a> (2011/02/20)</h3>
+<h3 id=v1.398>What's new in 1.398 (2011/02/20)</h3>
 <ul class=image>
   <li class=bug>
     MavenBuild does not respect the "alternate settings" value of its parent MavenModuleSetBuild
@@ -5464,7 +5464,7 @@ title: Changelog Archives
   <li class=rfe>
     Started exposing JENKINS_URL, JENKINS_SERVER_COOKIE env vars in addition to legacy HUDSON_* variables
 </ul>
-<h3><a name=v1.397>What's new in 1.397</a> (2011/02/12)</h3>
+<h3 id=v1.397>What's new in 1.397 (2011/02/12)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a master/slave communication problem since 1.378 that often manifests as "Not in GZIP format"
@@ -5505,7 +5505,7 @@ title: Changelog Archives
     Debian package will force-terminate Jenkins if it fails to shut down in 5 seconds.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5415">issue 5415</a>)
 </ul>
-<h3><a name=v1.396>What's new in 1.396</a> (2011/02/02)</h3>
+<h3 id=v1.396>What's new in 1.396 (2011/02/02)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in crontab "day of week" handling in locales where a week starts from Monday.
@@ -5522,7 +5522,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Fixed a trademark bug that caused a considerable fiasco by renaming to Jenkins
 </ul>
-<h3><a name=v1.395>What's new in 1.395</a> (2011/01/21)</h3>
+<h3 id=v1.395>What's new in 1.395 (2011/01/21)</h3>
 <ul class=image>
   <li class=bug>
     Do not chmod/chown symlink targets in /var/lib/hudson (debian package)
@@ -5554,7 +5554,7 @@ title: Changelog Archives
     Improved the error diagnosis if a build fails because of the slave connectivity problem.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5073">issue 5073</a>)
 </ul>
-<h3><a name=v1.394>What's new in 1.394</a> (2011/01/15)</h3>
+<h3 id=v1.394>What's new in 1.394 (2011/01/15)</h3>
 <ul class=image>
   <li class=bug> Parsing poms fails if a module is a path to a pom (and not to a directory)
    (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8445">issue 8445</a>)
@@ -5577,7 +5577,7 @@ title: Changelog Archives
    Maven 3 support : display same logging output as a maven build with the cli
    (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8490">issue 8490</a>)
 </ul>
-<h3><a name=v1.393>What's new in 1.393</a> (2011/01/09)</h3>
+<h3 id=v1.393>What's new in 1.393 (2011/01/09)</h3>
 <ul class=image>
   <li class=rfe>
    Added CharacterEncodingFilter to prevent Non-ASCII characters from getting garbled.
@@ -5590,7 +5590,7 @@ title: Changelog Archives
   <li class=bug> POMs parsing fails in m2 projects which has a wrong inheritence (m3 constraint).
    (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8390">issue 8390</a>)
 </ul>
-<h3><a name=v1.392>What's new in 1.392</a> (2010/12/31)</h3>
+<h3 id=v1.392>What's new in 1.392 (2010/12/31)</h3>
 <ul class=image>
   <li class='major rfe'>
     Maven 3 support in maven-plugin.
@@ -5605,7 +5605,7 @@ title: Changelog Archives
     Escape quotes.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8270">issue 8270</a>)
 </ul>
-<h3><a name=v1.391>What's new in 1.391</a> (2010/12/26)</h3>
+<h3 id=v1.391>What's new in 1.391 (2010/12/26)</h3>
 <ul class=image>
   <li class=bug>
     failed to build with "Trigger builds remotely" enabled.
@@ -5613,7 +5613,7 @@ title: Changelog Archives
   <li class=rfe>
     added a new extension point to use markup for job/user description
 </ul>
-<h3><a name=v1.390>What's new in 1.390</a> (2010/12/18)</h3>
+<h3 id=v1.390>What's new in 1.390 (2010/12/18)</h3>
 <ul class=image>
   <li class=bug>
     " (from WhateverTest)" gratuitously appended to test result detail pages.
@@ -5636,7 +5636,7 @@ title: Changelog Archives
   <li class=rfe>
     Allow the administrator to yank out dead executors.
 </ul>
-<h3><a name=v1.389>What's new in 1.389</a> (2010/12/11)</h3>
+<h3 id=v1.389>What's new in 1.389 (2010/12/11)</h3>
 <ul class=image>
   <li class=rfe>
     Hide executors for offline nodes to conserve space in Build Executors Status list.
@@ -5645,7 +5645,7 @@ title: Changelog Archives
     throw AccessDeniedException if "Authentication Token" is invalid.
     (<a href="http://hudson.361315.n4.nabble.com/-td3069369.html">hudson-ja</a>)
 </ul>
-<h3><a name=v1.388>What's new in 1.388</a> (2010/12/04)</h3>
+<h3 id=v1.388>What's new in 1.388 (2010/12/04)</h3>
 <ul class=image>
   <li class=bug>
     Failure to UDP broadcast shouldn't kill the Hudson bootup process.
@@ -5670,7 +5670,7 @@ title: Changelog Archives
   <li class=rfe>
     Added "set-build-description" CLI command.
 </ul>
-<h3><a name=v1.387>What's new in 1.387</a> (2010/11/27)</h3>
+<h3 id=v1.387>What's new in 1.387 (2010/11/27)</h3>
 <ul class=image>
   <li class=bug>
     Avoid <tt>AbstractMethodError</tt> in the executors rendering.
@@ -5690,7 +5690,7 @@ title: Changelog Archives
     to celebrate our 1.387 release (the feature is time bombed and will revert
     to the butler after that date.)
 </ul>
-<h3><a name=v1.386>What's new in 1.386</a> (2010/11/19)</h3>
+<h3 id=v1.386>What's new in 1.386 (2010/11/19)</h3>
 <ul class=image>
   <li class=bug>
     Support CSRF protection when submitting results of an external job.
@@ -5729,11 +5729,11 @@ title: Changelog Archives
   <li class=rfe>
     Update bundled subversion plugin to version 1.20 and ssh-slaves to version 0.14.
 </ul>
-<h4><s><a name=v1.385>What's new in 1.385</a> (2010/11/15)</s></h4>
+<h4 id=v1.385><s>What's new in 1.385 (2010/11/15)</s></h4>
 <ul class=image>
   <li class=rfe> Oops, same as 1.384
 </ul>
-<h3><a name=v1.384>What's new in 1.384</a> (2010/11/05)</h3>
+<h3 id=v1.384>What's new in 1.384 (2010/11/05)</h3>
 <ul class=image>
   <li class=bug>
     JDK download for auto installation was not honoring the proxy setting.
@@ -5751,7 +5751,7 @@ title: Changelog Archives
     Label expression textbox for "Restrict where this project can be run" now
     provides autocompletion suggestions.
 </ul>
-<h3><a name=v1.383>What's new in 1.383</a> (2010/10/29)</h3>
+<h3 id=v1.383>What's new in 1.383 (2010/10/29)</h3>
 <ul class=image>
   <li class="major bug">
     Fix security issue where a user with job configure permission could obtain
@@ -5770,7 +5770,7 @@ title: Changelog Archives
     the modules which are actually being build.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-6544">issue 6544</a>)
 </ul>
-<h3><a name=v1.382>What's new in 1.382</a> (2010/10/24)</h3>
+<h3 id=v1.382>What's new in 1.382 (2010/10/24)</h3>
 <ul class=image>
   <li class=bug>
     Recognize initialization tasks from plugins.
@@ -5780,7 +5780,7 @@ title: Changelog Archives
   <li class=bug>
     UI for tying jobs to labels wasn't shown in some situations.
 </ul>
-<h3><a name=v1.381>What's new in 1.381</a> (2010/10/16)</h3>
+<h3 id=v1.381>What's new in 1.381 (2010/10/16)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a race condition.
@@ -5792,7 +5792,7 @@ title: Changelog Archives
   <li class=rfe><a href="http://wiki.jenkins-ci.org/display/JENKINS//Extension+Point+for+Project+Views+Navigation">Extension Point to provide alternate UI for Project Views implemented</a>
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-1467">issue 1467</a>)
 </ul>
-<h3><a name=v1.380>What's new in 1.380</a> (2010/10/09)</h3>
+<h3 id=v1.380>What's new in 1.380 (2010/10/09)</h3>
 <ul class=image>
   <li class=bug>
     Safe restart was not working since 1.376
@@ -5808,7 +5808,7 @@ title: Changelog Archives
     Add "proxy compatible" option to default crumb issuing algoritm
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-7518">issue 7518</a>)
 </ul>
-<h3><a name=v1.379>What's new in 1.379</a> (2010/10/02)</h3>
+<h3 id=v1.379>What's new in 1.379 (2010/10/02)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a pipe clogging problem that can result in a hanging build.
@@ -5832,7 +5832,7 @@ title: Changelog Archives
     Supported failsafe reports for the Maven2 job type.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-4229">issue 4229</a>)
 </ul>
-<h3><a name=v1.378>What's new in 1.378</a> (2010/09/25)</h3>
+<h3 id=v1.378>What's new in 1.378 (2010/09/25)</h3>
 <ul class=image>
   <li class='major bug'>
     Improving the master/slave communication to avoid pipe clogging problem.
@@ -5874,7 +5874,7 @@ title: Changelog Archives
     Added a new classloader ("a la" child first for plugin)
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5360">issue 5360</a>)
 </ul>
-<h3><a name=v1.377>What's new in 1.377</a> (2010/09/19)</h3>
+<h3 id=v1.377>What's new in 1.377 (2010/09/19)</h3>
 <ul class=image>
   <li class=bug>
     Moved nulling out of buildEnvironments to cleanUp, so that node variables are available in Publishers.
@@ -5895,7 +5895,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Queue/execution model is extended to allow jobs that consume multiple executors on different nodes.
 </ul>
-<h3><a name=v1.376>What's new in 1.376</a> (2010/09/11)</h3>
+<h3 id=v1.376>What's new in 1.376 (2010/09/11)</h3>
 <ul class=image>
   <li class=bug>
     Error in some remote API requests since 1.373.
@@ -5912,7 +5912,7 @@ title: Changelog Archives
   <li class="rfe">
     Added downgrade support for the core and plugins.
 </ul>
-<h3><a name=v1.375>What's new in 1.375</a> (2010/09/07)</h3>
+<h3 id=v1.375>What's new in 1.375 (2010/09/07)</h3>
 <ul class=image>
   <li class=bug>
     CLI login did not work for about half of the CLI commands (those defined via @CLIMethod annotation).
@@ -5932,7 +5932,7 @@ title: Changelog Archives
   <li class=rfe>
     (Internal) ConsoleNotes can now inject its associated CSS.
 </ul>
-<h3><a name=v1.374>What's new in 1.374</a> (2010/08/27)</h3>
+<h3 id=v1.374>What's new in 1.374 (2010/08/27)</h3>
 <ul class=image>
   <li class=bug>
     Unable to add empty Ant properties on Windows since 1.370.
@@ -5955,7 +5955,7 @@ title: Changelog Archives
     Added "This build is disabled" on Matrix project when it disabled.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-7266">issue 7266</a>)
 </ul>
-<h3><a name=v1.373>What's new in 1.373</a> (2010/08/23)</h3>
+<h3 id=v1.373>What's new in 1.373 (2010/08/23)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a config page regression in the matrix project.
@@ -5982,7 +5982,7 @@ title: Changelog Archives
   <li class=rfe>
     Updated bundled ssh-slaves plugin to version 0.13.
 </ul>
-<h3><a name=v1.372>What's new in 1.372</a> (2010/08/13)</h3>
+<h3 id=v1.372>What's new in 1.372 (2010/08/13)</h3>
 <ul class=image>
   <li class=rfe>
     Persist matrix-based security settings in a consistent order
@@ -5990,14 +5990,14 @@ title: Changelog Archives
   <li class='major rfe'>
     Jobs can now use boolean expression over labels to control where they run.
 </ul>
-<h3><a name=v1.371>What's new in 1.371</a> (2010/08/09)</h3>
+<h3 id=v1.371>What's new in 1.371 (2010/08/09)</h3>
 <ul class=image>
   <li class="major bug">
     A security hole in CLI command implementations enable unauthorized users
     from executing commands.
     (SECURITY-5)
 </ul>
-<h3><a name=v1.370>What's new in 1.370</a> (2010/08/07)</h3>
+<h3 id=v1.370>What's new in 1.370 (2010/08/07)</h3>
 <ul class=image>
   <li class=bug>
     Added escaping of special characters when passing properties to Ant on Windows.
@@ -6013,7 +6013,7 @@ title: Changelog Archives
   <li class=rfe>
     Incorporated community contributed translations in Korean and Dutch.
 </ul>
-<h3><a name=v1.369>What's new in 1.369</a> (2010/07/30)</h3>
+<h3 id=v1.369>What's new in 1.369 (2010/07/30)</h3>
 <ul class=image>
   <li class="major bug">
     <code>X-Hudson</code> header not being sent in 1.368.
@@ -6040,7 +6040,7 @@ title: Changelog Archives
     CLI can now work with a reverse proxy that requires BASIC auth.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3796">issue 3796</a>)
 </ul>
-<h3><a name=v1.368>What's new in 1.368</a> (2010/07/26)</h3>
+<h3 id=v1.368>What's new in 1.368 (2010/07/26)</h3>
 <ul class=image>
   <li class=bug>
     Make <tt>/buildWithParameters</tt> support remote cause and user supplied cause text
@@ -6053,7 +6053,7 @@ title: Changelog Archives
     Modified to work with Tomcat 7.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-6738">issue 6738</a>)
 </ul>
-<h3><a name=v1.367>What's new in 1.367</a> (2010/07/16)</h3>
+<h3 id=v1.367>What's new in 1.367 (2010/07/16)</h3>
 <ul class=image>
   <li class=bug>
     Safe restart made Hudson unresponsive until all running jobs complete, since 1.361.
@@ -6076,7 +6076,7 @@ title: Changelog Archives
     Remote API now supports the 'tree' filter query parameter which is more efficient and easier to use.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5940">issue 5940</a>)
 </ul>
-<h3><a name=v1.366>What's new in 1.366</a> (2010/07/09)</h3>
+<h3 id=v1.366>What's new in 1.366 (2010/07/09)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a possible security issue where a malicious user with the project
@@ -6111,12 +6111,12 @@ title: Changelog Archives
     The "Let Hudson control this Windows slave as a Windows service" mode now allows the same Windows slave
     to be used by multiple Hudson masters.
 </ul>
-<h3><a name=v1.365>What's new in 1.365</a> (2010/07/05)</h3>
+<h3 id=v1.365>What's new in 1.365 (2010/07/05)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a critical security problem. See <a href="/security/advisory/2010-07-05/">the advisory</a> for more details.
 </ul>
-<h3><a name=v1.364>What's new in 1.364</a> (2010/06/25)</h3>
+<h3 id=v1.364>What's new in 1.364 (2010/06/25)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a race condition where a queued build may get executed multiple times.
@@ -6128,7 +6128,7 @@ title: Changelog Archives
     <tt>BuildWrapper</tt>s can now contribute build variables.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-6497">issue 6497</a>)
 </ul>
-<h3><a name=v1.363>What's new in 1.363</a> (2010/06/18)</h3>
+<h3 id=v1.363>What's new in 1.363 (2010/06/18)</h3>
 <ul class=image>
   <li class=bug>
     Fix queue handling to close locking gap between removing job from queue and starting build,
@@ -6160,7 +6160,7 @@ title: Changelog Archives
     Upgraded bundled Ant to version 1.8.1.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-6562">issue 6562</a>)
 </ul>
-<h3><a name=v1.362>What's new in 1.362</a> (2010/06/11)</h3>
+<h3 id=v1.362>What's new in 1.362 (2010/06/11)</h3>
 <ul class=image>
   <li class=bug>
     Restored optional container-based authentication for CLI.
@@ -6182,7 +6182,7 @@ title: Changelog Archives
     Added a proactive error diagnostics to look for a broken reverse proxy setup.
     (<a href="http://wiki.jenkins-ci.org/display/JENKINS//Running+Hudson+behind+Apache#RunningHudsonbehindApache-modproxywithHTTPS">report</a>)
 </ul>
-<h3><a name=v1.361>What's new in 1.361</a> (2010/06/04)</h3>
+<h3 id=v1.361>What's new in 1.361 (2010/06/04)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where IE shows empty client cert dialog when connecting to HTTPS site run by Winstone.
@@ -6228,7 +6228,7 @@ title: Changelog Archives
   <li class=rfe>
     Reduced logging from jmDNS.
 </ul>
-<h3><a name=v1.360>What's new in 1.360</a> (2010/05/28)</h3>
+<h3 id=v1.360>What's new in 1.360 (2010/05/28)</h3>
 <ul class=image>
   <li class=bug>
     A Java6 dependency had crept in in 1.359.
@@ -6240,7 +6240,7 @@ title: Changelog Archives
     Added an extension point to control the assignment of tasks to nodes.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-6598">issue 6598</a>)
 </ul>
-<h3><a name=v1.359>What's new in 1.359</a> (2010/05/21)</h3>
+<h3 id=v1.359>What's new in 1.359 (2010/05/21)</h3>
 <ul class=image>
   <li class=bug>
     Accept latest JRockit JVM release as a compatible JVM.
@@ -6250,7 +6250,7 @@ title: Changelog Archives
   <li class=rfe>
     Added the "-block" option to the "quiet-down" CLI command so that the command will block until the system really quiets down.
 </ul>
-<h3><a name=v1.358>What's new in 1.358</a> (2010/05/14)</h3>
+<h3 id=v1.358>What's new in 1.358 (2010/05/14)</h3>
 <ul class=image>
   <li class=bug>
     Too much memory used by stdout/stderr from test results.
@@ -6279,7 +6279,7 @@ title: Changelog Archives
   <li class=rfe>
     Hudson shouldn't show a login error page unless the user really failed to login (think about when the user presses a back button.)
 </ul>
-<h3><a name=v1.357>What's new in 1.357</a> (2010/05/07)</h3>
+<h3 id=v1.357>What's new in 1.357 (2010/05/07)</h3>
 <ul class=image>
   <li class=bug>
     Maven builds abort unexpectedly due to a SocketTimeoutException on machine with poor resources.
@@ -6322,7 +6322,7 @@ title: Changelog Archives
   <li class=rfe>
     Updated bundled subversion plugin to version 1.17.
 </ul>
-<h3><a name=v1.356>What's new in 1.356</a> (2010/05/03)</h3>
+<h3 id=v1.356>What's new in 1.356 (2010/05/03)</h3>
 <ul class=image>
   <li class=bug>
     Fix <tt>StringIndexOutOfBoundsException</tt> in console log from <tt>UrlAnnotator</tt>.
@@ -6344,7 +6344,7 @@ title: Changelog Archives
   <li class=rfe>
     Extension points can be now sorted.
 </ul>
-<h3><a name=v1.355>What's new in 1.355</a> (2010/04/16)</h3>
+<h3 id=v1.355>What's new in 1.355 (2010/04/16)</h3>
 <ul class=image>
   <li class=bug>
     Colored ball image at top of build pages was broken for Hudson in some web
@@ -6368,7 +6368,7 @@ title: Changelog Archives
   <li class=rfe>
     Added to configure charset option of Mailer.
 </ul>
-<h3><a name=v1.354>What's new in 1.354</a> (2010/04/12)</h3>
+<h3 id=v1.354>What's new in 1.354 (2010/04/12)</h3>
 <ul class=image>
   <li class=bug>
     POM parsing was still using the module root as the base for relative paths for alternate settings files.
@@ -6387,7 +6387,7 @@ title: Changelog Archives
   <li class=bug>
     Quiet period wasn't taking effect properly when doing parameterized builds.
 </ul>
-<h3><a name=v1.353>What's new in 1.353</a> (2010/03/29)</h3>
+<h3 id=v1.353>What's new in 1.353 (2010/03/29)</h3>
 <ul class=image>
   <li class=bug>
     Tagging a repository can result in NPE.
@@ -6407,7 +6407,7 @@ title: Changelog Archives
     Added link to builds in buildTimeTrend
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3993">issue 3993</a>)
 </ul>
-<h3><a name=v1.352>What's new in 1.352</a> (2010/03/19)</h3>
+<h3 id=v1.352>What's new in 1.352 (2010/03/19)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a file handle leak when a copy fails.
@@ -6451,13 +6451,13 @@ title: Changelog Archives
   <li class=rfe>
     Integrated a new round of community-contributed localizations (ca, es, fi, fr, hi_IN, it, nl, ru, and sv_SE locales.)
 </ul>
-<h3><a name=v1.351>What's new in 1.351</a> (2010/03/15)</h3>
+<h3 id=v1.351>What's new in 1.351 (2010/03/15)</h3>
 <ul class=image>
   <li class='major bug'>
     Regression in 1.350 that can delete old build artifacts.
     (<a href="http://n4.nabble.com/Warning-about-Hudson-1-350-Could-delete-your-artifacts-td1593483.html">report</a>)
 </ul>
-<h3><a name=v1.350>What's new in 1.350</a> (2010/03/12)</h3>
+<h3 id=v1.350>What's new in 1.350 (2010/03/12)</h3>
 <ul class=image>
   <li class=bug>
     Fix handling of relative paths in alternate settings.xml path for Maven projects.
@@ -6498,7 +6498,7 @@ title: Changelog Archives
   <li class=rfe>
     Added console annotation support to SCM polling logs.
 </ul>
-<h3><a name=v1.349>What's new in 1.349</a> (2010/03/05)</h3>
+<h3 id=v1.349>What's new in 1.349 (2010/03/05)</h3>
 <ul class=image>
   <li class=bug>
     Fix deserialization problem with fields containing double underscore.
@@ -6525,14 +6525,14 @@ title: Changelog Archives
     Added an extension point to annotate console output.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-2137">issue 2137</a>)
 </ul>
-<h3><a name=v1.348>What's new in 1.348</a> (2010/02/26)</h3>
+<h3 id=v1.348>What's new in 1.348 (2010/02/26)</h3>
 <ul class=image>
   <li class=rfe>
     Fixed a performance problem of the job/build top page when there are too many artifacts.
   <li class=rfe>
     Improved /etc/shadow permission checks.
 </ul>
-<h3><a name=v1.347>What's new in 1.347</a> (2010/02/19)</h3>
+<h3 id=v1.347>What's new in 1.347 (2010/02/19)</h3>
 <ul class=image>
   <li class=bug>
     Fix javascript problem showing test failure detail for test name with a quote character.
@@ -6555,7 +6555,7 @@ title: Changelog Archives
     Added message to slave log when it has successfully come online.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5630">issue 5630</a>)
 </ul>
-<h3><a name=v1.346>What's new in 1.346</a> (2010/02/12)</h3>
+<h3 id=v1.346>What's new in 1.346 (2010/02/12)</h3>
 <ul class=image>
   <li class=bug>
     Maven modules should not be buildable when the parent project is disabled.
@@ -6588,7 +6588,7 @@ title: Changelog Archives
   <li class=rfe>
     Speed/footprint improvement in the HTML rendering.
 </ul>
-<h3><a name=v1.345>What's new in 1.345</a> (2010/02/08)</h3>
+<h3 id=v1.345>What's new in 1.345 (2010/02/08)</h3>
 <ul class=image>
   <li class='major bug'>
     Update center retrieval, "build now" link, and real-time console update was broken in 1.344.
@@ -6597,7 +6597,7 @@ title: Changelog Archives
     Fixed the backward incompatibility introduced in JENKINS-5391 fix in 1.344.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5391">issue 5391</a>)
 </ul>
-<h3><a name=v1.344>What's new in 1.344</a> (2010/02/05)</h3>
+<h3 id=v1.344>What's new in 1.344 (2010/02/05)</h3>
 <ul class=image>
   <li class=bug>
     Removed the forced upper casing in parameterized builds.
@@ -6624,7 +6624,7 @@ title: Changelog Archives
     Make badges in build history line up.
     (<a href="http://n4.nabble.com/Align-lock-sign-of-keep-build-forever-td1016427.html">report</a>)
 </ul>
-<h3><a name=v1.343>What's new in 1.343</a> (2010/01/29)</h3>
+<h3 id=v1.343>What's new in 1.343 (2010/01/29)</h3>
 <ul class=image>
   <li class=bug>
     Don't report a computer as idle if it running the parent job for a matrix project.
@@ -6672,7 +6672,7 @@ title: Changelog Archives
     Formalized an extension point to control priority among builds in the queue.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-833">issue 833</a>)
 </ul>
-<h3><a name=v1.342>What's new in 1.342</a> (2010/01/22)</h3>
+<h3 id=v1.342>What's new in 1.342 (2010/01/22)</h3>
 <ul class=image>
   <li class=bug>
     Commands run on slaves (such as SCM operations) were not printed to the log
@@ -6719,7 +6719,7 @@ title: Changelog Archives
   <li class=rfe>
     Spanish translation made a great progress.
 </ul>
-<h3><a name=v1.341>What's new in 1.341</a> (2010/01/15)</h3>
+<h3 id=v1.341>What's new in 1.341 (2010/01/15)</h3>
 <ul class=image>
   <li class=bug>
     Completed fix started in 1.325 for updating bundled plugins, now working when security is enabled.
@@ -6746,7 +6746,7 @@ title: Changelog Archives
     SCM retry count and "Block build when upstream project is building" is now available on matrix projects.
     (<a href="http://n4.nabble.com/Advanced-configuration-in-matrix-projects-td1011215.html#a1011215">report</a>)
 </ul>
-<h3><a name=v1.340>What's new in 1.340</a> (2010/01/11)</h3>
+<h3 id=v1.340>What's new in 1.340 (2010/01/11)</h3>
 <ul class=image>
   <li class=bug>
     Non ASCII chars get mangled when a new user is created.
@@ -6769,7 +6769,7 @@ title: Changelog Archives
     CVS support is separated into a plugin, although it's still bundled by default for compatibility.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3101">issue 3101</a>)
 </ul>
-<h3><a name=v1.339>What's new in 1.339</a> (2009/12/24)</h3>
+<h3 id=v1.339>What's new in 1.339</a> (2009/12/24)</h3>
 <ul class=image>
   <li class=bug>
     <tt>slave.jar</tt> incorrectly shipped with a version number indicating a private build.
@@ -6794,7 +6794,7 @@ title: Changelog Archives
     Introduced a mechanism so that writing XSS-free code is easier.
     (<a href="http://wiki.jenkins-ci.org/display/JENKINS//Jelly+and+XSS+prevention">discussion</a>)
 </ul>
-<h3><a name=v1.338>What's new in 1.338</a> (2009/12/18)</h3>
+<h3 id=v1.338>What's new in 1.338</a> (2009/12/18)</h3>
 <ul class=image>
   <li class=rfe>
     Maven projects will now use per-project MAVEN_OPTS if defined first, then global MAVEN_OPTS if defined, and finally
@@ -6804,7 +6804,7 @@ title: Changelog Archives
     Expose upstream cause details via remote API.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5074">issue 5074</a>)
 </ul>
-<h3><a name=v1.337>What's new in 1.337</a> (2009/12/11)</h3>
+<h3 id=v1.337>What's new in 1.337</a> (2009/12/11)</h3>
 <ul class=image>
   <li class=bug>
     Matrix parent build shouldn't consume an executor.
@@ -6839,7 +6839,7 @@ title: Changelog Archives
     Implemented a proper serialization of multi-classloader object graph.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-5048">issue 5048</a>)
 </ul>
-<h3><a name=v1.336>What's new in 1.336</a> (2009/11/28)</h3>
+<h3 id=v1.336>What's new in 1.336</a> (2009/11/28)</h3>
 <ul class=image>
   <li class=bug>
     Update or remove lastSuccessful/lastStable symlinks on filesystem as appropriate
@@ -6891,7 +6891,7 @@ title: Changelog Archives
     Debian packages creates Hudson user with <tt>/bin/bash</tt> to accomodate some tools that want a valid shell.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-4830">issue 4830</a>)
 </ul>
-<h3><a name=v1.335>What's new in 1.335</a> (2009/11/20)</h3>
+<h3 id=v1.335>What's new in 1.335</a> (2009/11/20)</h3>
 <ul class=image>
   <li class=bug>
     Space in axis value for matrix type project was lost on reconfiguration.
@@ -6919,7 +6919,7 @@ title: Changelog Archives
   <li class=rfe>
     Hudson's UDP broadcast/discovery now supports IP multicast.
 </ul>
-<h3><a name=v1.334>What's new in 1.334</a> (2009/11/16)</h3>
+<h3 id=v1.334>What's new in 1.334</a> (2009/11/16)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a possible exception in submitting forms and obtaining update center metadata with Winstone in 1.333.
@@ -6973,7 +6973,7 @@ title: Changelog Archives
   <li class=rfe>
     Added new SaveableListener to be called when objects implementing Saveable are saved.
 </ul>
-<h3><a name=v1.333>What's new in 1.333</a> (2009/11/09)</h3>
+<h3 id=v1.333>What's new in 1.333</a> (2009/11/09)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a performance problem in the file upload with Winstone.
@@ -7011,7 +7011,7 @@ title: Changelog Archives
     Broke NetBeans integration and possibly others.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-4760">issue 4760</a>)
 </ul>
-<h3><a name=v1.332>What's new in 1.332</a> (2009/11/02)</h3>
+<h3 id=v1.332>What's new in 1.332</a> (2009/11/02)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a regression in 1.331 where previously disabled plugins and their artifacts in <tt>build.xml</tt> can cause build records to fail to load.
@@ -7023,7 +7023,7 @@ title: Changelog Archives
     Fixed <tt>IllegalArgumentException: name</tt>
     (<a href="http://old.nabble.com/bug-1.331-to26145963.html">report</a>)
 </ul>
-<h3><a name=v1.331>What's new in 1.331</a> (2009/10/30)</h3>
+<h3 id=v1.331>What's new in 1.331</a> (2009/10/30)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a memory leak problem with the groovysh Hudson CLI command.
@@ -7053,7 +7053,7 @@ title: Changelog Archives
     Added the "install-plugin" command to install plugins from CLI.
     (<a href="http://www.nabble.com/Setup-for-using-Hudson-to-deploy-into-Hudson-td25962271.html">report</a>)
 </ul>
-<h3><a name=v1.330>What's new in 1.330</a> (2009/10/23)</h3>
+<h3 id=v1.330>What's new in 1.330</a> (2009/10/23)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>NoSuchMethodError</tt> error during error recovery with Maven 2.1.
@@ -7072,7 +7072,7 @@ title: Changelog Archives
     Custom workspace is now subject to the variable expansion.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3997">issue 3997</a>)
 </ul>
-<h3><a name=v1.329>What's new in 1.329</a> (2009/10/16)</h3>
+<h3 id=v1.329>What's new in 1.329</a> (2009/10/16)</h3>
 <ul class=image>
   <li class=bug>
     Fixed UI selector (hetero-list) to handle nested selectors (resolves conflict between
@@ -7092,7 +7092,7 @@ title: Changelog Archives
     Fixed a bug in <tt>.cvspass</tt> form field persistence.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-4456">issue 4456</a>)
 </ul>
-<h3><a name=v1.328>What's new in 1.328</a> (2009/10/09)</h3>
+<h3 id=v1.328>What's new in 1.328</a> (2009/10/09)</h3>
 <ul class=image>
   <li class=bug>
     Overview of all SCM polling activity was never showing any entries.
@@ -7109,7 +7109,7 @@ title: Changelog Archives
     Improved the form validation in global e-mail configurations.
     (<a href="http://www.nabble.com/error-configuring-SMTP-Gmail-with-Hudson-td25736116.html">report</a>)
 </ul>
-<h3><a name=v1.327>What's new in 1.327</a> (2009/10/02)</h3>
+<h3 id=v1.327>What's new in 1.327</a> (2009/10/02)</h3>
 <ul class=image>
   <li class=bug>
     Worked around a possible Windows slave hang on start up.
@@ -7135,13 +7135,13 @@ title: Changelog Archives
     representation of a test case with the depth parameter.
     (<a href="http://www.nabble.com/Change-remote-API-visibility-for-CaseResult.getStdout-getStderr-td25619046.html">discussion</a>)
 </ul>
-<h3><a name=v1.326>What's new in 1.326</a> (2009/09/28)</h3>
+<h3 id=v1.326>What's new in 1.326</a> (2009/09/28)</h3>
 <ul class=image>
   <li class='major bug'>
     Hudson fails to update a plugin due to a bug in the up-to-date check logic.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-4353">issue 4353</a>)
 </ul>
-<h3><a name=v1.325>What's new in 1.325</a> (2009/09/25)</h3>
+<h3 id=v1.325>What's new in 1.325</a> (2009/09/25)</h3>
 <ul class=image>
   <li class=bug>
     Self restart was not working on Solaris 64bit JVM.
@@ -7183,7 +7183,7 @@ title: Changelog Archives
     JNLP clients now report the reason when the connection is rejected by the master.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3889">issue 3889</a>)
 </ul>
-<h3><a name=v1.324>What's new in 1.324</a> (2009/09/18)</h3>
+<h3 id=v1.324>What's new in 1.324</a> (2009/09/18)</h3>
 <ul class=image>
   <li class=bug>
     Added call to MailSender in RunnerImpl.cleanUp so that mail gets sent for top-level Maven project as well as individual modules. This means mail will be sent if there are POM parsing errors, etc.
@@ -7228,7 +7228,7 @@ title: Changelog Archives
     JNLP clients perform periodic ping to detect terminated connections and recover automatically.
     (<a href="http://www.nabble.com/Trying-to-investigate-JNLP-disconnection-issues-to25467992.html">report</a>)
 </ul>
-<h3><a name=v1.323>What's new in 1.323</a> (2009/09/04)</h3>
+<h3 id=v1.323>What's new in 1.323</a> (2009/09/04)</h3>
 <ul class=image>
   <li class=bug>
     Creation of symlinks failed (or created in wrong location) since 1.320.
@@ -7292,7 +7292,7 @@ title: Changelog Archives
   <li class=rfe>
     Fixed a bug in Winstone that hides the root cause of exceptions.
 </ul>
-<h3><a name=v1.322>What's new in 1.322</a> (2009/08/28)</h3>
+<h3 id=v1.322>What's new in 1.322</a> (2009/08/28)</h3>
 <ul class=image>
   <li class="major bug">
     NPE in Subversion polling problem.
@@ -7304,7 +7304,7 @@ title: Changelog Archives
     Debian init script now uses "su" to properly initialize the environment.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-4304">issue 4304</a>)
 </ul>
-<h3><a name=v1.321>What's new in 1.321</a> (2009/08/21)</h3>
+<h3 id=v1.321>What's new in 1.321</a> (2009/08/21)</h3>
 <ul class=image>
   <li class='major bug'>
     "Tag this build" was failing.
@@ -7373,7 +7373,7 @@ title: Changelog Archives
   <li class=rfe>
     Added <tt>restart</tt> CLI command.
 </ul>
-<h3><a name=v1.320>What's new in 1.320</a> (2009/08/14)</h3>
+<h3 id=v1.320>What's new in 1.320</a> (2009/08/14)</h3>
 <ul class=image>
   <li class=bug>
     Fixed an encoding problem in CVS changelog calculation.
@@ -7421,7 +7421,7 @@ title: Changelog Archives
   <li class='major rfe'>
     JUnit report improvements: A new extension point for contributing to test reports.
 </ul>
-<h3><a name=v1.319>What's new in 1.319</a> (2009/08/08)</h3>
+<h3 id=v1.319>What's new in 1.319</a> (2009/08/08)</h3>
 <ul class=image>
   <li class=bug>
     Improved the start up error handling with <tt>slave.jar -jnlpUrl</tt> option.
@@ -7459,7 +7459,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Hudson now allows builds of a single project to execute concurrently.
 </ul>
-<h3><a name=v1.318>What's new in 1.318</a> (2009/07/31)</h3>
+<h3 id=v1.318>What's new in 1.318</a> (2009/07/31)</h3>
 <ul class=image>
   <li class=bug>
     Removed a problematic MIME type entry that prevents Hudson from deploying on JOnAS.
@@ -7496,7 +7496,7 @@ title: Changelog Archives
     Modified the reconnection logic for slaves connecting via JNLP so that it works better with protected Hudson.
     (<a href="http://www.nabble.com/more-lenient-retry-logic-in-Engine.waitForServerToBack-td24703172.html">report</a>)
 </ul>
-<h3><a name=v1.317>What's new in 1.317</a> (2009/07/24)</h3>
+<h3 id=v1.317>What's new in 1.317</a> (2009/07/24)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in inferring root DN in non-anonymous LDAP environment.
@@ -7541,7 +7541,7 @@ title: Changelog Archives
     (This is only applicable to newly installed services.)
     (<a href="http://www.nabble.com/Windows-Service%3A-Error-193%3A-***-is-not-a-valid-Win32-application.-td24586795.html">report</a>)
 </ul>
-<h3><a name=v1.316>What's new in 1.316</a> (2009/07/17)</h3>
+<h3 id=v1.316>What's new in 1.316</a> (2009/07/17)</h3>
 <ul class=image>
   <li class=bug>
     Matrix configuration should show a test trend.
@@ -7600,7 +7600,7 @@ title: Changelog Archives
     Added MIME type mapping for several well-known file extensions so that it works everywhere.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3803">issue 3803</a>)
 </ul>
-<h3><a name=v1.315>What's new in 1.315</a> (2009/07/10)</h3>
+<h3 id=v1.315>What's new in 1.315</a> (2009/07/10)</h3>
 <ul class=image>
   <li class=bug>
     Hudson failed to notice a build result status change if aborted builds
@@ -7626,7 +7626,7 @@ title: Changelog Archives
     CLI slave agents show details of how it failed to connect.
     (<a href="http://www.nabble.com/Can%27t-start-a-slave-via-JNLP-td24363116.html">report</a>)
 </ul>
-<h3><a name=v1.314>What's new in 1.314</a> (2009/07/02)</h3>
+<h3 id=v1.314>What's new in 1.314</a> (2009/07/02)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a possible "Cannot create a file when that file already exists" error in managed Windows slave launcher.
@@ -7644,7 +7644,7 @@ title: Changelog Archives
     Allow Maven projects to have their own artifact archiver settings.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3289">issue 3289</a>)
 </ul>
-<h3><a name=v1.313>What's new in 1.313</a> (2009/06/26)</h3>
+<h3 id=v1.313>What's new in 1.313</a> (2009/06/26)</h3>
 <ul class=image>
   <li class=bug>
     Added copy-job, delete-job, enable-job, and disable-job command.
@@ -7668,7 +7668,7 @@ title: Changelog Archives
     Subversion checkout/update gets in an infinite loop when a previously valid password goes invalid.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-2909">issue 2909</a>)
 </ul>
-<h3><a name=v1.312>What's new in 1.312</a> (2009/06/23)</h3>
+<h3 id=v1.312>What's new in 1.312</a> (2009/06/23)</h3>
 <ul class=image>
   <li class=bug>
     1.311 jars were not properly signed
@@ -7676,7 +7676,7 @@ title: Changelog Archives
     Subversion SCM browsers were not working.
     (<a href="http://www.nabble.com/Build-311-breaks-change-logs-td24150221.html">report</a>)
 </ul>
-<h3><a name=v1.311>What's new in 1.311</a> (2009/06/19)</h3>
+<h3 id=v1.311>What's new in 1.311</a> (2009/06/19)</h3>
 <ul class=image>
   <li class=bug>
     Gracefully handle IBM JVMs on PowerPC.
@@ -7707,7 +7707,7 @@ title: Changelog Archives
     Set time out to avoid infinite hang when SMTP servers don't respond in time.
     (<a href="http://www.nabble.com/Lockup-during-e-mail-notification.-td23718820.html">report</a>)
 </ul>
-<h3><a name=v1.310>What's new in 1.310</a> (2009/06/14)</h3>
+<h3 id=v1.310>What's new in 1.310</a> (2009/06/14)</h3>
 <ul class=image>
   <li class=bug>
     Ant/Maven installers weren't setting the file permissions on Unix.
@@ -7733,13 +7733,13 @@ title: Changelog Archives
   <li class='major rfe'>
     Generate nonce values to prevent cross site request forgeries. Extension point to customize the nonce generation algorithm.
 </ul>
-<h3><a name=v1.309>What's new in 1.309</a> (2009/05/31)</h3>
+<h3 id=v1.309>What's new in 1.309</a> (2009/05/31)</h3>
 <ul class=image>
   <li class=bug>
     Reimplemented JDK auto installer to reduce Hudson footprint by 5MB. This also fix a failure to run on JBoss.
    (<a href="http://www.nabble.com/Hudson-1.308-seems-to-be-broken-with-Jboss-td23780609.html">report</a>)
 </ul>
-<h3><a name=v1.308>What's new in 1.308</a> (2009/05/28)</h3>
+<h3 id=v1.308>What's new in 1.308</a> (2009/05/28)</h3>
 <ul class=image>
   <li class=bug>
     Unit test trend graph was not displayed if there's no successful build.
@@ -7756,7 +7756,7 @@ title: Changelog Archives
   <li class=rfe>
     Maven can now be automatically installed from maven.apache.org.
 </ul>
-<h3><a name=v1.307>What's new in 1.307</a> (2009/05/22)</h3>
+<h3 id=v1.307>What's new in 1.307</a> (2009/05/22)</h3>
 <ul class=image>
   <li class=bug>
     AbstractProject.doWipeOutWorkspace() wasn't calling SCM.processWorkspaceBeforeDeletion.
@@ -7780,13 +7780,13 @@ title: Changelog Archives
     Some failures in Windows batch files didn't cause Hudson to fail the build.
     (<a href="http://www.nabble.com/Propagating-failure-in-Windows-Batch-actions-td23603409.html">report</a>)
 </ul>
-<h3><a name=v1.306>What's new in 1.306</a> (2009/05/16)</h3>
+<h3 id=v1.306>What's new in 1.306</a> (2009/05/16)</h3>
 <ul class=image>
   <li class=bug>
     Maven 2.1 support was not working on slaves.
     (<a href="http://www.nabble.com/1.305-fully-break-native-maven-support-td23575755.html">report</a>)
 </ul>
-<h3><a name=v1.305>What's new in 1.305</a> (2009/05/16)</h3>
+<h3 id=v1.305>What's new in 1.305</a> (2009/05/16)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug that caused Hudson to delete slave workspaces too often.
@@ -7810,7 +7810,7 @@ title: Changelog Archives
     The native m2 mode now works with Maven 2.1
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-2373">issue 2373</a>)
 </ul>
-<h3><a name=v1.304>What's new in 1.304</a> (2009/05/08)</h3>
+<h3 id=v1.304>What's new in 1.304</a> (2009/05/08)</h3>
 <ul class=image>
   <li class=bug>
     CLI didn't work with "java -jar hudson.war"
@@ -7831,7 +7831,7 @@ title: Changelog Archives
     Rolled back changes for JENKINS-3580 - workspace is once again deleted on svn checkout.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3580">issue 3580</a>)
 </ul>
-<h3><a name=v1.303>What's new in 1.303</a> (2009/05/03)</h3>
+<h3 id=v1.303>What's new in 1.303</a> (2009/05/03)</h3>
 <ul class=image>
   <li class='bug'>
     Fixed a binary incompatibility in <tt>UpstreamCause</tt> that results in <tt>NoSuchMethodError</tt>. Regression in 1.302.
@@ -7839,7 +7839,7 @@ title: Changelog Archives
   <li class='bug'>
     The "groovysh" CLI command puts "println" to server stdout, instead of CLI stdout.
 </ul>
-<h3><a name=v1.302>What's new in 1.302</a> (2009/05/01)</h3>
+<h3 id=v1.302>What's new in 1.302</a> (2009/05/01)</h3>
 <ul class=image>
   <li class='major bug'>
     The elusive 'Not in GZIP format' exception is finally fixed thanks to <tt>cristiano_k</tt>'s great detective work
@@ -7866,7 +7866,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Hudson's start up performance is improved by loading data concurrently.
 </ul>
-<h3><a name=v1.301>What's new in 1.301</a> (2009/04/25)</h3>
+<h3 id=v1.301>What's new in 1.301</a> (2009/04/25)</h3>
 <ul class=image>
   <li class=bug>
     When a SCM plugin is uninstalled, projects using it should fall back to "No SCM".
@@ -7895,7 +7895,7 @@ title: Changelog Archives
     Per-project read permission support.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-2324">issue 2324</a>)
 </ul>
-<h3><a name=v1.300>What's new in 1.300</a> (2009/04/17)</h3>
+<h3 id=v1.300>What's new in 1.300</a> (2009/04/17)</h3>
 <ul class=image>
   <li class='major bug'>
     Javadoc browsing broken since 1.297.
@@ -7907,7 +7907,7 @@ title: Changelog Archives
   <li class=bug>
     Fixed a Jelly bug in CVS after-the-fact tagging
 </ul>
-<h3><a name=v1.299>What's new in 1.299</a> (2009/04/10)</h3>
+<h3 id=v1.299>What's new in 1.299</a> (2009/04/10)</h3>
 <ul class=image>
   <li class='major bug'>
     Cross site scripting vulnerability in the search box.
@@ -7931,17 +7931,17 @@ title: Changelog Archives
     <tt>$HUDSON_HOME/userContent/</tt> is now exposed under <tt>http://server/hudson/userContent/</tt>.
     (<a href="http://www.nabble.com/Is-it-possible-to-add-a-custom-page-Hudson--td22794858.html">report</a>)
 </ul>
-<h3><a name=v1.298>What's new in 1.298</a></h3>
+<h3 id=v1.298>What's new in 1.298</a></h3>
 <p>
   Release process failed in a wrong part and we ended up skipping this release number.
 </p>
-<h3><a name=v1.297>What's new in 1.297</a> (2009/04/06)</h3>
+<h3 id=v1.297>What's new in 1.297</a> (2009/04/06)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a plugin compatibility regression issue introduced in 1.296
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=3436">issue 3436</a>)
 </ul>
-<h3><a name=v1.296>What's new in 1.296</a> (2009/04/03)</h3>
+<h3 id=v1.296>What's new in 1.296</a> (2009/04/03)</h3>
 <ul class=image>
   <li class="bug">
     Programmatically created jobs started builds at #0 rather than #1.
@@ -7958,13 +7958,13 @@ title: Changelog Archives
   <li class="rfe">
     Hudson now suggests to users to create a view if there are too many jobs but no views yet.
 </ul>
-<h3><a name=v1.295>What's new in 1.295</a> (2009/03/30)</h3>
+<h3 id=v1.295>What's new in 1.295</a> (2009/03/30)</h3>
 <ul class=image>
   <li class='major bug'>
     NPE in the global configuration of CVS.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=3382">issue 3382</a>)
 </ul>
-<h3><a name=v1.294>What's new in 1.294</a> (2009/03/28)</h3>
+<h3 id=v1.294>What's new in 1.294</a> (2009/03/28)</h3>
 <ul class=image>
   <li class="bug">
     Generated RSS 2.0 feeds weren't properly escaping e-mail addresses.
@@ -7982,7 +7982,7 @@ title: Changelog Archives
   <li class="rfe">
     XML API now exposes information about modules in a native Maven job.
 </ul>
-<h3><a name=v1.293>What's new in 1.293</a> (2009/03/20)</h3>
+<h3 id=v1.293>What's new in 1.293</a> (2009/03/20)</h3>
 <ul class=image>
   <li class=bug>
     ZIP archives created from workspace contents will render properly in Windows' built-in "compressed folder" views.
@@ -7996,7 +7996,7 @@ title: Changelog Archives
   <li class=rfe>
     Hudson now monitors the disk consumption of <tt>HUDSON_HOME</tt> by itself.
 </ul>
-<h3><a name=v1.292>What's new in 1.292</a> (2009/03/13)</h3>
+<h3 id=v1.292>What's new in 1.292</a> (2009/03/13)</h3>
 <ul class=image>
   <li class=bug>
     Fixed the possible "java.io.IOException: Not in GZIP format" problem when copying a file remotely.
@@ -8017,7 +8017,7 @@ title: Changelog Archives
     Improved the access denied error message to be more human readable.
     (<a href="http://www.nabble.com/Trouble-in-logging-in-with-Subversion-td22473876.html">report</a>)
 </ul>
-<h3><a name=v1.291>What's new in 1.291</a> (2009/03/10)</h3>
+<h3 id=v1.291>What's new in 1.291</a> (2009/03/10)</h3>
 <ul class=image>
   <li class=bug>
     <code>api/xml?xpath=...&amp;wrapper=...</code> behaved inconsistently for results of size 0 or 1.
@@ -8041,7 +8041,7 @@ title: Changelog Archives
     Recover gracefully from failing to load winp.
     (<a href="http://www.nabble.com/Unable-to-load-winp.dll-td22423157.html">report</a>)
 </ul>
-<h3><a name=v1.290>What's new in 1.290</a> (2009/03/06)</h3>
+<h3 id=v1.290>What's new in 1.290</a> (2009/03/06)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in 1.286 that broke findbugs and other plugins.
@@ -8060,7 +8060,7 @@ title: Changelog Archives
     detect failures in the master.
     (from IRC)
 </ul>
-<h3><a name=v1.289>What's new in 1.289</a> (2009/03/05)</h3>
+<h3 id=v1.289>What's new in 1.289</a> (2009/03/05)</h3>
 <ul class=image>
   <li class='major bug'>
     Could not run <code>java -jar hudson.war</code> using JDK 5.
@@ -8095,7 +8095,7 @@ title: Changelog Archives
     Automatically lookup email addresses in LDAP when LDAP authentication is used
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1475">issue 1475</a>)
 </ul>
-<h3><a name=v1.288>What's new in 1.288</a> (2009/03/03)</h3>
+<h3 id=v1.288>What's new in 1.288</a> (2009/03/03)</h3>
 <ul class=image>
   <li class='major bug'>
     The project-based security configuration didn't survive the configuration roundtrip since 1.284.
@@ -8111,7 +8111,7 @@ title: Changelog Archives
     Builds blocked by the shut-down process now reports its status accordingly.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=3152">issue 3152</a>)
 </ul>
-<h3><a name=v1.287>What's new in 1.287</a> (2009/02/27)</h3>
+<h3 id=v1.287>What's new in 1.287</a> (2009/02/27)</h3>
 <ul class=image>
   <li class=bug>
     Custom widgets were not rendered.
@@ -8129,7 +8129,7 @@ title: Changelog Archives
     Switched to Groovy 1.6.0, and did so in a way that avoids some of the library conflicts, such as asm.
     (<a href="http://www.nabble.com/Hudson-library-dependency-to-asm-2.2-td22233542.html">report</a>)
 </ul>
-<h3><a name=v1.286>What's new in 1.286</a> (2009/02/26)</h3>
+<h3 id=v1.286>What's new in 1.286</a> (2009/02/26)</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE in Pipe.EOF(0)
@@ -8163,7 +8163,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Internal restructuring for reducing singleton dependencies and automatic <tt>Descriptor</tt> discovery.
 </ul>
-<h3><a name=v1.285>What's new in 1.285</a> (2009/02/19)</h3>
+<h3 id=v1.285>What's new in 1.285</a> (2009/02/19)</h3>
 <ul class=image>
   <li class='major bug'>
     Build parameter settings are lost when you save the configuration. Regression since 1.284.
@@ -8186,7 +8186,7 @@ title: Changelog Archives
     Better CVS polling support - Trigger a build for changes in certain regions.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=3123">issue 3123</a>)
 </ul>
-<h3><a name=v1.284>What's new in 1.284</a> (2009/02/17)</h3>
+<h3 id=v1.284>What's new in 1.284</a> (2009/02/17)</h3>
 <ul class=image>
   <li class='major bug'>
     <tt>ProcessTreeKiller</tt> was not working on 64bit Windows, Windows 2000, and other minor platforms
@@ -8212,7 +8212,7 @@ title: Changelog Archives
     Suppress more pointless error messages in Winstone when clients cut the connection in the middle.
     (<a href="http://www.nabble.com/javax.servlet.%2CServletException-td22002253.html">report</a>)
 </ul>
-<h3><a name=v1.283>What's new in 1.283</a></h3>
+<h3 id=v1.283>What's new in 1.283</a></h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a concurrent build problem in the parallel parameterized build.
@@ -8245,7 +8245,7 @@ title: Changelog Archives
     the stability of the cluster.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2729">issue 2729</a>)
 </ul>
-<h3><a name=v1.282>What's new in 1.282</a> (2009/02/08)</h3>
+<h3 id=v1.282>What's new in 1.282</a> (2009/02/08)</h3>
 <ul class=image>
   <li class=bug>
     Matrix security username/groupname validation required admin permission even in project-specific permissions
@@ -8266,7 +8266,7 @@ title: Changelog Archives
   <li class='major rfe'>
     
 </ul>
-<h3><a name=v1.281>What's new in 1.281</a> (2009/02/05)</h3>
+<h3 id=v1.281>What's new in 1.281</a> (2009/02/05)</h3>
 <ul class=image>
   <li class='major bug'>
     Remote API access to test results was broken since 1.272.
@@ -8283,7 +8283,7 @@ title: Changelog Archives
     Remote API supports stdout/stderr from test reports.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2760">issue 2760</a>)
 </ul>
-<h3><a name=v1.280>What's new in 1.280</a> (2009/02/01)</h3>
+<h3 id=v1.280>What's new in 1.280</a> (2009/02/01)</h3>
 <ul class=image>
   <li class=bug>
     Fixed unnecessary builds triggered by SVN polling
@@ -8299,7 +8299,7 @@ title: Changelog Archives
   <li class=rfe>
     Added an extension point to manipulate <tt>Launcher</tt> used during a build.
 </ul>
-<h3><a name=v1.279>What's new in 1.279</a> (2009/01/28)</h3>
+<h3 id=v1.279>What's new in 1.279</a> (2009/01/28)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a security related regression in 1.278 where authorized users won't get access to the system. 
@@ -8320,7 +8320,7 @@ title: Changelog Archives
     Plugins can now add a new column to the list view.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2862">issue 2862</a>)
 </ul>
-<h3><a name=v1.278>What's new in 1.278</a> (2009/01/23)</h3>
+<h3 id=v1.278>What's new in 1.278</a> (2009/01/23)</h3>
 <ul class=image>
   <li class=bug>
     The "administer" permission should allow a person to do everything.
@@ -8337,7 +8337,7 @@ title: Changelog Archives
     Create "lastStable" symlink on the file system to point to the applicable build.
     (<a href="http://www.nabble.com/lastStable-link-td21582859.html">report</a>)
 </ul>
-<h3><a name=v1.277>What's new in 1.277</a> (2009/01/20)</h3>
+<h3 id=v1.277>What's new in 1.277</a> (2009/01/20)</h3>
 <ul class=image>
   <li class=bug>
     "Installing slave as Windows service" feature was broken since 1.272
@@ -8355,7 +8355,7 @@ title: Changelog Archives
     With the <tt>--logfile==/path/to/logfile</tt> option, Hudson now reacts <tt>SIGALRM</tt> and reopen the log file.
     This makes Hudson behave nicely wrt log rotation.
 </ul>
-<h3><a name=v1.276>What's new in 1.276</a> (2009/01/16)</h3>
+<h3 id=v1.276>What's new in 1.276</a> (2009/01/16)</h3>
 <ul class=image>
   <li class='major bug'>
     Ok button on New View page was always disabled when not using project-specific permissions.
@@ -8372,7 +8372,7 @@ title: Changelog Archives
   <li class=rfe>
     If a build has no change, e-mail shouldn't link to the empty changeset page.
 </ul>
-<h3><a name=v1.275>What's new in 1.275</a> (2009/01/15)</h3>
+<h3 id=v1.275>What's new in 1.275</a> (2009/01/15)</h3>
 <ul class=image>
   <li class=bug>
     Display of short time durations failed on locales with comma as fraction separator.
@@ -8390,7 +8390,7 @@ title: Changelog Archives
     Debian package now has the <tt>RUN_STANDALONE</tt> switch to control if hudson should be run as a daemon.
     (<a href="http://www.nabble.com/Debian-repo-tt21467102.html">report</a>)
 </ul>
-<h3><a name=v1.274>What's new in 1.274</a> (2009/01/12)</h3>
+<h3 id=v1.274>What's new in 1.274</a> (2009/01/12)</h3>
 <ul class=image>
   <li class=bug>
     Failure to compute Subversion changelog should result in a build failure.
@@ -8407,7 +8407,7 @@ title: Changelog Archives
   <li class=rfe>
     On Unix, Hudson will contain symlinks from build numbers to their corresponding build directories.
 </ul>
-<h3><a name=v1.273>What's new in 1.273</a> (2009/01/11)</h3>
+<h3 id=v1.273>What's new in 1.273</a> (2009/01/11)</h3>
 <ul class=image>
   <li class=bug>
     Load statistics chart had the blue line and the red line swapped.
@@ -8425,7 +8425,7 @@ title: Changelog Archives
     Added <tt>AdministrativeMonitor</tt> extension point for improving the autonomous monitoring
     of the system in Hudson.
 </ul>
-<h3><a name=v1.272>What's new in 1.272</a> (2009/01/10)</h3>
+<h3 id=v1.272>What's new in 1.272</a> (2009/01/10)</h3>
 <ul class=image>
   <li class=bug>
     Sometimes multi-line input field is not properly rendered as a text area.
@@ -8450,7 +8450,7 @@ title: Changelog Archives
     Remote XML API now suports the 'exclude' query parameter to remove nodes that match the specified XPath.
     (<a href="http://d.hatena.ne.jp/masanobuimai/20090109#1231507972">report</a>)
 </ul>
-<h3><a name=v1.271>What's new in 1.271</a> (2009/01/09)</h3>
+<h3 id=v1.271>What's new in 1.271</a> (2009/01/09)</h3>
 <ul class=image>
   <li class=bug>
     Fix URLs in junit test reports to handle some special characters.
@@ -8472,7 +8472,7 @@ title: Changelog Archives
     Added cloud support and internal restructuring to deal with this change. Note that a plugin is required to use
     any particular cloud implementation.
 </ul>
-<h3><a name=v1.270>What's new in 1.270</a> (2009/01/05)</h3>
+<h3 id=v1.270>What's new in 1.270</a> (2009/01/05)</h3>
 <ul class=image>
   <li class=bug>
     Hudson version number was not shown at bottom of pages since 1.269.
@@ -8495,7 +8495,7 @@ title: Changelog Archives
     Subversion polling didn't notice when you change your project configuration.
     (<a href="http://www.nabble.com/Proper-way-to-switch---relocate-SVN-tree---tt21173306.html">report</a>)
 </ul>
-<h3><a name=v1.269>What's new in 1.269</a> (2009/01/05)</h3>
+<h3 id=v1.269>What's new in 1.269</a> (2009/01/05)</h3>
 <ul class=image>
   <li class=bug>
     Manually making a Maven project as upstream and free-style project as a downstream wasn't working.
@@ -8529,7 +8529,7 @@ title: Changelog Archives
     Views are now extensible and can be contributed by plugins.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=234">issue 234</a>)
 </ul>
-<h3><a name=v1.268>What's new in 1.268</a> (2008/12/28)</h3>
+<h3 id=v1.268>What's new in 1.268</a> (2008/12/28)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in Subversion http check out over HTTP 1.0 server.
@@ -8541,7 +8541,7 @@ title: Changelog Archives
     Some plugins cause NPE in the form validation of the config screen since 1.267.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2771">issue 2771</a>)
 </ul>
-<h3><a name=v1.267>What's new in 1.267</a> (2008/12/24)</h3>
+<h3 id=v1.267>What's new in 1.267</a> (2008/12/24)</h3>
 <ul class=image>
   <li class=bug>
     If a view name or job name contains whitespace, the navigation bar doesn't show the current positions correctly.
@@ -8566,7 +8566,7 @@ title: Changelog Archives
     Working around <tt>HttpServletResponse.sendRedirect()</tt> problem in WebSphere.
     (<a href="http://www.nabble.com/Hudson%3A-1.262%3A-Broken-link-using-update-manager-td21067157.html">report</a>)
 </ul>
-<h3><a name=v1.266>What's new in 1.266</a> (2008/12/19)</h3>
+<h3 id=v1.266>What's new in 1.266</a> (2008/12/19)</h3>
 <ul class=image>
   <li class=bug>
     If there was no successful build, test result trend wasn't displayed.
@@ -8587,7 +8587,7 @@ title: Changelog Archives
   <li class=rfe>
     Improved accessibility for visually handicapped.
 </ul>
-<h3><a name=v1.265>What's new in 1.265</a> (2008/12/17)</h3>
+<h3 id=v1.265>What's new in 1.265</a> (2008/12/17)</h3>
 <ul class=image>
   <li class=bug>
     PluginWrapper.getLongName() always returned short name because it uses wrong property name. (<a href="http://www.nabble.com/Inconsistent-use-of-Long-Name-property-in-plugin-manifest.mf-to21041905.html">discussion</a>)
@@ -8616,7 +8616,7 @@ title: Changelog Archives
     In project-based matrix security, global setting should be inherited to per-job setting.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2186">issue 2186</a>)
 </ul>
-<h3><a name=v1.264>What's new in 1.264</a> (2008/12/16)</h3>
+<h3 id=v1.264>What's new in 1.264</a> (2008/12/16)</h3>
 <ul class=image>
   <li class=bug>
     Hudson reportedly used to invoke Java plugin unnecessarily. This is fixed.
@@ -8633,7 +8633,7 @@ title: Changelog Archives
   <li class=rfe>
     Can now append <code>/*plain*</code> to directory browsing in the workspace to get a plain-text dir listing.
 </ul>
-<h3><a name=v1.263>What's new in 1.263</a> (2008/12/11)</h3>
+<h3 id=v1.263>What's new in 1.263</a> (2008/12/11)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a problem in handling of '\' introduced in 1.260.
@@ -8655,7 +8655,7 @@ title: Changelog Archives
   <li class=rfe>
     XPath matching numbers and booleans in the remote API will render text/plain, instead of error.
 </ul>
-<h3><a name=v1.262>What's new in 1.262</a> (2008/11/14)</h3>
+<h3 id=v1.262>What's new in 1.262</a> (2008/11/14)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a Java6 dependency crept in in 1.261.
@@ -8673,7 +8673,7 @@ title: Changelog Archives
     Maven builder has the advanced section in the freestyle job, just like Ant builder.
     (<a href="http://ml.seasar.org/archives/operation/2008-November/004003.html">report</a>)
 </ul>
-<h3><a name=v1.261>What's new in 1.261</a> (2008/11/11)</h3>
+<h3 id=v1.261>What's new in 1.261</a> (2008/11/11)</h3>
 <ul class=image>
   <li class=bug>
     Using Maven inside a matrix project, axes were not expanded in the maven command line.
@@ -8690,7 +8690,7 @@ title: Changelog Archives
   <li class=rfe>
     If a build appears to be hanging for too long, Hudson turns the progress bar to red.
 </ul>
-<h3><a name=v1.260>What's new in 1.260</a> (2008/11/05)</h3>
+<h3 id=v1.260>What's new in 1.260</a> (2008/11/05)</h3>
 <ul class=image>
   <li class=bug>
     Fixed tokenization handling in command line that involves quotes (like <tt>-Dabc="abc def"</tt>
@@ -8709,7 +8709,7 @@ title: Changelog Archives
     Improved error diagnostics when a temp file creation failed.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2587">issue 2587</a>)
 </ul>
-<h3><a name=v1.259>What's new in 1.259</a> (2008/11/03)</h3>
+<h3 id=v1.259>What's new in 1.259</a> (2008/11/03)</h3>
 <ul class=image>
   <li class=bug>
     If a job is cancelled while it's already in the queue, remove the job from the queue.
@@ -8729,7 +8729,7 @@ title: Changelog Archives
     Bundled StAX implementation so that plugins would have easier time using it.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2547">issue 2547</a>)
 </ul>
-<h3><a name=v1.258>What's new in 1.258</a> (2008/10/30)</h3>
+<h3 id=v1.258>What's new in 1.258</a> (2008/10/30)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a class incompatibility introduced in 1.257 that breaks TFS and ClearCase plugins.
@@ -8738,7 +8738,7 @@ title: Changelog Archives
     Fixed a NPE when dealing with broken <tt>Action</tt> implementations.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2527">issue 2527</a>)
 </ul>
-<h3><a name=v1.257>What's new in 1.257</a> (2008/10/28)</h3>
+<h3 id=v1.257>What's new in 1.257</a> (2008/10/28)</h3>
 <ul class=image>
   <li class=bug>
     Fixed an encoding issue when the master and a slave use incompatible encodings.
@@ -8754,7 +8754,7 @@ title: Changelog Archives
   <li class=rfe>
     Expanded the remote API to disable/enable jobs remotely.
 </ul>
-<h3><a name=v1.256>What's new in 1.256</a> (2008/10/24)</h3>
+<h3 id=v1.256>What's new in 1.256</a> (2008/10/24)</h3>
 <ul class=image>
   <li class=bug>
     Hudson had two <tt>dom4j.jar</tt> that was causing a VerifyError in WebSphere.
@@ -8769,7 +8769,7 @@ title: Changelog Archives
     Automatic dependency management for Maven projects can be now disabled.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1714">issue 1714</a>)
 </ul>
-<h3><a name=v1.255>What's new in 1.255</a> (2008/10/01)</h3>
+<h3 id=v1.255>What's new in 1.255</a> (2008/10/01)</h3>
 <ul class=image>
   <li class=bug>
     Project-level ACL matrix shouldn't display "CREATE" permission.
@@ -8785,7 +8785,7 @@ title: Changelog Archives
   <li class=rfe>
     Hudson slave launched from JNLP is now capable of installing itself as a Windows service.
 </ul>
-<h3><a name=v1.254>What's new in 1.254</a> (2008/09/26)</h3>
+<h3 id=v1.254>What's new in 1.254</a> (2008/09/26)</h3>
 <ul class=image>
   <li class=bug>
     IllegalArgumentException in DeferredCreationLdapAuthoritiesPopulator if groupSearchBase is omitted.
@@ -8799,7 +8799,7 @@ title: Changelog Archives
     Improved the diagnostics of why Hudson needs to do a fresh check out.
     (<a href="http://www.nabble.com/Same-job-gets-rescheduled-again-and-again-td19662648.html">report</a>)
 </ul>
-<h3><a name=v1.253>What's new in 1.253</a> (2008/09/24)</h3>
+<h3 id=v1.253>What's new in 1.253</a> (2008/09/24)</h3>
 <ul class=image>
   <li class=bug>
     Fixed FormFieldValidator check for Windows path
@@ -8850,7 +8850,7 @@ title: Changelog Archives
   <li class=rfe>
     Improved the robustness of the loading of persisted records to simplify plugin evolution.
 </ul>
-<h3><a name=v1.252>What's new in 1.252</a> (2008/09/02)</h3>
+<h3 id=v1.252>What's new in 1.252</a> (2008/09/02)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a queue persistence problem where sometimes executors die with NPEs.
@@ -8867,13 +8867,13 @@ title: Changelog Archives
     Subversion SCM enhancement for allowing parametric builds on Tags and Branches.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2298">issue 2298</a>)
 </ul>
-<h3><a name=v1.251>What's new in 1.251</a> (2008/08/22)</h3>
+<h3 id=v1.251>What's new in 1.251</a> (2008/08/22)</h3>
 <ul class=image>
   <li class='major bug'>
     JavaScript error in the system configuration prevents a form submission.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2260">issue 2260</a>)
 </ul>
-<a name=v1.250><h3>What's new in 1.250</h3></a>
+<h3 id=v1.250>What's new in 1.250</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE in the workspace clean up thread when the slave is offline.
@@ -8888,7 +8888,7 @@ title: Changelog Archives
     Added LDAPS support
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1445">issue 1445</a>)
 </ul>
-<a name=v1.249><h3>What's new in 1.249</h3></a>
+<h3 id=v1.249>What's new in 1.249</h3>
 <ul class=image>
   <li class=bug>
     JNLP slave agent fails to launch when the anonymous user doesn't have a read access.
@@ -8904,7 +8904,7 @@ title: Changelog Archives
   <li class=rfe>
     Intorduced a mechanism to perform a bulk change to improve performance (and in preparation of version controlling config files)
 </ul>
-<a name=v1.248><h3>What's new in 1.248</h3></a>
+<h3 id=v1.248>What's new in 1.248</h3>
 <ul class=image>
   <li class=bug>
     Update center was failing to handle SNAPSHOTs correctly.
@@ -8915,7 +8915,7 @@ title: Changelog Archives
   <li class=rfe>
     Added an ability to manually wipe out the workspace.
 </ul>
-<a name=v1.247><h3>What's new in 1.247</h3></a>
+<h3 id=v1.247>What's new in 1.247</h3>
 <ul class=image>
   <li class=bug>
     Don't repeat the same "No suitable implementation found" error again and again in the log.
@@ -8936,13 +8936,13 @@ title: Changelog Archives
     Detect the updates to <tt>hudson.war</tt> and report it.
     (<a href="http://www.nabble.com/Re%3A-Bugzilla-plugin-1.1-released-p18683781.html">discussion</a>)
 </ul>
-<a name=v1.245><h3>What's new in 1.245</h3></a>
+<h3 id=v1.245>What's new in 1.245</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression introduced in 1.244 that causes NPE in Ant.perform()
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2177">issue 2177</a>)
 </ul>
-<a name=v1.244><h3>What's new in 1.244</h3></a>
+<h3 id=v1.244>What's new in 1.244</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug with "mvn assembly:directory" in the native m2 job type.
@@ -8963,7 +8963,7 @@ title: Changelog Archives
     Recover from corrupted fingerprint records in certain cases.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2012">issue 2012</a>)
 </ul>
-<a name=v1.243><h3>What's new in 1.243</h3></a>
+<h3 id=v1.243>What's new in 1.243</h3>
 <ul class=image>
   <li class=rfe>
     Launch Maven in the non-interactive mode.
@@ -8979,7 +8979,7 @@ title: Changelog Archives
   <li class=rfe>
     Monitor the response time of slaves and cut unresponsive ones out.
 </ul>
-<a name=v1.242><h3>What's new in 1.242</h3></a>
+<h3 id=v1.242>What's new in 1.242</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a problem where not configuring Ant or Maven causes the global configuration submission to fail.
@@ -8989,7 +8989,7 @@ title: Changelog Archives
     Fixed NPE in SVNKit.
     (<a href="http://www.nabble.com/Hudson-1.240-and-checking-out-Hudson-subversion-repository-throws-NullPointerException-td18764732.html">report</a>)
 </ul>
-<a name=v1.241><h3>What's new in 1.241</h3></a>
+<h3 id=v1.241>What's new in 1.241</h3>
 <ul class=image>
     <li class='major bug'>
       Fixed a data loss problem in Ant/Maven/etc global configuration when submitting a form.
@@ -9002,7 +9002,7 @@ title: Changelog Archives
       (<a href="http://www.nabble.com/Hudson-1.238-cannot-load-some-job-td18737135.html">report</a>,
        <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2140">issue 2140</a>)
 </ul>
-<a name=v1.240><h3>What's new in 1.240</h3></a>
+<h3 id=v1.240>What's new in 1.240</h3>
 <ul class=image>
   <li class='major bug'>
     <strike>Fixed a bug that prevented the matrix build job from loading correctly</strike>.
@@ -9011,7 +9011,7 @@ title: Changelog Archives
     Fixed a suspected NPE in <tt>View.java:172</tt>
     (<a href="http://www.nabble.com/Upgrade-hudson-1.34-to-1.38-corrupted-several-projects-td18737778.html">report</a>)
 </ul>
-<a name=v1.239><h3>What's new in 1.239</h3></a>
+<h3 id=v1.239>What's new in 1.239</h3>
 <ul class=image>
   <li class=bug>
     Fixed a JavaScript error in project-based matrix security.
@@ -9027,7 +9027,7 @@ title: Changelog Archives
     Corrupted JUnit reports no longer cause a fatal problem.
     (<a href="http://www.nabble.com/Better-error-reporting-for-failed-builds-td18531504.html#a18531504">discussion</a>)
 </ul>
-<a name=v1.238><h3>What's new in 1.238</h3></a>
+<h3 id=v1.238>What's new in 1.238</h3>
 <ul class=image>
   <li class=bug>
     If forked Maven fails to start normally in the native m2 job type, Hudson was hanging.
@@ -9054,7 +9054,7 @@ title: Changelog Archives
     Brought in SVNKit 1.2.0-beta-2 to support svn:// access to Subversion 1.5 server.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1856">issue 1856</a>)
 </ul>
-<a name=v1.237><h3>What's new in 1.237</h3></a>
+<h3 id=v1.237>What's new in 1.237</h3>
 <ul class=image>
   <li class=bug>
     Fixed a possible NPE in parallel module builds in Maven.{noformat}
@@ -9087,7 +9087,7 @@ title: Changelog Archives
     Builds can now take user-defined parameters given at the build schedule time.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1914">issue 1914</a>)
 </ul>
-<a name=v1.236><h3>What's new in 1.236</h3></a>
+<h3 id=v1.236>What's new in 1.236</h3>
 <ul class=image>
   <li class=bug>
     API .../computer/api/xml wasn't working.
@@ -9108,7 +9108,7 @@ title: Changelog Archives
     Extract the war file by default inside <tt>HUDSON_HOME</tt> by default.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2098">issue 2098</a>)
 </ul>
-<a name=v1.235><h3>What's new in 1.235</h3></a>
+<h3 id=v1.235>What's new in 1.235</h3>
 <ul class=image>
   <li class=bug>
     Read <tt>$M2_HOME/conf/setting.xml</tt> when doing Maven related things.
@@ -9123,7 +9123,7 @@ title: Changelog Archives
     Build history graph now shows unstable and aborted builds in proper color
     (<a href="http://www.nabble.com/Idea-for-new-plugin-td18391367.html">discussion</a>)
 </ul>
-<a name=v1.234><h3>What's new in 1.234</h3></a>
+<h3 id=v1.234>What's new in 1.234</h3>
 <ul class=image>
   <li class=bug>
     Fixed a concurrency issue around <tt>SimpleDateFormat</tt>. This manifests itself in many strange ways
@@ -9138,7 +9138,7 @@ title: Changelog Archives
     Update center accepts HTTP proxy username/password.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1833">issue 1833</a>)
 </ul>
-<a name=v1.233><h3>What's new in 1.233</h3></a>
+<h3 id=v1.233>What's new in 1.233</h3>
 <ul class=image>
   <li class='major bug'>
     Debug exception message crept in to the trunk code. Regression in 1.232.
@@ -9153,7 +9153,7 @@ title: Changelog Archives
     Take the clock difference between master and the slave into account when collecting test reports.
     (<a href="http://www.nabble.com/clock-difference---figuring-out-if-tests-results-are-new-or-old-td18319363.html">report</a>)
 </ul>
-<a name=v1.232><h3>What's new in 1.232</h3></a>
+<h3 id=v1.232>What's new in 1.232</h3>
 <ul class=image>
   <li class=bug>
     Fixed an interference between auto refresh and inline description editing.
@@ -9174,7 +9174,7 @@ title: Changelog Archives
     Executors are exposed to the remote API.
     (<a href="http://www.nabble.com/how-to-monitor-build-executors--tt18253458.html">report</a>)
 </ul>
-<a name=v1.231><h3>What's new in 1.231</h3></a>
+<h3 id=v1.231>What's new in 1.231</h3>
 <ul class=image>
   <li class=bug>
     <tt>Publisher.prebuild</tt> wasn't called for Maven builds.
@@ -9203,7 +9203,7 @@ title: Changelog Archives
     When the slave has less than 1GB available disk space, Hudson will automatically mark the node as temporarily offline.
     (<a href="http://www.nabble.com/builds-that-failed-because-of-space-constraints-tt18217298.html">discussion</a>)
 </ul>
-<a name=v1.230><h3>What's new in 1.230</h3></a>
+<h3 id=v1.230>What's new in 1.230</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in launching JNLP slaves when reverse proxy is involved.
@@ -9224,7 +9224,7 @@ title: Changelog Archives
   <li class=rfe>
     More progress in German translation.
 </ul>
-<a name=v1.229><h3>What's new in 1.229</h3></a>
+<h3 id=v1.229>What's new in 1.229</h3>
 <ul class=image>
   <li class='major bug'>
     Start-up "Hudson is preparing to work" screen doesn't render with <tt>AssertionFailure</tt>.
@@ -9233,7 +9233,7 @@ title: Changelog Archives
     Changing a job name to the same name with different case resulted in an error.
     (<a href="http://www.nabble.com/error-on-renaming-project-tt18061629.html">report</a>)
 </ul>
-<a name=v1.228><h3>What's new in 1.228</h3></a>
+<h3 id=v1.228>What's new in 1.228</h3>
 <ul class=image>
   <li class=bug>
     Plugin manager page wasn't hidden from anonymous users even when the security was enabled.
@@ -9265,7 +9265,7 @@ title: Changelog Archives
     Hudson checks if the container uses UTF-8 to decode URls.
 	(<a href="https://hudson.dev.java.net/servlets/ReadMsg?list=ja&msgNo=32">discussion</a>)
 </ul>
-<a name=v1.227><h3>What's new in 1.227</h3></a>
+<h3 id=v1.227>What's new in 1.227</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug in configuring repository browsers.
@@ -9286,7 +9286,7 @@ title: Changelog Archives
     Build queue is now exposed to the remote API.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1886">issue 1886</a>)
 </ul>
-<a name=v1.226><h3>What's new in 1.226</h3></a>
+<h3 id=v1.226>What's new in 1.226</h3>
 <ul class=image>
   <li class='major bug'>
     Anonymous user was able to modify user's description. This creates XSS vulnerability in Hudson.
@@ -9306,7 +9306,7 @@ title: Changelog Archives
     Hudson now performs environment variable expansions for commands to be launched, like shell does.
     (<a href="http://www.nabble.com/HUDSON_EXEC-exported-tt17135819.html">discussion</a>)
 </ul>
-<a name=v1.225><h3>What's new in 1.225</h3></a>
+<h3 id=v1.225>What's new in 1.225</h3>
 <ul class=image>
   <li class=bug>
     Fixed a leak in Winstone that can cause "ReqPool: Max requests in pool exceeded - denied"
@@ -9331,7 +9331,7 @@ title: Changelog Archives
     manually force update.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1849">issue 1849</a>)
 </ul>
-<a name=v1.224><h3>What's new in 1.224</h3></a>
+<h3 id=v1.224>What's new in 1.224</h3>
 <ul class=image>
   <li class=bug>
     "This is a tag, not a branch" option in CVS wasn't loaded in HTML page correctly,
@@ -9349,7 +9349,7 @@ title: Changelog Archives
     Re-implemented the proxy server support in the update center not to use system global properties.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1841">issue 1841</a>)
 </ul>
-<a name=v1.223><h3>What's new in 1.223</h3></a>
+<h3 id=v1.223>What's new in 1.223</h3>
 <ul class=image>
   <li class=bug>
     Users should be allowed to configure himself regardless of the permission setting.
@@ -9371,7 +9371,7 @@ title: Changelog Archives
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1044">issue 1044</a>,
      <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1282">issue 1282</a>)
 </ul>
-<a name=v1.222><h3>What's new in 1.222</h3></a>
+<h3 id=v1.222>What's new in 1.222</h3>
 <ul class=image>
   <li class=bug>
     A build in progress shouldn't be deletable.
@@ -9389,7 +9389,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Hudson now has an update center to simplify the installation of new plugins.
 </ul>
-<a name=v1.221><h3>What's new in 1.221</h3></a>
+<h3 id=v1.221>What's new in 1.221</h3>
 <ul class=image>
   <li class=bug>
     Some test result pages were incorrectly using absolute URLs.
@@ -9405,7 +9405,7 @@ title: Changelog Archives
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1762">issue 1762</a>,
      <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1772">issue 1772</a>)
 </ul>
-<a name=v1.220><h3>What's new in 1.220</h3></a>
+<h3 id=v1.220>What's new in 1.220</h3>
 <ul class=image>
   <li class=bug>
     Hudson added '/' to the menubar links incorrectly on some cases.
@@ -9433,7 +9433,7 @@ title: Changelog Archives
     Plugins can now contribute <tt>ServletFilter</tt>s
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1573">issue 1573</a>)
 </ul>
-<a name=v1.219><h3>What's new in 1.219</h3></a>
+<h3 id=v1.219>What's new in 1.219</h3>
 <ul class=image>
   <li class='major bug'>
     Hopefully fixed the hang issue with Windows &amp; Maven2 builds.
@@ -9456,7 +9456,7 @@ title: Changelog Archives
     Tagged builds now get a badge next to it, just like locked builds.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1730">issue 1730</a>)
 </ul>
-<a name=v1.218><h3>What's new in 1.218</h3></a>
+<h3 id=v1.218>What's new in 1.218</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE when launching a new slave.
@@ -9466,13 +9466,13 @@ title: Changelog Archives
     the system property <tt>hudson.master.headless</tt> to true.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1732">issue 1732</a>)
 </ul>
-<a name=v1.217><h3>What's new in 1.217</h3></a>
+<h3 id=v1.217>What's new in 1.217</h3>
 <ul class=image>
   <li class='major bug'>
     1.216 introduced a dependency to Java6
     <a href="http://www.nabble.com/Hudson-1.216---1.215-regression-issue-to17354559.html">report</a>
 </ul>
-<a name=v1.216><h3>What's new in 1.216</h3></a>
+<h3 id=v1.216>What's new in 1.216</h3>
 <ul class=image>
   <li class=bug>
     Fixed a problem where Hudson CVS polling with CVSNT and pserver detects a phantom changes.
@@ -9504,7 +9504,7 @@ title: Changelog Archives
     Configuration of the executors is split out from system configuration.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1632">issue 1632</a>)
 </ul>
-<a name=v1.215><h3>What's new in 1.215</h3></a>
+<h3 id=v1.215>What's new in 1.215</h3>
 <ul class=image>
   <li class='major bug'>
     Slave configuration fails to persist.
@@ -9518,7 +9518,7 @@ title: Changelog Archives
     Hudson now accepts SSH private key in the PuTTY's .ppk file format.
     (<a href="http://www.nabble.com/Problems-on-checkout-polling-subversion-with-svn%2Bssh-tt17212401.html">discussion</a>)
 </ul>
-<a name=v1.214><h3>What's new in 1.214</h3></a>
+<h3 id=v1.214>What's new in 1.214</h3>
 <ul class=image>
   <li class='major bug'>
     After-the-fact deployment of artifacts stopped working since 1.212.
@@ -9541,7 +9541,7 @@ title: Changelog Archives
     Supported HTTP DELETE method on job top page to delete it.
     (<a href="http://www.nabble.com/how-are-you-using-Hudson-for-non-Java-projects--to17145574.html#a17154167">discussion</a>)
 </ul>
-<a name=v1.213><h3>What's new in 1.213</h3></a>
+<h3 id=v1.213>What's new in 1.213</h3>
 <ul class=image>
   <li class=bug>
     Auto refresh should be disabled on plugin management page and the SVN credential dialog.
@@ -9563,7 +9563,7 @@ title: Changelog Archives
     Added View workspace permission to the matrix-based security.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=434">issue 434</a>)
 </ul>
-<a name=v1.212><h3>What's new in 1.212</h3></a>
+<h3 id=v1.212>What's new in 1.212</h3>
 <ul class=image>
   <li class=bug>
     Starting this version, Hudson no longer installs remotely built Maven artifacts
@@ -9586,7 +9586,7 @@ title: Changelog Archives
     Improved error diagnostics when the incorrect path to M2 is specified for the native m2 job type.
     (<a href="http://www.nabble.com/Default-Maven-Version-for-Distributed-Builds-td16854956.html">report</a>)
 </ul>
-<a name=v1.211><h3>What's new in 1.211</h3></a>
+<h3 id=v1.211>What's new in 1.211</h3>
 <ul class=image>
   <li class=bug>
     Hudson disables a project with Subversion too eagerly, when the user makes a mistake in the SVN URL.
@@ -9601,7 +9601,7 @@ title: Changelog Archives
     Hudson can now handle optional dependencies to other plugins.
     (<a href="http://www.nabble.com/Optional-dependencies-between-plugins-td16799403.html">report</a>)
 </ul>
-<a name=v1.210><h3>What's new in 1.210</h3></a>
+<h3 id=v1.210>What's new in 1.210</h3>
 <ul class=image>
   <li class=bug>
     Hudson can now wipe out files in a directory even if the directory is not writable.
@@ -9618,7 +9618,7 @@ title: Changelog Archives
     Tokenization now handles quotes and escapes like Unix shell does.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1553">issue 1553</a>)
 </ul>
-<a name=v1.209><h3>What's new in 1.209</h3></a>
+<h3 id=v1.209>What's new in 1.209</h3>
 <ul class=image>
   <li class='major bug'>
     Internet Explorer fails to submit a form.
@@ -9633,7 +9633,7 @@ title: Changelog Archives
     <strike>Distributed builds and native Maven job types were not working with OC4J.</strike>
     (<a href="http://www.nabble.com/Hudson-on-OC4J-tt16702113.html">report</a>)
 </ul>
-<a name=v1.207><h3>What's new in 1.207</h3></a>
+<h3 id=v1.207>What's new in 1.207</h3>
 <ul class=image>
   <li class=bug>
     After-the-fact Maven deployment wasn't working for POM-only modules.
@@ -9651,7 +9651,7 @@ title: Changelog Archives
   <li class=rfe>
     The first cut of Dutch localization is now available, thanks to <a href="https://launchpad.net/~wim-rosseel">Wim Rosseel</a>
 </ul>
-<a name=v1.206><h3>What's new in 1.206</h3></a>
+<h3 id=v1.206>What's new in 1.206</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed NPE in the SCM polling.
@@ -9672,7 +9672,7 @@ title: Changelog Archives
     Don't display the login form when the access is denied
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1510">issue 1510</a>)
 </ul>
-<a name=v1.205><h3>What's new in 1.205</h3></a>
+<h3 id=v1.205>What's new in 1.205</h3>
 <ul class=image>
   <li class=bug>
     Individual Maven module build records should be kept if the project build record is kept.
@@ -9690,7 +9690,7 @@ title: Changelog Archives
   <li class=rfe>
     First version to be released from Subversion repository.
 </ul>
-<a name=v1.204><h3>What's new in 1.204</h3></a>
+<h3 id=v1.204>What's new in 1.204</h3>
 <ul class=image>
   <li class=bug>
     Remoting API now serves properly escaped URLs
@@ -9710,7 +9710,7 @@ title: Changelog Archives
     <strike>Remoting API now exposes information attached by plugins</strike>
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1473">issue 1473</a>)
 </ul>
-<a name=v1.203><h3>What's new in 1.203</h3></a>
+<h3 id=v1.203>What's new in 1.203</h3>
 <ul class=image>
   <li class=bug>
     CVS polling was not working if it's configured to pull a tag
@@ -9733,7 +9733,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements in Russian, Brazilian Portuguese and Japanese localization.
 </ul>
-<a name=v1.202><h3>What's new in 1.202</h3></a>
+<h3 id=v1.202>What's new in 1.202</h3>
 <ul class=image>
   <li class=bug>
     If all executors are busy, the queue status was not getting updated.
@@ -9748,7 +9748,7 @@ title: Changelog Archives
     Display why matrix configuration build is blocked.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1455">issue 1455</a>)
 </ul>
-<a name=v1.201><h3>What's new in 1.201</h3></a>
+<h3 id=v1.201>What's new in 1.201</h3>
 <ul class=image>
   <li class=bug>
     Renaming plugins from their original names no longer cause problems in plugins.
@@ -9768,7 +9768,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements in Russian, Brazilian Portuguese and French localization.
 </ul>
-<a name=v1.200><h3>What's new in 1.200</h3></a>
+<h3 id=v1.200>What's new in 1.200</h3>
 <ul class=image>
   <li class=bug>
     Allow plugins to register actions with absolute URLs.
@@ -9785,7 +9785,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements in Turkish localization
 </ul>
-<a name=v1.199><h3>What's new in 1.199</h3></a>
+<h3 id=v1.199>What's new in 1.199</h3>
 <ul class=image>
   <li class=bug>
     login error should result in 401 status code.
@@ -9807,7 +9807,7 @@ title: Changelog Archives
     Artifact listing now prints a part of path if that's necessary to disambiguate names
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1435">issue 1435</a>)
 </ul>
-<a name=v1.198><h3>What's new in 1.198</h3></a>
+<h3 id=v1.198>What's new in 1.198</h3>
 <ul class=image>
   <li class='major bug'>
     Native maven2 job types didn't work with Surefire &lt; 2.4
@@ -9826,7 +9826,7 @@ title: Changelog Archives
   <li class=rfe>
     Localizatoin improvements in Russian, Brazilian Portuguese, Japanese, and French.
 </ul>
-<a name=v1.197><h3>What's new in 1.197</h3></a>
+<h3 id=v1.197>What's new in 1.197</h3>
 <ul class=image>
   <li class='major bug'>
     NPE when loading TestNG reports in the maven2 jobs.
@@ -9851,7 +9851,7 @@ title: Changelog Archives
     Hudson now workarounds bugs in IBM JDK and WebSphere.
     (<a href="http://www.nabble.com/WAS---Hudson-tt16026561.html">discussion</a>)
 </ul>
-<a name=v1.196><h3>What's new in 1.196</h3></a>
+<h3 id=v1.196>What's new in 1.196</h3>
 <ul class=image>
   <li class=bug>
     Loss of workspace shouldn't result in a new build with Subversion.
@@ -9873,7 +9873,7 @@ title: Changelog Archives
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=490">issue 
 490</a>)
 </ul>
-<a name=v1.195><h3>What's new in 1.195</h3></a>
+<h3 id=v1.195>What's new in 1.195</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed <tt>IllegalArgumentException</tt> when trying to submit configuration for Matrix job
@@ -9897,7 +9897,7 @@ title: Changelog Archives
   <li class=rfe>
     More progress on Turkish localization.
 </ul>
-<a name=v1.194><h3>What's new in 1.194</h3></a>
+<h3 id=v1.194>What's new in 1.194</h3>
 <ul class=image>
   <li class=bug>
     Hudson occasionally incorrectly report "0 tests started to fail".
@@ -9918,14 +9918,14 @@ title: Changelog Archives
   <li class=rfe>
     Added an extension point for plugins to add icons to the "manage Hudson" page.
 </ul>
-<a name=v1.193><h3>What's new in 1.193</h3></a>
+<h3 id=v1.193>What's new in 1.193</h3>
 <ul class=image>
   <li class='major bug'>
     There was a data corruption issue when you submit configuration for freestyle jobs.
   <li class=rfe>
     Improvement in French and Turkish localization.
 </ul>
-<a name=v1.192><h3><strike>What's new in 1.192</strike> Please use 1.193</h3></a>
+<h3 id=v1.192><h3><strike>What's new in 1.192</strike> Please use 1.193</h3>
 <ul class=image>
   <li class=bug>
     Matrix configuration run shouldn't wait for the quiet period.
@@ -9945,7 +9945,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements to French and Brazilian Portuguese localization.
 </ul>
-<a name=v1.191><h3><strike>What's new in 1.191</strike> Please use 1.193</h3></a>
+<h3 id=v1.191><h3><strike>What's new in 1.191</strike> Please use 1.193</h3>
 <ul class=image>
   <li class=bug>
     When explicit downstream dependencies are configured, Maven2 jobs were scheduling them twice.
@@ -9967,7 +9967,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements to Japanese and Turkish localization.
 </ul>
-<a name=v1.190><h3>What's new in 1.190</h3></a>
+<h3 id=v1.190>What's new in 1.190</h3>
 <ul class=image>
   <li class=bug>
     Downstream triggering now happens "correctly" with the matrix job type
@@ -9989,7 +9989,7 @@ title: Changelog Archives
     Initial Turkish localization, thanks to O&#x011F;uz Da&#x011F;.
     (<a href="http://www.nabble.com/-Fwd%3A--Kohsuke-Kawaguchi%27s-Blog--New-Comment-Posted-to-%27Internationalization-of-Hudson-----Help-wanted%21%27--tt15879811.html">announcement</a>)
 </ul>
-<a name=v1.189><h3>What's new in 1.189</h3></a>
+<h3 id=v1.189>What's new in 1.189</h3>
 <ul class=image>
   <li class=bug>
     Fixed bug in collecting of TestNG test results in Maven projects.
@@ -10005,7 +10005,7 @@ title: Changelog Archives
     Initial Russian translation contributed by Mike Salnikov
     (<a href="http://www.nabble.com/Russian-i18n-tt15867581.html">announcement</a>)
 </ul>
-<a name=v1.188><h3>What's new in 1.188</h3></a>
+<h3 id=v1.188>What's new in 1.188</h3>
 <ul class=image>
   <li class=bug>
     The "perform the build once to parse POM" message needed to have zero-delay query parameter.
@@ -10022,7 +10022,7 @@ title: Changelog Archives
     A node and a view now have its own aggregated build history view.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1174">issue 1174</a>)
 </ul>
-<a name=v1.187><h3>What's new in 1.187</h3></a>
+<h3 id=v1.187>What's new in 1.187</h3>
 <ul class=image>
   <li class=bug>
     Fixed bug in displaying the password field on a user page when using Hudson's own user database.
@@ -10037,7 +10037,7 @@ title: Changelog Archives
   <li class=rfe>
     German translation is making more progress.
 </ul>
-<a name=v1.186><h3>What's new in 1.186</h3></a>
+<h3 id=v1.186>What's new in 1.186</h3>
 <ul class=image>
   <li class=bug>
     Build descriptions edited in the UI were not persisted correctly.
@@ -10061,7 +10061,7 @@ title: Changelog Archives
     Error diagnosis is improved when two Hudson instances collide on each other on the same data directory
     (<a href="http://www.nabble.com/Re%3A-%22multiple-versions-installed%22-error.-tt15663750.html#a15663750">report</a>)
 </ul>
-<a name=v1.185><h3>What's new in 1.185</h3></a>
+<h3 id=v1.185>What's new in 1.185</h3>
 <ul class=image>
   <li class=bug>
     Builds are now run with the proper security privileges to do the work.
@@ -10074,7 +10074,7 @@ title: Changelog Archives
     German translation is started and is making a good progress, thanks to
     <a href="http://www.dr-wiest.com/">Simon Wiest</a>.
 </ul>
-<a name=v1.184><h3>What's new in 1.184</h3></a>
+<h3 id=v1.184>What's new in 1.184</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where build dependencies in the native m2 job type may create
@@ -10087,7 +10087,7 @@ title: Changelog Archives
     External job monitoring now avoids buffering the entire output on memory.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1283">issue 1283</a>)
 </ul>
-<a name=v1.183><h3>What's new in 1.183</h3></a>
+<h3 id=v1.183>What's new in 1.183</h3>
 <ul class=image>
   <li class=bug>
     Some form field validation errors were incorrectly reported as warnings.
@@ -10107,7 +10107,7 @@ title: Changelog Archives
     "Build now" really builds now, without any delay.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=356">issue 356</a>)
 </ul>
-<a name=v1.182><h3>What's new in 1.182</h3></a>
+<h3 id=v1.182>What's new in 1.182</h3>
 <ul class=image>
   <li class='major bug'>
     removed <tt>MSVCR90.DLL</tt> dependency on Windows when trying to abort builds.
@@ -10119,7 +10119,7 @@ title: Changelog Archives
     Fixed a bug in parsing TestNG report files.
     (<a href="http://www.nabble.com/Problems-with-testng-failed-test-parsing-tp15146287p15146287.html">report</a>)
 </ul>
-<a name=v1.181><h3>What's new in 1.181</h3></a>
+<h3 id=v1.181>What's new in 1.181</h3>
 <ul class=image>
   <li class=bug>
     If the CVS configuration is changed, polling should notice and start tracking the new location.
@@ -10146,7 +10146,7 @@ title: Changelog Archives
     When aborting a build on Windows, Hudson now terminates child processes recursively.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1245">issue 1245</a>)
 </ul>
-<a name=v1.180><h3>What's new in 1.180</h3></a>
+<h3 id=v1.180>What's new in 1.180</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the Windows/Unix handling logic when a file path includes ':' in Unix.
@@ -10168,7 +10168,7 @@ title: Changelog Archives
     Improved the form validation heuristics in the file mask check.
     (<a href="http://www.nabble.com/No-artifacts-found-for-matrix-project-tt15210002.html">report</a>)
 </ul>
-<a name=v1.179><h3>What's new in 1.179</h3></a>
+<h3 id=v1.179>What's new in 1.179</h3>
 <ul class=image>
   <li class='major bug'>
     JNLP slave agents stopped working since 1.175.
@@ -10183,7 +10183,7 @@ title: Changelog Archives
     Changed code so that plugins can never inadvertently update build timestamps.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1084">issue 1084</a>)
 </ul>
-<a name=v1.178><h3>What's new in 1.178</h3></a>
+<h3 id=v1.178>What's new in 1.178</h3>
 <ul class=image>
   <li class=bug>
     Skipped tests (TestNG) are no longer treated as if they had passed.
@@ -10203,7 +10203,7 @@ title: Changelog Archives
   <li class="major rfe">
     <tt>Publisher</tt>s are now available to the native m2 job type.
 </ul>
-<a name=v1.177><h3>What's new in 1.177</h3></a>
+<h3 id=v1.177>What's new in 1.177</h3>
 <ul class=image>
   <li class=bug>
     Removed the extra '$' sign from the permalinks that have accidentally crept in.
@@ -10221,7 +10221,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a Subversion repository browser implementation for CollabNet-powered sites (these include Java.net, Tigris.org and BEA's dev2dev).
 </ul>
-<a name=v1.176><h3>What's new in 1.176</h3></a>
+<h3 id=v1.176>What's new in 1.176</h3>
 <ul class=image>
   <li class=bug>
     Fixed a regression in 1.175 with LDAP authentication
@@ -10239,7 +10239,7 @@ title: Changelog Archives
     Environment variable expansions now work in <tt>MAVEN_OPTS</tt> setting.
     (<a href="http://www.nabble.com/-patch--allow-M2-projects-to-use-environment-variables-in-options-tt15061026.html">report</a>)
 </ul>
-<a name=v1.175><h3>What's new in 1.175</h3></a>
+<h3 id=v1.175>What's new in 1.175</h3>
 <ul class=image>
   <li class=bug>
     Don't allow # of executors to be 0.
@@ -10253,7 +10253,7 @@ title: Changelog Archives
   <li class="rfe">
     Added a probe to the running Maven process to assist trouble-shooting.
 </ul>
-<a name=v1.174><h3>What's new in 1.174</h3></a>
+<h3 id=v1.174>What's new in 1.174</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE in the remote API job creation during error recovery.
@@ -10270,7 +10270,7 @@ title: Changelog Archives
   <li class=rfe>
     Removed pointless svn update line about directories.
 </ul>
-<a name=v1.173><h3>What's new in 1.173</h3></a>
+<h3 id=v1.173>What's new in 1.173</h3>
 <ul class=image>
   <li class=bug>
     Fixed an HTML rendering issue in the slave list page.
@@ -10291,7 +10291,7 @@ title: Changelog Archives
   <li class=rfe>
     When using Hudson's own user database, password can be now reset via the web UI.
 </ul>
-<a name=v1.172><h3>What's new in 1.172</h3></a>
+<h3 id=v1.172>What's new in 1.172</h3>
 <ul class=image>
   <li class=bug>
     Fixed a broken link in the help of "Hudson's own user database"
@@ -10318,7 +10318,7 @@ title: Changelog Archives
     Allowing plugins to extend the navigation menu on left hand side of the top page.
     (<a href="http://www.nabble.com/Hudson-Tray-Monitor-Application-tt14708070.html#a14708070">report</a>)
 </ul>
-<a name=v1.171><h3>What's new in 1.171</h3></a>
+<h3 id=v1.171>What's new in 1.171</h3>
 <ul class=image>
   <li class=bug>
     Fixed inconsistent use of button visual style.
@@ -10336,7 +10336,7 @@ title: Changelog Archives
     Build health report is now a part of the remote API.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1146">issue 1146</a>)
 </ul>
-<a name=v1.170><h3>What's new in 1.170</h3></a>
+<h3 id=v1.170>What's new in 1.170</h3>
 <ul class=image>
   <li class=bug>
     Fixed an assertion error in <tt>MavenModuleSetBuild$Builder.postModule</tt>
@@ -10354,7 +10354,7 @@ title: Changelog Archives
     Improved the maven2 build performance.
     (<a href="http://www.nabble.com/Maven-job-5-times-slower-than-a-free-style-job--td14651245.html">report</a>)
 </ul>
-<a name=v1.169><h3>What's new in 1.169</h3></a>
+<h3 id=v1.169>What's new in 1.169</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in redirection after successful login.
@@ -10372,7 +10372,7 @@ title: Changelog Archives
     Fixed a problem where the new view links were not correctly displayed even for users with sufficient permissions.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1157">issue 1157</a>)
 </ul>
-<a name=v1.168><h3>What's new in 1.168</h3></a>
+<h3 id=v1.168>What's new in 1.168</h3>
 <ul class=image>
   <li class=bug>
     Ensure sidebar links use correct hostname rather than localhost.
@@ -10390,7 +10390,7 @@ title: Changelog Archives
     In addition to "login" link, "sign up" link is now displayed whenever applicable.
     (<a href="http://www.nabble.com/New-Security-Setup-tt14740386.html">thread</a>)
 </ul>
-<a name=v1.167><h3>What's new in 1.167</h3></a>
+<h3 id=v1.167>What's new in 1.167</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where project actions the modules of for m2 projects were not visible until a hudson restart.
@@ -10409,7 +10409,7 @@ title: Changelog Archives
     the amount of data you receive in a single call.
     (<a href="http://www.nabble.com/hudson-portlet-tt14692803.html">report</a>)
 </ul>
-<a name=v1.166><h3>What's new in 1.166</h3></a>
+<h3 id=v1.166>What's new in 1.166</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where successful authentication still results in 403 after login under some configurations.
@@ -10426,7 +10426,7 @@ title: Changelog Archives
   <li class="major rfe">
     Added LDAP authentication support
 </ul>
-<a name=v1.165><h3>What's new in 1.165</h3></a>
+<h3 id=v1.165>What's new in 1.165</h3>
 <ul class=image>
   <li class='rfe'>
     Specifying XPath in the remote API that matches multiple nodes is now reported as an error.
@@ -10435,7 +10435,7 @@ title: Changelog Archives
     Fixed a bug where secured Hudson fails to authorize admins to access pages.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1118">issue 1118</a>)
 </ul>
-<a name=v1.164><h3>What's new in 1.164</h3></a>
+<h3 id=v1.164>What's new in 1.164</h3>
 <ul class=image>
   <li class=bug>
     Hudson has been failing to serve workspace files that ends with "jelly" extension.
@@ -10456,7 +10456,7 @@ title: Changelog Archives
     Implemented fine-grained security
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=326">issue 326</a>)
 </ul>
-<a name=v1.163><h3>What's new in 1.163</h3></a>
+<h3 id=v1.163>What's new in 1.163</h3>
 <ul class=image>
   <li class=bug>
     Fixed a possible loading problem for user information
@@ -10467,7 +10467,7 @@ title: Changelog Archives
     Added the remote API support for the people page.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1103">issue 1103</a>)
 </ul>
-<a name=v1.162><h3>What's new in 1.162</h3></a>
+<h3 id=v1.162>What's new in 1.162</h3>
 <ul class=image>
   <li class=bug>
     Fixed a problem where Hudson fails to find wagon implementations.
@@ -10485,7 +10485,7 @@ title: Changelog Archives
     Exposed user e-mail address to the XML/JSON API.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1108">issue 1108</a>)
 </ul>
-<a name=v1.161><h3>What's new in 1.161</h3></a>
+<h3 id=v1.161>What's new in 1.161</h3>
 <ul class=image>
   <li class=bug>
     Fixed the wrong time zone use in some HTTP headers.
@@ -10508,7 +10508,7 @@ title: Changelog Archives
     Implemented ASCII-only remote communication mode for binary-unsafe transport.
     (<a href="http://www.nabble.com/telnet-slave-to14216635.html">report</a>)
 </ul>
-<a name=v1.160><h3>What's new in 1.160</h3></a>
+<h3 id=v1.160>What's new in 1.160</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the HTML rendering of repository browsers.
@@ -10534,7 +10534,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a feature to test SMTP setting by sending out a trial e-mail.
 </ul>
-<a name=v1.159><h3>What's new in 1.159</h3></a>
+<h3 id=v1.159>What's new in 1.159</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the remoting layer that prevented plugins from contributing to the native m2 build process.
@@ -10553,13 +10553,13 @@ title: Changelog Archives
     JUnit report recorder now reports time it took to run tests.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=656">issue 656</a>)
 </ul>
-<a name=v1.158><h3>What's new in 1.158</h3></a>
+<h3 id=v1.158>What's new in 1.158</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where the submission of the matrix project configuration clobeers the on-going build.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=981">issue 981</a>)
 </ul>
-<a name=v1.157><h3>What's new in 1.157</h3></a>
+<h3 id=v1.157>What's new in 1.157</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in handling whitespace in ant properties on Windows.
@@ -10575,7 +10575,7 @@ title: Changelog Archives
   <li class=rfe>
     Added support for <a href="http://www.sventon.org">sventon</a> as a repsotory browser for Subversion.
 </ul>
-<a name=v1.156><h3>What's new in 1.156</h3></a>
+<h3 id=v1.156>What's new in 1.156</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where the submission of Hudson cofiguration loses MAVEN_HOME entries
@@ -10584,7 +10584,7 @@ title: Changelog Archives
     Added "Expires" header to prevent unwanted page-caching in Opera.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=869">issue 869</a>)
 </ul>
-<a name=v1.155><h3>What's new in 1.155</h3></a>
+<h3 id=v1.155>What's new in 1.155</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in Ant that causes an empty "-file" line.
@@ -10601,7 +10601,7 @@ title: Changelog Archives
   <li class="rfe">
     Added additional logging for the workspace clean-up thread.
 </ul>
-<a name=v1.154><h3>What's new in 1.154</h3></a>
+<h3 id=v1.154>What's new in 1.154</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>IllegalArgumentException</tt> in trying to load data from old Hudson
@@ -10622,7 +10622,7 @@ title: Changelog Archives
   <li class="rfe">
     Added additional logging for project dependency related build ordering.
 </ul>
-<a name=v1.153><h3>What's new in 1.153</h3></a>
+<h3 id=v1.153>What's new in 1.153</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression introduced in 1.152 wrt spawning native m2 process remotely.
@@ -10639,7 +10639,7 @@ title: Changelog Archives
     Removed clock checking from the system configuration, as the same information
     is available from the node list view (<tt>http://SERVER/hudson/computer/</tt>)
 </ul>
-<a name=v1.152><h3>What's new in 1.152</h3></a>
+<h3 id=v1.152>What's new in 1.152</h3>
 <ul class=image>
   <li class=bug>
     <strike>Environment variables need to be case insensitive but case preserving.</strike>
@@ -10655,7 +10655,7 @@ title: Changelog Archives
   <li class=bug>
     Don't report the build duration as 0 seconds when it's building.
 </ul>
-<a name=v1.151><h3>What's new in 1.151</h3></a>
+<h3 id=v1.151>What's new in 1.151</h3>
 <ul class=image>
   <li class='major bug'>
     svn+ssh connection was not properly working.
@@ -10672,7 +10672,7 @@ title: Changelog Archives
   <li class=rfe>
     Added debug probe for ssh library
 </ul>
-<a name=v1.150><h3>What's new in 1.150</h3></a>
+<h3 id=v1.150>What's new in 1.150</h3>
 <ul class=image>
   <li class=bug>
     Tooltip for grey ball icon now correctly display different meanings of grey.
@@ -10698,7 +10698,7 @@ title: Changelog Archives
   <li class=rfe>
     Matrix build now exposes <tt>$JDK</tt> and <tt>$LABEL</tt>, just like other use-defined axes.
 </ul>
-<a name=v1.149><h3>What's new in 1.149</h3></a>
+<h3 id=v1.149>What's new in 1.149</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in 1.148 that made it impossible even for an admin to start a build
@@ -10715,7 +10715,7 @@ title: Changelog Archives
     combobox.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=659">issue 659</a>)
 </ul>
-<a name=v1.148><h3>What's new in 1.148</h3></a>
+<h3 id=v1.148>What's new in 1.148</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a security problem where project build URLs were not protected by default when security is enabled.
@@ -10738,7 +10738,7 @@ title: Changelog Archives
   <li class=rfe>
     Picked up the latest version of JEXL.
 </ul>
-<a name=v1.147><h3>What's new in 1.147</h3></a>
+<h3 id=v1.147>What's new in 1.147</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in computing the location of <tt>classworlds.jar</tt> for native m2 build.
@@ -10763,7 +10763,7 @@ title: Changelog Archives
     interference between security and cache control header.
     (<a href="http://www.nabble.com/No-browser-caching-with-Hudson--tf4601857.html#a13224961">report</a>) 
 </ul>
-<a name=v1.146><h3>What's new in 1.146</h3></a>
+<h3 id=v1.146>What's new in 1.146</h3>
 <ul class=image>
   <li class=bug>
     Disk space monitoring on slaves was not working
@@ -10790,7 +10790,7 @@ title: Changelog Archives
     Added an error margin on JUnit report archiver so that it doesn't report false positive
     "no new reports found" error.
 </ul>
-<a name=v1.145><h3>What's new in 1.145</h3></a>
+<h3 id=v1.145>What's new in 1.145</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where Ant support didn't run on Tiger.
@@ -10814,7 +10814,7 @@ title: Changelog Archives
   <li class=rfe>
     Added <tt>RunListener</tt> for getting notifications for all builds.
 </ul>
-<a name=v1.144><h3>What's new in 1.144</h3></a>
+<h3 id=v1.144>What's new in 1.144</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the "loading..." page auto refresh
@@ -10831,7 +10831,7 @@ title: Changelog Archives
     Text area is now much smarter. Its height is adjustable, and its size is pre-configured to fit to the content
     (as well as double-clicking the handle.)
 </ul>
-<a name=v1.143><h3>What's new in 1.143</h3></a>
+<h3 id=v1.143>What's new in 1.143</h3>
 <ul class=image>
   <li class=rfe>
     Axis names are now exported as environment variables in all upper case for better cross-platform behavior)
@@ -10848,7 +10848,7 @@ title: Changelog Archives
     Added a workaround for slow subversion check out
     (<a href="http://www.nabble.com/Slow-SVN-Checkout-tf4486786.html">report</a>)
 </ul>
-<a name=v1.142><h3>What's new in 1.142</h3></a>
+<h3 id=v1.142>What's new in 1.142</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a start up NPE problem in native maven2 projects, introduced in 1.141. 
@@ -10859,7 +10859,7 @@ title: Changelog Archives
     Added HTML titles to various test result related pages.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=843">issue 843</a>)
 </ul>
-<a name=v1.141><h3>What's new in 1.141</h3></a>
+<h3 id=v1.141>What's new in 1.141</h3>
 <ul class=image>
   <li class=bug>
     For SCM polling, resize the thread pool when <i>Max # of concurrent polling</i> is changed
@@ -10882,7 +10882,7 @@ title: Changelog Archives
     Fixed negative phrasing "don't send email on every unstable build"
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=827">issue 827</a>)
 </ul>
-<a name=v1.140><h3>What's new in 1.140</h3></a>
+<h3 id=v1.140>What's new in 1.140</h3>
 <ul class=image>
   <li class='major bug'>
     Fix a socket leak in SubversionSCM introduced in 1.137
@@ -10894,7 +10894,7 @@ title: Changelog Archives
   <li class=bug>
     Fixed a security hole that allows unauthenticated users to access logs that Hudson produces.
 </ul>
-<a name=v1.139><h3>What's new in 1.139</h3></a>
+<h3 id=v1.139>What's new in 1.139</h3>
 <ul class=image>
   <li class=bug>
     A failure in svnkit can cause an unexpected timer cancellation.
@@ -10915,7 +10915,7 @@ title: Changelog Archives
     Hudson now displays a dedicated UI during the initialization and reloading.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=756">issue 756</a>)
 </ul>
-<a name=v1.138><h3>What's new in 1.138</h3></a>
+<h3 id=v1.138>What's new in 1.138</h3>
 <ul class=image>
   <li class='major bug'>
     Disabled m2 module list actually showed the enabled modules.
@@ -10933,7 +10933,7 @@ title: Changelog Archives
   <li class=rfe>
     Search index now includes maven module display names.
 </ul>
-<a name=v1.137><h3>What's new in 1.137</h3></a>
+<h3 id=v1.137>What's new in 1.137</h3>
 <ul class=image>
   <li class='major bug'>
     Additional JavaScript memory leak fix.
@@ -10956,7 +10956,7 @@ title: Changelog Archives
     Remote API support was expanded to build records of all job types.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=804">issue 804</a>)
 </ul>
-<a name=v1.136><h3>What's new in 1.136</h3></a>
+<h3 id=v1.136>What's new in 1.136</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed JavaScript memory leak issues.
@@ -10973,7 +10973,7 @@ title: Changelog Archives
     Hudson now detects <a href="http://hudson.gotdns.com/wiki/display/HUDSON/Spawning+processes+from+build">a file descriptor leak situation</a> and report that as a warning, then let the build go.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=770">issue 770</a>)
 </ul>
-<a name=v1.135><h3>What's new in 1.135</h3></a>
+<h3 id=v1.135>What's new in 1.135</h3>
 <ul class=image>
   <li class=bug>
     Icon size choice should be persisted across browser sessions.
@@ -10995,7 +10995,7 @@ title: Changelog Archives
     Improved the absolute URL computation in Hudson to work better with httpd frontend.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=781">issue 781</a>)
 </ul>
-<a name=v1.134><h3>What's new in 1.134</h3></a>
+<h3 id=v1.134>What's new in 1.134</h3>
 <ul class=image>
   <li class=bug>
     Aggregator-style build setting in the native m2 project was put under the wrong "advanced" button.
@@ -11021,7 +11021,7 @@ title: Changelog Archives
     Maven project page now shows aggregated test result trend (regression.)
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=775">issue 775</a>)
 </ul>
-<a name=v1.133><h3>What's new in 1.133</h3></a>
+<h3 id=v1.133>What's new in 1.133</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the free-style maven/ant invocations when the master and slave run
@@ -11039,7 +11039,7 @@ title: Changelog Archives
     builds all the modules.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=557">issue 557</a>)
 </ul>
-<a name=v1.132><h3>What's new in 1.132</h3></a>
+<h3 id=v1.132>What's new in 1.132</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed the login link visibility issue.
@@ -11054,7 +11054,7 @@ title: Changelog Archives
     Added a work around necessary to run with OC4J.
     (<a href="http://www.nabble.com/forum/Search.jtp?forum=16872&local=y&query=oc4j">report</a>)
 </ul>
-<a name=v1.131><h3>What's new in 1.131</h3></a>
+<h3 id=v1.131>What's new in 1.131</h3>
 <ul class=image>
   <li class=bug>
     Running "javadoc:javadoc" in the native m2 project was not recording javadoc.
@@ -11074,7 +11074,7 @@ title: Changelog Archives
     Added search box for a quicker navigation around Hudson pages
     (<a href="http://hudson.gotdns.com/wiki/display/HUDSON/Search+Box">detail</a>)
 </ul>
-<a name=v1.130><h3>What's new in 1.130</h3></a>
+<h3 id=v1.130>What's new in 1.130</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug that matrix project initialization causes NPE.
@@ -11090,7 +11090,7 @@ title: Changelog Archives
     Archived Maven2 artifacts should honor the &lt;finalName> POM entry.
     (<a href="http://www.nabble.com/Maven-build-artifacts%3A-FinalName-wrong--tf4279077.html">report</a>)
 </ul>
-<a name=v1.129><h3>What's new in 1.129</h3></a>
+<h3 id=v1.129>What's new in 1.129</h3>
 <ul class=image>
   <li class=bug>
     Fixed a memory leak bug in distributed operations.
@@ -11122,7 +11122,7 @@ title: Changelog Archives
     that person is responsible for breaking the build, s/he now only gets one e-mail, not two.
     (<a href="http://www.nabble.com/Duplicate-mail-recipients-tf4254810.html">report</a>)
 </ul>
-<a name=v1.128><h3>What's new in 1.128</h3></a>
+<h3 id=v1.128>What's new in 1.128</h3>
 <ul class=image>
   <li class=bug>
     System log and slave log were not secured. 
@@ -11145,7 +11145,7 @@ title: Changelog Archives
     is needed for plugins to take effect
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=705">issue 705</a>)
 </ul>
-<a name=v1.127><h3>What's new in 1.127</h3></a>
+<h3 id=v1.127>What's new in 1.127</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug that prevented weather report detail table to show up.
@@ -11168,13 +11168,13 @@ title: Changelog Archives
   <li class=rfe>
     Updated the error diagnosis in the JUnit test result collection 
 </ul>
-<a name=v126><h3>What's new in 1.126</h3></a>
+<h3 id=v126>What's new in 1.126</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where "cvs co" put "-P" in a wrong position.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=696">issue 696</a>)
 </ul>
-<a name=v125><h3>What's new in 1.125</h3></a>
+<h3 id=v125>What's new in 1.125</h3>
 <ul class=image>
   <li class=bug>
     Fixed the character set handling in AJAX job/view description update
@@ -11192,7 +11192,7 @@ title: Changelog Archives
     Added a hook for plugins to specify additional CSS
    (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=695">issue 695</a>)
 </ul>
-<a name=v124><h3>What's new in 1.124</h3></a>
+<h3 id=v124>What's new in 1.124</h3>
 <ul class=image>
   <li class='major bug'>
     Build history listing always get doubled because of a bug in partial page update code.
@@ -11206,7 +11206,7 @@ title: Changelog Archives
   <li class=bug>
     Improved stability of the timer related code so that one failure won't shut down the entire timer. 
 </ul>
-<a name=v123><h3>What's new in 1.123</h3></a>
+<h3 id=v123>What's new in 1.123</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where remote API schema generation doesn't work with JDK1.5.
@@ -11234,7 +11234,7 @@ title: Changelog Archives
     for displaying a table of all health reports (as before accessible by hovering over the
     health/weather icon).
 </ul>
-<a name=v122><h3>What's new in 1.122</h3></a>
+<h3 id=v122>What's new in 1.122</h3>
 <ul class=image>
   <li class='major bug'>
     For some reason, a lot of Subversion related changes that were made in the past
@@ -11267,7 +11267,7 @@ title: Changelog Archives
     different configuration.
     (<a href="http://hudson.gotdns.com/wiki/display/HUDSON/Building+a+matrix+project">more</a>)
 </ul>
-<a name=v121><h3>What's new in 1.121</h3></a>
+<h3 id=v121>What's new in 1.121</h3>
 <ul class=image>
   <li class=bug>
     Fixed HTML escape related bugs in the project description.
@@ -11287,7 +11287,7 @@ title: Changelog Archives
     Changed the way Maven project build result is computed.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=651">issue 651</a>)
 </ul>
-<a name=v120><h3>What's new in 1.120</h3></a>
+<h3 id=v120>What's new in 1.120</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a security hole that allows non-admin users to disable/enable plugins.
@@ -11302,12 +11302,12 @@ title: Changelog Archives
     is CVS and a branch is set.
     (<a href="http://www.nabble.com/Getting-CVS-Branch-in-Ant-build-tf4104247.html">report</a>)
 </ul>
-<a name=v119><h3>What's new in 1.119</h3></a>
+<h3 id=v119>What's new in 1.119</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed NPE in the end of a build.
 </ul>
-<a name=v118><h3>What's new in 1.118</h3></a>
+<h3 id=v118>What's new in 1.118</h3>
 <ul class=image>
   <li class='major bug'>
     Memory fix bug in 1.117 was incorrect and Hudson fails to persist SVN credentials.
@@ -11324,7 +11324,7 @@ title: Changelog Archives
     Improved slave Unix/Windows detection
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=631">issue 631</a>)
 </ul>
-<a name=v117><h3>What's new in 1.117</h3></a>
+<h3 id=v117>What's new in 1.117</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where build queue gets very confused if modules exist in 2 native m2 projects
@@ -11348,7 +11348,7 @@ title: Changelog Archives
     [JIRA 1.3] JIRA plugin now works with the native m2 project type.
     (<a href="http://www.nabble.com/Jira-Plugin-Post-build-actions-not-appearing-tf4070397.html">report</a>)
 </ul>
-<a name=v116><h3>What's new in 1.116</h3></a>
+<h3 id=v116>What's new in 1.116</h3>
 <ul class=image>
   <li class=bug>
     Several subversion related error messages were incorrectly escaped.
@@ -11374,7 +11374,7 @@ title: Changelog Archives
     Auto-refresh cookie is now persisted.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=580">issue 580</a>)
 </ul>
-<a name=v115><h3>What's new in 1.115</h3></a>
+<h3 id=v115>What's new in 1.115</h3>
 <ul class=image>
   <li class='bug'>
     Modified to disable HTTP basic auth support (introduced in v1.112) when
@@ -11398,7 +11398,7 @@ title: Changelog Archives
     the icon's tooltip text. Initial health report providers are Test Result and Recent Build Status.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=615">issue 615</a>)
 </ul>
-<a name=v114><h3>What's new in 1.114</h3></a>
+<h3 id=v114>What's new in 1.114</h3>
 <ul class=image>
   <li class='bug'>
     Fixed 404 in Subversion config help link.
@@ -11419,7 +11419,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Internal code is refactored to make room for another job type.
 </ul>
-<a name=v113><h3>What's new in 1.113</h3></a>
+<h3 id=v113>What's new in 1.113</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed incorrect formatting in Subversion URL form validation.
@@ -11430,7 +11430,7 @@ title: Changelog Archives
   <li class='bug'>
     Fixed a bug in svn+ssh password authentication.
 </ul>
-<a name=v112><h3>What's new in 1.112</h3></a>
+<h3 id=v112>What's new in 1.112</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a problem where the user properties were not loaded correctly.
@@ -11456,7 +11456,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Added HTTP basic authentication support for scripting clients
 </ul>
-<a name=v111><h3>What's new in 1.111</h3></a>
+<h3 id=v111>What's new in 1.111</h3>
 <ul class=image>
   <li class=bug>
     Fixed a few file handle leaks in Subversion support.
@@ -11468,7 +11468,7 @@ title: Changelog Archives
     Fixed several cross-site scripting vulnerabilities.
     Thanks to <a href="http://opensource.fortifysoftware.com/">Fortify</a>.
 </ul>
-<a name=v110><h3>What's new in 1.110</h3></a>
+<h3 id=v110>What's new in 1.110</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a DOM leak that caused browsers to eventually hang where partial page updates are involved.
@@ -11487,7 +11487,7 @@ title: Changelog Archives
     Improved compatibility with older version of ViewCVS
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=589">issue 589</a>)
 </ul>
-<a name=v109><h3>What's new in 1.109</h3></a>
+<h3 id=v109>What's new in 1.109</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a NPE in <tt>MavenModule</tt>
@@ -11519,11 +11519,11 @@ title: Changelog Archives
     adding a link from the help page.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=571">issue 571</a>)
 </ul>
-<a name=v108><h3>What's new in 1.108</h3></a>
+<h3 id=v108>What's new in 1.108</h3>
 <p>
   No change
 </p>
-<a name=v107><h3>What's new in 1.107</h3></a>
+<h3 id=v107>What's new in 1.107</h3>
 <ul class=image>
   <li class=bug>
     Fixed an NPE when pom.xml has <tt>ciManagement</tt> doesn't have nested <tt>system</tt> element.
@@ -11543,7 +11543,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Slaves can now have labels, and jobs can be tied to labels.
 </ul>
-<a name=v106><h3>What's new in 1.106</h3></a>
+<h3 id=v106>What's new in 1.106</h3>
 <ul class=image>
   <li class='major bug'>
     Trying to update a module in a native m2 project fails with NPE.
@@ -11599,7 +11599,7 @@ title: Changelog Archives
     Jar/war/ear built by Maven now includes the Hudson version number
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=526">issue 526</a>)
 </ul>
-<a name=v105><h3>What's new in 1.105</h3></a>
+<h3 id=v105>What's new in 1.105</h3>
 <ul class=image>
   <li class="bug">
     Fixed a bug where the native m2 support doesn't honor the JDK setting.
@@ -11645,7 +11645,7 @@ title: Changelog Archives
     [JIRA 1.2] JIRA plugin now works with the native m2 support.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=465">issue 465</a>)
 </ul>
-<a name=v104><h3>What's new in 1.104</h3></a>
+<h3 id=v104>What's new in 1.104</h3>
 <ul class=image>
   <li class="major bug">
     Fixed NPE with the clean goal is run with the native m2 support.
@@ -11702,7 +11702,7 @@ title: Changelog Archives
   <li class="major rfe">
     [JABBER 0.2] Jabber plugin 0.2 release
 </ul>
-<a name=v103><h3>What's new in 1.103</h3></a>
+<h3 id=v103>What's new in 1.103</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a security hole where Hudson allowed anyone to tag the workspace.
@@ -11731,7 +11731,7 @@ title: Changelog Archives
     RSS/ATOM feeds now have more information 
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=461">issue 461</a>)
 </ul>
-<a name=v102><h3>What's new in 1.102</h3></a>
+<h3 id=v102>What's new in 1.102</h3>
 <ul class=image>
   <li class="major bug">
     Improved the fix for <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=389">#389</a>
@@ -11765,7 +11765,7 @@ title: Changelog Archives
     JNLP slave agent TCP listener port is now configurable when the security is enabled.
     (<a href="http://www.nabble.com/distributed-build-with-slaves-in-vpn-tf3553582.html">discussion</a>)
 </ul>
-<a name=v101><h3>What's new in 1.101</h3></a>
+<h3 id=v101>What's new in 1.101</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a bug where a long path name in javadoc or archived artifact causes the build to fail
@@ -11792,7 +11792,7 @@ title: Changelog Archives
     <a href="/remote-api.html">Remote API</a> is reimplemented so that Hudson
     can generate schema and documentation for the structure of JSON later.
 </ul>
-<a name=v100><h3>What's new in 1.100</h3></a>
+<h3 id=v100>What's new in 1.100</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a bug in running Subversion SCM on a slave.

--- a/content/changelog-stable.html.haml
+++ b/content/changelog-stable.html.haml
@@ -14,11 +14,8 @@ title: LTS Changelog
 .ratings
   - site.changelogs[:lts].reverse_each do | release |
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.stable)
-      %h3
-        %a{:name => "v#{release.version}" }
-          What's new in
-          = release.version
-        = "(#{release.date})"
+      %h3{:id => "v#{release.version}" }
+        = "What's new in #{release.version} (#{release.date})"
       -if release.changes and release.lts_changes and release.lts_baseline
         %div
           %strong

--- a/content/changelog.html.haml
+++ b/content/changelog.html.haml
@@ -8,11 +8,8 @@ title: Changelog
 .ratings
   - site.changelogs[:weekly].reverse_each do | release |
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
-      %h3
-        %a{:name => "v#{release.version}" }
-          What's new in
-          = release.version
-        = "(#{release.date})"
+      %h3{:id => "v#{release.version}" }
+        = "What's new in #{release.version} (#{release.date})"
       %ul.image
         = partial('changes.html.haml', :changes => release.changes)
   = partial('changelog-weekly.html')

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1,3 +1,15 @@
+/* https://github.com/twbs/bootstrap/issues/1768#issuecomment-46519033 */
+[id]:before {
+  display: block;
+  content: " ";
+
+  /* the top header wraps when the page isn't wide enough, but most of
+     the time the height of a single row of links should be correct */
+  margin-top: -55px;
+  height: 55px;
+  visibility: hidden;
+}
+
 body > .container {
   margin-top: 60px;
 }


### PR DESCRIPTION
## Depends on https://github.com/jenkins-infra/jenkins-infra/pull/692

Right now, linking to anchors (typically elements with ID) results in scroll positions with the link target hidden behind the top navigation bar. Examples:

https://jenkins.io/security/#team
https://jenkins.io/changelog-stable/#v1.625.3

This PR fixes that behavior by offsetting the effective position of the anchor by the height of the header to the top without changing how the page looks.

I couldn't get it to work for `a[name]` (different offset was needed and I didn't find out why), so rewriting the changelog to use header tags with ID as well. That's the bulk of this PR. This slightly changes the presentation, as headers in changelogs will no longer be link colored and get underlined on hover, but black with no underline (which IMO is an improvement)