### PR TITLE
Do not show unreleased changes in RSS feed

### DIFF
--- a/content/_partials/rss-changes.xml.haml
+++ b/content/_partials/rss-changes.xml.haml
@@ -1,32 +1,33 @@
 - page.releases.reverse_each do |release|
-  %item
-    %title Jenkins #{release.version}
-    %link
-      #{page.changelog_url}/#v#{release.version}
-    %description
+  - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
+    %item
+      %title Jenkins #{release.version}
+      %link
+        #{page.changelog_url}/#v#{release.version}
+      %description
 
-      - if release.lts_changes
-        = "<strong>Changes since #{release.lts_baseline}:</strong>".encode( { :xml => :text } )
-
-      = "<ul>".encode( { :xml => :text } )
-      - release.changes.each do | change |
-        = "<li>".encode( { :xml => :text } )
-        #{change.type.gsub(/\w+/, &:capitalize).gsub(/rfe/i, 'RFE')}:
-        = change.message.encode( { :xml => :text } )
-        = "</li>".encode( { :xml => :text } )
-      = "</ul>".encode( { :xml => :text } )
-
-      - if release.lts_changes
-        = "<strong>Notable changes since #{release.lts_predecessor}:</strong>".encode( { :xml => :text } )
+        - if release.lts_changes
+          = "<strong>Changes since #{release.lts_baseline}:</strong>".encode( { :xml => :text } )
 
         = "<ul>".encode( { :xml => :text } )
-        - release.lts_changes.each do | change |
+        - release.changes.each do | change |
           = "<li>".encode( { :xml => :text } )
           #{change.type.gsub(/\w+/, &:capitalize).gsub(/rfe/i, 'RFE')}:
           = change.message.encode( { :xml => :text } )
           = "</li>".encode( { :xml => :text } )
         = "</ul>".encode( { :xml => :text } )
-    %guid(isPermaLink='false')
-      jenkins-#{release.version}
-    %pubDate
-      = release.date.rfc822
+
+        - if release.lts_changes
+          = "<strong>Notable changes since #{release.lts_predecessor}:</strong>".encode( { :xml => :text } )
+
+          = "<ul>".encode( { :xml => :text } )
+          - release.lts_changes.each do | change |
+            = "<li>".encode( { :xml => :text } )
+            #{change.type.gsub(/\w+/, &:capitalize).gsub(/rfe/i, 'RFE')}:
+            = change.message.encode( { :xml => :text } )
+            = "</li>".encode( { :xml => :text } )
+          = "</ul>".encode( { :xml => :text } )
+      %guid(isPermaLink='false')
+        jenkins-#{release.version}
+      %pubDate
+        = release.date.rfc822

--- a/content/_partials/rss-changes.xml.haml
+++ b/content/_partials/rss-changes.xml.haml
@@ -1,5 +1,5 @@
 - page.releases.reverse_each do |release|
-  - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
+  - if Gem::Version.new(release.version) <= Gem::Version.new(page.newest_release)
     %item
       %title Jenkins #{release.version}
       %link

--- a/content/changelog-stable/rss.xml.haml
+++ b/content/changelog-stable/rss.xml.haml
@@ -13,4 +13,4 @@
       Changelog for Jenkins LTS releases
     %lastBuildDate
       #{Date.today.rfc822}
-    = partial('rss-changes.xml.haml', :releases => site.changelogs[:lts], :changelog_url => 'https://jenkins.io/changelog-stable/')
+    = partial('rss-changes.xml.haml', :releases => site.changelogs[:lts], :changelog_url => 'https://jenkins.io/changelog-stable/', :newest_release => site.jenkins.stable)

--- a/content/changelog/rss.xml.haml
+++ b/content/changelog/rss.xml.haml
@@ -13,4 +13,4 @@
       Changelog for Jenkins weekly releases
     %lastBuildDate
       #{Date.today.rfc822}
-    = partial('rss-changes.xml.haml', :releases => site.changelogs[:weekly], :changelog_url => 'https://jenkins.io/changelog/')
+    = partial('rss-changes.xml.haml', :releases => site.changelogs[:weekly], :changelog_url => 'https://jenkins.io/changelog/', :newest_release => site.jenkins.latest)


### PR DESCRIPTION
Because https://jenkins.io/changelog/rss.xml should not yet show 2.64.

Real diff: https://github.com/jenkins-infra/jenkins.io/pull/926/files?w=1