### PR TITLE
Update getting-started.adoc

### DIFF
--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -38,10 +38,12 @@ This has been deprecated in some Linux distributions, such as https://fedoraproj
 There is a way to circumvent the security check by lowering the accepted key size, but it is recommended to install Jenkins link:/doc/book/installing/index.adoc[locally] for now instead.
 
 To circumvent the security check:
-[source, bash]
-```
+
+[source]
+----
 sed -i s/2048/1024/ /etc/crypto-policies/back-ends/java.config
-```
+----
+
 ====
 
 ---

--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -29,7 +29,13 @@ For this tour, you will require:
 . Follow the instructions to complete the installation.
 
 When the installation is complete, you can start putting Jenkins to work!
+[NOTE]
+====
+There is a https://issues.jenkins-ci.org/browse/INFRA-1659[bug] in the current and older Jenkins builds when using Docker. The Jenkins certificate uses 1024-bit key. This has been deprecated in some Linux distrobutions, like https://fedoraproject.org/wiki/Changes/StrongCryptoSettings[Fedora 28+], because they accept at least 2048-bit keys. There is a way to circumvent the security check by lowering the accepted key size, but it is recommended to install Jenkins link:/doc/book/installing/index.adoc[locally] for now instead.
+To circumvent the security check:
 
+`# sed -i s/2048/1024/ /etc/crypto-policies/back-ends/java.config`
+====
 ---
 **link:../hello-world[Continue to "Create your first Pipeline"]**
 

--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -29,13 +29,21 @@ For this tour, you will require:
 . Follow the instructions to complete the installation.
 
 When the installation is complete, you can start putting Jenkins to work!
+
 [NOTE]
 ====
-There is a https://issues.jenkins-ci.org/browse/INFRA-1659[bug] in the current and older Jenkins builds when using Docker. The Jenkins certificate uses 1024-bit key. This has been deprecated in some Linux distrobutions, like https://fedoraproject.org/wiki/Changes/StrongCryptoSettings[Fedora 28+], because they accept at least 2048-bit keys. There is a way to circumvent the security check by lowering the accepted key size, but it is recommended to install Jenkins link:/doc/book/installing/index.adoc[locally] for now instead.
-To circumvent the security check:
+There is a https://issues.jenkins-ci.org/browse/INFRA-1659[bug] in the current and older Jenkins builds when using Docker.
+The Jenkins certificate uses 1024-bit key. 
+This has been deprecated in some Linux distributions, such as https://fedoraproject.org/wiki/Changes/StrongCryptoSettings[Fedora 28+], because they accept at least 2048-bit keys.
+There is a way to circumvent the security check by lowering the accepted key size, but it is recommended to install Jenkins link:/doc/book/installing/index.adoc[locally] for now instead.
 
-`# sed -i s/2048/1024/ /etc/crypto-policies/back-ends/java.config`
+To circumvent the security check:
+[source, bash]
+```
+sed -i s/2048/1024/ /etc/crypto-policies/back-ends/java.config
+```
 ====
+
 ---
 **link:../hello-world[Continue to "Create your first Pipeline"]**
 


### PR DESCRIPTION
documented bug that kept docker's build not working. I am rusty on relative links, and the [locally] link is probably not going to work, lol. I can't really test it yet though because it directs me to the source code instead of the website