### PR TITLE
Fix profiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,9 +144,9 @@ task fetchReleaseHistory(type: JavaExec) {
     def groovyScript = "${projectDir}/scripts/release.rss.groovy"
     args groovyScript, "https://updates.jenkins.io/release-history.json"
 
-    file(project.ext.siteOutputDir).mkdirs()
+    file(project.siteOutputDir).mkdirs()
 
-    standardOutput file("${project.ext.siteOutputDir}/releases.rss").newOutputStream()
+    standardOutput file("${project.siteOutputDir}/releases.rss").newOutputStream()
     inputs.source file(groovyScript)
 }
 
@@ -164,13 +164,9 @@ task compileContent(type: JRubyExec) {
     dependsOn 'fetchExternalResources', 'fetchExamples', 'prepareJavaScripts'
     script 'awestruct'
     scriptArgs '--generate', '--verbose',
-                /* forcefully set the site.base_url since the config is not
-                 * being respected
-                 */
-                '--url', 'https://jenkins.io',
                 '--source-dir', "${projectDir}/${contentDir}",
-                '--output-dir', project.ext.siteOutputDir
-    if (hasProperty('profile')) {
+                '--output-dir', project.siteOutputDir
+    if (project.hasProperty('profile')) {
         scriptArgs '--profile', profile
     }
     /* without the --force option, awestruct is not smart enough to regenerate
@@ -217,10 +213,10 @@ task printHandbook(type: JRubyExec) {
     configuration 'asciidoctor'
 
     doLast {
-        file(project.ext.siteOutputDir).mkdirs()
+        file(project.siteOutputDir).mkdirs()
         copy {
-            from "${project.ext.userHandbook}.pdf"
-            into project.ext.siteOutputDir
+            from "${project.userHandbook}.pdf"
+            into project.siteOutputDir
         }
     }
 
@@ -250,7 +246,7 @@ task archiveBeta(type: Zip) {
     description 'Create a zip archive of the site for deployment'
     dependsOn assemble
     archiveName "${computedDirName}.zip"
-    into(computedDirName) { from project.ext.siteOutputDir }
+    into(computedDirName) { from project.siteOutputDir }
 
     File targetDir = file("${buildDir}/archives")
     targetDir.mkdirs()
@@ -276,7 +272,7 @@ def defineDevTask(name, body) {
         script 'awestruct'
         scriptArgs '--dev',
                    '--source-dir', "${projectDir}/${contentDir}",
-                   '--output-dir', project.ext.siteOutputDir
+                   '--output-dir', project.siteOutputDir
         configuration 'asciidoctor'
         body.delegate = delegate
         body()

--- a/content/_config/site.yml
+++ b/content/_config/site.yml
@@ -34,10 +34,11 @@ asciidoctor:
     notitle: ''
 profiles:
   production:
+    base_url: https://jenkins.io/
+  development:
     # Don't log to GA while working on the site
     google_analytics:
       account: UA-000000-0
-  local:
     base_url: http://localhost:4242/
   hrmpw:
     base_url: https://hrmpw.github.io/jenkins.io/


### PR DESCRIPTION
* `project.ext` is only needed for the initial definition of a new property, after that it's redundant.
* I set a different `--url` and checked the output with and without it, in neither case did the new base URL actually show up anywhere.
* The `hasProperty` check looked at the task, not the project, so could never be true.
* Make `production` work even when there's a `development` profile through redundant base URL definition. (Should check PR build output just to be safe.)