### PR TITLE
Fix cron syntax examples

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -865,13 +865,13 @@ For example, `@hourly` is the same as `H * * * *` and could mean at any time dur
 |every fifteen minutes (perhaps at :07, :22, :37, :52)
 |`triggers{ cron('H/15 * * * *') }`
 |every ten minutes in the first half of every hour (three times, perhaps at :04, :14, :24)
-|`triggers{ H(0-29)/10 * * * *) }`
+|`triggers{ cron('H(0-29)/10 * * * *') }`
 |once every two hours at 45 minutes past the hour starting at 9:45 AM and finishing at 3:45 PM every weekday.
-|`triggers{ 45 9-16/2 * * 1-5) }`
+|`triggers{ cron('45 9-16/2 * * 1-5') }`
 |once in every two hours slot between 9 AM and 5 PM every weekday (perhaps at 10:38 AM, 12:38 PM, 2:38 PM, 4:38 PM)
-|`triggers{ H H(9-16)/2 * * 1-5) }`
+|`triggers{ cron('H H(9-16)/2 * * 1-5') }`
 |once a day on the 1st and 15th of every month except December
-|`triggers{ H H 1,15 1-11 *) }`
+|`triggers{ cron('H H 1,15 1-11 *') }`
 |===
 
 ==== stage


### PR DESCRIPTION
some of the examples where missing `cron('` and a quotation mark at the end.