### PR TITLE
Add support for data-based 'core' security advisories

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -4,7 +4,7 @@ section: security
 ---
 
 :ruby
-  plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
+  plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
   credits = page.issues.reduce({}) do |issues, issue|
     if issue.has_key?("reporter")
       if !issues.has_key?(issue.reporter)
@@ -29,7 +29,8 @@ section: security
 %p
   %ul
     - if page.core
-      Jenkins core
+      %li
+        Jenkins (core)
     - plugins.each do | plugin |
       %li
         %a{:href => 'https://plugins.jenkins.io/' + plugin.name }
@@ -50,6 +51,14 @@ section: security
 %h2
   Affected Versions
 %ul
+  - if page.core&.weekly&.previous
+    %li
+      Jenkins weekly up to and including
+      = page.core.weekly&.previous
+  - if page.core&.lts&.previous
+    %li
+      Jenkins LTS up to and including
+      = page.core.lts&.previous
   - plugins.each do | plugin |
     - if plugin.previous
       %li
@@ -60,8 +69,16 @@ section: security
 
 %h2
   Fix
-- if fixed_plugins.length > 0
+- if fixed_plugins.length > 0 || page.core&.weekly&.fixed || page.core&.lts&.fixed
   %ul
+    - if page.core&.weekly&.fixed
+      %li
+        Jenkins weekly should be updated to version
+        = page.core.weekly&.fixed
+    - if page.core&.lts&.fixed
+      %li
+        Jenkins LTS should be updated to version
+        = page.core.lts&.fixed
     - fixed_plugins.each do | plugin |
       %li
         %strong
@@ -72,6 +89,7 @@ section: security
     These versions include fixes to the vulnerabilities described above. All prior versions are considered to be affected by these vulnerabilities unless otherwise indicated.
 
 - if unfixed_plugins.length > 0
+  - # TODO layout does not support unfixed core releases
   %p
     As of publication of this advisory, no fixes are available for the following plugins:
   %ul
@@ -97,3 +115,13 @@ section: security
             = reporter
           for
           = issues.join(", ")
+
+- if page.resources && page.resources.length > 0
+  %h2
+    Other Resources
+
+  %ul
+    - page.resources.each do | resource |
+      %li
+        %a{:href => resource.url}
+          = resource.title

--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -104,7 +104,7 @@ section: security
 
   %p
     The Jenkins project would like to thank the reporters for discovering and
-    %a{href => expand_link('security/#reporting-vulnerabilities')}
+    %a{:href => expand_link('security/#reporting-vulnerabilities')}
       reporting
     these vulnerabilities:
 

--- a/content/security/advisory/2017-11-08.adoc
+++ b/content/security/advisory/2017-11-08.adoc
@@ -1,14 +1,34 @@
 ---
-layout: simplepage
+layout: advisory
 title: Jenkins Security Advisory 2017-11-08
 section: security
 kind: core
+core:
+  lts:
+    previous: 2.73.2
+    fixed: 2.73.3
+  weekly:
+    previous: 2.88
+    fixed: 2.89
+issues:
+- id: SECURITY-499
+  cvss:
+    severity: low
+    vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:L/A:L
+  reporter: Darren Zhao
+- id: SECURITY-641
+  reporter: Viktor Gazdag of NCC Group
+  cvss:
+    severity: low
+    vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N
+resources:
+- url: /blog/2017/11/08/security-updates/
+  title: Announcement blog post
 ---
-
-This advisory announces multiple vulnerabilities in Jenkins.
 
 == Description
 
+[#SECURITY-499]
 === Unsafe use of user names as directory names
 *SECURITY-499 / CVE-2017-1000391*
 
@@ -24,6 +44,7 @@ This is not limited to the _Jenkins user database_ security realm, other securit
 
 User names are now transformed into a filesystem-safe representation that is used as directory name.
 
+[#SECURITY-641]
 === Persisted XSS vulnerability in autocompletion suggestions
 *SECURITY-641 / CVE-2017-1000392*
 
@@ -32,39 +53,3 @@ Autocompletion suggestions for text fields were not escaped, resulting in a pers
 Known previously unsafe sources for these suggestions include the names of loggers in the log recorder condition, and agent labels.
 
 Autocompletion suggestions are now escaped and can no longer contain HTML-based formatting.
-
-
-== Severity
-
-* SECURITY-499: Various, the highest of which is *link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:L/A:L[low]*
-* SECURITY-641: *link:http://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N[low]*
-
-
-
-== Affected versions
-
-* Jenkins weekly up to and including 2.88
-* Jenkins LTS up to and including 2.73.2
-
-
-== Fix
-
-* Jenkins weekly should be updated to 2.89
-* Jenkins LTS should be updated to 2.73.3
-
-These versions include fixes to the vulnerabilities described above.
-All prior versions are affected by these vulnerabilities unless otherwise indicated.
-
-
-== Credit
-
-The Jenkins project would like to thank the reporters for discovering and link:/security/#reporting-vulnerabilities[reporting] these vulnerabilities:
-
-* *Darren Zhao* for SECURITY-499
-* *Viktor Gazdag of NCC Group* for SECURITY-641
-
-
-
-== Other Resources
-
-* link:/blog/2017/11/08/security-updates/[Announcement blog post]

--- a/content/security/advisory/2018-02-05.adoc
+++ b/content/security/advisory/2018-02-05.adoc
@@ -48,6 +48,9 @@ issues:
     - name: workflow-support
       fixed: 2.18
       previous: 2.17
+resources:
+- url: /blog/2018/02/05/security-updates/
+  title: Announcement blog post
 ---
 
 == Description


### PR DESCRIPTION
Implement on 2017-11-08 advisory.

Unrelated change:
Add link to blog post on 2018-02-05