### PR TITLE
Added prepareJavaScripts gradle task instructions to contribution guide

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,6 +16,11 @@ This project uses link:http://gradle.org[Gradle] to build, so as long as you
 have JDK7 or later in your path, you should be able to run the commands below.
 
 If you're working on content and want to test the site, the easiest way is:
+   
+    % ./gradlew prepareJavaScripts
+
+This will fetch JavaScript/CSS dependencies for generating the site. This is needed
+only once. Then you should run:
 
     % ./gradlew dev
 


### PR DESCRIPTION
Otherwise you end up with generated site with lots of js files missing and looking not very good. Observed that while making changes. Tested this on a fresh clone of the repo.
See this IRC log also:
```
18:17 <vkotovv> danielbeck: one more stupid question: looks like JS is not working for my debug server, take a look here: http://imgur.com/a/bI91o
18:17 <vkotovv> why is that so?
18:19 <danielbeck> vkotovv no idea, similar problem here. I think it started when we merged a "modern web framework" change a month or so ago
18:19 <danielbeck> vkotovv could be related to the active profile and which is the site.base_url, but maybe not
18:19 <vkotovv> too bad, cant test some changes..
18:20 <danielbeck> vkotovv `./gradlew cC`, then `(cd build/_site && python -m SimpleHTTPServer 4242)` -- takes longer and no live reload
18:26 <vkotovv> danielbeck: seems like a bunch of js files are not found: http://imgur.com/a/3TXuS
18:27 <danielbeck> vkotovv try `./gradlew bowerInstall` before `./gradlew dev`
18:30 <vkotovv> danielbeck: now the list is shorter, but 7 files are still missing
```