### PR TITLE
Hacktoberfest: amend FAQ to reflect the current status

### DIFF
--- a/content/blog/2018/10/2018-10-01-hacktoberfest.adoc
+++ b/content/blog/2018/10/2018-10-01-hacktoberfest.adoc
@@ -20,6 +20,10 @@ We welcome all contributors, regardless of their background and Jenkins experien
 
 image::/images/post-images/2018-hacktoberfest/social-card.png[Hacktoberfest, role=center]
 
+== Quick start
+
+1. Sign-up to Hacktoberfest on link:https://hacktoberfest.digitalocean.com[the event website].
+2. Everything is set, just start creating pull-requests!
 
 == Contributing to Jenkins
 
@@ -124,11 +128,8 @@ for more info.
 
 === FAQ
 
-==== Q: How do I sign up?
-
-1. Sign-up to Hacktoberfest on link:https://hacktoberfest.digitalocean.com[the event website].
-2. Join the link:https://gitter.im/jenkinsci/hacktoberfest-help[Hacktoberfest] channel in Gitter
-3. Everything is set, just start contributing!
+You can find Hacktoberfest FAQ link:https://hacktoberfest.digitalocean.com/faq[here].
+Below you can find answer to some Jenkins-specific questions.
 
 ==== Q: I am new to Jenkins, how do I start?
 
@@ -136,6 +137,13 @@ If you are new to Jenkins,
 you could start by fixing some small and well described issues.
 There are lists of such newbie-friendly issues, see the links in the table above.
 You can also submit your own issue and propose a fix.
+
+==== Q: I want to work on my own plugin, is it fine?
+
+Yes, it is fine!
+Any contributions count, your role in a repository does not matter.
+Just make sure you create pull requests instead of direct pushes
+(hint: it's a best practice if you have a CI configured for your repository).
 
 ==== Q: How to find documentation?
 
@@ -148,14 +156,6 @@ Here are some links which may help:
 * link:https://gitter.im/jenkinsci/jenkins[Gitter channel] for Q&A
 
 Projects in the table above also have their own documentation to help newcomers.
-
-
-==== Q: How do I label issues and pull requests?
-
-Hacktoberfest guidelines require issues and/or pull requests to be labeled with the `hacktoberfest` label.
-You may have no permissions to set labels on your own, but do not worry!
-In Jenkins GitHub organizations just mention `Hacktoberfest` in the title,
-and we will set the labels for you.
 
 ==== Q: How do I get reviews?
 


### PR DESCRIPTION
There are some last-minute changes in the documentation.

- Hacktoberfest does not longer require labeling issues. Registration on the site is enough
- There is a good FAQ page

I also moved Quick Start to the top

@jenkins-infra/copy-editors @jenkins-infra/hacktoberfest 

