### PR TITLE
Fix sponsors underline showing on hover

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1409,6 +1409,10 @@ p.details {
   padding: 1rem;
 }
 
+.sponsors a:hover {
+  text-decoration: none;
+}
+
 .supporters {
   padding-top: 1.5rem;
 }


### PR DESCRIPTION
This PR targets the link underline showing when hovering over images in the sponsors block.

<img width="1144" alt="screen shot 2018-12-02 at 9 53 26 am" src="https://user-images.githubusercontent.com/17571391/49338096-d7cfbb80-f61d-11e8-810e-81ce476b3152.png">