### PR TITLE
Add link back to advisories index

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 section: security
+notitle: true
 ---
 
 :ruby
@@ -24,6 +25,15 @@ section: security
 
   fixed_plugins = plugins.dup.keep_if { |p| p.fixed }
   unfixed_plugins = plugins.dup.keep_if { |p| !p.fixed }
+
+%p
+  %a{:href => '../../advisories'}
+    Security Advisories
+  &raquo;
+  = page.title
+
+%h1
+  = page.title
 
 %p
   This advisory announces vulnerabilities in the following Jenkins deliverables:


### PR DESCRIPTION
> ![screen shot](https://user-images.githubusercontent.com/1831569/36439981-c8adba88-166e-11e8-90c8-6eaf090abebc.png)

I don't really like how this looks, but it gets the job done. Not sure whether it's useful to have a full 'security section only' breadcrumb navigation, e.g.

> [Security](https://jenkins.io/security) » Advisories

(for the list)

and

> [Security](https://jenkins.io/security) » [Advisories](https://jenkins.io/security/advisories) » Security Advisory 2018-02-14

(for each advisory)