### PR TITLE
Fixed formatting in Care.com guest post

### DIFF
--- a/content/blog/2017/07/2017-07-17-speaker-blog-care.adoc
+++ b/content/blog/2017/07/2017-07-17-speaker-blog-care.adoc
@@ -122,7 +122,7 @@ PRIVATE_KEY=<my ssh private key, munged by a setup script>
 Jenkins stores its credentials and plugin information in various xml files.
 The `preStart` script modifies the relevant files,
 substituting the environment variables as appropriate,
-using a set of command line utilities called ``xmlstarlet``.
+using a set of command line utilities called `xmlstarlet`.
 Here is an example method from our `preStart` script that configures Github credentials:
 
 [source, bash]


### PR DESCRIPTION
Double backticks don't work.