### PR TITLE
GSoC 2018 - add a blogpost with results

### DIFF
--- a/content/blog/2018/10/2018-10-12-gsoc2018-results.adoc
+++ b/content/blog/2018/10/2018-10-12-gsoc2018-results.adoc
@@ -1,0 +1,190 @@
+---
+layout: post
+title: "Jenkins in Google Summer of Code 2018. Results"
+tags:
+- community
+- events
+- gsoc
+- gsoc2018
+author: oleg_nenashev
+---
+
+image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]
+
+It has been a while since the last blogpost about link:https://summerofcode.withgoogle.com/[Google Summer of Code] in Jenkins.
+GSoC 2018 has officially finished on August 23, and we had a link:https://www.meetup.com/Jenkins-online-meetup/events/253577758/[Jenkins Online Meetup] where we had final presentations of the GSoC projects.
+It is never late to provide more context, so I would like to summarize the results and provide updates of what was happening in link:/sigs/gsoc[Jenkins GSoC Special Interest Group] over last 2 months. 
+In this blogpost you can find project status overviews and updates from the Jenkins link:/sigs/gsoc[GSoC SIG].
+
+But first of all, I would like to thank all our students, their mentors
+and to all other contributors who proposed project ideas, participated in student selection, community bonding and further reviews.
+Google Summer of Code is a major effort which would not be possible without it.
+
+== Some stats
+
+This year we started preparing to Google Summer of Code in early December.
+After initial processing of project ideas,
+we have got 14 project ideas and 12 potential mentors.
+
+We had 3 projects this year:
+Code Coverage API plugin, Remoting over Apache Kafka, and Simple Pull-Request Job Plugin
+(also known as _Pipeline as YAML_).
+2 projects have been passed during the final evaluation.
+All these projects have a significant value to the Jenkins community.
+They were focused on areas which have been discussed in the community for a long time,
+but which had no progress so far.
+Google Summer of Code allowed us to kick-start these projects,
+and to get a significant progress.
+All projects have been released and made available in the Jenkins community (common or experimental update centers).
+
+In total there were 9 blogposts about GSoC projects on jenkins.io,
+and also 2 link:https://www.meetup.com/Jenkins-online-meetup[Jenkins Online Meetups].
+GSoC results have been also presented at DevOps World - Jenkins World conference and the contributor summit.
+
+++++
+<center>
+  <iframe src="https://docs.google.com/presentation/d/1YiN4nbc_uIt6L7iZ6VckF8sCPBAp1dqBkFexM7uAuiQ/embed?start=false&loop=false&delayms=60000" frameborder="0" width="720" height="434" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</center>
+++++
+
+== Code Coverage API Plugin
+
+* Student: link:https://github.com/cizezsy[Shenyu Zheng], Henan University, China
+* Mentors:
+    link:https://github.com/jeffpearce[Jeff Pearce],
+    link:https://github.com/christ66[Steven Christou],
+    link:https://github.com/oleg-nenashev[Oleg Nenashev],
+    link:https://github.com/Supun94[Supun Wanniarachchi]
+* link:/projects/gsoc/2018/code-coverage-api-plugin/[Project page]
+
+There are many code coverage plugins in Jenkins: Cobertura, JaCoCo, Emma, etc., etc.
+The problem with these plugins is that each of them implements all code coverage features on their own.
+So you get different feature sets, UIs, CLI commands and REST APIs.
+The idea of this project was to unify the existing functionality and offer a new API plugin which other plugins could extend.
+It would help to simplify existing plugin and to create new plugins for coverage tools.
+
+The project has started really well, and we had the first demo after a week of coding.
+Then Shenyu continued extending the plugin's functionality over coding periods.
+
+Here is the list of the key features offered by the plugin:
+
+* Flexible data structure for defining and storing coverage metrics within Jenkins
+* Coverage charts and trends
+* Source code navigation
+* REST API for retrieving coverage stats and trends
+* Report aggregation for parallel steps
+* Extension points which allow integrating other plugins
+
+In addition to the Code Coverage API Plugin, 
+Shenyu added integration to the plugin:cobertura[Cobertura Plugin] and also created a new link:https://github.com/jenkinsci/llvm-cov-plugin[llvm-cov plugin] which is expected to be released soon.
+
+After GSoC Shenyu continued contributing to the Jenkins project.
+He works on the Code Coverage API plugin and also participates in the link:/sigs/chinese-localization/[Chinese Localization SIG].
+
+== Simple Pull-Request Job Plugin
+
+* Student: link:https://github.com/gautamabhishek46/[Abhishek Gautam], Visvesvaraya National Institute of technology, India
+* Mentors:
+    link:https://github.com/martinda[Martin d'Anjou],
+    link:https://github.com/Jeff-Symphony[Jeff Knurek],
+    link:https://github.com/kwhetstone[Kristin Whetstone]
+* link:/projects/gsoc/2018/simple-pull-request-job-plugin/[Project page]
+
+This project by link: focused on introducing a way to
+easily define pull-request build job definitions in YAML.
+This project has been shaped a lot during the application period and community bonding,
+so that the project fit the existing Jenkins Ecosystem better.
+Finally it was decided to build the new plugin on the top of plugin:workflow-multibranch[Pipeline: Multi-Branch Plugin].
+There was also an idea to offer extra syntax sugar, templating and automatic resolution for common flows, 
+so that users need less time to define Pipelines for common use-cases.
+
+The plugin allows defining Pipeline jobs as YAML being stored in SCM.
+Original design presumed a new job type,
+but during community bonding and Phase 1 prototyping it was decided to build the plugin on the top of the existing Pipeline ecosystem and extension points.
+Currently the plugin generates Declarative Pipeline code from YAML so that it gets a lot of Pipeline features out-of-the box.
+In addition to that, Simple Pull Request Job Plugin uses a an engine provided by the link:https://github.com/jenkinsci/configuration-as-code-plugin[Configuration as Code plugin] to convert YAML snippets
+to Pipeline step definitions.
+
+The plugin has been well described by Abhishek in his link:/blog/2018/08/14/simple-pull-request-plugin-final-evaluation/[Pipeline as YAML] blogpost in August.
+Currently it is available in the link:/doc/developer/publishing/releasing-experimental-updates/[Experimental Update Center] as an alpha version.
+Pham Vu Tuan, one of our GSoC students, have also joined the plugin team.
+At the DevOps World - Jenkins World hackfest we had discussions with the Jenkins Pipeline team,
+and we have a plan towards making this plugin available as an Incubated Pipeline project.
+The final implementation may change,
+but in any case the project gave us a working prototype and a lot of information about  obstacles we need to resolve.
+
+== Remoting over Apache Kafka
+
+* Student: link:https://github.com/pvtuan10[Pham Vu Tuan], Nanyang Technological University, Singapore
+* Mentors:
+    link:https://github.com/oleg-nenashev[Oleg Nenashev],
+    link:https://github.com/Supun94[Supun Wanniarachchi]
+* link:/projects/gsoc/2018/remoting-over-message-bus/[Project page]
+
+Last but not least, Remoting over Kafka is another challenging project we had.
+To implement communication between its masters and agents, Jenkins widely uses home-grown protocol implementations based on TCP
+(link:https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md[JNLP 1..4 protocols]).
+There are some performance and stability implementations,
+and there have been discussions about using an industry-standard message bus or queue.
+Pham Vu Tuan proposed to use Apache Kafka for it,
+and after some experiments during community bonding and first coding phase we agreed to go forward with this implementation.
+
+During his project Vu Tuan extended Jenkins Core and Remoting to allow implementing an agent communication channel in a plugin.
+Then he has created a new plugin:remoting-kafka[Remoting over Kafka plugin]
+which is now available in the main Jenkins Update cente.
+Once the plugin is installed, it is possible to connect to agents over Apache Kafka and execute all types of Jenkins jobs there.
+There are also official link:https://hub.docker.com/r/jenkins/remoting-kafka-agent/[jenkins/remoting-kafka-agent] images available on DockerHub.
+
+Vu Tuan continued contributing to the Jenkins project after GSoC, currently he maintains the Remoting over Kafka plugin.
+He visited the link:https://www.cloudbees.com/devops-world/san-francisco[DevOps World - Jenkins World US] conference in September, presented his GSoC project at the
+link:/blog/2018/07/25/contributor-summit/[Jenkins Contributor Summit].
+You can find his slides link:https://docs.google.com/presentation/d/1drRIDNvDKdBE-VuuLFXlWRB0NhSFr1aWrg2p8qrF3co/edit?usp=sharing[here].
+After the conference he also participated in the hackfest where he helped to migrate Jenkins' DNS services to Microsoft Azure.
+
+== What could we do better?
+
+After the end of GSoC we had a link:https://docs.google.com/document/d/1sJ9KIYHUoFWWE9HmoZC7HPDxm2i3uMFGQ2KKZ_1TTjk/edit?usp=sharing[Retrospective] with GSoC students and mentors.
+We discussed issues we hit during the projects, 
+and ways to improve the student and mentor experience.
+
+Main takeaways for us:
+
+* GSoC projects should be aligned with link:/sigs[Jenkins Special Interest Groups (SIGs)] or link:/projects[subprojects] in order to get a wider list of stakeholders
+  Projects should be aligned with SIG priorities when possible
+* In addition to GSoC SIG meetings and Jenkins Online Meetups during student evaluation,
+  we should also run regular status updates within SIGs so that there more contributors involved in projects
+* We should invest more time into forming mentor teams before the application period starts.
+  This year there were changes in mentor teams after the community bonding started, and it complicated the work 
+* We should pay more attention to student eligibility.
+  This year we started from 4 projects, but unfortunately one project (EDA plugins for Jenkins) got cancelled due to the visa limitations the student had.
+* We should do regular office hours for mentors/students so that it is possible to exchange information between GSoC projects within the organization.
+  This year we cancelled them at the end of phase and relied only on regular project meetings and mailing lists, but this is not enough.
+
+For me personally the main takeaway is also to reduce direct involvement into the project as a mentor and technical advisor.
+Doing org administration, logistics and mentorship is not good from a bus factor PoV, 
+and I believe I was pushing my vision too hard in few cases.
+Will do my best to prevent it next year.
+
+If you want to share your feedback and ideas,
+please reach out to us using the link:https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public[GSoC SIG] mailing list.
+
+== What's next?
+
+According to the link:https://docs.google.com/document/d/1sJ9KIYHUoFWWE9HmoZC7HPDxm2i3uMFGQ2KKZ_1TTjk/edit?usp=sharing[Retrospective], next year we plan to invest more
+into communication with mentors.
+We will also try to tie new project proposals to Jenkins
+link:/sigs[Special Interest Groups] so that the students become a part
+of ongoing coordinated efforts.
+this week Martin d'Anjou, Jeff Pearce and me will be participating in the GSoC Mentor summit to share experiences and to study from other GSoC organizations.
+On October 17 we will have a GSoC SIG meeting to discuss our experience and to discuss next steps.
+
+In addition to that,
+Jenkins Google Summer of Code will be presented at link:https://www.cloudbees.com/devops-world/nice[DevOps World - Jenkins World Nice] and at the contributor summit.
+If you plan to visit the conference and you are interested to participate in Google Summer of Code and other community activities,
+please join us at the link:/blog/2018/08/21/contributor-summit-nice/[contributor summit] or stop by at the community booth.
+
+And, elephant in the room... GSoC 2019.
+Of course we are going to apply, stay tuned for new announcements.
+We have already started collecting project ideas for the next year.
+If you are interested to participate as a student or mentor,
+please reach out to us using the link:https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public[GSoC SIG mailing list].


### PR DESCRIPTION
Summary blogpost for Google Summer of Code. Some bit of conference-driven blogposting, but better late than never

CC @martinda @jeffpearce @jenkins-infra/copy-editors 
