### PR TITLE
Better redirect target for serialization-of-anonymous-classes

### DIFF
--- a/content/redirect/serialization-of-anonymous-classes.adoc
+++ b/content/redirect/serialization-of-anonymous-classes.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://issues.jenkins-ci.org/browse/JENKINS-49994
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Serialization+of+anonymous+classes
 ---


### PR DESCRIPTION
Amending #1439 with a [wiki page](https://wiki.jenkins.io/display/JENKINS/Serialization+of+anonymous+classes) I created with advice. CC @daniel-beck @oleg-nenashev