### PR TITLE
Fixing docker-env

### DIFF
--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -2,7 +2,7 @@
 
 
 # https://github.com/jenkins-infra/jenkins.io/pull/1129
-if [[ ! "$(docker version -f {{.Server.Version}})" =~ "^17\..*" ]]; then
+if [[ "$(docker version -f {{.Server.Version}})" =~ ^17\. ]]; then
     DELEGATED=:delegated
 fi;
 


### PR DESCRIPTION
#1142 did not work at all for me.

First of all, it seemed to be backwards. I am guessing you meant to use this new flag when you _are_ using Docker 17.*. I am using 1.12.6 and so cannot use it.

Second, the regexp match did not work for me in Bash 4.4.7 unless I deleted the double quotes. As of Bash 3 they are said to be unnecessary. Seems like some metacharacters gets disabled when you quote the regexp??

Also the matches are unanchored, so the trailing `.*` does nothing.

@reviewbybees