### PR TITLE
Add upgrade guide and changelog for 2.107.1

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1266,23 +1266,6 @@
       pull: 3256
       message: >
         When Jenkins fails to load plugins, show failures that users need to take action on separate from those due to other plugins failing to load.
-    - type: rfe
-      message: >
-        Various performance improvements.
-      references:
-        - pull: 3143
-        - pull: 3155
-        - pull: 3150
-        - pull: 3157
-        - pull: 3198
-        - pull: 3227
-        - pull: 3177
-        - issue: 48350
-        - issue: 48349
-        - issue: 47429
-        - issue: 48348
-        - issue: 48505
-        - issue: 20474
 
     # Most important fixes that might need user attention
     - type: major bug

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1295,26 +1295,15 @@
 
   # Developer
     - type: rfe
+      issue: 48638
+      pull: 3195
+      message: >
+        Developer: <code>Jenkins#getInstance()</code> is now deprecated as its semantics have been a source of confusion for some time. Use <code>#get()</code> in typical cases and <code>Jenkins#getInstanceOrNull()</code> in rare cases (see Javadoc).
+    - type: rfe
       issue: 47718
       pull: 3114
       message: >
         Developer: Deprecate the ambiguous <code>User#getUser(String)</code> in favor of the <code>User#getById()</code> or the new <code>User#getOrCreateByIdOrFullName()</code> methods.
-    - type: rfe
-      pull: 3122
-      message: >
-        Developer: Implement default methods in <code>TaskListener</code> and <code>BuildListener</code> interfaces so they don't have to be implemented in subclasses.
-    - type: rfe
-      pull: 3149
-      message: >
-        Developer: Add <code>AccessControlled#hasPermission(Authentication, Permission)</code> for convenience.
-    - type: rfe
-      pull: 3148
-      message: >
-        Developer: Add <code>ItemGroup#allItems</code> and similar default methods to <code>ItemGroup</code>.
-    - type: rfe
-      pull: 3142
-      message: >
-        Developer: Add default implementations of deprecated methods to <code>BuildableItem</code> and <code>Item</code> so they don't need to be implemented.
     - type: rfe
       pull: 3074
       issue: 27027
@@ -1324,33 +1313,6 @@
       pull: 3191
       message: >
         Developer: Deprecate <code>hudson.util.Service</code> in favor of Java's <code>ServiceLoader</code>.
-    - type: rfe
-      pull: 3162
-      message: >
-        Developer: Introduce <code>Cause.UserIdCause(String)</code> constructor, which allows creating causes for specified users without switching the user context.
-    - type: rfe
-      issue: 48638
-      pull: 3195
-      message: >
-        Developer: <code>Jenkins#getInstance()</code> is now deprecated as its semantics have been a source of confusion for some time. Use <code>#get()</code> in typical cases and <code>Jenkins#getInstanceOrNull()</code> in rare cases (see Javadoc).
-    - type: rfe
-      pull: 3220
-      message: >
-        Developer: Add a constructor to <code>ToolDescriptor</code> so that subclasses are not required
-        to be an inner class of their <code>Describable</code>.
-    - type: rfe
-      pull: 3260
-      message: >
-        Developer: Introduce <code>ACL#lambda</code> convenience method.
-      references:
-        - pull: 3260
-        # TODO: fix link to be more specific
-        - url: http://javadoc.jenkins-ci.org/hudson/security/ACL.html#method.summary
-          title: Javadoc
-    - type: rfe
-      pull: 3279
-      message: >
-        Internal/API: Add <code>DataBoundConstructor</code> to <code>LegacySecurityRealm</code> to facilitate reflective instantiation in Jenkins-related tools and frameworks.
 
   changes:
     - type: bug

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1122,6 +1122,266 @@
       issue: 48350
       message: >
         Improve UI performance with long list of running builds by caching the estimated duration.
