### PR TITLE
Add feedback footer to the end of each page of the User Handbook.

### DIFF
--- a/content/doc/book/appendix/index.adoc
+++ b/content/doc/book/appendix/index.adoc
@@ -21,3 +21,5 @@ In fact, topics that do not fit elsewhere may even be out of scope for this hand
 link:/participate[Contributing to Jenkins] for details of how to contact
 project contributors and discuss what you want to add.
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -101,3 +101,5 @@ NOTE: By default, when a Pull Request is closed,
 Jenkins will remove the Pipeline from Jenkins (to be cleaned up at a later date),
 and runs for that Pull Request will not longer be accessible from Jenkins.
 That can be changed by changing the configuration of the underlying Multi-branch Pipeline job.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -133,3 +133,5 @@ when those repositories already have `Jenkinsfile` entries in them.
 Repositories that do not contain `Jenkinsfile` entries are ignored.
 To create a new `Jenkinsfile` in a single repository that does not have one, use the
 "<<github-new-pipeline, New Pipeline>>" option instead.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -107,3 +107,5 @@ Blue Ocean represents Run Status using a consistent set of icons throughout.
 |image:blueocean/dashboard/status-aborted.png["Aborted" Status Icon, role=center]
 |*Aborted*
 |===
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -99,3 +99,5 @@ image::blueocean/intro/switch-classic.png[Returning to the "classic" web UI, rol
 Some links in Blue Ocean, like **Administration**, will also navigate to the
 classic web UI when there is no Blue Ocean equivalent.  In these cases, Blue
 Ocean will automatically take the user into the classic web UI as necessary.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -179,3 +179,5 @@ The source code can be found on Github:
 
 * link:http://github.com/jenkinsci/blueocean-plugin[Blue Ocean]
 * link:http://github.com/jenkinsci/jenkins-design-language[Jenkins Design Language]
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -138,3 +138,5 @@ The dialog also supports saving changes the same branch or entering a new branch
 Clicking on "Save & run" will save any changes to the Pipeline as a new commit,
 will start a new Pipeline Run based on those changes, and will navigate to the
 <<activity#, Activity View>> for this pipeline.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -113,3 +113,5 @@ Clicking on a item in the list will download it.
 The full output log from the Run can be downloaded from this list.
 
 image:blueocean/pipeline-run-details/artifacts-list.png[List of Artifacts from a Run, role=center]
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/getting-started/index.adoc
+++ b/content/doc/book/getting-started/index.adoc
@@ -27,3 +27,5 @@ If you are a Jenkins administrator and want to know more about managing Jenkins 
 
 If you are a system administrator and want learn how to back-up, restore, maintain as Jenkins servers and nodes, see
 <<system-administration#,Jenkins System Administration>>.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -133,3 +133,5 @@ Stable:: [[stable]]
 Successful:: [[successful]]
 Unstable:: [[unstable]]
 ////
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -611,3 +611,5 @@ plugins>>, Jenkins asks you to create your first administrator user.
 
 IMPORTANT: From this point on, the Jenkins UI is only accessible by providing
 valid username and password credentials.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -395,3 +395,5 @@ To get more information about the authentication process:
 . Click on *Save*
 
 When you try to authenticate, you can then refresh the page and see what happen internally.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -26,3 +26,5 @@ If you are already familiar with Jenkins basics and would like to delve deeper i
 
 If you are a system administrator and want learn how to back-up, restore, maintain as Jenkins servers and nodes, see
 <<system-administration#,Jenkins System Administration>>.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -21,3 +21,5 @@ Pages to mark as deprecated by this document:
 
 https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds
 ////
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -258,3 +258,5 @@ created/deleted to control the pinning behavior. If the `pinned` file is
 present, Jenkins will use whatever plugin version the user has specified.
 If the file is absent, Jenkins will restore the plugin to the default version
 on startup.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -137,3 +137,5 @@ Instead, it is usually more desirable to click *Approve assuming permissions
 check* which will cause the Script Approval engine to allow the method
 signature assuming the user running the script has the permissions to execute
 the method, such as the `Job/Read` permission in this example.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -22,3 +22,5 @@ https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Script+Console
 ====
 This is still very much a work in progress
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/security.adoc
+++ b/content/doc/book/managing/security.adoc
@@ -150,7 +150,7 @@ _what_ they can access in the Jenkins environment. By default Jenkins supports
 a few different Authorization options:
 
 
-Anyone can do anything:: Everyone gets full control of Jenkins, including 
+Anyone can do anything:: Everyone gets full control of Jenkins, including
 anonymous users who haven't logged in. *Do not use this setting* for anything
 other than local test Jenkins masters.
 Legacy mode:: Behaves exactly the same as Jenkins <1.164. Namely, if a user has
@@ -159,7 +159,7 @@ the "admin" role, they will be granted full control over the system, and otherwi
 setting* for anything other than local test Jenkins masters.
 Logged in users can do anything:: In this mode, every logged-in user gets full
 control of Jenkins. Depending on an advanced option, anonymous users get read
-access to Jenkins, or no access at all. This mode is useful to force users to 
+access to Jenkins, or no access at all. This mode is useful to force users to
 log in before taking actions, so that there is an audit trail of users' actions.
 Matrix-based security:: This authorization scheme allows for granular control
 over which users and groups are able to perform which actions in the Jenkins
@@ -202,7 +202,7 @@ to all authenticated users accessing the environment.
 The permissions granted in the matrix are additive. For example, if a user
 "kohsuke" is in the groups "developers" and "administrators", then the
 permissions granted to "kohsuke" will be a union of all those permissions
-granted to "kohsuke", "developers", "administrators", "authenticated", and 
+granted to "kohsuke", "developers", "administrators", "authenticated", and
 "anonymous."
 
 === Markup Formatter
@@ -232,7 +232,7 @@ by default with all Jenkins versions since 2.0.
 
 image::managing/configure-global-security-prevent-csrf.png["Configure Global Security - Prevent Cross Site Request Forgery exploits", role=center]
 
-When the option is enabled, Jenkins will check for a CSRF token, or "crumb", 
+When the option is enabled, Jenkins will check for a CSRF token, or "crumb",
 on any request that may change data in the Jenkins environment. This includes
 any form submission and calls to the remote API, including those using "Basic"
 authentication.
@@ -406,7 +406,7 @@ considered "trusted" to the same degree that the master is trusted, the
 Agent/Master Access Control feature may be disabled.
 
 Additionally, all the users in the Jenkins environment should have the same
-level of access to all configured projects. 
+level of access to all configured projects.
 
 An administrator can disable Agent/Master Access Control in the web UI by
 un-checking the box on the *Configure Global Security* page. Alternatively an
@@ -421,3 +421,4 @@ as the environment grows. Please consider scheduling regular "check-ups" to
 review whether any disabled security settings should be re-enabled.
 ====
 
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/system-configuration.adoc
+++ b/content/doc/book/managing/system-configuration.adoc
@@ -15,3 +15,4 @@ layout: section
 This is still very much a work in progress
 ====
 
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/tools.adoc
+++ b/content/doc/book/managing/tools.adoc
@@ -45,4 +45,4 @@ Q: how does this integrate with the Git plugin
 
 === Maven
 
-
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/managing/users.adoc
+++ b/content/doc/book/managing/users.adoc
@@ -15,3 +15,5 @@ layout: section
 ====
 This is still very much a work in progress
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -196,3 +196,5 @@ Pipeline steps are replaced with mock objects that you can use to check for expe
 behavior. New and rough around the edges, but promising.
 The link:https://github.com/lesfurets/JenkinsPipelineUnit/blob/master/README.md[README]
 for that project contains examples and usage instructions.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -469,3 +469,5 @@ node {
     }
 }
 ----
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -236,3 +236,5 @@ Jenkins Pipelines.
   Center.
 * link:/doc/pipeline/examples[Pipeline Examples], a
   community-curated collection of copyable Pipeline examples.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -204,3 +204,5 @@ Stage::
     entire Pipeline, for example: "Build", "Test", and "Deploy", which is used by many
     plugins to visualize or present Jenkins Pipeline status/progress.
     footnoteref:[blueocean,link:/projects/blueocean[Blue Ocean], link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin[Pipeline Stage View plugin]]
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -686,3 +686,4 @@ Instead of executing the tests on the "linux" and "windows" labelled nodes in
 series, they will now execute in parallel assuming the requisite capacity
 exists in the Jenkins environment.
 
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/multibranch.adoc
+++ b/content/doc/book/pipeline/multibranch.adoc
@@ -104,3 +104,5 @@ plugin:github-organization-folder[GitHub Organization Folder]
 and
 plugin:cloudbees-bitbucket-branch-source[Bitbucket Branch Source]
 plugins.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -671,3 +671,5 @@ Only entire `pipeline`s can be defined in shared libraries as of this time.
 This can only be done in `vars/*.groovy`, and only in a `call` method. Only one
 Declarative Pipeline can be executed in a single build, and if you attempt to
 execute a second one, your build will fail as a result.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1131,3 +1131,5 @@ declarative programming model.
 footnoteref:[declarative, link:https://en.wikipedia.org/wiki/Declarative_programming[Declarative Programming]]
 Whereas Scripted Pipelines follow a more imperative programming model..
 footnoteref:[imperative, link:https://en.wikipedia.org/wiki/Imperative_programming[Imperative Programming]]
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/scaling/index.adoc
+++ b/content/doc/book/scaling/index.adoc
@@ -26,3 +26,5 @@ into generally how to use various features, see
 
 If you are a Jenkins administrator and want to know more about managing Jenkins nodes and instances, see
 <<managing#,Managing Jenkins>>.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/system-administration/backing-up.adoc
+++ b/content/doc/book/system-administration/backing-up.adoc
@@ -14,3 +14,5 @@ layout: section
 ====
 This is still very much a work in progress
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/system-administration/index.adoc
+++ b/content/doc/book/system-administration/index.adoc
@@ -25,3 +25,5 @@ If you are already familiar with Jenkins basics and would like to delve deeper i
 
 If you are a Jenkins administrator and want to know more about managing Jenkins nodes and instances, see
 <<managing#,Managing Jenkins>>.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/system-administration/monitoring.adoc
+++ b/content/doc/book/system-administration/monitoring.adoc
@@ -14,3 +14,5 @@ layout: section
 ====
 This is still very much a work in progress
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -86,3 +86,5 @@ When this happens, you can fix this by the following steps:
   access to the system.
 
 If this is still not working, trying renaming or deleting `config.xml`.
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/system-administration/with-chef.adoc
+++ b/content/doc/book/system-administration/with-chef.adoc
@@ -14,3 +14,5 @@ layout: section
 ====
 This is still very much a work in progress
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/system-administration/with-puppet.adoc
+++ b/content/doc/book/system-administration/with-puppet.adoc
@@ -14,3 +14,5 @@ layout: section
 ====
 This is still very much a work in progress
 ====
+
+include::doc/_feedback-footer.adoc[]

--- a/content/doc/book/using/index.adoc
+++ b/content/doc/book/using/index.adoc
@@ -32,7 +32,6 @@ If you are a Jenkins administrator and want to know more about managing Jenkins 
 If you are a system administrator and want learn how to back-up, restore, maintain as Jenkins servers and nodes, see
 <<system-administration#,Jenkins System Administration>>.
 
-
 [WARNING]
 ====
 *To Contributors*:
@@ -41,3 +40,5 @@ but the format will be slightly different - see the description above.  We need 
 feature reference for experienced users with providing a continuing on-ramp for beginners. Sections should
 be written and ordered to only assume knowledge from "Getting Started" or from previous sections in this chapter.
 ====
+
+include::doc/_feedback-footer.adoc[]


### PR DESCRIPTION
When the feedback form footers were [initially added](https://github.com/jenkins-infra/jenkins.io/pull/1216) to the Jenkins User Documentation, they were only done so to pages of the Guided Tour and Tutorials parts.

This PR adds these form footers to the end of each page in the User Handbook.