### PR TITLE
Add support for plugins not currently published

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -6,7 +6,7 @@ section: security
 :ruby
   require 'asciidoctor'
 
-  plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
+  plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title || x.name) <=> (site._generated[:update_center].plugins[y.name]&.title || y.name) }
   credits = page.issues.reduce({}) do |issues, issue|
     if issue.has_key?("reporter")
       if !issues.has_key?(issue.reporter)
@@ -35,8 +35,13 @@ section: security
         Jenkins (core)
     - plugins.each do | plugin |
       %li
-        %a{:href => 'https://plugins.jenkins.io/' + plugin.name }
-          = site._generated[:update_center].plugins[plugin.name].title
+        - if site._generated[:update_center].plugins[plugin.name]
+          %a{:href => 'https://plugins.jenkins.io/' + plugin.name }
+            = site._generated[:update_center].plugins[plugin.name].title
+            Plugin
+        - else
+          = plugin.name
+          Plugin
 
 
 - described_issues = page.issues.keep_if { |i| i.title && i.description }
@@ -81,7 +86,8 @@ section: security
     - if plugin.previous
       %li
         %strong
-          = site._generated[:update_center].plugins[plugin.name].title
+          = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+          Plugin
         up to and including
         = plugin.previous
 
@@ -100,7 +106,8 @@ section: security
     - fixed_plugins.each do | plugin |
       %li
         %strong
-          = site._generated[:update_center].plugins[plugin.name].title
+          = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+          Plugin
         should be updated to version
         = plugin.fixed
   %p
@@ -113,7 +120,8 @@ section: security
   %ul
     - unfixed_plugins.each do | plugin |
       %li
-        = site._generated[:update_center].plugins[plugin.name].title
+        = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+        Plugin
 
 
 - if credits.length > 0

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -42,11 +42,14 @@ section: security
                         - if page.core
                           %li
                             Affects Jenkins Core
-                        - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| site._generated[:update_center].plugins[x.name].title <=> site._generated[:update_center].plugins[y.name].title }
+                        - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title || x.name) <=> (site._generated[:update_center].plugins[y.name]&.title || y.name) }
                         - if plugins.size > 0
                           %li
                             %span{:style => 'white-space: nowrap;'}
                               Affects Plugins:
                             - plugins.each_with_index do | plugin, idx |
-                              %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
-                                = site._generated[:update_center].plugins[plugin.name].title
+                              - if site._generated[:update_center].plugins[plugin.name]
+                                %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
+                                  = site._generated[:update_center].plugins[plugin.name].title
+                              - else
+                                = plugin.name


### PR DESCRIPTION
Also adds *Plugin* suffix on the advisory page. This is to prevent confusion in the current situation that calls e.g. "JUnit" a "Jenkins deliverable".

---

Tested locally with a slightly modified Feb 5 advisory:

> ![screen shot](https://user-images.githubusercontent.com/1831569/36233832-3506c32c-11e8-11e8-83bb-38595e016993.png)

> ![screen shot](https://user-images.githubusercontent.com/1831569/36233826-2a8c59fc-11e8-11e8-9b13-ed9ac3631bf6.png)
