### PR TITLE
[INFRA-1493] Add more explanation about IRC and the +r to help people rejected with non-registered nicks

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -7,6 +7,21 @@ The Jenkins community discusses various project-related topics in multiple chann
 
 For information on how to connect, see the http://freenode.net/[Freenode] website.
 
+[NOTE]
+====
+Because of irregular spam attacks, we sometimes have to make some channels protected.
+In such circumstances, we make the targetted channel(s) only accessible to registered IRC nicks.
+Example error:
+[source]
+----
+[10:28] -NickServ- my_nickname is not a registered nickname.
+[10:28] == #jenkins Cannot join channel (+r) - you need to be identified with services
+----
+That means you basically need to create a reserved nick for you, link:https://freenode.net/kb/answer/registration[following the official documentation].
+Once done, you will be able to connect to `#jenkins` even if that channel is undergoing a spam attack.
+Note that even without this, this is a recommended practice so that people *know* this is you, and cannot be someone else, when a given nick is online.
+====
+
 == Channels
 
 === `#jenkins`


### PR DESCRIPTION
[INFRA-1493](https://issues.jenkins-ci.org/browse/INFRA-1493)

As discovered during the Jenkins contributor meetup today, the current status could prevent people from logging in so added a quick explanation to help people know how to still access `#jenkins` under spam attacks.

Rendered using `make run`:
![image](https://user-images.githubusercontent.com/223853/35806898-5c4f4a1c-0a81-11e8-8c70-68c4cc1bf2f2.png)


@orrc @daniel-beck @rsandell