### PR TITLE
Update command for plugin creation

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -18,7 +18,7 @@ See link:https://wiki.jenkins-ci.org/display/JENKINS/Before+starting+a+new+plugi
 Open a command prompt and run the following command:
 
 [source]
-mvn -U hpi:create
+mvn -U archetype:generate -Dfilter=io.jenkins.archetypes:plugin
 
 It will download dependencies needed to create the project, and then ask for `groupId` (similar to Java packages) and `artifactId` (the name of your plugin).
 


### PR DESCRIPTION
`mvn -U hpi:create` is deprecated. Suggest using `mvn archetype:generate -Dfilter=io.jenkins.archetypes:plugin` instead.