### PR TITLE
Add reciprocal link between Pipeline Syntax and Pipeline Reference pages

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -102,6 +102,8 @@ section: doc
           %a{:href => '/node/tags/tutorial'}
             View all tutorial blog posts
 
+        %p
+
 
     .col-lg-9
       - unless page.notitle

--- a/content/_layouts/pipelinesteps.html.haml
+++ b/content/_layouts/pipelinesteps.html.haml
@@ -4,4 +4,18 @@ uneditable: true
 notitle: true
 ---
 
+%p
+  The following plugin provides functionality available through
+  Pipeline-compatible steps. Read more about how to integrate steps into your
+  Pipeline in the
+  %a{:href => "/doc/book/pipeline/syntax/#declarative-steps"} Steps
+  section of the
+  %a{:href => "/doc/book/pipeline/syntax"} Pipeline Syntax
+  page.
+
+%p
+  For a list of other such plugins, see the
+  %a{:href => "/doc/pipeline/steps/"} Pipeline Steps Reference
+  page.
+
 = content

--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -5,8 +5,16 @@ title: "Pipeline Steps Reference"
 
 - steps_dir = File.expand_path(File.dirname(__FILE__))
 %p
-  The following plugins offer Pipeline-compatible steps.  Each plugin link
-  offers more information about the parameters for each step.
+  The following plugins offer Pipeline-compatible steps. Each plugin link offers
+  more information about the parameters for each step.
+
+%p
+  Read more about how to
+  integrate steps into your Pipeline in the
+  %a{:href => "/doc/book/pipeline/syntax/#declarative-steps"} Steps
+  section of the
+  %a{:href => "/doc/book/pipeline/syntax"} Pipeline Syntax
+  page.
 
 %div
   %ul


### PR DESCRIPTION
The link to the Pipeline Reference page (from the Pipeline Syntax page) has existed for a while. However, these pages should have reciprocal links.