### PR TITLE
Add changelog for 2.60

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -494,6 +494,42 @@
     # Improved OldDataMonitorTest.unlocatableRun #2860
     # Indicate the actual protocol being served by TcpSlaveAgentListener #2863
     # Suppressing test flakiness #2871
+- version: "2.60"
+  date: 2017-05-10
+  changes:
+    - type: rfe
+      message: >
+        Update to Windows Service Wrapper 2.1.0 to support new features: <tt>download</tt> command with authentication, flag for startup failure on <tt>download</tt> error, Delayed Automatic Start mode.
+      issue: 43737
+      pull: 2870
+    - type: rfe
+      message: >
+        Windows services: Add system property that allows disabling WinSW automatic upgrade on agents.
+      references:
+        - issue: 43603
+        - url: https://github.com/jenkinsci/windows-slave-installer-module#disabling-automatic-upgrade
+          title: more information
+        # pull: 2870
+    - type: bug
+      message: >
+        Windows services: Restore compatibility of the <code>WindowsSlaveInstaller#generateSlaveXml()</code> method (regression in 2.50, no known external usages).
+      issue: 42745
+      pull: 2870
+    - type: bug
+      message: >
+        Windows services: Prevent fatal file descriptor leak when agent service installer fails to read data from the service <tt>startup.log</tt>.
+      issue: 43930
+      pull: 2870
+    - type: bug
+      message: >
+        Use full display name for runs in RSS feed to restore the project name there (regression in 2.59).
+      issue: 44117
+      pull: 2878
+    - type: rfe
+      message: >
+        Internal: Generalize the changelog API to support non-<code>AbstractBuild</code> run types.
+      issue: 24141
+      pull: 2730
 
 
 


### PR DESCRIPTION
As discussed in today's governance meeting, we're cutting 2.60 early. This will allow us to pick this release as the next LTS baseline in two weeks (assuming no major regressions) while not blocking further development of major changes whose inclusion would likely disqualify any release from becoming LTS baseline.

Meeting log with further details and discussion: http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-05-10-18.00.log.html#l-223

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/25919749/f3ec62a6-35cf-11e7-8790-49c8d510d177.png)

