### PR TITLE
HOUR is invalid time unit.

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -420,7 +420,7 @@ skipDefaultCheckout:: Skip checking out code from source control by default in
 the `agent` directive. For example: `options { skipDefaultCheckout() }`
 
 timeout:: Set a timeout period for the Pipeline run, after which Jenkins should
-abort the Pipeline. For example: `options { timeout(time: 1, unit: 'HOUR') }`
+abort the Pipeline. For example: `options { timeout(time: 1, unit: 'HOURS') }`
 
 retry:: On failure, retry the entire Pipeline the specified number of times.
 For example: `options { retry(3) }`
@@ -437,7 +437,7 @@ time at which the line was emitted. For example: `options { timestamps() }`
 pipeline {
     agent any
     options {
-        timeout(time: 1, unit: 'HOUR') // <1>
+        timeout(time: 1, unit: 'HOURS') // <1>
     }
     stages {
         stage('Example') {


### PR DESCRIPTION
Following the syntax in the tutorials as is throws this error:

`java.lang.IllegalArgumentException: Could not instantiate {time=1, unit=HOUR} for TimeoutStep(time: int, unit?: TimeUnit[NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]): java.lang.IllegalArgumentException: No enum constant java.util.concurrent.TimeUnit.HOUR`

Changing it to `HOURS` works as the documentation describes.