+- version: "2.107.1"
+  date: 2018-03-14
+  lts_predecessor: "2.89.4"
+  lts_baseline: "2.107"
+  banner: >
+    This is the first LTS release that includes <a href="https://jenkins.io/blog/2018/01/13/jep-200/">the JEP-200 Remoting and XStream serialization whitelist</a>.
+    This core change requires <a href="https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200">corresponding changes in many plugins</a> for them to be compatible.
+    We strongly recommend that you read the <a href="/doc/upgrade-guide/2.107">LTS upgrade guide</a>, make sure you have good backups before upgrading, and validate this release in a staging environment first.
+  lts_changes:
+
+    # JEP-200
+    - type: major rfe
+      pull: 3120 # and 3230
+      message: >
+        Switch Remoting/XStream blacklist to a whitelist.
+      references:
+        - issue: 47736
+        - url: /blog/2018/01/13/jep-200/
+          title: upgrade guidelines for admins and plugin maintainers
+        - url: https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200
+          title: list of plugins known to be impacted
+        # Whitelisting PRs:
+        # issue: 48946
+        # issue: 49000
+        # issue: 49025
+        # pull: 3234 # 3241, and 3245
+        # pull: 3251
+        # pull: 3252
+        # pull: 3253 # this one has no issue, so add all to references
+        # issue: 49070
+        # issue: 49071
+        # Original Tomcat fix:
+        # issue: 49147
+
+    # Most impactful changes first
+    - type: rfe
+      issue: 48463
+      pull: 3185
+      message: >
+        Jenkins now creates XML 1.1 files to be more accepting of unusual contents.
+
+    # NIO
+    - type: major rfe
+      references:
+        - issue: 36088
+        - issue: 39179
+      pull: 3133
+      message: >
+        Use Java NIO library instead of native code to create and detect symbolic links and Windows junctions to improve compatibility and robustness.
+    - type: rfe
+      pull: 3135
+      message: >
+        Use Java NIO to read and write Unix file permissions by default.
+        The previous behavior can be restored by setting the Java system property <code>hudson.Util.useNativeChmodAndMode</code> to <code>true</code>.
+      references:
+        - issue: 36088
+        - url: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+          title: Jenkins features controlled by system properties
+    - type: rfe
+      references:
+      - issue: 47324
+      - issue: 48405
+      pull: 3169 # and 3173
+      message: >
+        Improve robustness and error handling of various file operations by switching to NIO.
+
+    # Possibly deserving of user attention
+    - type: major rfe # Remoting -- multiple entries merged
+      pull: 3145 # and 3120, and #3071 -- oddly enough in reverse order
+      message: >
+        Update Remoting from 3.14 to 3.17 to integrate multiple fixes and improvements.
+      references:
+        - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md
+          title: full changelog
+        - issue: 37566
+        - issue: 37670
+        - issue: 38696
+        - issue: 46724
+        - issue: 47965
+        - issue: 48055
+        - issue: 48130
+        - issue: 48133
+        - issue: 48309
+        - issue: 47736
+        - issue: 48686
+        - issue: 27035
+        - issue: 49027
+    - type: rfe
+      pull: 3258
+      message: >
+        Remove support for unbounded number of SCM polling threads.
+        Previously, the default was infinite and could be set to between 10 and 100.
+        Existing installations with unbounded SCM polling threads will now use the default of 10, and it is no longer possible to use a value outside of this range.
+    - type: rfe
+      pull: 3129
+      issue: 22474
+      message: >
+        Do not require CSRF crumb to be provided when the request is authenticated using API token.
+    - type: rfe
+      pull: 3036
+      message: >
+        Introduce new <code>hudson.lifecycle.ExitLifecycle</code> to exit instead of restart.
+      references:
+        - issue: 47043
+        - url: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+          title: Jenkins features controlled by system properties
+    - type: rfe
+      message: >
+        Upgrade Executable War from 1.36 to 1.37 to allow supplying <code>jenkins.war</code> command-line arguments via standard input using the <code>--paramsFromStdIn</code> parameter.
+      references:
+        - pull: 3223
+        - title: documentation
+          url: https://github.com/jenkinsci/extras-executable-war#parameters-from-stdin
+
+    # Misc RFEs
+    - type: rfe # SSHD Module, two merged entries
+      message: >
+        Update SSHD Module 2.0 to 2.4 to update Apache Mina SSHD Core from 1.6.0 to 1.7.0, and fire authentication events in <tt>SecurityListener</tt>s when a user connects using SSH.
+      references:
+        - pull: 3278
+        - pull: 3111
+        - url: https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md
+          title: SSHD module changelog
+    - type: rfe
+      issue: 25286
+      pull: 1437
+      message: >
+        Export <tt>assignedLabels</tt> for agents and <tt>labelExpression</tt> for applicable job types in remote API.
+    - type: rfe
+      references:
+        - issue: 43786 # and 49129
+        - url: https://jenkins.io/blog/2018/01/21/overhaul-of-manage-jenkins-page/
+          title: blog post
+      pull: 2857 # and 3266
+      message: >
+        Re-style the Manage Jenkins page, including administrative monitors.
+    - type: rfe
+      pull: 3250
+      message: >
+        Define a minimum required version of the Remoting library (agent communication) and print warnings when an older version is connecting.
+    - type: rfe
+      pull: 3256
+      message: >
+        When Jenkins fails to load plugins, show failures that users need to take action on separate from those due to other plugins failing to load.
+    - type: rfe
+      message: >
+        Various performance improvements.
+      references:
+        - pull: 3143
+        - pull: 3155
+        - pull: 3150
+        - pull: 3157
+        - pull: 3198
+        - pull: 3227
+        - pull: 3177
+        - issue: 48350
+        - issue: 48349
+        - issue: 47429
+        - issue: 48348
+        - issue: 48505
+        - issue: 20474
+
+    # Most important fixes that might need user attention
+    - type: major bug
+      pull: 3196
+      issue: 21017
+      message: >
+        Updating Jenkins jobs and views by XML left fields at their old value if not defined in the new XML.
+    - type: bug
+      pull: 3178
+      issue: 48447
+      message: >
+        Fix HTTP 404 error when clicking on <em>New View</em> sidebar link from another view.
+    - type: bug
+      issue: 22088
+      pull: 3223
+      message: >
+        Upgrade Executable War from 1.36 to 1.37 to prevent multiple copies of <code>winstone-*.jar</code> in the temp folder from using up disk space needlessly.
+    # Task Reactor
+    - type: bug
+      references:
+        - issue: 48725
+        - url: https://github.com/jenkinsci/lib-task-reactor/blob/master/CHANGELOG.md#version-15
+          title: full changelog
+      pull: 3270
+      message: >
+        Update to task reactor version 1.5 to prevent hanging of Jenkins on startup/reload when an initialization task throws an unhandled exception.
+
+  # Developer
+    - type: rfe
+      issue: 47718
+      pull: 3114
+      message: >
+        Developer: Deprecate the ambiguous <code>User#getUser(String)</code> in favor of the <code>User#getById()</code> or the new <code>User#getOrCreateByIdOrFullName()</code> methods.
+    - type: rfe
+      pull: 3122
+      message: >
+        Developer: Implement default methods in <code>TaskListener</code> and <code>BuildListener</code> interfaces so they don't have to be implemented in subclasses.
+    - type: rfe
+      pull: 3149
+      message: >
+        Developer: Add <code>AccessControlled#hasPermission(Authentication, Permission)</code> for convenience.
+    - type: rfe
+      pull: 3148
+      message: >
+        Developer: Add <code>ItemGroup#allItems</code> and similar default methods to <code>ItemGroup</code>.
+    - type: rfe
+      pull: 3142
+      message: >
+        Developer: Add default implementations of deprecated methods to <code>BuildableItem</code> and <code>Item</code> so they don't need to be implemented.
+    - type: rfe
+      pull: 3074
+      issue: 27027
+      message: >
+        Developer: Capture more authentication-related events in <code>SecurityListener</code>.
+    - type: rfe
+      pull: 3191
+      message: >
+        Developer: Deprecate <code>hudson.util.Service</code> in favor of Java's <code>ServiceLoader</code>.
+    - type: rfe
+      pull: 3162
+      message: >
+        Developer: Introduce <code>Cause.UserIdCause(String)</code> constructor, which allows creating causes for specified users without switching the user context.
+    - type: rfe
+      issue: 48638
+      pull: 3195
+      message: >
+        Developer: <code>Jenkins#getInstance()</code> is now deprecated as its semantics have been a source of confusion for some time. Use <code>#get()</code> in typical cases and <code>Jenkins#getInstanceOrNull()</code> in rare cases (see Javadoc).
+    - type: rfe
+      pull: 3220
+      message: >
+        Developer: Add a constructor to <code>ToolDescriptor</code> so that subclasses are not required
+        to be an inner class of their <code>Describable</code>.
+    - type: rfe
+      pull: 3260
+      message: >
+        Developer: Introduce <code>ACL#lambda</code> convenience method.
+      references:
+        - pull: 3260
+        # TODO: fix link to be more specific
+        - url: http://javadoc.jenkins-ci.org/hudson/security/ACL.html#method.summary
+          title: Javadoc
+    - type: rfe
+      pull: 3279
+      message: >
+        Internal/API: Add <code>DataBoundConstructor</code> to <code>LegacySecurityRealm</code> to facilitate reflective instantiation in Jenkins-related tools and frameworks.
+
+  changes:
+    - type: bug
+      pull: 3313
+      issue: 49543
+      message: >
+        Make JEP-200 serialization whitelist more reliable on old versions of Tomcat 8.
+    - type: bug
+      pull: 3292
+      message: >
+        Don't show input validation errors in optional numeric form fields (regression in 2.105).
+      references:
+        - issue: 49387
+        - issue: 49520
 
 
 # DO NOT EDIT THIS FILE DIRECTLY

