### PR TITLE
[JENKINS-44108] - Mention Work Directories in Jenkins 2.73.1 upgrade guide

### DIFF
--- a/content/doc/upgrade-guide/2.73.adoc
+++ b/content/doc/upgrade-guide/2.73.adoc
@@ -88,3 +88,26 @@ This behavior has been changed, and Jenkins will now perform the permission chec
 
 To restore the previous behavior, configure a global *Project default Build Authorization* setting the default authorization to that of the anonymous user.
 This feature has been implemented in Authorize Project Plugin version 1.2.0.
+
+==== Remoting Work Directories
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-44108[JENKINS-44108],
+link:https://issues.jenkins-ci.org/browse/JENKINS-44112[JENKINS-44112]
+
+The embedded link:https:/projects/remoting/[Jenkins Remoting] version has been updated from 3.7 to 3.10.
+It introduces support of work directories, which may be used by Remoting to store caches, logs and other metadata.
+
+Once work directory mode is enabled, Jenkins agents start writing logs to the disk and change the default destination of the filesystem JAR Cache.
+In Remoting this opt-in feature can be enabled using the `-workDir=${ROOT_DIR}` command-line option, but the Jenkins defines custom behavior for some agent launchers:
+
+* Java Web Start Launcher (aka _JNLP agent_)
+** Old agents: Work directory needs to be enabled manually
+** New agents created from Web UI: Work directory is enabled by default, work directory points to _Remote root directory_ of the agent.
+** New agents created from CLI/API: Behavior depends on the passed configuration file, work directory is disabled by default
+* Command Launcher
+** No changes, work directory should be manually enabled in launch settings if required
+* Other Launcher types (e.g. SSH Launcher)
+** The behavior is defined in plugins, which have independent release cycle
+** Follow updates in tickets linked to link:https://issues.jenkins-ci.org/browse/JENKINS-44108[JENKINS-44108]
+
+You can find more information, examples and upgrade guides in link:https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md[Jenkins Remoting documentation].


### PR DESCRIPTION
I have added the Work Directory section as we discussed with @daniel-beck yesterday

@reviewbybees @daniel-beck