### PR TITLE
Add missing periods

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -17,13 +17,13 @@
         - issue: 36871
         - issue: 37565
     - type: major rfe
-      message: Show notification with popup on most pages when administrative monitors are active
+      message: Show notification with popup on most pages when administrative monitors are active.
       issue: 38391
     - type: rfe
-      message: Allow disabling/enabling administrative monitors on Configure Jenkins form
+      message: Allow disabling/enabling administrative monitors on Configure Jenkins form.
       issue: 38301
     - type: rfe
-      message: Ask for confirmation before canceling/aborting runs
+      message: Ask for confirmation before canceling/aborting runs.
       issue: 30565
     - type: rfe
       message: Prompt user whether to add the job to the current view.
@@ -45,7 +45,7 @@
         It was sometimes causing build failures with messages like <code>FATAL: Invalid object ID 184 iuota=187</code> and <code>java.lang.Exception: Object was recently deallocated</code>.
       issue: 23271
     - type: bug
-      message: Redirect to login page in the case of authorisation error when checking connectivity to the Update Center
+      message: Redirect to login page in the case of authorisation error when checking connectivity to the Update Center.
       issue: 39741
     - type: bug
       message: >
@@ -55,12 +55,12 @@
   date: 2017-02-01
   changes:
     - type: security
-      message: Important security fixes
+      message: Important security fixes.
       references:
         - url: https://jenkins.io/security/advisory/2017-02-01/
           title: security advisory
     - type: major rfe
-      message: Support displaying of warnings from the update site in the plugin manager and in administrative monitors
+      message: Support displaying of warnings from the update site in the plugin manager and in administrative monitors.
       references:
         - issue: 40494
         - url: https://jenkins.io/blog/2017/01/10/security-warnings/
@@ -96,7 +96,7 @@
         Performance: Use bulk change when submitting Job configurations to minimize the number of sequential <code>config.xml</code> write operations.
       issue: 40435
     - type: bug
-      message: Jobs were hanging during process termination on the Solaris 11 Intel platform, regression in 2.20
+      message: Jobs were hanging during process termination on the Solaris 11 Intel platform, regression in 2.20.
       issue: 40470
     - type: bug
       message: Restore option value for setting build result to unstable when loading shell and batch build steps from disk.


### PR DESCRIPTION
After merging #694's removal of `chomp` due to obvious problems, we need periods at the end of all messages.