### PR TITLE
Add missing full stop on Evergreen description

### DIFF
--- a/content/projects/evergreen/index.adoc
+++ b/content/projects/evergreen/index.adoc
@@ -13,7 +13,7 @@ links:
 image:/images/evergreen/magician_256.png[Jenkins Evergreen, role=center, float=right]
 
 Evergreen is an automatically updating rolling distribution system for
-Jenkins It consists of server-side, and client-side components to
+Jenkins. It consists of server-side, and client-side components to
 support a Chrome-like upgrade experience for Jenkins users.
 
 Jenkins Evergreen provides the end-user with a


### PR DESCRIPTION
Fixing a small typo, full stop is missing in the Evergreen project description.