### PR TITLE
Small fixes for Pipeline tour

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -165,3 +165,5 @@ node('docker') {
 }
 ----
 
+---
+**link:../running-multiple-steps[Continue to "Running multiple steps"]**

--- a/content/doc/pipeline/tour/running-multiple-steps.adoc
+++ b/content/doc/pipeline/tour/running-multiple-steps.adoc
@@ -19,7 +19,7 @@ considered to have successfully executed.
 
 === Linux, BSD, and Mac OS
 
-On Linux, bSD, and Mac OS (Unix-like) systems, the `sh` step is used to execute
+On Linux, BSD, and Mac OS (Unix-like) systems, the `sh` step is used to execute
 a shell command in a Pipeline.
 
 [pipeline]
@@ -101,7 +101,7 @@ pipeline {
                 }
 
                 timeout(time: 3, unit: 'MINUTES') {
-                    sh './slow-process.sh'
+                    sh './health-check.sh'
                 }
             }
         }
@@ -130,8 +130,8 @@ as having failed in the "Deploy" stage.
 including `timeout` or `retry`.
 
 We can compose these steps together. For example, if we wanted to retry our
-deployment 5 times, but never want to spend more than 3 minutes before failing
-the stage:
+deployment 5 times, but never want to spend more than 3 minutes in total before
+failing the stage:
 
 [pipeline]
 ----
@@ -142,7 +142,7 @@ pipeline {
         stage('Deploy') {
             steps {
                 timeout(time: 3, unit: 'MINUTES') {
-                    retry(3) {
+                    retry(5) {
                         sh './flakey-deploy.sh'
                     }
                 }
@@ -154,7 +154,7 @@ pipeline {
 node {
     stage('Deploy') {
         timeout(time: 3, unit: 'MINUTES') {
-            retry(3) {
+            retry(5) {
                 sh './flakey-deploy.sh'
             }
         }

--- a/content/doc/pipeline/tour/running-multiple-steps.adoc
+++ b/content/doc/pipeline/tour/running-multiple-steps.adoc
@@ -182,20 +182,20 @@ pipeline {
     }
     post {
         always {
-            sh 'This will always run'
+            echo 'This will always run'
         }
         success {
-            sh 'This will run only if successful'
+            echo 'This will run only if successful'
         }
         failure {
-            sh 'This will run only if failed'
+            echo 'This will run only if failed'
         }
         unstable {
-            sh 'This will run only if the run was marked as unstable'
+            echo 'This will run only if the run was marked as unstable'
         }
         changed {
-            sh 'This will run only if the state of the Pipeline has changed')
-            sh 'For example, the Pipeline was previously failing but is now successful'
+            echo 'This will run only if the state of the Pipeline has changed'
+            echo 'For example, if the Pipeline was previously failing but is now successful'
         }
     }
 }
@@ -205,18 +205,26 @@ node {
         stage('Test') {
             sh 'echo "Fail!"; exit 1'
         }
-        sh 'echo "This will run only if successful"'
-    }
-    catch (exc) {
-        if (currentBuild.result == 'UNSTABLE') {
-            sh 'echo "This will run only if the run was marked as unstable"'
+        echo 'This will run only if successful'
+    } catch (e) {
+        echo 'This will run only if failed'
+
+        // Since we're catching the exception in order to report on it,
+        // we need to re-throw it, to ensure that the build is marked as failed
+        throw e
+    } finally {
+        def currentResult = currentBuild.result ?: 'SUCCESS'
+        if (currentResult == 'UNSTABLE') {
+            echo 'This will run only if the run was marked as unstable'
         }
-        if (currentBuild.result == 'FAILURE') {
-            sh 'echo "This will run only if failed"'
+
+        def previousResult = currentBuild.previousBuild?.result
+        if (previousResult != null && previousResult != currentResult) {
+            echo 'This will run only if the state of the Pipeline has changed'
+            echo 'For example, if the Pipeline was previously failing but is now successful'
         }
-    }
-    finally {
-        sh 'echo "This will always run"'
+
+        echo 'This will always run'
     }
 }
 ----


### PR DESCRIPTION
I found a few small errors when going through the tour, which I fixed.

I also updated the post-build examples to work as expected — fixed a syntax error, used `echo` rather than `sh`, and ensured that failed builds are marked as such, rather than appearing successful. I  also added the "changed" post-build behaviour to the Scripted example.

Various scenarios in Declarative and Scripted were tested in Jenkins and worked as expected.