### PR TITLE
Fix blue ocean plugin link

### DIFF
--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -21,7 +21,7 @@ and how to get switch into and out of the Blue Ocean UI.
 Blue Ocean can be installed in an existing Jenkins environment or be run
 <<blueocean-docker, with Docker>>.
 
-To start using the plugin:blue-ocean[Blue Ocean plugin] in an existing Jenkins
+To start using the plugin:blueocean[Blue Ocean plugin] in an existing Jenkins
 environment, it must be running Jenkins 2.7.x or later.:
 
 . Login to your Jenkins server


### PR DESCRIPTION
Currently plugin link is pointing to: https://plugins.jenkins.io/blue-ocean, it will throw 404, the right url is: https://plugins.jenkins.io/blueocean