### PR TITLE
Tidy up the rendering of the security related pages

### DIFF
--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -20,8 +20,8 @@ layout: default
 
 .container
   .row.body
-    - unless page.notitle
-      %h1
-        = page.title
-
-    = content
+    .col-md-12
+      - unless page.notitle
+        %h1
+          = page.title
+      = content

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -10,18 +10,24 @@ section: security
   adocs = Dir.glob(File.join(advisories_dir, '*.{ad,adoc}'))
   years = adocs.select { |it| it =~ /(20\d\d)/ }.map { |it| /(20\d\d)/.match(it)[1] }.uniq.sort
 
-%p
-  This page lists all security advisories that have been published so far.
+.container
+  .row
+    %p
+      This page lists all security advisories that have been published so far.
 
-- years.reverse_each do |year|
-  %h3
-    = year
-  %ul
-    - advisories = Dir.glob(File.join(advisories_dir, year + '-*.{ad,adoc}'))
-    - advisories.sort.reverse_each do |advisory|
-      - page = pages_by_path[advisory]
-      %li
-        %a{:href => page.url}
-          = page.title
-          - if page.kind
-            = "(#{page.kind})"
+  - years.reverse_each do |year|
+    .row
+      .container
+        .row
+          %h3
+            = year
+        .row
+          %ul
+            - advisories = Dir.glob(File.join(advisories_dir, year + '-*.{ad,adoc}'))
+            - advisories.sort.reverse_each do |advisory|
+              - page = pages_by_path[advisory]
+              %li
+                %a{:href => page.url}
+                  = page.title
+                  - if page.kind
+                    = "(#{page.kind})"


### PR DESCRIPTION
Bootstrap gets grumpy when DOM elements are improperly contained in its grid
system. For example, outer DOM elements were "containers" but then stuff inside
them was all splashed about. Like with XML, the only solution is more containers.

Fixes WEBSITE-347

![advisories](https://cloud.githubusercontent.com/assets/26594/24760452/958aa1ca-1a9d-11e7-8f4d-2f94dd425b0b.png)
![security](https://cloud.githubusercontent.com/assets/26594/24760453/958c26b2-1a9d-11e7-928a-fb7aa9f0db77.png)
