### PR TITLE
Use title of depublished plugin if available

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -50,7 +50,7 @@ notitle: true
             = site._generated[:update_center].plugins[plugin.name].title
             Plugin
         - else
-          = plugin.name
+          = plugin.title || plugin.name
           Plugin
 
 
@@ -98,7 +98,7 @@ notitle: true
   - plugins.each do | plugin |
     %li
       %strong
-        = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+        = site._generated[:update_center].plugins[plugin.name]&.title || plugin.title || plugin.name
         Plugin
       - if plugin.previous
         up to and including
@@ -121,7 +121,7 @@ notitle: true
     - fixed_plugins.each do | plugin |
       %li
         %strong
-          = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+          = site._generated[:update_center].plugins[plugin.name]&.title || plugin.title || plugin.name
           Plugin
         should be updated to version
         = plugin.fixed
@@ -135,7 +135,7 @@ notitle: true
   %ul
     - unfixed_plugins.each do | plugin |
       %li
-        = site._generated[:update_center].plugins[plugin.name]&.title || plugin.name
+        = site._generated[:update_center].plugins[plugin.name]&.title || plugin.title || plugin.name
         Plugin
 
 

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -52,4 +52,4 @@ section: security
                                 %a{:href => 'https://plugins.jenkins.io/' + plugin.name, :style => 'white-space: nowrap; padding: 2px;'}
                                   = site._generated[:update_center].plugins[plugin.name].title
                               - else
-                                = plugin.name
+                                = plugin.title || plugin.name


### PR DESCRIPTION
Otherwise https://jenkins.io/security/advisory/2018-02-26/ looks weird.