### PR TITLE
Mention that SSH Slaves 1.20 is recommended in Java 8 note

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -350,7 +350,7 @@
     <strong>2.60.1 is the first Jenkins LTS release that requires Java 8 to run.</strong>
     If you're using the Maven Project type, please note that it needs to use a JDK capable of running Jenkins, i.e. JDK 8 or up.
     If you configure an older JDK in a Maven Project, Jenkins will attempt to find a newer JDK and use that automatically.
-    If your SSH Slaves fail to start and you have the plugin install the JRE to run them, make sure to update SSH Slaves Plugin to at least version 1.17.
+    If your SSH Slaves fail to start and you have the plugin install the JRE to run them, make sure to update SSH Slaves Plugin to at least version 1.17 (1.20 recommended).
   lts_changes:
     - type: major rfe
       message: >


### PR DESCRIPTION
Addressing a comment by @jglick late.