### PR TITLE
Fix broken links

### DIFF
--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -65,13 +65,13 @@ section: participate
         Help review changes to code or documentation.
       %ul
         %li
-          %a{:href => 'https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+team%3Ajenkinsci%2Fcode-reviewers'}
+          %a{:href => 'https://github.com/jenkinsci/jenkins/pulls?q=is%3Apr+is%3Aopen+label%3Aneeds-review'}
             List of open pull requests for which
             %strong
               code reviews
             have been requested
         %li
-          %a{:href => 'https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+team%3Ajenkins-infra%2Fcopy-editors'}
+          %a{:href => 'https://github.com/jenkinsci/jenkins/pulls?q=is%3Aopen+is%3Apr+label%3Aneeds-docs'}
             List of open pull requests for which
             %strong
               copy editing
@@ -122,7 +122,7 @@ section: participate
         Translate
       %p
         Jenkins is used all over the world by speakers of dozens of different languages. If you're fluent in languages other than English, consider improving support for those languages
-        %a{:href => 'https://wiki.jenkins-ci.org/display/JENKINS/Internationalization'}
+        %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Internationalization'}
           by contributing to core or plugin localizations.
 
       %h3


### PR DESCRIPTION
Two links were broken.
One was forwarding.

I don't know what "copy editing" is, but I mapped it to "needs-docs".