### PR TITLE
Point the accounts link to the final destination

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -235,7 +235,7 @@ To encourage migration of plugins from Subversion to Git, a daemon is used to mi
 
 === User Accounts
 
-The infrastructure admins run an LDAP server and link:https://jenkins-ci.org/account[a small frontend program] to let users create accounts on jenkins-ci.org. This account is used for all the software that we run ourselves.
+The infrastructure admins run an LDAP server and link:https://accounts.jenkins.io/[a small frontend program] to let users create accounts on jenkins-ci.org. This account is used for all the software that we run ourselves.
 
 === Wiki
 


### PR DESCRIPTION
The accounts page has been moved to a new URL, and setting the link to the final URL will avoid a redirection