### PR TITLE
[Platform SIG] - Add regular meetings, meeting notes, and page updates

### DIFF
--- a/content/_layouts/sig.html.haml
+++ b/content/_layouts/sig.html.haml
@@ -7,7 +7,7 @@ layout: project
     .col-lg-8
 
       - if page.logo
-        %img{:title => "Logo", :src => expand_link(page.logo), :style => "float:right"}
+        %img{:title => "Logo", :src => expand_link(page.logo), :style => "float:right", :width => "96"}
 
       %h2.title
         Overview

--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -47,6 +47,21 @@ notitle: true
 
               %h5.title
                 Project Meeting
+    .col-md-6.text-center
+      %ul.ji-item-list
+        %li.post.event.floating
+          %a.body{:href => 'https://jenkins.io/sigs/platform#meetings', :target => '_blank'}
+            .header.time
+              .date-time
+                .date
+                  .day.small
+                    Every other Thu
+                  .dow
+                    Thu
+                .time
+                  14h UTC
+              %h5.title
+                Platform SIG Meeting
 
   .row
     .col

--- a/content/sigs/index.html.haml
+++ b/content/sigs/index.html.haml
@@ -20,7 +20,7 @@ title: Jenkins Special Interest Groups
         %h1
           = item.title
         - if item.logo
-          %img{:title => "Logo", :src => expand_link(item.logo), :style => "float:right"}
+          %img{:title => "Logo", :src => expand_link(item.logo), :style => "float:right", :width => "96"}
             = item.overview
         %ul
           - if item.links.googlegroup

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -3,7 +3,7 @@ layout: sig
 title: "Platform"
 section: sigs
 sigId: "platform"
-logo: /images/user.gif
+logo: /images/logos/formal_java/256.png
 tags:
   - java
   - windows
@@ -23,7 +23,7 @@ participants:
 - name: "Samuel Van Oort"
   id: "svanoort"
   github: "svanoort"
-- name: "Nicolas De loof"
+- name: "Nicolas De Loof"
   id: "ndeloof"
   github: "ndeloof"
 - name: "Devin Nusbaum"
@@ -46,12 +46,23 @@ participants:
 - name: "David Currie"
   id: "dcurrie"
   github: "davidcurrie"
+- name: "Baptiste Mathus"
+  id: "batmat"
+  github: "batmat"
+- name: "Baptiste Mathus"
+  id: "batmat"
+  github: "batmat"
+- name: "Adrien Lecharpentier"
+  id: "alecharp"
+  github: "alecharp"
+- name: "Ramon Leon"
+  id: "MRamonLeon"
+  github: "MRamonLeon"
 links:
   gitter: "jenkinsci/platform-sig"
   googlegroup: "jenkins-platform-sig"
 meetings:
-  text: Every month, to be announced
-  link: TODO
+  text: Thursdays at 2PM UTC, every 2 weeks
 overview: >
   This special interest group offers a venue for all kinds of platform support discussions:
   Java, Operating Systems, Architectures, Docker, Packaging, Web Containers, etc.
@@ -77,27 +88,54 @@ if the topics related to Cloud-Native platforms like Kubernetes or Docker.
 === Topics
 
 * Defining platform support policies (e.g. “defining Windows support policy”)
-* Coordinating effort on new platform support (e.g. Java 10 in JEP-TODO)
+* Coordinating effort on new platform support (e.g. jep:211[Java 11 Support in Jenkins])
 * Working with external communities on better platform support and packaging
 (e.g. improving support of IBM Java, enabling OpenIndiana packaging,
 ARM Support in Jenkins, adapting RedHat packaging to best practices, etc.)
 * Reviewing JEPs submitted in the area
 
+=== Ongoing projects
+
+* Java 11 support in Jenkins (jep:211[])
+* Multi-architecture Docker images
+** Enabling official images to run on Arm, IBM s390x, and other platforms
+* Rework of Windows installers
+** New version of installers for 64but platforms
+** Removal of Java bundling
+** Creating an official link:https://chocolatey.org/packages/jenkins[Jenkins Chocolatey package]
+
+See the SIG meeting notes for more information about the ongoing projects.
+
 === Meetings
 
