### PR TITLE
[GSoC2017] - Shutdown the website.

### DIFF
--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -49,21 +49,6 @@ notitle: true
 
           %h5.title
             Project Meeting
-            
-    %li.post.event.floating
-      %a.body{:href => 'https://jenkins.io/projects/gsoc/#officehours', :target => '_blank'}
-        .header.time
-          .date-time
-            .date
-              .day
-                Fridays
-              .dow
-                Fri
-            .time
-              19h UTC
-
-          %h5.title
-            GSoC Office Hours
 
 %p
   Other recurring events can be found in the

--- a/content/projects/gsoc.adoc
+++ b/content/projects/gsoc.adoc
@@ -7,15 +7,8 @@ tags:
 - gsoc2017
 ---
 
-[NOTE]
-====
-This page is about Google Summer of Code (GSoC) 2017.
-Information about the previous year is archived and referenced below.
-
-Preparation is still underway for GSoC 2017; the project has not been accepted yet.
-The list of accepted organizations will be published on **Feb 28**.
-All students are welcome to start project discussions before this date.
-====
+WARNING: In 2017 Jenkins project does not participate in Google Summer of Code.
+We hope to apply on the next year.
 
 == About GSoC
 
@@ -33,194 +26,16 @@ In exchange, numerous Jenkins community members volunteer as "mentors"
 for students to help integrate them into the open source community and succeed
 in completing their summer projects.
 
