### PR TITLE
Tutorial fixes

### DIFF
--- a/content/doc/developer/tutorial/extend.adoc
+++ b/content/doc/developer/tutorial/extend.adoc
@@ -61,8 +61,9 @@ public class HelloWorldAction implements Action {
         this.name = name;
     }
 
-    public String getName() {}
-    return name;
+    public String getName() {
+        return name;
+    }
 
     (...)
 ----
@@ -139,11 +140,11 @@ First, we need to go back to the +HelloWorldAction+ and define an icon, title, a
         return "greeting"; // <3>
     }
 ----
-<1> This is the icon used for the sidepanel item. `document.png` is one of the predefined icons bundled with Jenkins.
-<2> This is the label used for the sidepanel item.
+<1> This is the icon used for the side panel item. `document.png` is one of the predefined icons bundled with Jenkins.
+<2> This is the label used for the side panel item.
 <3> This is the URL fragment used for this action.
 
-With these changes, the action will show in the build's sidepanel, and link to the URL +http://_JENKINS_/job/_JOBNAME_/_BUILDNUMBER_/greeting/+.
+With these changes, the action will show in the build's side panel, and link to the URL +http://_JENKINS_/job/_JOBNAME_/_BUILDNUMBER_/greeting/+.
 
 image::developer/tutorial/sidepanel-item.png[]
 
@@ -158,7 +159,7 @@ Create a file named `index.jelly` in `src/main/resources/org/jenkinsci/plugins/d
 [listing]
 ----
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
     <l:layout title="Greeting"> // <1>
         <l:main-panel> // <2>
             <h1> // <3>
@@ -168,8 +169,8 @@ Create a file named `index.jelly` in `src/main/resources/org/jenkinsci/plugins/d
     </l:layout>
 </j:jelly>
 ----
-<1> +layout+ is a reusable _tag_ defined in Jenkins core that provides the basic page layout with header, sidepanel, main content area, and footer.
-<2> To make the name show up in the main content area (rather than e.g. the sidepanel), we need to wrap our output in a `main-panel` tag.
+<1> +layout+ is a reusable _tag_ defined in Jenkins core that provides the basic page layout with header, side panel, main content area, and footer.
+<2> To make the name show up in the main content area (rather than e.g. the side panel), we need to wrap our output in a `main-panel` tag.
 <3> We can use any HTML tags and they will be used for the output.
 <4> This is a https://commons.apache.org/proper/commons-jexl/[JEXL] expression. +it+ is always the Java object corresponding to the view, in this case the `HelloWorldAction`. `it.name` is equivalent to a getter call (`getName()`).
 
@@ -177,9 +178,9 @@ The resulting page will look similar to this:
 
 image::developer/tutorial/view1.png[]
 
-== Add the sidepanel for the build to the view
+== Add the side panel for the build to the view
 
-In the output above, there is no side panel. As this view is related to a specific build, that build's side panel should be shown as well. To do that, we first need to obtain a reference to the corresponding build in our action, and then include the build's sidepanel view _fragment_ in the action's view.
+In the output above, there is no side panel. As this view is related to a specific build, that build's side panel should be shown as well. To do that, we first need to obtain a reference to the corresponding build in our action, and then include the build's side panel view _fragment_ in the action's view.
 
 To obtain a reference to the build (or, more generally, the +jenkinsdoc:Run[]+) the +HelloWorldAction+ belongs to, we need to make it implement +jenkinsdoc:RunAction2[]+. This interface adds two methods that are called when the run is first attached to a build (+onAttached(Run)+), and when the action and run are loaded from disk (+onLoad(Run)+), respectively.
 
@@ -214,7 +215,7 @@ public class HelloWorldAction implements RunAction2 { // <1>
 <4> Setting the field when loading this action from disk.
 <5> This will make the +Run+ available for use in the Jelly view -- it cannot access private fields.
 
-Once this is done, we need to extend the view to _include_ the sidepanel view fragment of the +Run+:
+Once this is done, we need to extend the view to _include_ the side panel view fragment of the +Run+:
 
 [listing]
 ----
@@ -229,7 +230,7 @@ Once this is done, we need to extend the view to _include_ the sidepanel view fr
     </l:layout>
 (...)
 ----
-<1> Similar to +main-panel+, we want the contents to show up only in the sidepanel, so we need to wrap them in this element.
+<1> Similar to +main-panel+, we want the contents to show up only in the side panel, so we need to wrap them in this element.
 <2> This _includes_ a view fragment (+sidepanel.jelly+) of another object (the +Run+) at this location. We mark this as optional so no error is shown if this view fragment doesn't exist, as the abstract class +Run+ does not define such a view, only its subclass +jenkinsdoc:AbstractBuild[]+.
 
 With these changes, the view we created properly integrates with the Jenkins UI, appearing no different from built-in pages related to a build:

--- a/content/doc/developer/tutorial/run.adoc
+++ b/content/doc/developer/tutorial/run.adoc
@@ -14,9 +14,12 @@ The Maven HPI Plugin provides a convenient way to run a Jenkins instance with yo
 [source]
 mvn hpi:run
 
-This will set up a Jenkins instance on `http://localhost:8080/jenkins`. Let's open a web browser and look at what the plugin does.
+This will set up a Jenkins instance on `http://localhost:8080/jenkins`. Wait for the following console output, then open a web browser and look at what the plugin does.
 
-NOTE: The Jenkins home directory used is the `work` directory in the plugin directory. This means that subsequent runs will keep their data.
+[listing]
+INFO: Jenkins is fully up and running
+
+NOTE: The Jenkins home directory used is the `work/` directory in the plugin directory. This means that subsequent runs will keep their data.
 
 Create a new freestyle project in Jenkins, and add the "Say hello world" build step. It will look like this:
 


### PR DESCRIPTION
* Fix Java syntax error related to getName
* Consistently use the "side panel" spelling
* Keep the `xmlns:st` in the first Jelly snippet as it's needed later
* Rephrase to indicate Jenkins startup takes a bit of time and include console output that shows it's done
* Add trailing slash when mentioning the 'work' directory name