### PR TITLE
Fix code formatting syntax for Grails plugin entry.

### DIFF
--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -263,7 +263,7 @@ To find out whether you're likely to be impacted by these changes, use link:http
 === Grails Plugin
 *SECURITY-458*
 
-This plugin allows users with Job/Configure permissions to run arbitrary Groovy code inside the Jenkins JVM by configuring a Groovy expression for the <tt>grails.work.dir</tt> option in a job configuration.
+This plugin allows users with Job/Configure permissions to run arbitrary Groovy code inside the Jenkins JVM by configuring a Groovy expression for the +grails.work.dir+ option in a job configuration.
 
 As of publication of this advisory, there is no fix.
 


### PR DESCRIPTION
Minor: `<tt>` currently appears literally on the page, rather than being `monospaced`.