### PR TITLE
Only show anchor links when they're hovered, not titles

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -15,6 +15,21 @@ h6[id]:before {
   visibility: hidden;
 }
 
+/* hide anchors unless they're hovered to offset the weird margin/padding
+   needed for anchored links to not hide the target behind the navigation bar */
+*:hover > .anchorjs-link {
+  opacity: 0;
+}
+
+.anchorjs-link:hover {
+  opacity: 1;
+}
+
+/* make anchor links easier to find */
+.anchorjs-link {
+  padding: 0.4em 1em 0.4em 0.5em !important;
+}
+
 body > .container {
   margin-top: 60px;
 }


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/pull/682#issuecomment-281479747 mentions some weird behavior with combining anchor links and the margin for headers to offset the navigation bar height.

This addresses the problem by not showing the anchor links when the header itself is hovered, only the area to its right. To make it not too difficult to find however, the area is enlarged at the same time (shown below as focus border).

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/23239615/a26b1a4c-f968-11e6-9644-f0df38624e8a.png)
