### PR TITLE
Rephrase warning to reference plugin page instead

### DIFF
--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -40,10 +40,7 @@ although initially no additional scripts or operations are approved for use.
 [IMPORTANT]
 ====
 Older versions of this plugin may not be safe to use. Please review the
-following advisory:
-link:/security/advisory/2016-04-11/[Groovy sandbox protection incomplete],
-and any subsequent
-link:/security/advisories/[security advisories],
+security warnings listed on plugin:script-security[the Script Security plugin page]
 in order to ensure that the plugin:script-security[Script Security plugin] is
 up to date.
 ====


### PR DESCRIPTION
Untested, because Docker.

Referring to this section in the sidebar of the plugin page:

> ![screen shot](https://user-images.githubusercontent.com/1831569/29126099-bef2b074-7d1d-11e7-9de1-7aa9a88bf9c7.png)