### PR TITLE
Editing a caption so that it matches the example

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -235,7 +235,7 @@ node {
     /* .. snip .. */
 }
 ----
-<1> Using an inline shell conditional (`sh 'make || true'`) ensures that the
+<1> Using an inline shell conditional (`sh 'make check || true'`) ensures that the
 `sh` step always sees a zero exit code, giving the `junit` step the opportunity
 to capture and process the test reports. Alternative approaches to this are
 covered in more detail in the <<handling-failure>> section below.


### PR DESCRIPTION
The sample Jenkinsfile uses the step `sh 'make check || true'` but the caption for that sample had it quoted as `sh 'make || true'`. This change makes the caption match the text in the example Jenkinsfile.