-There will be regular SIG meetings scheduled.
-Initially the meetings will be conducted once per month,
-then they may be adapted according to the activity.
+We have regular meetings on Thursdays every two weeks, at *2PM UTC*.
+See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
+At these meetings we discuss project statuses and do presentations/demos.
 
 Meetings will be conducted and recorded via Jenkins Hangouts-on-Air.
 Participant links will be posted in the SIG Gitter Chat within 10 minutes before the meeting starts.
 
-==== 2018-08-29. Multi-architecture docker image support for Jenkins
+==== 2018-11-19. Project sync-up
+
+Project sync-ups: Windows Installers, Java 11 packaging, Multi-architecture Docker images.
+
+* link:https://docs.google.com/document/d/1FARi55vDjsdzi6Nj9ZB9e1wh2dU8nyWK6mq_cge0ceg/edit?usp=sharing[Meeting notes]
+* link:https://youtu.be/Rv-KvlGvnio[Youtube recording]
+* link:https://docs.google.com/presentation/d/1lw4unaFhsQk7a8HzhxhgTK4X2X2ocv_W_VW7aoH2WkM/edit?usp=sharing[Slides: Java 11 Status update]
+
+==== 2018-09-27. Project sync-up
+
+Project sync-ups: Java 11 packaging, Multi-architecture Docker images.
+
+* link:https://docs.google.com/document/d/1nIz1STmwOVMJ3vx68m6Xc4pv2oEKDRdyeYUNI8zZJsg/edit?usp=sharing[Meeting notes]
+* link:https://www.youtube.com/watch?v=JmOnJopFix0[Video recording]
+
+==== 2018-08-29. Multi-architecture Docker images
 
 Sync-up call about jira:52785[Support of Multi-Architecture Docker images in Jenkins].
 We discussed ways to get these images built and/or hosted within Jenkins project.
 
-* link:https://docs.google.com/document/d/1YofL2uhy7xAa1mx_qFdDvDg4P-molmhDwFD0-8xX8mI/edit[Meeting notes]
+* link:https://docs.google.com/document/d/1YofL2uhy7xAa1mx_qFdDvDg4P-molmhDwFD0-8xX8mI/edit?usp=sharing[Meeting notes]
 * link:https://www.youtube.com/watch?v=6SeDJXgzUCA[Youtube video]
 
 ==== 2018-08-23. Eclipse OpenJ9 and Jenkins

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -88,7 +88,7 @@ if the topics related to Cloud-Native platforms like Kubernetes or Docker.
 * Coordinating effort on new platform support (e.g. jep:211[Java 11 Support in Jenkins])
 * Working with external communities on better platform support and packaging
 (e.g. improving support of IBM Java, enabling OpenIndiana packaging,
-ARM Support in Jenkins, adapting RedHat packaging to best practices, etc.)
+ARM architecture support in Jenkins, adapting RedHat packaging to best practices, etc.)
 * Reviewing JEPs submitted in the area
 
 === Ongoing projects

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -49,9 +49,6 @@ participants:
 - name: "Baptiste Mathus"
   id: "batmat"
   github: "batmat"
-- name: "Baptiste Mathus"
-  id: "batmat"
-  github: "batmat"
 - name: "Adrien Lecharpentier"
   id: "alecharp"
   github: "alecharp"
@@ -100,7 +97,7 @@ ARM Support in Jenkins, adapting RedHat packaging to best practices, etc.)
 * Multi-architecture Docker images
 ** Enabling official images to run on Arm, IBM s390x, and other platforms
 * Rework of Windows installers
-** New version of installers for 64but platforms
+** New version of installers for 64bit platforms
 ** Removal of Java bundling
 ** Creating an official link:https://chocolatey.org/packages/jenkins[Jenkins Chocolatey package]
 


### PR DESCRIPTION
- [x] Global: SIG templates now enforce the logo size
- [x] Use the Java 11 logo as a SIG logo as it was agreed on at the SIG meetings
- [x] Add some new members and ongoing project ideas (brief description)
- [x] Add regular meetings and list them on events
- [x] Add links to the previous meetings

<img width="956" alt="screenshot 2018-11-30 at 14 14 22" src="https://user-images.githubusercontent.com/3000480/49291339-47249e80-f4aa-11e8-960c-b25308263ea3.png">

<img width="834" alt="screenshot 2018-11-30 at 14 14 59" src="https://user-images.githubusercontent.com/3000480/49291357-57d51480-f4aa-11e8-981c-5a46459f32e4.png">


@batmat @alecharp @MRamonLeon @MarkEWaite @jenkins-infra/copy-editors 
