### PR TITLE
Clarify it's not just vulnerabilities

### DIFF
--- a/content/blog/2017/2017-04-10-security-advisory.adoc
+++ b/content/blog/2017/2017-04-10-security-advisory.adoc
@@ -9,7 +9,7 @@
 
 IMPORTANT: These are not security fixes you can apply blindly. We strongly recommend you read this post, as well as the link:/security/advisory/2017-04-10/[security advisory] to understand what the vulnerabilities are, whether and how they affect you, and what to expect when upgrading plugins.
 
-Multiple Jenkins plugins received updates today that fix several security vulnerabilities:
+Multiple Jenkins plugins received updates today that fix several security vulnerabilities or other security-related issues:
 
 * plugin:email-ext[Email Extension (Email-ext)]
 * plugin:envinject[Environment Injector (EnvInject)]

--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -14,7 +14,7 @@ kind: plugins
 </style>
 ++++
 
-This advisory announces vulnerabilities in these Jenkins plugins:
+This advisory announces vulnerabilities or security-related fixes in these Jenkins plugins:
 
 * https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Adaptive+Plugin[Adaptive DSL]
 * https://wiki.jenkins-ci.org/display/JENKINS/Application+Detector+Plugin[Application Detector]


### PR DESCRIPTION
Specifically, the authorization strategies aren't fixing vulnerabilities, just making it less easy to configure Jenkins in a typically undesired way (giving non-admins permission to run scripts).