### PR TITLE
Revert "Add 2.96 changelog even when not being distributed"

### DIFF
--- a/content/changelog/index.html.haml
+++ b/content/changelog/index.html.haml
@@ -8,7 +8,7 @@ title: Changelog
 .ratings
   - # source: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml
   - site.changelogs[:weekly].reverse_each do | release |
-    - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest) or release.version = "2.96"
+    - if Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest)
       %h3{:id => "v#{release.version}" }
         = "What's new in #{release.version} (#{release.date})"
       - if release.banner


### PR DESCRIPTION
This reverts commit ad22772448c9190aafca6df3238657d90d1d4de6.

Apparently I cannot Ruby, so we now have two changelog entries for 2.96 😢 