### PR TITLE
Use metadata for most security advisory sections

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -1,0 +1,97 @@
+---
+layout: simplepage
+section: security
+---
+
+:ruby
+  plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
+  credits = page.issues.reduce({}) do |issues, issue|
+    if issue.has_key?("reporter")
+      if !issues.has_key?(issue.reporter)
+        issues[issue.reporter] = []
+      end
+      if !issues[issue.reporter].include?(issue.id)
+        issues[issue.reporter] << issue.id
+      end
+    end
+    issues
+  end
+  credits = credits.sort_by { |k,v| k }
+
+  versions = page.issues.collect { |issue| issue.plugins }.flatten
+
+  fixed_plugins = plugins.dup.keep_if { |p| p.fixed }
+  unfixed_plugins = plugins.dup.keep_if { |p| !p.fixed }
+
+This advisory announces vulnerabilities in the following Jenkins deliverables:
+
+%ul
+  - if page.core
+    Jenkins core
+  - plugins.each do | plugin |
+    %li
+      %a{:href => 'https://plugins.jenkins.io/' + plugin.name }
+        = site._generated[:update_center].plugins[plugin.name].title
+
+= content
+
+%h2
+  Severity
+
+%ul
+  - page.issues.each do | issue |
+    %li
+      = "#{issue.id}:"
+      %a{ :href => 'http://www.first.org/cvss/calculator/3.0#' + issue.cvss.vector }
+        = issue.cvss.severity
+
+%h2
+  Affected Versions
+%ul
+  - plugins.each do | plugin |
+    - if plugin.previous
+      %li
+        %strong
+          = site._generated[:update_center].plugins[plugin.name].title
+        up to and including
+        = plugin.previous
+
+%h2
+  Fix
+- if fixed_plugins.length > 0
+  %ul
+    - fixed_plugins.each do | plugin |
+      %li
+        %strong
+          = site._generated[:update_center].plugins[plugin.name].title
+        should be updated to version
+        = plugin.fixed
+  %p
+    These versions include fixes to the vulnerabilities described above. All prior versions are considered to be affected by these vulnerabilities unless otherwise indicated.
+
+- if unfixed_plugins.length > 0
+  %p
+    As of publication of this advisory, no fixes are available for the following plugins:
+  %ul
+    - unfixed_plugins.each do | plugin |
+      %li
+        = site._generated[:update_center].plugins[plugin.name].title
+
+
+- if credits.length > 0
+  %h2
+    Credit
+
+  %p
+    The Jenkins project would like to thank the reporters for discovering and
+    %a{href => '/security/#reporting-vulnerabilities'}
+      reporting
+    these vulnerabilities:
+
+    %ul
+      - credits.each do | reporter, issues |
+        %li
+          %strong
+            = reporter
+          for
+          = issues.join(", ")

--- a/content/security/advisory/2018-01-22.adoc
+++ b/content/security/advisory/2018-01-22.adoc
@@ -1,21 +1,88 @@
 ---
-layout: simplepage
+layout: advisory
 title: Jenkins Security Advisory 2018-01-22
 section: security
 kind: plugins
+issues:
+- id: SECURITY-507
+  reporter: Oleg Nenashev, CloudBees, Inc.
+  cvss:
+    severity: low
+    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+  plugins:
+    - name: translation
+      fixed: 1.16
+      previous: 1.15
+- id: SECURITY-607
+  reporter: Jesse Glick, CloudBees, Inc.
+  cvss:
+    severity: medium
+    vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
+  plugins:
+    - name: release
+      fixed: 2.10
+      previous: 2.9
+- id: SECURITY-655
+  reporter: Adith Sudhakar
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+  plugins:
+    - name: pmd
+      fixed: 1.8
+      previous: 1.7
+- id: SECURITY-656
+  reporter: Adith Sudhakar
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+  plugins:
+    - name: checkstyle
+      fixed: 3.50
+      previous: 3.49
+- id: SECURITY-657
+  reporter: Adith Sudhakar
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+  plugins:
+    - name: dry
+      fixed: 2.50
+      previous: 2.49
+- id: SECURITY-658
+  reporter: Adith Sudhakar
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+  plugins:
+    - name: findbugs
+      fixed: 4.72
+      previous: 4.71
+- id: SECURITY-675
+  cvss:
+    severity: medium
+    vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N
+  plugins:
+    - name: warnings
+      fixed: 4.65
+      previous: 4.64
+- id: SECURITY-694
+  cvss:
+    severity: medium
+    vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N
+  plugins:
+    - name: ant
+      fixed: 1.8
+      previous: 1.7
+- id: SECURITY-695
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
+  plugins:
+    - name: workflow-durable-task-step
+      fixed: 2.18
+      previous: 2.17
 ---
