### PR TITLE
Add changelogs and upgrade guides for 2.138.4 and 2.150.1

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -2063,9 +2063,172 @@
       message: >
         Improve robustness when search items don't specify a display name.
     - type: rfe
+      references:
+      - pull: 3690
+      - url: https://github.com/stapler/stapler/pull/149
+        title: stapler/stapler#149
+      message: >
+        Update Stapler from 1.254.2 to 1.255 to integrate a fix related to <code>StaplerProxy#getTarget()</code> return value handling.
+    - type: rfe
       issue: 54029
       message: >
         Add telemetry trial related to Stapler request dispatching.
+- version: 2.138.4
+  date: 2018-12-05
+  changes:
+    - type: security
+      message: Important security fixes.
+      references:
+      - url: https://jenkins.io/security/advisory/2018-12-05/
+        title: security advisory
+- version: 2.150.1
+  date: 2018-12-05
+  lts_predecessor: "2.138.4"
+  lts_baseline: "2.150"
+  lts_changes:
+    - type: major rfe
+      message: >
+        Numerous fixes and improvements to better support running Jenkins on Java 11.
+      references:
+      - issue: 46523
+      - issue: 46725
+      - issue: 51805
+      - issue: 52019
+      - issue: 52024
+      - issue: 53693
+      - issue: 53710
+      - issue: 53929
+      - url: https://github.com/jenkinsci/pom/blob/master/CHANGELOG.md#149
+        title: Parent POM 1.49 changelog
+      - url: https://github.com/jenkinsci/winstone/blob/master/CHANGELOG.md#51
+        title: Winstone-Jetty 5.1 changelog
+      - url: http://groovy-lang.org/changelogs/changelog-2.4.12.html
+        title: Groovy 2.4.12 changelog
+      - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.12.v20180830
+        title: Jetty 9.4.12 changelog
+      # pull: 3637
+      # pull: 3641
+      # pull: 3643
+      # pull: 3650
+      # pull: 3659
+      # pull: 3660
+      # pull: 3682
+      # Fix problems with update center metadata signature check on Java 11.
+      # Update Groovy from 2.4.11 to 2.4.12 to pick up fixes towards Java 11 support.
+      # Update jnr-posix to 3.0.45 to prevent Illegal Reflective access warnings when running with Java 11.
+      # Update Unix process management logic to support Process Tree termination when running with Java 11.
+      # Update Winstone-Jetty from 5.0 to 5.1 to update Jetty to 9.4.12, picking up TLS 1.3 support and fixes towards Java 11.
+      # Developer: Update PowerMock and Mockito to versions compatible with Java 11.
+      # Internal: Update META-INF/services generator from 1.4 to 1.8 to fix compilation on JDK 10+.
+      # Internal: Update Parent POM to 1.49 to make the build flow compatible with Java 11.
+
+    # User major RFEs
+    - type: major rfe
+      pull: 3667
+      message: >
+        Migrate most Simplified Chinese translations into <a href="http://plugins.jenkins.io/localization-zh-cn">Localization: Chinese (Simplified)</a> Plugin.
+
+    # User RFEs
+    - type: rfe
+      issue: 52181
+      pull: 3527
+      message: >
+        Allow use of the <tt>console</tt> command with Job/Read permission.
+    - type: rfe
+      issue: 17116
+      pull: 3414
+      message: >
+        Wait up to two minutes for process termination before killing it (typically when aborting a build).
+    - type: rfe
+      issue: 53282
+      pull: 3603
+      message: >
+        Reduce logging level of restart and shutdown related notifications from SEVERE to INFO.
+    - type: rfe
+      pull: 3653
+      issue: 53792
+      message: >
+        New <code>JENKINS_USER_ID</code> and <code>JENKINS_API_TOKEN</code> environment variables can be used to configure the CLI authentication.
+    - type: rfe
+      pull: 3697
+      issue: 54137
+      message: >
+        Do not submit telemetry if there's no relevant data.
+    - type: rfe
+      pull: 3698
+      issue: 54136
+      message: >
+        Use per-trial correlation IDs for telemetry submissions.
+
+    # User bugs
+    - type: bug
+      message: >
+        Update Remoting from 3.26 to 3.27 to eliminate a potential deadlock.
+      pull: 3657
+      references:
+      - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#327
+        title: Full changelog
+      - issue: 53569
+
+    # Developer / API related
+    - type: rfe
+      issue: 52818
+      pull: 3570
+      message: >
+        Developer: Add support for the <code>@PostConstruct</code> lifecycle method annotation.
+    - type: rfe
+      issue: 52818
+      pull: 3570
+      message: >
+        Developer: Add interface <code>PersistentDescriptor</code> that allows implementing <code>Descriptor</code>s to skip explicit calls to <code>load()</code>.
+    - type: rfe
+      pull: 3639
+      issue: 53721
+      message: >
+        Developer: Introduce <code>getPlatform()</code> and <code>setPlatform()</code> methods in <code>hudson.EnvVars</code>.
+    - type: rfe
+      pull: 3656
+      message: >
+        Developer: Introduce new <code>hudson.Util#fixNull(value, defaultValue)</code> method.
+    - type: rfe
+      pull: 3611
+      issue: 36547
+      message: >
+        Developer: Add overridable <code>Queue.Task#getAffinityKey()</code> to allow consistent hashing for Pipeline builds in the future.
+    - type: bug
+      pull: 3662
+      message: >
+        Developer: <code>ConsoleAnnotatorFactory</code> mishandled its type parameter, effectively forcing all implementations to use <code>Object</code> or raw types.
+
+  changes:
+    - type: security
+      message: Important security fixes.
+      references:
+      - url: https://jenkins.io/security/advisory/2018-12-05/
+        title: security advisory
+    - type: bug
+      references:
+      - issue: 54261
+      - issue: 54333
+      - issue: 54570
+      pull: 3760
+      message: >
+        Revert compatibility fix for future releases of Firefox due to regressions it caused since 2.148.
+    - type: bug
+      pull: 3708
+      issue: 54310
+      message: >
+        Prevent <code>Stream is closed</code> error in case a CLI command finishes before the input is entirely read.
+    - type: bug
+      pull: 3695
+      issue: 49196
+      message: >
+        Avoid <code>Premature EOF</code> error when using the <code>shutdown</code> CLI command.
+    - type: bug
+      issue: 38719
+      pull: 3757
+      message: >
+        Do not cache CSS/JS resource files for console annotations like Timestamper Plugin across Jenkins restarts.
 
 
 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -3361,8 +3361,7 @@
     - type: major rfe
       pull: 3667
       message: >
