### PR TITLE
Add generated extensions index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ content/_data/_generated/
 # generated pipeline step documentation
 content/doc/pipeline/steps/*.adoc
 
+# generated extension points documentation
+content/doc/developer/extensions/*.adoc
+
 
 /.bundle/
 /.sass-cache/

--- a/content/_layouts/developer.html.haml
+++ b/content/_layouts/developer.html.haml
@@ -78,6 +78,10 @@ section: doc
               Plugins
 
         %h5
+          %a{:href => '/doc/developer/extensions/'}
+            Extensions Index
+
+        %h5
           Taglib Documentation
 
         %ul

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -37,6 +37,12 @@ RESOURCES = [
     nil,
     nil
   ],
+  [
+    'https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/lastSuccessfulBuild/artifact/*.adoc/*zip*/extension-indexer.zip',
+    'content/_tmp/extension-indexer.zip',
+    nil,
+    'content/doc/developer/extensions'
+  ],
 ]
 
 
@@ -78,6 +84,9 @@ class Fetcher
       #if downloading a zip file, extract it
       if origin.include? ".zip"
         Zip.on_exists_proc = true
+
+        FileUtils.mkdir_p zip_dest
+
         Zip::File.open(destination) do |zip_file|
           zip_file.each do |f|
             fpath = File.join(zip_dest, f.name)


### PR DESCRIPTION
Using a temporary URL while waiting for https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/1/ to finish. Then, URL will be `https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/lastSuccessfulBuild/artifact/*.adoc/*zip*/extension-indexer.zip`

Had to add `mkdirs_p` because Git cannot do empty directories, but missing directory failed the build.

Replaces https://wiki.jenkins-ci.org/display/JENKINS/Extension+points