### PR TITLE
fix dead link to register nickname on IRC

### DIFF
--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -47,7 +47,7 @@ In order to join, you'll need to:
 
 . have link:https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/[two-factor authentication enabled on GitHub],
 . have link:https://github.com/jenkinsci/infra-cla/[a CLA] in place, and
-. have a link:https://freenode.net/faq.shtml#userregistration[registered nickname on IRC].
+. have a link:https://freenode.net/kb/answer/registration[registered nickname on IRC].
 
 Then, just contact us on the link:/mailing-lists[jenkinsci-developers mailing list].
  Be sure to tell us your GitHub, Freenode (IRC), and link:http://accounts.jenkins.io/[Jenkins community] user names.


### PR DESCRIPTION
Old link: https://freenode.net/faq.shtml#userregistration
Corrected link for convince: https://freenode.net/kb/answer/registration