-== Student Application process
-
-=== Application steps
-
-. Check out the project ideas (see below).
-. Select an interesting project idea or draft your own proposal.
-. If you are not familiar with Jenkins, read the introductory info on the website and trying it out with one of your previous projects.
-. Join the _jenkinsci-dev_ and _jenkinsci-gsoc-all-public_ mailing lists
-. If you do not have a GitHub account, create one
-. Introduce yourself the community and start your project proposal discussion by sending an introductory email to the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[jenkinsci-dev] Google Group (see the guidelines below).
-. Join us at GSoC office hours.
-
-NOTE: 
-Please note that link:https://groups.google.com/forum/#!forum/jenkinsci-dev[jenkinsci-dev] mailing list is publicly visible inside and outside the community. 
-It is required for the initial review and feedback collection.
-
-=== First email to jenkinsci-dev
-
-* Please use the _[GSoC2017] -_ prefix in your message subject
-* In the first e-mail we would be interested to see the following information:
- * A short self-introduction: your area of study, interests, background
- * Motivation letter. Why are you interested in the Jenkins project? On which project areas would you like to work? If there are particular proposals, please let us know about them as well, and any initial thoughts on why you would be suited
- * If you participate in open-source projects, please reference them
- * If you have profile pages in professional networks like LinkedIn, please reference them
- * If you have a Twitter account, a blog or technical/scientific publications, please reference them as well
-
-NOTE: In GSoC we do not hire you in the common sense.
-Please do not **just** send us your CVs or universal cover letters.
-We are mostly interested to understand your interests and your motivation to work in the project.
-
-== Project ideas
-
-Below you can find project ideas proposed by potential mentors.
-Students are eligible to submit any other Jenkins-related ideas though it may be hard to find mentors in particular cases.
-
-=== Plugin Conversion to Blue Ocean
-
-One of the major initiatives in the Jenkins project is an updated interface and user experience, called link:https://jenkins.io/projects/blueocean/[Blue Ocean]. 
-Some of the popular Jenkins plugins will require conversion to the Blue Ocean plugin architecture.
-
-Students will use modern technologies (e.g. React, NodeJS, and/or Java) to help convert the most widely used plugins to work with Blue Ocean with help from Blue Ocean core developers.
-We expect students to select a particular plugin (or plugins) together with potential mentors and then to come up with a list of improvements to be made.
-
-Prerequisites:
-
-* Basic knowledge of the Web development area
-* Basic knowledge of Java and JavaScript programming languages
-
-Potential mentors: link:https://github.com/kzantow[Keith Zantow] and other Blue Ocean team members
-
-=== EDA tool integration plugin
-
-The idea is to create a Jenkins plugin for one of the widely used Electronic Design Automation (EDA) tools. 
-
-Tools from both ASIC or FPGA design flow are acceptable. 
-We are ready to consider conditionally-free and open-source tools, which would be available to the student and his mentors. 
-
-Prerequisites:
-
-* Basic knowledge of the hardware engineering area
-* Basic knowledge of Java programming language
-* Hands-on experience with the selected EDA tool
-* In the case of FPGA flows it would be useful to have a prototyping board as well
-
-Potential mentors: link:https://github.com/martinda[Martin d'Anjou], link:https://github.com/oleg-nenashev[Oleg Nenashev]
-
-=== Support core plugin improvements 
-
-It is often difficult for plugins developers to diagnose issues and analyse the user environment.
-
-The link:https://wiki.jenkins-ci.org/display/JENKINS/Support+Core+Plugin[Support Core plugin] allows users to generate a bundle to help on this but it is nowadays rarely used because it is isn't user friendly.
-Various fixes and improvements may help our community a lot. 
-
-Few ideas of new features to add:
-
-* Ease the management of bundles (UI to list, delete, browse, download bundles) - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
-* Provide anonymisation of the support bundle contents by default - link:https://issues.jenkins-ci.org/browse/JENKINS-21670[JENKINS-21670]
-* Submission of bundles in link:https://issues.jenkins-ci.org[our bug tracker] - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
-* etc.
-
-Prerequisites:
-
-* Basic knowledge of Jenkins (as a user)
-* Basic knowledge of Java programming language
-
-Potential mentors: link:https://github.com/alecharp[Adrien Lecharpentier], link:https://github.com/christ66[Steven Christou]
-
-
-== Getting in touch
-
-=== Chat and Mailing lists
-
-There are the following main resources:
-
-Technical conversations:
-
-* _jenkinsci-dev@googlegroups.com_ - for all technical discussions and the project application
-* _#jenkins_ IRC channel on FreeNode.
-link:https://wiki.jenkins-ci.org/display/JENKINS/IRC+Channel[More Info]
-
-Organizational questions:
-
-* _jenkinsci-gsoc-all-public@googlegroups.com_ - sync-ups on organizational topics (meeting scheduling, process Q&A)
-* _jenkinsci-gsoc-orgs@googlegroups.com_ - for private communications with Jenkins GSoC Org Admins (escalations)
-
-[[officehours]]
-=== Office hours
-
-During the GSoC timeframe we will have regular public office hours for students and mentors.
-These office hours will start when and if the project gets accepted.
-
-Schedule:
-
- * Every Friday, from _7PM_ .. _8PM_ UTC
- * Meetings will be held via Google Hangouts in link:https://jenkins.io/hangout[https://jenkins.io/hangout]
- * Office hours will **not** be recorded
- 
-In addition to public office hours, mentors will setup regular status meetings with students.
-
-=== Expectations from students
-
-NOTE: The section below is under development. 
-The expectations may slightly change before the beginning of the Student application period.
-
-==== Student application process
-
-. We expect students to get involved into project discussions on the beginning of the student application period in order to have opportunity to discuss the project with them and to jointly review the proposal drafts.
-. We expect students to attend at least one office hours during the application period.
-. We expect proposals to contain all the sections discussed in the link:http://write.flossmanuals.net/gsocstudentguide/what-is-google-summer-of-code/[GSoC Student Guide]
-
-==== Community bonding
-
-Students and mentors are expected to...
-
-. Work closely in order to study the area of their project and to get introduced to the key stakeholders and contributors in the area of the project
-. Define the communication ways (chats, etc.) and setup regular meetings (recommended - at least 2 meetings per week)
-. Create a mini-design for the project, which would include top-level architecture and implementation plan with milestones
-. Prepare the development environment, including setup of the development tools and getting of special permissions (if required)
-. Attend Jenkins governance meetings if the timezone allows
-. Spend a significant amount of time on study and design during the community bonding
-
-==== Coding period
-
-Students are expected to...
-
-. Work on the GSoC project as it is a full-time employment.
- * It means that 30..40 hours per week is an **expected** workload though it can be adjusted upon the agreements with mentors.
- * It also means that you have ~5 "vacation days" during the project, do not hesitate to use them if required
-. Use weekend to have a rest, avoid significant overwork and enjoy coding
-. Timely notify mentors in the case of emergencies and outages (missing scheduled meetings, etc.).
-. Timely notify mentors and org admins about unexpected time commitments
-. Be around in _#jenkins_ IRC and in the project chats during the working hours
-. Attend Jenkins governance meetings if the timezone allows
-. Be proactive; reach out to the community if required
-. Produce the good quality code with reasonable amount of testing and documentation
-. Have a finalized deliverable at the end of the project
-
-Students are **not** expected to...
-
-. Strictly follow the originally submitted mini-design and the project proposal
- * The world is not ideal, and there may be unexpected obstacles or shortcuts
- * Upon the discussion with mentors, any plan can be adjusted
- * We expect students to achieve at least some goals in the original proposal
-. Investigate and solve *every* issue on their own
- * We have mentors and experts, who can help you by answering questions and doing joint investigation if required
-
-==== Evaluations
-
-. At the end of the each coding phase students and mentors present the project status at the public meeting
-. As a part of the Final evaluation students present the project results at the link:https://www.meetup.com/Jenkins-online-meetup/[Jenkins Online Meetup]
-
-==== Post-GSoC
-
-Depending on the project results, and available budget, we may offer a sponsored trip
-to link:https://www.cloudbees.com/jenkinsworld/home[Jenkins world] or another Jenkins-related event to students
-who successfully finish their projects.
-This sponsorship is not guaranteed though.
-
-If students agree to go to such event, we expect them to present their project and to write a blog-post about the trip.
-
 == Links
 
