### PR TITLE
[WEBSITE-461] Update :imagesdir: references at the tops of Asciidoc files

### DIFF
--- a/content/doc/book/appendix/index.adoc
+++ b/content/doc/book/appendix/index.adoc
@@ -1,13 +1,16 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
 :notitle:
+endif::[]
 
+[appendix]
 = Appendix
 
 These sections are generally intended for Jenkins administrators and system administrators.

--- a/content/doc/book/architecting-for-manageability.adoc
+++ b/content/doc/book/architecting-for-manageability.adoc
@@ -2,6 +2,7 @@
 layout: documentation
 section: doc
 ---
+ifdef::backend-html5[]
 :doctitle: Architecting for Manageability
 :notitle:
 :description:
@@ -9,6 +10,7 @@ section: doc
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc:
+endif::[]
 
 == Architecting for Manageability
 

--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -2,6 +2,7 @@
 layout: documentation
 section: doc
 ---
+ifdef::backend-html5[]
 :doctitle: Architecting for Scale
 :notitle:
 :description:
@@ -10,6 +11,7 @@ section: doc
 :imagesdir: /doc/book/resources/
 :sectanchors:
 :toc: left
+endif::[]
 
 == Architecting for Scale
 

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -8,7 +8,8 @@ wip: true
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Activity View

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -3,6 +3,7 @@ layout: section
 title: Activity View
 wip: true
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -11,6 +12,7 @@ wip: true
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Activity View
 

--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -8,7 +8,8 @@ title: Create a Pipeline
 :sectanchors:
 :toc:
 :toclevels: 4
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 

--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -2,15 +2,15 @@
 layout: section
 title: Create a Pipeline
 ---
-////
+ifdef::backend-html5[]
 :description:
-////
 :sectanchors:
 :toc:
 :toclevels: 4
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 
 = Create a Pipeline

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -7,7 +7,8 @@ title: Dashboard
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Dashboard
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -10,6 +11,7 @@ title: Dashboard
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 
 = Dashboard

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -7,7 +7,8 @@ title: Getting Started  with Blue Ocean
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Getting Started with Blue Ocean

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -2,6 +2,8 @@
 layout: section
 title: Getting Started  with Blue Ocean
 ---
+
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -10,6 +12,7 @@ title: Getting Started  with Blue Ocean
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Getting Started with Blue Ocean
 

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -2,6 +2,7 @@
 layout: chapter
 title: Blue Ocean
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -9,6 +10,8 @@ title: Blue Ocean
 :sectanchors:
 :imagesdir: ../resources
 :toc:
+endif::[]
+
 
 [blue-ocean]
 = Blue Ocean
@@ -38,7 +41,7 @@ team.
 To start using Blue Ocean, see **<<blueocean/getting-started#,Getting Started
 with Blue Ocean>>**.
 
-ifdef::basebackend-html5[]
+ifdef::backend-html5[]
 ++++
 <center>
 <iframe width="853" height="480"
@@ -101,7 +104,7 @@ technically capable and extensible software automation tool in existence. Not
 doing anything to revolutionize the Jenkins developer experience today is just
 inviting someone else – in closed source – to do it.
 
-ifdef::basebackend-html5[]
+ifdef::backend-html5[]
 ++++
 <center>
 <iframe width="853" height="480"

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -7,7 +7,7 @@ title: Blue Ocean
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
-:imagesdir: /doc/book/resources
+:imagesdir: ../resources
 :toc:
 
 [blue-ocean]

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -3,6 +3,7 @@ layout: section
 title: Pipeline Editor
 wip: true
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -11,6 +12,7 @@ wip: true
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Pipeline Editor
 

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -8,7 +8,8 @@ wip: true
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Pipeline Editor

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -3,6 +3,7 @@ layout: section
 title: Pipeline Run Details View
 wip: true
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -11,6 +12,7 @@ wip: true
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Pipeline Run Details View
 

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -8,7 +8,8 @@ wip: true
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Pipeline Run Details View

