### PR TITLE
[JENKINS-47106] Add docs for alwaysDoDockerPull option

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -473,6 +473,9 @@ the `agent` directive. For example: `options { skipDefaultCheckout() }`
 
 skipStagesAfterUnstable:: Skip stages once the build status has gone to UNSTABLE. For example: `options { skipStagesAfterUnstable() }`
 
+alwaysDoDockerPull:: Always run `docker pull` for a `docker` `agent`, even if
+the image is already present locally. For example: `options { alwaysDoDockerPull() }`
+
 timeout:: Set a timeout period for the Pipeline run, after which Jenkins should
 abort the Pipeline. For example: `options { timeout(time: 1, unit: 'HOURS') }`
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -115,7 +115,9 @@ docker:: Execute the Pipeline, or stage, with the given container which will be
 dynamically provisioned on a <<../glossary#node, node>> pre-configured to
 accept Docker-based Pipelines, or on a node matching the optionally defined
 `label` parameter.  `docker` also optionally accepts an `args` parameter
-which may contain arguments to pass directly to a `docker run` invocation.
+which may contain arguments to pass directly to a `docker run` invocation, and
+an `alwaysDoPull` option, which will force a `docker pull` even if the image
+name is already present.
  For example: `agent { docker 'maven:3-alpine' }` or
 +
 [source,groovy]
@@ -472,9 +474,6 @@ skipDefaultCheckout:: Skip checking out code from source control by default in
 the `agent` directive. For example: `options { skipDefaultCheckout() }`
 
 skipStagesAfterUnstable:: Skip stages once the build status has gone to UNSTABLE. For example: `options { skipStagesAfterUnstable() }`
-
-alwaysDoDockerPull:: Always run `docker pull` for a `docker` `agent`, even if
-the image is already present locally. For example: `options { alwaysDoDockerPull() }`
 
 timeout:: Set a timeout period for the Pipeline run, after which Jenkins should
 abort the Pipeline. For example: `options { timeout(time: 1, unit: 'HOURS') }`

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -116,7 +116,7 @@ dynamically provisioned on a <<../glossary#node, node>> pre-configured to
 accept Docker-based Pipelines, or on a node matching the optionally defined
 `label` parameter.  `docker` also optionally accepts an `args` parameter
 which may contain arguments to pass directly to a `docker run` invocation, and
-an `alwaysDoPull` option, which will force a `docker pull` even if the image
+an `alwaysPull` option, which will force a `docker pull` even if the image
 name is already present.
  For example: `agent { docker 'maven:3-alpine' }` or
 +


### PR DESCRIPTION
[JENKINS-47106](https://issues.jenkins-ci.org/browse/JENKINS-47106)

Declarative PR introducing this is https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/199. This change will be in Declarative 1.2.1, which will probably be released as soon as that is merged.

