### PR TITLE
[SIGs] - Move the contacts to the main right panel

### DIFF
--- a/content/_layouts/project.html.haml
+++ b/content/_layouts/project.html.haml
@@ -44,11 +44,18 @@ layout: default
             Connect
 
           %ul
+            - if page.links.googlegroup
+              %li
+                %a{:href => "https://groups.google.com/forum/#!forum/#{page.links.googlegroup}", :target => "_blank"}
+                  Mailing List
             - if page.links.gitter
               %li
                 %a{:href => "https://gitter.im/#{page.links.gitter}", :target => "_blank"}
                   %img{:title => "Gitter", :src => "https://badges.gitter.im/#{page.links.gitter}.svg"}
-
+            - if page.links.github
+              %li
+                %a{:href => "https://github.com/#{page.links.github}", :target => "_blank"}
+                  Github repository
         %div
           - # Only render articles if we have them
           - if articles.size > 0

--- a/content/_layouts/sig.html.haml
+++ b/content/_layouts/sig.html.haml
@@ -4,10 +4,10 @@ layout: project
 
 .container
   .row.body
-    .col-lg-8
+    .col-lg-12
 
       - if page.logo
-        %img{:title => "Logo", :src => expand_link(page.logo), :style => "float:right", :width => "96"}
+        %img{:title => "Logo", :src => expand_link(page.logo), :style => "float:right", :width => "192"}
 
       %h2.title
         Overview
@@ -19,24 +19,6 @@ layout: project
 
       %a{:href => "/sigs", :target => "_blank"}
         (Back to List of Jenkins Special Interest Groups )
-
-    .col-lg-4
-      %h2.title
-        Links
-
-      %ul
-        - if page.links.googlegroup
-          %li
-            %a{:href => "https://groups.google.com/forum/#!forum/#{page.links.googlegroup}", :target => "_blank"}
-              Mailing List
-        - if page.links.gitter
-          %li
-            %a{:href => "https://gitter.im/#{page.links.gitter}?utm_source=share-link&utm_medium=link&utm_campaign=share-link", :target => "_blank"}
-              %img{:title => "Gitter", :src => "https://badges.gitter.im/#{page.links.gitter}.svg"}
-        - if page.links.github
-          %li
-            %a{:href => "https://github.com/#{page.links.github}", :target => "_blank"}
-              Github repository
 
   .row
     .col-lg-12


### PR DESCRIPTION
@jenkins-infra/copy-editors  @bitwiseman 

Changes the SIG layout a bit. All links are moved to the `project` layout so that they can be actually reused on other project pages if needed. Logo size was also increased since we have more space now.

## Before

<img width="1187" alt="screenshot 2018-12-08 at 00 29 37" src="https://user-images.githubusercontent.com/3000480/49678051-52fffa00-fa82-11e8-9dd4-d7a1fb65adcf.png">

<img width="1125" alt="screenshot 2018-12-08 at 00 30 08" src="https://user-images.githubusercontent.com/3000480/49678059-5c896200-fa82-11e8-8f13-7ae48fc23649.png">


## After

<img width="1030" alt="screenshot 2018-12-08 at 00 38 56" src="https://user-images.githubusercontent.com/3000480/49678074-6e6b0500-fa82-11e8-8fbf-e1c803f2062d.png">

<img width="1059" alt="screenshot 2018-12-08 at 00 40 54" src="https://user-images.githubusercontent.com/3000480/49678075-6e6b0500-fa82-11e8-997e-5f8a46cbe1d4.png">

