### PR TITLE
[JENKINS-46968] Add note on dropped TLS <1.2 support

### DIFF
--- a/content/doc/upgrade-guide/2.73.adoc
+++ b/content/doc/upgrade-guide/2.73.adoc
@@ -68,12 +68,18 @@ It may no longer be necessary to apply the `groovy.use.classvalue` workaround.
 
 ==== Winstone 4.1 Upgrade
 
-link:https://issues.jenkins-ci.org/browse/JENKINS-43713[JENKINS-43713]
+link:https://issues.jenkins-ci.org/browse/JENKINS-43713[JENKINS-43713], 
+link:https://issues.jenkins-ci.org/browse/JENKINS-46968[JENKINS-46968]
 
 The embedded Jetty container has been updated from version 9.2.15 to version 9.4.5.
+For a detailed list of changes, see link:https://github.com/eclipse/jetty.project/blob/master/VERSION.txt[the Jetty changelog].
+
 In this update, support for the optional `--spdy` parameter has been dropped.
 Jenkins will now refuse to start if the `---spdy` parameter is specified.
 It needs to be removed from any Jenkins init scripts.
+
+Additionally, support for all TLS versions before 1.2 has been dropped.
+If you're using the embedded Jetty container's HTTPS functionality, it will no longer accept TLS 1.0 or 1.1 connections.
 
 
 ==== Build Authorization


### PR DESCRIPTION
The Jetty changelog is the worst. Still linking to it though. Because I hate our users.

![screen shot](https://user-images.githubusercontent.com/1831569/30674115-17e8e36c-9e78-11e7-9ca5-238455a4dad6.png)
