### PR TITLE
Use expand link instead of absolute paths

### DIFF
--- a/content/_ext/activenav.rb
+++ b/content/_ext/activenav.rb
@@ -5,7 +5,7 @@ module ActiveNav
   end
 
   def expand_link(relative_url)
-    return [site.base_url, relative_url].join('/')
+    return [site.base_url, relative_url.sub(/^\//, '')].join('/')
   end
 
   def active_href(relative_url, text, options={:class => nil})

--- a/content/_ext/atom.xml.haml
+++ b/content/_ext/atom.xml.haml
@@ -15,7 +15,7 @@
         %name= site.author
   - unless page.entries.empty?
     %updated= page.entries.first.input_mtime.xmlschema
-    <link rel="self" type="application/atom+xml" href="#{site.base_url}#{page.url}" />
+    <link rel="self" type="application/atom+xml" href="#{expand_link(page.url)}" />
     <link rel="alternate" type="text/html" href="#{page.content_url}/" />
     - for entry in page.entries
       - # See https://issues.jenkins-ci.org/browse/WEBSITE-135
@@ -25,11 +25,11 @@
       - # implicitly a blog "post"
       - next unless entry.layout == 'post'
       %entry
-        %id #{site.base_url}#{entry.url}
+        %id #{expand_link(entry.url)}
         %title= escape_once( entry.title )
         %updated= entry.input_mtime.xmlschema
         %published= entry.date.xmlschema
-        <link rel="alternate" type="text/html" href="#{site.base_url}#{entry.url}" />
+        <link rel="alternate" type="text/html" href="#{expand_link(entry.url)}" />
         - if ( not entry.author.nil? )
           %author
             - if ( defined?( entry.author.name ) )

--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -86,7 +86,7 @@ section: security
 
   %p
     The Jenkins project would like to thank the reporters for discovering and
-    %a{href => '/security/#reporting-vulnerabilities'}
+    %a{href => expand_link('security/#reporting-vulnerabilities')}
       reporting
     these vulnerabilities:
 

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -5,17 +5,17 @@
       = page.title
     %meta{:'http-equiv' => 'Content-Type', :content => 'text/html; charset=UTF-8'}/
     %meta{:'name' => 'description', :content => 'Jenkins is an open source automation server'}/
-    %link{:rel => 'shortcut icon', :href => '/sites/default/files/jenkins_favicon.ico', :type => 'image/x-icon'}/
+    %link{:rel => 'shortcut icon', :href => expand_link('sites/default/files/jenkins_favicon.ico'), :type => 'image/x-icon'}/
 
     %meta{:charset => "utf-8"}/
     %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}/
     %meta{:content => "ie=edge", "http-equiv" => "x-ua-compatible"}/
-    %link{:href => "img/favicon.ico", :rel => "icon", :sizes => "32x32", :type => "img/png"}/
-    %link{:href => "img/favicon-32x32.png", :rel => "icon", :sizes => "32x32", :type => "image/png"}/
-    %link{:href => "img/favicon-16x16.png", :rel => "icon", :sizes => "16x16", :type => "image/png"}/
-    %link{:href => "img/apple-touch-icon-76x76.png", :rel => "apple-touch-icon", :sizes => "76x76"}/
-    %link{:href => "img/apple-touch-icon-120x120.png", :rel => "apple-touch-icon", :sizes => "120x120"}/
-    %link{:href => "img/apple-touch-icon-152x152.png", :rel => "apple-touch-icon", :sizes => "152x152"}/
+    %link{:href => expand_link("img/favicon.ico"), :rel => "icon", :sizes => "32x32", :type => "img/png"}/
+    %link{:href => expand_link("img/favicon-32x32.png"), :rel => "icon", :sizes => "32x32", :type => "image/png"}/
+    %link{:href => expand_link("img/favicon-16x16.png"), :rel => "icon", :sizes => "16x16", :type => "image/png"}/
+    %link{:href => expand_link("img/apple-touch-icon-76x76.png"), :rel => "apple-touch-icon", :sizes => "76x76"}/
+    %link{:href => expand_link("img/apple-touch-icon-120x120.png"), :rel => "apple-touch-icon", :sizes => "120x120"}/
+    %link{:href => expand_link("img/apple-touch-icon-152x152.png"), :rel => "apple-touch-icon", :sizes => "152x152"}/
     %meta{:content => page.title, :name => "apple-mobile-web-app-title"}/
     / Twitter Card data
     %meta{:content => "summary_large_image", :name => "twitter:card"}/
@@ -40,40 +40,40 @@
 
     - if page.css
       - for style in page.css
-        %link{:href => "#{site.base_url}#{style}", :rel => 'stylesheet', :media => 'screen'}/
+        %link{:href => expand_link("#{style}"), :rel => 'stylesheet', :media => 'screen'}/
     - else
-      %link{:href => "#{site.base_url}/assets/bower/bootstrap/css/bootstrap.min.css",
+      %link{:href => expand_link("/assets/bower/bootstrap/css/bootstrap.min.css"),
         :rel => 'stylesheet',
         :media => 'screen'}/
-      %link{:href => "#{site.base_url}/assets/bower/tether/css/tether.min.css",
+      %link{:href => expand_link("/assets/bower/tether/css/tether.min.css"),
         :rel => 'stylesheet',
         :media => 'screen'}/
-      %link{:href => "#{site.base_url}/css/font-icons.css",
+      %link{:href => expand_link("/css/font-icons.css"),
         :rel => 'stylesheet',
         :media => 'screen'}/
-      %link{:href => "#{site.base_url}/css/jenkins.css",
+      %link{:href => expand_link("/css/jenkins.css"),
         :rel => 'stylesheet',
         :media => 'screen'}/
 
     / Non-obtrusive CSS styles
-    %link{:href => "#{site.base_url}/assets/bower/ionicons/css/ionicons.min.css",
+    %link{:href => expand_link("/assets/bower/ionicons/css/ionicons.min.css"),
       :rel => 'stylesheet',
       :media => 'screen'}/
-    %link{:href => "#{site.base_url}/css/footer.css",
+    %link{:href => expand_link("/css/footer.css"),
       :rel => 'stylesheet',
       :media => 'screen'}/
-    %link{:href => "#{site.base_url}/css/font-awesome.min.css",
+    %link{:href => expand_link("/css/font-awesome.min.css"),
       :rel => 'stylesheet',
       :media => 'screen'}/
 
   %body
-    %script{:src => "#{site.base_url}/assets/bower/jquery/jquery.js"}
+    %script{:src => expand_link("/assets/bower/jquery/jquery.js")}
 
     = content
 
-    %script{:src => "#{site.base_url}/assets/bower/anchor-js/anchor.min.js"}
-    %script{:src => "#{site.base_url}/assets/bower/tether/js/tether.min.js"}
-    %script{:src => "#{site.base_url}/assets/bower/bootstrap/js/bootstrap.min.js"}
+    %script{:src => expand_link("/assets/bower/anchor-js/anchor.min.js")}
+    %script{:src => expand_link("/assets/bower/tether/js/tether.min.js")}
+    %script{:src => expand_link("/assets/bower/bootstrap/js/bootstrap.min.js")}
 
     %footer#footer
       .container
@@ -108,13 +108,13 @@
 
                     %ul.resources
                       %li
-                        %a{:href => "#{site.base_url}/events"}
+                        %a{:href => expand_link("events")}
                           Events
                       %li
-                        %a{:href => "#{site.base_url}/doc"}
+                        %a{:href => expand_link("doc")}
                           Documentation
                       %li
-                        %a{:href => "#{site.base_url}/node"}
+                        %a{:href => expand_link("node")}
                           Blog
 
                 .area.col-md-3
@@ -123,7 +123,7 @@
 
                     %ul
                       - site.solutions.keys.sort.each do |key|
-                        - link = "#{site.base_url}/solutions/#{key}"
+                        - link = expand_link("solutions/#{key}")
                         %li
                           %a{:href => link}
                             = site.solutions[key].usecase
@@ -137,7 +137,7 @@
                         %a{:href => 'https://issues.jenkins-ci.org'}
                           Issue tracker
                       %li
-                        %a{:href => 'https://wiki.jenkins-ci.org'}
+                        %a{:href => 'https://wiki.jenkins.io'}
                           Wiki
                       %li
                         %a{:href => 'https://github.com/jenkinsci'}
@@ -164,7 +164,7 @@
                         %a{:href => 'https://reddit.com/r/jenkinsci'}
                           Reddit
                       %li
-                        %a{:href => "#{site.base_url}/merchandise"}
+                        %a{:href => expand_link("merchandise")}
                           Merchandise
 
     = google_analytics_universal

--- a/content/_layouts/pipelinesteps.html.haml
+++ b/content/_layouts/pipelinesteps.html.haml
@@ -8,14 +8,14 @@ notitle: true
   The following plugin provides functionality available through
   Pipeline-compatible steps. Read more about how to integrate steps into your
   Pipeline in the
-  %a{:href => "/doc/book/pipeline/syntax/#declarative-steps"} Steps
+  %a{:href => expand_link("doc/book/pipeline/syntax/#declarative-steps")} Steps
   section of the
-  %a{:href => "/doc/book/pipeline/syntax"} Pipeline Syntax
+  %a{:href => expand_link("doc/book/pipeline/syntax")} Pipeline Syntax
   page.
 
 %p
   For a list of other such plugins, see the
-  %a{:href => "/doc/pipeline/steps/"} Pipeline Steps Reference
+  %a{:href => expand_link("doc/pipeline/steps/")} Pipeline Steps Reference
   page.
 
 = content

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -16,7 +16,7 @@ layout: default
     %div#content.col-md-11.col-md-offset-1{:class => 'main-content'}
       %div#content-top
         %h1
-          %a{:href => page.url, :title => page.title}
+          %a{:href => expand_link(page.url), :title => page.title}
             = page.title
 
         %div{:style => 'float: right; clear: all;'}
@@ -34,7 +34,7 @@ layout: default
             %ul.list-inline.tags
               - page.tags.each do |tag|
                 %li
-                  %a.tag-link{:href => "/node/tags/#{tag}"}
+                  %a.tag-link{:href => expand_link("node/tags/#{tag}")}
                     = tag
 
       = content

--- a/content/_partials/author.html.haml
+++ b/content/_partials/author.html.haml
@@ -11,9 +11,9 @@
           - author.avatar = Dir.glob("content/images/avatars/#{authorId}.{bmp,gif,ico,jpg,jpeg,png,svg}").first
           - if author.avatar
             - author.avatar.sub!('content','')
-            %img.author.logo{:src => author.avatar, :alt => author.name}
+            %img.author.logo{:src => expand_link(author.avatar), :alt => author.name}
           - else
-            %img.author.logo{:src => "/images/logos/transparent/transparent.svg", :alt => author.name}
+            %img.author.logo{:src => expand_link("images/logos/transparent/transparent.svg"), :alt => author.name}
         %td
           %b.author.name
             = author.name

--- a/content/_partials/blogcardlist.html.haml
+++ b/content/_partials/blogcardlist.html.haml
@@ -8,7 +8,7 @@
       - page.posts.each do |post|
         - next if post.layout != 'post'
         %li.post
-          %a.body{:href => post.url}
+          %a.body{:href => expand_link(post.url)}
             .header
               .date
                 .month
@@ -28,5 +28,5 @@
               - if post.tags
                 - post.tags.each do |tag|
                   %li
-                    %a.tag-link{:href => "/node/tags/#{tag}"}
+                    %a.tag-link{:href => expand_link("node/tags/#{tag}")}
                       = tag

--- a/content/changelog-stable/rss.xml.haml
+++ b/content/changelog-stable/rss.xml.haml
@@ -8,7 +8,7 @@
       Jenkins LTS Changelog
     %link
       https://jenkins.io/changelog-stable
-    %atom:link(href="#{site.base_url}#{page.url}" rel="self" type="application/rss+xml")
+    %atom:link(href="#{expand_link(page.url)}" rel="self" type="application/rss+xml")
     %description
       Changelog for Jenkins LTS releases
     %lastBuildDate

--- a/content/changelog/rss.xml.haml
+++ b/content/changelog/rss.xml.haml
@@ -8,7 +8,7 @@
       Jenkins Changelog
     %link
       https://jenkins.io/changelog
-    %atom:link(href="#{site.base_url}#{page.url}" rel="self" type="application/rss+xml")
+    %atom:link(href="#{expand_link(page.url)}" rel="self" type="application/rss+xml")
     %description
       Changelog for Jenkins weekly releases
     %lastBuildDate

--- a/content/doc/developer/book.html.haml
+++ b/content/doc/developer/book.html.haml
@@ -6,7 +6,7 @@ layout: developerguide
 %ol
   - site.devbook.chapters.each do |chapter|
     %li{:style => 'font-size: 24px;'}
-      %a{:href => chapter.page.url}
+      %a{:href => expand_link(chapter.page.url)}
         = chapter.title
       - if chapter.page.wip
         - if !chapter.page.references || chapter.page.references.length == 0
@@ -21,7 +21,7 @@ layout: developerguide
       %ol
         - chapter.sections.each do | section |
           %li{:style => 'font-size: 18px;'}
-            %a{:href => section.page.url}
+            %a{:href => expand_link(section.page.url)}
 
               = section.title
 

--- a/content/doc/developer/guides.html.haml
+++ b/content/doc/developer/guides.html.haml
@@ -7,5 +7,5 @@ noanchors: true
 %ul
   - site.devbook.guides.each do |g|
     %li
-      %a{:href => g.page.url}
+      %a{:href => expand_link(g.page.url)}
         = "#{g.chapter.title}: #{g.page.title}"

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -36,11 +36,11 @@ homepage: true
 = partial('downloadbanner.html.haml')
 
 = partial('projectjumbotron.html.haml',
-  :href => 'projects/blueocean',
+  :href => expand_link('projects/blueocean'),
   :title => 'Say &ldquo;hello&rdquo; to Blue Ocean',
   :intro => "Blue Ocean is a new user experience that puts Continuous Delivery in reach of any team &mdash; without sacrificing the power and sophistication of Jenkins.",
-  :image => 'images/blueocean/blueocean-successful-pipeline.png',
-  :call_to_action => {:text => 'Get started', :href => 'projects/blueocean'})
+  :image => expand_link('images/blueocean/blueocean-successful-pipeline.png'),
+  :call_to_action => {:text => 'Get started', :href => expand_link('projects/blueocean')})
 
 #feature-list-segment.segment
   .container

--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -36,7 +36,7 @@ section: blog
         %nav
           %ul.pagination
             %li.page-item{:class => (page.posts.previous_page or 'disabled')}
-              %a.page-link{:href => (page.posts.previous_page and page.posts.previous_page.url)}
+              %a.page-link{:href => (page.posts.previous_page and expand_link(page.posts.previous_page.url))}
                 &laquo;
             - page.posts.pages.each_index do |index|
               - if index == 0
@@ -60,7 +60,7 @@ section: blog
                   %a.page-link{:href => expand_link("node/page/#{index + 1}.html")}
                     = index + 1
             %li.page-item{:class => (page.posts.next_page or 'disabled')}
-              %a.page-link{:href => (page.posts.next_page and page.posts.next_page.url)}
+              %a.page-link{:href => (page.posts.next_page and expand_link(page.posts.next_page.url))}
                 &raquo;
 
 

--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -115,7 +115,7 @@ section: participate
       %p
         Are you an established contributor to Jenkins and looking for a new challenge?
         The Jenkins Security Team is looking for members willing to help improve Jenkins security.
-        %a{:href => '/security#team'}
+        %a{:href => expand_link('security#team')}
           Learn more.
 
       %h3

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -27,7 +27,7 @@ section: security
             - advisories.sort.reverse_each do |advisory|
               - page = pages_by_path[advisory]
               %li
-                %a{:href => page.url}
+                %a{:href => expand_link(page.url)}
                   = page.title
                   - if page.kind
                     = "(#{page.kind})"


### PR DESCRIPTION
This change runs most of the links generated by haml through the expand link method to create absolute paths.  This will make the demo sites much more useful.  

Example:  

Click on any blog link on this:
http://bitwiseman.github.io/jenkins.io/master/node/
vs

Click on any blog link on this:
http://bitwiseman.github.io/jenkins.io/expand_link/node/

NOTE: in the site output this changes links to longer form, `/node` to `http://bitwiseman.github.io/jenkins.io/expand_link/node`

