### PR TITLE
[JENKINS-53147] Rebrand Essentials to Evergreen

### DIFF
--- a/content/blog/2018/04/2018-04-06-jenkins-essentials.adoc
+++ b/content/blog/2018/04/2018-04-06-jenkins-essentials.adoc
@@ -6,6 +6,8 @@ tags:
 author: rtyler
 ---
 
+TIP: _Jenkins Essentials_ has been renamed to _Jenkins **Evergreen**_ since this was written.
+
 In his presentation at the 2017 link:http://jenkinsworld.com[Jenkins World] Contributor Summit,
 link:https://github.com/kohsuke[Kohsuke]
 challenged us to continue the work started with Jenkins 2 of making Jenkins

--- a/content/blog/2018/04/2018-04-27-essentials-versions-are-numbered.adoc
+++ b/content/blog/2018/04/2018-04-27-essentials-versions-are-numbered.adoc
@@ -6,6 +6,8 @@ tags:
 author: rtyler
 ---
 
+TIP: _Jenkins Essentials_ has been renamed to _Jenkins **Evergreen**_ since this was written.
+
 A couple weeks ago, I
 link:/blog/2018/04/06/jenkins-essentials/[wrote about the Jenkins Essentials]
 effort, on which we've been making steady progress. Personally, the most

--- a/content/blog/2018/06/2018-06-26-jenkins-essentials-at-eclipsecon-france.adoc
+++ b/content/blog/2018/06/2018-06-26-jenkins-essentials-at-eclipsecon-france.adoc
@@ -7,6 +7,7 @@ tags:
 - essentials
 ---
 
+TIP: _Jenkins Essentials_ has been renamed to _Jenkins **Evergreen**_ since this was written.
 
 It's been far too long since we posted an update on
 link:/blog/2018/04/06/jenkins-essentials/[Jenkins Essentials]. While it's not

--- a/content/blog/2018/07/2018-07-10-jenkins-essentials-on-aws.adoc
+++ b/content/blog/2018/07/2018-07-10-jenkins-essentials-on-aws.adoc
@@ -7,6 +7,8 @@ tags:
 - essentials
 ---
 
+TIP: _Jenkins Essentials_ has been renamed to _Jenkins **Evergreen**_ since this was written.
+
 image:/images/logos/magician/256.png[Jenkins Essentials, role="right"]
 
 Jenkins Essentials is about providing a link:/blog/2018/04/06/jenkins-essentials/[distribution of Jenkins in less than five minutes and five clicks].

--- a/content/blog/2018/07/2018-07-20-devops-world-jenkins-world-2018-agenda-is-live.adoc
+++ b/content/blog/2018/07/2018-07-20-devops-world-jenkins-world-2018-agenda-is-live.adoc
@@ -10,7 +10,7 @@ author: alyssat
 image::/images/conferences/devops-world-2018.jpg[role=right]
 
 This year the Jenkins project introduced a few exciting efforts:
-Configuration as Code, Jenkins X, Jenkins Essentials, Blue Ocean and Pipeline. 
+Configuration as Code, Jenkins X, Jenkins Evergreen, Blue Ocean and Pipeline.
 With DevOps World-Jenkins World San Francisco and Nice only a few short months away,
 we’ve made sure to include plenty of sessions related to these exciting efforts on the agenda.
 With that said, the agenda for both cities is now live and will include workshops and deep dive 
@@ -36,7 +36,7 @@ Here’s a glimpse of what’s on the agenda:
   link:https://devopsworldjenkinsworld2018.sched.com/speaker/baptiste_mathus.1y8j4rd6[Baptiste Mathus]
 * Running Jenkins at Scale on Kubernetes – Guillermo Palacio -
   link:https://devopsworldjenkinsworld2018.sched.com/speaker/guillermo_palacio.1y8j74is[Guillermo Palacio]
-* Continuously Delivering an Easy-to-Use Jenkins with Jenkins Essentials –  
+* Continuously Delivering an Easy-to-Use Jenkins with Jenkins Evergreen –
   link:https://devopsworldjenkinsworld2018.sched.com/speaker/r_tyler_croy.1y8j4r5l[Tyler Croy]
 * “Look ma, no hands” – Manage Configuration as Code 
   link:https://devopsworldjenkinsworld2018.sched.com/speaker/ewelina_wilkosz.1y8j4r8y[Ewelina Wilkosz] &

--- a/content/blog/2018/07/2018-07-25-contributor-summit.adoc
+++ b/content/blog/2018/07/2018-07-25-contributor-summit.adoc
@@ -21,7 +21,7 @@ There are plenty of exciting developments happening in the Jenkins community.
 The summit will feature a 'State of the Project' update including updates from the Jenkins officers. 
 We will also have updates on the 'Big 5' projects in active development:
 
-* link:/blog/2018/04/06/jenkins-essentials[Jenkins Essentials]
+* link:/blog/2018/04/06/jenkins-essentials[Jenkins Evergreen]
 * link:https://jenkins-x.io[Jenkins X]
 * link:https://www.praqma.com/stories/jenkins-configuration-as-code[Configuration as Code]
 * link:/doc/book/pipeline[Jenkins Pipeline]

--- a/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
+++ b/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
@@ -76,7 +76,7 @@ I hope that more SIGs get created soon so that contributors could focus on areas
 
 In the original proposal link:https://github.com/csanchez[Carlos Sanchez],
 the Cloud Native SIG chair, has described the purpose of the SIG well.
-There has been great progress this year in cloud-native-minded projects like Jenkins X and Jenkins Essentials,
+There has been great progress this year in cloud-native-minded projects like Jenkins X and Jenkins Evergreen,
 but the current Jenkins architecture does not offer particular
 features which could be utilized there:
 Pluggable Storage, High Availability, etc.


### PR DESCRIPTION
[JENKINS-53147](https://issues.jenkins-ci.org/browse/JENKINS-53147)

* Added just a note for older entries, as I guess we do want to somehow "rewrite history".
* For more recent ones in July+, I chose the "history rewriting" path, especially as it is often referring to upcoming Jenkins World, so we should start adjusting so that newcomers do not get confused by this and just know "Evergreen".

@jenkins-infra/copy-editors esp. @rtyler 