### PR TITLE
Fix outdated infomation on auto shared libraries

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -114,13 +114,8 @@ sandbox just like typical Pipelines.
 
 ===  Automatic Shared Libraries
 
-Other plugins may add ways of defining libraries on the fly.
-For example, the
-plugin:github-organization-folder[GitHub Organization Folder]
-plugin allows a script to use an untrusted library such as
-`github.com/someorg/somerepo` without any additional configuration.  In this
-case, the specified GitHub repository would be loaded, from the `master`
-branch, using an anonymous checkout.
+Other plugins may add ways of defining libraries on the fly. Check with the SCM
+plugin documentation in use to see if it implements such functionality.
 
 == Using libraries
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -288,7 +288,6 @@ image::pipeline/global-pipeline-library-legacy-scm.png["Configuring a 'Legacy SC
 
 If you only specify a library name (optionally with version after `@`) in the `library` step,
 Jenkins will look for a preconfigured library of that name.
-(Or in the case of a `github.com/owner/repo` automatic library it will load that.)
 
 But you may also specify the retrieval method dynamically,
 in which case there is no need for the library to have been predefined in Jenkins.


### PR DESCRIPTION
The automatic shared libraries section refers to a plugin that was tombstoned and replaced by the main github-branch-source plugin.

So far as I have seen in a quick investigation the automatic loading that the old Github origanization folder had was not part of the revamp at the SCM API 2.0 changes.

If automatic shared libraries was part of that change I'm struggling to find documentation on how that is meant to work, and at best this section is referring to a removed plugin.