--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -53,6 +53,13 @@ link:https://issues.jenkins-ci.org/browse/JENKINS-22474[JENKINS-22474]
 It is no longer necessary to provide a CSRF crumb when sending an HTTP request with `Basic` authentication that provides the authenticating user's API token in place of a password.
 // Included here so those for whom this prevented enabling CSRF crumbs can finally do this.
 
+==== Known issues
+
+This is a list of confirmed regressions introduced in this release.
+
+// JENKINS-48821 is not needed here as it was introduced in 2.89.x due to backport
+* link:https://issues.jenkins-ci.org/browse/JENKINS-49392[JENKINS-49392]:
+  Some job configuration forms may fail to load if plugin:violations[Violations Plugin] is installed.
 
 // TODO Unsure this change is notable enough. Thoughts?
 //==== Unbounded polling threads

--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -1,0 +1,71 @@
+---
+layout: documentation
+title:  Jenkins Upgrade Guide
+notitle: true
+---
+
+== Upgrading to Jenkins LTS 2.107.x
+
+Each section covers the upgrade from the previous LTS release, the section on 2.107.1 covers the upgrade from 2.89.4.
+
+=== Upgrading to Jenkins LTS 2.107.1
+
+==== Whitelist for Remoting and XStream (JEP-200)
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736],
+https://github.com/jenkinsci/jep/blob/master/jep/200/README.adoc[JEP-200 proposal and design],
+https://jenkins.io/blog/2018/01/13/jep-200/[announcement blog post from January 13]
+
+To prevent further security issues related to unsafe deserialization of Java objects, we switched to a whitelist for Remoting (the communication library mostly used between agents and master) and XStream (the XML serialization library).
+This change means that only classes considered to be safe to (de)serialize will now be (de)serialized.
+
+See https://jenkins.io/blog/2018/01/13/jep-200/#for-jenkins-administrators[the announcement blog post] for advice on how to upgrade Jenkins to a version that includes this change.
+
+Many plugins require updates to be compatible with this new restriction, otherwise they will fail to load or save data on disk, or fail to execute commands e.g. during a build.
+For a list of known affected plugins, see https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[this wiki page].
+For a list of issues related to JEP-200, see https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20JEP-200[the label JEP-200 in the issue tracker].
+
+==== XML files are now stored as XML 1.1
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-48463[JENKINS-48463]
+
+Jenkins now creates XML 1.1 files to be more accepting of unusual contents.
+The XML processing instruction in those XML files will now indicate the version 1.1 instead of 1.0 as before:
+
+  <?xml version="1.1" encoding="UTF-8" ?>
+
+Previous versions of Jenkins cannot read XML 1.1 files, so downgrading Jenkins to an earlier release will result in errors.
+
+In many cases, it _should_ be sufficient to just replace `1.1` with `1.0` to make them readable again, but note that downgrades of Jenkins are generally unsupported.
+
+==== Updating Jenkins jobs and views by XML now resets unspecified fields
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-21017[JENKINS-21017]
+
+In previous releases, updating jobs and views by XML left fields at their old value if not defined in the new XML file that the job or view is being updated with.
+This long-standing bug has now been fixed, and Jenkins will reset unspecified fields to their default value, instead of retaining the previously defined value.
+This impacts the Remote API (`POST config.xml`), the CLI (`update-job` and similar commands), and any plugins using the same mechanisms, such as Job DSL Plugin.
+
+==== CSRF crumb no longer required when authenticating using API token
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-22474[JENKINS-22474]
+
+It is no longer necessary to provide a CSRF crumb when sending an HTTP request with `Basic` authentication that provides the authenticating user's API token in place of a password.
+// Included here so those for whom this prevented enabling CSRF crumbs can finally do this.
+
+
+// TODO Unsure this change is notable enough. Thoughts?
+//==== Unbounded polling threads
+//
+//link:https://github.com/jenkinsci/jenkins/pull/3258[PR 3258]
+//
+//In previous releases, Jenkins allowed an unbounded number of SCM polling threads by default.
+//This could impact stability, as sometimes hundreds of threads would be blocked by SCM polling.
+//
+//Instances which previously had allowed an unbounded number of SCM polling threads will now use the default of 10.
+//It is no longer possible to use a value outside the range of 10 (minimum, inclusive) and 100 (maximum, inclusive).
+
+// TODO Unsure: Update SSHD Module 2.0 to 2.4 to update Apache Mina SSHD Core from 1.6.0 to 1.7.0
+
+// TODO Unsure due to lack of demonstrated use case: --paramsFromStdIn
+// TODO Unsure whether hudson.lifecycle.ExitLifecycle is notable enough

