### PR TITLE
Add changelog for 2.60.1

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -423,6 +423,13 @@
           title: full changelog
     # WINDOWS SERVICES END
 
+    # PACKAGING START
+    - type: bug
+      message: >
+        Packaging:
+        Do not invoke recursive <code>chown</code> in <code>JENKINS_HOME</code> during the RPM post-install step unless owned by a different user.
+      issue: 23273
+    # PACKAGING END
 
     # SEARCH START
     - type: rfe

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -342,6 +342,156 @@
       pull: 2868
       issue: 44010
 
+- version: "2.60.1"
+  date: 2017-06-21
+  lts_predecessor: "2.46.3"
+  lts_baseline: "2.60"
+  banner: >
+    <strong>2.60.1 is the first Jenkins LTS release that requires Java 8 to run.</strong>
+    If you're using the Maven Project type, please note that it needs to use a JDK capable of running Jenkins, i.e. JDK 8 or up.
+    If you configure an older JDK in a Maven Project, Jenkins will attempt to find a newer JDK and use that automatically.
+    If your SSH Slaves fail to start and you have the plugin install the JRE to run them, make sure to update SSH Slaves Plugin to at least version 1.17.
+  lts_changes:
+    - type: major rfe
+      message: >
+        <strong>Jenkins (master and agents) now requires Java 8 to run.</strong>
+      references:
+        - issue: 27624
+        - issue: 42709
+        - pull: 2802
+        - url: /blog/2017/04/10/jenkins-has-upgraded-to-java-8/
+          title: announcement blog post
+    - type: bug
+      message: >
+        Update Groovy to 2.4.8 to address memory leak issue.
+        <strong><em>Pipeline: Groovy</em> needs to be upgraded to 2.28 or higher to prevent regressions.</strong>
+      references:
+        - issue: 33358
+        - issue: 42189
+
+
+    # WINDOWS SERVICES START
+    - type: major rfe
+      message: >
+        Upgrade the Windows Agent Installer module from <code>1.6</code> to <code>1.7</code>.
+        This change picks major updates in Windows service management logic.
+      references:
+        - url: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#17
+          title: full changelog
+        - url: https://github.com/jenkinsci/windows-slave-installer-module#upgrading-old-agents
+          title: guide to upgrading old Windows service agents
+      pull: 2765
+    - type: major rfe
+      message: >
+        Windows services:
+        Upgrade the bundled <a href="https://github.com/kohsuke/winsw">Windows Service Wrapper</a> from <code>1.18</code> to <code>2.0.2</code>.
+      references:
+        - url: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md
+          title: full changelog
+      pull: 2765
+    - type: rfe
+      message: >
+        Windows services:
+        Enable <a href="https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md">Runaway Process Killer</a>
+        by default in new Agent and Master installations.
+      issue: 39231
+      pull: 2765
+    - type: rfe
+      message: >
+        Windows services:
+        Enable auto-upgrade of remoting on newly installed agents if they are connected by HTTPS.
+      issue: 39237
+      pull: 2765
+    - type: rfe
+      message: >
+        Windows services:
+        Add support of shared directories mapping in Windows agent services.
+      references:
+        - url: https://github.com/kohsuke/winsw/blob/master/doc/extensions/sharedDirectoryMapper.md
+          title: Shared Directory Mapper documentation
+      issue: 23487
+      pull: 2765
+    - type: bug
+      message: >
+        Windows services:
+        Integrate various stability and performance fixes in <a href="https://github.com/kohsuke/winsw">Windows Service Wrapper</a>
+        from <code>1.18</code> to <code>2.0.2</code>.
+        There are many fixes around configuration options and process termination.
+      pull: 2765
+      references:
+        - url: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md
+          title: full changelog
+    # WINDOWS SERVICES END
+
+
+    # SEARCH START
+    - type: rfe
+      message: >
+        Use case-insensitive search by default for new and anonymous users.
+      pull: 2801
+      issue: 42645
+    - type: rfe
+      message: >
+        Searching in the <code>Build History</code> widget takes into account user preferences (case sensitivity by default).
+      pull: 2683
+    - type: rfe
+      message: >
+        Allow searching by build parameter values in the <code>Build History</code> widget.
+      issue: 40718
+      pull: 2683
+    # SEARCH END
+
+
+    - type: rfe
+      message: >
+        Update the Trilead SSH library to get support of new Mac, Key, and Key Exchange Algorithms.
+      references:
+        - issue: 33021
+        - issue: 26379
+        - issue: 31549
+        - issue: 42959
+        - issue: 43979
+        - issue: 44046
+      pull: 2848
+      # Included issue reference to followup fix in pull 2872
+    - type: rfe
+      message: >
+        When creating temporary files, use the <code>jenkins</code> prefix instead of the old <code>hudson</code> one.
+      pull: 2778
+
+
+    # LOCALIZATIONS START
+    - type: rfe
+      message: Update German, French and Russian localizations.
+      references:
+        - pull: 2777
+        - pull: 2787
+        - pull: 2798
+    - type: rfe
+      message: >
+        Removed localizations with very low coverage: Albanian, Basque, Belarusian, Bengali, Esperanto, Galician, Georgian, Gujarati, Hindi, Icelandic, Indonesian, Irish, Kannada, Macedonian, Marathi, Mongolian, Occitan, Punjabi, Sinhala, Tamil, Telugu, Thai.
+      pull: 2813
+    # LOCALIZATIONS END
+
+    - type: rfe
+      message: >
+        Internal API:
+        Add the ability for <code>ItemListener</code> to veto copy operations;
+        make <code>Run#compareTo</code> work across jobs;
+        save <code>Jenkins</code> after calling <code>setSecurityRealm</code> or <code>setAuthorizationStrategy</code>.
+      references:
+        - issue: 34691
+        - issue: 42319
+        - pull: 2762
+        - pull: 2782
+        - pull: 2790
+        - pull: 2805
+  changes:
+    - type: bug
+      message: >
+        Fix for <code>NullPointerException</code> while initiating some SSH connections (regression in 2.59).
+      issue: 44120
+      pull: 2888
 
 # DO NOT EDIT THIS FILE DIRECTLY
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -30,12 +30,12 @@
       issue: 19142
     - type: rfe
       message: >
