### PR TITLE
Add changelog for 2.54 with new CLI and Java 8 requirement

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -60,7 +60,7 @@
       issue: 42141
       pull: 2752
     - type: bug
-      message: Use of the remote API to create items in views (<tt>/view/…/createItem</tt>) didn't actually add items to views since Jenkins 2.22.
+      message: Use of the remote API to create items in views (<code>/view/…/createItem</code>) didn't actually add items to views since Jenkins 2.22.
       issue: 41128
       pull: 2760
     - type: bug
@@ -70,7 +70,7 @@
       pull: 2758
     - type: rfe
       message: >
-        Developer: Allow referencing radio buttons in <tt>f:validateButton</tt> validation methods.
+        Developer: Allow referencing radio buttons in <code>f:validateButton</code> validation methods.
       pull: 2734
 - version: "2.49"
   date: 2017-03-05
@@ -211,7 +211,7 @@
     - type: major bug
       pull: 2803
       issue: 42724
-      message: Restore Windows Slaves Plugin 1.2 compatibility by restoring <tt>windows-service/jenkins.xml</tt>, regression in 2.50.
+      message: Restore Windows Slaves Plugin 1.2 compatibility by restoring <code>windows-service/jenkins.xml</code>, regression in 2.50.
     - type: rfe
       pull: 2796
       message: >
@@ -236,22 +236,22 @@
       pull: 2782
     - type: bug
       message: >
-        Internal API: Make <tt>Run#compareTo</tt> work across jobs.
+        Internal API: Make <code>Run#compareTo</code> work across jobs.
       issue: 42319
       pull: 2762
     - type: rfe
       message: >
-        Internal API: Save <tt>Jenkins</tt> after calling <tt>setSecurityRealm</tt> or <tt>setAuthorizationStrategy</tt>.
+        Internal API: Save <code>Jenkins</code> after calling <code>setSecurityRealm</code> or <code>setAuthorizationStrategy</code>.
       pull: 2790
     - type: rfe
       message: >
-        Internal API: Annotate <tt>PermissionGroup#owner</tt> <tt>@Nonnull</tt>.
+        Internal API: Annotate <code>PermissionGroup#owner</code> <code>@Nonnull</code>.
       pull: 2805
 - version: "2.52"
   date: 2017-03-26
   changes:
     - type: bug
-      message: <tt>Computer#addAction</tt> would throw an <tt>UnsupportedOperationException</tt> since Jenkins 2.30. Such a call site was released in SSH Slaves Plugin 1.15 for SECURITY-161.
+      message: <code>Computer#addAction</code> would throw an <code>UnsupportedOperationException</code> since Jenkins 2.30. Such a call site was released in SSH Slaves Plugin 1.15 for SECURITY-161.
       references:
         - issue: 42969
         - url: https://jenkins.io/security/advisory/2017-03-20/
@@ -268,11 +268,11 @@
   date: 2017-04-02
   changes:
     - type: major bug
-      issue: 42744
-      pull: 2826
       message: >
-        Update to Windows Service Wrapper <tt>2.0.3</tt> and Windows Agent Installer <tt>1.8</tt> to prevent conversion of environment variables to lowercase in the agent executable, regression in Jenkins <tt>2.50</tt>.
+        Update to Windows Service Wrapper 2.0.3 and Windows Agent Installer 1.8 to prevent conversion of environment variables to lowercase in the agent executable, regression in Jenkins 2.50.
       references:
+        - issue: 42744
+        # pull: 2826
         - url: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#203
           title: WinSW Changelog
         - url: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#18
@@ -283,14 +283,57 @@
       references:
         - url: https://bugs.openjdk.java.net/browse/JDK-8080225
           title: JDK-8080225
-      issue: 42934
-      pull: 2816
+        - issue: 42934
+        # pull: 2816
     - type: rfe
       issue: 34670
       pull: 2445
       message: >
         Internal API:
-        Add support of a new full screen mode in <tt>layout.jelly</tt>.
+        Add support of a new full screen mode in <code>layout.jelly</code>.
+- version: "2.54"
+  date: 2017-04-09
+  changes:
+      # Not notable PRs: 2833, 2830, and 2519 were just internal cleanup; #2832 a very minor localization change
+    - type: major rfe
+      message: >
+        Jenkins now requires Java 8 to run.
+      references:
+        - issue: 27624
+        - issue: 42709
+        - pull: 2802
+#        - url: TODO
+#          title: announcement blog post
+    - type: major rfe
+      message: >
+        Non-Remoting-based CLI.
+      references:
+        - issue: 41745
+        - pull: 2795
+#        - url: TODO
+#          title: announcement blog post
+    - type: rfe
+      message: >
+        Use case-insensitive search by default for new and anonymous users.
+      pull: 2801
+      issue: 42645
+    - type: bug
+      message: >
+        Introduce status indicator for skipped download job.
+      # TODO adequately explain what this does
+      issue: 40848
+      pull: 2705
+    - type: bug
+      message: >
+        Properly handle saving system configuration when disabling all administrative monitors.
+      issue: 42852
+      pull: 2828
+    - type: bug
+      message: >
+        When validating a cron expression, consider the specified time zone.
+      pull: 2824
+      issue: 43228
+
 
 # DO NOT EDIT THIS FILE DIRECTLY
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -324,12 +324,11 @@
     - type: bug
       message: >
         Introduce status indicator for skipped download job.
-      # TODO adequately explain what this does
       issue: 40848
       pull: 2705
     - type: bug
       message: >
-        Properly handle saving system configuration when disabling all administrative monitors.
+        Properly handle saving system configuration when disabling all, or all but one, administrative monitors.
       issue: 42852
       pull: 2828
     - type: bug

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -314,6 +314,10 @@
 #          title: announcement blog post
     - type: rfe
       message: >
+        Disable SSH server by default.
+      issue: 33595
+    - type: rfe
+      message: >
         Use case-insensitive search by default for new and anonymous users.
       pull: 2801
       issue: 42645

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -302,8 +302,8 @@
         - issue: 27624
         - issue: 42709
         - pull: 2802
-#        - url: TODO
-#          title: announcement blog post
+        - url: /blog/2017/01/17/Jenkins-is-upgrading-to-Java-8/
+          title: announcement blog post
     - type: major rfe
       message: >
         Non-Remoting-based CLI.

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -297,7 +297,7 @@
       # Not notable PRs: 2833, 2830, and 2519 were just internal cleanup; #2832 a very minor localization change
     - type: major rfe
       message: >
-        Jenkins now requires Java 8 to run.
+        <strong>Jenkins now requires Java 8 to run.</strong>
       references:
         - issue: 27624
         - issue: 42709


### PR DESCRIPTION
Also clean up some older entries:

- Use `<code>` rather than `<tt>` for code/file paths/similar
- Don't use any special highlighting for version numbers
- Don't use both top-level `issue` and `pull` _and_ `references`, the presentation is currently weird.

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/24829976/d194ca66-1c7c-11e7-92bf-e03e471e74a4.png)

----

@oleg-nenashev Could we standardize on the above for future changelog entries?