### PR TITLE
Add 'security' class to old changelog entries

### DIFF
--- a/content/_partials/changelog-stable.html
+++ b/content/_partials/changelog-stable.html
@@ -479,7 +479,7 @@ title: LTS Changelog
 
 <h3 id=v1.651.2>What's new in 1.651.2 (2016/05/11)</h3>
 <ul class=image>
-   <li class="major bug">
+   <li class="security">
      <strong>Important security fixes</strong>
      (<a href="https://jenkins.io/security/advisory/2016-05-11/">security advisory</a>)
 
@@ -611,7 +611,7 @@ title: LTS Changelog
 
     <h3 id=v1.642.2>What's new in 1.642.2 (2016/02/24)</h3>
     <ul class=image>
-       <li class="major bug">
+       <li class="security">
          <strong>Important security fixes</strong>
          (<a href="https://jenkins.io/security/advisory/2016-02-24/">security advisory</a>)
       <li class="bug">
@@ -685,7 +685,7 @@ title: LTS Changelog
 
     <h3 id=v1.625.3>What's new in 1.625.3 (2015/12/09)</h3>
     <ul class=image>
-  <li class="major bug">
+  <li class="security">
     <strong>Important security fixes</strong>
     (<a href="https://jenkins.io/security/advisory/2015-12-09/">security advisory</a>)
         <li class='bug'>
@@ -703,7 +703,7 @@ title: LTS Changelog
 
     <h3 id=v1.625.2>What's new in 1.625.2 (2015/11/11)</h3>
     <ul class=image>
-  <li class="major bug">
+  <li class="security">
     <strong>Important security fixes</strong>
     (<a href="https://jenkins.io/security/advisory/2015-11-11/">security advisory</a>)
   <li class='bug'>
@@ -938,7 +938,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.596.2>What's new in 1.596.2 (2015/03/23)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2015-03-23/">security advisory</a>)
         <li class='bug'>
@@ -965,7 +965,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.596.1>What's new in 1.596.1 (2015/02/28)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2015-02-27/">security advisory</a>)
         <li class='bug'>
@@ -1055,7 +1055,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.580.1>What's new in 1.580.1 (2014/10/29)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2014-10-30/">security advisory</a>)
         <li class='rfe'>
@@ -1076,7 +1076,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.565.3>What's new in 1.565.3 (2014/10/01)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2014-10-01/">security advisory</a>)
   <li class='bug'>
@@ -1328,7 +1328,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.532.2>What's new in 1.532.2 (2014/02/14)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2014-02-14/">security advisory</a>)
         <li class='bug'>
@@ -1678,7 +1678,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.509.1>What's new in 1.509.1 (2013/05/01)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2013-05-02/">security advisory</a>)
         <li class='bug'>
@@ -1700,7 +1700,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.480.3>What's new in 1.480.3 (2013/02/15)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2013-02-16/">security advisory</a>)
         <li class='bug'>
@@ -1743,7 +1743,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.480.1>What's new in 1.480.1 (2012/11/17)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2012-11-20/">security advisory</a>)
         <li class='bug'>
@@ -1767,7 +1767,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.466.2>What's new in 1.466.2 (2012/09/13)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2012-09-17/">security advisory</a>)
 
@@ -1840,7 +1840,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.424.6>What's new in 1.424.6 (2012/03/06)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2012-03-05/">security advisory</a>)
     </ul>
@@ -1885,7 +1885,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.424.2>What's new in 1.424.2 (2012/01/10)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2012-01-12/">security advisory</a>)
         <li class='bug'>
@@ -1903,7 +1903,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.424.1>What's new in 1.424.1 (2011/11/30)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2011-11-08/">security advisory</a>)
         <li class='bug'>
@@ -1943,7 +1943,7 @@ If your SSH Slaves fail to start and you have the plugin install the JRE to run 
 
     <h3 id=v1.409.3>What's new in 1.409.3 (2011/11/08)</h3>
     <ul class=image>
-      <li class="major bug">
+      <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://jenkins.io/security/advisory/2011-11-08/">security advisory</a>)
     </ul>

--- a/content/_partials/changelog-weekly.html
+++ b/content/_partials/changelog-weekly.html
@@ -47,7 +47,7 @@
 </ul>
 <h3 id=v2.44>What's new in 2.44 (2017/02/01)</h3>
 <ul class=image>
-    <li class="major bug">
+    <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01">security advisory</a>)
 </ul>
@@ -294,7 +294,7 @@
 </ul>
 <h3 id=v2.32>What's new in 2.32 (2016/11/16)</h3>
 <ul class=image>
-    <li class="major bug">
+    <li class="security">
         <strong>Important security fixes</strong>
         (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-11-16">security advisory</a>)
     <li class="rfe">
@@ -1182,7 +1182,7 @@
 </ul>
 <h3 id=v2.3>What's new in 2.3 (2016/05/11)</h3>
 <ul class=image>
-    <li class="major bug">
+    <li class="security">
         <strong>Important security fixes</strong>
         (see the <a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-05-11">security advisory</a> for details and plugin compatibility issues)
 </ul>


### PR DESCRIPTION
I skipped the `/changelog-old`, but its security fix entries were pretty crappy to begin with.