### PR TITLE
Add changelog and upgrade guide for 2.121.1

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1505,14 +1505,14 @@
         - issue: 49472
         - issue: 48561
         - issue: 49994
-        - issue: 50237
-        - issue: 49618 # TODO partly in LTS already?
+        # issue: 50237 # was backported in PR 3372
+        - issue: 49618
       pull: 3333 # and 3359, and 3398
       message: >
         Update Remoting from 3.17 to 3.20 in order to apply various performance and diagnosability improvements, such as logging warnings when anonymous classes are serialized over a Remoting channel, and allowing Jenkins core to always deserialize exceptions even if they're not whitelisted.
         To benefit from the latter improvement, Remoting needs to be updated on the agent side as well.
       references:
-        - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#319
+        - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#320
           title: full changelog
     - type: major bug
       pull: 3357 # and followup fix in 3419

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1477,6 +1477,193 @@
       issue: 44402
       message: >
         Make <em>Cancel Shutdown</em> link in side panel work without requiring the page to be reloaded.
+- version: "2.121.1"
+  date: 2018-06-07
+  lts_predecessor: "2.107.3"
+  lts_baseline: "2.121"
+  lts_changes:
+    - type: major rfe
+      issue: 22367
+      pull: 3301
+      message: >
+        <em>Install from java.sun.com</em> installation method for JDK tools has been moved to a new <a href="https://plugins.jenkins.io/jdk-tool">JDK Tool Plugin</a>.
+    - type: major rfe
+      issue: 22936
+      pull: 3289
+      message: >
+        It is no longer possible to rename jobs from their configuration page.
+        Jobs now have a link in the side panel titled "Rename" that links to a page specifically dedicated to renaming jobs.
+    - type: major rfe
+      pull: 882
+      issue: 14713
+      message: >
+        The Job/Build permission no longer implies the Job/Cancel permission.
+        The latter needs to be granted explicitly to users who previously got it via this relationship.
+    - type: major rfe
+      references:
+        - issue: 49415
+        - issue: 49472
+        - issue: 48561
+        - issue: 49994
+        - issue: 50237
+        - issue: 49618 # TODO partly in LTS already?
+      pull: 3333 # and 3359, and 3398
+      message: >
+        Update Remoting from 3.17 to 3.20 in order to apply various performance and diagnosability improvements, such as logging warnings when anonymous classes are serialized over a Remoting channel, and allowing Jenkins core to always deserialize exceptions even if they're not whitelisted.
+        To benefit from the latter improvement, Remoting needs to be updated on the agent side as well.
+      references:
+        - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#319
+          title: full changelog
+    - type: major bug
+      pull: 3357 # and followup fix in 3419
+      message: >
+        Fix issue preventing process killing vetoes being effective on agents.
+      references:
+        - issue: 9104
+        - title: <code>ProcessKillingVeto</code> extension point implementations
+          url: https://jenkins.io/doc/developer/extensions/jenkins-core/#processkillingveto
+
+    # Pipeline related
+    - type: rfe
+      issue: 46652
+      pull: 3254
+      message: >
+        Pipeline builds could not be started if the Authorize Project plugin was configured to associate the build with a user to whom the authorization strategy was configured to deny Agent/Build permission on the master node.
+    - type: rfe
+      issue: 47142
+      pull: 3265
+      message: >
+        <code>archiveArtifacts</code> in a Pipeline failed to throw a normal exception when there were no matches.
+    - type: rfe
+      pull: 3014
+      issue: 26143
+      message: >
+        Allow use of lists of options as provided by the Pipeline snippet generator for choice parameters.
+
+    # First startup
+    - type: rfe
+      pull: 3389
+      message: >
+        Default Crumb Issuer proxy compatibility can be enabled on first startup by setting the system property <code>jenkins.model.Jenkins.crumbIssuerProxyCompatibility</code> to <code>true</code> on startup.
+      references:
+        - issue: 50767
+        - url: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+          title: Jenkins features controlled by system properties
+    - type: rfe
+      pull: 3367
+      issue: 50291
+      message: >
+        Introduce <code>hudson.triggers.SafeTimerTask.logsTargetDir</code> system property to write logs usually written to <code>$JENKINS_HOME/logs</code> to another location.
+
+    # UI
+    - type: rfe
+      pull: 3364
+      message: >
+        Remove the options to define custom Build Record Root Directory and Workspace Root Directory on the Configure System form to prevent unexpected failures during runtime.
+        Instead, these locations can now be customized using system properties on startup.
+      references:
+        - issue: 50164
+        - url: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+          title: Jenkins features controlled by system properties
+    - type: rfe
+      pull: 3337
+      issue: 38812
+      message: >
+        Use case-insensitive autocompletion for item selection dialogs if the current user prefers case-insensitive search
+    - type: rfe
+      pull: 3345
+      message: >
+        Better autocompletion for loggers supporting multiple tokens and proposing useful parent loggers.
+    - type: rfe
+      pull: 3324
+      issue: 47020
+      message: >
+        Show more entries in the search results dropdown and search results page.
+    - type: rfe
+      issue: 31661
+      pull: 3082
+      message: >
+        Ensure as much as possible that the Jenkins root URL is defined by adding a new setup wizard page and an administrative monitor.
+
+    # Misc
+    - type: rfe
+      pull: 3304
+      issue: 49661
+      message: >
+        Add <code>agent</code> symbol for a permanent agent in <a href="https://plugins.jenkins.io/structs">Structs Plugin</a> based configuration.
+    - type: rfe
+      pull: 3312 # and 3325
+      issue: 49795
+      message: >
+        Issue warnings to the system log when attempts are made to use classes with unpredictable names and serial forms (such as anonymous classes) in Remoting or XStream (de)serialization.
+
+    # Dependency
+    - type: rfe
+      pull: 3378
+      references:
+        - title: full changelog
+          url: https://github.com/jenkinsci/winstone/blob/master/CHANGELOG.md#42
+        - title: Jetty 9.4.6 changelog
+          url: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.6.v20170531
+        - title: Jetty 9.4.7 changelog
+          url: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.7.v20170914
+        - title: Jetty 9.4.8 changelog
+          url: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.8.v20171121
+      message: >
+        Update Winstone from 4.1.2 to 4.2 to update Jetty from 9.4.5 to 9.4.8 for various bugfixes and improvements.
+
+    # Bugs
+    - type: bug
+      pull: 3400
+      issue: 13128
+      message: >
+        Archiving artifacts now preserves file permissions and last modification time.
+    - type: bug
+      issue: 46386
+      pull: 3362
+      message: >
+        Prevent some cases of linkage errors relating to Servlet classes when code is run on an agent.
+    - type: bug
+      issue: 50599
+      pull: 3383
+      message: >
+        Make the logic for adding nodes atomic, so that if a newly added node fails to be persisted it will not exist in a partly-initialized state.
+    - type: bug
+      references:
+        - issue: 48347
+        - url: https://github.com/kohsuke/winp/blob/master/CHANGELOG.md#126
+          title: full changelog
+      pull: 3399
+      message: >
+        Update WinP from 1.25 to 1.26 to fix loading of WinP libraries on Windows inside Weblogic web container.
+
+    # Developer
+    - type: major rfe
+      references:
+        - url: https://github.com/jenkinsci/jep/tree/master/jep/202
+          title: JEP-202
+        - pull: 3302
+      message: >
+        Developer: JEP-202: Extend <code>VirtualFile</code> API to streamline external artifact storage.
+        API additions are marked beta and may change at any time.
+    - type: major rfe
+      pull: 3289
+      issue: 22936
+      message: >
+        Developer: Subclasses of <code>AbstractItem</code> can implement <code>AbstractItem#isNameEditable</code> and return true to get automatic support for renames.
+        Subclasses are also able to dynamically validate renames by implementing <code>AbstractItem#checkRename</code>.
+
+    # Internal
+    - type: rfe
+      pull: 3311
+      message: >
+        Internal: Choose more mnemonic <code>artifactId</code>s for modules not consumed externally.
+  changes:
+    - type: rfe
+      pull: 3428
+      issue: 51205
+      message: >
+        Faster list rendering of <em>Plugin Manager » Available</em>.
 
 
 # DO NOT EDIT THIS FILE DIRECTLY

