### PR TITLE
Adapt python doc-page to wrapper layout

### DIFF
--- a/content/solutions/python.adoc
+++ b/content/solutions/python.adoc
@@ -28,8 +28,7 @@ image::/images/solution-images/jenkins-chart-pylint.png[role=center]
 == Resources
 
 Below are a collection of miscellaneous resources for working with Python on
-top of Jenkins. If you believe something is missing, please click the link at
-the lower right ("Improve this page") and submit a pull request!
+top of Jenkins. If you believe something is missing, please click ("link:https://github.com/jenkins-infra/jenkins.io/edit/master/content//solutions/python.adoc[here]") or the "Improve this Page" link in the lower right, and submit a pull request!
 
 === Templates
 


### PR DESCRIPTION
"Improve this Page" has apparently moved, so I added a direct link and updated the geometric reference.