### PR TITLE
Cloud Native sSIG: landing page rework

### DIFF
--- a/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
+++ b/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
@@ -184,13 +184,13 @@ Jesse Glick and Carlos Sanchez
 are returning to this story and plan to discuss it within the Cloud Native SIG.
 There are a number of Jenkins Enhancement proposals which have been submitted recently:
 
-* link:https://github.com/jenkinsci/jep/blob/master/jep/207/README.adoc[JEP-207] -
+* jep:207[] -
 External Build Logging support in the Jenkins Core
-* link:https://github.com/jenkinsci/jep/blob/master/jep/210/README.adoc[JEP-210] -
+* jep:210[] -
 External log storage for Pipeline
-* link:https://github.com/jenkinsci/jep/pull/151[Draft JEP] -
+* jep:212[] -
 External Logging API Plugin
-* link:https://github.com/jenkinsci/jep/blob/master/jep/206/README.adoc[JEP-206] -
+* jep:206[] -
 Use UTF-8 for Pipeline build logs
 
 In the linked documents you can find references to current reference implementations.

--- a/content/blog/2018/08/2018-08-06-jenkins-java10-hackathon-summary-community.adoc
+++ b/content/blog/2018/08/2018-08-06-jenkins-java10-hackathon-summary-community.adoc
@@ -1,0 +1,33 @@
+---
+:layout: post
+:title: "Jenkins & Java 10+ Online Hackathon. Summary and follow-ups"
+:tags:
+- events
+- community
+- developer
+- java10
+- java11
+:author: oleg_nenashev
+---
+
+// image:/images/logos/formal_java/256.png[Jenkins & Java, role=center, float=right]
+
+On June 18-22 we had a
+link:/blog/2018/06/08/jenkins-java10-hackathon/[Jenkins & Java 10 Online Hackathon].
+In this blogpost I would like to summarize summaries
+
+Below you can see the great infographics created by Tracy Miranda:
+
+TODO:
+
+### What did we achieve?
+
+### My takeaways
+
+
+### Links
+
+* link:https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I[Developer mailing list]
+* link:https://docs.google.com/document/d/1ed6wFOlq4cWrSL6UkCSzFbaY80AT-sk8ncB4Fz5QXyM/edit[Hackathon sync-up document]
+* link:/blog/2018/06/17/running-jenkins-with-java10-11/[Running Jenkins with Java 10 and 11]
+* link:https://www.meetup.com/ru-RU/Jenkins-online-meetup/events/251804751/[Jenkins Online Meetup page]

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -95,53 +95,111 @@ or using cloud services for their operation.
 
 === Areas for Improvement
 
-This section describes motivation and first topics for the SIG.
+There are the following main areas for the SIG:
+
+* Pluggable storage - Externalizing data being stored in `JENKINS_HOME`
+* Cloud Native Jenkins - Architecture changes and optimizations towards stateless Jenkins
+* Configuration as Code - Simplify creation of static Jenkins configurations
+
+=== Pluggable Storage
 
 The current default approach of storing everything into the filesystem is the main reason why Jenkins does not fit the "Cloud Native" model, with features like HA, zero downtime, or pay per use.
 While there are plenty of plugins that implement parts of this vision, this becomes cumbersome to configure and a usability nightmare for users, as the https://github.com/jenkinsci/jep/tree/master/jep/300[Essentials JEP] has pointed out.
 Going towards a model where cloud services are consumed where it makes sense, the overall complexity on operating Jenkins in a cloud or containerized environment is greatly reduced.
-Other related projects include https://github.com/jenkinsci/jep/tree/master/jep/400[Jenkins X] which would greatly benefit from a Cloud Native Jenkins inside Kubernetes.
+Other related projects include https://github.com/jenkinsci/jep/tree/master/jep/400[Jenkins X]
+and link:https://github.com/jenkins-infra/evergreen[Jenkins Evergreen]
+which would greatly benefit from a Cloud Native storage for Jenkins.
 
 There are several clear areas open for improvement, which are summarized here and will be detailed in future documents.
 A mayor pain point is the usage of local disk as all-purpose storage, which causes issues running on containerized or distributed environments, requiring highly performant filesystems, and all the configuration pain like initial sizing and resizing with downtime.
 We believe that by using cloud provided services the overall usability, performance and scalability can be improved while enabling new demanded functionality.
 
-By converting Jenkins to a "stateless" application long awaited features such as high availability and replication would help to operate Jenkins more efficiently, with zero downtime and reducing risk in upgrade operations by using canary or rolling deployments.
+Below you can find a list of ongoing work and their current status:
 
