### PR TITLE
[INFRA-897] Add link to core taglib documentation

### DIFF
--- a/content/_layouts/developer.html.haml
+++ b/content/_layouts/developer.html.haml
@@ -80,10 +80,9 @@ section: doc
           Taglib Documentation
 
         %ul
-          - # TODO https://issues.jenkins-ci.org/browse/INFRA-897
-          - #   %li
-          - #     %a{:href => 'TODO'}
-          - #       Core Taglib
+          %li
+            %a{:href => 'http://reports.jenkins.io/reports/core-taglib/jelly-taglib-ref.html'}
+              Core
           %li
             %a{:href => 'http://stapler.kohsuke.org/jelly-taglib-ref.html'}
               Stapler


### PR DESCRIPTION
**ON HOLD** Currently there's an issue with the content-type that the report files are served with.

Output generated by https://github.com/jenkins-infra/core-taglibs-report-generator