### PR TITLE
Fix data errors introduced in format migration

### DIFF
--- a/content/security/advisory/2018-01-22.adoc
+++ b/content/security/advisory/2018-01-22.adoc
@@ -26,7 +26,7 @@ issues:
   reporter: Adith Sudhakar
   cvss:
     severity: high
-    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
   plugins:
     - name: pmd
       fixed: 1.8
@@ -35,7 +35,7 @@ issues:
   reporter: Adith Sudhakar
   cvss:
     severity: high
-    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
   plugins:
     - name: checkstyle
       fixed: 3.50
@@ -44,7 +44,7 @@ issues:
   reporter: Adith Sudhakar
   cvss:
     severity: high
-    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
   plugins:
     - name: dry
       fixed: 2.50
@@ -53,16 +53,15 @@ issues:
   reporter: Adith Sudhakar
   cvss:
     severity: high
-    vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
   plugins:
     - name: findbugs
       fixed: 4.72
       previous: 4.71
-- id: SECURITY-675
-  reporter: Jesse Glick, CloudBees, Inc.
+- id: SECURITY-695
   cvss:
     severity: medium
-    vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N
+    vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
   plugins:
     - name: warnings
       fixed: 4.65
@@ -75,10 +74,11 @@ issues:
     - name: ant
       fixed: 1.8
       previous: 1.7
-- id: SECURITY-695
+- id: SECURITY-675
   cvss:
     severity: high
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
+  reporter: Jesse Glick, CloudBees, Inc.
   plugins:
     - name: workflow-durable-task-step
       fixed: 2.18


### PR DESCRIPTION
I messed up the migration in https://github.com/jenkins-infra/jenkins.io/commit/37a0b47b644d76ee32e8458ac0935e9731317c8b and introduced mistakes:

- Metadata for SECURITY-675 and SECUIRTY-695 were switched (severity is the only one shown).
- Link targets to CVSS vectors for multiple issues were wrong, but labels were correct.