### PR TITLE
Set pipeline syntax toc to depth 3

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -9,6 +9,7 @@ title: Pipeline Syntax
 :sectanchors:
 :imagesdir: /doc/book/resources
 :toc:
+:toclevels: 3
 
 = Pipeline Syntax
 


### PR DESCRIPTION
This makes the main sections and directives appear in the toc
for easier searching.



<img width="314" alt="New TOC" src="https://user-images.githubusercontent.com/1958953/27704998-4cc5b95a-5cc1-11e7-85b1-8f87764963c4.png">
