### PR TITLE
Make the How-To Guides look like they're not part of the book

### DIFF
--- a/content/_layouts/developerguide.html.haml
+++ b/content/_layouts/developerguide.html.haml
@@ -1,5 +1,5 @@
 ---
-layout: developerbook
+layout: developer
 ---
 
 = content


### PR DESCRIPTION
The main navigation to the developer no longer goes through the sidebar with chapters, so make the guides appear separate from that.