### PR TITLE
[GSoC] add Subject Matter Advice page

### DIFF
--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -34,6 +34,7 @@ Stay tuned for announcements.
 
 * link:/projects/gsoc/students[Information for students]
 * link:/projects/gsoc/mentors[Information for mentors]
+* link:/projects/gsoc/subject-matter-advice[Subject Matter Advice]
 * link:/sigs/gsoc[Jenkins GSoC Special Interest Group]
 
 === Contacts

--- a/content/projects/gsoc/subject-matter-advice.adoc
+++ b/content/projects/gsoc/subject-matter-advice.adoc
@@ -14,7 +14,7 @@ When their time permits, following people may have subject matter advice based o
 |Code Coverage API Plugin|Shenyu Zheng, Steven Christou, Supun Wanniarachchi, Jeff Pearce, Oleg Nenashev|GSoC 2018
 |External Workspace Manager Plugin|Alexandru Somai, Oleg Nenashev, Martin d'Anjou|GSoC 2016
 |Google didn't accept Hudson|Kohsuke Kawaguchi, Michael Donohue, Stephen Connolly,  Jesse Glick,  Ullrich Hafner|GSoC 2009
-|Google didn't accept Jenkins|Oleg Nenashev, Baptiste Mathus, R Tyler Croy, Steven Christou, Robert Sandell|GSoC 2017
+|Google didn't accept Jenkins|Oleg Nenashev, Baptiste Mathus, R. Tyler Croy, Steven Christou, Robert Sandell|GSoC 2017
 |Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration|Michael Neale, Merkushev Kirill, Samat Davletshin|GSoC 2016
 |Jenkins Remoting over Message Bus/Queue|Pham Vu Tuan, Oleg Nenashev, Supun Wanniarachchi|GSoC 2018
 |Jenkins Usage Statistics Analysis|Daniel Beck, Kohsuke Kawaguchi, Payal Priyadarshini|GSoC 2016

--- a/content/projects/gsoc/subject-matter-advice.adoc
+++ b/content/projects/gsoc/subject-matter-advice.adoc
@@ -1,0 +1,21 @@
+---
+layout: project
+title: "Subject Matter Advice"
+tags:
+- gsoc
+---
+
+When their time permits, following people may have subject matter advice based on experiences
+
+|=======
+|*Subject Matter* | *People* | *Experience*
+|Add audit logging to Jenkins | Matt Sicker, Liam Newman, Mark Waite, Daniel Beck, Latha Sekar, David Olorundare | Outreachy 2018
+|Automatic Plugin Documentation Publishing | R Tyler Croy, Baptiste Mathaus, Cynthia Anyango | GSoC 2016
+|Code Coverage API Plugin | Shenyu Zheng, Steven Christou, Supun Wanniarachchi, Jeff Pearce, Oleg Nenashev | GSoC 2018
+|External Workspace Manager Plugin | Alexandru Somai, Oleg Nenashev, Martin d’Anjou | GSoC 2016
+|Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration | Michael Neale, Merkushev Kirill, Samat Davletshin | GSoC 2016
+|Jenkins Remoting over Message Bus/Queue | Pham Vu Tuan, Oleg Nenashev, Supun Wanniarachchi | GSoC 2018
+|Jenkins Usage Statistics Analysis | Daniel Beck, Kohsuke Kawaguchi, Payal Priyadarshini | GSoC 2016
+|Simple Pull-Request Job Plugin | Pham Vu Tuan, Kristin Whetstone, Jeff Knurek, Martin d'Anjou, Sam Van Oort, Abhishek Gautam | GSoC 2018
+|Support-core plugin improvements | Arnaud Heritier, Steven Christou, Minudika	Malshan | GSoC 2016
+|=======

--- a/content/projects/gsoc/subject-matter-advice.adoc
+++ b/content/projects/gsoc/subject-matter-advice.adoc
@@ -10,12 +10,12 @@ When their time permits, following people may have subject matter advice based o
 |=======
 |*Subject Matter* | *People* | *Experience*
 |Add audit logging to Jenkins | Matt Sicker, Liam Newman, Mark Waite, Daniel Beck, Latha Sekar, David Olorundare | Outreachy 2018
-|Automatic Plugin Documentation Publishing | R Tyler Croy, Baptiste Mathaus, Cynthia Anyango | GSoC 2016
+|Automatic Plugin Documentation Publishing | R. Tyler Croy, Baptiste Mathaus, Cynthia Anyango | GSoC 2016
 |Code Coverage API Plugin | Shenyu Zheng, Steven Christou, Supun Wanniarachchi, Jeff Pearce, Oleg Nenashev | GSoC 2018
 |External Workspace Manager Plugin | Alexandru Somai, Oleg Nenashev, Martin d’Anjou | GSoC 2016
 |Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration | Michael Neale, Merkushev Kirill, Samat Davletshin | GSoC 2016
 |Jenkins Remoting over Message Bus/Queue | Pham Vu Tuan, Oleg Nenashev, Supun Wanniarachchi | GSoC 2018
 |Jenkins Usage Statistics Analysis | Daniel Beck, Kohsuke Kawaguchi, Payal Priyadarshini | GSoC 2016
 |Simple Pull-Request Job Plugin | Pham Vu Tuan, Kristin Whetstone, Jeff Knurek, Martin d'Anjou, Sam Van Oort, Abhishek Gautam | GSoC 2018
-|Support-core plugin improvements | Arnaud Heritier, Steven Christou, Minudika	Malshan | GSoC 2016
+|Support-core plugin improvements | Arnaud Heritier, Steven Christou, Minudika Malshan | GSoC 2016
 |=======

