### PR TITLE
GSoC: Move Mentor Guidelines from the announcement blogpost to the mentors page

### DIFF
--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -7,25 +7,66 @@ tags:
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]
 
-This page aggregates links to internal and external resources about resources for **mentors**.
+This page aggregates links to internal and external resources about resources
+for Google Summer of Code **mentors**.
 Student resources can be found link:/projects/gsoc/students[here].
 
 :toc:
 
 == Links
 
-=== External resources
-
 * link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide]
 * link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline]
-
-=== Internal resources
-
 * Mailing list for mentors: jenkinsci-gsoc-orgs@googlegroups.com
 * Mailing list for contacting Org Admins: jenkinsci-gsoc-orgs@googlegroups.com
 * link:/conduct[Code of Conduct]
 
-== Conflict of interest prevention
+== What do mentors get?
+
+* A student who works full-time in the area of your interest for several months
+* Joint projects with Jenkins experts, lots of fun and ability to study something together
+* Limited-edition of swags from Google and Jenkins project
+* Maybe: Participation in GSoC Mentor Summit and other GSoC events/meetups
+
+== How to become a mentor?
+
+During GSoC you can join an existing project at any time, including community bonding and coding periods.
+You can also propose your own projects for GSoC, see below.
+
+=== Proposing projects
+
+If you are interested in proposing a project or joining an existing one,
+please start a thread in the GSoC SIG mailing list and describe your idea there.
+
+* GSoC is about code (though it may and likely should include some documentation and testing work)
+* Projects should be about Jenkins (plugins, core, infrastructure, integrations, etc.)
+* Projects should be potentially doable by a student in 3-4 months
+
+You can find more information about requirements and practices in the
+link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide].
+
+== Details
+
+=== Expectations from mentors
+
+Mentors are expected to...
+
+* Be passionate about Jenkins
+* Lead the project in the area of their interest
+* Actively participate in the project during student selection, community bonding and coding phases (March - August)
+* Work in teams of 2+ mentors per 1 each student
+* Dedicate a consistent and significant amount of time, especially during the coding phase (_~5 hours_ per week in a team of two mentors)
+
+Mentorship does **NOT** require strong expertise in Jenkins plugin development.
+The main objective is to guide students and to get them involved into the Jenkins community.
+GSoC org admins will help to find advisors if a special expertise is needed.
+
+
+=== Expectations from mentors per phase
+
+This section is under construction.
+
+=== Conflict of interest prevention
 
 We will appreciate mentorship provided by any Jenkins contributor.
 On the other hand, we want to avoid any conflicts with GSoC rules and spirit.


### PR DESCRIPTION
Some minimal copy-edits, mostly copy-paste.
We will be improving guidelines later

@martinda @christ66 
