### PR TITLE
[WEBSITE-496] - Create Java Requirements and Web Browser compatibility pages

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -1,0 +1,53 @@
+---
+layout: documentation
+title:  Java requirements
+---
+
+There are separate run and job execution requirements for Jenkins installations.
+
+## Running Jenkins
+
+Modern Jenkins versions have the following Java requirements:
+
+* Java 8 is the **ONLY** supported runtime environment, both 32-bit and 64-bit versions are supported
+* Older versions of Java are not supported
+* Java 9 is not supported
+* Java 10 and 11 preview support is available
+** Support of these versions is available through custom packages
+** link:/blog/2018/06/17/running-jenkins-with-java10-11/[This page] provides guidelines about running Jenkins with these versions
+
+These requirements apply to all components of the Jenkins system including Jenkins master,
+all types of agents, CLI clients, and other components.
+
+Jenkins project performs a full test flow with the following JDK/JREs:
+
+* OpenJDK JDK / JRE 8 - 64 bits
+
+JRE/JDKs from other vendors are supported and may be used.
+See link:/redirect/issue-tracker[our Issue tracker] for known Java compatibility issues.
+
+## Executing jobs on Jenkins
+
+Jenkins jobs may be executed on Java versions different from the master/agent runtime.
+Generally, Jenkins allows ANY version of JRE/JDK to be invoked during the build.
+It includes:
+
+* Execution of Java commands from CLI
+* Installation and execution of build steps based on the plugin:jdk-tool plugin
+
+In the case of particular plugins, there are still Java requirements:
+
+* If you use plugin:maven-plugin[Maven Integration Plugin], version of JDK used for the build must be equal
+to the version used by Jenkins
+* If you use plugin:swarm[Swarm Plugin] to create agents,
+JRE version must be equal to the version of the master
+* If you use plugin:docker-workflow[Docker Pipeline Plugin] with a bundled JRE/JDK to execute jobs,
+versions of such bundled Java must be equal to the version of the master
+
+## Monitoring Java versions
+
+Modern versions of Jenkins master and agents verify Java requirements
+and notify users when they are launched with unsupported version.
+
+In order to do fine-grain monitoring of Java versions on agents,
+you can use plugin:versioncolumn[Jenkins Versions Node Monitors plugin] to setup Java version monitoring across the Jenkins system.

--- a/content/doc/administration/requirements/web-browsers.adoc
+++ b/content/doc/administration/requirements/web-browsers.adoc
@@ -1,0 +1,10 @@
+---
+layout: documentation
+title:  Browser compatibility
+wip: true
+---
+
+This page is under development.
+
+See
+link:https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[this Wiki page].

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -45,13 +45,10 @@ Recommended hardware configuration for a small team:
 * 1 GB+ of RAM
 * 50 GB+ of drive space
 
-Sofware requirements:
+Software requirements:
 
-* Java 8 - either a Java Runtime Environment (JRE) or a Java Development Kit
-  (JDK) is fine +
-  *Note:* This is not a requirement if running Jenkins as a <<docker,Docker>>
-  container.
-
+* Java: see the link:/doc/administration/requirements/java[Java Requirements] page
+* Web browser: see the link:/doc/administration/requirements/web-browsers[Web Browser Compatibility] page
 
 == Installation platforms
 

--- a/content/redirect/java-support.adoc
+++ b/content/redirect/java-support.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: /blog/2018/06/17/running-jenkins-with-java10-11/
+redirect_url: /doc/administration/requirements/java
 ---


### PR DESCRIPTION
As a part of the Hackathon we decided to make the Java support policy more explicit. Here is a page created by @tracymiranda and me, the structure follows agreements we reached during the discussion on Thursday.

https://issues.jenkins-ci.org/browse/WEBSITE-496

@jenkins-infra/copy-editors @bitwiseman @daniel-beck 
