### PR TITLE
Fix broken links to setup wizard on the general installation docs

### DIFF
--- a/content/doc/book/installing/_setup-wizard.adoc
+++ b/content/doc/book/installing/_setup-wizard.adoc
@@ -10,7 +10,7 @@ _run-jenkins-in-docker.adoc).
 ////
 
 
-[[setupwizard]]
+[[setup-wizard]]
 == Post-installation setup wizard
 
 After downloading, installing and running Jenkins using one of the procedures

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -146,7 +146,7 @@ any operating system or platform that supports Java.
 . Run the command `java -jar jenkins.war`.
 . Browse to `http://localhost:8080` and wait until the *Unlock Jenkins* page
   appears.
-. Continue on with the <<setupwizard,Post-installation setup wizard>> below.
+. Continue on with the <<setup-wizard,Post-installation setup wizard>> below.
 
 *Notes:*
 
@@ -270,7 +270,7 @@ Once Jenkins is running, consult the log
 (`/var/svc/log/network-http:jenkins.log`) to retrieve the generated
 administrator password for the initial set up of Jenkins, usually it will be
 found at `/var/lib/jenkins/home/secrets/initialAdminPassword`. Then navigate to
-link:http://localhost:8080[localhost:8080] to <<setupwizard, complete configuration of the
+link:http://localhost:8080[localhost:8080] to <<setup-wizard, complete configuration of the
 Jenkins instance>>.
 
 


### PR DESCRIPTION
* Made all links unanimously 'setup-wizard'.