### PR TITLE
[GSoC 2019] - Add links to office hours and schedule, cleanup the Org Admin mailing list

### DIFF
--- a/content/projects/gsoc/2019/index.adoc
+++ b/content/projects/gsoc/2019/index.adoc
@@ -38,7 +38,7 @@ GSoC Organization admins in 2019:
 * link:https://github.com/lloydchang[Lloyd Chang]
 * link:https://github.com/oleg-nenashev/[Oleg Nenashev]
 
-Jenkins Org Admins mailing list: jenkins-gsoc-2019-orgs@googlegroups.com.
+Jenkins Org Admins mailing list: jenkins-gsoc-2019-org-adminss@googlegroups.com.
 Use this mailing list if you need to discuss something privately with org admins.
 For all other use-cases,
 use public contacts listed link:/projects/gsoc/#contacts[here].

--- a/content/projects/gsoc/2019/index.adoc
+++ b/content/projects/gsoc/2019/index.adoc
@@ -16,6 +16,19 @@ See the link:/projects/gsoc/[main GSoC page] for the actual information.
 See the list of current project ideas link:/projects/gsoc/2019/project-ideas[here].
 You can also link:/projects/gsoc/proposing-project-ideas[propose your own project] for GSoC.
 
+== Schedule
+
+See link:/projects/gsoc/2019/schedule[Jenkins year-round GSoC schedule].
+
+== Call for mentors
+
+We continuously look for mentors and project ideas.
+You can propose your project at any time.
+
+Official 2019 guidelines have not been published yet,
+but there is a link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea] page with guidelines.
+Reach out to us using the link:/projects/gsoc/#contacts[GSoC contacts] if you are interested.
+
 === Org admins
 
 GSoC Organization admins in 2019:
@@ -25,10 +38,7 @@ GSoC Organization admins in 2019:
 * link:https://github.com/lloydchang[Lloyd Chang]
 * link:https://github.com/oleg-nenashev/[Oleg Nenashev]
 
-=== Links
-
-* link:/projects/gsoc/2019/schedule[Jenkins year-round GSoC schedule]
-* link:/projects/gsoc/gsoc2018-project-ideas[GSoC 2018 Project ideas]
-* link:/blog/2018/01/06/gsoc2018-call-for-mentors[Call for Mentors]
-* link:https://summerofcode.withgoogle.com/organizations/5572716199936000/[Jenkins page on GSoC 2018 website]
-
+Jenkins Org Admins mailing list: jenkins-gsoc-2019-orgs@googlegroups.com.
+Use this mailing list if you need to discuss something privately with org admins.
+For all other use-cases,
+use public contacts listed link:/projects/gsoc/#contacts[here].

--- a/content/projects/gsoc/2019/index.adoc
+++ b/content/projects/gsoc/2019/index.adoc
@@ -38,7 +38,7 @@ GSoC Organization admins in 2019:
 * link:https://github.com/lloydchang[Lloyd Chang]
 * link:https://github.com/oleg-nenashev/[Oleg Nenashev]
 
-Jenkins Org Admins mailing list: jenkins-gsoc-2019-org-adminss@googlegroups.com.
+Jenkins Org Admins mailing list: jenkins-gsoc-2019-org-admins@googlegroups.com.
 Use this mailing list if you need to discuss something privately with org admins.
 For all other use-cases,
 use public contacts listed link:/projects/gsoc/#contacts[here].

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -25,8 +25,10 @@ in completing their summer projects.
 We plan to participate in GSoC 2019.
 Stay tuned for announcements.
 
+* link:/projects/gsoc/2019/[GSoC 2019 page]
 * link:/projects/gsoc/2019/project-ideas[GSoC 2019 Project ideas]
 * link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
+* link:/projects/gsoc/2019/schedule[GSoC 2019 schedule].
 
 == Links
 
@@ -37,13 +39,19 @@ Stay tuned for announcements.
 === Contacts
 
 * Public mailing list: link:https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public[jenkinsci-gsoc-all-public@googlegroups.com]
-* Jenkins Org Admins mailing list: jenkinsci-gsoc-orgs@googlegroups.com
 * Chats:
 ** link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG room in Gitter] for organizational topics
 ** `#jenkins` on Freenode IRC network for technical topics. (link:/chat/[More info])
 ** each project also has its own Gitter chat, see project pages
 
 === Office hours
+
+There is a weekly GSoC SIG project meeting,
+which happens at 2PM UTC on Wednesdays.
+The meetings are usually recorded,
+and we post links in link:https://gitter.im/jenkinsci/gsoc-sig[our gitter channel]
+before the meeting starts.
+You can find recording of office hours link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
 
 Although we use mailing lists as the main communication channel,
 we also define regular timeslots aka "office hours".


### PR DESCRIPTION
- [x] - Remove the `Links` section in 2019, move data to the headers and expand info
- [x] - Change the address of the GSoC 2019 org admin mailing list
- [x] - Add information about office hours
- [x] - Link the 2019 landing page from the main GSoC page

I am still not sure that splitting the landing page and GSoC 2019 page was a good idea. Probably I will merge the pages and add a redirect in the next iteration.

@martinda @lloydchang @jeffpearce 