### PR TITLE
Add missing 'stage {' to the complete Pipeline code towards end of Python tutorial

### DIFF
--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -373,6 +373,7 @@ so that you end up with:
 ----
 pipeline {
     agent none
+    stages {
         stage('Build') {
             agent {
                 docker {


### PR DESCRIPTION
Whoops! This wouldn't have affected readers running through the tutorial in its entirety, but it would have affected people copying and pasting the last complete Pipeline code towards the end of the page.