### PR TITLE
Add comments directing people to actual changelog entries

### DIFF
--- a/content/changelog-stable.html.haml
+++ b/content/changelog-stable.html.haml
@@ -12,6 +12,7 @@ title: LTS Changelog
   for advice on upgrading Jenkins.
 
 .ratings
+  - # source: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/lts.yml
   - site.changelogs[:lts].reverse_each do | release |
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.stable)
       %h3{:id => "v#{release.version}" }

--- a/content/changelog.html.haml
+++ b/content/changelog.html.haml
@@ -6,6 +6,7 @@ title: Changelog
 = partial('changelog-header.html')
 
 .ratings
+  - # source: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml
   - site.changelogs[:weekly].reverse_each do | release |
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
       %h3{:id => "v#{release.version}" }


### PR DESCRIPTION
Pro: Otherwise, the "improve this page" link is pretty useless on the changelog pages for users who don't know how this works.

Con: URL may change and make the then-outdated comment extra confusing.

@rtyler WDYT?