### PR TITLE
Language Nits

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -235,7 +235,7 @@ pipeline {
 
 === Scripted Pipeline fundamentals
 
-In Scripted Pipeline syntax, one or more `node` blocks do/es the core work
+In Scripted Pipeline syntax, one or more `node` blocks do the core work
 throughout the entire Pipeline. Although this is not a mandatory requirement of
 Scripted Pipeline syntax, confining your Pipeline's work inside of a `node`
 block does two things:


### PR DESCRIPTION
Replace "do/es" with "do". Is correct and also improves readability.
Question about: "Scripted Pipeline provides clearer visualization" ... "clearer" than what? Clearer than the Declarative Syntax?
As a newbie I'm looking for some reason to favor one syntax over the other.  Is this a reason to favor the Scripted syntax?