### PR TITLE
fixed relative links on pipeline/development

### DIFF
--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -42,7 +42,7 @@ HTTP POST
 request with appropriate parameters.
 We recommended using the
 <<../managing/cli#ssh, SSH interface>>
-to run the linter. See the <<../managing/cli, Jenkins CLI documentation>> for details on how to properly configure
+to run the linter. See the <<../managing/cli#, Jenkins CLI documentation>> for details on how to properly configure
 Jenkins for secure command-line access.
 
 .Linting via the CLI with SSH
@@ -165,7 +165,7 @@ allows for easy parallel testing of different changes.
 As long as a Pipeline contained syntactically correct Groovy and was able to start,
 it can be Replayed.
 * *Referenced Shared Library code is also modifiable* - If a Pipeline run references a
-<<shared-libraries, Shared Library>>, the code from the shared library will
+<<shared-libraries#, Shared Library>>, the code from the shared library will
 also be shown and modifiable as part of the Replay page.
 
 === Limitations
@@ -190,7 +190,7 @@ by the Jenkins Project.
 The link:https://github.com/lesfurets/JenkinsPipelineUnit[Pipeline Unit Testing Framework]
 allows you to
 link:https://en.wikipedia.org/wiki/Unit_testing[unit test]
-Pipelines and <<shared-libraries, Shared Libraries>>
+Pipelines and <<shared-libraries#, Shared Libraries>>
 before running them in full. It provides a mock execution environment where real
 Pipeline steps are replaced with mock objects that you can use to check for expected
 behavior. New and rough around the edges, but promising.


### PR DESCRIPTION
Relative links to other documents require a trailing #, otherwise it becomes an anchor link.