--- a/content/doc/book/getting-started/index.adoc
+++ b/content/doc/book/getting-started/index.adoc
@@ -1,13 +1,14 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
 :notitle:
-
+endif::[]
 
 = User Handbook Overview
 

--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -1,11 +1,13 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc:
+endif::[]
 
 ////
 XXX: Pages to mark as deprecated by this document:

--- a/content/doc/book/hardware-recommendations.adoc
+++ b/content/doc/book/hardware-recommendations.adoc
@@ -2,6 +2,7 @@
 layout: documentation
 section: doc
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author: R. Tyler Croy
@@ -9,6 +10,7 @@ section: doc
 :imagesdir: /doc/book/resources/hardware-recommendations
 :sectanchors:
 :toc: left
+endif::[]
 
 == Hardware Recommendations
 

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -2,14 +2,14 @@
 layout: chapter
 title: Installing Jenkins
 ---
-////
+ifdef::backend-html5[]
 :notitle:
 :description:
-////
 :sectanchors:
 :toc:
 :toclevels: 4
 :imagesdir: ../resources
+endif::[]
 
 
 = Installing Jenkins

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -9,7 +9,7 @@ title: Installing Jenkins
 :sectanchors:
 :toc:
 :toclevels: 4
-:imagesdir: /doc/book/resources
+:imagesdir: ../resources
 
 
 = Installing Jenkins

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -10,6 +11,7 @@ layout: section
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Jenkins CLI
 

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -7,7 +7,8 @@ layout: section
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Jenkins CLI

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -1,6 +1,7 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -8,6 +9,7 @@ layout: chapter
 :sectanchors:
 :toc:
 :hide-uri-scheme:
+endif::[]
 
 = Managing Jenkins
 

--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -8,6 +9,7 @@ layout: section
 :sectanchors:
 :toc:
 :hide-uri-scheme:
+endif::[]
 
 = Managing Nodes
 

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -10,6 +11,7 @@ layout: section
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Managing Plugins
 

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -7,7 +7,8 @@ layout: section
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Managing Plugins

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -10,6 +11,7 @@ layout: section
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = In-process Script Approval
 

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -7,8 +7,9 @@ layout: section
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
-:imagesdir: /doc/book/resources
 
 = In-process Script Approval
 

--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -8,6 +9,7 @@ layout: section
 :sectanchors:
 :toc:
 :hide-uri-scheme:
+endif::[]
 
 = Script Console
 

--- a/content/doc/book/managing/security.adoc
+++ b/content/doc/book/managing/security.adoc
@@ -6,8 +6,9 @@ layout: section
 :author:
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
-:imagesdir: /doc/book/resources
 :toc:
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Managing Security

--- a/content/doc/book/managing/security.adoc
+++ b/content/doc/book/managing/security.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -10,6 +11,7 @@ layout: section
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Managing Security
 

--- a/content/doc/book/managing/system-configuration.adoc
+++ b/content/doc/book/managing/system-configuration.adoc
@@ -1,12 +1,14 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = Configuring the System
 

--- a/content/doc/book/managing/tools.adoc
+++ b/content/doc/book/managing/tools.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -8,6 +9,7 @@ layout: section
 :sectanchors:
 :toc:
 :hide-uri-scheme:
+endif::[]
 
 = Managing Tools
 

--- a/content/doc/book/managing/users.adoc
+++ b/content/doc/book/managing/users.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -8,6 +9,7 @@ layout: section
 :sectanchors:
 :toc:
 :hide-uri-scheme:
+endif::[]
 
 = Managing Users
 

--- a/content/doc/book/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline-as-code.adoc
@@ -2,6 +2,7 @@
 layout: documentation
 section: doc
 ---
+ifdef::backend-html5[]
 :doctitle: Pipeline as Code
 :notitle:
 :description:
