### PR TITLE
Ensure that og:image meta tags generate a full URL rather than absolute

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -35,7 +35,7 @@
     %meta{:content => "Jenkins – Continuous Delivery for every team", :property => "og:description"}/
     %meta{:content => page.title, :property => "og:site_name"}/
     - unless page.opengraph.nil?
-      %meta{:content => page.opengraph[:image], :property => "og:image"}/
+      %meta{:content => expand_link(page.opengraph[:image]), :property => "og:image"}/
 
     - if page.css
       - for style in page.css


### PR DESCRIPTION
From @brody "open graph is fine with the relative URL but twitter needs
absolute... short answer, Yes."

Closes #803