### PR TITLE
Added documentation for skipStagesAfterUnstable (JENKINS-42039)

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -459,6 +459,8 @@ example: `options { disableConcurrentBuilds() }`
 skipDefaultCheckout:: Skip checking out code from source control by default in
 the `agent` directive. For example: `options { skipDefaultCheckout() }`
 
+skipStagesAfterUnstable:: Skip stages once the build status has gone to UNSTABLE. For example: `options { skipStagesAfterUnstable() }`
+
 timeout:: Set a timeout period for the Pipeline run, after which Jenkins should
 abort the Pipeline. For example: `options { timeout(time: 1, unit: 'HOURS') }`
 


### PR DESCRIPTION
Added some documentation for `skipStagesAfterUnstable` ([JENKINS-42039](https://issues.jenkins-ci.org/browse/JENKINS-42039)), which was implemented in [this PR](https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/115).