### PR TITLE
[WEBSITE-442] Rework skipping the 'Run Jenkins in Docker' instructions in tutorials

### DIFF
--- a/content/doc/index.adoc
+++ b/content/doc/index.adoc
@@ -14,7 +14,8 @@ documentation).
 == What is Jenkins?
 
 Jenkins is a self-contained, open source automation server which can be used to
-automate all sorts of tasks related to building, testing, and deploying software.
+automate all sorts of tasks related to building, testing, and delivering or
+deploying software.
 
 Jenkins can be installed through native system packages, Docker, or even run
 standalone by any machine with a Java Runtime Environment (JRE) installed.

--- a/content/doc/tutorials/_run-jenkins-in-docker.adoc
+++ b/content/doc/tutorials/_run-jenkins-in-docker.adoc
@@ -12,13 +12,6 @@ link:/doc/book/installing/#downloading-and-running-jenkins-in-docker[Downloading
 and running Jenkins in Docker] sections of the
 link:/doc/book/installing/[Installing Jenkins] page.
 
-*Tip:* If you've already run though this procedure (perhaps from link:..[another
-tutorial]), then you can skip this section and
-<<fork-and-clone-the-sample-repository-on-github,jump to the next>>. However,
-if it's been a while since you last ran through this procedure, then it is
-recommended that you re-run `docker run ...` command below again (if you haven't
-already done so recently) to acquire any updates to this Docker image.
-
 ==== On macOS and Linux
 
 . Open up a terminal window.
@@ -167,6 +160,7 @@ which you ran the `docker run ...` command <<run-jenkins-in-docker,above>>.
 To restart the Jenkins/Blue Ocean Docker container:
 
 . Run the same `docker run ...` command you ran for <<on-macos-and-linux,macOS,
-  Linux>> or <<on-windows,Windows>> above.
+  Linux>> or <<on-windows,Windows>> above. +
+  *Note:* This process also updates the Docker image.
 . Browse to `http://localhost:8080`.
 . Wait until the log in page appears and log in.

--- a/content/doc/tutorials/building-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/building-a-java-app-with-maven.adoc
@@ -28,7 +28,7 @@ You can stop this tutorial at any point in time and continue from where you left
 off.
 
 If you've already run though link:..[another tutorial], you can skip the