-        Allow <code>CommandInterpreter</code> build steps to set a build result as <code>Unstable</code> via the return code.
+        Allow <code>CommandInterpreter</code> build steps to set a build result as <em>Unstable</em> via the return code.
         Shell and Batch build steps now support this feature.
       issue: 23786
     - type: rfe
       message: >
-        Internal: Upgrade Stapler library from <code>1.243</code> to <code>1.246</code> with fixes required for the Blue Ocean project.
+        Internal: Upgrade Stapler library from 1.243 to 1.246 with fixes required for the Blue Ocean project.
         Changes are listed <a href="https://github.com/stapler/stapler/compare/stapler-parent-1.243...stapler-parent-1.246">here</a>.
       pull: 2593
   changes:
@@ -81,7 +81,7 @@
         Prevent the <code>ClassNotFoundException: javax.servlet.ServletException</code> error when invoking shell tasks on remote agents.
       issue: 40863
     - type: bug
-      message: Properties were not passed to Maven command by Maven build step when the <code>Inject Build Variables</code> flag was not set.
+      message: Properties were not passed to Maven command by Maven build step when the <em>Inject Build Variables</em> flag was not set.
       issue: 39268
     - type: bug
       message: Job configuration submission now does not fail when there is no parameters property.
@@ -90,7 +90,7 @@
       message: Update remoting to 3.4 in order to properly terminate the channel in the case <code>Errors</code> and <code>Exception</code>s.
       issue: 39835
     - type: bug
-      message: <code>Check for Updates</code> button in the Plugin Manager was hidden in the <code>Updates</code> tab when there was no plugins updates available.
+      message: <em>Check for Updates</em> button in the Plugin Manager was hidden in the <em>Updates</em> tab when there was no plugins updates available.
       issue: 39971
     - type: bug
       message: >
@@ -147,7 +147,7 @@
   lts_changes:
     - type: rfe
       message: >
-        Update the <a href="https://github.com/jenkinsci/sshd-module">SSHD module</a> from <code>1.7</code> to <code>1.8</code>.
+        Update the <a href="https://github.com/jenkinsci/sshd-module">SSHD module</a> from 1.7 to 1.8.
         The change disables obsolete Ciphers: AES128CBC, TripleDESCBC, and BlowfishCBC.
     - type: rfe
       message: Enable the JNLP4 agent protocol by default.
