### PR TITLE
Remove JENKINS-9104 fix from release to unblock it

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -2552,14 +2552,6 @@
         - issue: 50616
       message:
         Whitelist <code>java.util.EnumMap</code> and <code>org.jruby.RubyNil</code> for use in XStream (XML serialization) and Remoting (agent communication).
-    - type: bug
-      pull: 3357
-      message: >
-        Fix issue preventing process killing vetoes being effective on agents.
-      references:
-        - issue: 9104
-        - title: <code>ProcessKillingVeto</code> extension point implementations
-          url: https://jenkins.io/doc/developer/extensions/jenkins-core/#processkillingveto
     - type: rfe
       pull: 3082
       message: >


### PR DESCRIPTION
The test for this change fails for KK, so to unblock the release he's going to release the previous commit.
