### PR TITLE
twitter:image needs absolute URL

### DIFF
--- a/content/projects/blueocean/index.html.haml
+++ b/content/projects/blueocean/index.html.haml
@@ -6,7 +6,7 @@ css:
   - '/css/blueocean-animate.css'
   - '/css/blueocean-style.css'
 opengraph:
-  image: 'img/blueocean.gif'
+  image: 'https://jenkins.io/projects/blueocean/img/blueocean.gif'
 ---
 
 %header#header.header


### PR DESCRIPTION
Fix for twitter:image

![image](https://cloud.githubusercontent.com/assets/5196868/24731186/bc582544-1aab-11e7-9bf5-1536573f1a53.png)
