### PR TITLE
Minor cleanup in security advisories

### DIFF
--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -11,6 +11,8 @@ section: security
   adocs = Dir.glob(File.join(advisories_dir, '*.{ad,adoc}'))
   years = adocs.select { |it| it =~ /(20\d\d)/ }.map { |it| /(20\d\d)/.match(it)[1] }.uniq.sort
 
+  Plugin = Struct.new(:name, :title)
+
 .container
   .row
     %p
@@ -42,7 +44,7 @@ section: security
                         - if page.core
                           %li
                             Affects Jenkins Core
-                        - plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
+                        - plugins = page.issues.collect { |issue| issue.plugins }.flatten.keep_if { |p| p }.collect { |p| Plugin.new(p.name, p.title) }.uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
                         - if plugins.size > 0
                           %li
                             %span{:style => 'white-space: nowrap;'}

--- a/content/security/advisory/2018-03-26.adoc
+++ b/content/security/advisory/2018-03-26.adoc
@@ -78,7 +78,7 @@ issues:
       title: Perforce
       previous: 1.3.36
   description: |
-    Perforce Plugin encrypts its credentials using DES and a public key stored in its public source code, so it only serves as basic obfuscation.
+    Perforce Plugin encrypts its credentials using DES and an encryption key stored in its public source code, so it only serves as basic obfuscation.
     This allowed users with Jenkins master local file system access and Jenkins administrators to retrieve the stored password.
     The latter could result in exposure of the passwords through browser extensions, cross-site scripting vulnerabilities, and similar situations.
 


### PR DESCRIPTION
- Don't list plugins twice if they have different properties
- Fix wrong word choice in 2018-03-26 advisory