### PR TITLE
Fix simple typo - Architecting for Scale

### DIFF
--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -703,7 +703,7 @@ Security Realm plugin] for authentication.
 
 .Step 3: Add build nodes (slaves) to master
 
-Ad build servers to your master to ensure you are conducting actual build
+Add build servers to your master to ensure you are conducting actual build
 execution off of the master, which is meant to be an orchestration hub, and
 onto a "dumb" machine with sufficient memory and I/O for a given job or test.
 


### PR DESCRIPTION
Change "ad" to "add"