### PR TITLE
Case sensitive search by default in 2.50 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -93,6 +93,10 @@
       pull: 2683
     - type: rfe
       message: >
+        Searching in the <code>Build History</code> widget takes into account user preferences (case sensitivity by default).
+      pull: 2683
+    - type: rfe
+      message: >
         When creating temporary files, use the <code>jenkins</code> prefix instead of the old <code>hudson</code> one.
       pull: 2778
     - type: bug


### PR DESCRIPTION
Minor change implemented on request in #2683 which potentially has large user impact.