@@ -172,7 +172,7 @@
       message: Do not print warnings about undefined parameters when <code>hudson.model.ParametersAction.keepUndefinedParameters</code> property is set to <code>false</code>.
       pull: 2687
     - type: rfe
-      message: Increase the <code>JENKINS_HOME</code> disk space threshold from <code>1Gb</code> to <code>10Gb</code> left. The warning will be shown only if more than <code>90%</code> of the disk is utilized.
+      message: Increase the <code>JENKINS_HOME</code> disk space threshold from 1 GB to 10 GB left. The warning will be shown only if more than 90% of the disk is utilized.
       issue: 40749
     - type: bug
       message: Delete obsolete pinning UI.
@@ -181,7 +181,7 @@
       message: Use project-specific validation URL for SCM Trigger, so <code>H</code> is handled correctly in preview.
       issue: 26977
     - type: bug
-      message: Failure to serialize a single <code>Action</code> could cause an entire REST export response to fail. Upgraded to Stapler <code>1.250</code> with a fix.
+      message: Failure to serialize a single <code>Action</code> could cause an entire REST export response to fail. Upgraded to Stapler 1.250 with a fix.
       issue: 40088
     - type: bug
       message: Add Usage Statistics section to the global configuration to make it easier to find.
@@ -198,7 +198,7 @@
       pull: 2793
     - type: bug
       message: >
-        Update Remoting from <code>3.5</code> to <code>3.7</code>
+        Update Remoting from 3.5 to 3.7
         in order to prevent file descriptor leaks on agents in the case of multiple connection attempts.
       references:
         - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#37
@@ -373,7 +373,7 @@
     # WINDOWS SERVICES START
     - type: major rfe
       message: >
-        Upgrade the Windows Agent Installer module from <code>1.6</code> to <code>1.7</code>.
+        Upgrade the Windows Agent Installer module from 1.6 to 1.7.
         This change picks major updates in Windows service management logic.
       references:
         - url: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#17
@@ -384,7 +384,7 @@
     - type: major rfe
       message: >
         Windows services:
-        Upgrade the bundled <a href="https://github.com/kohsuke/winsw">Windows Service Wrapper</a> from <code>1.18</code> to <code>2.0.2</code>.
+        Upgrade the bundled <a href="https://github.com/kohsuke/winsw">Windows Service Wrapper</a> from 1.18 to 2.0.2.
       references:
         - url: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md
           title: full changelog
@@ -415,7 +415,7 @@
       message: >
         Windows services:
         Integrate various stability and performance fixes in <a href="https://github.com/kohsuke/winsw">Windows Service Wrapper</a>
-        from <code>1.18</code> to <code>2.0.2</code>.
+        from 1.18 to 2.0.2.
         There are many fixes around configuration options and process termination.
       pull: 2765
       references:
@@ -432,11 +432,11 @@
       issue: 42645
     - type: rfe
       message: >
-        Searching in the <code>Build History</code> widget takes into account user preferences (case sensitivity by default).
+        Searching in the Build History widget takes into account user preferences (case sensitivity by default).
       pull: 2683
     - type: rfe
       message: >
-        Allow searching by build parameter values in the <code>Build History</code> widget.
+        Allow searching by build parameter values in the Build History widget.
       issue: 40718
       pull: 2683
     # SEARCH END

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -288,9 +288,8 @@
     - type: bug
       message: >
         Packaging:
-        Do not invoke recursive chown in JENKINS_HOME during the RPM post-install step.
-      references:
-        - issue: 23273
+        Do not invoke recursive <code>chown</code> in <code>JENKINS_HOME</code> during the RPM post-install step unless owned by a different user.
+      issue: 23273
     - type: rfe
       issue: 34670
       pull: 2445

--- a/content/changelog-stable/index.html.haml
+++ b/content/changelog-stable/index.html.haml
@@ -17,6 +17,9 @@ title: LTS Changelog
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.stable)
       %h3{:id => "v#{release.version}" }
         = "What's new in #{release.version} (#{release.date})"
