### PR TITLE
Additional details on the advisories index page

### DIFF
--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -41,12 +41,12 @@ section: security
                       %ul
                         - if page.core
                           %li
-                            About Jenkins Core
+                            Affects Jenkins Core
                         - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
                         - if plugins.size > 0
                           %li
                             %span{:style => 'white-space: nowrap;'}
-                              About Plugins:
+                              Affects Plugins:
                             - plugins.each_with_index do | plugin, idx |
                               %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
                                 = site._generated[:update_center].plugins[plugin.name].title

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -31,3 +31,17 @@ section: security
                   = page.title
                   - if page.kind
                     = "(#{page.kind})"
+                - if page.issues && year == '2018'
+                  %br
+                  %small
+                    %ul{:style => 'padding-left: 10px;'}
+                      - if page.core
+                        %li
+                          Jenkins (core)
+                      - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
+                      - if plugins.size > 0
+                        %li
+                          Included Plugins:
+                          - plugins.each_with_index do | plugin, idx |
+                            %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
+                              = site._generated[:update_center].plugins[plugin.name].title

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -5,6 +5,7 @@ section: security
 ---
 
 :ruby
+  require 'asciidoctor'
   advisories_dir = File.expand_path(File.dirname(__FILE__) + '/advisory')
   pages_by_path = site.pages.map { |p| [p.source_path, p] }.to_h
   adocs = Dir.glob(File.join(advisories_dir, '*.{ad,adoc}'))
@@ -31,18 +32,21 @@ section: security
                   = page.title
                   - if year.to_i < 2018
                     = "(#{page.kind})"
-                - if page.issues and year.to_i >= 2018
+                - if page.issues and year.to_i >= 2018 or page.index_details
                   %br
                   %small
-                    %ul{:style => 'padding-left: 10px;'}
-                      - if page.core
-                        %li
-                          About Jenkins Core
-                      - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
-                      - if plugins.size > 0
-                        %li
-                          %span{:style => 'white-space: nowrap;'}
-                            About Plugins:
-                          - plugins.each_with_index do | plugin, idx |
-                            %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
-                              = site._generated[:update_center].plugins[plugin.name].title
+                    - if page.index_details
+                      = Asciidoctor.convert page.index_details, safe: :safe
+                    - else
+                      %ul
+                        - if page.core
+                          %li
+                            About Jenkins Core
+                        - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
+                        - if plugins.size > 0
+                          %li
+                            %span{:style => 'white-space: nowrap;'}
+                              About Plugins:
+                            - plugins.each_with_index do | plugin, idx |
+                              %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
+                                = site._generated[:update_center].plugins[plugin.name].title

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -29,19 +29,20 @@ section: security
               %li
                 %a{:href => expand_link(page.url)}
                   = page.title
-                  - if page.kind
+                  - if year.to_i < 2018
                     = "(#{page.kind})"
-                - if page.issues && year == '2018'
+                - if page.issues and year.to_i >= 2018
                   %br
                   %small
                     %ul{:style => 'padding-left: 10px;'}
                       - if page.core
                         %li
-                          Jenkins (core)
+                          About Jenkins Core
                       - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
                       - if plugins.size > 0
                         %li
-                          Included Plugins:
+                          %span{:style => 'white-space: nowrap;'}
+                            About Plugins:
                           - plugins.each_with_index do | plugin, idx |
                             %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
                               = site._generated[:update_center].plugins[plugin.name].title


### PR DESCRIPTION
**Work in progress**
- [x] ~~~I first want a data-based core security update live and fully supported (some time after Wednesday, probably)~~~ (tested locally, works!)
- [x] I also want a fallback for advisories with special content that cannot be made data-based.

Sort of downstream from https://github.com/jenkins-infra/backend-update-center2/pull/187 (typically too complex/long display names otherwise)

Also sort of downstream from https://github.com/jenkins-infra/jenkins.io/pull/1382 as otherwise we cannot include core security updates adequately.

Screen shot:

> ![screen shot](https://user-images.githubusercontent.com/1831569/36080944-4821fb7c-0f98-11e8-8edd-59690c3f36e0.png)

@oleg-nenashev @Wadeck @orrc @batmat WDYT?