### PR TITLE
jira macro not linking correctly

### DIFF
--- a/content/blog/2018/09/2018-09-10-scaling-network-connections.adoc
+++ b/content/blog/2018/09/2018-09-10-scaling-network-connections.adoc
@@ -21,7 +21,7 @@ that allows a master to orchestrate agent activity and receive build results.
 Techniques such as tuning the agent launcher can improve service,
 but qualitative change can only come from fundamentally reworking what gets transmitted and how.
 
-In March, jira:27035[] introduced a framework for inspecting the traffic on a Remoting channel at a high level.
+In March, jira:JENKINS-27035[] introduced a framework for inspecting the traffic on a Remoting channel at a high level.
 Previously, developers could only use generic low-level tools such as Wireshark,
 which cannot identify the precise piece of Jenkins code responsible for traffic.
 


### PR DESCRIPTION
Amending #1762 since someone pointed out to me that the link target was to https://issues.jenkins-ci.org/browse/27035 which is of course wrong, despite the linked text getting the `JENKINS-` prefix. Seems like a bug in the macro @oleg-nenashev?