### PR TITLE
Fix links to Docker Hub

### DIFF
--- a/content/download.html.haml
+++ b/content/download.html.haml
@@ -79,7 +79,7 @@ title: Jenkins installation and setup
               for:
 
             .list-group
-              %a.list-group-item.list-group-item-action{:href=>'https://registry.hub.docker.com/_/jenkins/'}
+              %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/_/jenkins/'}
                 %span.icon
                 %span.title
                   Docker
@@ -127,7 +127,7 @@ title: Jenkins installation and setup
               for:
 
             .list-group
-              %a.list-group-item.list-group-item-action{:href=>'https://registry.hub.docker.com/r/jenkinsci/jenkins/'}
+              %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkinsci/jenkins/'}
                 %span.icon
                 %span.title
                   Docker


### PR DESCRIPTION
'registry.hub.docker.com' redirects now to 'hub.docker.com'.

This change also fixes a wrong redirect:
https://hub.docker.com/r/jenkinsci/jenkins/ would go to the home page.