+      - if release.banner
+        %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+          = release.banner
       -if release.changes and release.lts_changes and release.lts_baseline
         %div
           %strong

--- a/content/changelog/index.html.haml
+++ b/content/changelog/index.html.haml
@@ -11,6 +11,9 @@ title: Changelog
     - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
       %h3{:id => "v#{release.version}" }
         = "What's new in #{release.version} (#{release.date})"
+      - if release.banner
+        %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+          = release.banner
       %ul.image
         = partial('changelog-changes.html.haml', :changes => release.changes)
   = partial('changelog-weekly.html')

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -57,65 +57,9 @@ NOTE: All files inside `JENKINS_HOME` are expected to be owned, readable, and wr
 https://issues.jenkins-ci.org/browse/JENKINS-39231[JENKINS-39231],
 https://issues.jenkins-ci.org/browse/JENKINS-39237[JENKINS-39237]
 
-Jenkins 2.60.1 includes major improvements in Windows Service management,
-which were introduced from Jenkins 2.50 to 2.60.
+Jenkins 2.60.1 includes major improvements in Windows Service management, which were introduced from Jenkins 2.50 to 2.60.
 In particular, link:https://github.com/kohsuke/winsw[Windows Service Wrapper (WinSW)] has been updated to the 2.x baseline.
 
-Newly installed agent and master instances will get the features automatically, 
-but existing instances require extra configuration.
-In particular, the following features can be enabled: 
+Newly installed agent and master instances will get the features automatically, but existing instances require additional configuration.
 
-* Automatic upgrade of link:https://github.com/jenkinsci/remoting[Remoting] library (aka "slave.jar") on agents
-* Automatic termination of runaway agent processes on agents
-* Automatic termination of Jenkins master processes 
-
-NOTE: The described features and guidelines apply to classic JNLP agents installed as services.
-Plugins like link:https://plugins.jenkins.io/windows-slaves[Windows Agents Plugin] do not offer all features so far, see 
-link:https://issues.jenkins-ci.org/browse/JENKINS-42743[JENKINS-42743].
-
-===== Upgrading old Jenkins agents
-
-The upgrade steps are described in the 
-https://github.com/jenkinsci/windows-slave-installer-module#upgrading-old-agents[Agent Upgrade Guide]
-(Windows Agent Installer Module Docs). 
-
-The only non-trivial action is a XML configuration change. 
-During the `2.60.1` upgrade it is recommended to...
-
-1. Add the link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] extension. 
- ** See the example in the template referenced below.
-1. Enable automatic download of the `slave.jar` file
- ** Example: `<download from="JENKINS_URL/jnlpJars/slave.jar" to="%BASE%\slave.jar"/>` (replace `JENKINS_URL` by the actual URL)
- 
-NOTE: If you use Jenkins with HTTP over insecure network,
-be aware about potential MITM attacks.
-By default new agents have auto-update enabled for HTTPS only.
-
-When updating the `jenkins-slave.xml` configuration file, you can use 
-link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml[this file] 
-as a template for the new configuration.
-
-===== Upgrading Jenkins master
-
-Jenkins master executables may run away in some edge cases,
-hence it is recommended to enable link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] for them.
-
-In order to upgrade the master, do the following...
-
-1. Update Jenkins to 2.60.1 and start the instance. It will automatically upgrade the `jenkins.exe` file.
-1. Stop the Jenkins service
-1. Modify `jenkins.xml` in the installation root
-** To enable Runaway Process Killer, add link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml#L62-L75[the following entry] to `jenkins.xml`
-1. Start Jenkins instance again
-
-To verify the upgrade correctness, check the `jenkins.wrapper.log` output. 
-It should contain log entries for Runaway Process Killer after the successful startup.
-
-===== Enabling extra Windows service features
-
-WinSW and Agent installer offer many advanced features you may want to enable.
-See more details in these documents: 
- 
-* link:https://github.com/kohsuke/winsw/blob/master/README.md[WinSW Documentation]
-* link:https://github.com/jenkinsci/windows-slave-installer-module/blob/master/README.md[Windows Agent Installer Documentation]
-
+See link:windows[Upgrading Windows masters and agents] for more details.

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -51,3 +51,71 @@ Especially in the case of `JENKINS_HOME` this could lead to very long-running in
 This has been optimized to only perform the recursive `chown` if the Jenkins home directory is owned by a different user than the one the service would be running as.
 
 NOTE: All files inside `JENKINS_HOME` are expected to be owned, readable, and writable by the Jenkins user.
