### PR TITLE
Clarify post and condition descriptions on the Pipeline Syntax page

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -261,7 +261,7 @@ run has a different completion status from its previous run.
 `failure`:: Only run the steps in `post` if the current Pipeline's or stage's
 run has a "failed" status, typically denoted by red in the web UI.
 `success`:: Only run the steps in `post` if the current Pipeline's or stage's
-run ran successfully, typically denoted by blue or green in the web UI.
+run has a "success" status, typically denoted by blue or green in the web UI.
 `unstable`:: Only run the steps in `post` if the current Pipeline's or stage's
 run has an "unstable" status, usually caused by test failures, code violations,
 etc. This is typically denoted by yellow in the web UI.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -231,12 +231,13 @@ from the previous stage.
 
 ==== post
 
-The `post` section defines actions which will be run at the end of the Pipeline
-run or stage. A number of <<post-conditions, post-condition>>
-blocks are supported within the `post` section:
-`always`, `changed`, `failure`, `success`, `unstable`, and `aborted`.
-These blocks allow for the execution of steps at the end of the Pipeline run or stage,
-depending on the status of the Pipeline.
+The `post` section defines one or more additional <<declarative-steps,steps>>
+that are run upon the completion of a Pipeline's or stage's run (depending on
+the location the `post` section within the Pipeline). `post` can support one of
+the following <<post-conditions, post-condition>> blocks: `always`, `changed`,
+`failure`, `success`, `unstable`, and `aborted`. These condition blocks allow
+the execution of steps within the `post` section depending on the completion
+status of the Pipeline or stage.
 
 [cols="^10h,>90a",role=syntax]
 |===
@@ -253,19 +254,20 @@ depending on the status of the Pipeline.
 [[post-conditions]]
 ===== Conditions
 
-`always`:: Run regardless of the completion status of the Pipeline run.
-`changed`:: Only run if the current Pipeline run has a different status from
-the previously completed Pipeline.
-`failure`:: Only run if the current Pipeline has a "failed" status, typically
-denoted in the web UI with a red indication.
-`success`::  Only run if the current Pipeline has a "success" status, typically
-denoted in the web UI with a blue or green indication.
-`unstable`:: Only run if the current Pipeline has an "unstable" status,
-usually caused by test failures, code violations, etc. Typically denoted in the
-web UI with a yellow indication.
-`aborted`:: Only run if the current Pipeline has an "aborted" status, usually
-due to the Pipeline being manually aborted. Typically denoted in the
-web UI with a gray indication.
+`always`:: Run the steps in the `post` section regardless of the completion
+status of the Pipeline's or stage's run.
+`changed`:: Only run the steps in `post` if the current Pipeline's or stage's
+run has a different completion status from its previous run.
+`failure`:: Only run the steps in `post` if the current Pipeline's or stage's
+run has a "failed" status, typically denoted by red in the web UI.
+`success`:: Only run the steps in `post` if the current Pipeline's or stage's
+run ran successfully, typically denoted by blue or green in the web UI.
+`unstable`:: Only run the steps in `post` if the current Pipeline's or stage's
+run has an "unstable" status, usually caused by test failures, code violations,
+etc. This is typically denoted by yellow in the web UI.
+`aborted`:: Only run the steps in `post` if the current Pipeline's or stage's
+run has an "aborted" status, usually due to the Pipeline being manually aborted.
+This is typically denoted by gray in the web UI.
 
 [[post-example]]
 ===== Example

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -233,11 +233,11 @@ from the previous stage.
 
 The `post` section defines one or more additional <<declarative-steps,steps>>
 that are run upon the completion of a Pipeline's or stage's run (depending on
-the location the `post` section within the Pipeline). `post` can support one of
-the following <<post-conditions, post-condition>> blocks: `always`, `changed`,
-`failure`, `success`, `unstable`, and `aborted`. These condition blocks allow
-the execution of steps within the `post` section depending on the completion
-status of the Pipeline or stage.
+the location of the `post` section within the Pipeline). `post` can support one
+of the following <<post-conditions, post-condition>> blocks: `always`,
+`changed`, `failure`, `success`, `unstable`, and `aborted`. These condition
+blocks allow the execution of steps within the `post` section depending on the
+completion status of the Pipeline or stage.
 
 [cols="^10h,>90a",role=syntax]
 |===


### PR DESCRIPTION
This is to make it clearer that the conditions are also applicable to stages too.