### PR TITLE
[GSoC 2018] - Add extra office hours timeslots to the list

### DIFF
--- a/content/projects/gsoc.adoc
+++ b/content/projects/gsoc.adoc
@@ -60,6 +60,13 @@ Schedule:
 * Americas/Europe: Every Wednesday, 07:30-09:00 PM UTC
 ** link:https://calendar.google.com/event?action=TEMPLATE&tmeid=M2FrZjhjOTM3Y2diajhlOWg5YnE5YmcwbmJfMjAxODAzMDdUMTkzMDAwWiBvLnYubmVuYXNoZXZAbQ&tmsrc=o.v.nenashev%40gmail.com&scp=ALL[Add to your calendar]
 
+Extra sessions:
+
+* Mar 22, 06:00-07:00 PM UTC - Electronic Design Automation Plugin project idea sync-up
+* Mar 23, 08:00-09:00 AM UTC - General Q&A session
+* Mar 26, 08:00-09:00 AM UTC - General Q&A session
+* Mar 26, 06:00-07:00 PM UTC - General Q&A session
+
 More meetings may be scheduled on-demand.
 All meetings will be announced in the public GSoC mailing list.
 


### PR DESCRIPTION
I will announce it in the ML later.
IMHO there is no need to add them to the events list