### PR TITLE
Add 2.96 changelog even when not being distributed

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -1657,7 +1657,7 @@
 - version: "2.96"
   date: 2017-12-17
   banner: >
-    Upgrading to Jenkins 2.96 will downgrade Script Security Plugin to version 2.18.1, possibly resulting in cascading failures to load other plugins (and reintroduces a security issue). Update Script Security Plugin to its newest release and restart Jenkins to resolve this issue.
+    A bug introduced in Jenkins 2.96 will downgrade Script Security Plugin to version 2.18.1, possibly resulting in cascading failures to load other plugins (and reintroducing security issues). We recommend updating Script Security Plugin to its newest release and immediately restarting Jenkins to resolve this issue.
   changes:
     - type: major bug
       pull: 3193

--- a/content/changelog/index.html.haml
+++ b/content/changelog/index.html.haml
@@ -8,7 +8,7 @@ title: Changelog
 .ratings
   - # source: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml
   - site.changelogs[:weekly].reverse_each do | release |
-    - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
+    - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest) or release.version = "2.96"
       %h3{:id => "v#{release.version}" }
         = "What's new in #{release.version} (#{release.date})"
       - if release.banner


### PR DESCRIPTION
First commit's PR build output:

> ![screen shot](https://user-images.githubusercontent.com/1831569/34127305-e7051c60-e43c-11e7-8f4a-47e8c891eb14.png)
