### PR TITLE
Don't break CLI page layout

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -310,7 +310,9 @@ Go to *Manage Jenkins* > *Configure Global Security* and choose "Fixed" or
 
 [source]
 ----
-java.io.IOException: No X-Jenkins-CLI2-Port among [X-Jenkins, null, Server, X-Content-Type-Options, Connection, X-You-Are-In-Group, X-Hudson, X-Permission-Implied-By, Date, X-Jenkins-Session, X-You-Are-Authenticated-As, X-Required-Permission, Set-Cookie, Expires, Content-Length, Content-Type]
+java.io.IOException: No X-Jenkins-CLI2-Port among [X-Jenkins, null, Server, X-Content-Type-Options, Connection,
+        X-You-Are-In-Group, X-Hudson, X-Permission-Implied-By, Date, X-Jenkins-Session, X-You-Are-Authenticated-As,
+        X-Required-Permission, Set-Cookie, Expires, Content-Length, Content-Type]
     at hudson.cli.CLI.getCliTcpPort(CLI.java:284)
     at hudson.cli.CLI.<init>(CLI.java:128)
     at hudson.cli.CLIConnectionFactory.connect(CLIConnectionFactory.java:72)


### PR DESCRIPTION
Not sure whether this should be fixed a different way, but for now should fix the layout breakage in https://jenkins.io/doc/book/managing/cli/#common-problems-with-the-remoting-based-client