### PR TITLE
Wording for today's security blog post

### DIFF
--- a/content/blog/2018/05/2018-05-09-security-advisory.adoc
+++ b/content/blog/2018/05/2018-05-09-security-advisory.adoc
@@ -14,7 +14,7 @@ Additionally, we announce previously published security issues and corresponding
 
 * plugin:blackduck-hub[Black Duck Hub]
 * plugin:groovy-postbuild[Groovy Postbuild]
-* plugin:gitlab-hook[Gitlab Hook] (unreleased)
+* plugin:gitlab-hook[Gitlab Hook] (fix unreleased)
 
 For an overview of what was fixed, see the link:/security/advisory/2018-05-09[security advisory].
 For an overview on the possible impact of these changes on upgrading Jenkins LTS, see our link:/doc/upgrade-guide/2.107/#upgrading-to-jenkins-lts-2-107-3[LTS upgrade guide].


### PR DESCRIPTION
Clarify that the security fix is unreleased, not the plugin.