### PR TITLE
[FIXED JENKINS-48455] Add info on `filename` option for `Dockerfile`

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -137,7 +137,9 @@ the `Jenkinsfile` must be loaded from either a  Multibranch Pipeline, or a
 "Pipeline from SCM." Conventionally this is the `Dockerfile` in the root of the
 source repository: `agent { dockerfile true }`. If building a `Dockerfile` in
 another directory, use the `dir` option: `agent { dockerfile { dir 'someSubDir'
-} }`. You can pass additional arguments to the `docker build ...` command with
+} }`. If using a file named something other than `Dockerfile`, use the
+`filename` option: `agent { dockerfile { filename 'Dockerfile.other' }
+}`. You can pass additional arguments to the `docker build ...` command with
 the `additionalBuildArgs` option, like `agent { dockerfile {
 additionalBuildArgs '--build-arg foo=bar' } }`.
 


### PR DESCRIPTION
[JENKINS-48455](https://issues.jenkins-ci.org/browse/JENKINS-48455)

This is ready to go whenever - no change in Declarative needed. It's just something we missed in the docs. oops.