### PR TITLE
Update guidelines to reference the new BlueOcean image and suggest Java 11 by default

### DIFF
--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -51,7 +51,7 @@ The following tags are available:
 * `latest-jdk10` - Jenkins core build from the link:https://github.com/jenkinsci/jenkins/tree/java10-support[java10-support] branch
 * `latest-jdk11` - Automatic build from the core's link:https://github.com/jenkinsci/jenkins/tree/java11-support[java11-support] branch.
 * `blueocean-jdk10`, `blueocean-jdk11` - Experimental build, which bundles all Jenkins Pipeline and
-Blue Ocean patches required to run on Java 10/11.
+Blue Ocean patches required to run on Java 11.
 If you want to try Pipeline, use this image
 
 Java 10/11 images are fully compatible with the official

--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -25,7 +25,8 @@ It also lists known issues and provides contributor guidelines.
 --
 Update from the author: OpenJDK 11 has been released on September 25, 2018.
 Starting from this date, Java 10 is in the "end of life" state.
-Jenkins roject does not longer ship preview versions for Java 10, please use these guidelines only for Java 11 preview builds.
+The Jenkins project no longer ships preview versions for Java 10, 
+please use these guidelines only for Java 11 preview builds.
 --
 
 === Running in Docker

--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -21,6 +21,13 @@ the packages are ready for evaluation and exploratory testing.
 This article explains how to run Jenkins with Java 10 and 11 using Docker images and WAR files.
 It also lists known issues and provides contributor guidelines.
 
+[WARNING]
+--
+Update from the author: OpenJDK 11 has been released on September 25, 2018.
+Starting from this date, Java 10 is in the "end of life" state.
+Jenkins roject does not longer ship preview versions for Java 10, please use these guidelines only for Java 11 preview builds.
+--
+
 === Running in Docker
 
 In order to simplify testing, we have created a new
@@ -33,7 +40,7 @@ so now we can deliver patches for these images without waiting for weekly releas
 You can run the image simply as:
 
 ```
-docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins-experimental:latest-jdk10
+docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins-experimental:latest-jdk11
 ```
 
 The following tags are available:
@@ -42,8 +49,8 @@ The following tags are available:
 * `2.127-jdk11`, `2.128-jdk11` - Weekly releases packaged with Java 11
 * `latest-jdk10` - Jenkins core build from the link:https://github.com/jenkinsci/jenkins/tree/java10-support[java10-support] branch
 * `latest-jdk11` - Automatic build from the core's link:https://github.com/jenkinsci/jenkins/tree/java11-support[java11-support] branch.
-* `blueocean-jdk10` - Experimental build, which bundles all Jenkins Pipeline and
-Blue Ocean patches required to run on Java 10.
+* `blueocean-jdk10`, `blueocean-jdk11` - Experimental build, which bundles all Jenkins Pipeline and
+Blue Ocean patches required to run on Java 10/11.
 If you want to try Pipeline, use this image
 
 Java 10/11 images are fully compatible with the official
@@ -106,14 +113,14 @@ link:https://wiki.jenkins.io/display/JENKINS/Groovy+Hook+Script[Groovy Hooks]
 So far we know about the following issues:
 
 * Pipeline crashes immediately on Java 10 and 11 (link:https://issues.jenkins-ci.org/browse/JENKINS-46602[JENKINS-46602])
-* Git Client plugin 2.7.2 cannot be installed with Java 11,
-`3.0.0-beta3` from link:/doc/developer/publishing/releasing-experimental-updates/#configuring-jenkins-to-use-experimental-update-center[Experimental Update Center] is required
-(link:https://issues.jenkins-ci.org/browse/JENKINS-51871[JENKINS-51871])
+** Workaround: _Pipeline: Support_ plugin should be updated to version 2.21-rc591.43d37d4d080a from the Incrementals repo 
+    (link:https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc295.e017dc58c0a3/[download])
+* *FIXED* - Git Client plugin 2.7.2 cannot be installed when running with Java 11 build 18ea
 * There are many warnings about Illegal reflective access during execution
 (linked in link:https://issues.jenkins-ci.org/browse/JENKINS-40689[JENKINS-40689]).
 ** In current Java 10 and 11 releases it does not lead to failures,
 but we want to cleanup these warnings anyway
-* link:https://github.com/jenkinsci/configuration-as-code-plugin[Configuration-as-Code plugin] fails to export configurations on Java 10
+* *FIXED* - link:https://github.com/jenkinsci/configuration-as-code-plugin[Configuration-as-Code plugin] fails to export configurations on Java 10
 (link:https://issues.jenkins-ci.org/browse/JENKINS-51991[JENKINS-51991])
 
 We anticipate to discover and report more issues during the hackathon this week.


### PR DESCRIPTION
Adds warning to the blogpost and adds some updates to the text of the Java 10/11 running guidelines