### PR TITLE
Fix cron examples.

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -590,10 +590,10 @@ integration will likely already be present. The triggers currently available are
 
 
 cron:: Accepts a cron-style string to define a regular interval at which the
-Pipeline should be re-triggered, for example: `triggers { cron('H 4/* 0 0 1-5') }`
+Pipeline should be re-triggered, for example: `triggers { cron('H */4 * * 1-5') }`
 pollSCM:: Accepts a cron-style string to define a regular interval at which
 Jenkins should check for new source changes. If new changes exist, the Pipeline
-will be re-triggered. For example: `triggers { pollSCM('H 4/* 0 0 1-5') }`
+will be re-triggered. For example: `triggers { pollSCM('H */4 * * 1-5') }`
 upstream:: Accepts a comma separated string of jobs and a threshold. When any
 job in the string finishes with the minimum threshold, the Pipeline will be
 re-triggered. For example:
@@ -613,7 +613,7 @@ The `pollSCM` trigger is only available in Jenkins 2.22 or later.
 pipeline {
     agent any
     triggers {
-        cron('H 4/* 0 0 1-5')
+        cron('H */4 * * 1-5')
     }
     stages {
         stage('Example') {


### PR DESCRIPTION
As indicated on https://twitter.com/rompic/status/929752635493756928, the example cron expressions were:
* H 4/* 0 0 1-5
which is invalid syntax. Hence, this is changed to:
* H */4 * * 1-5
which is valid syntax. Read more about this here https://help.ubuntu.com/community/CronHowto.