### PR TITLE
Remove confusing mention of Credentials Plugin

### DIFF
--- a/content/security/advisory/2018-06-25.adoc
+++ b/content/security/advisory/2018-06-25.adoc
@@ -37,9 +37,6 @@ issues:
     - name: ssh-credentials
       fixed: 1.14
       previous: 1.13
-    - name: credentials
-      fixed: 2.1.17
-      previous: 2.1.16
   description: |
     SSH Credentials Plugin allowed the creation of SSH credentials with keys "From a file on Jenkins master".
     Credentials Binding Plugin 1.13 and newer allows binding SSH credentials to environment variables.


### PR DESCRIPTION
It's not just in affected/fixed, but also in the list of top. Since there's no dedicated entry, and SECURITY-440 doesn't mention it, its presence is just confusing.