### PR TITLE
[JENKINS-45828] Clarify that steps/this needs to be passed to classes

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -434,7 +434,9 @@ In the above, `name` is not referring to a field (even if you write it as `this.
 but to an entry created on demand in a `Script.binding`.
 To be clear about what data you intend to store and of what type,
 you can instead provide an explicit class declaration
-(the class name should match the file basename):
+(the class name should match the file basename, and Pipeline steps can
+only be invoked if `steps` or `this` is passed to the class or method,
+as with classes in `src` described above):
 
 [source,groovy]
 ----


### PR DESCRIPTION
[JENKINS-45828](https://issues.jenkins-ci.org/browse/JENKINS-45828)

This is already clear for things under `src`, but it's not made clear
that this is needed for an explicit class declaration in `vars` as well.