### PR TITLE
Use absolute URL for the OpenGraph canonical URL

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -32,7 +32,7 @@
     / Open Graph data
     %meta{:content => page.title, :property => "og:title"}/
     %meta{:content => "article", :property => "og:type"}/
-    %meta{:content => page.output_path, :property => "og:url"}/
+    %meta{:content => "#{site.base_url}#{page.output_path}", :property => "og:url"}/
     %meta{:content => "Jenkins – an open source automation server which enables developers around the world to reliably build, test, and deploy their software.", :name => "og:description"}/
     %meta{:content => page.title, :property => "og:site_name"}/
     - unless page.opengraph.nil?


### PR DESCRIPTION
OpenGraph spec indicated og:url is the canonical URL : http://ogp.me/ns/ogp.me.ttl
Canonical URL RFC specify a relative IRI may be used http://www.rfcreader.com/#rfc6596_line70
However, use of absolute absolute URL is recommended (to avoid multiple domain issues) : 
* https://support.google.com/webmasters/answer/139066?hl=en
* https://yoast.com/rel-canonical/