### PR TITLE
AsciiDoc relative links require closing [] to be clickable

### DIFF
--- a/content/projects/gsoc/roles-and-responsibilities.adoc
+++ b/content/projects/gsoc/roles-and-responsibilities.adoc
@@ -13,13 +13,13 @@ Champion: The person proposing and driving the project idea
 
 Project champion mentor: this is the mentor who proposes the idea, but may not have all the Jenkins code expertise needed. This mentor works with the student to define the project and acts mostly as a "customer" of the project. This mentor usually know enough about coding to comment on pull-requests with regards to the over quality, style and features of the code.
 
-To learn more, please see link:/projects/gsoc/mentors/
+To learn more, please see link:/projects/gsoc/mentors/[]
 
 *2. Technical mentor*
 
 Technical mentor: this is the mentor who knows enough about the Jenkins code to guide the student on coding, and to provide Jenkins specific code reviews on pull-requests, but has limited involvement outside the coding activity of the student.
 
-To learn more, please see link:/projects/gsoc/mentors/
+To learn more, please see link:/projects/gsoc/mentors/[]
 
 *3. Subject Matter Expert / Not a mentor*
 
@@ -31,7 +31,7 @@ A technical advisor is one type of subject matter expert.
 
 *4. Student*
 
-To learn more, please see link:/projects/gsoc/students/
+To learn more, please see link:/projects/gsoc/students/[]
 
 *5. Org Admin*
 


### PR DESCRIPTION
This fixes broken links in Roles and Responsibilities page