### PR TITLE
[JENKINS-53792] Add new environment variables for http authentication documentation

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -242,12 +242,16 @@ You can also precede the argument with `@` to load the same content from a file:
 java -jar jenkins-cli.jar [-s JENKINS_URL] -auth @/home/kohsuke/.jenkins-cli command ...
 ----
 
-The third and last authentication method is to configure environment variables in similar way as the `$JENKINS_URL`
-is used. The `username` can be specified via the environment variable `$JENKINS_USER_ID` while the `apitoken` can
-be specified via the variable `$JENKINS_API_TOKEN`. Both variables have to be set all at once.
+[WARNING]
+====
+For security reasons the use of a file to load the authentication credentials is the recommended authentication way.
+====
 
-In case these environment variables are configured you could override the authentication method using different 
-credentials with the `-auth` option, which takes preference over them.
+An alternative authentication method is to configure environment variables in similar way as the `$JENKINS_URL`
+is used.
+The `username` can be specified via the environment variable `$JENKINS_USER_ID` while the `apitoken` can
+be specified via the variable `$JENKINS_API_TOKEN`.
+Both variables have to be set all at once.
 
 [source]
 ----
@@ -256,11 +260,9 @@ export JENKINS_API_TOKEN=abc1234ffe4a
 java -jar jenkins-cli.jar [-s JENKINS_URL] command ...
 ----
 
-[WARNING]
-====
-For security reasons the recommended way to load the authentication credentials is the use of a file 
-preceded by the `@` character.
-====
+In case these environment variables are configured you could still override the authentication method using different 
+credentials with the `-auth` option, which takes preference over them.
+
 
 Generally no special system configuration need be done to enable HTTP-based CLI connections.
 If you are running Jenkins behind an HTTP(S) reverse proxy,

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -242,6 +242,26 @@ You can also precede the argument with `@` to load the same content from a file:
 java -jar jenkins-cli.jar [-s JENKINS_URL] -auth @/home/kohsuke/.jenkins-cli command ...
 ----
 
+The third and last authentication method is to configure environment variables in similar way as the `$JENKINS_URL`
+is used. The `username` can be specified via the environment variable `$JENKINS_USER_ID` while the `apitoken` can
+be specified via the variable `$JENKINS_API_TOKEN`. Both variables have to be set all at once.
+
+In case these environment variables are configured you could override the authentication method using different 
+credentials with the `-auth` option, which takes preference over them.
+
+[source]
+----
+export JENKINS_USER_ID=kohsuke
+export JENKINS_API_TOKEN=abc1234ffe4a
+java -jar jenkins-cli.jar [-s JENKINS_URL] command ...
+----
+
+[WARNING]
+====
+For security reasons the recommended way to load the authentication credentials is the use of a file 
+preceded by the `@` character.
+====
+
 Generally no special system configuration need be done to enable HTTP-based CLI connections.
 If you are running Jenkins behind an HTTP(S) reverse proxy,
 ensure it does not buffer request or response bodies.

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -247,7 +247,7 @@ java -jar jenkins-cli.jar [-s JENKINS_URL] -auth @/home/kohsuke/.jenkins-cli com
 For security reasons the use of a file to load the authentication credentials is the recommended authentication way.
 ====
 
-An alternative authentication method is to configure environment variables in similar way as the `$JENKINS_URL`
+An alternative authentication method is to configure environment variables in a similar way as the `$JENKINS_URL`
 is used.
 The `username` can be specified via the environment variable `$JENKINS_USER_ID` while the `apitoken` can
 be specified via the variable `$JENKINS_API_TOKEN`.


### PR DESCRIPTION
See [JENKINS-53792](https://issues.jenkins-ci.org/browse/JENKINS-53792).

Downstream of [jenkinsci/jenkins#3653](https://github.com/jenkinsci/jenkins/pull/3653): In a similar way that the environment variable `JENKINS_URL` allows to execute different CLI command without specifying the -s option continuously, environment variable such as `JENKINS_USER_ID` and `JENKINS_API_TOKEN` might help configuring easily the executions without specifying the `-auth` option in each executed command.

![seleccion_001](https://user-images.githubusercontent.com/31063239/46528670-aa23fb80-c894-11e8-8549-cd0b6209fab1.png)



@Wadeck @oleg-nenashev @daniel-beck @reviewbybees