### PR TITLE
Minor improvements to developer docs structure

### DIFF
--- a/content/_layouts/developer.html.haml
+++ b/content/_layouts/developer.html.haml
@@ -26,7 +26,7 @@ section: doc
       .sidebar-nav
 
         %h3
-          Developer Guides
+          Developer Docs
 
         %h4
           Getting Started
@@ -35,7 +35,7 @@ section: doc
             = active_href('doc/developer/plugin-tutorial', 'Plugin Tutorial', :fuzzy => true)
 
         %h4
-          Reference
+          Topics
         %ol
           - site.devbook.chapters.each do |chapter|
             %li
@@ -47,52 +47,31 @@ section: doc
                 - else
                   %i.icon-warning{:title => 'Partial work in progress', :style => 'opacity: 0.5;'}
                     &nbsp;
-          %li
-            = active_href('doc/developer/guides', 'Appendix C: Index of All How-To Guides', :fuzzy => true)
+
+        %h4
+          = active_href('doc/developer/guides', 'How-To Guides', :fuzzy => true)
 
         %h4
           Resources
 
         %h5
-          Jenkins Javadoc
+          = active_href('doc/developer/extensions', 'Extensions', :fuzzy => true)
+
+        %h5
+          = active_href('doc/developer/javadoc', 'Javadoc', :fuzzy => true)
+
+        %h5
+          Taglibs
 
         %ul
           %li
-            %a{:href => 'http://javadoc.jenkins.io/'}
-              Latest Jenkins Javadoc
-          - site._generated[:lts_baselines].results[0..9].each do | entry |
-            - version = entry.version.reverse[2..-1].reverse
-            %li
-              %a{:href => "http://javadoc.jenkins.io/archive/jenkins-#{version}"}
-                = version
-
-        %h5
-          Other Javadoc
-
-        %ul
-          %li
-            %a{:href => 'http://stapler.kohsuke.org/apidocs/'}
-              Stapler
-          %li
-            %a{:href => 'http://javadoc.jenkins.io/plugin/'}
-              Plugins
-
-        %h5
-          %a{:href => '/doc/developer/extensions/'}
-            Extensions Index
-
-        %h5
-          Taglib Documentation
-
-        %ul
-          %li
-            %a{:href => 'http://reports.jenkins.io/reports/core-taglib/jelly-taglib-ref.html'}
+            %a{:href => 'http://reports.jenkins.io/reports/core-taglib/jelly-taglib-ref.html', :target => '_blank'}
               Core
           %li
-            %a{:href => 'http://stapler.kohsuke.org/jelly-taglib-ref.html'}
+            %a{:href => 'http://stapler.kohsuke.org/jelly-taglib-ref.html', :target => '_blank'}
               Stapler
           %li
-            %a{:href => 'https://commons.apache.org/proper/commons-jelly/tags.html'}
+            %a{:href => 'https://commons.apache.org/proper/commons-jelly/tags.html', :target => '_blank'}
               Jelly Core
 
         %h5
@@ -100,7 +79,7 @@ section: doc
 
         %ul
           %li
-            %a{:href => 'https://jenkinsci.github.io/maven-hpi-plugin/'}
+            %a{:href => 'https://jenkinsci.github.io/maven-hpi-plugin/', :target => '_blank'}
               Maven HPI Plugin
 
     .col-lg-9

--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -78,10 +78,7 @@ section: doc
 
         %hr/
         %h4
-          Developers
-
-        %h5
-          = active_href('doc/developer', 'Reference Documentation')
+          = active_href('doc/developer', 'Developer Docs')
 
     .col-lg-9
       - unless page.notitle

--- a/content/doc/developer/_book.yml
+++ b/content/doc/developer/_book.yml
@@ -15,6 +15,6 @@ chapters:
   - cli
   - testing
   - plugin-development
+  - blueocean-plugin-development
   - building
   - development-environment
-  - blueocean-plugin-development

--- a/content/doc/developer/blueocean-plugin-development/index.adoc
+++ b/content/doc/developer/blueocean-plugin-development/index.adoc
@@ -2,7 +2,7 @@
 layout: developerchapter
 summary: How to develop plugins for Blue Ocean
 wip: true
-title: Extending Blue Ocean
+title: Blue Ocean
 references:
 - url: https://github.com/jenkinsci/blueocean-plugin
   title: Main Blue Ocean plugin repository

--- a/content/doc/developer/building/index.adoc
+++ b/content/doc/developer/building/index.adoc
@@ -10,4 +10,4 @@ references:
   title: Debugging native Maven jobs # TODO convert to guide
 ---
 
-= Appendix A&#58; Building and Debugging Jenkins
+= Building and Debugging

--- a/content/doc/developer/development-environment/index.adoc
+++ b/content/doc/developer/development-environment/index.adoc
@@ -21,4 +21,4 @@ references:
   title: Jenkins Development Environment with Nexus # TODO really?
 ---
 
-= Appendix B&#58; Setting up a Development Environment
+= Setting up a Development Environment

--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -1,0 +1,56 @@
+---
+layout: developer
+---
+
+%h1
+  Javadoc
+
+%h2
+  Jenkins Core
+
+%p
+  This is the Javadoc for Jenkins core. Multiple versions are available: The latest weekly release, as well as the most recent LTS baselines.
+  Unless a plugin requires very recent functionality, it should generally use one of the LTS baselines for its Jenkins core dependency.
+
+%h3
+  Weekly
+
+%ul
+  %li
+    %a{:href => 'http://javadoc.jenkins.io/', :target => '_blank'}
+      Latest Core Javadoc
+
+%h3
+  LTS Baselines
+
+%ul
+  - site._generated[:lts_baselines].results[0..9].each do | entry |
+    - version = entry.version.reverse[2..-1].reverse
+    %li
+      %a{:href => "http://javadoc.jenkins.io/archive/jenkins-#{version}", :target => '_blank'}
+        Jenkins Core
+        = version
+        Javadoc
+
+%h2
+  Stapler Javadoc
+
+%p
+  Stapler is the framework used by Jenkins to route requests to the objects handling them.
+  %a{:href => '/doc/developer/architecture/web/'}
+    Learn more.
+
+%p
+  %a{:href => 'http://stapler.kohsuke.org/apidocs/', :target => '_blank'}
+    Stapler Javadoc on the Stapler site
+
+
+%h2
+  Plugins Javadoc
+
+%p
+  This site collects and the Javadoc for the newest releases of all Jenkins plugins, if available.
+
+%p
+  %a{:href => 'http://javadoc.jenkins.io/plugin/', :target => '_blank'}
+    Plugins Javadoc

--- a/content/doc/developer/plugin-development/index.adoc
+++ b/content/doc/developer/plugin-development/index.adoc
@@ -4,6 +4,8 @@ summary: About Jenkins' internal extension functionality, modules, and plugins
 layout: developerchapter
 wip: true
 references:
+- url: https://github.com/jenkinsci/plugin-pom
+  title: Plugin parent POM on GitHub
 - url: https://wiki.jenkins-ci.org/display/JENKINS/Adding+tool+auto-installer
   title: Adding tool auto-installer
 - url: https://wiki.jenkins-ci.org/display/JENKINS/Choosing+Jenkins+version+to+build+against


### PR DESCRIPTION
- Restructure left navigation bar for developer docs
- add new page for links to Javadoc
- Move Blue Ocean doc up in the list to plugin dev.

---

> ![screen shot](https://user-images.githubusercontent.com/1831569/27003204-968db098-4df2-11e7-8daf-930d9482ad90.png)
