### PR TITLE
Support fancier bind mounts on later versions of docker

### DIFF
--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+
+# https://github.com/jenkins-infra/jenkins.io/pull/1129
+if [[ ! "$(docker version -f {{.Server.Version}})" =~ "^17\..*" ]]; then
+    DELEGATED=:delegated
+fi;
+

--- a/scripts/groovy
+++ b/scripts/groovy
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-exec docker run --rm  \
+source ./scripts/docker-env
+
+exec docker run --rm \
     -u $(id -u):$(id -g) \
     -e LANG=C.UTF-8 \
-    -v "${PWD}":"${PWD}":delegated \
+    -v "${PWD}":"${PWD}"${DELEGATED} \
     -w "${PWD}" \
     groovy:jre-alpine $@

--- a/scripts/node
+++ b/scripts/node
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+source ./scripts/docker-env
+
 exec docker run --rm \
     -u $(id -u):$(id -g) \
     -e HOME="${PWD}" \
-    -v "${PWD}":"${PWD}":delegated \
+    -v "${PWD}":"${PWD}"${DELEGATED} \
     -w "${PWD}" \
     node:alpine $@

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source ./scripts/docker-env
+
 if [ ! -z ${LISTEN+x} ]; then
     ADDITIONAL_ARGS="-p 4242:4242"
 fi;
@@ -13,6 +15,6 @@ exec docker run --rm \
     -e  BUNDLE_PATH="${PWD}/vendor/gems" \
     -e  BUNDLE_APP_CONFIG="${PWD}/vendor/gems/.bundle" \
     -e  BUNDLE_DISABLE_SHARED_GEMS=true \
-    -v "${PWD}":"${PWD}":delegated \
+    -v "${PWD}":"${PWD}"${DELEGATED} \
     -w "${PWD}" \
     ruby:2.3 $@


### PR DESCRIPTION
While still supporting o.g. installations.

Closes #1129