### PR TITLE
Add `args` to list of common-to-multiple-agent-types options.

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -161,6 +161,7 @@ agent {
         dir 'build'
         label 'my-defined-label'
         additionalBuildArgs  '--build-arg version=1.0.2'
+        args '-v /tmp:/tmp'
     }
 }
 ----
@@ -198,6 +199,10 @@ on a new node entirely.
 +
 This option is valid for `docker` and `dockerfile`, and only has an effect when
 used on an `agent` for an individual `stage`.
+
+args:: A string. Runtime arguments to pass to `docker run`.
++
+This option is valid for `docker` and `dockerfile`.
 
 [[agent-example]]
 ===== Example


### PR DESCRIPTION
Also add `args` to the example for `dockerfile` just to be safe. =)