### PR TITLE
[WEBSITE-527] - Create base pages for GSoC 2019

### DIFF
--- a/content/projects/gsoc/2019/index.adoc
+++ b/content/projects/gsoc/2019/index.adoc
@@ -1,0 +1,31 @@
+---
+layout: project
+title: "Jenkins in Google Summer of Code 2019"
+tags:
+- gsoc
+---
+
+In 2019 we plan to apply to Google Summer of Code.
+This page contains only the 2019-specific information.
+See the link:/projects/gsoc/[main GSoC page] for the actual information.
+
+== Project ideas
+
+See the list of current project ideas link:/projects/gsoc/2019/project-ideas[here].
+You can also link:/projects/gsoc/proposing-project-ideas[propose your own project] for GSoC.
+
+=== Org admins
+
+GSoC Organization admins in 2019:
+
+* link:https://github.com/martinda[Martin d'Anjou]
+* link:https://github.com/jeffpearce[Jeff Pearce]
+* link:https://github.com/lloydchang[Lloyd Chang]
+* link:https://github.com/oleg-nenashev/[Oleg Nenashev]
+
+=== Links
+
+* link:/projects/gsoc/gsoc2018-project-ideas[GSoC 2018 Project ideas]
+* link:/blog/2018/01/06/gsoc2018-call-for-mentors[Call for Mentors]
+* link:https://summerofcode.withgoogle.com/organizations/5572716199936000/[Jenkins page on GSoC 2018 website]
+

