### PR TITLE
Add redirect used by matrix-auth plugin

### DIFF
--- a/content/redirect/dangerous-permissions.adoc
+++ b/content/redirect/dangerous-permissions.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Matrix-based+security
+---


### PR DESCRIPTION
Oops, forgot to add this to jenkins.io:
https://github.com/jenkinsci/matrix-auth-plugin/blob/2ab009dc87468716d99a125d670d143f852be903/src/main/resources/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor/message.groovy#L36