### PR TITLE
Wider table of contents

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1385,7 +1385,7 @@ blockquote {
     background-color: #f9f9f9;
     border-left: 1px solid #c9c9c9;
     float: right;
-    width: 10rem;
+    width: 20rem;
     margin-left: 15px;
     padding: 10px;
     clear: right;


### PR DESCRIPTION
Still not great (it's sometimes a bit wasteful now), but less easily broken.

New:
> ![screen shot 2017-02-26 at 15 23 07](https://cloud.githubusercontent.com/assets/1831569/23340516/da4ac5f8-fc37-11e6-9b39-e6f5433250fe.png)

Old:
> ![screen shot 2017-02-26 at 15 23 21](https://cloud.githubusercontent.com/assets/1831569/23340517/dbb8112a-fc37-11e6-8041-c6a5e621c7d5.png)

Example of some documentation page showing how this would look:
> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/23340530/1da47812-fc38-11e6-8406-e3e1d28d6f00.png)

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/23340539/3d368a6c-fc38-11e6-9bdb-482bd582c2f7.png)
