### PR TITLE
Reference plugins site URL in releases.rss

### DIFF
--- a/scripts/release.rss.groovy
+++ b/scripts/release.rss.groovy
@@ -34,7 +34,7 @@ json.releaseHistory.reverse().each { i ->
 def xml = new MarkupBuilder(new OutputStreamWriter(System.out))
 xml.feed(xmlns:"http://www.w3.org/2005/Atom") {
   title("Jenkins plugin releases")
-  link(href:"http://jenkins-ci.org/")
+  link(href:"https://jenkins.io/")
   link(href:"http://kohsuke.org/test.atom",rel:"self",type:"application/atom+xml")
   updated(xsd(new Date()))
   author { name("Jenkins History Bot") }

--- a/scripts/release.rss.groovy
+++ b/scripts/release.rss.groovy
@@ -46,9 +46,9 @@ xml.feed(xmlns:"http://www.w3.org/2005/Atom") {
         entry {
           s = (first[toGA(r.gav)] == r.gav) ? " (new)" : ""
           title("${r.title} ${r.version}${s}")
-          link(href:r.wiki,rel:"alternate",type:"text/html")
+          link(href:r.url,rel:"alternate",type:"text/html")
           id("urn:63067410335c11e0bc8e0800200c9a66:${r.gav}")
-          pubished(xsd(new Date(r.timestamp)))
+          published(xsd(new Date(r.timestamp)))
           updated(xsd(new Date(r.timestamp)))
           summary("${r.title} ${r.version}")
         }


### PR DESCRIPTION
Depends on https://github.com/jenkins-infra/backend-update-center2/pull/118

Untested.

---

Also fixes a typo. I doubt that one is intentional…?