### PR TITLE
Don't modify page.issues when loading an advisory

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -39,7 +39,7 @@ section: security
           = site._generated[:update_center].plugins[plugin.name].title
 
 
-- described_issues = page.issues.keep_if { |i| i.title && i.description }
+- described_issues = page.issues.dup.keep_if { |i| i.title && i.description }
 - if described_issues.size > 0
   %h2
     Descriptions


### PR DESCRIPTION
Otherwise, the page data (well, `page.issues`) is empty after loading the advisory once.