### PR TITLE
Add important clarifications throughout the 'Create Pipeline in Blue Ocean' tutorial.

### DIFF
--- a/content/doc/tutorials/building-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/building-a-java-app-with-maven.adoc
@@ -394,7 +394,7 @@ Blue Ocean interface with all previous runs displayed",width=100%]
 Well done! You've just used Jenkins to build a simple Java application with
 Maven!
 
-The "build", "test" and "deliver" stages you created above are the basis for
+The "Build", "Test" and "Deliver" stages you created above are the basis for
 building more complex Java applications with Maven in Jenkins, as well as Java
 and Maven applications that integrate with other technology stacks.
 

--- a/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
@@ -457,7 +457,7 @@ Blue Ocean interface with all previous runs displayed",width=100%]
 Well done! You've just used Jenkins to build a simple Node.js and React
 application with npm!
 
-The "build", "test" and "deliver" stages you created above are the basis for
+The "Build", "Test" and "Deliver" stages you created above are the basis for
 building more complex Node.js and React applications in Jenkins, as well as
 Node.js and React applications that integrate with other technology stacks.
 

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -369,23 +369,22 @@ directive. This directive's location within the "Test" stage means that the
 environment variable `CI` (with its value of `true`) is only available within
 the scope of this "Test" stage.
 
