### PR TITLE
Fix Groovy syntax page link

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -50,7 +50,7 @@ pipeline {
 
 The basic statements and expressions which are valid in Declarative Pipeline
 follow the same rules as
-link:https://groovy-lang.org/syntax.html[Groovy's syntax]
+link:http://groovy-lang.org/syntax.html[Groovy's syntax]
 with the following exceptions:
 
 * The top-level of the Pipeline must be a _block_, specifically: `pipeline { }`


### PR DESCRIPTION
https doesn't appear to work when trying to access http://groovy-lang.org/