### PR TITLE
jenkins now requires java 8

### DIFF
--- a/content/doc/index.adoc
+++ b/content/doc/index.adoc
@@ -12,8 +12,7 @@ standalone by any machine with the Java Runtime Environment installed.
 == Guided Tour
 
 This guided tour will use the "standalone" Jenkins distribution which requires
-a minimum of Java 7, though Java 8 is recommended. A system with more than
-512MB of RAM is also recommended.
+a minimum of Java 8. A system with more than 512MB of RAM is also recommended.
 
 . http://mirrors.jenkins.io/war-stable/latest/jenkins.war[Download Jenkins].
 . Open up a terminal in the download directory and run `java -jar jenkins.war`

--- a/content/doc/index.adoc
+++ b/content/doc/index.adoc
@@ -12,7 +12,7 @@ standalone by any machine with the Java Runtime Environment installed.
 == Guided Tour
 
 This guided tour will use the "standalone" Jenkins distribution which requires
-a minimum of Java 8. A system with more than 512MB of RAM is also recommended.
+Java 8. A system with more than 512MB of RAM is also recommended.
 
 . http://mirrors.jenkins.io/war-stable/latest/jenkins.war[Download Jenkins].
 . Open up a terminal in the download directory and run `java -jar jenkins.war`


### PR DESCRIPTION
jenkins >=2.60.1 requires java 8 (on both master and slaves)