### PR TITLE
Added information about Eclipse Plugin

### DIFF
--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -31,6 +31,18 @@ parallel branches, and steps in a Pipeline. The editor validates Pipeline change
 made, eliminating many errors before they are even committed.  Behind the scenes
 it still generates Declarative Pipeline code.
 
+== Eclipse Jenkins Editor
+There exists an Eclipse Plugin called `Jenkins Editor` at https://marketplace.eclipse.org/content/jenkins-editor[Eclipse Marketplace].
+This special text editor provides some features for defining pipelines e.g:
+
+- Validate pipeline scripts by <<#linter,Jenkins Linter Validation>>. Failures are shown as eclipse markers
+- An Outline with dedicated icons (for declarative Jenkins pipelines )
+- Syntax / keyword highlighting
+- Groovy validation
+
+NOTE: The Jenkins Editor Plugin is a third-party tool that is not supported
+by the Jenkins Project.
+
 [[linter]]
 == Command-line Pipeline Linter
 

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -31,8 +31,9 @@ parallel branches, and steps in a Pipeline. The editor validates Pipeline change
 made, eliminating many errors before they are even committed.  Behind the scenes
 it still generates Declarative Pipeline code.
 
-== Eclipse Jenkins Editor
-There exists an Eclipse Plugin called `Jenkins Editor` at https://marketplace.eclipse.org/content/jenkins-editor[Eclipse Marketplace].
+== IDE Integrations
+=== Eclipse Jenkins Editor
+There exists an Eclipse plugin called `Jenkins Editor` at https://marketplace.eclipse.org/content/jenkins-editor[Eclipse Marketplace].
 This special text editor provides some features for defining pipelines e.g:
 
 - Validate pipeline scripts by <<#linter,Jenkins Linter Validation>>. Failures are shown as eclipse markers

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -20,7 +20,6 @@ to the currently installed version of Jenkins and related plugins.
 In this section, we'll discuss other tools and resources
 that may help with development of Jenkins Pipelines.
 
-
 == Blue Ocean Editor
 
 The
@@ -30,19 +29,6 @@ way to create Declarative Pipelines. The editor offers a structural view of all 
 parallel branches, and steps in a Pipeline. The editor validates Pipeline changes as they are
 made, eliminating many errors before they are even committed.  Behind the scenes
 it still generates Declarative Pipeline code.
-
-== IDE Integrations
-=== Eclipse Jenkins Editor
-There exists an Eclipse plugin called `Jenkins Editor` at https://marketplace.eclipse.org/content/jenkins-editor[Eclipse Marketplace].
-This special text editor provides some features for defining pipelines e.g:
-
-- Validate pipeline scripts by <<#linter,Jenkins Linter Validation>>. Failures are shown as eclipse markers
-- An Outline with dedicated icons (for declarative Jenkins pipelines )
-- Syntax / keyword highlighting
-- Groovy validation
-
-NOTE: The Jenkins Editor Plugin is a third-party tool that is not supported
-by the Jenkins Project.
 
 [[linter]]
 == Command-line Pipeline Linter
@@ -192,6 +178,21 @@ See link:https://issues.jenkins-ci.org/browse/JENKINS-37589[JENKINS-37589]
 For Pipelines that are not part of a Multi-branch Pipeline,
 the commit information may differ for the original run and the Replayed run.
 See link:https://issues.jenkins-ci.org/browse/JENKINS-36453[JENKINS-36453]
+
+== IDE Integrations
+
+=== Eclipse Jenkins Editor
+There exists an Eclipse plugin called `Jenkins Editor` at https://marketplace.eclipse.org/content/jenkins-editor[Eclipse Marketplace].
+This special text editor provides some features for defining pipelines e.g:
+
+- Validate pipeline scripts by <<#linter,Jenkins Linter Validation>>. Failures are shown as eclipse markers
+- An Outline with dedicated icons (for declarative Jenkins pipelines )
+- Syntax / keyword highlighting
+- Groovy validation
+
+NOTE: The Jenkins Editor Plugin is a third-party tool that is not supported
+by the Jenkins Project.
+
 
 
 [[unit-test]]


### PR DESCRIPTION
- added information about Jenkins Editor plugin at https://marketplace.eclipse.org/content/jenkins-editor 
- the plugin is OSS and has Apache 2.0 License and is hosted at https://github.com/de-jcup/eclipse-jenkins-editor