### PR TITLE
Fixed link to pipeline activity blog post

### DIFF
--- a/content/blog/2017/04/2017-04-06-welcome-to-blue-ocean-editor.adoc
+++ b/content/blog/2017/04/2017-04-06-welcome-to-blue-ocean-editor.adoc
@@ -24,7 +24,7 @@ Starting from a clean Jenkins install, the video below will guide you through
 creating and running your first Pipeline in Blue Ocean with the Visual Pipeline Editor.
 
 Please Enjoy! In my next video, I'll go over the
-link:/blog/2017/04/10/welcome-to-blue-ocean-pipeline-activity[Blue Ocean Pipeline Activity View].
+link:/blog/2017/04/11/welcome-to-blue-ocean-pipeline-activity[Blue Ocean Pipeline Activity View].
 
 ++++
 <center>


### PR DESCRIPTION
If you look [here](https://jenkins.io/blog/2017/04/06/welcome-to-blue-ocean-editor/), link to next post is broken. I've fixed that. Please refer to similar PR #861, this is an addition to it.