### PR TITLE
Allow injecting summary strings in Weekly and LTS changelogs

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -58,6 +58,7 @@
       issue: 24453
 - version: "2.32.2"
   date: 2017-02-01
+  summary: Important security fixes and bugfix backports.
   changes:
     - type: security
       message: Important security fixes.
@@ -114,6 +115,7 @@
       issue: 25333
 - version: "2.32.3"
   date: 2017-03-01
+  summary: Important bugfix backports.
   changes:
     - type: bug
       message: >

--- a/content/changelog-stable.html.haml
+++ b/content/changelog-stable.html.haml
@@ -16,6 +16,11 @@ title: LTS Changelog
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.stable)
       %h3{:id => "v#{release.version}" }
         = "What's new in #{release.version} (#{release.date})"
+      - if release.summary
+        %p
+          %b
+            = "Summary: "
+          = "#{release.summary}"
       -if release.changes and release.lts_changes and release.lts_baseline
         %div
           %strong

--- a/content/changelog.html.haml
+++ b/content/changelog.html.haml
@@ -10,6 +10,11 @@ title: Changelog
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
       %h3{:id => "v#{release.version}" }
         = "What's new in #{release.version} (#{release.date})"
+      - if release.summary
+        %p
+          %b
+            = "Summary: "
+          = "#{release.summary}"
       %ul.image
         = partial('changes.html.haml', :changes => release.changes)
   = partial('changelog-weekly.html')


### PR DESCRIPTION
This is just a Utility feature, which allows injecting HTML-formatted summary text in the beginning of the changelog entries. It may be useful to highlight particular features or to add summary links.

In the future summaries may be used in e.g. Jenkins Update Manager UI or Twitter to provide more details about new releases. Moon shot, of course

Example:

![screen shot 2017-03-09 at 12 36 53](https://cloud.githubusercontent.com/assets/3000480/23748857/aaa3d736-04c5-11e7-8535-93c3e5556aa6.png)
