### PR TITLE
Fixed link to pipeline activity blog post

### DIFF
--- a/content/blog/2017/04/2017-04-12-welcome-to-blue-ocean-dashboard.adoc
+++ b/content/blog/2017/04/2017-04-12-welcome-to-blue-ocean-dashboard.adoc
@@ -17,7 +17,7 @@ Technical Evangelist at link:https://cloudbees.com[CloudBees].
 Blue Ocean is a new user experience for Jenkins,
 and version 1.0 is now live!
 Blue Ocean makes Jenkins, and continuous delivery, approachable to all team members.
-In my link:/blog/2017/04/06/welcome-to-blue-ocean-pipeline-activity[previous post],
+In my link:/blog/2017/04/11/welcome-to-blue-ocean-pipeline-activity[previous post],
 I used the Blue Ocean Activity View to track the state of branches and
 Pull Requests in one project.
 In this video, I'll use the Blue Ocean Dashboard get a personalized view of the


### PR DESCRIPTION
If you look [here](https://jenkins.io/blog/2017/04/12/welcome-to-blue-ocean-dashboard/), the link in the post is broken. It looks like the date is wrong. Here is the [correct link](https://jenkins.io/blog/2017/04/11/welcome-to-blue-ocean-pipeline-activity/) that should be present.