### PR TITLE
Fix 'For' typo in Hacktoberfest Blog Post

### DIFF
--- a/content/blog/2017/10/2017-10-06-hacktoberfest.adoc
+++ b/content/blog/2017/10/2017-10-06-hacktoberfest.adoc
@@ -33,7 +33,7 @@ write link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.
 * Translate and link:https://wiki.jenkins.io/display/JENKINS/Internationalization[internationalize] components
 * Design - artwork and UI improvements also count!
 
-See the link:https://jenkins.io/participate/[Contribute and Participate] page for fore information.
+See the link:https://jenkins.io/participate/[Contribute and Participate] page for for information.
 
 ### Where can I contribute?
 


### PR DESCRIPTION
The blog currently says 'fore', this seems like a typo which should be 'for'