### PR TITLE
Fix JENKINS-48527

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -341,6 +341,8 @@ package org.foo;
 def checkOutFrom(repo) {
   git url: "git@github.com:jenkinsci/${repo}"
 }
+
+return this
 ----
 
 Which can then be called from a Scripted Pipeline:


### PR DESCRIPTION
There is a missing return this in the example for Zot.groovy. Without this, the issue in the issue arises. This clarifies the example to make sure the user knows that `return this` is needed