-==== Artifact Storage
+|=========================================================
+|Type | Status | JEPs | Comment
 
-The current approach of storing artifacts in the filesystem prevents users from taking advantage of cloud provided blob stores (ie. AWS S3), which provide a lot more features for this use case.
+| Artifacts
+| Available
+| jep:202[]
+|
 
-Sizing becomes a problem as disk usage needs to be accounted for all the future artifacts stored or forces the need for resizing, which causes downtime.
-Typical use cases such as versioning, expiration or pay per use are impossible to implement today.
+| Credentials
+| Available
+| N/A
+| Completed before the JEP process was introduced
 
-While currently it is possible to use specific plugins to store artifacts in blob stores such as the https://plugins.jenkins.io/s3[S3 plugin],
-this forces explicit configuration in jobs and makes configuration harder.
+| Build logs
+| In progress
+| jep:207[], jep:210[], jep:212[]
+|
 
-==== Log Storage
-
-Logs disk usage causes the same issues previously mentioned for artifacts.
-Plus a external focused log storage such as https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html[AWS CloudWatch Logs] allows demanded features as centralized log management, log retention policies, advanced querying, ...
-
-There are already options to externally ship the logs to a backend, or plugins that would do that like the  https://github.com/jenkinsci/aws-cloudwatch-logs-publisher-plugin[aws-cloudwatch-logs-publisher-plugin], but there is no integrated way to both send and display logs from external log storage.
-
-The External log storage work is tracked as
-link:https://issues.jenkins-ci.org/browse/JENKINS-38313[JENKINS-38313].
-
-==== Configuration Storage
-
-While xml files do not typically take a big amount of disk space, they make it really hard to query information about the system.
-This configuration is better suited in a cloud provided database in combination with https://github.com/jenkinsci/configuration-as-code-plugin Configuration as Code
-
-==== Replication
-
-If all the data currently stored in the filesystem is moved to external storage a replicated Jenkins service becomes possible, and the next steps are true High Availability, rolling or canary upgrades and zero downtime.
+| System logs
+| Available
+| N/A
+| Jenkins supports custom log appenders using standard `java.util.logging`
+  link:http://tutorials.jenkov.com/java-logging/configuration.html[configuration options].
 
 
-==== Configuration as Code
+| Task logs
+| Not started
+|
+| Storage of system logs and various tasks (e.g. agent connection or SCM polling)
 
-Configuration as Code related topics belong to Cloud Native SIG.
+| Configurations
+| In progress
+| jep:213[]
+|
 
+| Test results
+| In progress
+| Coming soon
+|
+
+| Code coverage results
+| In exploration
+| TBD
+|
+
+| Runs
+| Not started
+|
+| Storage of full run records in an external database
+
+| Jobs
+| Not started
+|
+| Storage of Job configurations and job-specific metadata in an external database.
+  Existing plugins like Jenkins Pipeline and JobDSL partially address this case
+  by keeping configurations in SCM.
+
+| Fingerprints
+| Not started
+|
+|
+|=========================================================
+
+The list above is not complete.
+Other storage types may be considered according to the feedback.
+You can find more information about Pluggable Storage and priorities
+in link:/blog/2018/07/30/introducing-cloud-native-sig/[this blogpost].
+
+See the link:pluggable-storage[Pluggable Storage page] for more information about the projects.
+
+=== Cloud Native Jenkins
+
+If all the data currently stored in the filesystem is moved to external storage a replicated Jenkins service becomes possible,
+and the next steps are true High Availability, rolling or canary upgrades and zero downtime.
+
+It also opens a way towards stateless Jenkins.
+By converting Jenkins to a "stateless" application long awaited features such as high availability and replication would help to operate Jenkins more efficiently,
+with zero downtime and reducing risk in upgrade operations by using canary or rolling deployments.
+
+Currently there is no JEPs associated with this topic.
+
+=== Configuration as Code
+
+Configuration as Code related topics belong to the Cloud Native SIG.
 The Configuration as Code (casc) group consists of contributors and collaborators focuses on improving Jenkins configuration as code related tools and practices.
 
 The target audience are both existing and new Jenkins users that use, or would prefer to use,
@@ -163,7 +221,7 @@ then they may be adapted according to the activity.
 
 Meetings will be conducted and recorded via Jenkins Hangouts-on-Air.
 
-==== 2018-09-17. Meeting at Jenkins Contributor summit
+==== 2018-09-17. Meeting at the Jenkins Contributor summit
 
 We will have a BoF table at the link:/2018/07/25/contributor-summit/[Jenkins Contributor Summit]
 in San Francisco on Sep 17.

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -92,52 +92,6 @@ The improvements are targeted at both existing and new Jenkins users that use, o
 Jenkins deployed in one of the cloud providers,
 or using cloud services for their operation.
 
