### PR TITLE
[WEBSITE-491] Fix pagination

### DIFF
--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -54,7 +54,8 @@ section: blog
                 %li.page-item{:class => ((page_index == index) and 'active')}
                   %a.page-link{:href => expand_link('node')}
                     1
-              - elsif linked_pages.include?(index)
+              - elsif linked_pages.include?(index) or (linked_pages.include?(index - 1) and linked_pages.include?(index + 1))
+                - # page is defined to be linked, or is surrounded by linked pages -- i.e. no gaps of just 1 page
                 - previous_visible = true
                 %li.page-item{:class => ((page_index == index) and 'active')}
                   %a.page-link{:href => expand_link("node/page/#{index + 1}.html")}

--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -6,9 +6,19 @@ section: blog
 
 :ruby
   page_index = page.posts.current_page_index
-  first_skip = false
-  second_skip = false
-  skip_window = 3
+  page_count = page.posts.pages.size
+  linked_pages = Array.new
+  linked_pages << 0
+  linked_pages << 1
+  linked_pages << 2
+  linked_pages << page_index
+  linked_pages << page_index - 1
+  linked_pages << page_index - 2
+  linked_pages << page_index + 1
+  linked_pages << page_index + 2
+  linked_pages << page_count - 1
+  linked_pages << page_count - 2
+  linked_pages << page_count - 3
 
 %div.container.blog-post
   .row.body
@@ -38,27 +48,23 @@ section: blog
             %li.page-item{:class => (page.posts.previous_page or 'disabled')}
               %a.page-link{:href => (page.posts.previous_page and expand_link(page.posts.previous_page.url))}
                 &laquo;
+            - previous_visible = false
             - page.posts.pages.each_index do |index|
               - if index == 0
                 %li.page-item{:class => ((page_index == index) and 'active')}
                   %a.page-link{:href => expand_link('node')}
-                    = index + 1
-              - elsif (index >= skip_window) && !first_skip
-                - first_skip = true
-                %li.page-item.disabled
-                  %a.page-link{:href => '#'}
-                    \...
-              - elsif (( index >= (page_index + skip_window)) && (index < ((page.posts.pages.size - skip_window) - 1)) && !second_skip )
-                - second_skip = true
-                %li.page-item.disabled
-                  %a.page-link{:href => '#'}
-                    \...
-              - elsif second_skip && ((index < (page.posts.pages.size - skip_window) - 1))
-                - next
-              - else
+                    1
+              - elsif linked_pages.include?(index)
+                - previous_visible = true
                 %li.page-item{:class => ((page_index == index) and 'active')}
                   %a.page-link{:href => expand_link("node/page/#{index + 1}.html")}
                     = index + 1
+              - else
+                - if previous_visible
+                  %li.page-item.disabled
+                    %a.page-link{:href => '#'}
+                      \...
+                  - previous_visible = false
             %li.page-item{:class => (page.posts.next_page or 'disabled')}
               %a.page-link{:href => (page.posts.next_page and expand_link(page.posts.next_page.url))}
                 &raquo;


### PR DESCRIPTION
[WEBSITE-491](https://issues.jenkins-ci.org/browse/WEBSITE-491)

* Page 4 was never linked.
* The first skip section was always only 1 page (page 4)
* Both skip sections were shown side by side when on page 1
* It linked the first 3, but last 4 pages.

This fixes all of this, always showing the current page, the two pages before and after it, and the first and last three pages.

## Before

![before1](https://user-images.githubusercontent.com/1831569/43026466-27522c04-8c76-11e8-865e-f11310d805ed.png)
![before3](https://user-images.githubusercontent.com/1831569/43026467-28c0dbf8-8c76-11e8-9c40-e76e2e3349a4.png)
![before5](https://user-images.githubusercontent.com/1831569/43026468-2a3a2a70-8c76-11e8-8e12-c05fb0cca250.png)
![before7](https://user-images.githubusercontent.com/1831569/43026470-2b5d2e84-8c76-11e8-900b-d5a697237996.png)
![before15](https://user-images.githubusercontent.com/1831569/43026476-2ee0fea0-8c76-11e8-9b63-0adf936be481.png)
![before39](https://user-images.githubusercontent.com/1831569/43026481-30128884-8c76-11e8-9091-1f637df0b413.png)

## After

![after1](https://user-images.githubusercontent.com/1831569/43026575-98112e5e-8c76-11e8-9b90-95f031edff56.png)
![after3](https://user-images.githubusercontent.com/1831569/43026577-99c82784-8c76-11e8-8db9-a130ed26ffab.png)
![after5](https://user-images.githubusercontent.com/1831569/43026581-9aec0252-8c76-11e8-8051-160532198873.png)
![after7](https://user-images.githubusercontent.com/1831569/43026584-9bd8ab98-8c76-11e8-9e8f-44434653824b.png)
![after15](https://user-images.githubusercontent.com/1831569/43026586-9d1e6d6c-8c76-11e8-932e-9dee14e89c79.png)
![after39](https://user-images.githubusercontent.com/1831569/43026589-9eeefbde-8c76-11e8-9936-3e22df3b0047.png)
![after75](https://user-images.githubusercontent.com/1831569/43026613-bec118fc-8c76-11e8-8ead-76a720c6f238.png)
