### PR TITLE
Fix erroneous use of 'SUCCESS' in Pipeline examples in blog posts.

### DIFF
--- a/content/blog/2016/2016-07-18-pipline-notifications.adoc
+++ b/content/blog/2016/2016-07-18-pipline-notifications.adoc
@@ -262,7 +262,7 @@ node {
 
 def notifyBuild(String buildStatus = 'STARTED') {
   // build status of null means successful
-  buildStatus =  buildStatus ?: 'SUCCESSFUL'
+  buildStatus = buildStatus ?: 'SUCCESS'
 
   // Default values
   def colorName = 'RED'
@@ -276,7 +276,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
   if (buildStatus == 'STARTED') {
     color = 'YELLOW'
     colorCode = '#FFFF00'
-  } else if (buildStatus == 'SUCCESSFUL') {
+  } else if (buildStatus == 'SUCCESS') {
     color = 'GREEN'
     colorCode = '#00FF00'
   } else {

--- a/content/blog/2017/2017-02-15-declarative-notifications.adoc
+++ b/content/blog/2017/2017-02-15-declarative-notifications.adoc
@@ -279,7 +279,7 @@ That is often a `using` statement, but that isn't needed here so by convention w
  */
 def call(String buildStatus = 'STARTED') {
   // build status of null means successful
-  buildStatus =  buildStatus ?: 'SUCCESSFUL'
+  buildStatus = buildStatus ?: 'SUCCESS'
 
   // Default values
   def colorName = 'RED'
@@ -293,7 +293,7 @@ def call(String buildStatus = 'STARTED') {
   if (buildStatus == 'STARTED') {
     color = 'YELLOW'
     colorCode = '#FFFF00'
-  } else if (buildStatus == 'SUCCESSFUL') {
+  } else if (buildStatus == 'SUCCESS') {
     color = 'GREEN'
     colorCode = '#00FF00'
   } else {


### PR DESCRIPTION
The workflow-support-plugin [intends][0] to make checking for `currentBuild.result == null` redundant in future.

However, this will have a knock-on effect for pipelines that only check for `null` and not additionally for `'SUCCESS'`.  As noted in that PR comment, there are a number of pipelines in the wild that would be affected — including one which copy-pasted from the Jenkins blog at some point.

In future, if `currentBuild.result` returns `'SUCCESS'` where it previously returned `null`, the code `buildStatus ?: 'SUCCESSFUL'` as used in these blog posts would break — the `if` statement would fall through to the `else` branch.

This change fixes the example code to be future-proof by using the [correct `Result` constant][1].

[0]:https://github.com/jenkinsci/workflow-support-plugin/pull/31#issuecomment-285923403
[1]:http://javadoc.jenkins-ci.org/hudson/model/Result.html#SUCCESS