--- a/content/projects/gsoc/2019/project-ideas.adoc
+++ b/content/projects/gsoc/2019/project-ideas.adoc
@@ -1,0 +1,125 @@
+---
+layout: project
+title: "GSoC 2019 Project Ideas"
+tags:
+- gsoc
+- gsoc2019
+---
+
+image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]
+
+This page aggregates project ideas for Google Summer of Code 2019.
+See more information about this project and applications at link:/projects/gsoc/[the project's page].
+
+Below you can find project ideas proposed by potential mentors.
+Other ideas may be proposed by students (e.g. new features in the core, "write a plugin for MY_TOOL_OR_SERVICE", etc.).
+Such project applications will be considered though applicants may need to work
+with the community and GSoC admins to find potential mentors.
+
+:toc:
+
+== Cloud Features for External Workspace Manager Plugin
+
+We wish to add Cloud features to the Jenkins External Workspace Manager Plugin.
+
+This would allow Jenkins workspaces to be cloud based or located remotely, rather than being local.
+These features include:
+
+* Cloud-based storage support (link:https://groups.google.com/d/msg/jenkinsci-dev/z40kn8IqFb8/YkdgbuScCgAJ[discussion])
+* Support use of multiple discard strategies
+* Integration with the core's “Discard old builds” feature
+* Improvements to data retention policies (e.g.
+link:https://issues.jenkins-ci.org/browse/JENKINS-48715[JENKINS-48715],
+link:https://issues.jenkins-ci.org/browse/JENKINS-2111[JENKINS-2111],
+link:https://issues.jenkins-ci.org/browse/JENKINS-38764[JENKINS-38764])
+* Workspace usage statistics
+* Improvements to workspace usage statistics
+* Better workspace cleanup management, e.g. matrix workspaces cleanup link:https://issues.jenkins-ci.org/browse/JENKINS-27329[JENKINS-27329]
+
+**SIGs:**
+link:/sigs/cloud-native
+
+**Skills:**
+Java, Cloud-based storage
+
+**Potential mentors:**
+link:https://github.com/martinda[Martin d'Anjou],
+link:https://github.com/oleg-nenashev[Oleg Nenashev]
+
+== Role Strategy Plugin performance and/or user experience
+
+link:https://wiki.jenkins.io/display/JENKINS/Role+Strategy+Plugin[Role Strategy Plugin] is widely used in Jenkins as an authorization engine,
+but it has known performance limitations for large-scale setups.
+In this project the proposal is to improve the plugin's performance and to create a proper testing framework for Jenkins security plugins.
+Web interfaces of this plugin can be also improved.
+
+**Skills:**
+Java, performance testing, profiling tools, JavaScript (for UX part)
+
+== Plugin(s) for Electronic Design Automation tools
+
+The idea is to create a Jenkins plugin for one of widely used EDA tools.
+Both ASIC or FPGA design flow are acceptable, the tool should be proposed by the potential student.
+Open-source EDA tools would be preferable (e.g. Yosys, FuseSoC, ArachnePnR, icetools), but we also consider
+conditionally-free tools (like FPGA design EDAs).
+
+
+Examples of tool integration:
+
+* Tool launch and publishing steps for Free-style and/or Pipeline jobs
+* Integration with Warnings Plugin for report parsing.
+* Reporting of FPGA resource utilization (per build + trends)
+* Timing report trend publishing
+* Integrating UVM reports into Jenkins build and project pages
+
+**Skills:**
+Jenkins as a user, Java
+
+**Special requirements:**
+In the case of FPGA tools integration, a prototyping board will be required.
+
+== Improvements to the Jenkins Acceptance Test Harness
+
+The link:https://github.com/jenkinsci/acceptance-test-harness[Jenkins Acceptance Test Harness (ATH)] is a great vehicle
+to test Jenkinsfiles and custom DSL libraries ahead of deploying them to production servers.
+However, it has couple of drawbacks.
+
+* it can be quite slow as it needs to bootstrap an entire Jenkins instance for each test method.
+* real production environments typically need to use a very specific plugin list of pre-defined plugins and plugin versions
+
+Improving these two areas would make the ATH more efficient and easy to use for Jenkinsfile and custom DSL library testing.
+
+For example, instead of dynamically creating a Jenkins instance for each test, an instance could be built as a docker image,
+loaded as a java link:https://github.com/testcontainers/testcontainers-java[testcontainers], and injected with the DSL to be tested.
+
+**Skills:**
+Java, Selenium, Docker
+
+**Potential mentors:**
+link:https://github.com/martinda[Martin d'Anjou]
+
+== Discard Builds Step Plugin
+
+The idea behind this plugin is to give users more options to manage and implement a data retention policy that covers their build histories, artifacts
+and workspaces (internal and external).
+This responsibility typically falls on the shoulders of Jenkins administrators,
+but since projects can have unique data retention requirements, this responsibility should be with project contributors.
+This plugin would enable users to specify their own data retention policy via a Pipeline build step.
+
+The current Discard Old Builds feature could be improved, however to use it one must resort to clicking buttons in the UI, which is not
+desirable in the context of configuration-as-code. Also, the plugin would offer features above and beyond the existing Discard Old Builds functionality.
+
+The plugin would internally work in two phases:
+
+* Determine a list of builds to discard by looking at the build history of a given project.
+* Perform the discard actions on the builds that were made elements of the list of builds to discard.
+
+This plugin would leverage and enhance the link:https://github.com/jenkinsci/run-selector-plugin/blob/master/README.md[Run Selector Plugin] for selecting builds to discard, and new code would be written to perform the data discard actions.
+
+More information regarding this proposal is available link:https://docs.google.com/document/d/1q2p_XZEdbkcVDMpEPTtjPS15i2Oq3CQgH_geJjPhofY/edit#heading=h.h6ynt8ul8vwx[here].
+
+**Skills:**
+Java
+
+**Potential mentors**
+link:https://github.com/martinda[Martin d'Anjou]

--- a/content/projects/gsoc/gsoc2018-project-ideas.adoc
+++ b/content/projects/gsoc/gsoc2018-project-ideas.adoc
@@ -6,6 +6,9 @@ tags:
 - gsoc2018
 ---
 
+WARNING: This is an archived page about Jenkins project participation in Google Summer of Code 2016.
+See link:/projects/gsoc[the main GSoC project] page of the information about the current and previous years.
+
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]
 
 This page aggregates project ideas for Google Summer of Code 2018.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -25,11 +25,14 @@ in completing their summer projects.
 We plan to participate in GSoC 2019.
 Stay tuned for announcements.
 
+* link:/projects/gsoc/2019/project-ideas[GSoC 2019 Project ideas]
+* link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
+
 == Links
 
 * link:/projects/gsoc/students[Information for students]
 * link:/projects/gsoc/mentors[Information for mentors]
-* link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline].
+* link:/sigs/gsoc[Jenkins GSoC Special Interest Group]
 
 === Contacts
 
@@ -51,12 +54,6 @@ Video calls will be conducted on-demand.
 In addition to these meetings,
 each GSoC project has regular meetings during community bonding and coding phases.
 See the project pages for the schedule.
-
-=== Org admins
-
-* link:https://github.com/oleg-nenashev/[Oleg Nenashev]
-* link:https://github.com/martinda[Martin d'Anjou]
-* link:https://github.com/christ66[Steven Christou]
 
 == Previous years
 

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -31,19 +31,8 @@ Student resources can be found link:/projects/gsoc/students[here].
 == How to become a mentor?
 
 During GSoC you can join an existing project at any time, including community bonding and coding periods.
-You can also propose your own projects for GSoC, see below.
-
-=== Proposing projects
-
-If you are interested in proposing a project or joining an existing one,
-please start a thread in the GSoC SIG mailing list and describe your idea there.
-
-* GSoC is about code (though it may and likely should include some documentation and testing work)
-* Projects should be about Jenkins (plugins, core, infrastructure, integrations, etc.)
-* Projects should be potentially doable by a student in 3-4 months
-
-You can find more information about requirements and practices in the
-link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide].
+Just send an email to our GSoC mailing list.
+You can also link:/projects/gsoc/proposing-project-ideas[propose your own project] for GSoC, see below.
 
 == Details
 

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -1,0 +1,45 @@
+---
+layout: project
+title: "Proposing new project ideas"
+tags:
+- gsoc
+---
+
+:toc:
+
+If you are interested in proposing a project or joining an existing one,
+please start a thread in the GSoC SIG mailing list and describe your idea there.
+New ideas can be proposed by mentors and/or students.
+In order to propose a new project idea, create a draft description and start a new thread in the GSoC SIG mailing list
+(use the _[GSoC]_ prefix in the email subject).
+
+== Requirements
+
+* GSoC is about code (though it may and likely should include some documentation and testing work)
+* Projects should be about Jenkins (plugins, core, infrastructure, integrations, etc.)
+* Projects should be potentially doable by a student in 3-4 months
+
+You can find more information about requirements and practices in the
+link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide].
+
+== Examples
+
+Need some hints? Here are examples of project ideas:
+
+* A new plugin for integration with various development tools or services
+* link:https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopting an existing plugin],
+extending it by adding new features like link:/doc/book/pipeline/[Jenkins Pipeline]
+* Working on major feature requests from the link:https://issues.jenkins-ci.org/secure/Dashboard.jspa[Jenkins bugtracker]
+* Creating new demo and reference setups,
+powered by various "-as-Code" engines (e.g. Jenkins Pipeline, JobDSL, Docker, link:/projects/gsoc/gsoc2018-project-ideas/#jenkins-configuration-as-code[Configuration-as-Code plugin], etc.)
+
+Once the project idea is proposed in the mailing list,
+link:/projects/gsoc/#mentors-and-org-admins[GSoC org admins] will help to finalize the idea and to reach out to potential mentors/co-mentors.
+
+== Notes for students
+
+Although we encourage students to propose their own project ideas, we cannot guarantee
+that will find potential mentors for every proposal, especially for narrow areas.
+During the selection phase we won't be able to accept proposals without mentors, so
+we highly recommend getting initial feedback in the mailing lists before spending too much
+time on such proposals.


### PR DESCRIPTION
This change does some initialization for GSoC 2019 pages. It does not rework project ideas to the new layout we discussed before, but it should be a good starting point for rework.

- [x] - Create a landing page for GSoC 2019
- [x] - Move viable 2018 project ideas to 2019
- [x] - Deduplicate "proposing GSoC project ideas" and move the content to a separate page

@martinda @jeffpearce @lloydchang