### PR TITLE
Add table showing actual GitHub permissions

### DIFF
--- a/content/doc/developer/publishing/source-code-hosting.adoc
+++ b/content/doc/developer/publishing/source-code-hosting.adoc
@@ -9,3 +9,42 @@ The canonical source code repository is in the +jenkinsci+ GitHub organization t
 Some plugins we distribute are currently maintained outside the +jenkinsci+ GitHub organization for historical reasons, but this is discouraged.
 
 Plugin maintainers typically have repository admin permissions for plugins they maintain, but some features (like transfer and deletion of repos) are disabled.
+
+This table shows the permissions currently granted to contributors in the +jenkinsci+ GitHub repositories:
+
+++++
+    <style type="text/css">
+    @import url(https://cdn.datatables.net/1.10.16/css/jquery.dataTables.min.css);
+    </style>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript">
+$(document).ready(function() {
+    $('#permissions').DataTable( {
+        ajax: 'http://reports.jenkins.io/reports/github-jenkinsci-permissions-report.json',
+        columns: [
+            { title: "Repository" },
+            { title: "User" },
+            { title: "Access" }
+        ]
+    } );
+} );
+    </script>
+    <table id="permissions" class="display" cellspacing="0" width="100%">
+      <thead>
+        <tr>
+          <th>Repository</th>
+          <th>User</th>
+          <th>Access</th>
+        </tr>
+      </thead>
+      <tfoot>
+        <tr>
+          <th>Repository</th>
+          <th>User</th>
+          <th>Access</th>
+          </tr>
+      </tfoot>
+    </table>
+
+++++


### PR DESCRIPTION
> ![screen shot](https://user-images.githubusercontent.com/1831569/41982608-2a0df65a-7a2c-11e8-96a3-01d65b5527d0.png)

(The screenshot still used a local data source, rather than the reports host, but due to CORS I cannot show a live example, or even try it, before this is merged.)