### PR TITLE
Clarify the policy about first-posters on -dev

### DIFF
--- a/content/mailing-lists.adoc
+++ b/content/mailing-lists.adoc
@@ -33,7 +33,9 @@ mailto:jenkinsci-users+unsubscribe@googlegroups.com[unsubscribe]
 Mailing list for *developers* of Jenkins.
 Post your Jenkins core development and plugin development questions here, as well as topics related to project governance.
 
-WARNING: Questions that should be asked on the _jenkinsci-users_ list will be ignored. Do not cross-post.
+WARNING: *Questions that should be asked on the _jenkinsci-users_ list will be ignored*.
+That means your email will be moderated and not posted to the list.
+Do not cross-post.
 
 link:http://groups.google.com/group/jenkinsci-dev/topics[archive] |
 mailto:jenkinsci-dev+subscribe@googlegroups.com[subscribe] |


### PR DESCRIPTION
Irrelevant emails will not be posted. That means: not only spam, but also emails clearly targeting -users ML and not following the advice already in bold for long...

![image](https://cloud.githubusercontent.com/assets/223853/25693371/371a2396-30a9-11e7-834f-5d8eba242865.png)
