### PR TITLE
Noting that buffering should be disabled in reverse proxies

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -238,6 +238,10 @@ You can also precede the argument with `@` to load the same content from a file:
 java -jar jenkins-cli.jar [-s JENKINS_URL] -auth @/home/kohsuke/.jenkins-cli command ...
 ----
 
+Generally no special system configuration need be done to enable HTTP-based CLI connections.
+If you are running Jenkins behind an HTTP(S) reverse proxy,
+ensure it does not buffer request or response bodies.
+
 ==== SSH connection mode
 
 Authentication is via SSH keypair.


### PR DESCRIPTION
Integrating testing of the new `-http` mode of `jenkins-cli.jar` turned up a problem with an nginx reverse proxy that enabled `proxy_request_buffering`. While we cannot provide exhaustive guides to proxy configuration here, we can at least remind readers to check these settings.

@reviewbybees