+* link:/projects/gsoc/students[Information for students] 
 * link:https://developers.google.com/open-source/gsoc/[Google Summer of Code page]
 * link:http://write.flossmanuals.net/gsocstudentguide/what-is-google-summer-of-code/[GSoC Student Guide]
 * link:http://archive.flossmanuals.net/gsocmentoring/[GSoC Mentor Guide]
 
 == Previous years
 
+* link:/projects/gsoc/gsoc2017[Google Summer of Code 2017] (not accepted)
 * link:/projects/gsoc/gsoc2016[Google Summer of Code 2016] (5 student projects)
 
 

--- a/content/projects/gsoc/gsoc2017.adoc
+++ b/content/projects/gsoc/gsoc2017.adoc
@@ -1,0 +1,69 @@
+---
+layout: project
+title: "Google Summer of Code 2017"
+tags:
+- gsoc
+- gsoc2017
+---
+
+WARNING: This is an archived page about Jenkins project participation in Google Summer of Code 2017.
+See link:/projects/gsoc[the main GSoC project] page of the information about other years.
+
+== Status
+
+In 2017 Jenkins application has not been accepted to Google Summer of Code.
+This page contains some information, which may be reused in the future.
+
+== Project Ideas 
+
+=== Plugin Conversion to Blue Ocean
+
+One of the major initiatives in the Jenkins project is an updated interface and user experience, called link:https://jenkins.io/projects/blueocean/[Blue Ocean]. 
+Some of the popular Jenkins plugins will require conversion to the Blue Ocean plugin architecture.
+
+Students will use modern technologies (e.g. React, NodeJS, and/or Java) to help convert the most widely used plugins to work with Blue Ocean with help from Blue Ocean core developers.
+We expect students to select a particular plugin (or plugins) together with potential mentors and then to come up with a list of improvements to be made.
+
+Prerequisites:
+
+* Basic knowledge of the Web development area
+* Basic knowledge of Java and JavaScript programming languages
+
+Potential mentors: link:https://github.com/kzantow[Keith Zantow] and other Blue Ocean team members
+
+=== EDA tool integration plugin
+
+The idea is to create a Jenkins plugin for one of the widely used Electronic Design Automation (EDA) tools. 
+
+Tools from both ASIC or FPGA design flow are acceptable. 
+We are ready to consider conditionally-free and open-source tools, which would be available to the student and his mentors. 
+
+Prerequisites:
+
+* Basic knowledge of the hardware engineering area
+* Basic knowledge of Java programming language
+* Hands-on experience with the selected EDA tool
+* In the case of FPGA flows it would be useful to have a prototyping board as well
+
+Potential mentors: link:https://github.com/martinda[Martin d'Anjou], link:https://github.com/oleg-nenashev[Oleg Nenashev]
+
+=== Support core plugin improvements 
+
+It is often difficult for plugins developers to diagnose issues and analyse the user environment.
+
+The link:https://wiki.jenkins-ci.org/display/JENKINS/Support+Core+Plugin[Support Core plugin] allows users to generate a bundle to help on this but it is nowadays rarely used because it is isn't user friendly.
+Various fixes and improvements may help our community a lot. 
+
+Few ideas of new features to add:
+
+* Ease the management of bundles (UI to list, delete, browse, download bundles) - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
+* Provide anonymisation of the support bundle contents by default - link:https://issues.jenkins-ci.org/browse/JENKINS-21670[JENKINS-21670]
+* Submission of bundles in link:https://issues.jenkins-ci.org[our bug tracker] - link:https://issues.jenkins-ci.org/browse/JENKINS-33090[JENKINS-33090]
+* etc.
+
+Prerequisites:
+
+* Basic knowledge of Jenkins (as a user)
+* Basic knowledge of Java programming language
+
+Potential mentors: link:https://github.com/alecharp[Adrien Lecharpentier], link:https://github.com/christ66[Steven Christou]

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -1,0 +1,126 @@
+---
+layout: project
+title: "Google Summer of Code. Information for students"
+tags:
+- gsoc
+---
+
+WARNING: In 2017 Jenkins project does not participate in Google Summer of Code.
+We hope to apply on the next year.
+
+
+This page provides information for students about participating in Jenkins GSoC.
+See link:/projects/gsoc[the main GSoC project] page for other information and links.
+
+== Student Application process
+
+=== Application steps
+
+. Check out the project ideas (see below). 
+. Select an interesting project idea or draft your own proposal.
+. If you are not familiar with Jenkins, read the introductory info on the website and trying it out with one of your previous projects.
+. Join the _jenkinsci-dev_ and _jenkinsci-gsoc-all-public_ mailing lists
+. If you do not have a GitHub account, create one
+. Introduce yourself the community and start your project proposal discussion by sending an introductory email to the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[jenkinsci-dev] Google Group (see the guidelines below).
+. Join us at GSoC office hours.
+
+NOTE: 
+Please note that link:https://groups.google.com/forum/#!forum/jenkinsci-dev[jenkinsci-dev] mailing list is publicly visible inside and outside the community. 
+It is required for the initial review and feedback collection.
+
+=== First email to jenkinsci-dev
+
+* Please use the _[GSoC]_ prefix in your message subject
+* In the first e-mail we would be interested to see the following information:
+ * A short self-introduction: your area of study, interests, background
+ * Motivation letter. Why are you interested in the Jenkins project? On which project areas would you like to work? If there are particular proposals, please let us know about them as well, and any initial thoughts on why you would be suited
+ * If you participate in open-source projects, please reference them
+ * If you have profile pages in professional networks like LinkedIn, please reference them
+ * If you have a Twitter account, a blog or technical/scientific publications, please reference them as well
+
+NOTE: In GSoC we do not hire you in the common sense.
+Please do not **just** send us your CVs or universal cover letters.
+We are mostly interested to understand your interests and your motivation to work in the project.
+
+== Getting in touch
+
+=== Chat and Mailing lists
+
+There are the following main resources:
+
+Technical conversations:
+
+* _jenkinsci-dev@googlegroups.com_ - for all technical discussions and the project application
+* _#jenkins_ IRC channel on FreeNode.
+link:https://wiki.jenkins-ci.org/display/JENKINS/IRC+Channel[More Info]
+
+Organizational questions:
+
+* _jenkinsci-gsoc-all-public@googlegroups.com_ - sync-ups on organizational topics (meeting scheduling, process Q&A)
+* _jenkinsci-gsoc-orgs@googlegroups.com_ - for private communications with Jenkins GSoC Org Admins (escalations)
+
+[[officehours]]
+== Office hours
+
+We do not conduct office hours in 2017 since the project has not been accepted.
+
+== Expectations from students
+
+NOTE: The section below is under development. 
+The expectations may slightly change before the beginning of the Student application period.
+
+=== Student application process
+
+. We expect students to get involved into project discussions on the beginning of the student application period in order to have opportunity to discuss the project with them and to jointly review the proposal drafts.
+. We expect students to attend at least one office hours during the application period.
+. We expect proposals to contain all the sections discussed in the link:http://write.flossmanuals.net/gsocstudentguide/what-is-google-summer-of-code/[GSoC Student Guide]
+
+=== Community bonding
+
+Students and mentors are expected to...
+
+. Work closely in order to study the area of their project and to get introduced to the key stakeholders and contributors in the area of the project
+. Define the communication ways (chats, etc.) and setup regular meetings (recommended - at least 2 meetings per week)
+. Create a mini-design for the project, which would include top-level architecture and implementation plan with milestones
+. Prepare the development environment, including setup of the development tools and getting of special permissions (if required)
+. Attend Jenkins governance meetings if the timezone allows
+. Spend a significant amount of time on study and design during the community bonding
+
+=== Coding period
+
+Students are expected to...
+
+. Work on the GSoC project as it is a full-time employment.
+ * It means that 30..40 hours per week is an **expected** workload though it can be adjusted upon the agreements with mentors.
+ * It also means that you have ~5 "vacation days" during the project, do not hesitate to use them if required
+. Use weekend to have a rest, avoid significant overwork and enjoy coding
+. Timely notify mentors in the case of emergencies and outages (missing scheduled meetings, etc.).
+. Timely notify mentors and org admins about unexpected time commitments
+. Be around in _#jenkins_ IRC and in the project chats during the working hours
+. Attend Jenkins governance meetings if the timezone allows
+. Be proactive; reach out to the community if required
+. Produce the good quality code with reasonable amount of testing and documentation
+. Have a finalized deliverable at the end of the project
+
+Students are **not** expected to...
+
+. Strictly follow the originally submitted mini-design and the project proposal
+ * The world is not ideal, and there may be unexpected obstacles or shortcuts
+ * Upon the discussion with mentors, any plan can be adjusted
+ * We expect students to achieve at least some goals in the original proposal
+. Investigate and solve *every* issue on their own
+ * We have mentors and experts, who can help you by answering questions and doing joint investigation if required
+
+=== Evaluations
+
+. At the end of the each coding phase students and mentors present the project status at the public meeting
+. As a part of the Final evaluation students present the project results at the link:https://www.meetup.com/Jenkins-online-meetup/[Jenkins Online Meetup]
+
+=== Post-GSoC
+
+Depending on the project results, and available budget, we may offer a sponsored trip
+to link:https://www.cloudbees.com/jenkinsworld/home[Jenkins world] or another Jenkins-related event to students
+who successfully finish their projects.
+This sponsorship is not guaranteed though.
+
+If students agree to go to such event, we expect them to present their project and to write a blog-post about the trip.


### PR DESCRIPTION
The project application has been rejected, so let's cleanup the content

- [x] - Remove the office hours from the calendar
- [x] - Archive the 2017 project ideas
- [x] - Move information for students to a separate page
- [x] - Add the 2017 status warnings

CC @rtyler @batmat @chtist66 @rsandell