### PR TITLE
[JENKINS-49226] Documentation for new equals condition

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -878,6 +878,9 @@ a multibranch Pipeline.
 environment:: Execute the stage when the specified environment variable is set
 to the given value, for example: `when { environment name: 'DEPLOY_TO', value: 'production' }`
 
+equals:: Execute the stage when the expected value is equal to the actual value,
+for example: `when { equals expected: 2, actual: currentBuild.number }`
+
 expression:: Execute the stage when the specified Groovy expression evaluates
 to true, for example: `when { expression { return params.DEBUG_BUILD } }`
 


### PR DESCRIPTION
[JENKINS-49226](https://issues.jenkins-ci.org/browse/JENKINS-49226)

Downstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/243

Not ready to merge until Declarative 1.2.8 is released.