### PR TITLE
Recommend simple Map-based functions rather than the builder pattern

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -541,18 +541,11 @@ tested in the same way, so we might write a step named
 [source,groovy]
 ----
 // vars/buildPlugin.groovy
-def call(body) {
-    // evaluate the body block, and collect configuration into the object
-    def config = [:]
-    body.resolveStrategy = Closure.DELEGATE_FIRST
-    body.delegate = config
-    body()
-
-    // now build, based on the configuration provided
+def call(Map config) {
     node {
         git url: "https://github.com/jenkinsci/${config.name}-plugin.git"
-        sh "mvn install"
-        mail to: "...", subject: "${config.name} plugin build", body: "..."
+        sh 'mvn install'
+        mail to: '...', subject: "${config.name} plugin build", body: '...'
     }
 }
 ----
@@ -565,11 +558,13 @@ the resulting `Jenkinsfile` will be dramatically simpler:
 [pipeline]
 ----
 // Script //
-buildPlugin {
-    name = 'git'
-}
+buildPlugin name: 'git'
 // Declarative not yet implemented //
 ----
+
+There is also a “builder pattern” trick using Groovy’s `Closure.DELEGATE_FIRST`,
+which permits `Jenkinsfile` to look slightly more like a configuration file than a program,
+but this is more complex and error-prone and is not recommended.
 
 === Using third-party libraries
 


### PR DESCRIPTION
A recommendation I made in #611. For example, look at https://github.com/cloudbeers/multibranch-demo/pull/22 + https://github.com/cloudbeers/multibranch-demo-lib/commit/335dc32bb9f73ca06b843b426904c6a36c05f438. And lots of Groovy weirdness just disappears when closure scopes go away, as the commit sequence in https://github.com/cloudbeers/multibranch-demo/pull/26 demonstrates.

@reviewbybees esp. @abayer & @raul-arabaolaza