### PR TITLE
Improve user-site behavior

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -462,7 +462,6 @@ without reviewers needing to fetch and build those changes locally.
 To generate your site from local changes:
 
 . Make changes in a local branch (for example, `my_branch_name`).
-. Commit those changes as you would normally.
 . Run the command `make user-site GITHUB_USER=<your_username>`,
   replacing `<your_username>` with your GitHub user name. This will regenerate
   the site based on your changes and push it to `origin/gh-pages` (of your
@@ -489,8 +488,4 @@ Known issues/limitations:
 
 * Images and other internal site links that use _absolute_ path references
   (as opposed to _relative_ paths) will appear broken or "not found".
-* Source changes must be committed to your local branch before publishing your
-  site using the process above. However, source changes do not need to be pushed
-  before publishing. So, it is possible to publish a version of your site whose
-  source is only on your local machine.
 ====

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ FONTS_DIR=$(OUTPUT_DIR)/css/fonts
 VERSION=$(BUILD_NUMBER)-$(shell git rev-parse --short HEAD)
 GITHUB_USER=$(USER)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-AWESTRUCT_USER_SITE=-P user-site --url "https://$(GITHUB_USER).github.io/jenkins.io/$(BRANCH)/"
+USER_SITE_URL=https://$(GITHUB_USER).github.io/jenkins.io/$(BRANCH)/
+AWESTRUCT_USER_SITE=-P user-site --url "$(USER_SITE_URL)"
 
 
 # Generate everything
@@ -26,6 +27,7 @@ site: prepare scripts/awestruct
 user-site: prepare scripts/awestruct
 	./scripts/awestruct --generate --verbose $(AWESTRUCT_CONFIG) $(AWESTRUCT_USER_SITE)
 	./scripts/user-site-deploy.sh $(BRANCH)
+	@echo SUCCESS: Published to $(USER_SITE_URL)
 
 pdfs: prepare scripts/generate-handbook-pdf scripts/asciidoctor-pdf
 	./scripts/ruby scripts/generate-handbook-pdf $(BUILD_DIR)/user-handbook.adoc

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ site: prepare scripts/awestruct
 user-site: prepare scripts/awestruct
 	./scripts/awestruct --generate --verbose $(AWESTRUCT_CONFIG) $(AWESTRUCT_USER_SITE)
 	./scripts/user-site-deploy.sh $(BRANCH)
-	@echo SUCCESS: Published to $(USER_SITE_URL)
+	@echo SUCCESS: Published to $(USER_SITE_URL)index.html
 
 pdfs: prepare scripts/generate-handbook-pdf scripts/asciidoctor-pdf
 	./scripts/ruby scripts/generate-handbook-pdf $(BUILD_DIR)/user-handbook.adoc

--- a/scripts/user-site-deploy.sh
+++ b/scripts/user-site-deploy.sh
@@ -6,6 +6,17 @@ if [ -z "$1" ] ; then
 fi
 
 BRANCH=$1
+GHP_PATH=./build/_gh-pages
+
+if [ ! -f "${GHP_PATH}/.git" ]; then
+  echo "Setting up user-site work tree under ${GHP_PATH}"
+  rm -rf "${GHP_PATH}"
+  git worktree prune -v
+  git worktree add --no-checkout "${GHP_PATH}" HEAD || exit 1
+fi
+
+pushd "${GHP_PATH}" || exit 1
+rm -rf ./"${BRANCH}"
 
 # if there is no remote gh-pages
 if git ls-remote --exit-code --heads origin gh-pages; then
@@ -23,15 +34,12 @@ else
   fi
 fi
 
-mkdir -p build/_gh-pages &&
-  cp -r build/_site build/_gh-pages/"${BRANCH}"
-  git --work-tree build/_gh-pages/ add --all -- "${BRANCH}" &&
+cp -r ../_site ./"${BRANCH}" &&
+  git add --all -- "${BRANCH}" &&
   git commit -m "Publish site for ${BRANCH} branch to gh-pages" &&
   git push origin gh-pages
 
 RESULT=$?
-rm -rf build/_gh-pages
-rm -rf "${BRANCH}"
-git reset --hard && git checkout - || exit 1
+popd
 
 exit $RESULT


### PR DESCRIPTION
Instead of nuking the working directory every publish,
create a worktree under build/_gh-pages.

This stops strange editor behavior and allows users
to publish changes without committing them.  
