### PR TITLE
Use a new Google Hangout

### DIFF
--- a/content/hangout.adoc
+++ b/content/hangout.adoc
@@ -1,4 +1,4 @@
 ---
 layout: refresh
-refresh_to_post_id: 'https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38'
+refresh_to_post_id: 'https://hangouts.google.com/call/Qa3sj3yJTDb-VGxJFjLcAEEE'
 ---


### PR DESCRIPTION
The older Hangout seemed to be restricted to the CloudBees organization.