### PR TITLE
Use GSoC Logo, update for current year

### DIFF
--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -34,10 +34,10 @@ link:blueocean[*Learn more*]
 
 == Google Summer of Code
 
-image:/images/plugin.png["Summer of Code", role=left]
+image:/images/gsoc/jenkins-gsoc-logo_small.png["Summer of Code", role=left, width=128]
 
 The
-link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
+link:https://summerofcode.withgoogle.com/archive/[Google Summer of Code]
 (GSoC) project is an annual, international, program which encourages
 college-aged students to participate with open source projects during the summer
 break between classes. Students accepted into the program receive a stipend,
@@ -46,8 +46,8 @@ project.  In exchange, numerous Jenkins community members volunteer as "mentors"
 for students to help integrate them into the open source community and succeed
 in completing their summer projects.
 
-The Jenkins project participated in the Google Summer of Code 2016 with
-link:https://summerofcode.withgoogle.com/organizations/5668199471251456/[five student projects].
+The Jenkins project participated in the Google Summer of Code 2018 with
+link:https://summerofcode.withgoogle.com/archive/2018/organizations/5245157809061888/[two student projects].
 
 link:gsoc[*Learn more*]
 


### PR DESCRIPTION
@jenkins-infra/copy-editors @bitwiseman

Use the Jenkins GSoC Logo on the Jenkins Sub-Projects page, and update the paragraph for the current year.