### PR TITLE
Fix pollSCM trigger description and example in pipeline syntax description

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -522,7 +522,7 @@ The `triggers` directive defines the automated ways in which the Pipeline
 should be re-triggered. For Pipelines which are integrated with a source such
 as GitHub or BitBucket, `triggers` may not be necessary as webhooks-based
 integration will likely already be present. Currently the only two available
-triggers are `cron` and `pollScm`.
+triggers are `cron` and `pollSCM`.
 
 [cols="^10h,>90a",role=syntax]
 |===
@@ -539,13 +539,13 @@ triggers are `cron` and `pollScm`.
 
 cron:: Accepts a cron-style string to define a regular interval at which the
 Pipeline should be re-triggered, for example: `triggers { cron('H 4/* 0 0 1-5') }`
-pollScm:: Accepts a cron-style string to define a regular interval at which
+pollSCM:: Accepts a cron-style string to define a regular interval at which
 Jenkins should check for new source changes. If new changes exist, the Pipeline
-will be re-triggered. For example: `triggers { pollScm('H 4/* 0 0 1-5') }`
+will be re-triggered. For example: `triggers { pollSCM('H 4/* 0 0 1-5') }`
 
 [NOTE]
 ====
-The `pollScm` trigger is only available in Jenkins 2.22 or later.
+The `pollSCM` trigger is only available in Jenkins 2.22 or later.
 ====
 
 [[triggers-example]]


### PR DESCRIPTION
When testing out the multibranch pipeline build i also used the currently documented 'pollScm' trigger, which led to an error with a message telling me the correct naming 'pollSCM' with capitalized SCM letters.

```
WorkflowScript: 14: Invalid trigger type "pollScm". Valid trigger types: [upstream, cron, pollSCM] @ line 14, column 3.
   		pollScm('H/2 8-18 * * 1-5')
     ^

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1085)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:603)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:67)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:429)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:392)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:238)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:405)
```