+
+==== Windows Services Upgrade
+
+https://issues.jenkins-ci.org/browse/JENKINS-39231[JENKINS-39231],
+https://issues.jenkins-ci.org/browse/JENKINS-39237[JENKINS-39237]
+
+Jenkins 2.60.1 includes major improvements in Windows Service management,
+which were introduced from Jenkins 2.50 to 2.60.
+In particular, link:https://github.com/kohsuke/winsw[Windows Service Wrapper (WinSW)] has been updated to the 2.x baseline.
+
+Newly installed agent and master instances will get the features automatically, 
+but existing instances require extra configuration.
+In particular, the following features can be enabled: 
+
+* Automatic upgrade of link:https://github.com/jenkinsci/remoting[Remoting] library (aka "slave.jar") on agents
+* Automatic termination of runaway agent processes on agents
+* Automatic termination of Jenkins master processes 
+
+NOTE: The described features and guidelines apply to classic JNLP agents installed as services.
+Plugins like link:https://plugins.jenkins.io/windows-slaves[Windows Agents Plugin] do not offer all features so far, see 
+link:https://issues.jenkins-ci.org/browse/JENKINS-42743[JENKINS-42743].
+
+===== Upgrading old Jenkins agents
+
+The upgrade steps are described in the 
+https://github.com/jenkinsci/windows-slave-installer-module#upgrading-old-agents[Agent Upgrade Guide]
+(Windows Agent Installer Module Docs). 
+
+The only non-trivial action is a XML configuration change. 
+During the `2.60.1` upgrade it is recommended to...
+
+1. Add the link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] extension. 
+ ** See the example in the template referenced below.
+1. Enable automatic download of the `slave.jar` file
+ ** Example: `<download from="JENKINS_URL/jnlpJars/slave.jar" to="%BASE%\slave.jar"/>` (replace `JENKINS_URL` by the actual URL)
+ 
+NOTE: If you use Jenkins with HTTP over insecure network,
+be aware about potential MITM attacks.
+By default new agents have auto-update enabled for HTTPS only.
+
+When updating the `jenkins-slave.xml` configuration file, you can use 
+link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml[this file] 
+as a template for the new configuration.
+
+===== Upgrading Jenkins master
+
+Jenkins master executables may run away in some edge cases,
+hence it is recommended to enable link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] for them.
+
+In order to upgrade the master, do the following...
+
+1. Update Jenkins to 2.60.1 and start the instance. It will automatically upgrade the `jenkins.exe` file.
+1. Stop the Jenkins service
+1. Modify `jenkins.xml` in the installation root
+** To enable Runaway Process Killer, add link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml#L62-L75[the following entry] to `jenkins.xml`
+1. Start Jenkins instance again
+
+To verify the upgrade correctness, check the `jenkins.wrapper.log` output. 
+It should contain log entries for Runaway Process Killer after the successful startup.
+
+===== Enabling extra Windows service features
+
+WinSW and Agent installer offer many advanced features you may want to enable.
+See more details in these documents: 
+ 
+* link:https://github.com/kohsuke/winsw/blob/master/README.md[WinSW Documentation]
+* link:https://github.com/jenkinsci/windows-slave-installer-module/blob/master/README.md[Windows Agent Installer Documentation]
+

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -19,17 +19,34 @@ If you're using the Maven Plugin for your Maven-based builds, note that the JDK 
 If an older JDK is configured, Jenkins will attempt to find a more recent JDK automatically.
 If your Maven projects need to be built with JDK 7, consider converting them to freestyle projects, or look into Maven toolchains.
 
+// If you're using the plugin:ssh-slaves[SSH Slaves] plugin,
+// TODO explain the minimum version mess unless we manage to fix it before release
+
 ==== Groovy 2.4.8 Upgrade
 
 https://issues.jenkins-ci.org/browse/JENKINS-33358[JENKINS-33358],
 https://issues.jenkins-ci.org/browse/JENKINS-42189[JENKINS-42189]
 
 Groovy has been upgraded to 2.4.8 to fix a memory leak.
