### PR TITLE
Add wiki page link to the chapter

### DIFF
--- a/content/doc/developer/publishing/_chapter.yml
+++ b/content/doc/developer/publishing/_chapter.yml
@@ -3,7 +3,7 @@ sections:
 - style-guides
 - source-code-hosting
 - artifact-repository
-#- wiki-page
+- wiki-page
 #- issue-tracker
 #- update-center
 - plugin-site


### PR DESCRIPTION
Has existed for a long time here, just was not listed:
https://jenkins.io/doc/developer/publishing/wiki-page/