### PR TITLE
specify port option explicitly

### DIFF
--- a/content/doc/index.adoc
+++ b/content/doc/index.adoc
@@ -15,7 +15,7 @@ This guided tour will use the "standalone" Jenkins distribution which requires
 Java 8. A system with more than 512MB of RAM is also recommended.
 
 . http://mirrors.jenkins.io/war-stable/latest/jenkins.war[Download Jenkins].
-. Open up a terminal in the download directory and run `java -jar jenkins.war`
+. Open up a terminal in the download directory and run `java -jar jenkins.war --httpPort=8080`
 . Browse to `http://localhost:8080` and follow the instructions to complete the installation.
 . Many Pipeline examples require an
   https://docs.docker.com/engine/installation[installed Docker]


### PR DESCRIPTION
I follow the instruction in "Guided Tour",
However, `java -jar jenkins.war` cause following error, because another application was binding 8080 port.

```
8 12, 2017 2:40:42 午後 org.eclipse.jetty.util.log.JavaUtilLog warn
警告: FAILED ServerConnector@5778826f{HTTP/1.1}{0.0.0.0:8080}: java.net.BindException: アドレスは既に使用中です
java.net.BindException: アドレスは既に使用中です
```

If we have `--httpPort=8080` explicitly in the instruction, user can quickly reach the solution of using another port.