### PR TITLE
Missing 'w' for gradle wrapper

### DIFF
--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -71,7 +71,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh './gradle build'
+                sh './gradlew build'
             }
         }
         stage('Test') {


### PR DESCRIPTION
Example code is missing a character.