### PR TITLE
Added better error reporting in events

### DIFF
--- a/content/_data/events/Toulouse_jam_june2017.adoc
+++ b/content/_data/events/Toulouse_jam_june2017.adoc
@@ -1,5 +1,5 @@
 ---
-Title: "Toulouse JAM"
+title: "Toulouse JAM"
 date: "2017-06-15T12:30:00"
 link: "https://www.meetup.com/Toulouse-Jenkins-Area-Meetup/events/240109116/"
 ---

--- a/content/_partials/events.html.haml
+++ b/content/_partials/events.html.haml
@@ -1,11 +1,19 @@
 %div.item-list
   %ul.ji-date-list.ji-item-list
     - # Sort by the date defined for each of the events
-    - site.events.keys.sort { |x,y| Time.parse(site.events[x].date) <=> Time.parse(site.events[y].date) }.each do |name|
+    - now = Time.now.utc
+    - site.events.keys.each do |name|
       - data = site.events[name]
-      - raise "No `date` specified!" unless data.date
-      - event_time = Time.parse(data.date)
-      - next unless event_time > Time.now.utc
+      -# The error handling the partials.rb is broken.
+      -# We depend on content/events.html.haml to report errors instead.
+      -# raise ArgumentError.new("No `date` specified: #{name}")  unless data.date
+      -# raise ArgumentError.new("No `title` specified: #{name}") unless data.title
+      -# raise ArgumentError.new("No `link` specified: #{name}") unless data.link
+      - data.event_time = data.date ? Time.parse(data.date) : now
+    - site.events.keys.sort { |x,y| site.events[x].event_time <=> site.events[y].event_time }.each do |name|
+      - data = site.events[name]
+      - event_time = data.event_time
+      - next unless event_time > now
       %li.post.event
         %a.body{:href => data.link, :target => '_blank'}
           .header.time

--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -58,11 +58,17 @@ notitle: true
       Upcoming Events
   .row
     - # Sort by the date defined for each of the events
-    - site.events.keys.sort { |x,y| Time.parse(site.events[x].date) <=> Time.parse(site.events[y].date) }.each do |name|
+    - now = Time.now.utc
+    - site.events.keys.each do |name|
       - data = site.events[name]
-      - raise "No `date` specified!" unless data.date
-      - event_time = Time.parse(data.date)
-      - next unless event_time > Time.now.utc
+      - raise ArgumentError.new("No `date` specified: #{name}")  unless data.date
+      - raise ArgumentError.new("No `title` specified: #{name}") unless data.title
+      - raise ArgumentError.new("No `link` specified: #{name}") unless data.link
+      - data.event_time = Time.parse(data.date)
+    - site.events.keys.sort { |x,y| site.events[x].event_time <=> site.events[y].event_time }.each do |name|
+      - data = site.events[name]
+      - event_time = data.event_time
+      - next unless event_time > now
       .col-md-3.text-center
         %ul.ji-item-list
           %li.post.event.floating


### PR DESCRIPTION
@rtyler @daniel-beck 
The previously when an event had a bad header it would produce pages of errors.

With this change the error output is reduced to one page and the broken file is named:

```
While processing file /Users/bitwiseman/github/infra/jenkins.io/content/events.html.haml
An error occurred: No `date` specified: albuquerque-jam-nov16
/Users/bitwiseman/github/infra/jenkins.io/content/events.html.haml:64:in `block (2 levels) in singleton class'
/Users/bitwiseman/github/infra/jenkins.io/content/events.html.haml:62:in `each'
/Users/bitwiseman/github/infra/jenkins.io/content/events.html.haml:62:in `block in singleton class'
...
```