-
-This advisory announces vulnerabilities in these Jenkins plugins:
-
-* plugin:ant[Ant]
-* plugin:checkstyle[Checkstyle]
-* plugin:dry[DRY]
-* plugin:findbugs[FindBugs]
-* plugin:workflow-durable-task-step[Pipeline: Nodes and Processes]
-* plugin:pmd[PMD]
-* plugin:release[Release]
-* plugin:translation[Translation Assistance]
-* plugin:warnings[Warnings]
 
 == Description
 
@@ -64,52 +131,3 @@ This is the same vulnerability that was announced without a fix on link:/securit
 Contrary to what we wrote in that security advisory, Ant Plugin shows both the JDK and Ant tools on the configuration screen, and the vulnerability in Ant plugin was responsible for both problems we confirmed in the previous advisory.
 
 Ant plugin now correctly escapes tool names shown on the job configuration screen.
-
-
-== Severity
-
-* SECURITY-507: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N[low]
-* SECURITY-607: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N[medium]
-* SECURITY-655: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-656: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-657: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-658: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-675: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N[medium]
-* SECURITY-694: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N[medium]
-* SECURITY-695: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-
-
-== Affected versions
-* Ant plugin up to and including 1.7
-* Checkstyle plugin up to and including 3.49
-* DRY plugin up to and including 2.49
-* FindBugs plugin up to and including 4.71
-* Pipeline: Nodes and Processes plugin up to and including 2.17
-* PMD plugin up to and including 3.49
-* Release plugin up to and including 2.9
-* Translation Assistance plugin up to and including 1.15
-* Warnings plugin up to and including 4.64
-
-
-== Fix
-* Ant plugin should be updated to version 1.8
-* Checkstyle plugin should be updated to version 3.50
-* DRY plugin should be updated to version 2.50
-* FindBugs plugin should be updated to version 4.72
-* Pipeline: Nodes and Processes plugin should be updated to version 2.18
-* PMD plugin should be updated to version 3.50
-* Release plugin should be updated to version 2.10
-* Translation Assistance plugin should be updated to version 1.16
-* Warnings plugin should be updated to version 4.65
-
-These versions include fixes to the vulnerabilities described above.
-All prior versions are considered to be affected by these vulnerabilities unless otherwise indicated.
-
-
-== Credit
-
-The Jenkins project would like to thank the reporters for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
-
-* *Adith Sudhakar* for SECURITY-655, SECURITY-656, SECURITY-657, SECURITY-658
-* *Jesse Glick, CloudBees, Inc.* for SECURITY-607, SECURITY-675
-* *Oleg Nenashev, CloudBees, Inc.* for SECURITY-507

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -38,6 +38,12 @@ RESOURCES = [
     nil
   ],
   [
+    'https://updates.jenkins.io/update-center.actual.json',
+    'content/_data/_generated/update_center.yml',
+    nil,
+    nil
+  ],
+  [
     'https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/lastSuccessfulBuild/artifact/*.adoc/*zip*/extension-indexer.zip',
     'content/_tmp/extension-indexer.zip',
     nil,


### PR DESCRIPTION
Some restrictions apply:

* Still needs to be tested with 'no fix available' (implemented but untested), core security updates (half implemented) etc. -- basically every advisory that isn't the latest one, which I developped this with. Can be done as needed, or we just don't convert those advisories to 'data'.
* ~~PR build should fail because of an unnecessary escape sequence in the new JSON file (`\/` around character \~565700 for an 'experimental' note that shouldn't be there in the first place).~~

Future improvements:

* The update center serves 'dirty' display names ("Jenkins Foo Plug-in" instead of "Foo"), so sorting even by display name is a mess. Either needs to add support for cleaning display names in the update site, or just bite the bullet and do it in update center so it doesn't need to be replicated everywhere.
* Somehow re-use the JSON file we download for the `plugin:` macro for the rest of the site (as default label when writing e.g. `plugin:git[]`).

@Wadeck WDYT, is this an improvement? You saw me forget the version numbers over and over 😆 