### PR TITLE
Noting org.jenkinsci.main.modules.sshd.SSHD.hostName

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -254,6 +254,11 @@ java -jar jenkins-cli.jar [-s JENKINS_URL] -ssh -user kohsuke command ...
 
 In this mode, the client acts essentially like a native `ssh` command.
 
+By default the client will try to connect to an SSH port on the same host as is used in the `JENKINS_URL`.
+If Jenkins is behind an HTTP reverse proxy, this will not generally work,
+so run Jenkins with the system property `-Dorg.jenkinsci.main.modules.sshd.SSHD.hostName=ACTUALHOST`
+to define a hostname or IP address for the SSH endpoint.
+
 ==== Remoting connection mode
 
 This was the only mode supported by clients downloaded from a pre-2.54 Jenkins server


### PR DESCRIPTION
The [wiki mentions this property](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+SSH) but it is newly relevant since this is the first time the CLI is paying attention to the SSH endpoint.

@reviewbybees