### PR TITLE
Fixing scripted example try-finally blocks

### DIFF
--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -40,11 +40,11 @@ pipeline {
 }
 // Scripted //
 node {
-    try{
+    try {
         stage('Test') {
             sh './gradlew check'
         }
-    finally {
+    } finally {
         junit 'build/reports/**/*.xml'
     }
 }
@@ -90,11 +90,11 @@ pipeline {
 }
 // Scripted //
 node {
-    try{
+    try {
         stage('Test') {
             sh './gradlew check'
         }
-    finally {
+    } finally {
         archiveArtifacts artifacts: 'build/libs/**/*.jar', fingerprint: true
         junit 'build/reports/**/*.xml'
     }


### PR DESCRIPTION
I would also like to modify the explanation to describe what `fingerprint: true` does on `archiveArtifacts` but I'm not sure myself.