### PR TITLE
[JENKINS-47372] - Add CSRF Protection Page redirect

### DIFF
--- a/content/redirect/csrf-protection.adoc
+++ b/content/redirect/csrf-protection.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/CSRF+Protection
+---


### PR DESCRIPTION
It is required for the help message in [JENKINS-47372](https://issues.jenkins-ci.org/browse/JENKINS-47372). Downstream PR is underway.

@wadeck @daniel-beck @reviewbybees