### PR TITLE
[JENKINS-54386] Fix example for preserveStashes.

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -558,7 +558,7 @@ disable branch indexing triggers for this job only.
 preserveStashes:: Preserve stashes from completed builds, for use with
 stage restarting. For example: `options { preserveStashes() }` to
 preserve the stashes from the most recent completed build, or `options
-{ preserveStashes(5) }` to preserve the stashes from the five most
+{ preserveStashes(buildCount: 5) }` to preserve the stashes from the five most
 recent completed builds.
 
 quietPeriod:: Set the quiet period, in seconds, for the Pipeline, overriding the global default.


### PR DESCRIPTION
It requires a named parameter, and I gave a bad example. Fixed.