### PR TITLE
Forgot to put alt titles for depublished plugins

### DIFF
--- a/content/security/advisory/2018-03-26.adoc
+++ b/content/security/advisory/2018-03-26.adoc
@@ -71,6 +71,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   plugins:
     - name: perforce
+      title: Perforce
       previous: 1.3.36
   description: |
     Perforce Plugin encrypts its credentials using DES and a public key stored in its public source code, so it only serves as basic obfuscation.
@@ -125,6 +126,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   plugins:
     - name: liquibase-runner
+      title: Liquibase Runner
       previous: 1.3.0
   description: |
     Liquibase Runner Plugin allows users with Job/Configure permission to configure its build step in a way that loads arbitrary class files into the Jenkins master JVM, resulting in arbitrary code execution.
@@ -139,6 +141,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   plugins:
     - name: perforce
+      title: Perforce
       previous: 1.3.36
   description: |
     Jenkins prevents users with Extended Read permission from obtaining secrets such as credentials stored in job configurations.
@@ -159,6 +162,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
   plugins:
     - name: copy-to-slave
+      title: Copy To Slave
       previous: 1.4.4
   description: |
     Copy To Slave Plugin allows users with Job/Configure permissions to configure it in such a way that it allows obtaining arbitrary files accessible to the Jenkins master process from the Jenkins master file system.


### PR DESCRIPTION
Plugins that have been removed from publication don't get automatic titles, so provide them explicitly.