### PR TITLE
[WEBSITE-531] Add new CLI commands for enabling and disabling plugins

### DIFF
--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -227,11 +227,11 @@ otherwise ignored.
 
 ==== Using the Jenkins CLI
 
-Making use of the <<cli#,Jenkins CLI>> it is also possible to enable and disable
-plugins. Since Jenkins 2.136, administrators may invoke the `enable-plugin` 
-command to re-enable again a collection of plugins which were previously disabled
-and since Jenkins 2.151, the `disable-plugin` command is included, which provides
-a command to disable installed plugins.
+It is also possible to enable and disable plugins using the <<cli#,Jenkins CLI>>.
+Since Jenkins 2.136, administrators may invoke the `enable-plugin` command to 
+re-enable again a collection of plugins which were previously disabled and since
+Jenkins 2.151, the `disable-plugin` command is included, which provides a command
+to disable installed plugins.
 
 The `enable-plugin` command receives as parameter a list of plugins to be enabled.
 If any of the plugins have one or more dependencies, these plugins will be enabled

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -225,6 +225,67 @@ The configuration(s) created by the disabled plugin behave as if the plugin
 were uninstalled, insofar that they result in warnings on boot but are
 otherwise ignored.
 
+==== Using the Jenkins CLI
+
+Making use of the <<cli#,Jenkins CLI>> it is also possible to enable and disable
+plugins. Since Jenkins 2.136, administrators may invoke the `enable-plugin` 
+command to re-enable again a collection of plugins which were previously disabled
+and since Jenkins 2.151, the `disable-plugin` command is included, which provides
+a command to disable installed plugins.
+
+The `enable-plugin` command receives as parameter a list of plugins to be enabled.
+If any of the plugins have one or more dependencies, these plugins will be enabled
+as well.
+
+[source]
+----
+java -jar jenkins-cli.jar -s http://localhost:8080/ enable-plugin PLUGIN ... [-restart]
+
+Enables one or more installed plugins transitively.
+
+ PLUGIN   : Enables the plugins with the given short names and their
+            dependencies.
+ -restart : Restart Jenkins after enabling plugins.
+----
+
+The `disable-plugin` command receives as parameter a list of plugins to disable.
+The output will display messages for both successful and failed operations. In 
+case that only the error messages are desired, the execution should add the 
+`-quiet` option. How to deal with other plugins which depend on one or more of 
+the plugins passed as parameter may be specified with the `-strategy` option.
+
+[source]
+----
+java -jar jenkins-cli.jar -s http://localhost:8080/ disable-plugin PLUGIN ... [-quiet (-q)]
+[-restart (-r)] [-strategy (-s) strategy]
+
+Disable one or more installed plugins.
+Disable the plugins with the given short names. You can define how to proceed with the 
+dependant plugins and if a restart after should be done. You can also set the quiet mode 
+to avoid extra info in the console.
+
+ PLUGIN                  : Plugins to be disabled.
+ -quiet (-q)             : Be quiet, print only the error messages
+ -restart (-r)           : Restart Jenkins after disabling plugins.
+ -strategy (-s) strategy : How to process the dependant plugins. 
+                           - none: if a mandatory dependant plugin exists and
+                           it is enabled, the plugin cannot be disabled
+                           (default value).
+                           - mandatory: all mandatory dependant plugins are
+                           also disabled, optional dependant plugins remain
+                           enabled.
+                           - all: all dependant plugins are also disabled, no
+                           matter if its dependency is optional or mandatory.
+----
+
+[CAUTION]
+====
+In the same way than enabling and disabling plugins from the UI need a restart 
+to complete the process, the changes made with the CLI commands will take effect
+once Jenkins is restarted. The `-restart` option forces the instance to restart
+once the command has successfully finished, so the changes will be immediately
+applied.
+====
 
 == Pinned plugins
 

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -236,9 +236,8 @@ The `enable-plugin` command was added to Jenkins in https://jenkins.io/changelog
 The `disable-plugin` command was added to Jenkins in https://jenkins.io/changelog/#v2.151[v2.151].
 ====
 
-The `enable-plugin` command receives a list of plugins to be enabled. If any of 
-the plugins have one or more dependencies, these plugins and their dependencies
-will be enabled.
+The `enable-plugin` command receives a list of plugins to be enabled. 
+Any plugins which a selected plugin depends on will also be enabled by this command.
 
 [source]
 ----
@@ -252,10 +251,10 @@ Enables one or more installed plugins transitively.
 ----
 
 The `disable-plugin` command receives a list of plugins to be disabled. The 
