### PR TITLE
Clarify JCasC as a Plugin in a section title

### DIFF
--- a/content/projects/gsoc/gsoc2018-project-ideas.adoc
+++ b/content/projects/gsoc/gsoc2018-project-ideas.adoc
@@ -18,7 +18,7 @@ with the community and GSoC admins to find potential mentors.
 
 :toc:
 
-== Jenkins Configuration as Code
+== Jenkins Configuration as Code Plugin
 
 link:https://github.com/jenkinsci/configuration-as-code-plugin[Configuration-as-Code] plugin has been designed
 as an opinionated way to configure Jenkins based on human-readable declarative configuration files (YAML).


### PR DESCRIPTION
It wasn't obvious for some readers that Jenkins Configuration as Code is a plugin. It is mentioned in description but I updated also the section title