### PR TITLE
Reduce number of top menu items

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -13,13 +13,21 @@
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-            Documentation
+            Docs
 
           .dropdown-menu
             %a.dropdown-item{:href => expand_link('doc')}
               Use Jenkins
             %a.dropdown-item{:href => expand_link('doc/developer')}
               Extend Jenkins
+            %span.dropdown-item
+              %strong
+                Use-cases
+            - site.solutions.keys.sort.each do |key|
+              - link = expand_link("solutions/#{key}")
+              %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
+                = '&nbsp;-&nbsp;' + site.solutions[key].usecase
+
 
         %li.nav-item{:class => active_link?('plugins')}
           %a.nav-link{:href => 'https://plugins.jenkins.io/'}
@@ -27,16 +35,26 @@
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-            Use-cases
-          .dropdown-menu
-            - site.solutions.keys.sort.each do |key|
-              - link = expand_link("solutions/#{key}")
-              %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
-                = site.solutions[key].usecase
-
-        %li.nav-item{:class => active_link?('participate')}
-          %a.nav-link{:href => expand_link("participate")}
             Participate
+
+          .dropdown-menu
+            %a.dropdown-item.feature{:href => expand_link("participate")}
+              Overview
+            %a.dropdown-item.feature{:href => expand_link('chat'), :title => "Chat with the rest of the Jenkins community on IRC"}
+              Chat
+            %a.dropdown-item.feature{:href => expand_link('projects/jam')}
+              Meet
+            %a.dropdown-item.feature{:href => expand_link('events')}
+              Events
+            %a.dropdown-item.feature{:href => "https://issues.jenkins-ci.org/"}
+              Issue Tracker
+            %a.dropdown-item.feature{:href => expand_link('mailing-lists'),
+                              :title => "Browse Jenkins mailing list archives and/or subscribe to lists"}
+              Mailing Lists
+            %a.dropdown-item.feature{:href => "https://wiki.jenkins-ci.org/"}
+              Wiki
+            %a.dropdown-item.feature{:href => "https://accounts.jenkins.io/", :title => "Create/manage your account for accessing wiki, issue tracker, etc"}
+              Account Management
 
         %li.dropdown.nav-item
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Sub-projects
@@ -57,26 +75,6 @@
               - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
               %a.dropdown-item.feature{:href => expand_link(page.url)}
                 = page.title
-
-        %li.nav-item.dropdown
-          .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-            Resources
-
-          .dropdown-menu
-            %a.dropdown-item.feature{:href => "https://accounts.jenkins.io/", :title => "Create/manage your account for accessing wiki, issue tracker, etc"}
-              Account Management
-
-            %a.dropdown-item{:href => expand_link('chat'), :title => "Chat with the rest of the Jenkins community on IRC"}
-              Chat
-            %a.dropdown-item.feature{:href => "https://issues.jenkins-ci.org/"}
-              Issue Tracker
-            %a.dropdown-item{:href => expand_link('mailing-lists'),
-                              :title => "Browse Jenkins mailing list archives and/or subscribe to lists"}
-              Mailing Lists
-            %a.dropdown-item.feature{:href => expand_link('events')}
-              Events
-            %a.dropdown-item.feature{:href => "https://wiki.jenkins-ci.org/"}
-              Wiki
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -35,7 +35,7 @@
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-            Participate
+            Community
 
           .dropdown-menu
             %a.dropdown-item.feature{:href => expand_link("participate")}
@@ -56,6 +56,14 @@
             %a.dropdown-item.feature{:href => "https://accounts.jenkins.io/", :title => "Create/manage your account for accessing wiki, issue tracker, etc"}
               Account Management
 
+            %a.dropdown-item.feature{:href => expand_link('sigs/')}
+              %strong
+                Special Interest Groups
+            - site.pages.map do |page|
+              - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
+              %a.dropdown-item.feature{:href => expand_link(page.url)}
+                = '&nbsp;-&nbsp;' + page.title
+
         %li.dropdown.nav-item
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Sub-projects
           .dropdown-menu
@@ -63,16 +71,6 @@
               Overview
             - site.pages.map do |page|
               - next unless page.url.match(/\/projects\/([^\/]+)\/$/)
-              %a.dropdown-item.feature{:href => expand_link(page.url)}
-                = page.title
-
-        %li.dropdown.nav-item
-          .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Special Interest Groups
-          .dropdown-menu
-            %a.dropdown-item.feature{:href => expand_link('sigs/')}
-              Overview
-            - site.pages.map do |page|
-              - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
               %a.dropdown-item.feature{:href => expand_link(page.url)}
                 = page.title
 

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -13,7 +13,7 @@
 
         %li.nav-item.dropdown
           .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-            Docs
+            Documentation
 
           .dropdown-menu
             %a.dropdown-item{:href => expand_link('doc')}
@@ -51,7 +51,7 @@
             %a.dropdown-item.feature{:href => expand_link('mailing-lists'),
                               :title => "Browse Jenkins mailing list archives and/or subscribe to lists"}
               Mailing Lists
-            %a.dropdown-item.feature{:href => "https://wiki.jenkins-ci.org/"}
+            %a.dropdown-item.feature{:href => "https://wiki.jenkins.io/"}
               Wiki
             %a.dropdown-item.feature{:href => "https://accounts.jenkins.io/", :title => "Create/manage your account for accessing wiki, issue tracker, etc"}
               Account Management


### PR DESCRIPTION
Since the addition of "Special Interest Groups" to the top nav bar, it has looked pretty bad:

<img width="1172" alt="screen shot 2018-08-15 at 6 35 23 pm" src="https://user-images.githubusercontent.com/1958953/44182184-a8bb2b80-a0ba-11e8-9f9d-328b9ecbde8f.png">

The change reduces the number of top level items to fix the issue: 
1. Move use-cases under documentation
2. Rename Participate to Community
3. Moves Resources under Community
4. Move Special Interest Groups under Community


<img width="1219" alt="screen shot 2018-08-15 at 6 55 38 pm" src="https://user-images.githubusercontent.com/1958953/44182726-f46ed480-a0bc-11e8-9b01-41c587cc77b9.png">


This is my first cut at this and I'm open to feedback.  However we should do something as it currently doesn't look great.

You can see this working at https://bitwiseman.github.io/jenkins.io/top-menu/


