### PR TITLE
fix example to make sidecar instance persistent within build

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -267,7 +267,7 @@ node {
      * In order to communicate with the MySQL server, this Pipeline explicitly
      * maps the port (`3306`) to a known port on the host machine.
      */
-    docker.image('mysql:5').withRun('-p 3306:3306') { c ->
+    docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw" -p 3306:3306') { c ->
         /* Run some tests which require MySQL */
         sh 'make check'
     }
@@ -283,7 +283,7 @@ link:https://docs.docker.com/engine/userguide/networking/default_network/dockerl
 ----
 node {
     checkout scm
-    docker.image('mysql:5').withRun { c ->
+    docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw"') { c ->
         docker.image('centos:7').inside("--link ${c.id}:db") {
             /*
              * Run some tests which require MySQL, and assume that it is


### PR DESCRIPTION
When I try example in
https://jenkins.io/doc/book/pipeline/docker/#running-sidecar-containers
--link fails since mysql:5 instance exit immediately without envionment variable
MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD or
MYSQL_RANDOM_ROOT_PASSWORD.
It took me a while to solve the error, and I thought it is more convenient if there is
a working example.

Thanks,