### PR TITLE
[WEBSITE-416] Add 'boxshadow' to 'jenkins.css' + implement in published tutorial.

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1380,6 +1380,19 @@ p.details {
   text-align: center;
 }
 
+.imageblock.boxshadow img {
+  margin: 5px 5px 5px 5px;
+  -moz-box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.5);
+}
+
+.paragraph.boxshadow img {
+  margin: 5px 5px 5px 5px;
+  -moz-box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 15px 0px rgba(0, 0, 0, 0.5);
+}
 
 #sponsorsblock {
   padding: 1rem 2rem;

--- a/content/doc/tutorials/using-jenkins-to-build-a-java-maven-project.adoc
+++ b/content/doc/tutorials/using-jenkins-to-build-a-java-maven-project.adoc
@@ -172,7 +172,6 @@ the downloaded Maven repository artifacts each time Docker restarts.
 <4> This `sh` step (of the link:/doc/book/pipeline/syntax/#steps[`steps`]
 section) runs the Maven command to cleanly build your Java application (without
 running any tests).
-+
 . Save your amended `Jenkinsfile` and commit it to your local
   `simple-java-maven-app` Git repository. E.g. Within the
   `simple-java-maven-app` directory, run the commands: +
@@ -184,35 +183,36 @@ running any tests).
 . In the *This job has not been run* message box, click *Run*, then quickly
   click the *OPEN* link which appears briefly at the lower-right to see Jenkins
   building your Pipeline project. If you weren't able to click the *OPEN* link,
-  click the row on the main Blue Ocean interface to access this feature.
-
-+
-*Note:* You may need to wait several minutes for this first run to complete.
-After making a clone of your local `simple-java-maven-app` Git repository
-itself, Jenkins:
-
+  click the row on the main Blue Ocean interface to access this feature. +
+  *Note:* You may need to wait several minutes for this first run to complete.
+  After making a clone of your local `simple-java-maven-app` Git repository
+  itself, Jenkins:
 .. Initially queues the project to be built on the agent.
