### PR TITLE
Add changelog and upgrade guide for 2.138.3

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -2049,6 +2049,23 @@
     message: >
       Nested <code>f:repeatable</code>/<code>f:repeatableProperty</code> form elements inherited <code>minimum</code> when they shouldn't.
   # pull: 3621 too minor (JENKINS-53549: docs on workspace location)
+- version: 2.138.3
+  date: 2018-10-08
+  changes:
+    - type: bug
+      issue: 48516
+      pull: 3672
+      message: >
+        The initial visibility of nested groups of radio buttons did not accurately reflect the current values.
+    - type: bug
+      issue: 50795
+      pull: 3614
+      message: >
+        Improve robustness when search items don't specify a display name.
+    - type: rfe
+      issue: 54029
+      message: >
+        Add telemetry trial related to Stapler request dispatching.
 
 
 

--- a/content/doc/upgrade-guide/2.138.adoc
+++ b/content/doc/upgrade-guide/2.138.adoc
@@ -8,6 +8,10 @@ notitle: true
 
 Each section covers the upgrade from the previous LTS release, the section on 2.138.1 covers the upgrade from 2.121.3.
 
+=== Upgrading to Jenkins LTS 2.138.3
+
+No notable changes requiring upgrade notes.
+
 === Upgrading to Jenkins LTS 2.138.2
 
 ==== Security hardening to prevent XSS vulnerabilities


### PR DESCRIPTION
> ![screen shot](https://user-images.githubusercontent.com/1831569/48228668-233bd480-e3a6-11e8-9a24-9b55d289caf2.png)

Per yesterday's meeting, I asked @kohsuke to release today.