-        Migrate all Simplified Chinese translations into <a href="http://plugins.jenkins.io/localization-zh-cn">Localization: Chinese (Simplified)</a> Plugin.
-        Jenkins (core) now no longer contains Simplified Chinese translations.
+        Migrate most Simplified Chinese translations into <a href="http://plugins.jenkins.io/localization-zh-cn">Localization: Chinese (Simplified)</a> Plugin.
     - type: bug
       issue: 31448
       pull: 3671

--- a/content/changelog-stable/index.html.haml
+++ b/content/changelog-stable/index.html.haml
@@ -6,7 +6,7 @@ title: LTS Changelog
 = partial('changelog-header.html')
 
 %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
-  See our new
+  See the
   %a{:href => '/doc/upgrade-guide/'}
     LTS upgrade guide
   for advice on upgrading Jenkins.

--- a/content/doc/upgrade-guide/2.138.adoc
+++ b/content/doc/upgrade-guide/2.138.adoc
@@ -8,6 +8,10 @@ notitle: true
 
 Each section covers the upgrade from the previous LTS release, the section on 2.138.1 covers the upgrade from 2.121.3.
 
+=== Upgrading to Jenkins LTS 2.138.4
+
+No notable changes requiring upgrade notes.
+
 === Upgrading to Jenkins LTS 2.138.3
 
 No notable changes requiring upgrade notes.

--- a/content/doc/upgrade-guide/2.150.adoc
+++ b/content/doc/upgrade-guide/2.150.adoc
@@ -1,0 +1,17 @@
+---
+layout: documentation
+title:  Jenkins Upgrade Guide
+notitle: true
+---
+
+== Upgrading to Jenkins LTS 2.150.x
+
+Each section covers the upgrade from the previous LTS release, the section on 2.138.1 covers the upgrade from 2.138.4.
+
+=== Upgrading to Jenkins LTS 2.150.1
+
+NOTE: 2.150.1 and 2.138.4 were released on the same day.
+Please note that this upgrade guide only covers the upgrade from 2.138.4.
+See link:../2.138/[its upgrade guide] for information related to upgrading from 2.138.3.
+
+No notable changes requiring upgrade notes.


### PR DESCRIPTION
Public preliminary changelog and upgrade guides for 2.138.4 and 2.150.1 ([see announcement](https://groups.google.com/d/msg/jenkinsci-advisories/krQ9g3TOqWI/9Vkf1sf9BAAJ)).

----

> ![screen shot](https://user-images.githubusercontent.com/1831569/49245416-83a4bb80-f412-11e8-817d-51a2ef738ae4.png)
