### PR TITLE
Fix broken links in tutorials ...

### DIFF
--- a/content/doc/tutorials/_run-jenkins-in-docker.adoc
+++ b/content/doc/tutorials/_run-jenkins-in-docker.adoc
@@ -166,6 +166,7 @@ To restart the Jenkins/Blue Ocean Docker container:
 
 . Run the same `docker run ...` command you ran for <<on-macos-and-linux,macOS,
   Linux>> or <<on-windows,Windows>> above. +
-  *Note:* This process also updates the Docker image.
+  *Note:* This process also updates the `jenkinsci/blueocean` Docker image, if
+  an updated one is available.
 . Browse to `http://localhost:8080`.
 . Wait until the log in page appears and log in.

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -99,7 +99,7 @@ and then cloning this fork locally.
   Management (SCM), which will be your locally cloned Git repository.
 . From the *SCM* field, choose *Git*.
 . In the *Repository URL* field, specify the directory path of your locally
-  cloned repository <<fork-and-clone-the-sample-repository-on-github,above>>,
+  cloned repository <<fork-sample-repository,above>>,
   which is from your user account/home directory on your host machine, mapped to
   the `/home` directory of the Jenkins container - i.e.
 * For macOS - `/home/Documents/GitHub/simple-java-maven-app`

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -140,7 +140,7 @@ project as a "Multibranch Pipeline" project.
 . In *Where do you store your code?*, click *Git* (_not_ *GitHub*).
 . In the *Repository URL* field (within *Connect to a Git repository*), specify
   the directory path of your locally cloned repository
-  <<fork-and-clone-the-sample-repository-on-github,above>>, which is from your
+  <<fork-sample-repository,above>>, which is from your
   user account/home directory on your host machine, mapped to the `/home`
   directory of the Jenkins container - i.e.
 * For macOS - `/home/Documents/GitHub/building-a-multibranch-pipeline-project`

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -102,7 +102,7 @@ GitHub account and then cloning this fork locally.
   Management (SCM), which will be your locally cloned Git repository.
 . From the *SCM* field, choose *Git*.
 . In the *Repository URL* field, specify the directory path of your locally
-  cloned repository <<fork-and-clone-the-sample-repository-on-github,above>>,
+  cloned repository <<fork-sample-repository,above>>,
   which is from your user account/home directory on your host machine, mapped to
   the `/home` directory of the Jenkins container - i.e.
 * For macOS - `/home/Documents/GitHub/simple-node-js-react-npm-app`

--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -111,7 +111,7 @@ then cloning this fork locally.
   Management (SCM), which will be your locally cloned Git repository.
 . From the *SCM* field, choose *Git*.
 . In the *Repository URL* field, specify the directory path of your locally
-  cloned repository <<fork-and-clone-the-sample-repository-on-github,above>>,
+  cloned repository <<fork-sample-repository,above>>,
   which is from your user account/home directory on your host machine, mapped to
   the `/home` directory of the Jenkins container - i.e.
 * For macOS - `/home/Documents/GitHub/simple-python-pyinstaller-app`

--- a/content/doc/tutorials/create-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/create-a-pipeline-in-blue-ocean.adoc
@@ -103,7 +103,7 @@ to GitHub",width=80%] +
   (provided by your access token).
 . In *Which organization does the repository belong
   to?*, click your GitHub account (where you forked the repository
-  <<fork-the-sample-repository-on-github,above>>).
+  <<fork-sample-repository,above>>).
 . In *Choose a repository*, click your forked repository
   *creating-a-pipeline-in-blue-ocean*.
 . Click *Create Pipeline*. +


### PR DESCRIPTION
* Add more infomation about Docker image updates.

This work is a hangover from the custom anchors implemented as part of https://github.com/jenkins-infra/jenkins.io/pull/1244