### PR TITLE
Adding .build() examples to explain passing arguments

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -373,37 +373,40 @@ node {
 ----
 
 The `build()` method builds the `Dockerfile` in the current directory by 
-default. This can be overridden by providing a second argument with the path of
-a directory containing a `Dockerfile`, for example:
+default. This can be overridden by providing a directory path 
+containing a `Dockerfile` as the second argument of the `build()` method, for example:
 
 [source,groovy]
 ----
 node {
     checkout scm
-    def testImage = docker.build("test-image", "./dockerfiles/test")
+    def testImage = docker.build("test-image", "./dockerfiles/test") // <1>
 
     testImage.inside {
         sh 'make test'
     }
 }
 ----
+<1> Builds `test-image` from the Dockerfile found at `./dockerfiles/test/Dockerfile`.
 
-It is possible to pass arguments that 
+It is possible to pass other arguments to 
 link:https://docs.docker.com/engine/reference/commandline/build/[docker build]
-accepts via the second argument of the `build()` method. When this argument is
-supplied a path is required as well.
+by adding them to the second argument of the `build()` method.
+When passing arguments this way, the last value in the that string must be 
+the path to the docker file.
 
-This is another way to override the default `Dockerfile`, by passing the `-f`
-flag, for example:
+This example overrides the default `Dockerfile` by passing the `-f`
+flag:
 
 [source,groovy]
 ----
 node {
     checkout scm
     def dockerfile = 'Dockerfile.test'
-    def customImage = docker.build("my-image:${env.BUILD_ID}", "-f ${dockerfile} .")
+    def customImage = docker.build("my-image:${env.BUILD_ID}", "-f ${dockerfile} ./dockerfiles") // <1>
 }
 ----
+<1> Builds `my-image:${env.BUILD_ID}` from the Dockerfile found at `./dockerfiles/Dockerfile.test`. 
 
 === Using a remote Docker server
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -372,6 +372,38 @@ node {
 }
 ----
 
+The `build()` method builds the `Dockerfile` in the current directory by 
+default. This can be overridden by providing a second argument with the path of
+a directory containing a `Dockerfile`, for example:
+
+[source,groovy]
+----
+node {
+    checkout scm
+    def testImage = docker.build("test-image", "./docker/test/")
+
+    testImage.inside {
+        sh 'make test'
+    }
+}
+----
+
+It is possible to pass arguments that 
+link:https://docs.docker.com/engine/reference/commandline/build/[docker build]
+accepts via the second argument of the `build()` method. When this argument is
+supplied the path to the `Dockerfile` is required as well.
+
+A common use case for this is to supply build arguments for the image,
+for example:
+
+[source,groovy]
+----
+node {
+    checkout scm
+    def proxyUrl = 'http://10.20.30.2:1234'
+    def customImage = docker.build("my-image:${env.BUILD_ID}", "--build-arg HTTP_PROXY=${proxyUrl} .")
+}
+----
 
 === Using a remote Docker server
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -380,7 +380,7 @@ a directory containing a `Dockerfile`, for example:
 ----
 node {
     checkout scm
-    def testImage = docker.build("test-image", "./docker/test/")
+    def testImage = docker.build("test-image", "./dockerfiles/test")
 
     testImage.inside {
         sh 'make test'
@@ -391,17 +391,17 @@ node {
 It is possible to pass arguments that 
 link:https://docs.docker.com/engine/reference/commandline/build/[docker build]
 accepts via the second argument of the `build()` method. When this argument is
-supplied the path to the `Dockerfile` is required as well.
+supplied a path is required as well.
 
-A common use case for this is to supply build arguments for the image,
-for example:
+This is another way to override the default `Dockerfile`, by passing the `-f`
+flag, for example:
 
 [source,groovy]
 ----
 node {
     checkout scm
-    def proxyUrl = 'http://10.20.30.2:1234'
-    def customImage = docker.build("my-image:${env.BUILD_ID}", "--build-arg HTTP_PROXY=${proxyUrl} .")
+    def dockerfile = 'Dockerfile.test'
+    def customImage = docker.build("my-image:${env.BUILD_ID}", "-f ${dockerfile} .")
 }
 ----
 


### PR DESCRIPTION
This adds some documentation pertaining to the second argument that `docker.build()` accepts.