### PR TITLE
Add reference to wiki page tracking affected plugins

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -2016,6 +2016,8 @@
         title: announcement blog post
       - url: /doc/upgrade-guide/2.138/#security-hardening-to-prevent-xss-vulnerabilities
         title: LTS upgrade guide
+      - url: https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+2018-10-10+Stapler+security+hardening
+        title: list of affected plugins
   - type: major bug
     references:
     - issue: 53239

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -3438,6 +3438,8 @@
       title: announcement blog post
     - url: /doc/upgrade-guide/2.138/#security-hardening-to-prevent-xss-vulnerabilities
       title: LTS upgrade guide
+    - url: https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+2018-10-10+Stapler+security+hardening
+      title: list of affected plugins
   - type: rfe
     message: Security hardening related to Stapler routing.
   - type: rfe

--- a/content/blog/2018/10/2018-10-10-security-updates.adoc
+++ b/content/blog/2018/10/2018-10-10-security-updates.adoc
@@ -28,5 +28,6 @@ This has resulted in a number of cross-site scripting (XSS) vulnerabilities, mos
 For that reason, we have decided to enable this automatic escaping by default if plugins do not specify a preference.
 This can result in problems with some plugins if they need their output to remain unescaped.
 We expect that those plugins will adapt pretty quickly to this change, as the fix is typically straightforward.
+We track known affected plugins and their status on https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+2018-10-10+Stapler+security+hardening[the Jenkins wiki].
 
 In the mean time, users can set the https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[system property] `org.kohsuke.stapler.jelly.CustomJellyContext.escapeByDefault` to `false` to disable this additional protection.

--- a/content/doc/upgrade-guide/2.138.adoc
+++ b/content/doc/upgrade-guide/2.138.adoc
@@ -16,6 +16,7 @@ A security hardening to prevent cross-site scripting vulnerabilities from being 
 This can in rare cases result in views having some content escaped twice (typically resulting in visible HTML entities).
 
 We consider these effects to be a bug in plugins that either opt out of the default test suite, or use outdated toolchains.
+We track known affected plugins and their status on https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+2018-10-10+Stapler+security+hardening[the Jenkins wiki].
 
 As a temporary workaround, this hardening can be disabled by setting the system property `org.kohsuke.stapler.jelly.CustomJellyContext.escapeByDefault` to `false`.
 


### PR DESCRIPTION
https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+2018-10-10+Stapler+security+hardening