### PR TITLE
Make crushinate safe for files with spaces

### DIFF
--- a/scripts/crushinator.sh
+++ b/scripts/crushinator.sh
@@ -16,11 +16,11 @@ if [ $? -ne 0 ]; then
 fi;
 
 
-pngcrush -reduce $FILENAME $OUTPUTFILE
+pngcrush -reduce "$FILENAME" "$OUTPUTFILE"
 
 if [ $? -ne 0 ]; then
     echo "Error crushing ${FILENAME} to ${OUTPUTFILE}"
     exit 1;
 fi;
 
-mv $OUTPUTFILE $FILENAME
+mv "$OUTPUTFILE" "$FILENAME"


### PR DESCRIPTION
@rtyler @oleg-nenashev 
Crushinator script generates this output: 

```
$ ./scripts/crushinator.sh "content/images/post-images/Screen Shot 2016-11-08 at 4.23.34 PM.png"
./scripts/crushinator.sh: line 6: [: too many arguments
Could not find file: content/images/post-images/Screen
Could not find file: Shot
Could not find file: 2016-11-09
Could not find file: at
Could not find file: 3.36.27
Could not find file: PM.png
Could not find file: content/images/post-images/Screen
Could not find file: Shot
Could not find file: 2016-11-09
Could not find file: at
Could not find file: 3.36.27
Could not find file: PM.png_pngcrush_201804091329
CPU time decode 0.000000, encode 0.000000, other 0.000460, total 0.000460 sec
usage: mv [-f | -i | -n] [-v] source target
       mv [-f | -i | -n] [-v] source ... directory
```

This fixes.