### PR TITLE
Add changelog for 2.105

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -1997,10 +1997,27 @@
       pull: 3256
       message: >
         When Jenkins fails to load plugins, show failures that users need to take action on separate from those due to other plugins failing to load.
+    - type: rfe
+      message: >
+        Upgrade Executable War from 1.36 to 1.37 to allow supplying <code>jenkins.war</code> command-line arguments via standard input using the <code>--paramsFromStdIn</code> parameter.
+      references:
+        - pull: 3223
+        - title: documentation
+          url: https://github.com/jenkinsci/extras-executable-war#parameters-from-stdin
     - type: bug
       issue: 47793
       message: >
         Form validation for number of executors now properly shows validation errors and user-friendly message on form submission.
+    - type: bug
+      issue: 49206
+      pull: 3272
+      message: >
+        Ensure that threads for background tasks cannot be created with a custom classloader to prevent possible Groovy memory leaks.
+    - type: bug
+      issue: 22088
+      pull: 3223
+      message: >
+        Upgrade Executable War from 1.36 to 1.37 to prevent multiple copies of <code>winstone-*.jar</code> in the temp folder from using up disk space needlessly.
     - type: bug
       references:
         - issue: 48725

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -1990,6 +1990,36 @@
     # pull: 3257 too minor (adapt new admin monitor to restyling)
     # pull: 3262 too minor (fix Spanish typo)
     # pull: 3261 too minor (fix bold formatting on Old data monitor page)
+- version: "2.105"
+  date: 2018-02-04
+  changes:
+    - type: rfe
+      pull: 3256
+      message: >
+        When Jenkins fails to load plugins, show failures that users need to take action on separate from those due to other plugins failing to load.
+    - type: bug
+      issue: 47793
+      message: >
+        Form validation for number of executors now properly shows validation errors and user-friendly message on form submission.
+    - type: bug
+      references:
+        - issue: 48725
+        - url: https://github.com/jenkinsci/lib-task-reactor/blob/master/CHANGELOG.md#version-15
+          title: full changelog
+      pull: 3270
+      message: >
+        Update to task reactor version 1.5 to prevent hanging of Jenkins on startup/reload when an initialization task throws an unhandled exception.
+    - type: rfe
+      pull: 3260
+      message: >
+        Developer: Introduce <code>ACL#lambda</code> convenience method.
+      references:
+        - pull: 3260
+        # TODO: fix link to be more specific
+        - url: http://javadoc.jenkins-ci.org/hudson/security/ACL.html#method.summary
+          title: Javadoc
+    # pull: 3274 disables test (should be in 2.104 but whatever)
+    # pull: 3275 enables test
 
 
 


### PR DESCRIPTION
~~Might not be complete yet.~~

Missed https://github.com/jenkinsci/jenkins/pull/3272 because https://github.com/jenkinsci/jenkins/compare/jenkins-2.104...master doesn't include it when searching for ` (#` *or* `pull request #`.

One of the reasons I hate unnecessary squash merges.