### PR TITLE
Add overrideIndexTriggers to declarative options

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -463,6 +463,11 @@ disableConcurrentBuilds:: Disallow concurrent executions of the Pipeline. Can
 be useful for preventing simultaneous accesses to shared resources, etc. For
 example: `options { disableConcurrentBuilds() }`
 
+overrideIndexTriggers:: Allows overriding default treatment of branch indexing triggers. 
+If branch indexing triggers are disabled at the multibranch or organization label, `options { overrideIndexTriggers(true) }`  
+will enable them for this job only. Otherwise, `options { overrideIndexTriggers(false) }` will 
+disable branch indexing triggers for this job only.
+
 skipDefaultCheckout:: Skip checking out code from source control by default in
 the `agent` directive. For example: `options { skipDefaultCheckout() }`
 


### PR DESCRIPTION
This is fairly inconsistent with other option examples, but the usage isn't extremely clear except through the snippet generator. It would be nice to have `enableIndexTriggers()` and `disableIndexTriggers()`, but not sure if there's a clean way to do that through DataBoundConstructor (and obviously out of scope of this). 