### PR TITLE
Add required 'docker run ...' option for JNLP-based Jenkins agents ...

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -65,7 +65,7 @@ want your Jenkins state to persist each time you restart Jenkins (via this
 `docker run ...` command). If you do not specify this option, then Jenkins will
 effectively reset to a new instance after each restart. +
 *Notes:*
-This volume could also be created independently using the
+The `jenkins-data` volume could also be created independently using the
 link:https://docs.docker.com/engine/reference/commandline/volume_create/[`docker
 volume create`] command: +
 `docker volume create jenkins-data` +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -64,7 +64,7 @@ will automatically create the volume for you. This option is required if you
 want your Jenkins state to persist each time you restart Jenkins (via this
 `docker run ...` command). If you do not specify this option, then Jenkins will
 effectively reset to a new instance after each restart. +
-*Notes:* +
+*Notes:*
 This volume could also be created independently using the
 link:https://docs.docker.com/engine/reference/commandline/volume_create/[`docker
 volume create`] command: +
@@ -81,8 +81,9 @@ through which the Docker daemon listens on. This mapping allows the
 `jenkinsci/blueocean` container to communicate with the Docker daemon, which is
 required if the `jenkinsci/blueocean` container needs to instantiate other
 Docker containers. This option is necessary if you run declarative Pipelines
-containing the syntax `agent { docker { ... } }`. <<pipeline/syntax#agent,Read
-more>> about this on the <<pipeline/syntax#,Pipeline Syntax>> page.
+whose syntax contains the <<pipeline/syntax#agent,`agent`>> section with the
+`docker` parameter - i.e. `agent { docker { ... } }`. Read more about this on
+the <<pipeline/syntax#,Pipeline Syntax>> page.
 <7> The `jenkinsci/blueocean` Docker image itself. If this image has not already
 been downloaded, then this `docker run` command will automtically download the
 image for you. Furthermore, if any updates to this image were published since

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -82,8 +82,9 @@ through which the Docker daemon listens on. This mapping allows the
 required if the `jenkinsci/blueocean` container needs to instantiate other
 Docker containers. This option is necessary if you run declarative Pipelines
 whose syntax contains the <<pipeline/syntax#agent,`agent`>> section with the
-`docker` parameter - i.e. `agent { docker { ... } }`. Read more about this on
-the <<pipeline/syntax#,Pipeline Syntax>> page.
+`docker` parameter - i.e. +
+`agent { docker { ... } }`. Read more about this on the
+<<pipeline/syntax#,Pipeline Syntax>> page.
 <7> The `jenkinsci/blueocean` Docker image itself. If this image has not already
 been downloaded, then this `docker run` command will automtically download the
 image for you. Furthermore, if any updates to this image were published since

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -25,9 +25,10 @@ docker run \
   --rm \  # <1>
   -d \ # <2>
   -p 8080:8080 \ # <3>
-  -v jenkins-data:/var/jenkins_home \ # <4>
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  jenkinsci/blueocean # <5>
+  -p 50000:50000 \ # <4>
+  -v jenkins-data:/var/jenkins_home \ # <5>
+  -v /var/run/docker.sock:/var/run/docker.sock \ # <6>
+  jenkinsci/blueocean # <7>
 ----
 <1> ( _Optional_ ) Automatically removes the Docker container (which is the
 instantiation of the `jenkinsci/blueocean` image below) when it is shut down.
@@ -36,16 +37,34 @@ This keeps things tidy if you need to quit Jenkins.
 (i.e. "detached" mode) and outputs the container ID. If you do not specify this
 option, then the running Docker log for this container is output in the terminal
 window.
-<3> Makes (i.e. "publishes") port 8080 of the `jenkinsci/blueocean` container to
-port 8080 on the host machine. The 1st number represents the port on the host
-while the 2nd represents the container's port. Therefore, if you specified `-p
-49001:8080` for this option, you would be accessing Jenkins on your host machine
-through port 49001.
-<4> Maps the `/var/jenkins_home` directory in the container to the Docker
+<3> Maps (i.e. "publishes") port 8080 of the `jenkinsci/blueocean` container to
+port 8080 on the host machine. The first number represents the port on the host
+while the last represents the container's port. Therefore, if you specified `-p
+49000:8080` for this option, you would be accessing Jenkins on your host machine
+through port 49000.
+<4> ( _Optional_ ) Maps port 50000 of the `jenkinsci/blueocean` container to
+port 50000 on the host machine. This is only necessary if you have set up one or
+more JNLP-based Jenkins agents on other machines, which in turn interact with
+the `jenkinsci/blueocean` container (acting as the "master" Jenkins server, or
+simply "Jenkins master"). JNLP-based Jenkins agents communicate with the Jenkins
+master through TCP port 50000 by default. You can change this port number on
+your Jenkins master through the <<managing/security#,Configure Global Security>>
+page. If you were to change your Jenkins master's *TCP port for JNLP agents*
+value to 51000 (for example), then you would need to re-run Jenkins (via this
+`docker run ...` command) and specify this "publish" option with something like
+`-p 52000:51000`, where the last value matches this changed value on the Jenkins
+master and the first value is the port number on the Jenkins master's host
+machine through which the JNLP-based Jenkins agents communicate (to the Jenkins
+master) - i.e. 52000.
+<5> ( _Optional but highly recommended_ ) Maps the `/var/jenkins_home` directory
+in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
 `jenkins-data`. If this volume does not exist, then this `docker run` command
-will automatically create the volume for you. +
-*Notes:*
+will automatically create the volume for you. This option is required if you
+want your Jenkins state to persist each time you restart Jenkins (via this
+`docker run ...` command). If you do not specify this option, then Jenkins will
+effectively reset to a new instance after each restart. +
+*Notes:* +
 This volume could also be created independently using the
 link:https://docs.docker.com/engine/reference/commandline/volume_create/[`docker
 volume create`] command: +
@@ -57,7 +76,14 @@ example, specifying the option +
 `/var/jenkins_home` directory to the `jenkins` subdirectory within the `$HOME`
 directory on your local machine, which would typically be
 `/Users/<your-username>/jenkins` or `/home/<your-username>/jenkins`.
-<5> The `jenkinsci/blueocean` Docker image itself. If this image has not already
+<6> ( _Optional_ ) `/var/run/docker.sock` represents the Unix-based socket
+through which the Docker daemon listens on. This mapping allows the
+`jenkinsci/blueocean` container to communicate with the Docker daemon, which is
+required if the `jenkinsci/blueocean` container needs to instantiate other
+Docker containers. This option is necessary if you run declarative Pipelines
+containing the syntax `agent { docker { ... } }`. <<pipeline/syntax#agent,Read
+more>> about this on the <<pipeline/syntax#,Pipeline Syntax>> page.
+<7> The `jenkinsci/blueocean` Docker image itself. If this image has not already
 been downloaded, then this `docker run` command will automtically download the
 image for you. Furthermore, if any updates to this image were published since
 you last ran this command, then running this command again will automatically
@@ -78,6 +104,7 @@ docker run \
   --rm \
   -d \
   -p 8080:8080 \
+  -p 50000:50000 \
   -v jenkins-data:/var/jenkins_home \
   -v /var/run/docker.sock:/var/run/docker.sock \
   jenkinsci/blueocean
@@ -100,6 +127,7 @@ docker run ^
   --rm ^
   -d ^
   -p 8080:8080 ^
+  -p 50000:50000 ^
   -v jenkins-data:/var/jenkins_home ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
   jenkinsci/blueocean


### PR DESCRIPTION
* ... to the [run Jenkins in Docker instructions](https://jenkins.io/doc/book/installing/#downloading-and-running-jenkins-in-docker), including an explanation of this option's usage and configuration.
* Also finally add an explanation for the `/var/run/docker.sock` option.

This relates to a discussion I had with @bitwiseman earlier today.

Fyi - this is also setting some groundwork for when the [Managing Nodes](https://jenkins.io/doc/book/managing/nodes/) page finally gets some content, which as of last month, at least 10 respondents had chosen "No" for "Was this page helpful?".