### PR TITLE
Somehow this class is needed to make active links bold.

### DIFF
--- a/content/_layouts/developerbook.html.haml
+++ b/content/_layouts/developerbook.html.haml
@@ -23,7 +23,7 @@ layout: default
 
     .col-lg-3
 
-      .sidebar-nav
+      .sidebar-nav.tour
 
         %h4
           Topics


### PR DESCRIPTION
I'm pretty sure it wasn't necessary before, but it's in #571
and so apparently has always been in there.