### PR TITLE
Change the grep command to ignore the case

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -57,7 +57,7 @@ inspect the headers returned on a Jenkins URL, for example:
 
 [source]
 ----
-% curl -Lv https://JENKINS_URL/login 2>&1 | grep 'X-SSH-Endpoint'
+% curl -Lv https://JENKINS_URL/login 2>&1 | grep -i 'x-ssh-endpoint'
 < X-SSH-Endpoint: localhost:53801
 %
 ----


### PR DESCRIPTION
HTTP/2 uses lower case headers so it's better to ignore the case so that the command is compatible with known HTTP's versions: 1.0, 1,1 and 2.