### PR TITLE
Fix wrong when directive usage in `Using a Jenkinsfile` doc

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -253,7 +253,11 @@ pipeline {
 
     stages {
         stage('Deploy') {
-            when { expression { currentBuild.result == 'SUCCESS' } } // <1>
+            when {
+              expression {
+                currentBuild.result == null || currentBuild.result == 'SUCCESS' // <1>
+              }
+            }
             steps {
                 sh 'make publish'
             }
@@ -264,7 +268,7 @@ pipeline {
 node {
     /* .. snip .. */
     stage('Deploy') {
-        if (currentBuild.result == 'SUCCESS') { // <1>
+        if (currentBuild.result == null || currentBuild.result == 'SUCCESS') { // <1>
             sh 'make publish'
         }
     }

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -253,7 +253,7 @@ pipeline {
 
     stages {
         stage('Deploy') {
-            when { currentBuild.result == 'SUCCESS' } // <1>
+            when { expression { currentBuild.result == 'SUCCESS' } } // <1>
             steps {
                 sh 'make publish'
             }


### PR DESCRIPTION
The original Jenkinsfile sample causes the following error:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 6: Expected a step @ line 6, column 20.
               when { currentBuild.result == 'SUCCESS' } // <1>
                                     ^

WorkflowScript: 6: Unknown conditional null. Valid conditionals are: branch, environment, expression @ line 6, column 20.
               when { currentBuild.result == 'SUCCESS' } // <1>
```