### PR TITLE
Link to OpenIndiana in Weekly download list

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -163,7 +163,7 @@ title: Jenkins installation and setup
                 %span.icon
                 %span.title
                   Ubuntu/Debian
-              %a.list-group-item.list-group-item-action{:href=>'http://pkg.openindiana.org/hipster/en/search.shtml%3Ftoken=jenkins&amp;action=Search'}
+              %a.list-group-item.list-group-item-action{:href=>'http://pkg.openindiana.org/hipster/en/search.shtml%3Ftoken=jenkins&amp;action=Search'}
                 %span.icon
                 %span.title
                   OpenIndiana/Hipster

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -163,7 +163,7 @@ title: Jenkins installation and setup
                 %span.icon
                 %span.title
                   Ubuntu/Debian
-              %a.list-group-item.list-group-item-action{:href=>'http://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins&action=Search'}
+              %a.list-group-item.list-group-item-action{:href=>'http://pkg.openindiana.org/hipster/en/search.shtml%3Ftoken=jenkins&amp;action=Search'}
                 %span.icon
                 %span.title
                   OpenIndiana/Hipster

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -163,6 +163,10 @@ title: Jenkins installation and setup
                 %span.icon
                 %span.title
                   Ubuntu/Debian
+              %a.list-group-item.list-group-item-action{:href=>'http://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins&action=Search'}
+                %span.icon
+                %span.title
+                  OpenIndiana/Hipster
               %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer'}
                 %span.icon
                 %span.title


### PR DESCRIPTION
Finally, there is a recipe for pre-packaged support to install Jenkins Weeklies in OpenIndiana Hipster. Link to the distribution's package repository details from the Download page.