### PR TITLE
Clarify that global variables as steps

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -451,10 +451,9 @@ def yourField = [:]
 def yourFunction.... 
 ----
 
-With the exception of exposing global variables that have `def call(...)` methods as functions (i.e. steps),
-declarative Pipeline does not allow global variable usage outside of a `script`
-directive
+Declarative Pipeline does not allow method calls on objects outside "script" blocks.
 (link:https://issues.jenkins-ci.org/browse/JENKINS-42360[JENKINS-42360]).
+The method calls above would need to be put inside a `script` directive:
 
 .Jenkinsfile
 [source,groovy]
@@ -465,15 +464,17 @@ pipeline {
     agent none
     stage ('Example') {
         steps {
-             script { // <1>
-                 log.info 'Starting'
-                 log.warning 'Nothing to do!'
-             }
+            // log.info 'Starting' // <1>
+            script { // <2>
+                log.info 'Starting'
+                log.warning 'Nothing to do!'
+            }
         }
     }
 }
 ----
-<1> `script` directive required to access global variables in Declarative Pipeline.
+<1> This method call would fail because it is outside a `script` directive.
+<2> `script` directive required to access global variables in Declarative Pipeline.
 
 [NOTE]
 ====

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -451,7 +451,8 @@ def yourField = [:]
 def yourFunction.... 
 ----
 
-Declarative Pipeline does not allow global variable usage outside of a `script`
+With the exception of exposing global variables that have `def call(...)` methods as functions (i.e. steps),
+declarative Pipeline does not allow global variable usage outside of a `script`
 directive
 (link:https://issues.jenkins-ci.org/browse/JENKINS-42360[JENKINS-42360]).
 


### PR DESCRIPTION
Global variables are indeed useful outside of `script` blocks:

They enable one to define custom steps.