### PR TITLE
Clean up how 'references' work in the changelog.

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -270,7 +270,7 @@
         - issue: 42969
         - url: https://jenkins.io/security/advisory/2017-03-20/
           title: security advisory including SECURITY-161
-      # pull: 2819
+      pull: 2819
     - type: bug
       message: Search results page did not correctly encode query parameters.
       issue: 42390

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -256,7 +256,7 @@
         - issue: 42969
         - url: https://jenkins.io/security/advisory/2017-03-20/
           title: security advisory including SECURITY-161
-      # pull: 2819
+      pull: 2819
     - type: rfe
       message: Update German localization.
       pull: 2777
@@ -270,9 +270,9 @@
     - type: major bug
       message: >
         Update to Windows Service Wrapper 2.0.3 and Windows Agent Installer 1.8 to prevent conversion of environment variables to lowercase in the agent executable, regression in Jenkins 2.50.
+      pull: 2826
       references:
         - issue: 42744
-        # pull: 2826
         - url: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#203
           title: WinSW Changelog
         - url: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#18
@@ -284,7 +284,7 @@
         - url: https://bugs.openjdk.java.net/browse/JDK-8080225
           title: JDK-8080225
         - issue: 42934
-        # pull: 2816
+      pull: 2816
     - type: rfe
       issue: 34670
       pull: 2445
@@ -442,7 +442,7 @@
         - issue: 33021
         - issue: 26379
         - issue: 31549
-        # pull: 2848
+      pull: 2848
     - type: rfe
       message: >
         Migrate legacy users only once per restart to improve performance of the user retrieval logic.
@@ -467,7 +467,7 @@
         - issue: 42959
         - issue: 43979
         - issue: 44046
-        # pull: 2872
+      pull: 2872
     - type: rfe
       message: Prevent Internet Explorer from caching AJAX requests using <tt>Cache-Control</tt> header.
       pull: 2861
@@ -505,11 +505,11 @@
     - type: rfe
       message: >
         Windows services: Add system property that allows disabling WinSW automatic upgrade on agents.
+      pull: 2870
       references:
         - issue: 43603
         - url: https://github.com/jenkinsci/windows-slave-installer-module#disabling-automatic-upgrade
           title: more information
-        # pull: 2870
     - type: bug
       message: >
         Windows services: Restore compatibility of the <code>WindowsSlaveInstaller#generateSlaveXml()</code> method (regression in 2.50, no known external usages).

--- a/content/_partials/changes.html.haml
+++ b/content/_partials/changes.html.haml
@@ -1,16 +1,6 @@
 - page.changes.each do | change |
   %li{:class => change.type }
     = change.message
-    - if change.issue
-      (
-      %a{:href => "https://issues.jenkins-ci.org/browse/JENKINS-#{change.issue}" }<>
-        = "issue #{change.issue}"
-      )
-    - elsif change.pull
-      (
-      %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{change.pull}" }<>
-        = "pull #{change.pull}"
-      )
     - if change.references
       - change.references.each_with_index do | reference, index |
         - if index == 0
@@ -31,3 +21,13 @@
               = reference.url
         - if index == change.references.count - 1
           )
+    - elsif change.issue
+      (
+      %a{:href => "https://issues.jenkins-ci.org/browse/JENKINS-#{change.issue}" }<>
+        = "issue #{change.issue}"
+      )
+    - elsif change.pull
+      (
+      %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{change.pull}" }<>
+        = "pull #{change.pull}"
+      )


### PR DESCRIPTION
Previously, if both 'references' and top-level 'issue' and/or 'pull'
were set, both were displayed in independent sets of parentheses.

Now, if 'references' is defined, everything in it is shown and nothing
else. Only if 'references' doesn't exist, a top-level 'issue' is shown
and only if neither exists will a top-level 'pull' be shown.

----

This has been slightly weird for a while, now it's cleaned up (well, mostly -- cleaner would be to wrap all in references, but for now I still favor the shorter top-level `pull`/`issue` elements for the 90% case).

Now with more flexibility: There's both an issue and a PR, but for some reason we only want to show the latter? Just do the following, as now `references` take precedence over other top-level elements if both exist:

    issue: 12345
    references: 
      - pull: 1234

This PR should not result in presentation changes (spot checked), as the weird double parens sets situation has been prevented by commenting out elements previously. That is now no longer necessary.

@oleg-nenashev WDYT?

CC @rtyler who wondered about commented out elements and @olivergondza who may have tooling that's impacted.