-If you're using Pipeline, note that you will need to update the Pipeline: Groovy plugin to version 2.28 or later.
+
+If you're using Pipeline, note that you will need to update the plugin:workflow-cps[Pipeline: Groovy] plugin to version 2.28 or later.
 
 ==== Trilead SSH Library Upgrade
 
 https://issues.jenkins-ci.org/browse/JENKINS-42959[JENKINS-42959]
 
 The Trilead SSH library bundled with Jenkins has been upgraded.
-If you're using the SSH slaves plugin to connect agents via SSH, a known issue is TODO
+If you're using the SSH slaves plugin to connect agents via SSH, a known issue resulting from that upgrade can result in connection failures.
+
+The plugin:ssh-slaves[SSH Slaves] plugin should be upgraded to version 1.8 or newer.
+
+==== RPM Packaging No Longer Performs Recursive <code>chown</code>
+
+https://issues.jenkins-ci.org/browse/JENKINS-23273[JENKINS-23273]
+
+The RPM packaging post-install step used to perform a recursive <code>chown</code> on <code>JENKINS_HOME</code> and other directories to ensure correct ownership.
+Especially in the case of <code>JENKINS_HOME</code> this could lead to very long-running installations and updates.
+
+This has been optimized to only perform the recursive <code>chown</code> if the Jenkins home directory is owned by a different user than the one the service would be running as.
+
+NOTE: All files inside <code>JENKINS_HOME</code> are expected to be owned, readable, and writable by the Jenkins user.

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -21,6 +21,7 @@ If your Maven projects need to be built with JDK 7, consider converting them to 
 
 If you're using the plugin:ssh-slaves[SSH Slaves] plugin, it may attempt to start the agent process on an unsupported JRE, which will fail.
 If this happens, make sure to install a supported JRE (8 or newer) on the agent system and make it available on the PATH.
+If you rely on SSH Slaves plugin to automatically install a Java runtime on the agent, delete the existing one inside the agent root directory after upgrading to SSH Slaves 1.17 or newer (1.20 recommended, see below).
 
 ==== Groovy 2.4.8 Upgrade
 
@@ -38,7 +39,7 @@ https://issues.jenkins-ci.org/browse/JENKINS-42959[JENKINS-42959]
 The Trilead SSH library bundled with Jenkins has been upgraded.
 If you're using the SSH slaves plugin to connect agents via SSH, a known issue resulting from that upgrade can result in connection failures.
 
-The plugin:ssh-slaves[SSH Slaves] plugin should be upgraded to version 1.8 or newer.
+The plugin:ssh-slaves[SSH Slaves] plugin should be upgraded to version 1.20 or newer.
 
 ==== RPM Packaging No Longer Performs Recursive <code>chown</code>
 

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -1,0 +1,35 @@
+---
+layout: documentation
+title:  Jenkins Upgrade Guide
+notitle: true
+---
+
+== Upgrading to Jenkins LTS 2.60.x
+
+Each section covers the upgrade from the previous LTS release, the section on 2.60.1 covers the upgrade from 2.46.3.
+
+=== Upgrading to Jenkins LTS 2.60.1
+
+==== Java 8 Required
+
+Jenkins 2.60.1 is the first LTS release to require Java 8.
+This applies to both master and agents.
+
+If you're using the Maven Plugin for your Maven-based builds, note that the JDK selected for them needs to be at least Java 8 as well with this change.
+If an older JDK is configured, Jenkins will attempt to find a more recent JDK automatically.
+If your Maven projects need to be built with JDK 7, consider converting them to freestyle projects, or look into Maven toolchains.
+
+==== Groovy 2.4.8 Upgrade
+
+https://issues.jenkins-ci.org/browse/JENKINS-33358[JENKINS-33358],
+https://issues.jenkins-ci.org/browse/JENKINS-42189[JENKINS-42189]
+
+Groovy has been upgraded to 2.4.8 to fix a memory leak.
+If you're using Pipeline, note that you will need to update the Pipeline: Groovy plugin to version 2.28 or later.
+
+==== Trilead SSH Library Upgrade
+
+https://issues.jenkins-ci.org/browse/JENKINS-42959[JENKINS-42959]
+
+The Trilead SSH library bundled with Jenkins has been upgraded.
+If you're using the SSH slaves plugin to connect agents via SSH, a known issue is TODO

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -19,8 +19,8 @@ If you're using the Maven Plugin for your Maven-based builds, note that the JDK 
 If an older JDK is configured, Jenkins will attempt to find a more recent JDK automatically.
 If your Maven projects need to be built with JDK 7, consider converting them to freestyle projects, or look into Maven toolchains.
 