-How might you set this directive in Blue Ocean so that its environment variable
-is available globally throughout Pipeline (as is the case in the
-link:../building-a-node-js-and-react-app-with-npm/[Using Jenkins to build
-a Node.js and React application with npm] tutorial)?
+You can set this directive in Blue Ocean so that its environment variable is
+available globally throughout Pipeline (as is the case in the
+link:../building-a-node-js-and-react-app-with-npm/[Using Jenkins to build a
+Node.js and React application with npm] tutorial). To do this:
 
 . From the main Blue Ocean interface, click *Branches* at the top-right to
   access your respository's `master` branch.
 . Click the `master` branch's "Edit Pipeline" icon
   image:tutorials/pipeline-in-blueocean-21a-edit-pipeline-on-branch.png[alt="Edit
-  Pipeline on branch",width=3%]
-  to open the Pipeline editor for this branch.
+  Pipeline on branch",width=3%] to open the Pipeline editor for this branch.
 . In the main Pipeline editor, click the *Test* stage you created
   <<add-a-test-stage-to-your-pipeline,above>> to begin editing it.
 . In the stage panel on the right, click *Settings* to reveal this section of
   the panel.
-. Click the minus (*-*) icon at the right of the `CI` environment directive you
-  created earlier.
+. Click the minus (*-*) icon at the right of the `CI` environment directive (you
+  created earlier) to delete it.
 . Click the top-left back arrow icon
   image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
   from step icon",width=3%] to return to the main Pipeline editor.

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -149,10 +149,7 @@ step type",width=50%] +
   *Tip:* The most commonly used step types appear closest to the top of this
   list. To find other steps further down this list, you can filter this list
   using the *Find steps by name* option.
-. In the *Build / Shell Script* panel, specify `npm  install` and then click the
-  top-left back arrow icon
-  image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
-  from step icon",width=3%] to return to the main Pipeline editor. +
+. In the *Build / Shell Script* panel, specify `npm  install`. +
 [.boxshadow]
 image:tutorials/pipeline-in-blueocean-16-specifying-a-shell-step-value.png[alt="Specifying
 a shell step value",width=80%] +
@@ -161,6 +158,9 @@ a shell step value",width=80%] +
   link:../building-a-node-js-and-react-app-with-npm/#create-your-initial-pipeline-as-a-jenkinsfile[``Create
   your initial Pipeline...'' section of the building a Node.js and React
   application] tutorial.
+. ( _Optional_ ) Click the top-left back arrow icon
+  image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
+  from step icon",width=3%] to return to the main Pipeline editor.
 . Click the *Save* button at the top right to begin saving your new Pipeline
   with its "Build" stage.
 . In the *Save Pipeline* dialog box, specify the commit message in the
@@ -169,7 +169,9 @@ a shell step value",width=80%] +
 image:tutorials/pipeline-in-blueocean-18-save-pipeline-dialog-box.png[alt="Save
 Pipeline dialog box",width=70%] +
 . Leaving all other options as is, click *Save & run* and Jenkins proceeds to
-  build your Pipeline. +
+  build your Pipeline.
+. When the main Blue Ocean interface appears, click the row to see Jenkins build
+  your Pipeline project. +
   *Note:* You may need to wait several minutes for this first run to complete.
   During this time, Jenkins does the following:
 .. Commits your Pipeline as a `Jenkinsfile` to the only branch (i.e. `master`)
@@ -225,7 +227,7 @@ stage",width=45%]
 . In the resulting *Test / Shell Script* panel, specify
   `./jenkins/scripts/test.sh` and then click the top-left back arrow icon
   image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
-  from step icon",width=3%] to return to the main Pipeline editor. +
+  from step icon",width=3%] to return to the Pipeline stage editor. +
 . At the lower-right of the panel, click *Settings* to reveal this section of
   the panel.
 . Click the *+* icon at the right of the *Environment* heading (for which you'll
@@ -240,12 +242,17 @@ directive",width=50%] +
   link:../building-a-node-js-and-react-app-with-npm/#add-a-test-stage-to-your-pipeline[``Add
   a test stage...'' section of the building a Node.js and React application]
   tutorial.
+. ( _Optional_ ) Click the top-left back arrow icon
+  image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
+  from step icon",width=3%] to return to the main Pipeline editor.
 . Click the *Save* button at the top right to begin saving your Pipeline with
   with its new "Test" stage.
 . In the *Save Pipeline* dialog box, specify the commit message in the
   *Description* field (e.g. `Add 'Test' stage`).
 . Leaving all other options as is, click *Save & run* and Jenkins proceeds to
-  build your amended Pipeline. +
+  build your amended Pipeline.
+. When the main Blue Ocean interface appears, click the _top_ row to see Jenkins
+  build your Pipeline project. +
   *Note:* You'll notice from this run that Jenkins no longer needs to download
   the Node Docker image. Instead, Jenkins only needs to run a new container from
   the Node image downloaded previously. Therefore, running your Pipeline this
@@ -279,7 +286,7 @@ stage",width=60%]
 . In the resulting *Deliver / Shell Script* panel, specify
   `./jenkins/scripts/deliver.sh` and then click the top-left back arrow icon
   image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
-  from step icon",width=3%] to return to the main Pipeline editor.
+  from step icon",width=3%] to return to the Pipeline stage editor.
 [.boxshadow]
 image:tutorials/pipeline-in-blueocean-32-add-next-step.png[alt="Add next
 step",width=50%] +
@@ -296,7 +303,7 @@ the input step type",width=50%]
   `Finished using the web site? (Click "Proceed" to continue)` in the *Message*
   field and then click the top-left back arrow icon
   image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
-  from step icon",width=3%] to return to the main Pipeline editor.
+  from step icon",width=3%] to return to the Pipeline stage editor.
 [.boxshadow]
 image:tutorials/pipeline-in-blueocean-34-specifying-input-step-message-value.png[alt="Specifying
 input step message value",width=55%] +
@@ -308,17 +315,20 @@ input step message value",width=55%] +
 . Click the *Add Step* button (last time).
 . Click *Shell Script* near the top of the list.
 . In the resulting *Deliver / Shell Script* panel, specify
-  `./jenkins/scripts/kill.sh` and then click the top-left back arrow icon
-  image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
-  from step icon",width=3%] to return to the main Pipeline editor. +
+  `./jenkins/scripts/kill.sh`. +
   *Note:* For an explanation of this step, refer to the `kill.sh` file itself
   located in the `jenkins/scripts` of your forked repository on GitHub.
+. ( _Optional_ ) Click the top-left back arrow icon
+  image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
+  from step icon",width=3%] to return to the main Pipeline editor.
 . Click the *Save* button at the top right to begin saving your Pipeline with
   with its new "Deliver" stage.
 . In the *Save Pipeline* dialog box, specify the commit message in the
   *Description* field (e.g. `Add 'Deliver' stage`).
 . Leaving all other options as is, click *Save & run* and Jenkins proceeds to
-  build your amended Pipeline. +
+  build your amended Pipeline.
+. When the main Blue Ocean interface appears, click the _top_ row to see Jenkins
+  build your Pipeline project. +
   If your amended Pipeline ran successfully, here's what the Blue Ocean
   interface should look like. Notice the additional "Deliver" stage. Click on
   the previous "Test" and "Build" stage circles to access the outputs from those
@@ -354,9 +364,19 @@ Blue Ocean interface with all previous runs displayed",width=100%]
 Well done! You've just used the Blue Ocean feature of Jenkins to build a simple
 Node.js and React application with npm!
 
-The "build", "test" and "deliver" stages you created above are the basis for
-building more complex Node.js and React applications in Jenkins, as well as
-Node.js and React applications that integrate with other technology stacks.
+Notice where Blue Ocean placed the
+link:/doc/book/pipeline/syntax#environment[`environment`] directive in its
+Jenkinsfile. This directive's location within the "Test" stage means that the
+environment variable `CI` (with its value of `true`) is only available within
+the scope of this "Test" stage. How might you set this directive in Blue Ocean
+so that its environment variable is available globally throughout Pipeline (as
+is the case in the link:../building-a-node-js-and-react-app-with-npm/[Using
+Jenkins to build a Node.js and React application with npm] tutorial)?
+
+The "Build", "Test" and "Deliver" stages you created above are the basis for
+building other applications in Jenkins with any technology stack, including
+more complex applications and ones that combine multiple technology stacks
+together.
 
 Because Jenkins is extremely extensible, it can be modified and configured to
 handle practically any aspect of build orchestration and automation.

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -360,19 +360,58 @@ image:tutorials/pipeline-in-blueocean-38-main-blue-ocean-interface-with-all-prev
 Blue Ocean interface with all previous runs displayed",width=100%]
 
 
+=== Follow up (optional)
+
+If you check the contents of the `Jenkinsfile` that Blue Ocean created at the
+root of your forked `creating-a-pipeline-in-blue-ocean` repository, notice the
+location of the link:/doc/book/pipeline/syntax#environment[`environment`]
+directive. This directive's location within the "Test" stage means that the
+environment variable `CI` (with its value of `true`) is only available within
+the scope of this "Test" stage.
+
+How might you set this directive in Blue Ocean so that its environment variable
+is available globally throughout Pipeline (as is the case in the
+link:../building-a-node-js-and-react-app-with-npm/[Using Jenkins to build
+a Node.js and React application with npm] tutorial)?
+
+. From the main Blue Ocean interface, click *Branches* at the top-right to
+  access your respository's `master` branch.
+. Click the `master` branch's "Edit Pipeline" icon
+  image:tutorials/pipeline-in-blueocean-21a-edit-pipeline-on-branch.png[alt="Edit
+  Pipeline on branch",width=3%]
+  to open the Pipeline editor for this branch.
+. In the main Pipeline editor, click the *Test* stage you created
+  <<add-a-test-stage-to-your-pipeline,above>> to begin editing it.
+. In the stage panel on the right, click *Settings* to reveal this section of
+  the panel.
+. Click the minus (*-*) icon at the right of the `CI` environment directive you
+  created earlier.
+. Click the top-left back arrow icon
+  image:tutorials/pipeline-in-blueocean-16a-return-from-step-icon.png[alt="Return
+  from step icon",width=3%] to return to the main Pipeline editor.
+. In the *Pipeline Settings* panel, click the *+* icon at the right of the
+  *Environment* heading (for which you'll configure a _global_ environment
+  directive).
+. In the *Name* and *Value* fields that appear, specify `CI` and `true`,
+  respectively.
+. Click the *Save* button at the top right to begin saving your Pipeline with
+  with its relocated environment directive.
+. In the *Save Pipeline* dialog box, specify the commit message in the
+  *Description* field (e.g. `Make environment directive global`).
+. Leaving all other options as is, click *Save & run* and Jenkins proceeds to
+  build your amended Pipeline.
+. When the main Blue Ocean interface appears, click the _top_ row to see Jenkins
+  build your Pipeline project. +
+  You should see the same build process you saw when you completed adding the
+  final deliver stage (<<add-a-final-deliver-stage-to-your-pipeline,above>>).
+  However, when you inspect the `Jenkinsfile` again, you'll notice that the
+  `environment` directive is now a sibling of the `agent` section.
+
+
 === Wrapping up
 
 Well done! You've just used the Blue Ocean feature of Jenkins to build a simple
 Node.js and React application with npm!
-
-Notice where Blue Ocean placed the
-link:/doc/book/pipeline/syntax#environment[`environment`] directive in its
-Jenkinsfile. This directive's location within the "Test" stage means that the
-environment variable `CI` (with its value of `true`) is only available within
-the scope of this "Test" stage. How might you set this directive in Blue Ocean
-so that its environment variable is available globally throughout Pipeline (as
-is the case in the link:../building-a-node-js-and-react-app-with-npm/[Using
-Jenkins to build a Node.js and React application with npm] tutorial)?
 
 The "Build", "Test" and "Deliver" stages you created above are the basis for
 building other applications in Jenkins with any technology stack, including

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -149,7 +149,8 @@ step type",width=50%] +
   *Tip:* The most commonly used step types appear closest to the top of this
   list. To find other steps further down this list, you can filter this list
   using the *Find steps by name* option.
-. In the *Build / Shell Script* panel, specify `npm  install`. +
+. In the *Build / Shell Script* panel, specify `npm
+  install`. +
 [.boxshadow]
 image:tutorials/pipeline-in-blueocean-16-specifying-a-shell-step-value.png[alt="Specifying
 a shell step value",width=80%] +


### PR DESCRIPTION
* Also, expand wrap-up section to correlate outcomes of this tutorial
with the original Node.js and React one.

Essentially:
* The back arrow does not need to be used when it takes you back to the main Pipeline editor (i.e. not the Pipeline stage editor area). Therefore, the optional bits are now marked as such.
* Steps were missing to click the relevant build rows from the main Blue Ocean UI (i.e. to see build details in progress). These steps are now indicated - since their omission may confuse newbies to Blue Ocean.
* In the Wrapping Up section, I explained the difference between the placement of the 'environment' directive in this tutorial compared to the earlier Node.js and React one. I left it with a rhetorical question since readers should be in a position to work out how to make this directive apply globally after they get familiarised with the Blue Ocean UI (which this tutorial aims to achieve).