@@ -9,6 +10,7 @@ section: doc
 :email: jenkinsci-users@googlegroups.com
 :imagesdir: /doc/book/resources/pipeline-as-code
 :toc: left
+endif::[]
 
 == Pipeline as Code
 

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Pipeline Development Tools
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -10,6 +11,8 @@ title: Pipeline Development Tools
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
+ifdef::basebackend-dockbook[:imagesdir: doc/book/resources]
 
 = Pipeline Development Tools
 

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -7,7 +7,8 @@ title: Pipeline Development Tools
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Pipeline Development Tools

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Using Docker with Pipeline
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -10,6 +11,7 @@ title: Using Docker with Pipeline
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 = Using Docker with Pipeline
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -7,7 +7,8 @@ title: Using Docker with Pipeline
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 
 = Using Docker with Pipeline

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Getting Started with Pipeline
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -10,6 +11,7 @@ title: Getting Started with Pipeline
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
+endif::[]
 
 
 = Getting Started with Pipeline

--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -2,6 +2,7 @@
 layout: chapter
 title: Pipeline
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -9,6 +10,7 @@ title: Pipeline
 :sectanchors:
 :imagesdir: ../resources
 :toc:
+endif::[]
 
 
 = Pipeline

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Using a Jenkinsfile
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -9,6 +10,7 @@ title: Using a Jenkinsfile
 :toc:
 :toclevels: 4
 :hide-uri-scheme:
+endif::[]
 
 
 = Using a Jenkinsfile

--- a/content/doc/book/pipeline/multibranch.adoc
+++ b/content/doc/book/pipeline/multibranch.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Branches and Pull Requests
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -10,6 +11,7 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 :toc:
+endif::[]
 
 = Branches and Pull Requests
 

--- a/content/doc/book/pipeline/multibranch.adoc
+++ b/content/doc/book/pipeline/multibranch.adoc
@@ -6,7 +6,8 @@ title: Branches and Pull Requests
 :author:
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
-:imagesdir: /doc/book/resources/
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 :toc:
 

--- a/content/doc/book/pipeline/scaling-pipeline.adoc
+++ b/content/doc/book/pipeline/scaling-pipeline.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Scaling Pipelines
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author: Sam Van Oort
@@ -11,6 +12,7 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 :toc:
+endif::[]
 
 = Using Speed/Durability Settings To Reduce Disk I/O Needs
 

--- a/content/doc/book/pipeline/scaling-pipeline.adoc
+++ b/content/doc/book/pipeline/scaling-pipeline.adoc
@@ -7,7 +7,8 @@ title: Scaling Pipelines
 :author: Sam Van Oort
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 :toc:
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Extending with Shared Libraries
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -11,6 +12,7 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 :toc:
+endif::[]
 
 = Extending with Shared Libraries
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -7,7 +7,8 @@ title: Extending with Shared Libraries
 :author:
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 :toc:
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -7,7 +7,8 @@ title: Pipeline Syntax
 :author:
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :toc:
 :toclevels: 3
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Pipeline Syntax
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -11,6 +12,7 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :toc:
 :toclevels: 3
+endif::[]
 
 = Pipeline Syntax
 

--- a/content/doc/book/scaling/index.adoc
+++ b/content/doc/book/scaling/index.adoc
@@ -1,12 +1,14 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = Scaling Jenkins
 

--- a/content/doc/book/system-administration/backing-up.adoc
+++ b/content/doc/book/system-administration/backing-up.adoc
@@ -1,12 +1,14 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = Backing-up/Restoring Jenkins
 

--- a/content/doc/book/system-administration/index.adoc
+++ b/content/doc/book/system-administration/index.adoc
@@ -1,12 +1,14 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = System Administration
 

