### PR TITLE
Add JEP-200 warning to the 2.103 changelog banner

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -1873,6 +1873,11 @@
     # pull 3219: too minor (hudson.util.fileToPath() refactoring)
 - version: "2.103"
   date: 2018-01-21
+  banner: >
+    JEP-200: &quot;Switch Remoting/XStream blacklist to a whitelist&quot; has been integrated into 2.102.
+    This change implies a HIGH RISK of regressions in plugins.
+    See <a href="/blog/2018/01/13/jep-200/">this blogpost</a> for list of plugins known to be affected,
+    with instructions how to resolve possible problems.
   changes:
     - type: rfe
       message: >


### PR DESCRIPTION
We are getting more regression reports after 2.103, so IMHO it makes sense to keep the banner in this release as well.

@reviewbybees @jglick @daniel-beck 