### PR TITLE
Update to current Java requirements status

### DIFF
--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -116,7 +116,7 @@ link:https://wiki.jenkins.io/display/JENKINS/Groovy+Hook+Script[Groovy Hooks]
 So far we know about the following issues:
 
 * Pipeline crashes immediately on Java 10 and 11 (link:https://issues.jenkins-ci.org/browse/JENKINS-46602[JENKINS-46602])
-** Workaround: _Pipeline: Support_ plugin should be updated to version 2.21-rc591.43d37d4d080a from the Incrementals repo
+** Workaround: _Pipeline: Support_ plugin should be updated to version 3.0-java11-alpha-1-rc684.d802f5d9aeed from the Incrementals repo
     (link:https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc295.e017dc58c0a3/[download])
 * *FIXED* - Git Client plugin 2.7.2 cannot be installed when running with Java 11 build 18ea
 * There are many warnings about Illegal reflective access during execution

--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -9,6 +9,8 @@ tags:
 author: oleg_nenashev
 ---
 
+CAUTION: See link:/doc/administration/requirements/java/[the dedicated about Java support on Jenkins for more up-to-date information.]
+
 As you probably know, we will have a
 link:/blog/2018/06/08/jenkins-java10-hackathon/[Jenkins and Java 10+ online hackathon] this week.
 In order to enable early adopters to try out Jenkins with new Java versions,
@@ -25,7 +27,7 @@ It also lists known issues and provides contributor guidelines.
 --
 Update from the author: OpenJDK 11 has been released on September 25, 2018.
 Starting from this date, Java 10 is in the "end of life" state.
-The Jenkins project no longer ships preview versions for Java 10, 
+The Jenkins project no longer ships preview versions for Java 10,
 please use these guidelines only for Java 11 preview builds.
 --
 
@@ -114,7 +116,7 @@ link:https://wiki.jenkins.io/display/JENKINS/Groovy+Hook+Script[Groovy Hooks]
 So far we know about the following issues:
 
 * Pipeline crashes immediately on Java 10 and 11 (link:https://issues.jenkins-ci.org/browse/JENKINS-46602[JENKINS-46602])
-** Workaround: _Pipeline: Support_ plugin should be updated to version 2.21-rc591.43d37d4d080a from the Incrementals repo 
+** Workaround: _Pipeline: Support_ plugin should be updated to version 2.21-rc591.43d37d4d080a from the Incrementals repo
     (link:https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc295.e017dc58c0a3/[download])
 * *FIXED* - Git Client plugin 2.7.2 cannot be installed when running with Java 11 build 18ea
 * There are many warnings about Illegal reflective access during execution

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -9,10 +9,10 @@ There are separate run and job execution requirements for Jenkins installations.
 
 Modern Jenkins versions have the following Java requirements:
 
-* Java 8 is the **ONLY** supported runtime environment, both 32-bit and 64-bit versions are supported
+* Java 8 is the **ONLY** currently supported runtime environment, both 32-bit and 64-bit versions are supported
 * Older versions of Java are not supported
-* Java 9 is not supported
-* Java 10 and 11 preview support is available
+* Java 9 and Java 10 are not supported
+* Java 11 preview support is available
 ** Support of these versions is available through custom packages
 ** link:/blog/2018/06/17/running-jenkins-with-java10-11/[This page] provides guidelines about running Jenkins with these versions
 


### PR DESCRIPTION
Updated to current support status (Java 10 not supported, for instance)
Added a warning link from the blog entry to the up to date solution page to drive users to the updated information.

cc @oleg-nenashev @MRamonLeon @alecharp 

Renders as:

![image](https://user-images.githubusercontent.com/223853/49597834-9290ee00-f97d-11e8-92a2-85c05206b164.png)

![image](https://user-images.githubusercontent.com/223853/49597853-9de41980-f97d-11e8-81c6-274296a96018.png)