--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -27,15 +27,18 @@ For a list of issues related to JEP-200, see https://issues.jenkins-ci.org/issue
 
 ==== XML files are now stored as XML 1.1
 
-link:https://issues.jenkins-ci.org/browse/JENKINS-48463[JENKINS-48463]
+link:https://issues.jenkins-ci.org/browse/JENKINS-48463[JENKINS-48463],
+link:https://issues.jenkins-ci.org/browse/JENKINS-50126[JENKINS-50126]
 
 Jenkins now creates XML 1.1 files to be more accepting of unusual contents.
 The XML processing instruction in those XML files will now indicate the version 1.1 instead of 1.0 as before:
 
   <?xml version="1.1" encoding="UTF-8" ?>
 
-Previous versions of Jenkins cannot read XML 1.1 files, so downgrading Jenkins to an earlier release will result in errors.
+This change may result in Jenkins refusing to load or parse malformed files differently from previous releases:
+For example, we have received a report (JENKINS-50126) that it now refuses to load XML files from disk that do not start with an XML processing instruction, but instead with a line break (empty line).
 
+Previous versions of Jenkins cannot read XML 1.1 files, so downgrading Jenkins to an earlier release will result in errors.
 In many cases, it _should_ be sufficient to just replace `1.1` with `1.0` to make them readable again, but note that downgrades of Jenkins are generally unsupported.
 
 ==== Updating Jenkins jobs and views by XML now resets unspecified fields


### PR DESCRIPTION
# Changelog

I added *all* "developer" entries, might be a bit much. I plan to cull the minor ones. `Jenkins#getInstance` stays though, possibly others.

> ![changelog](https://user-images.githubusercontent.com/1831569/36984763-efc9add0-2095-11e8-955b-486694df5d0b.png)

---

# Upgrade Guide

Please see the sources for some items I wasn't sure are notable enough. Feedback would be appreciated.

> ![upgrade guide](https://user-images.githubusercontent.com/1831569/36984773-f3b8e9f6-2095-11e8-8968-1744e9ae6353.png)

