### PR TITLE
adding "filename" option on dockerfile + example

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -137,9 +137,25 @@ the `Jenkinsfile` must be loaded from either a  Multibranch Pipeline, or a
 "Pipeline from SCM." Conventionally this is the `Dockerfile` in the root of the
 source repository: `agent { dockerfile true }`. If building a `Dockerfile` in
 another directory, use the `dir` option: `agent { dockerfile { dir 'someSubDir'
-} }`. You can pass additional arguments to the `docker build ...` command with
-the `additionalBuildArgs` option, like `agent { dockerfile {
+} }`. If your `Dockerfile` as another name, you can specify the file name with
+the `filename` option. You can pass additional arguments to the `docker build ...`
+command with the `additionalBuildArgs` option, like `agent { dockerfile {
 additionalBuildArgs '--build-arg foo=bar' } }`.
+For example, a repository with the file `build/Dockerfile.build`, expecting
+a build argument `version`:
++
+[source,groovy]
+----
+agent {
+    // Equivalent to "docker build -f Dockerfile.build --build-arg version=1.0.2 ./build/
+    dockerfile {
+        filename 'Dockerfile.build'
+        dir 'build'
+        label 'my-defined-label'
+        additionalBuildArgs  '--build-arg version=1.0.2'
+    }
+}
+----
 
 ===== Common Options
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -137,7 +137,7 @@ the `Jenkinsfile` must be loaded from either a  Multibranch Pipeline, or a
 "Pipeline from SCM." Conventionally this is the `Dockerfile` in the root of the
 source repository: `agent { dockerfile true }`. If building a `Dockerfile` in
 another directory, use the `dir` option: `agent { dockerfile { dir 'someSubDir'
-} }`. If your `Dockerfile` as another name, you can specify the file name with
+} }`. If your `Dockerfile` has another name, you can specify the file name with
 the `filename` option. You can pass additional arguments to the `docker build ...`
 command with the `additionalBuildArgs` option, like `agent { dockerfile {
 additionalBuildArgs '--build-arg foo=bar' } }`.


### PR DESCRIPTION
Some links from the declarative pipeline plugin repository or JIRA: 
* https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/1e1452409af43d15356d6591002317bd8b0c4216/pipeline-model-definition/src/test/resources/fromAlternateDockerfile.groovy
* Auto documentation: https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/7080fce379ced865e73947b6d9e44a46af6b9c03/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile/help-filename.html