### PR TITLE
Lower the number of items in the atom feed to 20

### DIFF
--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -21,7 +21,8 @@ Awestruct::Extensions::Pipeline.new do
   extension Awestruct::Extensions::Atomizer.new(:posts,
                                                 '/rss.xml',
                                                 :feed_title => 'Jenkins Blog',
-                                                :template => '_ext/atom.xml.haml')
+                                                :template => '_ext/atom.xml.haml',
+                                                :num_entries => 20)
 
   extension Awestruct::Extensions::Tagger.new(:posts,
                                               '/node/index',


### PR DESCRIPTION
Some feed readers have difficulty coping with a big giant atom feed, so this
should be a good middle-ground

Fixes WEBSITE-369