### PR TITLE
Updated prawn to 2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     /* pin prawnpdf to 2.1.0 to avoid issues with prawn-templates
      * <https://github.com/prawnpdf/prawn-templates/issues/14>
      */
-    asciidoctor 'rubygems:prawn:2.1.0'
+    asciidoctor 'rubygems:prawn:2.2.1'
 
     /* listen 3.1.2 breaks support for JRuby see :
      * <https://github.com/guard/listen/pull/377#issuecomment-216241081>


### PR DESCRIPTION
Fixed dependency incompatibility:
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dev'.
> Could not resolve all dependencies for configuration ':asciidoctor'.
   > Could not resolve rubygems:prawn:[2.2.1,).
     Required by:
         :jenkins.io:2.0.0+4e5e16d > rubygems:asciidoctor-pdf:1.5.0.alpha.15-SNAPSHOT > rubygems:prawn-templates:0.0.5
      > there is no overlap for [2.1.0,2.1.0] and [2.2.1,)