### PR TITLE
Run on pre-CE Docker

### DIFF
--- a/scripts/groovy
+++ b/scripts/groovy
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+# TODO detect $(docker version --format '{{.Server.Version}}') is 17.06+ and add :delegated to -v (ditto in node & ruby)
+
 exec docker run --rm  \
     -u $(id -u):$(id -g) \
     -e LANG=C.UTF-8 \
-    -v "${PWD}":"${PWD}":delegated \
+    -v "${PWD}":"${PWD}" \
     -w "${PWD}" \
     groovy:jre-alpine $@

--- a/scripts/node
+++ b/scripts/node
@@ -3,6 +3,6 @@
 exec docker run --rm \
     -u $(id -u):$(id -g) \
     -e HOME="${PWD}" \
-    -v "${PWD}":"${PWD}":delegated \
+    -v "${PWD}":"${PWD}" \
     -w "${PWD}" \
     node:alpine $@

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -13,6 +13,6 @@ exec docker run --rm \
     -e  BUNDLE_PATH="${PWD}/vendor/gems" \
     -e  BUNDLE_APP_CONFIG="${PWD}/vendor/gems/.bundle" \
     -e  BUNDLE_DISABLE_SHARED_GEMS=true \
-    -v "${PWD}":"${PWD}":delegated \
+    -v "${PWD}":"${PWD}" \
     -w "${PWD}" \
     ruby:2.3 $@


### PR DESCRIPTION
Using Docker 1.12.6 (the default on the current version of Ubuntu), I would get

```
jenkins.io$ make prepare
./scripts/ruby bundle install --path=vendor/gems
docker: Error response from daemon: Invalid bind mount spec "/…/jenkins-infra/jenkins.io:/…/jenkins-infra/jenkins.io:delegated": invalid mode: delegated.
See 'docker run --help'.
Makefile:45: recipe for target 'depends-ruby' failed
make: *** [depends-ruby] Error 125
```

I could not verify that everything really worked because `make run` started but then every attempt to view http://localhost:4242/ failed with

```
[…] ERROR NoMethodError: undefined method `[]' for nil:NilClass
	/…/jenkins-infra/jenkins.io/vendor/gems/ruby/2.3.0/gems/awestruct-0.5.7/lib/awestruct/rack/generate.rb:19:in `call'
	/…/jenkins-infra/jenkins.io/vendor/gems/ruby/2.3.0/gems/rack-1.6.8/lib/rack/builder.rb:153:in `call'
	/…/jenkins-infra/jenkins.io/vendor/gems/ruby/2.3.0/gems/rack-1.6.8/lib/rack/handler/webrick.rb:88:in `service'
	/usr/local/lib/ruby/2.3.0/webrick/httpserver.rb:140:in `service'
	/usr/local/lib/ruby/2.3.0/webrick/httpserver.rb:96:in `run'
	/usr/local/lib/ruby/2.3.0/webrick/server.rb:296:in `block in start_thread'
	/…/jenkins-infra/jenkins.io/vendor/gems/ruby/2.3.0/gems/logging-2.2.2/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
… - - […] "GET / HTTP/1.1" 500 316
- -> /
```

which is Greek to me.

@reviewbybees