### PR TITLE
Minor fixes and improvements to changelog feed output

### DIFF
--- a/content/_partials/rss-changes.xml.haml
+++ b/content/_partials/rss-changes.xml.haml
@@ -26,7 +26,7 @@
           = change.message.encode( { :xml => :text } )
           = "</li>".encode( { :xml => :text } )
         = "</ul>".encode( { :xml => :text } )
-    %guid
+    %guid(isPermaLink='false')
       jenkins-#{release.version}
     %pubDate
       = release.date.rfc822

--- a/content/changelog-stable/rss.xml.haml
+++ b/content/changelog-stable/rss.xml.haml
@@ -8,6 +8,7 @@
       Jenkins LTS Changelog
     %link
       https://jenkins.io/changelog-stable
+    %atom:link(href="#{site.base_url}#{page.url}" rel="self" type="application/rss+xml")
     %description
       Changelog for Jenkins LTS releases
     %lastBuildDate

--- a/content/changelog/rss.xml.haml
+++ b/content/changelog/rss.xml.haml
@@ -8,6 +8,7 @@
       Jenkins Changelog
     %link
       https://jenkins.io/changelog
+    %atom:link(href="#{site.base_url}#{page.url}" rel="self" type="application/rss+xml")
     %description
       Changelog for Jenkins weekly releases
     %lastBuildDate


### PR DESCRIPTION
Turns out https://validator.w3.org/feed/ exists, and leaving off `isPermaLink` for the `guid` was an error (I read the spec wrong).

The other (the feed URL) is improving compatibility per https://validator.w3.org/feed/docs/warning/MissingAtomSelfLink.html