### PR TITLE
[INFRA-1635] Correct the property name for 2.107 advisory / upgrade guide

### DIFF
--- a/content/doc/upgrade-guide/2.107.adoc
+++ b/content/doc/upgrade-guide/2.107.adoc
@@ -17,7 +17,7 @@ link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786]
 The Jenkins user database now restricts user names for user signup.
 Only alphanumeric, dash, and underscore characters are allowed.
 
-To change what user names are legal, set the system property `hudson.model.HudsonPrivateSecurityRealm.ID_REGEX` to a regular expression that any legal user name must match.
+To change what user names are legal, set the system property `hudson.security.HudsonPrivateSecurityRealm.ID_REGEX` to a regular expression that any legal user name must match.
 
 
 === Upgrading to Jenkins LTS 2.107.2

--- a/content/security/advisory/2018-05-09.adoc
+++ b/content/security/advisory/2018-05-09.adoc
@@ -39,7 +39,7 @@ issues:
     This could be used to confuse administrators (appearing to be a different user) while preventing deletion of such users through the UI.
 
     User registration in the built-in Jenkins user database now limits user names to those containing alphanumeric, dash, and underscore characters.
-    Administrators can customize this restriction by setting the `hudson.model.HudsonPrivateSecurityRealm.ID_REGEX` system property to a regular expression that will be used instead to determine whether a given user name is valid.
+    Administrators can customize this restriction by setting the `hudson.security.HudsonPrivateSecurityRealm.ID_REGEX` system property to a regular expression that will be used instead to determine whether a given user name is valid.
 
 
 - id: SECURITY-788


### PR DESCRIPTION
From `hudson.model.HudsonPrivateSecurityRealm.ID_REGEX` to `hudson.security.HudsonPrivateSecurityRealm.ID_REGEX`

[INFRA-1635](https://issues.jenkins-ci.org/browse/INFRA-1635)

@reviewbybees @daniel-beck