### PR TITLE
Tidy up this footnote

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -19,7 +19,7 @@ Jenkins Pipeline provides an extensible set of tools for modeling
 simple-to-complex delivery pipelines "as code". The definition of a Jenkins
 Pipeline is typically written into a text file (called a `Jenkinsfile`) which in
 turn is checked into a project's source control repository.
-footnoteref:[scm,https://en.wikipedia.org/wiki/Source_control_management[Source Control Management]]
+footnoteref:[scm,link:https://en.wikipedia.org/wiki/Source_control_management[Source Control Management]]
 
 For more information about Pipeline and what a `Jenkinsfile` is, refer to the
 respective link:/doc/book/pipeline[Pipeline] and


### PR DESCRIPTION
The `link:` addition is required, otherwise AsciiDoctor doesn't know that this
supposed to be rendered as a marked up link in the footnotes.

Let this serve as a warning to the otherwise lazy no-link:-adding asciidoc
authors out there :smiling_imp:

Fixes WEBSITE-482