### PR TITLE
Add Organizations to SIGs

### DIFF
--- a/content/_layouts/sig.html.haml
+++ b/content/_layouts/sig.html.haml
@@ -4,7 +4,7 @@ layout: project
 
 .container
   .row.body
-    .col-lg-11
+    .col-lg-8
 
       - if page.logo
         %img{:title => "Logo", :src => expand_link(page.logo), :style => "float:right"}
@@ -20,31 +20,10 @@ layout: project
       %a{:href => "/sigs", :target => "_blank"}
         (Back to List of Jenkins Special Interest Groups )
 
-  .row.body
-    .col-lg-6
-      %h2.title
-        Members
-
-      - if page.leads
-        Lead#{if page.leads.length > 1 then 's' end}:
-
-        %ul
-          - page.leads.each do |item|
-            %li
-              %a{:href => "https://github.com/#{item.github}", :target => "_blank"}
-                = item.name
-
-      - if page.participants
-        Participants:
-        %ul
-          - page.participants.each do |item|
-            %li
-              %a{:href => "https://github.com/#{item.github}", :target => "_blank"}
-                = item.name
-
-    .col-lg-6
+    .col-lg-4
       %h2.title
         Links
+
       %ul
         - if page.links.googlegroup
           %li
@@ -59,9 +38,55 @@ layout: project
             %a{:href => "https://github.com/#{page.links.github}", :target => "_blank"}
               Github repository
 
+  .row
+    .col-lg-12
+      %h2.title
+        Members
 
-  .row.body
-    .col-lg-11
+    .col-lg-4
+      - if page.leads
+        Lead#{if page.leads.length > 1 then 's' end}:
+
+        %ul
+          - page.leads.each do |item|
+            %li
+              %a{:href => "https://github.com/#{item.github}", :target => "_blank"}
+                = item.name
+
+      - if page.organizations
+        Organizations:
+        %ul
+          - page.organizations.each do |item|
+            %li
+              %a{:href => "https://github.com/#{item.github}", :target => "_blank"}
+                = item.name
+
+    .col-lg-4
+      - if page.participants
+        - part1 = page.participants.sort_by { |x| x.name }
+        - part2 = []
+        - if part1.length > 8
+          - part1,part2 = part1.each_slice( (part1.size/2.0).round ).to_a
+
+        Participants:
+        %ul
+          - part1.each do |item|
+            %li
+              %a{:href => "https://github.com/#{item.github}", :target => "_blank"}
+                = item.name
+
+    .col-lg-4
+      - if page.participants
+        &nbsp;
+        %ul
+          - part2.each do |item|
+            %li
+              %a{:href => "https://github.com/#{item.github}", :target => "_blank"}
+                = item.name
+
+
+  .row
+    .col-lg-12
       %h2.title
         Description
 

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -56,6 +56,12 @@ participants:
   id: "LinuxSuRen"
   github: "LinuxSuRen"
 
+organizations:
+- name: "CloudBees"
+  github: "cloudbees"
+- name: "Google Cloud Platform"
+  github: "GoogleCloudPlatform"
+
 links:
   gitter: jenkinsci/cloud-native-sig
   googlegroup: jenkins-cloud-native-sig


### PR DESCRIPTION
@tracymiranda @oleg-nenashev 

Adds organizations to SIG pages
Also partially addresses Oleg's concerns about participant list length by splitting across two columns.

Waiting for update to https://github.com/jenkinsci/jep/pull/138 to specify how orgs sign up.

<img width="1117" alt="screen shot 2018-07-23 at 5 49 03 am" src="https://user-images.githubusercontent.com/1958953/43077385-395069b2-8e3c-11e8-820d-446e1f54a76c.png">