-// If you're using the plugin:ssh-slaves[SSH Slaves] plugin,
-// TODO explain the minimum version mess unless we manage to fix it before release
+If you're using the plugin:ssh-slaves[SSH Slaves] plugin, it may attempt to start the agent process on an unsupported JRE, which will fail.
+If this happens, make sure to install a supported JRE (8 or newer) on the agent system and make it available on the PATH.
 
 ==== Groovy 2.4.8 Upgrade
 

--- a/content/doc/upgrade-guide/2.60.adoc
+++ b/content/doc/upgrade-guide/2.60.adoc
@@ -41,13 +41,13 @@ If you're using the SSH slaves plugin to connect agents via SSH, a known issue r
 
 The plugin:ssh-slaves[SSH Slaves] plugin should be upgraded to version 1.20 or newer.
 
-==== RPM Packaging No Longer Performs Recursive <code>chown</code>
+==== RPM Packaging No Longer Performs Recursive `chown`
 
 https://issues.jenkins-ci.org/browse/JENKINS-23273[JENKINS-23273]
 
-The RPM packaging post-install step used to perform a recursive <code>chown</code> on <code>JENKINS_HOME</code> and other directories to ensure correct ownership.
-Especially in the case of <code>JENKINS_HOME</code> this could lead to very long-running installations and updates.
+The RPM packaging post-install step used to perform a recursive `chown` on `JENKINS_HOME` and other directories to ensure correct ownership.
+Especially in the case of `JENKINS_HOME` this could lead to very long-running installations and updates.
 
-This has been optimized to only perform the recursive <code>chown</code> if the Jenkins home directory is owned by a different user than the one the service would be running as.
+This has been optimized to only perform the recursive `chown` if the Jenkins home directory is owned by a different user than the one the service would be running as.
 
-NOTE: All files inside <code>JENKINS_HOME</code> are expected to be owned, readable, and writable by the Jenkins user.
+NOTE: All files inside `JENKINS_HOME` are expected to be owned, readable, and writable by the Jenkins user.

--- a/content/doc/upgrade-guide/2.60/windows.adoc
+++ b/content/doc/upgrade-guide/2.60/windows.adoc
@@ -1,0 +1,58 @@
+---
+layout: documentation
+title:  Upgrading Windows masters and agents
+notitle: true
+---
+
+== Upgrading Windows masters and agents for 2.60.1
+
+The following features can be enabled after upgrading Jenkins to 2.60.1:
+
+* Automatic upgrade of link:https://github.com/jenkinsci/remoting[Remoting] library (aka "slave.jar") on agents
+* Automatic termination of runaway agent processes on agents
+* Automatic termination of Jenkins master processes
+
+NOTE: The described features and guidelines apply to classic JNLP agents installed as services.
+Plugins like link:https://plugins.jenkins.io/windows-slaves[Windows Agents Plugin] do not offer all features so far, see link:https://issues.jenkins-ci.org/browse/JENKINS-42743[JENKINS-42743].
+
+=== Upgrading old Jenkins agents
+
+The upgrade steps are described in the https://github.com/jenkinsci/windows-slave-installer-module#upgrading-old-agents[Agent Upgrade Guide] (Windows Agent Installer Module Docs).
+
+The only non-trivial action is a XML configuration change.
+During the 2.60.1 upgrade it is recommended to perform the following steps:
+
+1. Add the link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] extension.
+ ** See the example in the template referenced below.
+1. Enable automatic download of the `slave.jar` file
+ ** Example: `<download from="JENKINS_URL/jnlpJars/slave.jar" to="%BASE%\slave.jar"/>` (replace `JENKINS_URL` by the actual URL)
+
+NOTE: If you use Jenkins with HTTP over insecure network, be aware of the risk of MITM attacks.
+By default new agents have auto-update enabled for HTTPS only.
+
+When updating the `jenkins-slave.xml` configuration file, you can use
+link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml[this file]
+as a template for the new configuration.
+
+=== Upgrading Jenkins master
+
+Jenkins master executables may run away in some rare cases, hence it is recommended to enable the link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] for them.
+
+In order to upgrade the master and enable this feature, perform the following steps:
+
+1. Update Jenkins to 2.60.1 and start the instance. It will automatically upgrade the `jenkins.exe` file.
+1. Stop the Jenkins service
+1. Modify `jenkins.xml` in the Jenkins home directory
+** To enable Runaway Process Killer, add link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml#L62-L75[the following entry] to `jenkins.xml`
+1. Start Jenkins again
+
+To verify the upgrade correctness, check the `jenkins.wrapper.log` output.
+It should contain log entries related Runaway Process Killer after the successful startup.
+
+=== Enabling extra Windows service features
+
+WinSW and Agent installer offer many advanced features you may want to enable.
+For more details see these documents:
+
+* link:https://github.com/kohsuke/winsw/blob/master/README.md[WinSW Documentation]
+* link:https://github.com/jenkinsci/windows-slave-installer-module/blob/master/README.md[Windows Agent Installer Documentation]

