### PR TITLE
Updated CLI redirect

### DIFF
--- a/content/redirect/cli.adoc
+++ b/content/redirect/cli.adoc
@@ -1,6 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI
-localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Jenkins+CLI
+redirect_url: /doc/book/managing/cli/
 ---


### PR DESCRIPTION
The [wiki page](https://wiki.jenkins.io/display/JENKINS/Jenkins+CLI) actually says

> More up-to-date information is available in the Jenkins documentation at https://jenkins.io/doc/book/managing/cli/

so why not go there directly?

Shown from `/cli/` in the product:

```html
<p>You can access various features in Jenkins through a command-line tool. See <a href="https://jenkins.io/redirect/cli">the documentation</a> for more details of this feature.To get started, download <a href="/jnlpJars/jenkins-cli.jar">jenkins-cli.jar</a>, and run it as follows:</p>
```

@reviewbybees