### PR TITLE
Remove unnecessary semicolons in shared-libraries.adoc

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -322,11 +322,11 @@ is okay for use. Different data structures, utility methods, etc, such as:
 [source,groovy]
 ----
 // src/org/foo/Point.groovy
-package org.foo;
+package org.foo
 
 // point in 3D space
 class Point {
-  float x,y,z;
+  float x,y,z
 }
 ----
 
@@ -339,7 +339,7 @@ class, which in turn invoke Pipeline steps, for example:
 [source,groovy]
 ----
 // src/org/foo/Zot.groovy
-package org.foo;
+package org.foo
 
 def checkOutFrom(repo) {
   git url: "git@github.com:jenkinsci/${repo}"


### PR DESCRIPTION
Remove unnecessary semicolons in /content/doc/book/pipeline/shared-libraries.adoc.