### PR TITLE
[JENKINS-42693] Add 'additionalBuildArgs' dockerfile option

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -269,7 +269,9 @@ dockerfile:: Execute the Pipeline, or stage, with a container built from a
 `Dockerfile` contained in the source repository. Conventionally this is the
 `Dockerfile` in the root of the source repository: `agent { dockerfile
 true }`. If building a `Dockerfile` in another directory, use the `dir`
-option: `agent { dockerfile { dir 'someSubDir' } }`.
+option: `agent { dockerfile { dir 'someSubDir' } }`. You can pass additional
+arguments to the `docker build ...` command with the `additionalBuildArgs`
+option, like `agent { dockerfile { additionalBuildArgs '--build-arg foo=bar' } }`.
 
 
 [[agent-example]]


### PR DESCRIPTION
[JENKINS-42693](https://issues.jenkins-ci.org/browse/JENKINS-42693) - [PR 136](https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/136)

Planned for next Declarative release (`1.2` if there isn't a `1.1.x` release beforehand).

I'm not sure about the formatting - how do we want to handle/display
multiple options for agent types?

cc @rtyler @bitwiseman 