### PR TITLE
Add anchor links to headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ bower {
     'tether' ('1.1.1') {
         source 'dist/**'
     }
+
+    'anchor-js' ('3.2.2') {
+        source '**/*.js'
+    }
 }
 
 task fetchExamples(type: Exec) {

--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -14,6 +14,16 @@ section: doc
     end
   end
 
+:javascript
+  $(function () {
+    anchors.add('.container .row .col-lg-9 h1');
+    anchors.add('.container .row .col-lg-9 h2');
+    anchors.add('.container .row .col-lg-9 h3');
+    anchors.add('.container .row .col-lg-9 h4');
+    anchors.add('.container .row .col-lg-9 h5');
+    anchors.add('.container .row .col-lg-9 h6');
+  })
+
 .container
   .row
     .col-lg-3

--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -16,12 +16,9 @@ section: doc
 
 :javascript
   $(function () {
-    anchors.add('.container .row .col-lg-9 h1');
-    anchors.add('.container .row .col-lg-9 h2');
-    anchors.add('.container .row .col-lg-9 h3');
-    anchors.add('.container .row .col-lg-9 h4');
-    anchors.add('.container .row .col-lg-9 h5');
-    anchors.add('.container .row .col-lg-9 h6');
+    for (var i = 1 ; i <= 6 ; i ++) {
+      anchors.add('.container .row .col-lg-9 h' + i);
+    }
   })
 
 .container

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -5,12 +5,9 @@ layout: default
 
 :javascript
   $(function () {
-    anchors.add('#content > h1');
-    anchors.add('#content > h2');
-    anchors.add('#content > h3');
-    anchors.add('#content > h4');
-    anchors.add('#content > h5');
-    anchors.add('#content > h6');
+    for (var i = 1 ; i <= 6 ; i ++) {
+      anchors.add('#content h' + i);
+    }
   })
 
 

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -3,6 +3,17 @@ layout: default
 ---
 
 
+:javascript
+  $(function () {
+    anchors.add('#content > h1');
+    anchors.add('#content > h2');
+    anchors.add('#content > h3');
+    anchors.add('#content > h4');
+    anchors.add('#content > h5');
+    anchors.add('#content > h6');
+  })
+
+
 %div.container.blog-post.no-margin
   .row.body
     %div#content.col-md-11.col-md-offset-1{:class => 'main-content'}

--- a/content/_layouts/project.html.haml
+++ b/content/_layouts/project.html.haml
@@ -16,6 +16,16 @@ layout: default
     articles = articles.compact.slice(0, 10)
   end
 
+:javascript
+  $(function () {
+    anchors.add('.container .row .col-lg9 h1');
+    anchors.add('.container .row .col-lg9 h2');
+    anchors.add('.container .row .col-lg9 h3');
+    anchors.add('.container .row .col-lg9 h4');
+    anchors.add('.container .row .col-lg9 h5');
+    anchors.add('.container .row .col-lg9 h6');
+  })
+
 .container
   .row
     .col-lg-9

--- a/content/_layouts/project.html.haml
+++ b/content/_layouts/project.html.haml
@@ -18,12 +18,9 @@ layout: default
 
 :javascript
   $(function () {
-    anchors.add('.container .row .col-lg9 h1');
-    anchors.add('.container .row .col-lg9 h2');
-    anchors.add('.container .row .col-lg9 h3');
-    anchors.add('.container .row .col-lg9 h4');
-    anchors.add('.container .row .col-lg9 h5');
-    anchors.add('.container .row .col-lg9 h6');
+    for (var i = 1 ; i <= 6 ; i ++) {
+      anchors.add('.container .row .col-lg9 h' + i);
+    }
   })
 
 .container

--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -10,6 +10,17 @@ layout: default
   .toc {
       float: right;
   }
+
+:javascript
+  $(function () {
+    anchors.add('.container .row.body h1');
+    anchors.add('.container .row.body h2');
+    anchors.add('.container .row.body h3');
+    anchors.add('.container .row.body h4');
+    anchors.add('.container .row.body h5');
+    anchors.add('.container .row.body h6');
+  })
+
 .container
   .row.body
     - unless page.notitle

--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -13,12 +13,9 @@ layout: default
 
 :javascript
   $(function () {
-    anchors.add('.container .row.body h1');
-    anchors.add('.container .row.body h2');
-    anchors.add('.container .row.body h3');
-    anchors.add('.container .row.body h4');
-    anchors.add('.container .row.body h5');
-    anchors.add('.container .row.body h6');
+    for (var i = 1 ; i <= 6 ; i ++) {
+      anchors.add('.container .row.body h' + i);
+    }
   })
 
 .container

--- a/content/_partials/scriptlinks.html.haml
+++ b/content/_partials/scriptlinks.html.haml
@@ -21,3 +21,4 @@
 %script{:src => "#{site.base_url}/assets/bower/tether/js/tether.min.js"}
 %script{:src => "#{site.base_url}/assets/bower/bootstrap/js/bootstrap.min.js"}
 %script{:src => "#{site.base_url}/assets/bower/ekko-lightbox/ekko-lightbox.min.js"}
+%script{:src => "#{site.base_url}/assets/bower/anchor-js/anchor.min.js"}

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -8,12 +8,6 @@
 
 :javascript
   $(function () {
-    anchors.options.placement = 'left';
-    anchors.add('.container .body h1, .container .body h2, .container .body h3, .container .body h4, .container .body h5, .container .body h6');
-  })
-
-:javascript
-  $(function () {
     function doPopovers(buttonContainer, placement, extraClass){
       var $popovers = $(buttonContainer + ' [data-toggle="popover"]');
       var $popLayer = $('#popover-layer');

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -8,6 +8,12 @@
 
 :javascript
   $(function () {
+    anchors.options.placement = 'left';
+    anchors.add('.container .body h1, .container .body h2, .container .body h3, .container .body h4, .container .body h5, .container .body h6');
+  })
+
+:javascript
+  $(function () {
     function doPopovers(buttonContainer, placement, extraClass){
       var $popovers = $(buttonContainer + ' [data-toggle="popover"]');
       var $popLayer = $('#popover-layer');


### PR DESCRIPTION
Similar to GitHub documentation rendering, shows anchor link to the header on hover.

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/23166801/4d2cfd4c-f842-11e6-8af0-2515722e9471.png)

This is limited to `.content .body`, which means the current `documentation` layout is not supported. Unclear to me why that's not `class="row body"` like e.g. `simplepage`. Adaptation also needs to think about the side bar, to not make those headers clickable (or maybe we do want that? Not sure).
