### PR TITLE
[JENKINS-47279] Add warning for HTTP mode CLI with Apache reverse proxies

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -243,6 +243,15 @@ Generally no special system configuration need be done to enable HTTP-based CLI 
 If you are running Jenkins behind an HTTP(S) reverse proxy,
 ensure it does not buffer request or response bodies.
 
+[WARNING]
+====
+The HTTP(S) connection mode of the CLI in Jenkins 2.54 and newer does not work
+correctly behind an Apache HTTP reverse proxy server. Workarounds include using
+a different reverse proxy such as Nginx or HAProxy, or using the SSH connection
+mode where possible. See
+link:https://issues.jenkins-ci.org/browse/JENKINS-47279[JENKINS-47279].
+====
+
 ==== SSH connection mode
 
 Authentication is via SSH keypair.

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -246,7 +246,7 @@ ensure it does not buffer request or response bodies.
 [WARNING]
 ====
 The HTTP(S) connection mode of the CLI in Jenkins 2.54 and newer does not work
-correctly behind an Apache HTTP reverse proxy server. Workarounds include using
+correctly behind an Apache HTTP reverse proxy server using mod_proxy. Workarounds include using
 a different reverse proxy such as Nginx or HAProxy, or using the SSH connection
 mode where possible. See
 link:https://issues.jenkins-ci.org/browse/JENKINS-47279[JENKINS-47279].


### PR DESCRIPTION
See [JENKINS-47279](https://issues.jenkins-ci.org/browse/JENKINS-47279).

I've updated the relevant [wiki article](https://wiki.jenkins.io/display/JENKINS/Running+Jenkins+behind+Apache#RunningJenkinsbehindApache-ProxyingCLIcommandsusingtheHTTP(S)transportwithJenkins>=2.54) with this information, but @jglick mentioned that it would be a good idea to add a warning to the documentation as well.  

@reviewbybees