### PR TITLE
When not specifying a last affected version, all are.

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -83,13 +83,15 @@ section: security
       Jenkins LTS up to and including
       = page.core.lts&.previous
   - plugins.each do | plugin |
-    - if plugin.previous
-      %li
-        %strong
-          = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
-          Plugin
+    %li
+      %strong
+        = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+        Plugin
+      - if plugin.previous
         up to and including
         = plugin.previous
+      - else
+        (all versions)
 
 %h2
   Fix


### PR DESCRIPTION
Would look like this:

![screen shot](https://user-images.githubusercontent.com/1831569/36510180-7d356e08-1762-11e8-8915-b0abaf5d5dd2.png)