-output will display messages for both successful and failed operations. In case
-that only the error messages are desired, the `-quiet` option can be specified.
-How to deal with other plugins which depend on one or more of the plugins 
-passed as parameter may be specified with the `-strategy` option.
+output will display messages for both successful and failed operations. If you
+only want to see error messages, the `-quiet` option can be specified.
+The `-strategy` option controls what action will be taken when one of the specified plugins
+is listed as an optional or mandatory dependency of another enabled plugin. 
 
 [source]
 ----
@@ -283,7 +282,7 @@ to avoid extra info in the console.
 
 [CAUTION]
 ====
-In the same way than enabling and disabling plugins from the UI need a restart 
+In the same way than enabling and disabling plugins from the UI requires a restart 
 to complete the process, the changes made with the CLI commands will take effect
 once Jenkins is restarted. The `-restart` option forces a safe restart of the 
 instance once the command has successfully finished, so the changes will be 

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -227,11 +227,14 @@ otherwise ignored.
 
 ==== Using the Jenkins CLI
 
-It is also possible to enable and disable plugins using the <<cli#,Jenkins CLI>>.
-Since https://jenkins.io/changelog/#v2.136[Jenkins 2.136], administrators may 
-invoke the `enable-plugin` command to re-enable a collection of plugins which 
-were previously disabled and since https://jenkins.io/changelog/#v2.151[Jenkins 2.151] 
-the `disable-plugin`, which provides a command to disable installed plugins, is included.
+It is also possible to enable or disable plugins via the <<cli#,Jenkins CLI>> 
+using the `enable-plugin` or `disable-plugin` commands.
+
+[NOTE]
+====
+The `enable-plugin` command was added to Jenkins in https://jenkins.io/changelog/#v2.136[v2.136].
+The `disable-plugin` command was added to Jenkins in https://jenkins.io/changelog/#v2.151[v2.151].
+====
 
 The `enable-plugin` command receives a list of plugins to be enabled. If any of 
 the plugins have one or more dependencies, these plugins and their dependencies

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -228,14 +228,14 @@ otherwise ignored.
 ==== Using the Jenkins CLI
 
 It is also possible to enable and disable plugins using the <<cli#,Jenkins CLI>>.
-Since Jenkins 2.136, administrators may invoke the `enable-plugin` command to 
-re-enable again a collection of plugins which were previously disabled and since
-Jenkins 2.151, the `disable-plugin` command is included, which provides a command
-to disable installed plugins.
+Since https://jenkins.io/changelog/#v2.136[Jenkins 2.136], administrators may 
+invoke the `enable-plugin` command to re-enable a collection of plugins which 
+were previously disabled and since https://jenkins.io/changelog/#v2.151[Jenkins 2.151] 
+the `disable-plugin`, which provides a command to disable installed plugins, is included.
 
-The `enable-plugin` command receives as parameter a list of plugins to be enabled.
-If any of the plugins have one or more dependencies, these plugins will be enabled
-as well.
+The `enable-plugin` command receives a list of plugins to be enabled. If any of 
+the plugins have one or more dependencies, these plugins and their dependencies
+will be enabled.
 
 [source]
 ----
@@ -248,11 +248,11 @@ Enables one or more installed plugins transitively.
  -restart : Restart Jenkins after enabling plugins.
 ----
 
-The `disable-plugin` command receives as parameter a list of plugins to disable.
-The output will display messages for both successful and failed operations. In 
-case that only the error messages are desired, the execution should add the 
-`-quiet` option. How to deal with other plugins which depend on one or more of 
-the plugins passed as parameter may be specified with the `-strategy` option.
+The `disable-plugin` command receives a list of plugins to be disabled. The 
+output will display messages for both successful and failed operations. In case
+that only the error messages are desired, the `-quiet` option can be specified.
+How to deal with other plugins which depend on one or more of the plugins 
+passed as parameter may be specified with the `-strategy` option.
 
 [source]
 ----
@@ -282,9 +282,9 @@ to avoid extra info in the console.
 ====
 In the same way than enabling and disabling plugins from the UI need a restart 
 to complete the process, the changes made with the CLI commands will take effect
-once Jenkins is restarted. The `-restart` option forces the instance to restart
-once the command has successfully finished, so the changes will be immediately
-applied.
+once Jenkins is restarted. The `-restart` option forces a safe restart of the 
+instance once the command has successfully finished, so the changes will be 
+immediately applied.
 ====
 
 == Pinned plugins


### PR DESCRIPTION
See [WEBSITE-531](https://issues.jenkins-ci.org/browse/WEBSITE-531)

New CLI commands for enabling and disabling plugins have been included in Jenkins:
- enable-plugin command was included in jenkins-2.136
- disable-plugin command was included in jenkins-2.151

Let's update the managing plugins contents referring those commands.

![cli-commands](https://user-images.githubusercontent.com/31063239/48411995-a3b25a80-e743-11e8-838b-afea4ccef2ee.png)

@reviewbybees
@jvz @MRamonLeon as developers