### PR TITLE
[JEP-200] - Suggest running Maven with suppressed enforcer for testing JEP

### DIFF
--- a/content/blog/2018/01/2018-01-13-jep-200.adoc
+++ b/content/blog/2018/01/2018-01-13-jep-200.adoc
@@ -74,7 +74,7 @@ when running Jenkins 2.102 or newer to reproduce the error.
 
 [source,sh]
 ----
-mvn test -Djenkins.version=2.102
+mvn test -Djenkins.version=2.102 -Denforcer.skip=true
 ----
 
 The above assumes you are using a recent 2.x or 3.x parent link:https://github.com/jenkinsci/plugin-pom[Plugin POM].


### PR DESCRIPTION
Otherwise developers will likely see a bloodbath of dependencies if they use recent Parent POMs and old cores.

@reviewbybees @jglick 


