### PR TITLE
Add Sentry as a supporter

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -30,6 +30,7 @@ homepage: true
                 ['JFrog', 'https://jfrog.com'],
                 ['Mac Cloud', 'http://maccloud.me/'],
                 ['PagerDuty', 'https://pagerduty.com'],
+                ['Sentry', 'https://sentry.io/'],
                 ['XMission', 'https://xmission.com'],
   ]
 


### PR DESCRIPTION
Sentry has provided a free account for use in Evergreen and other backend
projects