### PR TITLE
Add documentation for upstream trigger syntax

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -465,9 +465,9 @@ disableConcurrentBuilds:: Disallow concurrent executions of the Pipeline. Can
 be useful for preventing simultaneous accesses to shared resources, etc. For
 example: `options { disableConcurrentBuilds() }`
 
-overrideIndexTriggers:: Allows overriding default treatment of branch indexing triggers. 
-If branch indexing triggers are disabled at the multibranch or organization label, `options { overrideIndexTriggers(true) }`  
-will enable them for this job only. Otherwise, `options { overrideIndexTriggers(false) }` will 
+overrideIndexTriggers:: Allows overriding default treatment of branch indexing triggers.
+If branch indexing triggers are disabled at the multibranch or organization label, `options { overrideIndexTriggers(true) }`
+will enable them for this job only. Otherwise, `options { overrideIndexTriggers(false) }` will
 disable branch indexing triggers for this job only.
 
 skipDefaultCheckout:: Skip checking out code from source control by default in
@@ -594,6 +594,10 @@ Pipeline should be re-triggered, for example: `triggers { cron('H 4/* 0 0 1-5') 
 pollSCM:: Accepts a cron-style string to define a regular interval at which
 Jenkins should check for new source changes. If new changes exist, the Pipeline
 will be re-triggered. For example: `triggers { pollSCM('H 4/* 0 0 1-5') }`
+upstream:: Accepts a comma separated string of jobs and a threshold. When any
+job in the string finishes with the minimum threshold, the Pipeline will be
+re-triggered. For example:
+`triggers { upstream(upstreamProjects: 'job1,job2', threshold: Hudson.model.Result.SUCCESS) }`
 
 [NOTE]
 ====


### PR DESCRIPTION
Only reference guide for this is various stack overflow posts and the (no longer maintained) pipeline model definition [wiki](https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Trigger-runs#other-available-triggers).