### PR TITLE
Fix backtick syntax

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1078,7 +1078,7 @@ further `parallel` stages themselves, but otherwise behave the same as
 any other `stage`. Any stage containing `parallel` cannot contain `agent` or
 `tools`, since those are not relevant without `steps`.
 
-In addition, you can force your `parallel` `stage`s to all be aborted when one
+In addition, you can force your `parallel` stages to all be aborted when one
 of them fails, by adding `failFast true` to the `stage` containing the
 `parallel`.
 


### PR DESCRIPTION
A backtick without spaces is not treated as a monospace.

Previous output:

![screen shot 2018-02-12 at 17 17 49](https://user-images.githubusercontent.com/70800/36109899-b078a632-1018-11e8-9c9b-cf7f13bcdcef.png)