-.. Downloads the Maven Docker image and runs it in a container on Docker. +
-   image:tutorials/java-maven-01-downloading-maven-docker-image.png[alt="Downloading
-   Maven Docker image",width=100%]
+.. Downloads the Maven Docker image and runs it in a container on Docker.
++
+[.boxshadow]
+image:tutorials/java-maven-01-downloading-maven-docker-image.png[alt="Downloading
+Maven Docker image",width=100%]
 .. Executes the `Build` stage (defined in the `Jenkinsfile`) on the Maven
    container. During this time, Maven will download many artifacts necessary to
    build your Java application, which will ultimately be stored in Jenkins's
-   local Maven repository (in the Docker host's filesystem). +
-   image:tutorials/java-maven-02-initial-pipeline-downloading-maven-artifacts.png[alt="Downloading
-   Maven artifacts",width=100%]
+   local Maven repository (in the Docker host's filesystem).
+[.boxshadow]
+image:tutorials/java-maven-02-initial-pipeline-downloading-maven-artifacts.png[alt="Downloading
+Maven artifacts",width=100%]
 
 +
 The Blue Ocean interface turns green if Jenkins built your Java application
-successfully. +
+successfully.
+[.boxshadow]
 image:tutorials/java-maven-03-initial-pipeline-runs-successfully.png[alt="Initial
 Pipeline runs successfully",width=100%]
-
 . Click the *X* at the top-right to return to the main Blue Ocean interface.
-
 +
+[.boxshadow]
 image:tutorials/java-maven-05-main-blue-ocean-interface.png[alt="Main Blue Ocean
 interface",width=100%]
+
 
 === Add a test stage to your Pipeline
 
@@ -228,7 +228,6 @@ interface",width=100%]
             }
         }
 ----
-+
 so that you end up with:
 +
 [source,groovy]
@@ -254,12 +253,10 @@ pipeline {
     }
 }
 ----
-+
 <1> Defines a new stage called `Test` that appears on the Jenkins UI.
 <2> This `sh` step (of the link:/doc/book/pipeline/syntax/#steps[`steps`]
 section) runs the Maven command to run a unit test on your simple Java
 application.
-+
 . Save your amended `Jenkinsfile` and commit it to your local
   `simple-java-maven-app` Git repository. E.g. Within the
   `simple-java-maven-app` directory, run the commands: +
@@ -271,22 +268,19 @@ application.
 . Click *Run* at the top left, then quickly click the *OPEN* link which appears
   briefly at the lower-right to see Jenkins building your amended Pipeline
   project. If you weren't able to click the **OPEN** link, click the _top_ row
-  on the Blue Ocean interface to access this feature.
-
-+
-*Note:* You'll notice from this run that Jenkins no longer needs to download the
-Maven Docker image. Instead, Jenkins only needs to run a new container from the
-Maven image downloaded previously. Also, if Docker had not restarted since you
-last ran the Pipeline <<create-your-initial-pipeline-as-a-jenkinsfile,above>>,
-then no Maven artifacts need to be downloaded during the "Build" stage.
-Therefore, running your Pipeline this subsequent time should be much faster. +
-If your amended Pipeline ran successfully, here's what the Blue Ocean interface
-should look like. Notice the additional "Test" stage. You can click on the
-previous "Build" stage circle to access the output from that stage. +
+  on the Blue Ocean interface to access this feature. +
+  *Note:* You'll notice from this run that Jenkins no longer needs to download
+  the Maven Docker image. Instead, Jenkins only needs to run a new container
+  from the Maven image downloaded previously. Also, if Docker had not restarted
+  since you last ran the Pipeline <<create-your-initial-pipeline-as-a-jenkinsfile,above>>,
+  then no Maven artifacts need to be downloaded during the "Build" stage.
+  Therefore, running your Pipeline this subsequent time should be much faster. +
+  If your amended Pipeline ran successfully, here's what the Blue Ocean
+  interface should look like. Notice the additional "Test" stage. You can click
+  on the previous "Build" stage circle to access the output from that stage.
+[.boxshadow]
 image:tutorials/java-maven-12-test-stage-runs-successfully-with-output.png[alt="Test
 stage runs successfully (with output)",width=100%]
-
-+
 . Click the *X* at the top-right to return to the main Blue Ocean interface.
 
 
@@ -304,7 +298,6 @@ stage runs successfully (with output)",width=100%]
             }
         }
 ----
-+
 so that you end up with:
 +
 [source,groovy]
@@ -335,7 +328,6 @@ pipeline {
     }
 }
 ----
-+
 <1> Defines a new stage called `Deliver` that appears on the Jenkins UI.
 <2> This `sh` step (of the link:/doc/book/pipeline/syntax/#steps[`steps`]
 section) runs the shell script `deliver.sh` located in the `jenkins/scripts`
@@ -344,8 +336,6 @@ principle, it's a good idea to keep your Pipeline code (i.e. the `Jenkinsfile`)
 as tidy as possible and place more complex build scripting steps into separate
 shell script files like the `deliver.sh` file. This ultimately makes maintaining
 your Pipeline code easier, especially if your Pipeline gains more complexity.
-
-+
 . Save your amended `Jenkinsfile` and commit it to your local
   `simple-java-maven-app` Git repository. E.g. Within the
   `simple-java-maven-app` directory, run the commands: +
@@ -361,17 +351,23 @@ your Pipeline code easier, especially if your Pipeline gains more complexity.
   If your amended Pipeline ran successfully, here's what the Blue Ocean
   interface should look like. Notice the additional "Deliver" stage. Click on
   the previous "Test" and "Build" stage circles to access the outputs from those
-  stages. +
-  image:tutorials/java-maven-23-deliver-stage-runs-successfully.png[alt="Deliver
-  stage runs successfully",width=100%] +
-  Here's what the output of the "Deliver" stage should look like, showing you
-  the execution results of your Java application at the end. +
-  image:tutorials/java-maven-25-deliver-stage-output-only.png[alt="Deliver
-  stage output only",width=100%]
+  stages.
++
+[.boxshadow]
+image:tutorials/java-maven-23-deliver-stage-runs-successfully.png[alt="Deliver
+stage runs successfully",width=100%]
+
++
+Here's what the output of the "Deliver" stage should look like, showing you the
+execution results of your Java application at the end.
+[.boxshadow]
+image:tutorials/java-maven-25-deliver-stage-output-only.png[alt="Deliver stage
+output only",width=100%]
 . Click the *X* at the top-right to return to the main Blue Ocean interface,
-  which lists your previous Pipeline runs in reverse chronological order. +
-  image:tutorials/java-maven-26-main-blue-ocean-interface-with-all-previous-runs-displayed.png[alt="Main
-  Blue Ocean interface with all previous runs displayed",width=100%]
+  which lists your previous Pipeline runs in reverse chronological order.
+[.boxshadow]
+image:tutorials/java-maven-26-main-blue-ocean-interface-with-all-previous-runs-displayed.png[alt="Main
+Blue Ocean interface with all previous runs displayed",width=100%]
 
 ////
 Hide this warning due to temporary addition to 'mvn jar:jar install:install'


### PR DESCRIPTION
* Essentially, add [.boxshadow] above an image reference from now on to generate a box-shadow around it.
* I tested out this new CSS feature on the already-published 'Using Jenkins to build a Java/Maven' project.
* Also, tidied up some Asciidoc syntax in the tutorial.

See https://issues.jenkins-ci.org/browse/WEBSITE-416 for more information.