### PR TITLE
Update the list of known issues in 2.107.1

### DIFF
--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -60,9 +60,16 @@ It is no longer necessary to provide a CSRF crumb when sending an HTTP request w
 
 This is a list of confirmed regressions introduced in this release.
 
+// TODO: post known regressions for all releases?
+// JENKINS-48770 - introduced in 2.89
 // JENKINS-48821 is not needed here as it was introduced in 2.89.x due to backport
 * link:https://issues.jenkins-ci.org/browse/JENKINS-49392[JENKINS-49392]:
   Some job configuration forms may fail to load if plugin:violations[Violations Plugin] is installed.
+
+In addition to the list above,
+there is a number of link:https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins affected by fix for JEP-200]
+which have not been fixed yet.
+Please refer to the linked page to see the current status.
 
 // TODO Unsure this change is notable enough. Thoughts?
 //==== Unbounded polling threads

--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -66,11 +66,9 @@ This is a list of confirmed regressions introduced in this release.
 // JENKINS-49588 - unconfirmed, maybe introduced in 2.107
 * link:https://issues.jenkins-ci.org/browse/JENKINS-49392[JENKINS-49392]:
   Some job configuration forms may fail to load if plugin:violations[Violations Plugin] is installed.
-
-In addition to the list above,
-there is a number of link:https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins affected by fix for JEP-200]
-which have not been fixed yet.
-Please refer to the linked page to see the current status.
+* link:https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736]:
+  Some link:https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins affected by fix for JEP-200]
+  may be not fixed yet. Check the linked page for the up-to-date state and workarounds.
 
 // TODO Unsure this change is notable enough. Thoughts?
 //==== Unbounded polling threads

--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -63,6 +63,7 @@ This is a list of confirmed regressions introduced in this release.
 // TODO: post known regressions for all releases?
 // JENKINS-48770 - introduced in 2.89
 // JENKINS-48821 is not needed here as it was introduced in 2.89.x due to backport
+// JENKINS-49588 - unconfirmed, maybe introduced in 2.107
 * link:https://issues.jenkins-ci.org/browse/JENKINS-49392[JENKINS-49392]:
   Some job configuration forms may fail to load if plugin:violations[Violations Plugin] is installed.
 

--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -68,7 +68,8 @@ This is a list of confirmed regressions introduced in this release.
   Some job configuration forms may fail to load if plugin:violations[Violations Plugin] is installed.
 * link:https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736]:
   Some link:https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins affected by fix for JEP-200]
-  may be not fixed yet. Check the linked page for the up-to-date state and workarounds.
+  may be not fixed yet.
+** Check the linked page for the up-to-date state and workarounds.
 
 // TODO Unsure this change is notable enough. Thoughts?
 //==== Unbounded polling threads


### PR DESCRIPTION
Follow-up to @rtyler's request at the governance meeting.  I have reviewed the recently reported issues, and I do not see new&&confirmed regressions excepting the JEP-200 plugin fallout. So I just added other regression-alike issues which should be ignored + a paragraph about JEP-200

@daniel-beck 
