### PR TITLE
Again fixing monospace formatting in Rosetta Stone blog post

### DIFF
--- a/content/blog/2017/07/2017-07-13-speaker-blog-rosetta-stone.adoc
+++ b/content/blog/2017/07/2017-07-13-speaker-blog-rosetta-stone.adoc
@@ -60,7 +60,7 @@ The steps in the auto-maintain script look like this:
 
 We do the same thing with library dependencies.
 If our Gemfile.lock is referencing an old library, running auto-maintain will update things.
-The same applies to our ``Jenkinsfile``s. If we decide to implement a new policy where we
+The same applies to our ++Jenkinsfile++s. If we decide to implement a new policy where we
 discard old builds, we update `auto-maintain` so that it will bring each app into
 compliance with the policy, by changing, for example, this Jenkinsfile:
 


### PR DESCRIPTION
Follow-up to #994. For some reason, double backtick syntax did not work. Need to test such cases before creating PRs. I've tested this one now.
Not sure why double backtick syntax is not working. Maybe asciidoctor version is different? Some more info:
- https://github.com/asciidoctor/asciidoctor/issues/714
- https://github.com/asciidoctor/asciidoctor/issues/718