### PR TITLE
Fix typo in the March’s DFW JAM announcement

### DIFF
--- a/content/_data/events/2018-03-20-dallas.adoc
+++ b/content/_data/events/2018-03-20-dallas.adoc
@@ -3,4 +3,4 @@ title: "DFW JAM"
 date: "2018-03-20T19:30:00"
 link: "https://www.meetup.com/DFW-Jenkins-Area-Meetup/events/248036262/"
 ---
-This month, Andrew Bayer will preset: Declarative Pipelines: Tips, Tricks, and Gotchas
+This month, Andrew Bayer will present: Declarative Pipelines: Tips, Tricks, and Gotchas


### PR DESCRIPTION
Just noticed it while working on #1433 

@jenkins-infra/copy-editors @abayer 
