### PR TITLE
Redirect to Wikipedia for Java 11 Web Start deprecation

### DIFF
--- a/content/redirect/java11-java-web-start.adoc
+++ b/content/redirect/java11-java-web-start.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://en.wikipedia.org/wiki/Java_Web_Start#Deprecation
+---


### PR DESCRIPTION
Oracle announced in March 2018 that it will not include Java Web Start in Java SE 11.  Jenkins provides a "Java Web Start" button to simplify launching of clients with Java Web Start.  That simplified start technique is often used for Windows agents.  Jenkins on Java 11 can't use that button because the underlying Java implementation does not support it.

The communication protocol used by agent.jar continues to be fully supported and operational with Java 11.  Only the Java Web Start button from the web page is not supported in Java 11.

See [JENKINS-52282](https://issues.jenkins-ci.org/browse/JENKINS-52282) and [PR-3766](https://github.com/jenkinsci/jenkins/pull/3766) for more details.