--- a/content/doc/book/system-administration/monitoring.adoc
+++ b/content/doc/book/system-administration/monitoring.adoc
@@ -1,12 +1,14 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = Monitoring Jenkins
 

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -5,7 +5,8 @@ layout: section
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
-:imagesdir: /doc/book/resources/securing-jenkins
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 :toc: left
 
 = Securing Jenkins

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -1,6 +1,7 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
@@ -8,6 +9,7 @@ layout: section
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :toc: left
+endif::[]
 
 = Securing Jenkins
 

--- a/content/doc/book/system-administration/with-chef.adoc
+++ b/content/doc/book/system-administration/with-chef.adoc
@@ -1,12 +1,14 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = Managing Jenkins with Chef
 

--- a/content/doc/book/system-administration/with-puppet.adoc
+++ b/content/doc/book/system-administration/with-puppet.adoc
@@ -1,12 +1,14 @@
 ---
 layout: section
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 = Managing Jenkins with Puppet
 

--- a/content/doc/book/using/index.adoc
+++ b/content/doc/book/using/index.adoc
@@ -1,12 +1,14 @@
 ---
 layout: chapter
 ---
+ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
 :toc: left
+endif::[]
 
 
 = Using Jenkins

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -2,6 +2,7 @@
 layout: section
 title: Using credentials
 ---
+ifdef::backend-html5[]
 :description:
 :author:
 :email: jenkinsci-docs@googlegroups.com
@@ -9,6 +10,7 @@ title: Using credentials
 :toc:
 :toclevels: 4
 :hide-uri-scheme:
+endif::[]
 
 
 = Using credentials

--- a/content/doc/pipeline/tour/agents.adoc
+++ b/content/doc/pipeline/tour/agents.adoc
@@ -5,7 +5,7 @@ title: Defining execution environments
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+:imagesdir: ../../../book/resources
 :hide-uri-scheme:
 
 

--- a/content/doc/pipeline/tour/deployment.adoc
+++ b/content/doc/pipeline/tour/deployment.adoc
@@ -5,7 +5,7 @@ title: Deployment
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+:imagesdir: ../../../book/resources
 :hide-uri-scheme:
 
 The most basic continuous delivery pipeline will have, at minimum, three stages

--- a/content/doc/pipeline/tour/environment.adoc
+++ b/content/doc/pipeline/tour/environment.adoc
@@ -5,7 +5,7 @@ title: Using environment variables
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+:imagesdir: ../../../book/resources
 :hide-uri-scheme:
 
 

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -5,7 +5,7 @@ section: doc
 ---
 
 :toc:
-:imagesdir: /doc/book/resources
+:imagesdir: ../../../book/resources
 
 === What is a Jenkins Pipeline?
 

--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -6,7 +6,7 @@ title: Recording tests and artifacts
 :email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
-:imagesdir: /doc/book/resources
+:imagesdir: ../../../book/resources
 :hide-uri-scheme:
 
 

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -6,8 +6,7 @@ section: doc
 
 :toc:
 :toclevels: 3
-ifdef::env-github[:imagesdir: ../resources]
-ifndef::env-github[:imagesdir: ../../resources]
+:imagesdir: ../../book/resources
 
 This tutorial shows you how to use Jenkins to orchestrate building a simple Java
 application with https://maven.apache.org/[Maven].

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -6,7 +6,8 @@ section: doc
 
 :toc:
 :toclevels: 3
-:imagesdir: /doc/book/resources
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
 
 This tutorial shows you how to use Jenkins to orchestrate building a simple Java
 application with https://maven.apache.org/[Maven].

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -6,7 +6,7 @@ section: doc
 
 :toc:
 :toclevels: 3
-:imagesdir: /doc/book/resources
+:imagesdir: ../../book/resources
 
 This tutorial shows you how to use Jenkins to orchestrate building and testing
 a simple https://nodejs.org/en/[Node.js] and https://reactjs.org/[React]

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -6,7 +6,7 @@ section: doc
 
 :toc:
 :toclevels: 3
-:imagesdir: /doc/book/resources
+:imagesdir: ../../book/resources
 
 This tutorial shows you how to use Jenkins to orchestrate building a simple
 https://nodejs.org/en/[Node.js] and https://reactjs.org/[React] application

