### PR TITLE
Correct link.

### DIFF
--- a/content/doc/index.adoc
+++ b/content/doc/index.adoc
@@ -52,7 +52,7 @@ documentation covered in the <<doc/pipeline/tour/getting-started#,Guided Tour>>,
 this documentation are based on a <<doc/book/installing#,Jenkins installation>>
 with the <<doc/book/blueocean/getting-started#,Blue Ocean plugins installed>>,
 as well as the "suggested plugins", which are specified when running through the
-<<doc/book/installing/#setup-wizard,Post-installation setup wizard>>.
+<<doc/book/installing#setup-wizard,Post-installation setup wizard>>.
 
 
 '''


### PR DESCRIPTION
This will allow images to render correctly at the link's target subsection of the Installing Jenkins page.