### PR TITLE
Fix text formatting in Rosetta Stone's blog post

### DIFF
--- a/content/blog/2017/07/2017-07-13-speaker-blog-rosetta-stone.adoc
+++ b/content/blog/2017/07/2017-07-13-speaker-blog-rosetta-stone.adoc
@@ -60,7 +60,7 @@ The steps in the auto-maintain script look like this:
 
 We do the same thing with library dependencies.
 If our Gemfile.lock is referencing an old library, running auto-maintain will update things.
-The same applies to our `Jenkinsfile`s. If we decide to implement a new policy where we
+The same applies to our ``Jenkinsfile``s. If we decide to implement a new policy where we
 discard old builds, we update `auto-maintain` so that it will bring each app into
 compliance with the policy, by changing, for example, this Jenkinsfile:
 


### PR DESCRIPTION
We need to use double backticks in this case as per guide: http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#formatted-text.
Otherwise it breaks further formatting.