### PR TITLE
Don't use smaller text for short label

### DIFF
--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -55,7 +55,7 @@ notitle: true
         .header.time
           .date-time
             .date
-              .day.small
+              .day
                 Fridays
               .dow
                 Fri


### PR DESCRIPTION
Followup to @oleg-nenashev's #689 in which a short label was used, but the workaround for long labels applied anyway.