### PR TITLE
Fixed a typo in 2017-07-27-standardizing-builds-with-shared-libraries blog post

### DIFF
--- a/content/blog/2017/07/2017-07-27-standardizing-builds-with-shared-libraries.adoc
+++ b/content/blog/2017/07/2017-07-27-standardizing-builds-with-shared-libraries.adoc
@@ -103,7 +103,7 @@ Come see how we can turn a `Jenkinsfile` with just a set of parameters like this
 [source, groovy]
 ----
 standardBuild {
-    machien          = 'docker'
+    machine          = 'docker'
     dev_branch       = 'develop'
     release_branch   = 'master'
     artifact_apttern = '*.rpm'


### PR DESCRIPTION
I suppose this is a typo