### PR TITLE
Add pseudo project for Cloud Native Jenkins

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -48,6 +48,16 @@
               %a.dropdown-item.feature{:href => expand_link(page.url)}
                 = page.title
 
+        %li.dropdown.nav-item
+          .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Special Interest Groups
+          .dropdown-menu
+            %a.dropdown-item.feature{:href => expand_link('sigs/')}
+              Overview
+            - site.pages.map do |page|
+              - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
+              %a.dropdown-item.feature{:href => expand_link(page.url)}
+                = page.title
+
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
             Resources
@@ -67,8 +77,6 @@
               Events
             %a.dropdown-item.feature{:href => "https://wiki.jenkins-ci.org/"}
               Wiki
-            %a.dropdown-item.feature{:href => expand_link("sigs"), :title => "Special Interest Groups"}
-              Special Interest Groups
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}

--- a/content/projects/cloud-native/index.adoc
+++ b/content/projects/cloud-native/index.adoc
@@ -1,5 +1,0 @@
----
-title: "Jenkins Cloud Native"
-layout: redirect
-redirect_url: ../../sigs/cloud-native
----

--- a/content/projects/cloud-native/index.adoc
+++ b/content/projects/cloud-native/index.adoc
@@ -1,0 +1,5 @@
+---
+title: "Jenkins Cloud Native"
+layout: redirect
+redirect_url: ../../sigs/cloud-native
+---

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -1,6 +1,6 @@
 ---
 layout: sig
-title: "Cloud Native SIG"
+title: "Cloud Native"
 section: sigs
 sigId: "cloud-native"
 logo: /images/user.gif

--- a/content/sigs/index.html.haml
+++ b/content/sigs/index.html.haml
@@ -33,6 +33,7 @@ title: Jenkins Special Interest Groups
                 %img{:title => "Gitter", :src => "https://badges.gitter.im/#{item.links.gitter}.svg"}
         %p
           %a{:href => item.url}
-            More info
+            %strong
+              Learn More
     .col-lg-3
       .sidebar-nav

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -1,6 +1,6 @@
 ---
 layout: sig
-title: "Platform SIG"
+title: "Platform"
 section: sigs
 sigId: "platform"
 logo: /images/user.gif


### PR DESCRIPTION
This is intendent to get top-level visibilty for Cloud Native
while we consider ways to reorganize sub-projects and SIGs.

<img width="288" alt="screen shot 2018-08-01 at 5 38 27 pm" src="https://user-images.githubusercontent.com/1958953/43555902-c9139d9a-95b1-11e8-96c4-ece1e426180f.png">
