### PR TITLE
Fix property GlobalMatrixAuthorizationStrategy.dangerousPermissions

### DIFF
--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -652,7 +652,7 @@ If any of the affected permissions were granted to users who aren't also granted
 Additionally, an administrative monitor will inform administrators about this possible misconfiguration.
 If the additional permissions are then removed from the affected non-admin users, the columns for these permissions will no longer be shown.
 
-If you want to retain the old, unsafe behavior, set the system property +hudson.security.GlobalMatrixAuthorizationStrategy..dangerousPermissions+ to +true+.
+If you want to retain the old, unsafe behavior, set the system property +hudson.security.GlobalMatrixAuthorizationStrategy.dangerousPermissions+ to +true+.
 The plugin retains permissions configured before upgrading, so there should be no changes in behavior afterwards.
 
 === Role-based Authorization Strategy Plugin allowed configuring dangerous permissions


### PR DESCRIPTION
ref: https://github.com/jenkinsci/matrix-auth-plugin/blob/master/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java#L464

There is no reason to have two dots in `hudson.security.GlobalMatrixAuthorizationStrategy..dangerousPermissions`

please review @daniel-beck 