--- a/content/doc/upgrade-guide/2.60/windows.adoc
+++ b/content/doc/upgrade-guide/2.60/windows.adoc
@@ -24,7 +24,7 @@ During the 2.60.1 upgrade it is recommended to perform the following steps:
 
 1. Add the link:https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md[Runaway Process Killer] extension.
  ** See the example in the template referenced below.
-1. Enable automatic download of the `slave.jar` file
+2. Enable automatic download of the `slave.jar` file
  ** Example: `<download from="JENKINS_URL/jnlpJars/slave.jar" to="%BASE%\slave.jar"/>` (replace `JENKINS_URL` by the actual URL)
 
 NOTE: If you use Jenkins with HTTP over insecure network, be aware of the risk of MITM attacks.
@@ -41,10 +41,10 @@ Jenkins master executables may run away in some rare cases, hence it is recommen
 In order to upgrade the master and enable this feature, perform the following steps:
 
 1. Update Jenkins to 2.60.1 and start the instance. It will automatically upgrade the `jenkins.exe` file.
-1. Stop the Jenkins service
-1. Modify `jenkins.xml` in the Jenkins home directory
+2. Stop the Jenkins service
+3. Modify `jenkins.xml` in the Jenkins home directory
 ** To enable Runaway Process Killer, add link:https://github.com/jenkinsci/windows-slave-installer-module/blob/windows-slave-installer-1.9/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml#L62-L75[the following entry] to `jenkins.xml`
-1. Start Jenkins again
+4. Start Jenkins again
 
 To verify the upgrade correctness, check the `jenkins.wrapper.log` output.
 It should contain log entries related Runaway Process Killer after the successful startup.

--- a/content/doc/upgrade-guide/2.60/windows.adoc
+++ b/content/doc/upgrade-guide/2.60/windows.adoc
@@ -8,7 +8,7 @@ notitle: true
 
 The following features can be enabled after upgrading Jenkins to 2.60.1:
 
-* Automatic upgrade of link:https://github.com/jenkinsci/remoting[Remoting] library (aka "slave.jar") on agents
+* Automatic upgrade of link:https://github.com/jenkinsci/remoting[Remoting] library (`slave.jar`) on agents
 * Automatic termination of runaway agent processes on agents
 * Automatic termination of Jenkins master processes
 


### PR DESCRIPTION
Only the changelog for now, upgrade guide will follow.

> ![screen shot](https://user-images.githubusercontent.com/1831569/27007086-be09bfdc-4e46-11e7-94dc-add2104032de.png)


Also add the `banner` entry to support highlighting very notable changes, such as the Java 8 requirement here, mirroring https://jenkins.io/changelog-stable/#v1.625.1

---

@oleg-nenashev @olivergondza 

PTAL @jglick Is the advice on SSH Slaves 1.17 (https://github.com/jenkinsci/ssh-slaves-plugin/pull/43) and Pipeline: Groovy still correct?