### PR TITLE
corrects syntax of agent sections

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -53,7 +53,7 @@ various languages.
 ----
 // Declarative //
 pipeline {
-    agent { docker 'maven:3.3.3' }
+    agent { docker { image 'maven:3.3.3' } }
     stages {
         stage('build') {
             steps {
@@ -80,7 +80,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker 'node:6.3' }
+    agent { docker { image 'node:6.3' } }
     stages {
         stage('build') {
             steps {
@@ -107,7 +107,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker 'ruby' }
+    agent { docker { image 'ruby' } }
     stages {
         stage('build') {
             steps {
@@ -134,7 +134,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker 'python:3.5.1' }
+    agent { docker { image 'python:3.5.1' } }
     stages {
         stage('build') {
             steps {
@@ -161,7 +161,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker 'php' }
+    agent { docker { image 'php' } }
     stages {
         stage('build') {
             steps {


### PR DESCRIPTION
Change lines like `agent { docker 'node:6.3' }` to lines like `agent { docker { image 'node:6.3' } }`.