### PR TITLE
Update the 'Securing a Jenkins instance on Azure' blog post

### DIFF
--- a/content/blog/2017/04/2017-04-20-secure-jenkins-on-azure.adoc
+++ b/content/blog/2017/04/2017-04-20-secure-jenkins-on-azure.adoc
@@ -25,12 +25,7 @@ the JNLP protocol.
 
 == Deploy Jenkins
 
-The simplest way to deploy a secure Jenkins instance is to use one of these Azure QuickStart templates:
-
-* https://aka.ms/101-jenkins-ssh[Jenkins instance on a Virtual Machine secured by SSH public key]
-* https://aka.ms/101-jenkins-pwd[Jenkins instance on a Virtual Machine secured by user name and password]
-
-If you have an existing Jenkins instance or want to setup your instance manually, follow the steps below.
+The simplest way to deploy a secure Jenkins instance is by using the https://aka.ms/jenkins-on-azure[Azure Marketplace offer]. If you have an existing Jenkins instance or want to setup your instance manually, follow the steps below.
 
 == Securely log in to Jenkins
 After you've deployed your new virtual machine with a hosted Jenkins instance, you will notice that by default the instance listens on port 8080 using 'HTTP'. If you want to set up 'HTTPS' communication, you will need to provide an SSL certificate. Unfortunately, most certificate authorities are not cheap and other free services like https://letsencrypt.org/[Let's Encrypt] have a very small quota (about 20 certificates per week for the entire 'azure.com' subdomain). The only other option is to use a self-signed certificate, but then users must explicitly verify and mark your certificate as trusted, which is not recommended.


### PR DESCRIPTION
I've replaced the links to the Azure QuickStart templates with a link to the Azure Marketplace. That offer will be kept up to date and it's much simpler to use and deploy.