### PR TITLE
Switch the Events page away from a simplepage

### DIFF
--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -1,11 +1,14 @@
 ---
-layout: simplepage
+layout: default
 title: "Events"
 # no such section (yet)
 section: events
 notitle: true
 ---
 
+/ Some more spacing from the navbar
+.pt-4
+  &nbsp;
 
 .container
   .row


### PR DESCRIPTION
This makes it such that the page doesn't get any anchor-js anchors

@daniel-beck whatcha think?

![events-no-anchorjs](https://cloud.githubusercontent.com/assets/26594/24722420/834b0a68-19f8-11e7-8383-09dee205d082.png)
