### PR TITLE
[JEP-4] - Draft the SIGs list and SIG pages

### DIFF
--- a/content/_data/sigs/platform.adoc
+++ b/content/_data/sigs/platform.adoc
@@ -1,0 +1,35 @@
+---
+layout: sig
+title: "Platform SIG"
+section: sigs
+logo: /images/user.gif
+tags:
+  - java
+  - windows
+  - linux
+  - platform_sig
+leads:
+- name: "Oleg Nenashev"
+  id: "oleg_nenashev"
+  github: "oleg-nenashev"
+  irc: "oleg_nenashev"
+  twitter: "oleg_nenashev"
+participants:
+- name: "Tracy Miranda"
+  id: "tracymiranda"
+  github: "tracymiranda"
+  irc: "tracymiranda"
+links:
+  gitter: "jenkinsci/platform-sig"
+  googlegroup: "jenkins-platform-sig"
+meetings:
+  text: Every month, to be announced
+  link: TODO
+---
+
+This special interest group offers a venue for all kinds of platform support discussions:
+Java, Operating Systems, Architectures, Docker, Packaging, Web Containers, etc.
+
+The SIG works on defining platform support policies,
+coordinating platform support efforts with contributors and external communities,
+and reviewing proposals in the area.

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -158,6 +158,9 @@
                         %a{:href => 'https://groups.google.com/forum/#!forum/jenkinsci-dev'}
                           Developers mailing list
                       %li
+                        %a{:href => expand_link("sigs")}
+                          Special Interest Groups
+                      %li
                         %a{:href => 'https://twitter.com/jenkinsci'}
                           Twitter
                       %li

--- a/content/_layouts/sig.html.haml
+++ b/content/_layouts/sig.html.haml
@@ -1,0 +1,48 @@
+---
+layout: project
+---
+
+- data = site.sigs[page.sigId]
+- if page.logo
+  %img{:title => "Logo", :src => expand_link(data.logo), :style => "float:right"}
+
+= content
+
+%h3.title
+  Participants
+
+- if data.leads
+  Leads:
+  %ul
+    - data.leads.each do |lead|
+      %li
+        %a{:href => "https://github.com/#{lead.github}", :target => "_blank"}
+          = lead.name
+- if data.participants
+  Participants:
+  %ul
+    - data.participants.each do |participant|
+      %li
+        %a{:href => "https://github.com/#{participant.github}", :target => "_blank"}
+          = participant.name
+
+%h3.title
+  Links
+%ul
+  - if data.links.googlegroup
+    %li
+      %a{:href => "https://groups.google.com/forum/#!forum/{data.links.googlegroup}", :target => "_blank"}
+        Mailing List
+  - if data.links.gitter
+    %li
+      %a{:href => "https://gitter.im/#{data.links.gitter}?utm_source=share-link&utm_medium=link&utm_campaign=share-link", :target => "_blank"}
+        %img{:title => "Gitter", :src => "https://badges.gitter.im/#{data.links.gitter}.svg"}
+  - if data.links.github
+    %li
+      %a{:href => "https://github.com/#{data.links.github}", :target => "_blank"}
+        Github repository
+
+  %li
+    %a{:href => "/sigs", :target => "_blank"}
+      Jenkins Special Interest Groups
+

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -34,9 +34,19 @@
               %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
                 = site.solutions[key].usecase
 
-        %li.nav-item{:class => active_link?('participate')}
-          %a.nav-link{:href => expand_link("participate")}
+        %li.nav-item.dropdown
+          .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
             Participate
+
+          .dropdown-menu
+            %a.dropdown-item.feature{:href => expand_link("participate"), :title => "Getting started"}
+              Getting started
+          .dropdown-menu
+            %a.dropdown-item.feature{:href => expand_link("sigs"), :title => "Special Interest Groups"}
+              Special Interest Groups
+          .dropdown-menu
+            %a.dropdown-item.feature{:href => "https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin", :title => "Adopt a plugin"}
+              Adopt a plugin
 
         %li.dropdown.nav-item
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Sub-projects

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -34,17 +34,8 @@
               %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
                 = site.solutions[key].usecase
 
-        %li.nav-item.dropdown
-          .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-            Participate
-
-          .dropdown-menu
-            %a.dropdown-item.feature{:href => expand_link("participate"), :title => "Getting started"}
-              Getting started
-            %a.dropdown-item.feature{:href => expand_link("sigs"), :title => "Special Interest Groups"}
-              Special Interest Groups
-            %a.dropdown-item.feature{:href => "https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin", :title => "Adopt a plugin"}
-              Adopt a plugin
+        %li.nav-item{:class => active_link?('participate')}
+          %a.nav-link{:href => expand_link("participate")}
 
         %li.dropdown.nav-item
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Sub-projects
@@ -75,6 +66,8 @@
               Events
             %a.dropdown-item.feature{:href => "https://wiki.jenkins-ci.org/"}
               Wiki
