### PR TITLE
Update the download page with 3rd-party disclaimer

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -23,6 +23,12 @@ title: Jenkins installation and setup
             %code
               \.war
             files, native packages, installers, and Docker containers.
+          %p
+            Please note that packages delivered by operating system distributions
+            (where URLs below point outside the "jenkins.io" or "jenkins-ci.org"
+            Internet domains) are updated according to schedules, policies and
+            capacities of corresponding OS maintainers. The Jenkins project is
+            not directly responsible for contents of those third-party packages.
         .row
           .col-md-6
             %h4


### PR DESCRIPTION
As discussed in PR #1026, the Jenkins project can not be held directly responsible for contents of packages prepared by other organizations, such as untimely delivery of bug fixes or infrequent updates of claimed "weekly" packages, even if the Jenkins and OS-maintenance teams do their best to coordinate such operations.