### PR TITLE
Fix pagination for tags

### DIFF
--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -19,7 +19,6 @@ section: blog
   linked_pages << page_count - 1
   linked_pages << page_count - 2
   linked_pages << page_count - 3
-  puts "Loading #{page.url}..."
 
 %div.container.blog-post
   .row.body

--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -19,6 +19,7 @@ section: blog
   linked_pages << page_count - 1
   linked_pages << page_count - 2
   linked_pages << page_count - 3
+  puts "Loading #{page.url}..."
 
 %div.container.blog-post
   .row.body
@@ -50,15 +51,39 @@ section: blog
                 &laquo;
             - previous_visible = false
             - page.posts.pages.each_index do |index|
+              - # The url changed depending on if we are on the first page or later pages.
+              - # These must be relative links to handle pagination of tags.
+              - # First page on blog or tags:
+              - # http://jenkins.io/node/
+              - # http://jenkins.io/node/tags/pipeline/
+              - # Other pages on blog or tags:
+              - # http://jenkins.io/node/page/4.html
+              - # http://jenkins.io/node/tags/pipeline/page/4.html
+              - if page_index == 0
+                - if index == 0
+                  - # link to first page from first page
+                  - link_url = '.'
+                - else
+                  - # link to other page from first page
+                  - link_url = "./page/#{index + 1}.html"
+              - else
+                - if index == 0
+                  - # link to first page from other page
+                  - link_url = '..'
+                - else
+                  - # link to other page from other page
+                  - link_url = "../page/#{index + 1}.html"
+
+              - # whatever the link url, the text is the same
               - if index == 0
                 %li.page-item{:class => ((page_index == index) and 'active')}
-                  %a.page-link{:href => expand_link('node')}
+                  %a.page-link{:href => link_url}
                     1
               - elsif linked_pages.include?(index) or (linked_pages.include?(index - 1) and linked_pages.include?(index + 1))
                 - # page is defined to be linked, or is surrounded by linked pages -- i.e. no gaps of just 1 page
                 - previous_visible = true
                 %li.page-item{:class => ((page_index == index) and 'active')}
-                  %a.page-link{:href => expand_link("node/page/#{index + 1}.html")}
+                  %a.page-link{:href => link_url}
                     = index + 1
               - else
                 - if previous_visible


### PR DESCRIPTION
The existing page linking logic only works for the general blogs list.
When looking at tags with multiple pages of results, the pagination
links back to the general blog pages instead of more tag results.

I recently tried to direct someone to a list of all the blog posts that have to do with pipeline and noticed that pagination within a tag wasn't working.  

If I go to https://jenkins.io/node/tags/jenkinsworld/  and then try to navigate to page 3 using the pagination it leads to https://jenkins.io/node/page/3.html instead of https://jenkins.io/node/tags/jenkinsworld/page/3.html . 

<img width="553" alt="screen shot 2018-09-15 at 3 38 22 pm" src="https://user-images.githubusercontent.com/1958953/45591111-6ecd8700-b8fd-11e8-943d-60ebd4f5641f.png">


This change fixes this by using relative links to stay within the page
structure that it starts in.  It also adjusts the links generated depending
on if this the first page (which has a non-numbered url) or later pages
(which have numbers from 2 up).

<img width="567" alt="screen shot 2018-09-15 at 3 39 33 pm" src="https://user-images.githubusercontent.com/1958953/45591115-91f83680-b8fd-11e8-95a1-b36d9d60f69c.png">
