### PR TITLE
[INFRA-1666] If we are naming a file *.yml, convert from JSON first

### DIFF
--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -7,6 +7,7 @@
 require 'faraday'
 require 'faraday_middleware'
 require 'fileutils'
+require 'json'
 require 'uri'
 require 'yaml'
 require 'zip'
@@ -84,7 +85,13 @@ class Fetcher
           f.write(frontmatter.to_yaml)
           f.write("---\n")
         end
-        f.write(response.body)
+        puts "Writing #{destination}"
+        if destination.include? ".yml"
+          puts "Converting JSON to YAML"
+          f.write(YAML.dump(JSON.load(response.body)))
+        else
+          f.write(response.body)
+        end
       end
 
       #if downloading a zip file, extract it


### PR DESCRIPTION
…since there are apparently some subtle differences in metacharacter escapes.

Prerequisite for https://github.com/jenkins-infra/update-center2/pull/217 to be merged acc. to @daniel-beck. I managed to reproduce the stated error by

```diff
diff --git a/scripts/fetch-external-resources b/scripts/fetch-external-resources
index b4902e5f..21e39f3a 100755
--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -39,7 +39,7 @@ RESOURCES = [
     nil
   ],
   [
-    'https://updates.jenkins.io/update-center.actual.json',
+    'https://ci.jenkins.io/job/Infra/job/update-center2/job/PR-217/2/artifact/output/latest/update-center.actual.json',
     'content/_data/_generated/update_center.yml',
     nil,
     nil
```

After applying this patch, the error goes away, and the security advisories index page and individual advisory pages appear to render correctly.