### PR TITLE
JENKINS-41118 - add customWorkspace docs

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -250,15 +250,18 @@ environment with the provided label. For example: `agent { label 'my-defined-lab
 
 node:: Execute the Pipeline, or stage, on an agent available in the Jenkins
 environment with the provided label, with additional options. For example:
+
 [source,groovy]
 ----
 agent {
     node {
         label 'my-defined-label'
-        customWorkspace '/some/other/path'
+        customWorkspace '/some/other/path' // <1>
     }
 }
 ----
+<1> See <<Common Options>> below for more information on the `customWorkspace`
+option.
 
 docker:: Execute the Pipeline, or stage, with the given container which will be
 dynamically provisioned on a <<../glossary#node, node>> pre-configured to
@@ -283,21 +286,29 @@ dockerfile:: Execute the Pipeline, or stage, with a container built from a
 true }`. If building a `Dockerfile` in another directory, use the `dir`
 option: `agent { dockerfile { dir 'someSubDir' } }`.
 
-===== Additional Options
+===== Common Options
 
 These are a few options for two or more `agent` implementations. They are not
-required.
+required unless explicitly stated.
+
+label:: A string. The label on which to run the Pipeline or individual `stage`.
+
+This option is valid for `node`, `docker` and `dockerfile`, and is required for
+`node`.
 
 customWorkspace:: A string. Run the Pipeline or individual `stage` this `agent`
 is applied to within this custom workspace, rather than the default. It can be
 either a relative path, in which case the custom workspace will be under the
-workspace root on the node, or an absolute path. This option is valid for
-`node`, `docker` and `dockerfile`.
+workspace root on the node, or an absolute path.
+
+This option is valid for `node`, `docker` and `dockerfile`.
 
 reuseNode:: A boolean, false by default. If true, run the container in the node
 specified at the top-level of the Pipeline, in the same workspace, rather than
-on a new node entirely. This option is valid for `docker` and `dockerfile`, and
-only has an effect when used on an `agent` for an individual `stage`.
+on a new node entirely.
+
+This option is valid for `docker` and `dockerfile`, and only has an effect when
+used on an `agent` for an individual `stage`.
 
 [[agent-example]]
 ===== Example

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -248,20 +248,9 @@ need to contain its own `agent` directive. For example: `agent none`
 label:: Execute the Pipeline, or stage, on an agent available in the Jenkins
 environment with the provided label. For example: `agent { label 'my-defined-label' }`
 
-node:: Execute the Pipeline, or stage, on an agent available in the Jenkins
-environment with the provided label, with additional options. For example:
-
-[source,groovy]
-----
-agent {
-    node {
-        label 'my-defined-label'
-        customWorkspace '/some/other/path' // <1>
-    }
-}
-----
-<1> See <<Common Options>> below for more information on the `customWorkspace`
-option.
+node:: `agent { node { label 'labelName' } }` behaves the same as
+`agent { label 'labelName' }`, but `node` allows for additional options (such
+as `customWorkspace`).
 
 docker:: Execute the Pipeline, or stage, with the given container which will be
 dynamically provisioned on a <<../glossary#node, node>> pre-configured to
@@ -299,7 +288,17 @@ This option is valid for `node`, `docker` and `dockerfile`, and is required for
 customWorkspace:: A string. Run the Pipeline or individual `stage` this `agent`
 is applied to within this custom workspace, rather than the default. It can be
 either a relative path, in which case the custom workspace will be under the
-workspace root on the node, or an absolute path.
+workspace root on the node, or an absolute path. For example:
+
+[source,groovy]
+----
+agent {
+    node {
+        label 'my-defined-label'
+        customWorkspace '/some/other/path'
+    }
+}
+----
 
 This option is valid for `node`, `docker` and `dockerfile`.
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -248,6 +248,18 @@ need to contain its own `agent` directive. For example: `agent none`
 label:: Execute the Pipeline, or stage, on an agent available in the Jenkins
 environment with the provided label. For example: `agent { label 'my-defined-label' }`
 
+node:: Execute the Pipeline, or stage, on an agent available in the Jenkins
+environment with the provided label, with additional options. For example:
+[source,groovy]
+----
+agent {
+    node {
+        label 'my-defined-label'
+        customWorkspace '/some/other/path'
+    }
+}
+----
+
 docker:: Execute the Pipeline, or stage, with the given container which will be
 dynamically provisioned on a <<../glossary#node, node>> pre-configured to
 accept Docker-based Pipelines, or on a node matching the optionally defined
@@ -271,6 +283,21 @@ dockerfile:: Execute the Pipeline, or stage, with a container built from a
 true }`. If building a `Dockerfile` in another directory, use the `dir`
 option: `agent { dockerfile { dir 'someSubDir' } }`.
 
+===== Additional Options
+
+These are a few options for two or more `agent` implementations. They are not
+required.
+
+customWorkspace:: A string. Run the Pipeline or individual `stage` this `agent`
+is applied to within this custom workspace, rather than the default. It can be
+either a relative path, in which case the custom workspace will be under the
+workspace root on the node, or an absolute path. This option is valid for
+`node`, `docker` and `dockerfile`.
+
+reuseNode:: A boolean, false by default. If true, run the container in the node
+specified at the top-level of the Pipeline, in the same workspace, rather than
+on a new node entirely. This option is valid for `docker` and `dockerfile`, and
+only has an effect when used on an `agent` for an individual `stage`.
 
 [[agent-example]]
 ===== Example

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -258,6 +258,7 @@ accept Docker-based Pipelines, or on a node matching the optionally defined
 `label` parameter.  `docker` also optionally accepts an `args` parameter
 which may contain arguments to pass directly to a `docker run` invocation.
  For example: `agent { docker 'maven:3-alpine' }` or
++
 [source,groovy]
 ----
 agent {
@@ -281,7 +282,7 @@ These are a few options for two or more `agent` implementations. They are not
 required unless explicitly stated.
 
 label:: A string. The label on which to run the Pipeline or individual `stage`.
-
++
 This option is valid for `node`, `docker` and `dockerfile`, and is required for
 `node`.
 
@@ -289,7 +290,7 @@ customWorkspace:: A string. Run the Pipeline or individual `stage` this `agent`
 is applied to within this custom workspace, rather than the default. It can be
 either a relative path, in which case the custom workspace will be under the
 workspace root on the node, or an absolute path. For example:
-
++
 [source,groovy]
 ----
 agent {
@@ -299,13 +300,13 @@ agent {
     }
 }
 ----
-
++
 This option is valid for `node`, `docker` and `dockerfile`.
 
 reuseNode:: A boolean, false by default. If true, run the container in the node
 specified at the top-level of the Pipeline, in the same workspace, rather than
 on a new node entirely.
-
++
 This option is valid for `docker` and `dockerfile`, and only has an effect when
 used on an `agent` for an individual `stage`.
 


### PR DESCRIPTION
[JENKINS-41118](https://issues.jenkins-ci.org/browse/JENKINS-41118) - Declarative PR [#123](https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/123)

Also adding `node` `agent` type (which is just an alias for `label`,
but hey) and the `reuseNode` option for `docker` and `dockerfile`,
which we should have added earlier but forgot. Whoops.

The Declarative PR will be merged shortly, with the 1.1 release of Declarative planned for later this month. I'll remove the WIP tag when the release is done.

cc @bitwiseman @rtyler 