### PR TITLE
List all SECURITY-595 reporters and contributors in credits section

### DIFF
--- a/content/security/advisory/2018-12-05.adoc
+++ b/content/security/advisory/2018-12-05.adoc
@@ -14,7 +14,13 @@ issues:
 
 - id: SECURITY-595
   title: Code execution through crafted URLs
-  reporter: Daniel Beck, CloudBees, Inc. and Jesse Glick, CloudBees, Inc. # Considering these the discoverers (covering basically the full scope), and the others contributing.
+  reporter: >
+    Daniel Beck, CloudBees, Inc., Jesse Glick, CloudBees, Inc., and Wadeck Follonier, CloudBees, Inc.;
+    and, independently,
+    Apple Information Security;
+    Evan Grant of Tenable; and
+    Orange Tsai(@orange_8361) from DEVCORE
+
   cve: CVE pending
   cvss:
     severity: critical
@@ -61,13 +67,6 @@ issues:
     The most likely effect is that some URLs now return `404 Not Found`.
     In rare cases, the responses returned might not be `404 Not Found`, but still different than they would have been before this fix was applied.
     We track known affected plugins and their status in link:https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+the+SECURITY-595+fix[the Jenkins wiki].
-
-    The Jenkins project would like to thank the following individuals and groups for their contributions to our understanding of this issue:
-
-    * Apple Information Security
-    * Evan Grant of Tenable
-    * Orange Tsai(@orange_8361) from DEVCORE
-    * Wadeck Follonier, CloudBees, Inc.
 
 - id: SECURITY-1072
   title: Forced migration of user records


### PR DESCRIPTION
@orangetw wondered where their credit is, so reformat.

Really unsure how to credit additional reports, especially if they're much later than others, or incomplete, but not opposed to doing it this way, even if it looks a bit weird.

> ![screen shot](https://user-images.githubusercontent.com/1831569/49510802-a5c29180-f889-11e8-834b-29a69f5d6a2c.png)
