### PR TITLE
Add CVEs for 2018-05-09 advisory

### DIFF
--- a/content/security/advisory/2018-05-09.adoc
+++ b/content/security/advisory/2018-05-09.adoc
@@ -15,7 +15,7 @@ issues:
 - id: SECURITY-771
   title: CLI and UI allow non-admin users to enumerate installed plugins
   reporter: Devin Nusbaum, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000192
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -28,7 +28,7 @@ issues:
 - id: SECURITY-786
   title: Users were able to register user names containing control characters
   reporter: Sureshbabu Narvaneni
-  cve: CVE pending
+  cve: CVE-2018-1000193
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:L/A:L
@@ -45,7 +45,7 @@ issues:
 - id: SECURITY-788
   title: Path traversal vulnerability in agent to master security subsystem
   reporter: Jesse Glick, CloudBees, Inc. and Kalle Niemitalo, Procomp Solutions Oy
-  cve: CVE pending
+  cve: CVE-2018-1000194
   cvss:
     severity: high
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H
@@ -61,7 +61,7 @@ issues:
 - id: SECURITY-794
   title: Users with Overall/Read permission were able to send GET requests to any URL
   reporter: Thomas de Grenier de Latour
-  cve: CVE pending
+  cve: CVE-2018-1000195
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:L/I:N/A:N
@@ -76,7 +76,7 @@ issues:
 - id: SECURITY-263
   title: Gitlab Hook Plugin stores and displays GitLab API token in plain text
   reporter: Steve Marlowe &lt;smarlowe@cisco.com&gt; of Cisco ASIG
-  cve: CVE pending
+  cve: CVE-2018-1000196
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
@@ -97,7 +97,7 @@ issues:
 - id: SECURITY-670
   title: Black Duck Hub Plugin allowed any user with Overall/Read to read and write its configuration
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000197
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
@@ -116,7 +116,7 @@ issues:
 - id: SECURITY-671
   title: XML Exernal Entitity processing vulnerability in Black Duck Hub Plugin
   reporter: James Nord, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000198
   cvss:
     severity: high
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L
@@ -134,7 +134,7 @@ issues:
 - id: SECURITY-821
   title: Persisted cross-site scripting vulnerability in Groovy Postbuild Plugin
   # reporter: Did not want to be credited
-  cve: CVE pending
+  cve: CVE-2018-1000202
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N


### PR DESCRIPTION
Another benefit of https://github.com/jenkinsci/jep/tree/master/jep/6: I cannot overlook CVE assignments in my inbox 🤦‍♂️ 

https://github.com/CVEProject/cvelist/pull/572