### PR TITLE
Fix underlined trailing space in sponsor links

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -190,5 +190,4 @@ homepage: true
     %ul
       - supporters.each do |name, url|
         %li
-          %a{:href => url, :target => '_blank'}
-            = name
+          %a{:href => url, :target => '_blank'}= name


### PR DESCRIPTION
Another small fix, this time targeting the underlined trailing space from each sponsor link.

<img width="888" alt="screen shot 2018-12-05 at 7 07 43 pm" src="https://user-images.githubusercontent.com/17571391/49534121-15a03e80-f8c1-11e8-8f27-0740089ab676.png">