+            %a.dropdown-item.feature{:href => expand_link("sigs"), :title => "Special Interest Groups"}
+              Special Interest Groups
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -36,6 +36,7 @@
 
         %li.nav-item{:class => active_link?('participate')}
           %a.nav-link{:href => expand_link("participate")}
+            Participate
 
         %li.dropdown.nav-item
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Sub-projects

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -41,10 +41,8 @@
           .dropdown-menu
             %a.dropdown-item.feature{:href => expand_link("participate"), :title => "Getting started"}
               Getting started
-          .dropdown-menu
             %a.dropdown-item.feature{:href => expand_link("sigs"), :title => "Special Interest Groups"}
               Special Interest Groups
-          .dropdown-menu
             %a.dropdown-item.feature{:href => "https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin", :title => "Adopt a plugin"}
               Adopt a plugin
 

--- a/content/sigs/index.html.haml
+++ b/content/sigs/index.html.haml
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Jenkins Special Interest Groups
+---
+
+.container
+  .row.body
+    .col-lg-9
+      %h1
+        Jenkins Special Interest Groups
+      %p
+        This page lists active Jenkins Special Interest Groups (SIGs).
+        See
+        %a{:href => "link:https://github.com/jenkinsci/jep/tree/master/jep/4", :target => "_blank"}
+          JEP-4
+        for more information about SiGs and the process for creating new ones.
+
+      - site.sigs.keys.each do |name|
+
+        - data = site.sigs[name]
+        %h1
+          = data.title
+        - if data.logo
+          %img{:title => "Logo", :src => expand_link(data.logo), :style => "float:right"}
+            = data.raw_content
+        %ul
+          - if data.links.googlegroup
+            %li
+              %a{:href => "https://groups.google.com/forum/#!forum/{data.links.googlegroup}", :target => "_blank"}
+                Mailing List
+          - if data.links.gitter
+            %li
+              %a{:href => "https://gitter.im/#{data.links.gitter}?utm_source=share-link&utm_medium=link&utm_campaign=share-link", :target => "_blank"}
+                %img{:title => "Gitter", :src => "https://badges.gitter.im/#{data.links.gitter}.svg"}
+        %p
+          %a{:href => name}
+            More info
+    .col-lg-3
+      .sidebar-nav

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -1,0 +1,38 @@
+---
+layout: sig
+title: "Platform SIG"
+section: sigs
+sigId: "platform"
+---
+
+The special interest group offers a venue for all kinds of platform support discussions:
+Java, Operating Systems, Architectures, Docker, Packaging, Web Containers, etc.
+
+The group focuses on technologies used in Jenkins:
+
+* Java Virtual Machines: versions, compatibility and optmizations
+* Operating Systems: native components, packaging
+* Architectures and platforms
+* Web Containers
+
+Platform SIG may be cooperating with other groups.
+For example, we will be cooperating with the link:/sigs/cloud-native-jenkins[Cloud-Native Jenkins group]
+if the topics related to Cloud-Native platforms like Kubernetes or Docker.
+
+### Topics
+
+* Defining platform support policies (e.g. “defining Windows support policy”)
+* Coordinating effort on new platform support (e.g. Java 10 in JEP-TODO)
+* Working with external communities on better platform support and packaging
+(e.g. improving support of IBM Java, enabling OpenIndiana packaging,
+ARM Support in Jenkins, adapting RedHat packaging to best practices, etc.)
+* Reviewing JEPs submitted in the area
+
+### Meetings
+
+There will be regular SIG meetings scheduled.
+Initially the meetings will be conducted once per month,
+then they may be adapted according to the activity.
+
+Meetings will be conducted and recorded via Jenkins Hangouts-on-Air.
+Participant links will be posted in the SIG Chat within 10 minutes before the meeting starts.


### PR DESCRIPTION
This page offers a location for SiGs on jenkins.io. See https://github.com/jenkinsci/jep/tree/master/jep/4 . https://github.com/jenkinsci/jep/pull/135 and https://github.com/jenkinsci/jep/pull/136 are used as examples.

The PR is WiP, but ready for initial review:

* "Participate" link is converted to dropdown with beginner guidelines, SIGs and Adopt a plugin
* Draft landing SIG. There is some space reserved for right panel
*Draft pages for Platform and Cloud Native Jenkins SIGs

<img width="982" alt="screen shot 2018-07-05 at 18 09 34" src="https://user-images.githubusercontent.com/3000480/42334809-a021bab8-807e-11e8-9537-132f452a0e7c.png">

<img width="1200" alt="screen shot 2018-07-05 at 14 01 02" src="https://user-images.githubusercontent.com/3000480/42322694-b199dec2-805d-11e8-995e-0cabd3ccbccb.png">

@tracymiranda @bitwiseman @carlossg @rtyler 
