### PR TITLE
Dcoument the Jenkins cron syntax

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -748,6 +748,83 @@ pipeline {
 // Script //
 ----
 
+[[cron-syntax]]
+==== Jenkins cron syntax
+The Jenkins cron syntax follows the syntax of the cron utility (with minor differences).
+Specifically, each line consists of 5 fields separated by TAB or whitespace:
+
+[%header,cols=5*]
+|===
+|MINUTE
+|HOUR
+|DOM
+|MONTH
+|DOW
+
+|Minutes within the hour (0–59)
+|The hour of the day (0–23)
+|The day of the month (1–31)</td>
+|The month (1–12)
+|The day of the week (0–7) where 0 and 7 are Sunday.</td>
+|===
+
+To specify multiple values for one field, the following operators are
+available. In the order of precedence,
+
+* `*` specifies all valid values
+* `M-N` specifies a range of values
+* `M-N/X` or `*/X` steps by intervals of `X` through the specified range or whole valid range
+* `A,B,...,Z` enumerates multiple values
+
+To allow periodically scheduled tasks to produce even load on the system,
+the symbol `H` (for “hash”) should be used wherever possible.
+For example, using `0 0 * * *` for a dozen daily jobs
+will cause a large spike at midnight.
+In contrast, using `H H * * *` would still execute each job once a day,
+but not all at the same time, better using limited resources.
+
+The `H` symbol can be used with a range. For example, `H H(0-7) * * *`
+means some time between 12:00 AM (midnight) to 7:59 AM.
+You can also use step intervals with `H`, with or without ranges.
+
+The `H` symbol can be thought of as a random value over a range,
+but it actually is a hash of the job name, not a random function, so that
+the value remains stable for any given project.
+
+Beware that for the day of month field, short cycles such as `*/3`
+or `H/3` will not work consistently near the end of most months,
+due to variable month lengths.  For example, `*/3`j will run on the
+1st, 4th, …31st days of a long month, then again the next day of
+the next month.  Hashes are always chosen in the 1-28 range, so
+`H/3` will produce a gap between runs of between 3 and 6 days at
+the end of a month.  (Longer cycles will also have inconsistent
+lengths but the effect may be relatively less noticeable.)
+
+Empty lines and lines that start with `#` will be ignored as comments.
+
+In addition, `@yearly`, `@annually`, `@monthly`,
+`@weekly`, `@daily`, `@midnight`,
+and `@hourly` are supported as convenient aliases.
+These use the hash system for automatic balancing.
+For example, `@hourly` is the same as `H * * * *` and could mean at any time during the hour.
+`@midnight` actually means some time between 12:00 AM and 2:59 AM.
+
+[[cron-syntax-examples]]
+.Jenkins cron syntax examples
+[cols=1]
+|===
+|every fifteen minutes (perhaps at :07, :22, :37, :52)
+|`triggers{ cron('H/15 * * * *') }`
+|every ten minutes in the first half of every hour (three times, perhaps at :04, :14, :24)
+|`triggers{ H(0-29)/10 * * * *) }`
+|once every two hours at 45 minutes past the hour starting at 9:45 AM and finishing at 3:45 PM every weekday.
+|`triggers{ 45 9-16/2 * * 1-5) }`
+|once in every two hours slot between 9 AM and 5 PM every weekday (perhaps at 10:38 AM, 12:38 PM, 2:38 PM, 4:38 PM)
+|`triggers{ H H(9-16)/2 * * 1-5) }`
+|once a day on the 1st and 15th of every month except December
+|`triggers{ H H 1,15 1-11 *) }`
+|===
+
 ==== stage
 
 The `stage` directive goes in the `stages` section and should contain a


### PR DESCRIPTION
Take the text from https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly
and put it in the online pipeline syntax documentation.