### PR TITLE
Fix link to SECURITY-162

### DIFF
--- a/content/security/advisory/2018-12-05.adoc
+++ b/content/security/advisory/2018-12-05.adoc
@@ -107,7 +107,7 @@ issues:
 
     NOTE: While the same component allows browsing archived artifacts, this fix does not apply to archived artifacts.
     Valid symbolic links are archived as the files and directories they point to on the agent, while invalid symlinks cannot escape the root directory for archived artifacts on the Jenkins master.
-    This was previously fixed as SECURITY-162 in the link:../2018-02-27/[2018-02-27 security advisory].
+    This was previously fixed as SECURITY-162 in the link:../2015-02-27/[2015-02-27 security advisory].
 
 - id: SECURITY-1193
   title: Potential denial of service through cron expression form validation


### PR DESCRIPTION
Year of the announce for SECURITY-162 seems wrong, therefore link was broken.