### PR TITLE
Add redirect for https://jenkins.io/doc/book/managing/cli/#http-connection-mode

### DIFF
--- a/content/redirect/cli-http-connection-mode
+++ b/content/redirect/cli-http-connection-mode
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://jenkins.io/doc/book/managing/cli/#http-connection-mode
+---


### PR DESCRIPTION
Same as https://github.com/jenkins-infra/jenkins.io/blob/master/content/redirect/cli-command-requires-channel.adoc

CC @daniel-beck 
