### PR TITLE
Update prepare.adoc

### DIFF
--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -98,7 +98,7 @@ For Windows users, the directory and file to use here is `%USERPROFILE%\.m2\sett
 <1> This will let you use the short name for the link:https://jenkinsci.github.io/maven-hpi-plugin/[Maven HPI Plugin], `hpi`, on the command line, instead of `org.jenkins-ci.tools:maven-hpi-plugin`.
   If you don't understand what this means, don't worry -- we'll get there in a moment.
 <2> You could set this to `false` if you use Maven for more than just Jenkins development. If you do, make sure to always add the `-P jenkins` argument to Maven invocations.
-<3> Both of the repository entries are needed to make `hpi:create` (used in the next section) work.
+<3> Both of the repository entries are needed to make `hpi:*` (used in the next section) work.
 
 // TODO Most of this configuration should be obsolete after switching to the archetype.
 


### PR DESCRIPTION
Missed a ´hpi:create´ when switching documentation to use the new archetype