### PR TITLE
Updated junit and archiveArtifact step examples

### DIFF
--- a/content/blog/2016/2016-04-07-pipeline-for-runs-on-hardware.adoc
+++ b/content/blog/2016/2016-04-07-pipeline-for-runs-on-hardware.adoc
@@ -170,7 +170,7 @@ node ("linux && $fpgaId") {
   stage "Auto Tests"
   sh "make FPGA_TYPE=$fpgaId tests"
   sh "perl scripts/convertToJunit.pl --from=target/test-results/* --to=target/report_${fpgaId}.xml --classPrefix=\"myprj-${fpgaId}.\""
-  step([$class:"JUnitResultArchiver", testResults:"target/report_${fpgaId}.xml"])
+  junit "target/report_${fpgaId}.xml"
 
   stage "Finalization"
   sh "make FPGA_TYPE=$fpgaId flush_fpga"

--- a/content/blog/2016/2016-06-16-parallel-test-executor-plugin.adoc
+++ b/content/blog/2016/2016-06-16-parallel-test-executor-plugin.adoc
@@ -61,7 +61,7 @@ void runTests(def args) {
   mvn "install -Dmaven.test.failure.ignore=true"
 
   /* Archive the test results */
-  step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+  junit '**/target/surefire-reports/TEST-*.xml'
 }
 
 /* Run Maven */
@@ -157,7 +157,7 @@ void runTests(def args) {
         mvn mavenInstall
 
         /* Archive the test results */
-        step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+        junit '**/target/surefire-reports/TEST-*.xml'
       }
     }
   }

--- a/content/doc/book/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline-as-code.adoc
@@ -446,7 +446,7 @@ using any given artifact. To fingerprint with Pipeline, simply add a
 
 [source, groovy]
 ----
-step([$class: 'ArtifactArchiver', artifacts: '**/target/*.war’, fingerprint: true])
+archiveArtifacts artifacts: '**', fingerprint: true
 ----
 
 will archive any WAR artifacts created in the Pipeline and fingerprint them for

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -538,8 +538,8 @@ node {
     git url: 'https://github.com/joe_user/simple-maven-project-with-tests.git'
     def mvnHome = tool 'M3'
     sh "${mvnHome}/bin/mvn -B -Dmaven.test.failure.ignore verify"
-    step([$class: 'ArtifactArchiver', artifacts: '**/target/*.jar', fingerprint: true])
-    step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+    archiveArtifacts artifacts: '**/target/*.jar', fingerprint: true
+    junit **/target/surefire-reports/TEST-*.xml'
 }
 ----
 


### PR DESCRIPTION
The junit and archiveArtifacts steps have human friendly names now.  We should show those, not the `step([])` syntax.
 
@oleg-nenashev 