### PR TITLE
Add Microsoft Azure to Cloud Native SIG organization list

### DIFF
--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -63,6 +63,8 @@ organizations:
   github: "cloudbees"
 - name: "Google Cloud Platform"
   github: "GoogleCloudPlatform"
+- name: "Microsoft Azure"
+  github: "azure"
 
 links:
   gitter: jenkinsci/cloud-native-sig


### PR DESCRIPTION
PC Chan & Yuwei Zhou have joined SIG mailing list and requested Microsoft Azure be listed as the representative organization. 