### PR TITLE
Changed the name of the multibranch tutorial

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -71,7 +71,7 @@ section: doc
           %li
             = active_href('doc/tutorials/create-a-pipeline-in-blue-ocean', 'Create a Pipeline in Blue Ocean')
           %li
-            = active_href('doc/tutorials/build-a-multibranch-pipeline-project', 'Build a multibranch Pipeline project')
+            = active_href('doc/tutorials/build-a-multibranch-pipeline-project', 'End-to-End Multibranch Pipeline Project Creation')
 
         %h4
           User Handbook

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -1,6 +1,6 @@
 ---
 layout: documentation
-title: Build a multibranch Pipeline project
+title: End-to-End Multibranch Pipeline Project Creation
 section: doc
 ---
 

--- a/content/doc/tutorials/index.adoc
+++ b/content/doc/tutorials/index.adoc
@@ -37,8 +37,7 @@ processes to build your applications:
 The following tutorials demonstrate more advanced features of Jenkins and how
 to manage your Pipeline projects with greater sophistication and flexibility.
 
-* link:build-a-multibranch-pipeline-project[Build a multibranch Pipeline
-  project]
+* link:build-a-multibranch-pipeline-project[End-to-End Multibranch Pipeline Project Creation]
 
 
 '''


### PR DESCRIPTION
Changed the name of the multibranch tutorial to reflect that it is not an "intro to multibranch projects" but will create the stup such that things like webhooks will trigger the multibranch which feels more complete than a basic intro