### PR TITLE
Fixed broken links in SIG blog post

### DIFF
--- a/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
+++ b/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
@@ -25,7 +25,7 @@ We have also created a number of JEPs for External Logging
 and created a new link:/sigs/cloud-native[Cloud Native Special Interest Group (SIG)]
 to offer a venue for discussing changes and to keep them as open as possible.
 
-Tomorrow link:https:/github.com/jglick[Jesse Glick] and I will be
+Tomorrow link:https://github.com/jglick[Jesse Glick] and I will be
 presenting the current External Logging designs at the
 Cloud Native SIG online meeting,
 you can find more info about the meeting link:https://groups.google.com/forum/#!topic/jenkins-cloud-native-sig/rvc4qfl8Ks4[here].
@@ -39,7 +39,7 @@ If you follow the developer mailing list,
 you may have seen the discussion about introducing SIGs
 in the Jenkins project.
 The SIG model has been proposed by
-link:https://github.com[R. Tyler Croy],
+link:https://github.com/rtyler[R. Tyler Croy],
 and it largely follows the successful
 link:https://github.com/kubernetes/community/blob/master/sig-list.md[Kubernetes SIG] model.
 The objective of these SIGs is to make the community more transparent to contributors


### PR DESCRIPTION
Fixed links to profiles. Also, link to GSOC SIG is not working - https://jenkins.io/sigs/gsoc. Is it not available now or just the link is wrong?