### PR TITLE
[JEP-200] - Update maintenance guidelines to reflect the May 01 change

### DIFF
--- a/content/blog/2018/03/2018-03-15-jep-200-lts.adoc
+++ b/content/blog/2018/03/2018-03-15-jep-200-lts.adoc
@@ -122,6 +122,14 @@ If you see this kind of message, we highly recommend reporting it so that it can
 
 === Reporting JEP-200 issues
 
+[NOTE]
+====
+Starting from May 01, JEP-200 issues are triaged by plugin and core maintainers.
+JEP-200 maintainers are available for code reviews if needed,
+but they will not be reviewing cases in JIRA and searching for miscategorized issues on a daily basis.
+If you experience new JEP-200 regressions, please follow the guidelines below.
+====
+
 Please report any issues you encounter matching the above pattern in the 
 link:https://issues.jenkins-ci.org/[Jenkins issue tracker], under the appropriate plugin component.
 Before reporting please check whether this issue has already been reported.
@@ -133,7 +141,8 @@ Before reporting please check whether this issue has already been reported.
 You can find examples of previously reported issues using link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20JEP-200[this query].
 
 Jenkins developers will evaluate issues and strive to offer a fix in the form of a core and/or plugin update.
-Right after the feature release there will be a special team triaging the reports with high priority
+Right after the feature release there was be a special team triaging the reports.
+Starting from May 01 the issues will be triaged by plugin and core maintainers.
 See link:https://github.com/jenkinsci/jep/tree/master/jep/200#rollout-plan[JEP-200 Maintenance plan] for more info.
 
 For more details and current status, see


### PR DESCRIPTION
Follow-up to https://groups.google.com/forum/#!topic/jenkinsci-dev/AUdrTLmezgU . There was no votes against the change, so I propose to go forward and update the docs.

<img width="1113" alt="screen shot 2018-04-30 at 12 28 25" src="https://user-images.githubusercontent.com/3000480/39438571-dbb96bc4-4ca4-11e8-9962-f89f88ff364a.png">


Also Wiki update: https://wiki.jenkins.io/pages/viewpreviousversions.action?pageId=138446089

@jglick @reviewbybees
