### PR TITLE
Use "docs" site as Docker starting point

### DIFF
--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -17,7 +17,7 @@ For this tour, you will require:
 ** 10 GB of drive space (for Jenkins and your Docker image)
 * The following software installed:
 ** Java 8 (either a JRE or Java Development Kit (JDK) is fine)
-** https://www.docker.com/[Docker] (navigate to *Get Docker* at the top of the
+** https://docs.docker.com/[Docker] (navigate to *Get Docker* at the top of the
    website to access the Docker download that's suitable for your platform)
 
 === Download and run Jenkins


### PR DESCRIPTION
There's no longer a "Get Docker" link on the homepage of www.docker.com. But there is on docs.docker.com. Changed link to point to the doc site.