-=== Meetings
-
-There will be regular SIG meetings scheduled.
-Initially the meetings will be conducted once per month,
-then they may be adapted according to the activity.
-
-Meetings will be conducted and recorded via Jenkins Hangouts-on-Air.
-
-==== Configuration as Code
-
-Configuration as Code related topics belong to Cloud Native SIG.
-
-The Configuration as Code (casc) group consists of contributors and collaborators focuses on improving Jenkins configuration as code related tools and practices.
-
-The target audience are both existing and new Jenkins users that use, or would prefer to use,
-different ways to configure Jenkins as code.
-
-There is a separate link:https://calendar.google.com/event?action=TEMPLATE&tmeid=a28yZTc0cGdxcHZwcHJ1aWNjZWcyMnU5ZGdfMjAxODA5MTJUMDcwMDAwWiBld2VAcHJhcW1hLm5ldA&tmsrc=ewe%40praqma.net&scp=ALL[Office Hours meeting] conducted every second week on Wednesdays, 9am CEST.
-Click on a link:https://calendar.google.com/event?action=TEMPLATE&tmeid=a28yZTc0cGdxcHZwcHJ1aWNjZWcyMnU5ZGdfMjAxODA5MTJUMDcwMDAwWiBld2VAcHJhcW1hLm5ldA&tmsrc=ewe%40praqma.net&scp=ALL[link] for an invitation.
-Anyone can join a meeting, meetings will be recorded via Jenkins Hangouts-on-Air.
-
-Participant links will be posted in the link:https://gitter.im/jenkinsci/configuration-as-code-plugin[Configuration as Code Gitter Chat] within 10 minutes before the meeting starts.
-
-When needed the topics discussed at Office Hours meeting will be reported back at Cloud Native SIG meeting.
-
-==== 2018-08-16. Status meeting
-
-Status sync-up: External Build Log Storage (JEP-207, JEP-210, JEP-212),
-External Configuration Storage (JEP-213),
-Jenkins Configuration-as-Code.
-
-* link:https://www.youtube.com/watch?v=aoJn4AgAEdk[Youtube video]
-* link:https://docs.google.com/document/d/1_lciDKHI7iKc6X043eWl1rMCcn_ixVgpwcKRLLu12Ts/edit[Meeting Agenda and Notes]
-
-
-==== 2018-07-31. External Build Log Storage
-
-At this inaugural meeting we had introductions from SIG participants.
-Then link:https://github.com/oleg-nenashev[Oleg Nenashev] and
-link:https://github.com/jglick[Jesse Glick] presented  and discussed
-the current state of the External Build Log Storage work
-(link:https://issues.jenkins-ci.org/browse/JENKINS-38313[JENKINS-38313]).
-
-* link:https://docs.google.com/presentation/d/1wcbvqmOhY0jIrKt_X9XEBfcXe29zycvhoWoI3qgSyDM/[Intro Slides]
-* link:https://www.youtube.com/watch?v=9lTOtC9wA_I[Video recording]
-* link:https://docs.google.com/document/d/1sWpIOY0jtHMTXa3H58Rmdp7untoTjKnpEfUbwIPdeQk/edit[Meeting Notes]
 
 === Areas for Improvement
 
@@ -183,3 +137,58 @@ This configuration is better suited in a cloud provided database in combination 
 
 If all the data currently stored in the filesystem is moved to external storage a replicated Jenkins service becomes possible, and the next steps are true High Availability, rolling or canary upgrades and zero downtime.
 
+
+==== Configuration as Code
+
+Configuration as Code related topics belong to Cloud Native SIG.
+
+The Configuration as Code (casc) group consists of contributors and collaborators focuses on improving Jenkins configuration as code related tools and practices.
+
+The target audience are both existing and new Jenkins users that use, or would prefer to use,
+different ways to configure Jenkins as code.
+
+There is a separate link:https://calendar.google.com/event?action=TEMPLATE&tmeid=a28yZTc0cGdxcHZwcHJ1aWNjZWcyMnU5ZGdfMjAxODA5MTJUMDcwMDAwWiBld2VAcHJhcW1hLm5ldA&tmsrc=ewe%40praqma.net&scp=ALL[Office Hours meeting] conducted every second week on Wednesdays, 9am CEST.
+Click on a link:https://calendar.google.com/event?action=TEMPLATE&tmeid=a28yZTc0cGdxcHZwcHJ1aWNjZWcyMnU5ZGdfMjAxODA5MTJUMDcwMDAwWiBld2VAcHJhcW1hLm5ldA&tmsrc=ewe%40praqma.net&scp=ALL[link] for an invitation.
+Anyone can join a meeting, meetings will be recorded via Jenkins Hangouts-on-Air.
+
+Participant links will be posted in the link:https://gitter.im/jenkinsci/configuration-as-code-plugin[Configuration as Code Gitter Chat] within 10 minutes before the meeting starts.
+
+When needed the topics discussed at Office Hours meeting will be reported back at Cloud Native SIG meeting.
+
+=== Meetings
+
+There will be regular SIG meetings scheduled.
+Initially the meetings will be conducted once per month,
+then they may be adapted according to the activity.
+
+Meetings will be conducted and recorded via Jenkins Hangouts-on-Air.
+
+==== 2018-09-17. Meeting at Jenkins Contributor summit
+
+We will have a BoF table at the link:/2018/07/25/contributor-summit/[Jenkins Contributor Summit]
+in San Francisco on Sep 17.
+There will be no recording, but we will still have public meeting notes from the event
+
+* link:https://docs.google.com/document/d/1Hw1mpXSpH8BAe2YK5SrCfFuHQLRf__KnjDBK_SbhGls/edit?usp=sharing[Meeting notes]
+
+==== 2018-08-16. Status meeting
+
+Status sync-up: External Build Log Storage (JEP-207, JEP-210, JEP-212),
+External Configuration Storage (JEP-213),
+Jenkins Configuration-as-Code.
+
+* link:https://www.youtube.com/watch?v=aoJn4AgAEdk[Youtube video]
+* link:https://docs.google.com/document/d/1_lciDKHI7iKc6X043eWl1rMCcn_ixVgpwcKRLLu12Ts/edit[Meeting Agenda and Notes]
+
+
+==== 2018-07-31. External Build Log Storage
+
+At this inaugural meeting we had introductions from SIG participants.
+Then link:https://github.com/oleg-nenashev[Oleg Nenashev] and
+link:https://github.com/jglick[Jesse Glick] presented  and discussed
+the current state of the External Build Log Storage work
+(link:https://issues.jenkins-ci.org/browse/JENKINS-38313[JENKINS-38313]).
+
+* link:https://docs.google.com/presentation/d/1wcbvqmOhY0jIrKt_X9XEBfcXe29zycvhoWoI3qgSyDM/[Intro Slides]
+* link:https://www.youtube.com/watch?v=9lTOtC9wA_I[Video recording]
+* link:https://docs.google.com/document/d/1sWpIOY0jtHMTXa3H58Rmdp7untoTjKnpEfUbwIPdeQk/edit[Meeting Notes]

--- a/content/sigs/cloud-native/pluggable-storage.adoc
+++ b/content/sigs/cloud-native/pluggable-storage.adoc
@@ -1,0 +1,123 @@
+---
+layout: project
+title: "Cloud Native SIG - Pluggable Storage"
+tags:
+- pluggable-storage
+- cloud-native
+- cloud-native-sig
+---
+
+The current default approach of storing everything into the filesystem is the main reason why Jenkins does not fit the "Cloud Native" model, with features like HA, zero downtime, or pay per use.
+While there are plenty of plugins that implement parts of this vision, this becomes cumbersome to configure and a usability nightmare for users, as the https://github.com/jenkinsci/jep/tree/master/jep/300[Essentials JEP] has pointed out.
+Going towards a model where cloud services are consumed where it makes sense, the overall complexity on operating Jenkins in a cloud or containerized environment is greatly reduced.
+Other related projects include https://github.com/jenkinsci/jep/tree/master/jep/400[Jenkins X]
+and link:https://github.com/jenkins-infra/evergreen[Jenkins Evergreen]
+which would greatly benefit from a Cloud Native storage for Jenkins.
+
+There are several clear areas open for improvement, which are summarized here and will be detailed in future documents.
+A mayor pain point is the usage of local disk as all-purpose storage, which causes issues running on containerized or distributed environments, requiring highly performant filesystems, and all the configuration pain like initial sizing and resizing with downtime.
+We believe that by using cloud provided services the overall usability, performance and scalability can be improved while enabling new demanded functionality.
+
+You can find more information about Pluggable Storage and priorities
+in link:/blog/2018/07/30/introducing-cloud-native-sig/[this blogpost].
+Full list of Jenkins Enhancement Proposals is provided on the
+link:/sigs/cloud-native[Cloud Native SIG Page].
+
+=== Artifact Storage
+
+There are many existing plugins allowing to upload and download artifacts from external storage
+(e.g. S3, Artifactory, Publish over SFTP, etc., etc.),
+but there are no plugins which can do it transparently without using
+new steps.
+In many cases the artifacts also get uploaded through master,
+and it increases load on the system.
+It would be great if there was a layer which would allow storing artifacts externally
+when using common steps like _Archive Artifacts_.
+
+Jenkins 2.118+ offers an extended javadoc:jenkins.util.VirtualFile[] API
+which allows implementing external artifact managers using the
+link:https://jenkins.io/doc/developer/extensions/jenkins-core/#artifactmanagerfactory[ArtifactManagerFactory]
+extension point.
+
+Implementation examples:
+
+* plugin:artifact-manager-s3[Artifact Manager for S3]
+
+Related JEPs:
+
+* jep:202[External Artifact Storage]
+
+=== Build Log Storage
+
+Logs disk usage causes the same issues previously mentioned for artifacts.
+Plus a external focused log storage such as https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html[AWS CloudWatch Logs] allows demanded features as centralized log management, log retention policies, advanced querying, etc.
+There are already options to externally ship the logs to a backend, or plugins that would do that like the  https://github.com/jenkinsci/aws-cloudwatch-logs-publisher-plugin[aws-cloudwatch-logs-publisher-plugin], but there is no integrated way to both send and display logs from external log storage.
+The External log storage work is tracked as issue:38313[].
+
+Reference implementations:
+
+* link:https://github.com/jenkinsci/pipeline-log-fluentd-cloudwatch-plugin[Pipeline Logging over fluentd + CloudWatch Plugin]
+* link:https://github.com/jenkinsci/external-logging-elasticsearch-plugin[External Logging for Elasticsearch]
+
+Related JEPs:
+
+* jep:207[External Build Logging support in the Jenkins Core]
+* jep:210[External log storage for Pipeline]
+* jep:212[External Logging API Plugin]
+* jep:206[Use UTF-8 for Pipeline build logs]
+
+=== Configuration Storage
+
+Although configurations are not big, externalizing them is a critical task
+for getting highly-available or disposable Jenkins masters.
+There are many ways to store configurations in Jenkins,
+but 95% of cases are covered by the `XmlFile` layer which
+serializes objects to disk and reads them using the XStream library.
+Externalizing these ``XmlFile``s would be a great step forward.
+
+There are several prototypes for externalizing configurations, e.g. in DotCI.
+There are also other implementations which could be upstreamed to the Jenkins core.
+
+Related JEPs:
+
+* jep:213[Configuration Storage API in the Jenkins Core]
+
+=== Credentials
+
+In plugin:credentials[Credentials Plugin] 1.15+ there
+is a link:https://jenkins.io/doc/developer/extensions/credentials/#credentialsprovider[CredentialsProvider]
+extension point which allows referencing and resolving external credentials.
+This engine allows implementing external credentials for plugins implementing Credentials API..
+
+Implementation examples:
+
+* plugin:kubernetes-credentials-provider[Kubernetes Credentials Provider]
+* plugin:amazon-ecr[Amazon ECR] - converts Amazon Credentials into a Docker CLI Authentication Token
+* plugin:google-container-registry-auth[Google Container Registry Auth] - same for the Google Container Registry
+
+Other credentials API in Jenkins (like javadoc:hudson.util.Secret) are not supported.
+
+=== Test results
+
+In common CI/CD use-cases a lot of the space is being consumed by test reports.
+This data is stored within `JENKINS_HOME`,
+and the current storage format requires huge overheads when retrieving statistics and, especially, trends.
+In order to display trends, each report has to be loaded and then processed in-memory.
+
+The main purpose of externalising Test Results is to optimize Jenkins logic
+by querying the desired data from specialized external storages,
+e.g. from Document-based databases like Elasticsearch.
+According to the current plan, plugin:junit[JUnit Plugin] will be extended
+in order to support such external storage in its APIs being widely used by test reporting plugins.
+
+Status:
+
+* Foundation work started
+* Prototype API: https://github.com/jenkinsci/junit-plugin/pull/110
+
+=== Other Pluggable storage stories
+
+This page summarizes statuses of the ongoing work only.
+There are other Pluggable Storage stories we consider in the Cloud Native SIG.
+See the link:/sigs/cloud-native[SIG's page] for more details and links.
+


### PR DESCRIPTION
- [x] Add a table with a list of JEPs related to the Pluggable storage
- [x] Move details about Pluggable Storage to a separate page. Rewrite entries using http://localhost:4242/blog/2018/07/30/introducing-cloud-native-sig/ as a source 
- [x] Add the DW|JW Meeting page
- [x] Fix error with mispositioning of the Configuration-as-Code section

@carlossg @jglick 