### PR TITLE
Change 2018-02-05 advisory into new format with metadata

### DIFF
--- a/content/security/advisory/2018-02-05.adoc
+++ b/content/security/advisory/2018-02-05.adoc
@@ -1,17 +1,54 @@
 ---
-layout: simplepage
+layout: advisory
 title: Jenkins Security Advisory 2018-02-05
 section: security
 kind: plugins
+issues:
+- id: SECURITY-521
+  reporter: James Nord, CloudBees, Inc.
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
+  plugins:
+    - name: junit
+      fixed: 1.24
+      previous: 1.23
+- id: SECURITY-659
+  reporter: Adith Sudhakar
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
+  plugins:
+    - name: ccm
+      fixed: 3.2
+      previous: 3.1
+- id: SECURITY-660
+  reporter: Adith Sudhakar
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
+  plugins:
+    - name: android-lint
+      fixed: 2.6
+      previous: 2.5
+- id: SECURITY-698
+  cvss:
+    severity: low
+    vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N
+  plugins:
+    - name: credentials-binding
+      fixed: 1.15
+      previous: 1.14
+- id: SECURITY-699
+  reporter: Aleksandr Kazakov
+  cvss:
+    severity: high
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  plugins:
+    - name: workflow-support
+      fixed: 2.18
+      previous: 2.17
 ---
-
-This advisory announces vulnerabilities in these Jenkins plugins:
-
-* plugin:android-lint[Android Lint]
-* plugin:ccm[CCM]
-* plugin:credentials-binding[Credentials Binding]
-* plugin:junit[JUnit]
-* plugin:workflow-support[Pipeline: Supporting APIs]
 
 == Description
 
@@ -26,7 +63,7 @@ This allows an attacker to configure build processes such that one of these plug
 
 External entity resolution has been disabled for these plugins.
 
-
+[#junit]
 === XXE vulnerability in JUnit plugin
 
 *SECURITY-521 / CVE-2018-1000056*
@@ -36,7 +73,7 @@ This allows an attacker to configure build processes such that JUnit plugin pars
 
 External entity resolution has been adjusted to avoid XXE and still satisfy the existing features.
 
-
+[#credentials-binding]
 === Credentials Binding plugin did not mask the secret actually provided to the build in rare circumstances
 // That title took a lot of work, but in the end it doesn't matter that the actual password is masked if that's not what's used in the build
 
@@ -53,7 +90,7 @@ Credentials Binding plugin will now escape any ++$++ characters in password valu
 
 This issue did apply to freestyle and other classic job types, but does not apply to Pipelines.
 
-
+[#workflow-support]
 === Arbitrary code execution due to incomplete sandbox protection in Pipeline: Supporting APIs Plugin
 
 *SECURITY-699 / CVE-2018-1000058*
@@ -69,41 +106,3 @@ Deserialization of objects in Pipeline is now also subject to sandbox protection
 This change may cause existing scripts relying on the incomplete sandbox protection to start failing, and requiring additional script approval.
 
 NOTE: This change requires that Pipeline: Groovy plugin is also updated to version 2.44, otherwise Pipeline builds using untrusted (folder-scoped) libraries will not be able to resume after a Jenkins master restart.
-
-== Severity
-
-* SECURITY-521: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-659: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-660: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L[high]
-* SECURITY-698: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N[low]
-* SECURITY-699: link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H[high]
-
-
-== Affected versions
-
-* Android Lint plugin up to and including 2.5
-* CCM plugin up to and including 3.1
-* Credentials Binding plugin up to and including 1.14
-* JUnit plugin up to and including 1.23
-* Pipeline: Supporting APIs plugin up to and including 2.17
-
-
-== Fix
-
-* Android Lint plugin should be updated to version 2.6
-* CCM plugin should be updated to version 3.2
-* Credentials Binding plugin should be updated to version 1.15
-* JUnit plugin should be updated to version 1.24
-* Pipeline: Supporting APIs plugin should be updated to version 2.18
-
-These versions include fixes to the vulnerabilities described above.
-All prior versions are considered to be affected by these vulnerabilities unless otherwise indicated.
-
-
-== Credit
-
-The Jenkins project would like to thank the reporters for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
-
-* *Adith Sudhakar* for SECURITY-659, SECURITY-660
-* *Aleksandr Kazakov* for SECURITY-699
-* *James Nord, CloudBees, Inc.* for SECURITY-521


### PR DESCRIPTION
Also add link anchors that are plugin IDs

---

Output is basically the same except for very minor formatting changes, and that some of the plugins have the *Plugin* or *Plug-In* suffix due to uncontrolled display name messes.