### PR TITLE
Fix xref to Declarative Directive Generator

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -66,7 +66,8 @@ with the following exceptions:
 * A property reference statement is treated as no-argument method invocation. So for
   example, input is treated as input()
 
-You can use the <<getting-started#directive-generator,Declarative Directive Generator>> 
+You can use the
+link:../getting-started/#directive-generator[Declarative Directive Generator]
 to help you get started with configuring the directives and sections in your
 Declarative Pipeline.
 
@@ -262,7 +263,7 @@ of the following <<post-conditions, post-condition>> blocks: `always`,
 `unstable`, and `cleanup`. These condition blocks allow the execution
 of steps inside each condition depending on the completion status of
 the Pipeline or stage. The condition blocks are executed in the order
-shown below. 
+shown below.
 
 [cols="^10h,>90a",role=syntax]
 |===
@@ -906,19 +907,19 @@ for example: `when { changeset glob: "ReadMe.*", caseSensitive: true }`
 
 changeRequest:: Executes the stage if the current build is for a "change request"
 (a.k.a. Pull Request on GitHub and Bitbucket, Merge Request on GitLab or Change in Gerrit etc.).
-When no parameters are passed the stage runs on every change request, 
-for example: `when { changeRequest() }`. 
+When no parameters are passed the stage runs on every change request,
+for example: `when { changeRequest() }`.
 +
-By adding a filter attribute with parameter to the change request, 
+By adding a filter attribute with parameter to the change request,
 the stage can be made to run only on matching change requests.
-Possible attributes are 
-`id`, `target`, `branch`, `fork`, `url`, `title`, `author`, `authorDisplayName`, and `authorEmail`. 
+Possible attributes are
+`id`, `target`, `branch`, `fork`, `url`, `title`, `author`, `authorDisplayName`, and `authorEmail`.
 Each of these corresponds to
 a `CHANGE_*` environment variable, for example: `when { changeRequest target: 'master' }`.
 +
-The optional parameter `comparator` may be added after an attribute 
-to specify how any patterns are evaluated for a match: 
-`EQUALS` for a simple string comparison (the default), 
+The optional parameter `comparator` may be added after an attribute
+to specify how any patterns are evaluated for a match:
+`EQUALS` for a simple string comparison (the default),
 `GLOB` for an ANT style path glob (same as for example `changeset`), or
 `REGEXP` for regular expression matching.
 Example: `when { changeRequest authorEmail: "[\\w_-.]+@example.com", comparator: 'REGEXP' }`
@@ -937,11 +938,11 @@ Example: `when { tag "release-*" }`.
 If an empty pattern is provided the stage will execute if the `TAG_NAME` variable exists
 (same as `buildingTag()`).
 +
-The optional parameter `comparator` may be added after an attribute 
-to specify how any patterns are evaluated for a match: 
-`EQUALS` for a simple string comparison, 
+The optional parameter `comparator` may be added after an attribute
+to specify how any patterns are evaluated for a match:
+`EQUALS` for a simple string comparison,
 `GLOB` (the default) for an ANT style path glob (same as for example `changeset`), or
-`REGEXP` for regular expression matching. 
+`REGEXP` for regular expression matching.
 For example: `when { tag pattern: "release-\\d+", comparator: "REGEXP"}`
 
 not:: Execute the stage when the nested condition is false.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -66,7 +66,7 @@ with the following exceptions:
 * A property reference statement is treated as no-argument method invocation. So for
   example, input is treated as input()
 
-You can use the link://../getting-started#directive-generator[Declarative Directive Generator]
+You can use the <<getting-started#directive-generator,Declarative Directive Generator>> 
 to help you get started with configuring the directives and sections in your
 Declarative Pipeline.
 


### PR DESCRIPTION
The current "link:" syntax results in a 404. Updated the link to use AsciiDoc cross-reference syntax, per https://asciidoctor.org/docs/asciidoc-writers-guide/#cross-references.