### PR TITLE
Minor wording improvement on the Pipeline Syntax page.

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -573,8 +573,8 @@ link:https://issues.jenkins-ci.org/browse/INFRA-1053[INFRA-1503].
 The `triggers` directive defines the automated ways in which the Pipeline
 should be re-triggered. For Pipelines which are integrated with a source such
 as GitHub or BitBucket, `triggers` may not be necessary as webhooks-based
-integration will likely already be present. Currently the only available
-triggers are `cron`, `pollSCM` and `upstream`.
+integration will likely already be present. The triggers currently available are
+`cron`, `pollSCM` and `upstream`.
 
 [cols="^10h,>90a",role=syntax]
 |===


### PR DESCRIPTION
* To reduce wording maintenance when more triggers are added.
* This pull request stems from a comment I wrote in [PR 1203](https://github.com/jenkins-infra/jenkins.io/pull/1203).