--- a/content/projects/gsoc/subject-matter-advice.adoc
+++ b/content/projects/gsoc/subject-matter-advice.adoc
@@ -13,8 +13,8 @@ When their time permits, following people may have subject matter advice based o
 |Automatic Plugin Documentation Publishing|R. Tyler Croy, Baptiste Mathaus, Cynthia Anyango|GSoC 2016
 |Code Coverage API Plugin|Shenyu Zheng, Steven Christou, Supun Wanniarachchi, Jeff Pearce, Oleg Nenashev|GSoC 2018
 |External Workspace Manager Plugin|Alexandru Somai, Oleg Nenashev, Martin d'Anjou|GSoC 2016
-|Google rejected Hudson|Kohsuke Kawaguchi, Michael Donohue, Stephen Connolly,  Jesse Glick,  Ullrich Hafner|GSoC 2009
-|Google rejected Jenkins|Oleg Nenashev, Baptiste Mathus, R Tyler Croy, Steven Christou, Robert Sandell|GSoC 2017
+|Google didn't accept Hudson|Kohsuke Kawaguchi, Michael Donohue, Stephen Connolly,  Jesse Glick,  Ullrich Hafner|GSoC 2009
+|Google didn't accept Jenkins|Oleg Nenashev, Baptiste Mathus, R Tyler Croy, Steven Christou, Robert Sandell|GSoC 2017
 |Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration|Michael Neale, Merkushev Kirill, Samat Davletshin|GSoC 2016
 |Jenkins Remoting over Message Bus/Queue|Pham Vu Tuan, Oleg Nenashev, Supun Wanniarachchi|GSoC 2018
 |Jenkins Usage Statistics Analysis|Daniel Beck, Kohsuke Kawaguchi, Payal Priyadarshini|GSoC 2016

--- a/content/projects/gsoc/subject-matter-advice.adoc
+++ b/content/projects/gsoc/subject-matter-advice.adoc
@@ -8,14 +8,16 @@ tags:
 When their time permits, following people may have subject matter advice based on experiences
 
 |=======
-|*Subject Matter* | *People* | *Experience*
-|Add audit logging to Jenkins | Matt Sicker, Liam Newman, Mark Waite, Daniel Beck, Latha Sekar, David Olorundare | Outreachy 2018
-|Automatic Plugin Documentation Publishing | R. Tyler Croy, Baptiste Mathaus, Cynthia Anyango | GSoC 2016
-|Code Coverage API Plugin | Shenyu Zheng, Steven Christou, Supun Wanniarachchi, Jeff Pearce, Oleg Nenashev | GSoC 2018
-|External Workspace Manager Plugin | Alexandru Somai, Oleg Nenashev, Martin d’Anjou | GSoC 2016
-|Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration | Michael Neale, Merkushev Kirill, Samat Davletshin | GSoC 2016
-|Jenkins Remoting over Message Bus/Queue | Pham Vu Tuan, Oleg Nenashev, Supun Wanniarachchi | GSoC 2018
-|Jenkins Usage Statistics Analysis | Daniel Beck, Kohsuke Kawaguchi, Payal Priyadarshini | GSoC 2016
-|Simple Pull-Request Job Plugin | Pham Vu Tuan, Kristin Whetstone, Jeff Knurek, Martin d'Anjou, Sam Van Oort, Abhishek Gautam | GSoC 2018
-|Support-core plugin improvements | Arnaud Heritier, Steven Christou, Minudika Malshan | GSoC 2016
+|*Subject Matter*|*People*|*Experience*
+|Add audit logging to Jenkins|Matt Sicker, Liam Newman, Mark Waite, Daniel Beck, Latha Sekar, David Olorundare|Outreachy 2018
+|Automatic Plugin Documentation Publishing|R. Tyler Croy, Baptiste Mathaus, Cynthia Anyango|GSoC 2016
+|Code Coverage API Plugin|Shenyu Zheng, Steven Christou, Supun Wanniarachchi, Jeff Pearce, Oleg Nenashev|GSoC 2018
+|External Workspace Manager Plugin|Alexandru Somai, Oleg Nenashev, Martin d'Anjou|GSoC 2016
+|Google rejected Hudson|Kohsuke Kawaguchi, Michael Donohue, Stephen Connolly,  Jesse Glick,  Ullrich Hafner|GSoC 2009
+|Google rejected Jenkins|Oleg Nenashev, Baptiste Mathus, R Tyler Croy, Steven Christou, Robert Sandell|GSoC 2017
+|Jenkins 2.0 Web Interface Improvements: New Job Creation and Configuration|Michael Neale, Merkushev Kirill, Samat Davletshin|GSoC 2016
+|Jenkins Remoting over Message Bus/Queue|Pham Vu Tuan, Oleg Nenashev, Supun Wanniarachchi|GSoC 2018
+|Jenkins Usage Statistics Analysis|Daniel Beck, Kohsuke Kawaguchi, Payal Priyadarshini|GSoC 2016
+|Simple Pull-Request Job Plugin|Pham Vu Tuan, Kristin Whetstone, Jeff Knurek, Martin d'Anjou, Sam Van Oort, Abhishek Gautam|GSoC 2018
+|Support-core plugin improvements|Arnaud Heritier, Steven Christou, Minudika Malshan|GSoC 2016
 |=======


### PR DESCRIPTION
To provide context, @martinda described a [Subject Matter Expert (SME)](https://jenkins.io/blog/2018/11/13/martinda-gsoc-mentor-summit-experience/) role for GSoC 2019 onwards.

While I support that vision, how would one identify subject matter experts in the future?

Consider this page, Subject Matter Advice, as a starting point reference:
1. As people gain experiences, they may learn and start forming opinions
2. When their time permits, people may have subject matter advice based on experiences