-<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+<<prerequisites,Prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
 Docker>> sections below and proceed on to <<fork-sample-repository,forking the
 sample repository>>. (Just ensure you have
 link:https://git-scm.com/downloads[Git] installed locally.) If you need to

--- a/content/doc/tutorials/building-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/building-a-java-app-with-maven.adoc
@@ -27,13 +27,23 @@ depend on the speed of your machine and whether or not you've already
 You can stop this tutorial at any point in time and continue from where you left
 off.
 
+If you've already run though link:..[another tutorial], you can skip the
+<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+Docker>> sections below and proceed on to <<fork-sample-repository,forking the
+sample repository>>. (Just ensure you have
+link:https://git-scm.com/downloads[Git] installed locally.) If you need to
+restart Jenkins, simply follow the restart instructions in
+<<stopping-and-restarting-jenkins,Stopping and restarting Jenkins>> and then
+proceed on.
+
 include::doc/tutorials/_prerequisites.adoc[]
-** https://git-scm.com/downloads[Git] and optionally
-   https://desktop.github.com/[GitHub Desktop].
+** link:https://git-scm.com/downloads[Git] and optionally
+   link:https://desktop.github.com/[GitHub Desktop].
 
 include::doc/tutorials/_run-jenkins-in-docker.adoc[]
 
 
+[[fork-sample-repository]]
 === Fork and clone the sample repository on GitHub
 
 Obtain the simple "Hello world!" Java application from GitHub, by forking the

--- a/content/doc/tutorials/building-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/building-a-multibranch-pipeline-project.adoc
@@ -24,11 +24,11 @@ In this tutorial, you'll use the same application that the
 link:../building-a-node-js-and-react-app-with-npm[Using Jenkins to build a
 Node.js and React application with npm] tutorial is based on. Therefore, you'll
 be building and testing the same application but this time, its delivery will be
-different depending on the Git branch that your Jenkins build runs. That is, the
+different depending on the Git branch that Jenkins builds from. That is, the
 branch being built determines which delivery stage of your Pipeline is executed.
 
 *Duration:* This tutorial takes 30-50 minutes to complete (assuming you've
-already met the <<prerequisites,prerequisites>> below). The exact duration will
+already met the <<prerequisites,Prerequisites>> below). The exact duration will
 depend on the speed of your machine and whether or not you've already
 <<run-jenkins-in-docker,run Jenkins in Docker>> from link:..[another tutorial].
 

--- a/content/doc/tutorials/building-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/building-a-multibranch-pipeline-project.adoc
@@ -35,13 +35,23 @@ depend on the speed of your machine and whether or not you've already
 You can stop this tutorial at any point in time and continue from where you left
 off.
 
+If you've already run though link:..[another tutorial], you can skip the
+<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+Docker>> sections below and proceed on to <<fork-sample-repository,forking the
+sample repository>>. (Just ensure you have
+link:https://git-scm.com/downloads[Git] installed locally.) If you need to
+restart Jenkins, simply follow the restart instructions in
+<<stopping-and-restarting-jenkins,Stopping and restarting Jenkins>> and then
+proceed on.
+
 include::doc/tutorials/_prerequisites.adoc[]
-** https://git-scm.com/downloads[Git] and optionally
-   https://desktop.github.com/[GitHub Desktop].
+** link:https://git-scm.com/downloads[Git] and optionally
+   link:https://desktop.github.com/[GitHub Desktop].
 
 include::doc/tutorials/_run-jenkins-in-docker.adoc[]
 
 
+[[fork-sample-repository]]
 === Fork and clone the sample repository on GitHub
 
 Obtain the simple "Welcome to React" Node.js and React application from GitHub,

--- a/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
@@ -30,7 +30,7 @@ You can stop this tutorial at any point in time and continue from where you left
 off.
 
 If you've already run though link:..[another tutorial], you can skip the
-<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+<<prerequisites,Prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
 Docker>> sections below and proceed on to <<fork-sample-repository,forking the
 sample repository>>. (Just ensure you have
 link:https://git-scm.com/downloads[Git] installed locally.) If you need to

--- a/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/building-a-node-js-and-react-app-with-npm.adoc
@@ -29,13 +29,23 @@ depend on the speed of your machine and whether or not you've already
 You can stop this tutorial at any point in time and continue from where you left
 off.
 
+If you've already run though link:..[another tutorial], you can skip the
+<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+Docker>> sections below and proceed on to <<fork-sample-repository,forking the
+sample repository>>. (Just ensure you have
+link:https://git-scm.com/downloads[Git] installed locally.) If you need to
+restart Jenkins, simply follow the restart instructions in
+<<stopping-and-restarting-jenkins,Stopping and restarting Jenkins>> and then
+proceed on.
+
 include::doc/tutorials/_prerequisites.adoc[]
-** https://git-scm.com/downloads[Git] and optionally
-   https://desktop.github.com/[GitHub Desktop].
+** link:https://git-scm.com/downloads[Git] and optionally
+   link:https://desktop.github.com/[GitHub Desktop].
 
 include::doc/tutorials/_run-jenkins-in-docker.adoc[]
 
 
+[[fork-sample-repository]]
 === Fork and clone the sample repository on GitHub
 
 Obtain the simple "Welcome to React" Node.js and React application from GitHub,

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -35,7 +35,7 @@ You can stop this tutorial at any point in time and continue from where you left
 off.
 
 If you've already run though link:..[another tutorial], you can skip the
-<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+<<prerequisites,Prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
 Docker>> sections below and proceed on to <<fork-sample-repository,forking the
 sample repository>>. If you need to restart Jenkins, simply follow the restart
 instructions in <<stopping-and-restarting-jenkins,Stopping and restarting

--- a/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/creating-a-pipeline-in-blue-ocean.adoc
@@ -34,11 +34,19 @@ depend on the speed of your machine and whether or not you've already
 You can stop this tutorial at any point in time and continue from where you left
 off.
 
+If you've already run though link:..[another tutorial], you can skip the
+<<prerequisites,prerequisites>> and <<run-jenkins-in-docker,Run Jenkins in
+Docker>> sections below and proceed on to <<fork-sample-repository,forking the
+sample repository>>. If you need to restart Jenkins, simply follow the restart
+instructions in <<stopping-and-restarting-jenkins,Stopping and restarting
+Jenkins>> and then proceed on.
+
 include::doc/tutorials/_prerequisites.adoc[]
 
 include::doc/tutorials/_run-jenkins-in-docker.adoc[]
 
 
+[[fork-sample-repository]]
 === Fork the sample repository on GitHub
 
 Fork the simple "Welcome to React" Node.js and React application on GitHub into


### PR DESCRIPTION
May convert the replicated content into an inclusion if more tutorials crop up with the same content re-used.

See https://issues.jenkins-ci.org/browse/WEBSITE-442 for details.