### PR TITLE
Fix changelog for 2.125

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -2707,7 +2707,6 @@
       issue: 27329
       message: >
         Do not remove workspaces for projects with builds in progress.
-    - type: rfe
     # pull: 3436 too minor (queue API messages)
 
 


### PR DESCRIPTION
PR builds don't run reliably, so we broke the site build in https://github.com/jenkins-infra/jenkins.io/pull/1569 😢 