### PR TITLE
Add @deepy to the list of SIG participants (JEP-213)

### DIFF
--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -62,6 +62,9 @@ participants:
 - name: "David Currie"
   id: "dcurrie"
   github: "davidcurrie"
+- name: "Alex Nordlund"
+  id: "deepy"
+  github: "deepy"
 
 organizations:
 - name: "CloudBees"


### PR DESCRIPTION
Adding @deepy to the SIG, because he actively contributes to the External Configuration Storage story.

@tracymiranda @bitwiseman @carlossg. Managing SIG participants in the current way is an uphill battle, there are already 36 members. I would propose so somehow embed the list from the Google Group or so.

