### PR TITLE
Revert "Pin our prawn gem dependency (used to render PDFs) to 2.1.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,6 @@ dependencies {
 
     /* needed for generating handbook PDFs and others */
     asciidoctor 'rubygems:asciidoctor-pdf:[1.5.0,)'
-    /* pin prawnpdf to 2.1.0 to avoid issues with prawn-templates
-     * <https://github.com/prawnpdf/prawn-templates/issues/14>
-     */
-    asciidoctor 'rubygems:prawn:2.1.0'
 
     /* listen 3.1.2 breaks support for JRuby see :
      * <https://github.com/guard/listen/pull/377#issuecomment-216241081>


### PR DESCRIPTION
The upstream issues have been fixed \o/

This reverts commit 829374d3f352b3f31c69488d140c2ca833dc13a8.