### PR TITLE
Amend tutorial repository URLs after moving them from 'gilesgas' to 'jenkins-docs'

### DIFF
--- a/content/doc/tutorials/building-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/building-a-java-app-with-maven.adoc
@@ -45,7 +45,7 @@ and then cloning this fork locally.
   GitHub account, sign up for a free one on the https://github.com/[GitHub
   website].
 . Fork the
-  https://github.com/gilesgas/simple-java-maven-app[`simple-java-maven-app`] on
+  https://github.com/jenkins-docs/simple-java-maven-app[`simple-java-maven-app`] on
   GitHub into your local GitHub account. If you need help with this process,
   refer to the https://help.github.com/articles/fork-a-repo/[Fork A Repo]
   documentation on the GitHub website for more information.

--- a/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
@@ -47,7 +47,7 @@ GitHub account and then cloning this fork locally.
   GitHub account, sign up for a free one on the https://github.com/[GitHub
   website].
 . Fork the
-  https://github.com/gilesgas/simple-node-js-react-npm-app[`simple-node-js-react-npm-app`]
+  https://github.com/jenkins-docs/simple-node-js-react-npm-app[`simple-node-js-react-npm-app`]
   on GitHub into your local GitHub account. If you need help with this process,
   refer to the https://help.github.com/articles/fork-a-repo/[Fork A Repo]
   documentation on the GitHub website for more information.

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -49,7 +49,7 @@ your own GitHub account.
   GitHub account, sign up for a free one on the https://github.com/[GitHub
   website].
 . Fork the
-  https://github.com/gilesgas/creating-a-pipeline-in-blue-ocean[`creating-a-pipeline-in-blue-ocean`]
+  https://github.com/jenkins-docs/creating-a-pipeline-in-blue-ocean[`creating-a-pipeline-in-blue-ocean`]
   on GitHub into your local GitHub account. If you need help with this process,
   refer to the https://help.github.com/articles/fork-a-repo/[Fork A Repo]
   documentation on the GitHub website for more information. +


### PR DESCRIPTION
In the meantime, the old URLs will be redirected correctly - thanks to GitHub's built in functionality to automatically redirect repositories moved between accounts/organisations.