### PR TITLE
Change declarative Pipeline to recommend using the 'archiveArtifacts' step ...

### DIFF
--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -104,9 +104,9 @@ node {
 If more than one parameter is specified in the `archiveArtifacts` step, then
 each parameter's name must explicitly be specified in the step code - i.e.
 `artifacts` for the artifact's path and file name and `fingerprint` to choose
-this option. If you are only specifying the artifacts' path and file name/s, then
-you can omit the parameter name `artifacts` - e.g.
-`archiveArtifacts 'build/libs/**/*.jar'`.
+this option. If you only need to specify the artifacts' path and file name/s,
+then you can omit the parameter name `artifacts` - e.g. +
+`archiveArtifacts 'build/libs/**/*.jar'`
 
 Recording tests and artifacts in Jenkins is useful for quickly and easily
 surfacing information to various members of the team. In the next section we'll

--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -60,8 +60,8 @@ Jenkins for local analysis and investigation. This is made practical by
 Jenkins's built-in support for storing "artifacts", files generated during the
 execution of the Pipeline.
 
-This is easily done with the `archive` step and a file-globbing expression, as
-is demonstrated in the example below:
+This is easily done with the `archiveArtifacts` step and a file-globbing
+expression, as is demonstrated in the example below:
 
 [pipeline]
 ----
@@ -83,7 +83,7 @@ pipeline {
 
     post {
         always {
-            archive 'build/libs/**/*.jar'
+            archiveArtifacts artifacts: 'build/libs/**/*.jar', fingerprint: true
             junit 'build/reports/**/*.xml'
         }
     }
@@ -100,6 +100,13 @@ node {
     }
 }
 ----
+
+If more than one parameter is specified in the `archiveArtifacts` step, then
+each parameter's name must explicitly be specified in the step code - i.e.
+`artifacts` for the artifact's path and file name and `fingerprint` to choose
+this option. If you are only specifying the artifacts' path and file name/s, then
+you can omit the parameter name `artifacts` - e.g.
+`archiveArtifacts 'build/libs/**/*.jar'`.
 
 Recording tests and artifacts in Jenkins is useful for quickly and easily
 surfacing information to various members of the team. In the next section we'll


### PR DESCRIPTION
... rather than the deprecated 'archive' step.

Add blurb about when it's okay to omit the 'archive' parameter name.