### PR TITLE
wait for mysql service to start in sidecar container example

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -268,6 +268,8 @@ node {
      * maps the port (`3306`) to a known port on the host machine.
      */
     docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw" -p 3306:3306') { c ->
+        /* Wait until mysql service is up */
+        sh 'while ! mysqladmin ping -h0.0.0.0 --silent; do sleep 1; done'
         /* Run some tests which require MySQL */
         sh 'make check'
     }
@@ -284,6 +286,10 @@ link:https://docs.docker.com/engine/userguide/networking/default_network/dockerl
 node {
     checkout scm
     docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw"') { c ->
+        docker.image('mysql:5').inside("--link ${c.id}:db") {
+            /* Wait until mysql service is up */
+            sh 'while ! mysqladmin ping -hdb --silent; do sleep 1; done'
+        }
         docker.image('centos:7').inside("--link ${c.id}:db") {
             /*
              * Run some tests which require MySQL, and assume that it is


### PR DESCRIPTION
I'm using mysql sidecar container to run test.
I took some time to find out the need to wait for the service startup.
I think it would be helpful if the example include it.

Thanks,