### PR TITLE
Amend introductory 'Run Jenkins in Docker' blurb to encourage readers...

### DIFF
--- a/content/doc/tutorials/_run-jenkins-in-docker.adoc
+++ b/content/doc/tutorials/_run-jenkins-in-docker.adoc
@@ -8,7 +8,7 @@ In this tutorial, you'll be running Jenkins as a Docker container from the
 link:https://hub.docker.com/r/jenkinsci/blueocean/[`jenkinsci/blueocean`] Docker
 image.
 
-To run Jenkins in Docker, follow the relevant instructions for either
+To run Jenkins in Docker, follow the relevant instructions below for either
 <<on-macos-and-linux,macOS and Linux>> or <<on-windows,Windows>>.
 
 You can read more about Docker container and image concepts in the

--- a/content/doc/tutorials/_run-jenkins-in-docker.adoc
+++ b/content/doc/tutorials/_run-jenkins-in-docker.adoc
@@ -6,7 +6,12 @@ This file is only meant to be included as a snippet in other documents.
 
 In this tutorial, you'll be running Jenkins as a Docker container from the
 link:https://hub.docker.com/r/jenkinsci/blueocean/[`jenkinsci/blueocean`] Docker
-image. Read more about these concepts in the
+image.
+
+To run Jenkins in Docker, follow the relevant instructions for either
+<<on-macos-and-linux,macOS and Linux>> or <<on-windows,Windows>>.
+
+You can read more about Docker container and image concepts in the
 link:/doc/book/installing/#docker[Docker] and
 link:/doc/book/installing/#downloading-and-running-jenkins-in-docker[Downloading
 and running Jenkins in Docker] sections of the
@@ -76,7 +81,7 @@ docker run ^
   -v "%HOMEPATH%":/home ^
   jenkinsci/blueocean
 ----
-For an explanation of these options, refer to the <<on-macos-and-linux, macOS
+For an explanation of these options, refer to the <<on-macos-and-linux,macOS
 and Linux>> instructions above.
 . Proceed to the <<setup-wizard,Setup wizard>>.
 


### PR DESCRIPTION
* ... to use the 'docker run ...' instructions on the tutorial page
itself rather than using the more generically-aimed instructions on the
'Installing Jenkins' page.