--- a/content/doc/upgrade-guide/2.121.adoc
+++ b/content/doc/upgrade-guide/2.121.adoc
@@ -1,0 +1,58 @@
+---
+layout: documentation
+title:  Jenkins Upgrade Guide
+notitle: true
+---
+
+== Upgrading to Jenkins LTS 2.121.x
+
+Each section covers the upgrade from the previous LTS release, the section on 2.121.1 covers the upgrade from 2.107.3.
+
+=== Upgrading to Jenkins LTS 2.121.1
+
+==== Job/Build permission no longer implies Job/Cancel permission
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-14713[JENKINS-14713]
+
+To allow greater flexibility in configuring permissions, the 'implies' relationship between Job/Build and Job/Cancel has been removed.
+Users now need to be granted the Job/Cancel permission explicitly to cancel builds, even those they started themselves.
+
+==== UI for renaming jobs has been changed
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-22936[JENKINS-22936]
+
+It is no longer possible to rename jobs from their configuration page.
+Jobs now have a link in the side panel titled "Rename" that links to a page specifically dedicated to renaming jobs.
+
+==== New administrative monitor warns about undefined root URL
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-31661[JENKINS-31661]
+
+If you have not defined a root URL, various Jenkins features will not work correctly.
+To ensure to the extent possible that a root URL is configured, an administative monitor will show when it's not.
+
+==== JDK Tool Plugin detached from Jenkins core
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-22367[JENKINS-22367]
+
+The automatic installer for JDKs has been moved into a plugin to have a lifecycle independent from Jenkins core.
+
+==== UI option for custom builds and workspace directories on the master has been removed
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-50164[JENKINS-50164]
+
+Build Record Root Directory and Workspace Root Directory can no longer be configured through the UI as these options were generally unsafe to use while Jenkins was running.
+Instead, these locations can now be customized using system properties on startup.
+Existing changes to these options will be retained unless and until overridden at startup.
+
+==== Pipeline improvements
+
+link:https://issues.jenkins-ci.org/browse/JENKINS-46652[JENKINS-46652]
+link:https://issues.jenkins-ci.org/browse/JENKINS-47142[JENKINS-47142]
+link:https://issues.jenkins-ci.org/browse/JENKINS-26143[JENKINS-26143]
+
+Various changes to Jenkins core make it easier to use Pipelines:
+
+* Choice parameters now allow the use of a list of options instead of a string of options separated by line breaks.
+* `archiveArtifacts` now throws a normal exception when no matching files could be found.
+* Jenkins no longer prevents the execution of pipelines running as a user without Job/Build permission on the master node with Authorize Project Plugin.

