### PR TITLE
Fix warnings about wrong header sequence

### DIFF
--- a/content/mailing-lists.adoc
+++ b/content/mailing-lists.adoc
@@ -14,7 +14,7 @@ To subscribe to a mailing list, send an empty email to the "subscribe" email add
 == English-language discussion lists
 
 
-==== jenkinsci-users@googlegroups.com
+=== jenkinsci-users@googlegroups.com
 
 Mailing list for users of Jenkins.
 Post your questions on how to use Jenkins and Jenkins plugins here.
@@ -25,7 +25,7 @@ link:http://groups.google.com/group/jenkinsci-users/topics[archive] |
 mailto:jenkinsci-users+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-users+unsubscribe@googlegroups.com[unsubscribe]
 
-==== jenkinsci-dev@googlegroups.com
+=== jenkinsci-dev@googlegroups.com
 
 Mailing list for *developers* of Jenkins.
 Post your Jenkins core development and plugin development questions here, as well as topics related to project governance.
@@ -36,28 +36,28 @@ link:http://groups.google.com/group/jenkinsci-dev/topics[archive] |
 mailto:jenkinsci-dev+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-dev+unsubscribe@googlegroups.com[unsubscribe]
 
-==== events@lists.jenkins-ci.org
+=== events@lists.jenkins-ci.org
 
 Mailing list for events, meet-ups, and fostering local communities. +
 link:http://lists.jenkins-ci.org/pipermail/jenkins-events/[archive] |
 link:http://lists.jenkins-ci.org/mailman/listinfo/jenkins-events[subscribe] |
 link:http://lists.jenkins-ci.org/mailman/listinfo/jenkins-events[unsubscribe]
 
-==== jenkinsci-jam@googlegroups.com
+=== jenkinsci-jam@googlegroups.com
 
 Mailing list for link:/projects/jam/[Jenkins Area Meetup] coordination. +
 link:http://groups.google.com/group/jenkinsci-jam/topics[archive] |
 mailto:jenkinsci-jam+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-jam+unsubscribe@googlegroups.com[unsubscribe]
 
-==== infra@lists.jenkins-ci.org
+=== infra@lists.jenkins-ci.org
 
 Mailing list for jenkins-ci.org operations and infrastructure. +
 link:http://lists.jenkins-ci.org/pipermail/jenkins-infra/[archive] |
 link:http://lists.jenkins-ci.org/mailman/listinfo/jenkins-infra[subscribe] |
 link:http://lists.jenkins-ci.org/mailman/listinfo/jenkins-infra[unsubscribe]
 
-==== jenkinsci-docs@googlegroups.com
+=== jenkinsci-docs@googlegroups.com
 
 Mailing list for collaborating on Jenkins user and developer documentation. +
 link:http://groups.google.com/group/jenkinsci-docs/topics[archive] |
@@ -66,21 +66,21 @@ mailto:jenkinsci-docs+unsubscribe@googlegroups.com[unsubscribe]
 
 == Discussion lists in other languages
 
-==== jenkinsci-br@googlegroups.com
+=== jenkinsci-br@googlegroups.com
 
 Jenkins grupo de usuários em Português do Brasil +
 link:http://groups.google.com/group/jenkinsci-br/topics[archive] |
 mailto:jenkinsci-br+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-br+unsubscribe@googlegroups.com[unsubscribe]
 
-==== jenkinsci-ja@googlegroups.com
+=== jenkinsci-ja@googlegroups.com
 
 日本語ユーザーおよび開発者の為のメーリングリスト +
 link:http://groups.google.com/group/jenkinsci-ja/topics[archive] |
 mailto:jenkinsci-ja+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-ja+unsubscribe@googlegroups.com[unsubscribe]
 
-==== jenkinsci-kr@googlegroups.com
+=== jenkinsci-kr@googlegroups.com
 
 Jenkins users list in Korean +
 link:http://groups.google.com/group/jenkinsci-kr/topics[archive] |
@@ -89,21 +89,21 @@ mailto:jenkinsci-kr+unsubscribe@googlegroups.com[unsubscribe]
 
 == Read-only lists
 
-==== jenkinsci-advisories@googlegroups.com
+=== jenkinsci-advisories@googlegroups.com
 
 Security Advisory announcements are sent to this list. link:/security[More about security in Jenkins] +
 link:http://groups.google.com/group/jenkinsci-advisories/topics[archive] |
 mailto:jenkinsci-advisories+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-advisories+unsubscribe@googlegroups.com[unsubscribe]
 
-==== jenkinsci-commits@googlegroups.com
+=== jenkinsci-commits@googlegroups.com
 
 Automated core and plugin commit notifications. +
 link:http://groups.google.com/group/jenkinsci-commits/topics[archive] |
 mailto:jenkinsci-commits+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-commits+unsubscribe@googlegroups.com[unsubscribe]
 
-==== jenkinsci-issues@googlegroups.com
+=== jenkinsci-issues@googlegroups.com
 
 Automated notifications from JIRA (JENKINS project only). +
 link:http://groups.google.com/group/jenkinsci-issues/topics[archive] |


### PR DESCRIPTION
	Generating pages...
	asciidoctor: WARNING: mailing-lists.adoc: line 13: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 24: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 35: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 42: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 49: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 56: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 65: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 72: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 79: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 88: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 95: section title out of sequence: expected level 2, got level 3
	asciidoctor: WARNING: mailing-lists.adoc: line 102: section title out of sequence: expected level 2, got level 3

I don't know why the warnings check didn't catch it.