### PR TITLE
downloads: Rephrase 3rd-party gear tooltip

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -5,7 +5,7 @@ title: Jenkins installation and setup
 
 :ruby
   def third_party_href(url)
-    third_party = {'data-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => 'This package is supported by a third party which may not be frequently updated as packages supported by the Jenkins project'}
+    third_party = {'data-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => 'This is a package supported by a third party which may be not as frequently updated as packages supported by the Jenkins project directly'}
     return third_party.merge({:href => url})
   end
 
@@ -31,8 +31,7 @@ title: Jenkins installation and setup
               \.war
             files, native packages, installers, and Docker containers. Packages with the
             %span.icon-gear-menu-o
-              gear icon
-            are maintained by third parties.
+            gear icon are maintained by third parties.
         .row
           .col-md-6
             %h4


### PR DESCRIPTION
Also try to fix the different-looking font for the "gear icon" text.

Follows up on #1027 and #1029.