### PR TITLE
[WEBSITE-493] - Add Java 10+ hackathon to Events

### DIFF
--- a/content/_data/events/2018-06-18-java10-hackathon.adoc
+++ b/content/_data/events/2018-06-18-java10-hackathon.adoc
@@ -1,0 +1,7 @@
+---
+title: "Java 10+ online hackathon"
+date: "2018-06-18T16:00"
+link: "/blog/2018/06/08/jenkins-java10-hackathon/"
+---
+June 18-22.
+Work together to find/fix compatibility issues in Jenkins, share experiences and have fun.


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/WEBSITE-493

Had to play a bit with text, didn't look well otherwise. IIUC there is also no support of multi-day events, which may be a problem here since people may join at any day.

<img width="316" alt="screen shot 2018-06-11 at 18 56 11" src="https://user-images.githubusercontent.com/3000480/41245844-7d9dd5ae-6da9-11e8-92dc-7fad8464865e.png">

<img width="817" alt="screen shot 2018-06-11 at 18 56 24" src="https://user-images.githubusercontent.com/3000480/41245845-7dbbb524-6da9-11e8-897f-9c3dc6416307.png">

@jenkins-infra/copy-editors @bitwiseman 
