### PR TITLE
[JENKINS-41334] Add parallel stages documentation

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -620,3 +620,53 @@ library sources will not be checked out again.)
 
 _Replay_ is not currently supported for trusted libraries.
 Modifying resource files is also not currently supported during _Replay_.
+
+=== Defining Declarative Pipelines
+
+Starting with Declarative 1.2, released in late September, 2017, you can define
+Declarative Pipelines in your shared libraries as well. Here's an example,
+which will execute a different Declarative Pipeline depending on whether the
+build number is odd or even:
+
+[source,groovy]
+----
+// vars/evenOrOdd.groovy
+def call(int buildNumber) {
+  if (buildNumber % 2 == 0) {
+    pipeline {
+      agent any
+      stages {
+        stage('Even Stage') {
+          steps {
+            echo "The build number is even"
+          }
+        }
+      }
+    }
+  } else {
+    pipeline {
+      agent any
+      stages {
+        stage('Odd Stage') {
+          steps {
+            echo "The build number is odd"
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+[source,groovy]
+----
+// Jenkinsfile
+@Library('my-shared-library') _
+
+evenOrOdd(currentBuild.getNumber())
+----
+
+Only entire `pipeline`s can be defined in shared libraries as of this time.
+This can only be done in `vars/*.groovy`, and only in a `call` method. Only one
+Declarative Pipeline can be executed in a single build, and if you attempt to
+execute a second one, your build will fail as a result.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -889,6 +889,60 @@ pipeline {
 // Script //
 ----
 
+=== Parallel
+
+Stages in Declarative Pipeline may declare a number of nested stages within
+them, which will be executed in parallel. Note that a stage must have one and
+only one of either `steps` or `parallel`. The nested stages may use all other
+configuration available for stages in Declarative Pipeline, including `when`,
+`environment`, `agent`, `post`, and `tools`, but are required to have `steps`
+and cannot contain further `parallel` stages themselves. Any stage containing
+`parallel` cannot contain `agent` or `tools`, since those are not relevant
+without `steps`.
+
+[[parallel-stages-example]]
+===== Example
+
+[pipeline]
+----
+// Declarative //
+pipeline {
+    agent any
+    stages {
+        stage('Non-Parallel Stage') {
+            steps {
+                echo 'This stage will be executed first.'
+            }
+        }
+        stage('Parallel Stage') {
+            when {
+                branch 'master'
+            }
+            parallel {
+                stage('Branch A') {
+                    agent {
+                        label "for-branch-a"
+                    }
+                    steps {
+                        echo "On Branch A"
+                    }
+                }
+                stage('Branch B') {
+                    agent {
+                        label "for-branch-b"
+                    }
+                    steps {
+                        echo "On Branch B"
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Script //
+----
+
 [[declarative-steps]]
 === Steps
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -893,12 +893,10 @@ pipeline {
 
 Stages in Declarative Pipeline may declare a number of nested stages within
 them, which will be executed in parallel. Note that a stage must have one and
-only one of either `steps` or `parallel`. The nested stages may use all other
-configuration available for stages in Declarative Pipeline, including `when`,
-`environment`, `agent`, `post`, and `tools`, but are required to have `steps`
-and cannot contain further `parallel` stages themselves. Any stage containing
-`parallel` cannot contain `agent` or `tools`, since those are not relevant
-without `steps`.
+only one of either `steps` or `parallel`. The nested stages cannot contain
+further `parallel` stages themselves, but otherwise behave the same as
+any other `stage`. Any stage containing `parallel` cannot contain `agent` or
+`tools`, since those are not relevant without `steps`.
 
 [[parallel-stages-example]]
 ===== Example


### PR DESCRIPTION
[JENKINS-41334](https://issues.jenkins-ci.org/browse/JENKINS-41334)

https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/152 has been merged, albeit not yet released, so here's a first draft of documentation for parallel stages.