### PR TITLE
Revise message for 2.54 (stress java8 on agents)

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -298,7 +298,7 @@
     - type: major rfe
       message: >
         <strong>Jenkins now requires Java 8 to run.</strong>
-         Note this applies to "slaves" too (you can configure a custom <code>JavaPath</code> in their "Advanced" properties)!
+         Note this applies to "agents" too (you can configure a custom <code>JavaPath</code> in their "Advanced" properties)!
       references:
         - issue: 27624
         - issue: 42709

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -295,7 +295,6 @@
   date: 2017-04-09
   changes:
       # Not notable PRs: 2833, 2830, and 2519 were just internal cleanup; #2832 a very minor localization change
-      # Java8 heads-up applies to JREs running all Jenkins components including master, agents, CLI and related components like Maven Interceptors in Maven Project Plugin. Note that JDKs for builds are configured independently of the java running the Jenkins processes. Also note that for agents in particular, if needed you can install a dedicated JRE on the remote hosts and configure a custom <code>JavaPath</code> in their "Advanced" properties.
     - type: major rfe
       message: >
         <strong>Jenkins (master and agents) now requires Java 8 to run.</strong>
@@ -305,6 +304,7 @@
         - pull: 2802
         - url: /blog/2017/04/10/jenkins-has-upgraded-to-java-8/
           title: announcement blog post
+        # Notes: Java8 heads-up applies to JREs running all Jenkins components including master, agents, CLI and related components like Maven Interceptors in Maven Project Plugin. Note that JDKs for builds are configured independently of the java running the Jenkins processes. Also note that for agents in particular, if needed you can install a dedicated JRE on the remote hosts and configure a custom JavaPath in their "Advanced" properties.
     - type: major rfe
       message: >
         Non-Remoting-based CLI.

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -298,7 +298,8 @@
     - type: major rfe
       message: >
         <strong>Jenkins now requires Java 8 to run.</strong>
-         Note this applies to "agents" too (you can configure a custom <code>JavaPath</code> in their "Advanced" properties)!
+        This applies to JREs running all Jenkins components including master, agents, CLI and related components like Maven Interceptors in Maven Project Plugin. (Note that JDKs for builds are configured independently of the <code>java</code> running the Jenkins processes)
+        Also note that for agents in particular, if needed you can install a dedicated JRE on the remote hosts and configure a custom <code>JavaPath</code> in their "Advanced" properties.
       references:
         - issue: 27624
         - issue: 42709

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -295,11 +295,10 @@
   date: 2017-04-09
   changes:
       # Not notable PRs: 2833, 2830, and 2519 were just internal cleanup; #2832 a very minor localization change
+      # Java8 heads-up applies to JREs running all Jenkins components including master, agents, CLI and related components like Maven Interceptors in Maven Project Plugin. Note that JDKs for builds are configured independently of the java running the Jenkins processes. Also note that for agents in particular, if needed you can install a dedicated JRE on the remote hosts and configure a custom <code>JavaPath</code> in their "Advanced" properties.
     - type: major rfe
       message: >
-        <strong>Jenkins now requires Java 8 to run.</strong>
-        This applies to JREs running all Jenkins components including master, agents, CLI and related components like Maven Interceptors in Maven Project Plugin. (Note that JDKs for builds are configured independently of the <code>java</code> running the Jenkins processes)
-        Also note that for agents in particular, if needed you can install a dedicated JRE on the remote hosts and configure a custom <code>JavaPath</code> in their "Advanced" properties.
+        <strong>Jenkins (master and agents) now requires Java 8 to run.</strong>
       references:
         - issue: 27624
         - issue: 42709

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -298,6 +298,7 @@
     - type: major rfe
       message: >
         <strong>Jenkins now requires Java 8 to run.</strong>
+         Note this applies to "slaves" too (you can configure a custom <code>JavaPath</code> in their "Advanced" properties)!
       references:
         - issue: 27624
         - issue: 42709

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -304,7 +304,6 @@
         - pull: 2802
         - url: /blog/2017/04/10/jenkins-has-upgraded-to-java-8/
           title: announcement blog post
-        # Notes: Java8 heads-up applies to JREs running all Jenkins components including master, agents, CLI and related components like Maven Interceptors in Maven Project Plugin. Note that JDKs for builds are configured independently of the java running the Jenkins processes. Also note that for agents in particular, if needed you can install a dedicated JRE on the remote hosts and configure a custom JavaPath in their "Advanced" properties.
     - type: major rfe
       message: >
         Non-Remoting-based CLI.


### PR DESCRIPTION
It was not apparent when we updated our hosts and lost the connections to workers... so as we figured it out (and lost some time doing so), we thought it should have been more visible from the changelog.