### PR TITLE
Add support for issue title and description in data

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -4,6 +4,8 @@ section: security
 ---
 
 :ruby
+  require 'asciidoctor'
+
   plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
   credits = page.issues.reduce({}) do |issues, issue|
     if issue.has_key?("reporter")
@@ -36,7 +38,23 @@ section: security
         %a{:href => 'https://plugins.jenkins.io/' + plugin.name }
           = site._generated[:update_center].plugins[plugin.name].title
 
-= content
+
+- described_issues = page.issues.keep_if { |i| i.title && i.description }
+- if described_issues.size > 0:
+  %h2
+    Descriptions
+  - described_issues.each do | issue |
+    %h3{:id => issue.id}
+      = issue.title
+    %strong
+      = issue.id
+      - if issue.cve
+        \/
+        = issue.cve
+    = Asciidoctor.convert issue.description, safe: :safe
+- else
+  - # If there is any content, it's the issue descriptions -- but only show if there are none in the data
+  = content
 
 %h2
   Severity

--- a/content/security/advisory/2017-11-08.adoc
+++ b/content/security/advisory/2017-11-08.adoc
@@ -16,40 +16,34 @@ issues:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:L/A:L
   reporter: Darren Zhao
+  title: Unsafe use of user names as directory names
+  cve: CVE-2017-1000391
+  description: |
+    Jenkins stores metadata related to _people_, which encompasses actual user accounts, as well as users appearing in SCM, in directories corresponding to the user ID on disk.
+    These directories used the user ID for their name without additional escaping.
+    This potentially resulted in a number of problems, such as the following:
+
+    . User names consisting of a single forward slash would have their user record stored in the parent directory; deleting this user deleted all user records.
+    . User names containing character sequences such as `..` could be used to clobber other configuration files in Jenkins.
+    . User names could consist of reserved names such as `COM` (on Windows).
+
+    This is not limited to the _Jenkins user database_ security realm, other security realms such as LDAP may allow users to create user names that result in problems in Jenkins.
+
+    User names are now transformed into a filesystem-safe representation that is used as directory name.
 - id: SECURITY-641
   reporter: Viktor Gazdag of NCC Group
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N
+  cve: CVE-2017-1000392
+  title: Persisted XSS vulnerability in autocompletion suggestions
+  description: |
+    Autocompletion suggestions for text fields were not escaped, resulting in a persisted cross-site scripting vulnerability if the source for the suggestions allowed specifying text that includes HTML metacharacters like less-than and greater-than characters.
+
+    Known previously unsafe sources for these suggestions include the names of loggers in the log recorder condition, and agent labels.
+
+    Autocompletion suggestions are now escaped and can no longer contain HTML-based formatting.
 resources:
 - url: /blog/2017/11/08/security-updates/
   title: Announcement blog post
 ---
-
-== Description
-
-[#SECURITY-499]
-=== Unsafe use of user names as directory names
-*SECURITY-499 / CVE-2017-1000391*
-
-Jenkins stores metadata related to _people_, which encompasses actual user accounts, as well as users appearing in SCM, in directories corresponding to the user ID on disk.
-These directories used the user ID for their name without additional escaping.
-This potentially resulted in a number of problems, such as the following:
-
-. User names consisting of a single forward slash would have their user record stored in the parent directory; deleting this user deleted all user records.
-. User names containing character sequences such as `..` could be used to clobber other configuration files in Jenkins.
-. User names could consist of reserved names such as `COM` (on Windows).
-
-This is not limited to the _Jenkins user database_ security realm, other security realms such as LDAP may allow users to create user names that result in problems in Jenkins.
-
-User names are now transformed into a filesystem-safe representation that is used as directory name.
-
-[#SECURITY-641]
-=== Persisted XSS vulnerability in autocompletion suggestions
-*SECURITY-641 / CVE-2017-1000392*
-
-Autocompletion suggestions for text fields were not escaped, resulting in a persisted cross-site scripting vulnerability if the source for the suggestions allowed specifying text that includes HTML metacharacters like less-than and greater-than characters.
-
-Known previously unsafe sources for these suggestions include the names of loggers in the log recorder condition, and agent labels.
-
-Autocompletion suggestions are now escaped and can no longer contain HTML-based formatting.


### PR DESCRIPTION
Implement for 2017-11-08 advisory.
2018-01-22 and 2018-02-05 show that there's still support for
descriptions in content.

---

Not sure yet whether this is great long term (and writing it will be annoying due to data not getting updated live), but it gives greater flexibility in formatting advisories.