--- a/content/doc/upgrade-guide/2.121.adoc
+++ b/content/doc/upgrade-guide/2.121.adoc
@@ -10,6 +10,16 @@ Each section covers the upgrade from the previous LTS release, the section on 2.
 
 === Upgrading to Jenkins LTS 2.121.1
 
+==== Remoting update
+
+https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#320[Remoting changelog],
+https://issues.jenkins-ci.org/browse/JENKINS-50237[JENKINS-50237]
+
+The remoting library has been updated to improve diagnosability and reliability.
+
+One of those changes, JENKINS-50237, requires that the `agent.jar` / `slave.jar` on agents is updated as well to be effective.
+plugin:ssh-slaves[SSH Slaves] based agents will always use the latest `agent.jar`, but other agent types may need to have their `agent.jar` updated manually.
+
 ==== Job/Build permission no longer implies Job/Cancel permission
 
 link:https://issues.jenkins-ci.org/browse/JENKINS-14713[JENKINS-14713]

--- a/content/doc/upgrade-guide/2.121.adoc
+++ b/content/doc/upgrade-guide/2.121.adoc
@@ -15,10 +15,19 @@ Each section covers the upgrade from the previous LTS release, the section on 2.
 https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#320[Remoting changelog],
 https://issues.jenkins-ci.org/browse/JENKINS-50237[JENKINS-50237]
 
-The remoting library has been updated to improve diagnosability and reliability.
+The Remoting library has been updated to improve diagnosability and reliability.
+One of those changes ensures that exceptions are always properly serialized over the channel, even if some exception fields are blocked by https://jenkins.io/redirect/class-filter/[JEP-200 class filters].
 
-One of those changes, JENKINS-50237, requires that the `agent.jar` / `slave.jar` on agents is updated as well to be effective.
+In order to get this fix applied, Remoting needs to be updated to version 3.13 or newer on the agent side.
+Without this upgrade, some remote operations on agents may fail if the call results in an exception, even if a the exception could be handled.
+
 plugin:ssh-slaves[SSH Slaves] based agents will always use the latest `agent.jar`, but other agent types may need to have their `agent.jar` updated manually.
+The following agent types should be updated:
+
+* Java Web Start agents with `agent.jar` / `slave.jar` JARs on the disk need to update those to version 3.19 or above.
+* plugin:swarm[Swarm Plugin] Client needs to be updated to version 3.11 or above.
+* Agent Docker Packages offered by the Jenkins project (https://hub.docker.com/r/jenkins/slave/[jenkins/slave] and https://hub.docker.com/r/jenkins/jnlp-slave/[jenkins/jnlp-slave]) need to be updated to version 3.19-1 or above.
+
 
 ==== Job/Build permission no longer implies Job/Cancel permission
 


### PR DESCRIPTION
Untested as `make run` doesn't work for me right now.