### PR TITLE
Typo: replace essense with essence.

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -250,7 +250,7 @@ organization requirements, and may be anything from publishing built artifacts
 to an Artifactory server, to pushing code to a production system.
 
 At this stage of the example Pipeline, both the "Build" and "Test" stages have
-successfully executed. In essense, the "Deploy" stage will only execute
+successfully executed. In essence, the "Deploy" stage will only execute
 assuming previous stages completed successfully, otherwise the Pipeline would
 have exited early.
 


### PR DESCRIPTION
In the Jenkinsfile documentation the word `essense` should be spelled `essence`.