### PR TITLE
[JENKINS-49994] Set up a redirect for messages about serialization of anonymous classes

### DIFF
--- a/content/redirect/serialization-of-anonymous-classes.adoc
+++ b/content/redirect/serialization-of-anonymous-classes.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://issues.jenkins-ci.org/browse/JENKINS-49994
+---


### PR DESCRIPTION
Placeholder for messages produced by https://github.com/jenkinsci/remoting/pull/259, as suggested in https://github.com/jenkinsci/jenkins/pull/3332#issuecomment-371144549. I may change the link target to a wiki page or a blog post or something later—just wanted a redirect in place so that the code PRs would have something better to point to.

@reviewbybees @oleg-nenashev @daniel-beck @rysteboe