### PR TITLE
Disable the dependency checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,12 +59,6 @@ try {
                     set -o nounset
                     set -o pipefail
                     set -o xtrace
-                    make update
-                    if [[ -n "$( git diff )" ]] ; then
-                        echo "A node or ruby dependency has changed."
-                        echo "Run 'make update' and commit resulting changes."
-                        exit 1
-                    fi
 
                     make all
 


### PR DESCRIPTION
I'm sick of hearing complaints about having to run `make update` in order to
help keep the site's dependencies up to date, so I'm just going to revert this
@bitwiseman