--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -6,7 +6,7 @@ section: doc
 
 :toc:
 :toclevels: 3
-:imagesdir: /doc/book/resources
+:imagesdir: ../../book/resources
 
 This tutorial shows you how to use Jenkins to orchestrate building a simple
 Python application with http://www.pyinstaller.org/[PyInstaller].

--- a/content/doc/tutorials/create-a-pipeline-in-blue-ocean.adoc
+++ b/content/doc/tutorials/create-a-pipeline-in-blue-ocean.adoc
@@ -6,7 +6,7 @@ section: doc
 
 :toc:
 :toclevels: 3
-:imagesdir: /doc/book/resources
+:imagesdir: ../../book/resources
 
 This tutorial shows you how to use the link:/doc/book/blueocean/[Blue Ocean]
 feature of Jenkins to create a Pipeline that will orchestrate building a simple

--- a/scripts/asciidoctor-pdf
+++ b/scripts/asciidoctor-pdf
@@ -5,8 +5,13 @@ mkdir -p build
     cat build/error.txt >&2
     exit 1
 }
-if [[ -n "$( grep --fixed-strings WARNING build/error.txt | grep --fixed-strings --invert-match user-handbook.adoc | grep --fixed-strings --invert-match 'conversion missing in backend pdf' )" ]] ; then
+if [[ -n "$( grep --fixed-strings WARNING build/error.txt | grep --fixed-strings --invert-match 'user-handbook.adoc')" ]] ; then
     echo "Failing build due to warnings in log output:" >&2
     cat build/error.txt >&2
+
+    grep -q --fixed-strings 'conversion missing in backend pdf' build/error.txt && {
+        echo "NOTE: 'missing conversion' means an asciidoc is"
+        echo "  missing ifdef::backend-html5[] around some html-specific markup."
+    }
     exit 1
 fi

--- a/scripts/generate-handbook-pdf
+++ b/scripts/generate-handbook-pdf
@@ -33,15 +33,12 @@ def read_adoc(filepath)
     buffer = buffer[(frontmatter_end + 2) .. -1]
   end
 
-  # Filter any document properties
-  output = buffer.reject do |line|
-    line.start_with?(':') || line.start_with?('ifdef::') || line.start_with?('ifndef::')
-  end
-  return output.join('')
+  return buffer.join('') + "\n\n"
 end
 
 File.open(OUTPUT_ADOC, 'w+') do |f|
   f.write <<-EOF
+= Jenkins User Handbook
 :description: Jenkins User Handbook
 :doctype: book
 :author: jenkinsci-docs@googlegroups.com
@@ -50,12 +47,13 @@ File.open(OUTPUT_ADOC, 'w+') do |f|
 :hide-uri-scheme:
 :toc:
 :imagesdir: doc/book/resources
-
-= Jenkins User Handbook
+:leveloffset: +1
 
 EOF
 
   documents.each do |document|
+    f.write "// #{document}\n"
     f.write read_adoc(document)
   end
+
 end

--- a/scripts/generate-handbook-pdf
+++ b/scripts/generate-handbook-pdf
@@ -35,7 +35,7 @@ def read_adoc(filepath)
 
   # Filter any document properties
   output = buffer.reject do |line|
-    line.start_with?(':')
+    line.start_with?(':') || line.start_with?('ifdef::') || line.start_with?('ifndef::')
   end
   return output.join('')
 end


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-461 for details.

This is to allow the images to render when a contributor publishes their changes to their GitHub account's GH pages site.

See the [relevant section of the CONTRIBUTING guide](https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#deploying-jenkins-io-on-github-pages) for details.

FYI - here's what my GH pages site looks like: https://gilesgas.github.io/jenkins.io/WEBSITE-461-update-imagesdir-references/doc/ ... all images in the Jenkins User Documentation now show up.