### PR TITLE
changed links to point to the Job DSL wiki

### DIFF
--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -627,8 +627,8 @@ A new side bar menu _Authorization_ will appear in job pages where different str
 
 More information about this, including how the various options affect Job DSL, can be found in the plugin documentation:
 
-* link:https://github.com/jenkinsci/job-dsl-plugin/blob/master/docs/Migration.md[Migrating to 1.60]
-* link:https://github.com/jenkinsci/job-dsl-plugin/blob/master/docs/Script-Security.md[Script Security]
+* link:https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#migrating-to-160[Migrating to 1.60]
+* link:https://github.com/jenkinsci/job-dsl-plugin/wiki/Script-Security[Script Security]
 
 === Matrix Authorization Strategy Plugin allowed configuring dangerous permissions
 *SECURITY-410*

--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -323,8 +323,8 @@ It is strongly recommended not to do this.
 
 More information:
 
-* link:https://github.com/jenkinsci/job-dsl-plugin/blob/master/docs/Migration.md[Migrating to 1.60]
-* link:https://github.com/jenkinsci/job-dsl-plugin/blob/master/docs/Script-Security.md[Script Security]
+* link:https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#migrating-to-160[Migrating to 1.60]
+* link:https://github.com/jenkinsci/job-dsl-plugin/wiki/Script-Security[Script Security]
 
 
 === Lockable Resources Plugin


### PR DESCRIPTION
internal links on pages do not work outside the wiki