### PR TITLE
[JENKINS-51227] Add `quietPeriod` Declarative option to docs

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -519,6 +519,9 @@ preserve the stashes from the most recent completed build, or `options
 { preserveStashes(5) }` to preserve the stashes from the five most
 recent completed builds.
 
+quietPeriod:: Set the quiet period, in seconds, for the Pipeline, overriding the global default.
+For example: `options { quietPeriod(30) }`
+
 retry:: On failure, retry the entire Pipeline the specified number of times.
 For example: `options { retry(3) }`
 


### PR DESCRIPTION
See [JENKINS-51227](https://issues.jenkins-ci.org/browse/JENKINS-51227). This'll be in Declarative 1.3.2.