### PR TITLE
Redirect stderr to stdout and exclude user handbook warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ try {
                             set -o pipefail
                             set -o xtrace
                             ./gradlew --quiet --console=plain --no-daemon --info --stacktrace 2>&1 | tee build.log
-                            if [[ -n "$( grep --fixed-strings WARNING build.log )" ]] ; then
+                            if [[ -n "$( grep --fixed-strings WARNING build.log | grep --fixed-strings --invert-match user-handbook.adoc )" ]] ; then
                                 echo "Failing build due to warnings in log output" >&2
                                 exit 1
                             fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ try {
                             set -o nounset
                             set -o pipefail
                             set -o xtrace
-                            ./gradlew --quiet --console=plain --no-daemon --info --stacktrace | tee build.log
+                            ./gradlew --quiet --console=plain --no-daemon --info --stacktrace 2>&1 | tee build.log
                             if [[ -n "$( grep --fixed-strings WARNING build.log )" ]] ; then
                                 echo "Failing build due to warnings in log output" >&2
                                 exit 1


### PR DESCRIPTION
If I'm guessing right, this PR build should fail while #685 isn't merged.