### PR TITLE
Fix code formatting in advisory

### DIFF
--- a/content/security/advisory/2018-02-26.adoc
+++ b/content/security/advisory/2018-02-26.adoc
@@ -34,7 +34,7 @@ issues:
     * Disable the visualization of Injected Environment variables in the global configuration.
       After this change the data will be accessible only to those ones who have access to raw build.xml files.
       This is a reversible action that can be applied immediately, and can be reverted once you've purged the data on disk (below).
-    * Remove the sensitive data from disk by manually removing corresponding entries from +injectedEnvVars.txt+ files, or deleting the +injectedEnvVars.txt+ files in old build directories.
+    * Remove the sensitive data from disk by manually removing corresponding entries from `injectedEnvVars.txt` files, or deleting the `injectedEnvVars.txt` files in old build directories.
     * Rotate all secrets that have potentially been exposed.
 
 
@@ -176,12 +176,12 @@ issues:
       fixed: 3.8.0
       previous: 3.7.0
   description: |
-    The class handling unauthenticated Git post-commit hook notification requests at the +/git/+ path unnecessarily extended another type that handled requests to the +…/search/+ sub-path.
+    The class handling unauthenticated Git post-commit hook notification requests at the `/git/` path unnecessarily extended another type that handled requests to the `…/search/` sub-path.
 
     This allowed submission of search queries to Jenkins, and getting a list of search results usually available to anyone with Overall/Read permission.
     In current Jenkins releases, those are typically the names of known users (both actual users of Jenkins, and known SCM committers) and nodes (master and agents).
 
-    The class handling requests to +/git/+ no longer extends the class handling requests to the +…/search/+ sub-path, therefore any such requests will fail.
+    The class handling requests to `/git/` no longer extends the class handling requests to the `…/search/` sub-path, therefore any such requests will fail.
 
 
 - id: SECURITY-724
@@ -195,12 +195,12 @@ issues:
       fixed: 2.10.3
       previous: 2.10.2
   description: |
-    The class handling unauthenticated Subversion post-commit hook notification requests at the +/subversion/+ path unnecessarily extended another type that handled requests to the +…/search/+ sub-path.
+    The class handling unauthenticated Subversion post-commit hook notification requests at the `/subversion/` path unnecessarily extended another type that handled requests to the `…/search/` sub-path.
 
     This allowed submission of search queries to Jenkins, and getting a list of search results usually available to anyone with Overall/Read permission.
     In current Jenkins releases, those are typically the names of known users (both actual users of Jenkins, and known SCM committers) and nodes (master and agents).
 
-    The class handling requests to +/subversion/+ no longer extends the class handling requests to the +…/search/+ sub-path, therefore any such requests will fail.
+    The class handling requests to `/subversion/` no longer extends the class handling requests to the `…/search/` sub-path, therefore any such requests will fail.
 
 
 - id: SECURITY-726
@@ -214,12 +214,12 @@ issues:
       fixed: 2.3
       previous: 2.2
   description: |
-    The class handling unauthenticated Mercurial post-commit hook notification requests at the +/mercurial/+ path unnecessarily extended another type that handled requests to the +…/search/+ sub-path.
+    The class handling unauthenticated Mercurial post-commit hook notification requests at the `/mercurial/` path unnecessarily extended another type that handled requests to the `…/search/` sub-path.
 
     This allowed submission of search queries to Jenkins, and getting a list of search results usually available to anyone with Overall/Read permission.
     In current Jenkins releases, those are typically the names of known users (both actual users of Jenkins, and known SCM committers) and nodes (master and agents).
 
-    The class handling requests to +/mercurial/+ no longer extends the class handling requests to the +…/search/+ sub-path, therefore any such requests will fail.
+    The class handling requests to `/mercurial/` no longer extends the class handling requests to the `…/search/` sub-path, therefore any such requests will fail.
 
 
 - id: SECURITY-731


### PR DESCRIPTION
I don't understand why, but the monospace formatting didn't get applied with `+`.