### PR TITLE
Fixed typo in folder name (shared-libraries.adoc).

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -417,7 +417,7 @@ Internally, scripts in the `vars` directory are instantiated on-demand  as
 singletons. This allows multiple methods to be defined in a
 single `.groovy` file for convenience.  For example:
 
-.var/log.groovy
+.vars/log.groovy
 [source,groovy]
 ----
 def info(message) {


### PR DESCRIPTION
The typo is for a folder name (vars) that must be named precisely for a shared pipeline library to be loaded correctly.

I happened to have been using this section of the documentation when creating my shared library.  As a result, my library would load because I was using the incorrect folder name listed here.