### PR TITLE
Add missing doctitle to content/doc/book/hardware-recommendations.adoc

### DIFF
--- a/content/doc/book/hardware-recommendations.adoc
+++ b/content/doc/book/hardware-recommendations.adoc
@@ -3,6 +3,7 @@ layout: documentation
 section: doc
 ---
 ifdef::backend-html5[]
+:doctitle: Hardware Recommendations
 :notitle:
 :description:
 :author: R. Tyler Croy


### PR DESCRIPTION
Just a missing `:doctitle:` at  `content/doc/book/hardware-recommendations.adoc` file.