### PR TITLE
[GSoC 2018] - update Code Coverage API Plugin page

### DIFF
--- a/content/projects/gsoc/2018/code-coverage-api-plugin.adoc
+++ b/content/projects/gsoc/2018/code-coverage-api-plugin.adoc
@@ -7,7 +7,6 @@ student:
   name: "Shenyu Zheng"
   id: "cizezsy"
   github: "cizezsy"
-  irc: "TODO"
 mentors:
 - name: "Steven Christou"
   id: "schristou"
@@ -25,3 +24,8 @@ however they all are using similar charts and similar content.
 Instead of having one plugin for each code coverage result it would be best if we could merge them all into one plugin which will handle code coverage.
 
 link:https://docs.google.com/document/d/10ko6W07pIpRqgYcv2Eq6tZwSg1UUybzJ9AsMZszfiXA/edit#heading=h.jv1f2icy8a5j[More info about the project]
+
+=== Others
+
+- Chat: https://gitter.im/jenkinsci/code-coverage-api-plugin[Gitter]
+- Repo: https://github.com/jenkinsci/code-coverage-api-plugin[code-coverage-api-plugin]

--- a/content/projects/gsoc/2018/code-coverage-api-plugin.adoc
+++ b/content/projects/gsoc/2018/code-coverage-api-plugin.adoc
@@ -7,6 +7,7 @@ student:
   name: "Shenyu Zheng"
   id: "cizezsy"
   github: "cizezsy"
+  irc: "cizezsy"
 mentors:
 - name: "Steven Christou"
   id: "schristou"
@@ -27,8 +28,3 @@ however they all are using similar charts and similar content.
 Instead of having one plugin for each code coverage result it would be best if we could merge them all into one plugin which will handle code coverage.
 
 link:https://docs.google.com/document/d/10ko6W07pIpRqgYcv2Eq6tZwSg1UUybzJ9AsMZszfiXA/edit#heading=h.jv1f2icy8a5j[More info about the project]
-
-=== Others
-
-- Chat: https://gitter.im/jenkinsci/code-coverage-api-plugin[Gitter]
-- Repo: https://github.com/jenkinsci/code-coverage-api-plugin[code-coverage-api-plugin]


### PR DESCRIPTION
Adding chat channel and repository address in Code Coverage API Plugin project page.