### PR TITLE
Amend pipeline scalability guidance to reflect the more common shared libraries

### DIFF
--- a/content/blog/2017/02/2017-02-01-pipeline-scalability-best-practice.adoc
+++ b/content/blog/2017/02/2017-02-01-pipeline-scalability-best-practice.adoc
@@ -71,7 +71,7 @@ general-purpose programming language.
 ..    Pipeline restricts all variables to `Serializable` types, so keeping
 Pipeline logic simple helps avoid a `NotSerializableException` - see
 appendix at the bottom.
-.  *Use trusted global libraries or `@NonCPS`-annotated functions for slightly more complex work.*
+.  *Use `@NonCPS`-annotated functions for slightly more complex work.*
 This means more involved processing, logic, and transformations. This
 lets you leverage additional Groovy & functional features for more
 powerful, concise, and performant code.


### PR DESCRIPTION
As opposed to the kind of hacky native groovy libraries people were sometimes using, this reflects the proper shared libraries feature, which *does* get CPS-transformed.