### PR TITLE
More makefile tweaks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,12 +66,7 @@ try {
                         exit 1
                     fi
 
-                    mkdir -p build
-                    make all 2>&1 | tee build/log.txt
-                    if [[ -n "$( grep --fixed-strings WARNING build/log.txt | grep --fixed-strings --invert-match user-handbook.adoc | grep --fixed-strings --invert-match 'conversion missing in backend pdf' )" ]] ; then
-                        echo "Failing build due to warnings in log output" >&2
-                        exit 1
-                    fi
+                    make all
 
                     illegal_htaccess_content="$( find content -name '.htaccess' -type f -exec grep --extended-regexp --invert-match '^(#|ErrorDocument)' {} \\; )"
                     if [[ -n "$illegal_htaccess_content" ]] ; then

--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,20 @@ all: fetch-reset prepare generate archive
 prepare: fetch depends assets
 
 # Run a local dev server on localhost:4242
-run: prepare
-	LISTEN=true ./scripts/ruby bundle exec awestruct --bind 0.0.0.0 --dev $(AWESTRUCT_CONFIG)
+run: prepare scripts/awestruct
+	LISTEN=true ./scripts/awestruct --dev --bind 0.0.0.0  $(AWESTRUCT_CONFIG)
 
 generate: site pdfs
 
-site: prepare
-	./scripts/ruby bundle exec awestruct --generate --verbose $(AWESTRUCT_CONFIG)
+site: prepare scripts/awestruct
+	./scripts/awestruct --generate --verbose $(AWESTRUCT_CONFIG)
 
-pdfs: prepare scripts/generate-handbook-pdf
+pdfs: prepare scripts/generate-handbook-pdf scripts/asciidoctor-pdf
 	./scripts/ruby scripts/generate-handbook-pdf $(BUILD_DIR)/user-handbook.adoc
-	./scripts/ruby bundle exec asciidoctor-pdf -a allow-uri-read \
+	./scripts/asciidoctor-pdf -a allow-uri-read \
 		--base-dir content \
 		--out-file user-handbook.pdf \
 		$(BUILD_DIR)/user-handbook.adoc
-
 
 # Fetching and generating content from external sources
 #######################################################

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,23 @@ BUILD_DIR=build
 OUTPUT_DIR=$(BUILD_DIR)/_site
 AWESTRUCT_CONFIG=--source-dir=content --output-dir=$(OUTPUT_DIR)
 ASSETS_DIR=$(OUTPUT_DIR)/assets/bower
+FONTS_DIR=$(OUTPUT_DIR)/css/fonts
 VERSION=$(BUILD_NUMBER)-$(shell git rev-parse --short HEAD)
 
 # Generate everything
-all: fetch-reset fetch generate archive
+all: fetch-reset prepare generate archive
 prepare: fetch depends assets
 
 # Run a local dev server on localhost:4242
-run: fetch depends-ruby assets
+run: prepare
 	LISTEN=true ./scripts/ruby bundle exec awestruct --bind 0.0.0.0 --dev $(AWESTRUCT_CONFIG)
 
 generate: site pdfs
 
-site: fetch $(OUTPUT_DIR) depends-ruby assets
+site: prepare
 	./scripts/ruby bundle exec awestruct --generate --verbose $(AWESTRUCT_CONFIG)
 
-pdfs: fetch $(OUTPUT_DIR)/user-handbook.pdf
-
-$(OUTPUT_DIR)/user-handbook.pdf: $(OUTPUT_DIR) depends-ruby scripts/generate-handbook-pdf
+pdfs: prepare scripts/generate-handbook-pdf
 	./scripts/ruby scripts/generate-handbook-pdf $(BUILD_DIR)/user-handbook.adoc
 	./scripts/ruby bundle exec asciidoctor-pdf -a allow-uri-read \
 		--base-dir content \
@@ -31,59 +30,56 @@ $(OUTPUT_DIR)/user-handbook.pdf: $(OUTPUT_DIR) depends-ruby scripts/generate-han
 # Fetching and generating content from external sources
 #######################################################
 # NOTE: Fetch only runs once until flag is reset
-fetch: depends-ruby $(BUILD_DIR)/fetched
+fetch: $(BUILD_DIR)/fetch
 
 # force fetching of resources
-fetch-reset: $(OUTPUT_DIR)
-	@rm -f $(BUILD_DIR)/fetched
+fetch-reset:
+	@rm -f $(BUILD_DIR)/fetch
 
-$(BUILD_DIR)/fetched: $(OUTPUT_DIR) $(OUTPUT_DIR)/releases.rss scripts/fetch-examples scripts/fetch-external-resources
-	./scripts/fetch-examples
-	./scripts/ruby bundle exec ./scripts/fetch-external-resources
-	@touch $(BUILD_DIR)/fetched
-
-$(OUTPUT_DIR)/releases.rss: $(OUTPUT_DIR) scripts/release.rss.groovy
+$(BUILD_DIR)/fetch: $(BUILD_DIR)/ruby scripts/release.rss.groovy scripts/fetch-examples scripts/fetch-external-resources | $(OUTPUT_DIR)
 	./scripts/groovy pull
 	./scripts/groovy scripts/release.rss.groovy 'https://updates.jenkins.io/release-history.json' > $(OUTPUT_DIR)/releases.rss
+	./scripts/fetch-examples
+	./scripts/ruby bundle exec ./scripts/fetch-external-resources
+	@touch $(BUILD_DIR)/fetch
+
 #######################################################
 
 
 # Handling dependencies
 #######################################################
-depends: depends-ruby depends-node
+depends: $(BUILD_DIR)/ruby $(BUILD_DIR)/node
 
 # update dependencies information
 update: depends
 	./scripts/ruby bundle update
 	./scripts/node npm update
 
-depends-ruby: vendor/gems
-
 # when we pull dependencies also pull docker image
 # without this images can get stale and out of sync from CI system
-vendor/gems: Gemfile Gemfile.lock
+$(BUILD_DIR)/ruby: Gemfile Gemfile.lock scripts/ruby | $(OUTPUT_DIR)
 	./scripts/ruby pull
 	./scripts/ruby bundle install --path=vendor/gems
-	@touch vendor/gems
-
-depends-node: node_modules
+	@touch $(BUILD_DIR)/ruby
 
 # when we pull dependencies also pull docker image
 # without this images can get stale and out of sync from CI system
-node_modules: package.json package-lock.json
+$(BUILD_DIR)/node: package.json package-lock.json scripts/node | $(OUTPUT_DIR)
 	./scripts/node pull
 	./scripts/node npm install
-	@touch node_modules
+	@touch $(BUILD_DIR)/node
 
-assets: depends-node
-	mkdir -p $(ASSETS_DIR)
-	mkdir -p $(OUTPUT_DIR)/css/fonts
+assets: $(BUILD_DIR)/assets
+
+$(BUILD_DIR)/assets: $(BUILD_DIR)/node $(shell find . -ipath "./node_modules/*")
+	@mkdir -p $(FONTS_DIR)
+	@mkdir -p $(ASSETS_DIR)
 	@for f in $(shell find node_modules \( -iname "*.eot" -o -iname "*.woff" -o -iname "*.ttf" \)); do \
-		echo ">> $$f => $(OUTPUT_DIR)/css/fonts/"; \
-		cp $$f $(OUTPUT_DIR)/css/fonts/; \
+		echo "Copying $$f into $(FONTS_DIR)"; \
+		cp $$f $(FONTS_DIR); \
 	done;
 	@for d in bootstrap jquery tether; do \
-		echo ">> Copying node_modules/$$d/dist/* into $(ASSETS_DIR)/$$d/"; \
+		echo "Copying node_modules/$$d/dist/* into $(ASSETS_DIR)/$$d/"; \
 		mkdir -p $(ASSETS_DIR)/$$d; \
 		cp -R node_modules/$$d/dist/* $(ASSETS_DIR)/$$d/ ; \
 	done;
@@ -92,12 +88,14 @@ assets: depends-node
 	mkdir -p $(ASSETS_DIR)/ionicons
 	cp -R node_modules/ionicons/css $(ASSETS_DIR)/ionicons
 	cp -R node_modules/ionicons/fonts $(ASSETS_DIR)/ionicons
+	@touch $(BUILD_DIR)/assets
+
 #######################################################
 
 
 # Archive tasks
 #######################################################
-archive: $(OUTPUT_DIR)
+archive: generate
 	mkdir -p $(BUILD_DIR)/archives
 	(cd $(BUILD_DIR) && \
 		rm -f archives/jenkins.io-$(VERSION).zip && \
@@ -113,9 +111,9 @@ $(OUTPUT_DIR):
 
 clean:
 	rm -rf vendor/gems
-	rm -rf build/
+	rm -rf $(BUILD_DIR)
 	rm -rf node_modules/
 #######################################################
 
-.PHONY: all archive assets clean depends depends-node depends-ruby \
+.PHONY: all archive assets clean depends \
 		fetch fetch-reset generate pdfs prepare run site update

--- a/scripts/asciidoctor-pdf
+++ b/scripts/asciidoctor-pdf
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+mkdir -p build
+./scripts/ruby bundle exec asciidoctor-pdf $@ 2> build/error.txt || {
+    cat build/error.txt >&2
+    exit 1
+}
+if [[ -n "$( grep --fixed-strings WARNING build/error.txt | grep --fixed-strings --invert-match user-handbook.adoc | grep --fixed-strings --invert-match 'conversion missing in backend pdf' )" ]] ; then
+    echo "Failing build due to warnings in log output:" >&2
+    cat build/error.txt >&2
+    exit 1
+fi

--- a/scripts/awestruct
+++ b/scripts/awestruct
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [[ "$1" = "--dev" ]] ; then
+    ./scripts/ruby bundle exec awestruct $@
+else
+    mkdir -p build
+    ./scripts/ruby bundle exec awestruct $@ 2> build/error.txt || {
+        cat build/error.txt >&2
+        exit 1
+    }
+    if [[ -n "$( grep --fixed-strings WARNING build/error.txt )" ]] ; then
+        echo "Failing build due to warnings in log output:" >&2
+        cat build/error.txt >&2
+        exit 1
+    fi
+fi
+


### PR DESCRIPTION
`depends` and `assets` run only when required by file changes.  Using flag files for both. 
Also moved warning filtering from Jenkinsfile to scripts which make calls.  This will result in clearer output when errors occur. 