### PR TITLE
Backfill old Hudson release dates

### DIFF
--- a/content/changelog-old.html
+++ b/content/changelog-old.html
@@ -1023,7 +1023,6 @@ title: Changelog Archives
   <li class="major rfe">
     Adapt the Setup Wizard GUI to provide a similar user experience when upgrading Jenkins.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-33663">issue 33663</a>)
-    <!--TODO: add a links to the Extension points when Wiki get's updated-->
   <li class="rfe">
     Improve extensibility of the Setup Wizard GUI:
     <code>InstallState</code> and <code>InstallStateFilter</code> extension points.
@@ -10223,7 +10222,7 @@ title: Changelog Archives
     JavaScript error in the system configuration prevents a form submission.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2260">issue 2260</a>)
 </ul>
-<h3 id=v1.250>What's new in 1.250</h3>
+<h3 id=v1.250>What's new in 1.250 (08-22-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE in the workspace clean up thread when the slave is offline.
@@ -10238,7 +10237,7 @@ title: Changelog Archives
     Added LDAPS support
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1445">issue 1445</a>)
 </ul>
-<h3 id=v1.249>What's new in 1.249</h3>
+<h3 id=v1.249>What's new in 1.249 (08-19-2008)</h3>
 <ul class=image>
   <li class=bug>
     JNLP slave agent fails to launch when the anonymous user doesn't have a read access.
@@ -10254,7 +10253,7 @@ title: Changelog Archives
   <li class=rfe>
     Intorduced a mechanism to perform a bulk change to improve performance (and in preparation of version controlling config files)
 </ul>
-<h3 id=v1.248>What's new in 1.248</h3>
+<h3 id=v1.248>What's new in 1.248 (08-15-2008)</h3>
 <ul class=image>
   <li class=bug>
     Update center was failing to handle SNAPSHOTs correctly.
@@ -10265,7 +10264,7 @@ title: Changelog Archives
   <li class=rfe>
     Added an ability to manually wipe out the workspace.
 </ul>
-<h3 id=v1.247>What's new in 1.247</h3>
+<h3 id=v1.247>What's new in 1.247 (08-12-2008)</h3>
 <ul class=image>
   <li class=bug>
     Don't repeat the same "No suitable implementation found" error again and again in the log.
@@ -10286,13 +10285,13 @@ title: Changelog Archives
     Detect the updates to <tt>hudson.war</tt> and report it.
     (<a href="http://www.nabble.com/Re%3A-Bugzilla-plugin-1.1-released-p18683781.html">discussion</a>)
 </ul>
-<h3 id=v1.245>What's new in 1.245</h3>
+<h3 id=v1.245>What's new in 1.245 (08-06-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression introduced in 1.244 that causes NPE in Ant.perform()
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2177">issue 2177</a>)
 </ul>
-<h3 id=v1.244>What's new in 1.244</h3>
+<h3 id=v1.244>What's new in 1.244 (08-06-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug with "mvn assembly:directory" in the native m2 job type.
@@ -10313,7 +10312,7 @@ title: Changelog Archives
     Recover from corrupted fingerprint records in certain cases.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2012">issue 2012</a>)
 </ul>
-<h3 id=v1.243>What's new in 1.243</h3>
+<h3 id=v1.243>What's new in 1.243 (08-05-2008)</h3>
 <ul class=image>
   <li class=rfe>
     Launch Maven in the non-interactive mode.
@@ -10329,7 +10328,7 @@ title: Changelog Archives
   <li class=rfe>
     Monitor the response time of slaves and cut unresponsive ones out.
 </ul>
-<h3 id=v1.242>What's new in 1.242</h3>
+<h3 id=v1.242>What's new in 1.242 (08-01-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a problem where not configuring Ant or Maven causes the global configuration submission to fail.
@@ -10339,7 +10338,7 @@ title: Changelog Archives
     Fixed NPE in SVNKit.
     (<a href="http://www.nabble.com/Hudson-1.240-and-checking-out-Hudson-subversion-repository-throws-NullPointerException-td18764732.html">report</a>)
 </ul>
-<h3 id=v1.241>What's new in 1.241</h3>
+<h3 id=v1.241>What's new in 1.241 (07-31-2008)</h3>
 <ul class=image>
     <li class='major bug'>
       Fixed a data loss problem in Ant/Maven/etc global configuration when submitting a form.
@@ -10352,7 +10351,7 @@ title: Changelog Archives
       (<a href="http://www.nabble.com/Hudson-1.238-cannot-load-some-job-td18737135.html">report</a>,
        <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2140">issue 2140</a>)
 </ul>
-<h3 id=v1.240>What's new in 1.240</h3>
+<h3 id=v1.240>What's new in 1.240 (07-31-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     <strike>Fixed a bug that prevented the matrix build job from loading correctly</strike>.
@@ -10361,7 +10360,7 @@ title: Changelog Archives
     Fixed a suspected NPE in <tt>View.java:172</tt>
     (<a href="http://www.nabble.com/Upgrade-hudson-1.34-to-1.38-corrupted-several-projects-td18737778.html">report</a>)
 </ul>
-<h3 id=v1.239>What's new in 1.239</h3>
+<h3 id=v1.239>What's new in 1.239 (07-30-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a JavaScript error in project-based matrix security.
@@ -10377,7 +10376,7 @@ title: Changelog Archives
     Corrupted JUnit reports no longer cause a fatal problem.
     (<a href="http://www.nabble.com/Better-error-reporting-for-failed-builds-td18531504.html#a18531504">discussion</a>)
 </ul>
-<h3 id=v1.238>What's new in 1.238</h3>
+<h3 id=v1.238>What's new in 1.238 (07-26-2008)</h3>
 <ul class=image>
   <li class=bug>
     If forked Maven fails to start normally in the native m2 job type, Hudson was hanging.
@@ -10404,7 +10403,7 @@ title: Changelog Archives
     Brought in SVNKit 1.2.0-beta-2 to support svn:// access to Subversion 1.5 server.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1856">issue 1856</a>)
 </ul>
-<h3 id=v1.237>What's new in 1.237</h3>
+<h3 id=v1.237>What's new in 1.237 (07-23-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a possible NPE in parallel module builds in Maven.{noformat}
@@ -10437,7 +10436,7 @@ title: Changelog Archives
     Builds can now take user-defined parameters given at the build schedule time.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1914">issue 1914</a>)
 </ul>
-<h3 id=v1.236>What's new in 1.236</h3>
+<h3 id=v1.236>What's new in 1.236 (07-20-2008)</h3>
 <ul class=image>
   <li class=bug>
     API .../computer/api/xml wasn't working.
@@ -10458,7 +10457,7 @@ title: Changelog Archives
     Extract the war file by default inside <tt>HUDSON_HOME</tt> by default.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=2098">issue 2098</a>)
 </ul>
-<h3 id=v1.235>What's new in 1.235</h3>
+<h3 id=v1.235>What's new in 1.235 (07-15-2008)</h3>
 <ul class=image>
   <li class=bug>
     Read <tt>$M2_HOME/conf/setting.xml</tt> when doing Maven related things.
@@ -10473,7 +10472,7 @@ title: Changelog Archives
     Build history graph now shows unstable and aborted builds in proper color
     (<a href="http://www.nabble.com/Idea-for-new-plugin-td18391367.html">discussion</a>)
 </ul>
-<h3 id=v1.234>What's new in 1.234</h3>
+<h3 id=v1.234>What's new in 1.234 (07-11-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a concurrency issue around <tt>SimpleDateFormat</tt>. This manifests itself in many strange ways
@@ -10488,7 +10487,7 @@ title: Changelog Archives
     Update center accepts HTTP proxy username/password.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1833">issue 1833</a>)
 </ul>
-<h3 id=v1.233>What's new in 1.233</h3>
+<h3 id=v1.233>What's new in 1.233 (07-08-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Debug exception message crept in to the trunk code. Regression in 1.232.
@@ -10503,7 +10502,7 @@ title: Changelog Archives
     Take the clock difference between master and the slave into account when collecting test reports.
     (<a href="http://www.nabble.com/clock-difference---figuring-out-if-tests-results-are-new-or-old-td18319363.html">report</a>)
 </ul>
-<h3 id=v1.232>What's new in 1.232</h3>
+<h3 id=v1.232>What's new in 1.232 (07-03-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed an interference between auto refresh and inline description editing.
@@ -10524,7 +10523,7 @@ title: Changelog Archives
     Executors are exposed to the remote API.
     (<a href="http://www.nabble.com/how-to-monitor-build-executors--tt18253458.html">report</a>)
 </ul>
-<h3 id=v1.231>What's new in 1.231</h3>
+<h3 id=v1.231>What's new in 1.231 (07-02-2008)</h3>
 <ul class=image>
   <li class=bug>
     <tt>Publisher.prebuild</tt> wasn't called for Maven builds.
@@ -10553,7 +10552,7 @@ title: Changelog Archives
     When the slave has less than 1GB available disk space, Hudson will automatically mark the node as temporarily offline.
     (<a href="http://www.nabble.com/builds-that-failed-because-of-space-constraints-tt18217298.html">discussion</a>)
 </ul>
-<h3 id=v1.230>What's new in 1.230</h3>
+<h3 id=v1.230>What's new in 1.230 (06-27-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in launching JNLP slaves when reverse proxy is involved.
@@ -10574,7 +10573,7 @@ title: Changelog Archives
   <li class=rfe>
     More progress in German translation.
 </ul>
-<h3 id=v1.229>What's new in 1.229</h3>
+<h3 id=v1.229>What's new in 1.229 (06-24-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Start-up "Hudson is preparing to work" screen doesn't render with <tt>AssertionFailure</tt>.
@@ -10583,7 +10582,7 @@ title: Changelog Archives
     Changing a job name to the same name with different case resulted in an error.
     (<a href="http://www.nabble.com/error-on-renaming-project-tt18061629.html">report</a>)
 </ul>
-<h3 id=v1.228>What's new in 1.228</h3>
+<h3 id=v1.228>What's new in 1.228 (06-23-2008)</h3>
 <ul class=image>
   <li class=bug>
     Plugin manager page wasn't hidden from anonymous users even when the security was enabled.
@@ -10615,7 +10614,7 @@ title: Changelog Archives
     Hudson checks if the container uses UTF-8 to decode URls.
 	(<a href="https://hudson.dev.java.net/servlets/ReadMsg?list=ja&msgNo=32">discussion</a>)
 </ul>
-<h3 id=v1.227>What's new in 1.227</h3>
+<h3 id=v1.227>What's new in 1.227 (06-20-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug in configuring repository browsers.
@@ -10636,7 +10635,7 @@ title: Changelog Archives
     Build queue is now exposed to the remote API.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1886">issue 1886</a>)
 </ul>
-<h3 id=v1.226>What's new in 1.226</h3>
+<h3 id=v1.226>What's new in 1.226 (06-17-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Anonymous user was able to modify user's description. This creates XSS vulnerability in Hudson.
@@ -10656,7 +10655,7 @@ title: Changelog Archives
     Hudson now performs environment variable expansions for commands to be launched, like shell does.
     (<a href="http://www.nabble.com/HUDSON_EXEC-exported-tt17135819.html">discussion</a>)
 </ul>
-<h3 id=v1.225>What's new in 1.225</h3>
+<h3 id=v1.225>What's new in 1.225 (06-16-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a leak in Winstone that can cause "ReqPool: Max requests in pool exceeded - denied"
@@ -10681,7 +10680,7 @@ title: Changelog Archives
     manually force update.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1849">issue 1849</a>)
 </ul>
-<h3 id=v1.224>What's new in 1.224</h3>
+<h3 id=v1.224>What's new in 1.224 (06-13-2008)</h3>
 <ul class=image>
   <li class=bug>
     "This is a tag, not a branch" option in CVS wasn't loaded in HTML page correctly,
@@ -10699,7 +10698,7 @@ title: Changelog Archives
     Re-implemented the proxy server support in the update center not to use system global properties.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1841">issue 1841</a>)
 </ul>
-<h3 id=v1.223>What's new in 1.223</h3>
+<h3 id=v1.223>What's new in 1.223 (06-11-2008)</h3>
 <ul class=image>
   <li class=bug>
     Users should be allowed to configure himself regardless of the permission setting.
@@ -10721,7 +10720,7 @@ title: Changelog Archives
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1044">issue 1044</a>,
      <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1282">issue 1282</a>)
 </ul>
-<h3 id=v1.222>What's new in 1.222</h3>
+<h3 id=v1.222>What's new in 1.222 (06-09-2008)</h3>
 <ul class=image>
   <li class=bug>
     A build in progress shouldn't be deletable.
@@ -10739,7 +10738,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Hudson now has an update center to simplify the installation of new plugins.
 </ul>
-<h3 id=v1.221>What's new in 1.221</h3>
+<h3 id=v1.221>What's new in 1.221 (06-04-2008)</h3>
 <ul class=image>
   <li class=bug>
     Some test result pages were incorrectly using absolute URLs.
@@ -10755,7 +10754,7 @@ title: Changelog Archives
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1762">issue 1762</a>,
      <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1772">issue 1772</a>)
 </ul>
-<h3 id=v1.220>What's new in 1.220</h3>
+<h3 id=v1.220>What's new in 1.220 (06-02-2008)</h3>
 <ul class=image>
   <li class=bug>
     Hudson added '/' to the menubar links incorrectly on some cases.
@@ -10783,7 +10782,7 @@ title: Changelog Archives
     Plugins can now contribute <tt>ServletFilter</tt>s
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1573">issue 1573</a>)
 </ul>
-<h3 id=v1.219>What's new in 1.219</h3>
+<h3 id=v1.219>What's new in 1.219 (05-27-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Hopefully fixed the hang issue with Windows &amp; Maven2 builds.
@@ -10806,7 +10805,7 @@ title: Changelog Archives
     Tagged builds now get a badge next to it, just like locked builds.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1730">issue 1730</a>)
 </ul>
-<h3 id=v1.218>What's new in 1.218</h3>
+<h3 id=v1.218>What's new in 1.218 (05-21-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE when launching a new slave.
@@ -10816,13 +10815,13 @@ title: Changelog Archives
     the system property <tt>hudson.master.headless</tt> to true.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1732">issue 1732</a>)
 </ul>
-<h3 id=v1.217>What's new in 1.217</h3>
+<h3 id=v1.217>What's new in 1.217 (05-21-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     1.216 introduced a dependency to Java6
     <a href="http://www.nabble.com/Hudson-1.216---1.215-regression-issue-to17354559.html">report</a>
 </ul>
-<h3 id=v1.216>What's new in 1.216</h3>
+<h3 id=v1.216>What's new in 1.216 (05-21-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a problem where Hudson CVS polling with CVSNT and pserver detects a phantom changes.
@@ -10854,7 +10853,7 @@ title: Changelog Archives
     Configuration of the executors is split out from system configuration.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1632">issue 1632</a>)
 </ul>
-<h3 id=v1.215>What's new in 1.215</h3>
+<h3 id=v1.215>What's new in 1.215 (05-16-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Slave configuration fails to persist.
@@ -10868,7 +10867,7 @@ title: Changelog Archives
     Hudson now accepts SSH private key in the PuTTY's .ppk file format.
     (<a href="http://www.nabble.com/Problems-on-checkout-polling-subversion-with-svn%2Bssh-tt17212401.html">discussion</a>)
 </ul>
-<h3 id=v1.214>What's new in 1.214</h3>
+<h3 id=v1.214>What's new in 1.214 (05-14-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     After-the-fact deployment of artifacts stopped working since 1.212.
@@ -10891,7 +10890,7 @@ title: Changelog Archives
     Supported HTTP DELETE method on job top page to delete it.
     (<a href="http://www.nabble.com/how-are-you-using-Hudson-for-non-Java-projects--to17145574.html#a17154167">discussion</a>)
 </ul>
-<h3 id=v1.213>What's new in 1.213</h3>
+<h3 id=v1.213>What's new in 1.213 (05-02-2008)</h3>
 <ul class=image>
   <li class=bug>
     Auto refresh should be disabled on plugin management page and the SVN credential dialog.
@@ -10913,7 +10912,7 @@ title: Changelog Archives
     Added View workspace permission to the matrix-based security.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=434">issue 434</a>)
 </ul>
-<h3 id=v1.212>What's new in 1.212</h3>
+<h3 id=v1.212>What's new in 1.212 (04-28-2008)</h3>
 <ul class=image>
   <li class=bug>
     Starting this version, Hudson no longer installs remotely built Maven artifacts
@@ -10936,7 +10935,7 @@ title: Changelog Archives
     Improved error diagnostics when the incorrect path to M2 is specified for the native m2 job type.
     (<a href="http://www.nabble.com/Default-Maven-Version-for-Distributed-Builds-td16854956.html">report</a>)
 </ul>
-<h3 id=v1.211>What's new in 1.211</h3>
+<h3 id=v1.211>What's new in 1.211 (04-24-2008)</h3>
 <ul class=image>
   <li class=bug>
     Hudson disables a project with Subversion too eagerly, when the user makes a mistake in the SVN URL.
@@ -10951,7 +10950,7 @@ title: Changelog Archives
     Hudson can now handle optional dependencies to other plugins.
     (<a href="http://www.nabble.com/Optional-dependencies-between-plugins-td16799403.html">report</a>)
 </ul>
-<h3 id=v1.210>What's new in 1.210</h3>
+<h3 id=v1.210>What's new in 1.210 (04-19-2008)</h3>
 <ul class=image>
   <li class=bug>
     Hudson can now wipe out files in a directory even if the directory is not writable.
@@ -10968,7 +10967,7 @@ title: Changelog Archives
     Tokenization now handles quotes and escapes like Unix shell does.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1553">issue 1553</a>)
 </ul>
-<h3 id=v1.209>What's new in 1.209</h3>
+<h3 id=v1.209>What's new in 1.209 (04-16-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Internet Explorer fails to submit a form.
@@ -10983,7 +10982,7 @@ title: Changelog Archives
     <strike>Distributed builds and native Maven job types were not working with OC4J.</strike>
     (<a href="http://www.nabble.com/Hudson-on-OC4J-tt16702113.html">report</a>)
 </ul>
-<h3 id=v1.207>What's new in 1.207</h3>
+<h3 id=v1.207>What's new in 1.207 (04-15-2008)</h3>
 <ul class=image>
   <li class=bug>
     After-the-fact Maven deployment wasn't working for POM-only modules.
@@ -11001,7 +11000,7 @@ title: Changelog Archives
   <li class=rfe>
     The first cut of Dutch localization is now available, thanks to <a href="https://launchpad.net/~wim-rosseel">Wim Rosseel</a>
 </ul>
-<h3 id=v1.206>What's new in 1.206</h3>
+<h3 id=v1.206>What's new in 1.206 (04-09-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed NPE in the SCM polling.
@@ -11022,7 +11021,7 @@ title: Changelog Archives
     Don't display the login form when the access is denied
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1510">issue 1510</a>)
 </ul>
-<h3 id=v1.205>What's new in 1.205</h3>
+<h3 id=v1.205>What's new in 1.205 (04-08-2008)</h3>
 <ul class=image>
   <li class=bug>
     Individual Maven module build records should be kept if the project build record is kept.
@@ -11040,7 +11039,7 @@ title: Changelog Archives
   <li class=rfe>
     First version to be released from Subversion repository.
 </ul>
-<h3 id=v1.204>What's new in 1.204</h3>
+<h3 id=v1.204>What's new in 1.204 (04-05-2008)</h3>
 <ul class=image>
   <li class=bug>
     Remoting API now serves properly escaped URLs
@@ -11060,7 +11059,7 @@ title: Changelog Archives
     <strike>Remoting API now exposes information attached by plugins</strike>
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1473">issue 1473</a>)
 </ul>
-<h3 id=v1.203>What's new in 1.203</h3>
+<h3 id=v1.203>What's new in 1.203 (04-03-2008)</h3>
 <ul class=image>
   <li class=bug>
     CVS polling was not working if it's configured to pull a tag
@@ -11083,7 +11082,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements in Russian, Brazilian Portuguese and Japanese localization.
 </ul>
-<h3 id=v1.202>What's new in 1.202</h3>
+<h3 id=v1.202>What's new in 1.202 (04-02-2008)</h3>
 <ul class=image>
   <li class=bug>
     If all executors are busy, the queue status was not getting updated.
@@ -11098,7 +11097,7 @@ title: Changelog Archives
     Display why matrix configuration build is blocked.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1455">issue 1455</a>)
 </ul>
-<h3 id=v1.201>What's new in 1.201</h3>
+<h3 id=v1.201>What's new in 1.201 (03-29-2008)</h3>
 <ul class=image>
   <li class=bug>
     Renaming plugins from their original names no longer cause problems in plugins.
@@ -11118,7 +11117,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements in Russian, Brazilian Portuguese and French localization.
 </ul>
-<h3 id=v1.200>What's new in 1.200</h3>
+<h3 id=v1.200>What's new in 1.200 (03-22-2008)</h3>
 <ul class=image>
   <li class=bug>
     Allow plugins to register actions with absolute URLs.
@@ -11135,7 +11134,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements in Turkish localization
 </ul>
-<h3 id=v1.199>What's new in 1.199</h3>
+<h3 id=v1.199>What's new in 1.199 (03-20-2008)</h3>
 <ul class=image>
   <li class=bug>
     login error should result in 401 status code.
@@ -11157,7 +11156,7 @@ title: Changelog Archives
     Artifact listing now prints a part of path if that's necessary to disambiguate names
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1435">issue 1435</a>)
 </ul>
-<h3 id=v1.198>What's new in 1.198</h3>
+<h3 id=v1.198>What's new in 1.198 (03-19-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Native maven2 job types didn't work with Surefire &lt; 2.4
@@ -11176,7 +11175,7 @@ title: Changelog Archives
   <li class=rfe>
     Localizatoin improvements in Russian, Brazilian Portuguese, Japanese, and French.
 </ul>
-<h3 id=v1.197>What's new in 1.197</h3>
+<h3 id=v1.197>What's new in 1.197 (03-17-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     NPE when loading TestNG reports in the maven2 jobs.
@@ -11201,7 +11200,7 @@ title: Changelog Archives
     Hudson now workarounds bugs in IBM JDK and WebSphere.
     (<a href="http://www.nabble.com/WAS---Hudson-tt16026561.html">discussion</a>)
 </ul>
-<h3 id=v1.196>What's new in 1.196</h3>
+<h3 id=v1.196>What's new in 1.196 (03-15-2008)</h3>
 <ul class=image>
   <li class=bug>
     Loss of workspace shouldn't result in a new build with Subversion.
@@ -11223,7 +11222,7 @@ title: Changelog Archives
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=490">issue
 490</a>)
 </ul>
-<h3 id=v1.195>What's new in 1.195</h3>
+<h3 id=v1.195>What's new in 1.195 (03-13-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed <tt>IllegalArgumentException</tt> when trying to submit configuration for Matrix job
@@ -11247,7 +11246,7 @@ title: Changelog Archives
   <li class=rfe>
     More progress on Turkish localization.
 </ul>
-<h3 id=v1.194>What's new in 1.194</h3>
+<h3 id=v1.194>What's new in 1.194 (03-13-2008)</h3>
 <ul class=image>
   <li class=bug>
     Hudson occasionally incorrectly report "0 tests started to fail".
@@ -11268,14 +11267,14 @@ title: Changelog Archives
   <li class=rfe>
     Added an extension point for plugins to add icons to the "manage Hudson" page.
 </ul>
-<h3 id=v1.193>What's new in 1.193</h3>
+<h3 id=v1.193>What's new in 1.193 (03-11-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     There was a data corruption issue when you submit configuration for freestyle jobs.
   <li class=rfe>
     Improvement in French and Turkish localization.
 </ul>
-<h3 id=v1.192><strike>What's new in 1.192</strike> Please use 1.193</h3>
+<h3 id=v1.192><strike>What's new in 1.192 (03-11-2008)</strike> Please use 1.193</h3>
 <ul class=image>
   <li class=bug>
     Matrix configuration run shouldn't wait for the quiet period.
@@ -11295,7 +11294,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements to French and Brazilian Portuguese localization.
 </ul>
-<h3 id=v1.191><strike>What's new in 1.191</strike> Please use 1.193</h3>
+<h3 id=v1.191><strike>What's new in 1.191 (03-10-2008)</strike> Please use 1.193</h3>
 <ul class=image>
   <li class=bug>
     When explicit downstream dependencies are configured, Maven2 jobs were scheduling them twice.
@@ -11317,7 +11316,7 @@ title: Changelog Archives
   <li class=rfe>
     Improvements to Japanese and Turkish localization.
 </ul>
-<h3 id=v1.190>What's new in 1.190</h3>
+<h3 id=v1.190>What's new in 1.190 (03-07-2008)</h3>
 <ul class=image>
   <li class=bug>
     Downstream triggering now happens "correctly" with the matrix job type
@@ -11339,7 +11338,7 @@ title: Changelog Archives
     Initial Turkish localization, thanks to O&#x011F;uz Da&#x011F;.
     (<a href="http://www.nabble.com/-Fwd%3A--Kohsuke-Kawaguchi%27s-Blog--New-Comment-Posted-to-%27Internationalization-of-Hudson-----Help-wanted%21%27--tt15879811.html">announcement</a>)
 </ul>
-<h3 id=v1.189>What's new in 1.189</h3>
+<h3 id=v1.189>What's new in 1.189 (03-07-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed bug in collecting of TestNG test results in Maven projects.
@@ -11355,7 +11354,7 @@ title: Changelog Archives
     Initial Russian translation contributed by Mike Salnikov
     (<a href="http://www.nabble.com/Russian-i18n-tt15867581.html">announcement</a>)
 </ul>
-<h3 id=v1.188>What's new in 1.188</h3>
+<h3 id=v1.188>What's new in 1.188 (03-05-2008)</h3>
 <ul class=image>
   <li class=bug>
     The "perform the build once to parse POM" message needed to have zero-delay query parameter.
@@ -11372,7 +11371,7 @@ title: Changelog Archives
     A node and a view now have its own aggregated build history view.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1174">issue 1174</a>)
 </ul>
-<h3 id=v1.187>What's new in 1.187</h3>
+<h3 id=v1.187>What's new in 1.187 (03-04-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed bug in displaying the password field on a user page when using Hudson's own user database.
@@ -11387,7 +11386,7 @@ title: Changelog Archives
   <li class=rfe>
     German translation is making more progress.
 </ul>
-<h3 id=v1.186>What's new in 1.186</h3>
+<h3 id=v1.186>What's new in 1.186 (02-29-2008)</h3>
 <ul class=image>
   <li class=bug>
     Build descriptions edited in the UI were not persisted correctly.
@@ -11411,7 +11410,7 @@ title: Changelog Archives
     Error diagnosis is improved when two Hudson instances collide on each other on the same data directory
     (<a href="http://www.nabble.com/Re%3A-%22multiple-versions-installed%22-error.-tt15663750.html#a15663750">report</a>)
 </ul>
-<h3 id=v1.185>What's new in 1.185</h3>
+<h3 id=v1.185>What's new in 1.185 (02-26-2008)</h3>
 <ul class=image>
   <li class=bug>
     Builds are now run with the proper security privileges to do the work.
@@ -11424,7 +11423,7 @@ title: Changelog Archives
     German translation is started and is making a good progress, thanks to
     <a href="http://www.dr-wiest.com/">Simon Wiest</a>.
 </ul>
-<h3 id=v1.184>What's new in 1.184</h3>
+<h3 id=v1.184>What's new in 1.184 (02-13-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where build dependencies in the native m2 job type may create
@@ -11437,7 +11436,7 @@ title: Changelog Archives
     External job monitoring now avoids buffering the entire output on memory.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1283">issue 1283</a>)
 </ul>
-<h3 id=v1.183>What's new in 1.183</h3>
+<h3 id=v1.183>What's new in 1.183 (02-10-2008)</h3>
 <ul class=image>
   <li class=bug>
     Some form field validation errors were incorrectly reported as warnings.
@@ -11457,7 +11456,7 @@ title: Changelog Archives
     "Build now" really builds now, without any delay.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=356">issue 356</a>)
 </ul>
-<h3 id=v1.182>What's new in 1.182</h3>
+<h3 id=v1.182>What's new in 1.182 (02-09-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     removed <tt>MSVCR90.DLL</tt> dependency on Windows when trying to abort builds.
@@ -11469,7 +11468,7 @@ title: Changelog Archives
     Fixed a bug in parsing TestNG report files.
     (<a href="http://www.nabble.com/Problems-with-testng-failed-test-parsing-tp15146287p15146287.html">report</a>)
 </ul>
-<h3 id=v1.181>What's new in 1.181</h3>
+<h3 id=v1.181>What's new in 1.181 (02-08-2008)</h3>
 <ul class=image>
   <li class=bug>
     If the CVS configuration is changed, polling should notice and start tracking the new location.
@@ -11496,7 +11495,7 @@ title: Changelog Archives
     When aborting a build on Windows, Hudson now terminates child processes recursively.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1245">issue 1245</a>)
 </ul>
-<h3 id=v1.180>What's new in 1.180</h3>
+<h3 id=v1.180>What's new in 1.180 (02-05-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the Windows/Unix handling logic when a file path includes ':' in Unix.
@@ -11518,7 +11517,7 @@ title: Changelog Archives
     Improved the form validation heuristics in the file mask check.
     (<a href="http://www.nabble.com/No-artifacts-found-for-matrix-project-tt15210002.html">report</a>)
 </ul>
-<h3 id=v1.179>What's new in 1.179</h3>
+<h3 id=v1.179>What's new in 1.179 (02-03-2008)</h3>
 <ul class=image>
   <li class='major bug'>
     JNLP slave agents stopped working since 1.175.
@@ -11533,7 +11532,7 @@ title: Changelog Archives
     Changed code so that plugins can never inadvertently update build timestamps.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1084">issue 1084</a>)
 </ul>
-<h3 id=v1.178>What's new in 1.178</h3>
+<h3 id=v1.178>What's new in 1.178 (02-03-2008)</h3>
 <ul class=image>
   <li class=bug>
     Skipped tests (TestNG) are no longer treated as if they had passed.
@@ -11553,7 +11552,7 @@ title: Changelog Archives
   <li class="major rfe">
     <tt>Publisher</tt>s are now available to the native m2 job type.
 </ul>
-<h3 id=v1.177>What's new in 1.177</h3>
+<h3 id=v1.177>What's new in 1.177 (01-30-2008)</h3>
 <ul class=image>
   <li class=bug>
     Removed the extra '$' sign from the permalinks that have accidentally crept in.
@@ -11571,7 +11570,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a Subversion repository browser implementation for CollabNet-powered sites (these include Java.net, Tigris.org and BEA's dev2dev).
 </ul>
-<h3 id=v1.176>What's new in 1.176</h3>
+<h3 id=v1.176>What's new in 1.176 (01-25-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a regression in 1.175 with LDAP authentication
@@ -11589,7 +11588,7 @@ title: Changelog Archives
     Environment variable expansions now work in <tt>MAVEN_OPTS</tt> setting.
     (<a href="http://www.nabble.com/-patch--allow-M2-projects-to-use-environment-variables-in-options-tt15061026.html">report</a>)
 </ul>
-<h3 id=v1.175>What's new in 1.175</h3>
+<h3 id=v1.175>What's new in 1.175 (01-21-2008)</h3>
 <ul class=image>
   <li class=bug>
     Don't allow # of executors to be 0.
@@ -11603,7 +11602,7 @@ title: Changelog Archives
   <li class="rfe">
     Added a probe to the running Maven process to assist trouble-shooting.
 </ul>
-<h3 id=v1.174>What's new in 1.174</h3>
+<h3 id=v1.174>What's new in 1.174 (01-19-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed NPE in the remote API job creation during error recovery.
@@ -11620,7 +11619,7 @@ title: Changelog Archives
   <li class=rfe>
     Removed pointless svn update line about directories.
 </ul>
-<h3 id=v1.173>What's new in 1.173</h3>
+<h3 id=v1.173>What's new in 1.173 (01-17-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed an HTML rendering issue in the slave list page.
@@ -11641,7 +11640,7 @@ title: Changelog Archives
   <li class=rfe>
     When using Hudson's own user database, password can be now reset via the web UI.
 </ul>
-<h3 id=v1.172>What's new in 1.172</h3>
+<h3 id=v1.172>What's new in 1.172 (01-16-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a broken link in the help of "Hudson's own user database"
@@ -11668,7 +11667,7 @@ title: Changelog Archives
     Allowing plugins to extend the navigation menu on left hand side of the top page.
     (<a href="http://www.nabble.com/Hudson-Tray-Monitor-Application-tt14708070.html#a14708070">report</a>)
 </ul>
-<h3 id=v1.171>What's new in 1.171</h3>
+<h3 id=v1.171>What's new in 1.171 (01-14-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed inconsistent use of button visual style.
@@ -11686,7 +11685,7 @@ title: Changelog Archives
     Build health report is now a part of the remote API.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1146">issue 1146</a>)
 </ul>
-<h3 id=v1.170>What's new in 1.170</h3>
+<h3 id=v1.170>What's new in 1.170 (01-13-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed an assertion error in <tt>MavenModuleSetBuild$Builder.postModule</tt>
@@ -11704,7 +11703,7 @@ title: Changelog Archives
     Improved the maven2 build performance.
     (<a href="http://www.nabble.com/Maven-job-5-times-slower-than-a-free-style-job--td14651245.html">report</a>)
 </ul>
-<h3 id=v1.169>What's new in 1.169</h3>
+<h3 id=v1.169>What's new in 1.169 (01-12-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in redirection after successful login.
@@ -11722,7 +11721,7 @@ title: Changelog Archives
     Fixed a problem where the new view links were not correctly displayed even for users with sufficient permissions.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1157">issue 1157</a>)
 </ul>
-<h3 id=v1.168>What's new in 1.168</h3>
+<h3 id=v1.168>What's new in 1.168 (01-11-2008)</h3>
 <ul class=image>
   <li class=bug>
     Ensure sidebar links use correct hostname rather than localhost.
@@ -11740,7 +11739,7 @@ title: Changelog Archives
     In addition to "login" link, "sign up" link is now displayed whenever applicable.
     (<a href="http://www.nabble.com/New-Security-Setup-tt14740386.html">thread</a>)
 </ul>
-<h3 id=v1.167>What's new in 1.167</h3>
+<h3 id=v1.167>What's new in 1.167 (01-10-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where project actions the modules of for m2 projects were not visible until a hudson restart.
@@ -11759,7 +11758,7 @@ title: Changelog Archives
     the amount of data you receive in a single call.
     (<a href="http://www.nabble.com/hudson-portlet-tt14692803.html">report</a>)
 </ul>
-<h3 id=v1.166>What's new in 1.166</h3>
+<h3 id=v1.166>What's new in 1.166 (01-05-2008)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where successful authentication still results in 403 after login under some configurations.
@@ -11776,7 +11775,7 @@ title: Changelog Archives
   <li class="major rfe">
     Added LDAP authentication support
 </ul>
-<h3 id=v1.165>What's new in 1.165</h3>
+<h3 id=v1.165>What's new in 1.165 (01-02-2008)</h3>
 <ul class=image>
   <li class='rfe'>
     Specifying XPath in the remote API that matches multiple nodes is now reported as an error.
@@ -11785,7 +11784,7 @@ title: Changelog Archives
     Fixed a bug where secured Hudson fails to authorize admins to access pages.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1118">issue 1118</a>)
 </ul>
-<h3 id=v1.164>What's new in 1.164</h3>
+<h3 id=v1.164>What's new in 1.164 (12-29-2007)</h3>
 <ul class=image>
   <li class=bug>
     Hudson has been failing to serve workspace files that ends with "jelly" extension.
@@ -11806,7 +11805,7 @@ title: Changelog Archives
     Implemented fine-grained security
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=326">issue 326</a>)
 </ul>
-<h3 id=v1.163>What's new in 1.163</h3>
+<h3 id=v1.163>What's new in 1.163 (12-22-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a possible loading problem for user information
@@ -11817,7 +11816,7 @@ title: Changelog Archives
     Added the remote API support for the people page.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1103">issue 1103</a>)
 </ul>
-<h3 id=v1.162>What's new in 1.162</h3>
+<h3 id=v1.162>What's new in 1.162 (12-22-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a problem where Hudson fails to find wagon implementations.
@@ -11835,7 +11834,7 @@ title: Changelog Archives
     Exposed user e-mail address to the XML/JSON API.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=1108">issue 1108</a>)
 </ul>
-<h3 id=v1.161>What's new in 1.161</h3>
+<h3 id=v1.161>What's new in 1.161 (12-16-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed the wrong time zone use in some HTTP headers.
@@ -11858,7 +11857,7 @@ title: Changelog Archives
     Implemented ASCII-only remote communication mode for binary-unsafe transport.
     (<a href="http://www.nabble.com/telnet-slave-to14216635.html">report</a>)
 </ul>
-<h3 id=v1.160>What's new in 1.160</h3>
+<h3 id=v1.160>What's new in 1.160 (11-30-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the HTML rendering of repository browsers.
@@ -11884,7 +11883,7 @@ title: Changelog Archives
   <li class=rfe>
     Added a feature to test SMTP setting by sending out a trial e-mail.
 </ul>
-<h3 id=v1.159>What's new in 1.159</h3>
+<h3 id=v1.159>What's new in 1.159 (11-22-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the remoting layer that prevented plugins from contributing to the native m2 build process.
@@ -11903,13 +11902,13 @@ title: Changelog Archives
     JUnit report recorder now reports time it took to run tests.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=656">issue 656</a>)
 </ul>
-<h3 id=v1.158>What's new in 1.158</h3>
+<h3 id=v1.158>What's new in 1.158 (11-21-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where the submission of the matrix project configuration clobeers the on-going build.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=981">issue 981</a>)
 </ul>
-<h3 id=v1.157>What's new in 1.157</h3>
+<h3 id=v1.157>What's new in 1.157 (11-20-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in handling whitespace in ant properties on Windows.
@@ -11925,7 +11924,7 @@ title: Changelog Archives
   <li class=rfe>
     Added support for <a href="http://www.sventon.org">sventon</a> as a repsotory browser for Subversion.
 </ul>
-<h3 id=v1.156>What's new in 1.156</h3>
+<h3 id=v1.156>What's new in 1.156 (11-13-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where the submission of Hudson cofiguration loses MAVEN_HOME entries
@@ -11934,7 +11933,7 @@ title: Changelog Archives
     Added "Expires" header to prevent unwanted page-caching in Opera.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=869">issue 869</a>)
 </ul>
-<h3 id=v1.155>What's new in 1.155</h3>
+<h3 id=v1.155>What's new in 1.155 (11-13-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in Ant that causes an empty "-file" line.
@@ -11951,7 +11950,7 @@ title: Changelog Archives
   <li class="rfe">
     Added additional logging for the workspace clean-up thread.
 </ul>
-<h3 id=v1.154>What's new in 1.154</h3>
+<h3 id=v1.154>What's new in 1.154 (11-12-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>IllegalArgumentException</tt> in trying to load data from old Hudson
@@ -11972,7 +11971,7 @@ title: Changelog Archives
   <li class="rfe">
     Added additional logging for project dependency related build ordering.
 </ul>
-<h3 id=v1.153>What's new in 1.153</h3>
+<h3 id=v1.153>What's new in 1.153 (11-06-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression introduced in 1.152 wrt spawning native m2 process remotely.
@@ -11989,7 +11988,7 @@ title: Changelog Archives
     Removed clock checking from the system configuration, as the same information
     is available from the node list view (<tt>http://SERVER/hudson/computer/</tt>)
 </ul>
-<h3 id=v1.152>What's new in 1.152</h3>
+<h3 id=v1.152>What's new in 1.152 (11-05-2007)</h3>
 <ul class=image>
   <li class=bug>
     <strike>Environment variables need to be case insensitive but case preserving.</strike>
@@ -12005,7 +12004,7 @@ title: Changelog Archives
   <li class=bug>
     Don't report the build duration as 0 seconds when it's building.
 </ul>
-<h3 id=v1.151>What's new in 1.151</h3>
+<h3 id=v1.151>What's new in 1.151 (11-03-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     svn+ssh connection was not properly working.
@@ -12022,7 +12021,7 @@ title: Changelog Archives
   <li class=rfe>
     Added debug probe for ssh library
 </ul>
-<h3 id=v1.150>What's new in 1.150</h3>
+<h3 id=v1.150>What's new in 1.150 (10-30-2007)</h3>
 <ul class=image>
   <li class=bug>
     Tooltip for grey ball icon now correctly display different meanings of grey.
@@ -12048,7 +12047,7 @@ title: Changelog Archives
   <li class=rfe>
     Matrix build now exposes <tt>$JDK</tt> and <tt>$LABEL</tt>, just like other use-defined axes.
 </ul>
-<h3 id=v1.149>What's new in 1.149</h3>
+<h3 id=v1.149>What's new in 1.149 (10-23-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a regression in 1.148 that made it impossible even for an admin to start a build
@@ -12065,7 +12064,7 @@ title: Changelog Archives
     combobox.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=659">issue 659</a>)
 </ul>
-<h3 id=v1.148>What's new in 1.148</h3>
+<h3 id=v1.148>What's new in 1.148 (10-22-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a security problem where project build URLs were not protected by default when security is enabled.
@@ -12088,7 +12087,7 @@ title: Changelog Archives
   <li class=rfe>
     Picked up the latest version of JEXL.
 </ul>
-<h3 id=v1.147>What's new in 1.147</h3>
+<h3 id=v1.147>What's new in 1.147 (10-19-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in computing the location of <tt>classworlds.jar</tt> for native m2 build.
@@ -12113,7 +12112,7 @@ title: Changelog Archives
     interference between security and cache control header.
     (<a href="http://www.nabble.com/No-browser-caching-with-Hudson--tf4601857.html#a13224961">report</a>)
 </ul>
-<h3 id=v1.146>What's new in 1.146</h3>
+<h3 id=v1.146>What's new in 1.146 (10-09-2007)</h3>
 <ul class=image>
   <li class=bug>
     Disk space monitoring on slaves was not working
@@ -12140,7 +12139,7 @@ title: Changelog Archives
     Added an error margin on JUnit report archiver so that it doesn't report false positive
     "no new reports found" error.
 </ul>
-<h3 id=v1.145>What's new in 1.145</h3>
+<h3 id=v1.145>What's new in 1.145 (10-04-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where Ant support didn't run on Tiger.
@@ -12164,7 +12163,7 @@ title: Changelog Archives
   <li class=rfe>
     Added <tt>RunListener</tt> for getting notifications for all builds.
 </ul>
-<h3 id=v1.144>What's new in 1.144</h3>
+<h3 id=v1.144>What's new in 1.144 (09-27-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the "loading..." page auto refresh
@@ -12181,7 +12180,7 @@ title: Changelog Archives
     Text area is now much smarter. Its height is adjustable, and its size is pre-configured to fit to the content
     (as well as double-clicking the handle.)
 </ul>
-<h3 id=v1.143>What's new in 1.143</h3>
+<h3 id=v1.143>What's new in 1.143 (09-24-2007)</h3>
 <ul class=image>
   <li class=rfe>
     Axis names are now exported as environment variables in all upper case for better cross-platform behavior)
@@ -12198,7 +12197,7 @@ title: Changelog Archives
     Added a workaround for slow subversion check out
     (<a href="http://www.nabble.com/Slow-SVN-Checkout-tf4486786.html">report</a>)
 </ul>
-<h3 id=v1.142>What's new in 1.142</h3>
+<h3 id=v1.142>What's new in 1.142 (09-22-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a start up NPE problem in native maven2 projects, introduced in 1.141.
@@ -12209,7 +12208,7 @@ title: Changelog Archives
     Added HTML titles to various test result related pages.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=843">issue 843</a>)
 </ul>
-<h3 id=v1.141>What's new in 1.141</h3>
+<h3 id=v1.141>What's new in 1.141 (09-21-2007)</h3>
 <ul class=image>
   <li class=bug>
     For SCM polling, resize the thread pool when <i>Max # of concurrent polling</i> is changed
@@ -12232,7 +12231,7 @@ title: Changelog Archives
     Fixed negative phrasing "don't send email on every unstable build"
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=827">issue 827</a>)
 </ul>
-<h3 id=v1.140>What's new in 1.140</h3>
+<h3 id=v1.140>What's new in 1.140 (09-19-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fix a socket leak in SubversionSCM introduced in 1.137
@@ -12244,7 +12243,7 @@ title: Changelog Archives
   <li class=bug>
     Fixed a security hole that allows unauthenticated users to access logs that Hudson produces.
 </ul>
-<h3 id=v1.139>What's new in 1.139</h3>
+<h3 id=v1.139>What's new in 1.139 (09-16-2007)</h3>
 <ul class=image>
   <li class=bug>
     A failure in svnkit can cause an unexpected timer cancellation.
@@ -12265,7 +12264,7 @@ title: Changelog Archives
     Hudson now displays a dedicated UI during the initialization and reloading.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=756">issue 756</a>)
 </ul>
-<h3 id=v1.138>What's new in 1.138</h3>
+<h3 id=v1.138>What's new in 1.138 (09-14-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Disabled m2 module list actually showed the enabled modules.
@@ -12283,7 +12282,7 @@ title: Changelog Archives
   <li class=rfe>
     Search index now includes maven module display names.
 </ul>
-<h3 id=v1.137>What's new in 1.137</h3>
+<h3 id=v1.137>What's new in 1.137 (09-12-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Additional JavaScript memory leak fix.
@@ -12306,7 +12305,7 @@ title: Changelog Archives
     Remote API support was expanded to build records of all job types.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=804">issue 804</a>)
 </ul>
-<h3 id=v1.136>What's new in 1.136</h3>
+<h3 id=v1.136>What's new in 1.136 (09-04-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed JavaScript memory leak issues.
@@ -12323,7 +12322,7 @@ title: Changelog Archives
     Hudson now detects <a href="http://hudson.gotdns.com/wiki/display/HUDSON/Spawning+processes+from+build">a file descriptor leak situation</a> and report that as a warning, then let the build go.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=770">issue 770</a>)
 </ul>
-<h3 id=v1.135>What's new in 1.135</h3>
+<h3 id=v1.135>What's new in 1.135 (09-02-2007)</h3>
 <ul class=image>
   <li class=bug>
     Icon size choice should be persisted across browser sessions.
@@ -12345,7 +12344,7 @@ title: Changelog Archives
     Improved the absolute URL computation in Hudson to work better with httpd frontend.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=781">issue 781</a>)
 </ul>
-<h3 id=v1.134>What's new in 1.134</h3>
+<h3 id=v1.134>What's new in 1.134 (09-01-2007)</h3>
 <ul class=image>
   <li class=bug>
     Aggregator-style build setting in the native m2 project was put under the wrong "advanced" button.
@@ -12371,7 +12370,7 @@ title: Changelog Archives
     Maven project page now shows aggregated test result trend (regression.)
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=775">issue 775</a>)
 </ul>
-<h3 id=v1.133>What's new in 1.133</h3>
+<h3 id=v1.133>What's new in 1.133 (08-28-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug in the free-style maven/ant invocations when the master and slave run
@@ -12389,7 +12388,7 @@ title: Changelog Archives
     builds all the modules.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=557">issue 557</a>)
 </ul>
-<h3 id=v1.132>What's new in 1.132</h3>
+<h3 id=v1.132>What's new in 1.132 (08-22-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed the login link visibility issue.
@@ -12404,7 +12403,7 @@ title: Changelog Archives
     Added a work around necessary to run with OC4J.
     (<a href="http://www.nabble.com/forum/Search.jtp?forum=16872&local=y&query=oc4j">report</a>)
 </ul>
-<h3 id=v1.131>What's new in 1.131</h3>
+<h3 id=v1.131>What's new in 1.131 (08-21-2007)</h3>
 <ul class=image>
   <li class=bug>
     Running "javadoc:javadoc" in the native m2 project was not recording javadoc.
@@ -12424,7 +12423,7 @@ title: Changelog Archives
     Added search box for a quicker navigation around Hudson pages
     (<a href="http://hudson.gotdns.com/wiki/display/HUDSON/Search+Box">detail</a>)
 </ul>
-<h3 id=v1.130>What's new in 1.130</h3>
+<h3 id=v1.130>What's new in 1.130 (08-18-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug that matrix project initialization causes NPE.
@@ -12440,7 +12439,7 @@ title: Changelog Archives
     Archived Maven2 artifacts should honor the &lt;finalName> POM entry.
     (<a href="http://www.nabble.com/Maven-build-artifacts%3A-FinalName-wrong--tf4279077.html">report</a>)
 </ul>
-<h3 id=v1.129>What's new in 1.129</h3>
+<h3 id=v1.129>What's new in 1.129 (08-15-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a memory leak bug in distributed operations.
@@ -12472,7 +12471,7 @@ title: Changelog Archives
     that person is responsible for breaking the build, s/he now only gets one e-mail, not two.
     (<a href="http://www.nabble.com/Duplicate-mail-recipients-tf4254810.html">report</a>)
 </ul>
-<h3 id=v1.128>What's new in 1.128</h3>
+<h3 id=v1.128>What's new in 1.128 (08-10-2007)</h3>
 <ul class=image>
   <li class=bug>
     System log and slave log were not secured.
@@ -12495,7 +12494,7 @@ title: Changelog Archives
     is needed for plugins to take effect
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=705">issue 705</a>)
 </ul>
-<h3 id=v1.127>What's new in 1.127</h3>
+<h3 id=v1.127>What's new in 1.127 (08-07-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug that prevented weather report detail table to show up.
@@ -12518,13 +12517,13 @@ title: Changelog Archives
   <li class=rfe>
     Updated the error diagnosis in the JUnit test result collection
 </ul>
-<h3 id=v126>What's new in 1.126</h3>
+<h3 id=v126>What's new in 1.126 (08-03-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where "cvs co" put "-P" in a wrong position.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=696">issue 696</a>)
 </ul>
-<h3 id=v125>What's new in 1.125</h3>
+<h3 id=v125>What's new in 1.125 (08-03-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed the character set handling in AJAX job/view description update
@@ -12542,7 +12541,7 @@ title: Changelog Archives
     Added a hook for plugins to specify additional CSS
    (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=695">issue 695</a>)
 </ul>
-<h3 id=v124>What's new in 1.124</h3>
+<h3 id=v124>What's new in 1.124 (08-01-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Build history listing always get doubled because of a bug in partial page update code.
@@ -12556,7 +12555,7 @@ title: Changelog Archives
   <li class=bug>
     Improved stability of the timer related code so that one failure won't shut down the entire timer.
 </ul>
-<h3 id=v123>What's new in 1.123</h3>
+<h3 id=v123>What's new in 1.123 (07-30-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a bug where remote API schema generation doesn't work with JDK1.5.
@@ -12584,7 +12583,7 @@ title: Changelog Archives
     for displaying a table of all health reports (as before accessible by hovering over the
     health/weather icon).
 </ul>
-<h3 id=v122>What's new in 1.122</h3>
+<h3 id=v122>What's new in 1.122 (07-27-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     For some reason, a lot of Subversion related changes that were made in the past
@@ -12617,7 +12616,7 @@ title: Changelog Archives
     different configuration.
     (<a href="http://hudson.gotdns.com/wiki/display/HUDSON/Building+a+matrix+project">more</a>)
 </ul>
-<h3 id=v121>What's new in 1.121</h3>
+<h3 id=v121>What's new in 1.121 (07-23-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed HTML escape related bugs in the project description.
@@ -12637,7 +12636,7 @@ title: Changelog Archives
     Changed the way Maven project build result is computed.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=651">issue 651</a>)
 </ul>
-<h3 id=v120>What's new in 1.120</h3>
+<h3 id=v120>What's new in 1.120 (07-19-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a security hole that allows non-admin users to disable/enable plugins.
@@ -12652,12 +12651,12 @@ title: Changelog Archives
     is CVS and a branch is set.
     (<a href="http://www.nabble.com/Getting-CVS-Branch-in-Ant-build-tf4104247.html">report</a>)
 </ul>
-<h3 id=v119>What's new in 1.119</h3>
+<h3 id=v119>What's new in 1.119 (07-15-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed NPE in the end of a build.
 </ul>
-<h3 id=v118>What's new in 1.118</h3>
+<h3 id=v118>What's new in 1.118 (07-14-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Memory fix bug in 1.117 was incorrect and Hudson fails to persist SVN credentials.
@@ -12674,7 +12673,7 @@ title: Changelog Archives
     Improved slave Unix/Windows detection
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=631">issue 631</a>)
 </ul>
-<h3 id=v117>What's new in 1.117</h3>
+<h3 id=v117>What's new in 1.117 (07-13-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a bug where build queue gets very confused if modules exist in 2 native m2 projects
@@ -12698,7 +12697,7 @@ title: Changelog Archives
     [JIRA 1.3] JIRA plugin now works with the native m2 project type.
     (<a href="http://www.nabble.com/Jira-Plugin-Post-build-actions-not-appearing-tf4070397.html">report</a>)
 </ul>
-<h3 id=v116>What's new in 1.116</h3>
+<h3 id=v116>What's new in 1.116 (07-11-2007)</h3>
 <ul class=image>
   <li class=bug>
     Several subversion related error messages were incorrectly escaped.
@@ -12724,7 +12723,7 @@ title: Changelog Archives
     Auto-refresh cookie is now persisted.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=580">issue 580</a>)
 </ul>
-<h3 id=v115>What's new in 1.115</h3>
+<h3 id=v115>What's new in 1.115 (07-02-2007)</h3>
 <ul class=image>
   <li class='bug'>
     Modified to disable HTTP basic auth support (introduced in v1.112) when
@@ -12748,7 +12747,7 @@ title: Changelog Archives
     the icon's tooltip text. Initial health report providers are Test Result and Recent Build Status.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=615">issue 615</a>)
 </ul>
-<h3 id=v114>What's new in 1.114</h3>
+<h3 id=v114>What's new in 1.114 (06-26-2007)</h3>
 <ul class=image>
   <li class='bug'>
     Fixed 404 in Subversion config help link.
@@ -12769,7 +12768,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Internal code is refactored to make room for another job type.
 </ul>
-<h3 id=v113>What's new in 1.113</h3>
+<h3 id=v113>What's new in 1.113 (06-19-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed incorrect formatting in Subversion URL form validation.
@@ -12780,7 +12779,7 @@ title: Changelog Archives
   <li class='bug'>
     Fixed a bug in svn+ssh password authentication.
 </ul>
-<h3 id=v112>What's new in 1.112</h3>
+<h3 id=v112>What's new in 1.112 (06-18-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a problem where the user properties were not loaded correctly.
@@ -12806,7 +12805,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Added HTTP basic authentication support for scripting clients
 </ul>
-<h3 id=v111>What's new in 1.111</h3>
+<h3 id=v111>What's new in 1.111 (06-15-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a few file handle leaks in Subversion support.
@@ -12818,7 +12817,7 @@ title: Changelog Archives
     Fixed several cross-site scripting vulnerabilities.
     Thanks to <a href="http://opensource.fortifysoftware.com/">Fortify</a>.
 </ul>
-<h3 id=v110>What's new in 1.110</h3>
+<h3 id=v110>What's new in 1.110 (06-13-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a DOM leak that caused browsers to eventually hang where partial page updates are involved.
@@ -12837,7 +12836,7 @@ title: Changelog Archives
     Improved compatibility with older version of ViewCVS
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=589">issue 589</a>)
 </ul>
-<h3 id=v109>What's new in 1.109</h3>
+<h3 id=v109>What's new in 1.109 (06-08-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixed a NPE in <tt>MavenModule</tt>
@@ -12869,11 +12868,11 @@ title: Changelog Archives
     adding a link from the help page.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=571">issue 571</a>)
 </ul>
-<h3 id=v108>What's new in 1.108</h3>
+<h3 id=v108>What's new in 1.108 (06-01-2007)</h3>
 <p>
   No change
 </p>
-<h3 id=v107>What's new in 1.107</h3>
+<h3 id=v107>What's new in 1.107 (06-01-2007)</h3>
 <ul class=image>
   <li class=bug>
     Fixed an NPE when pom.xml has <tt>ciManagement</tt> doesn't have nested <tt>system</tt> element.
@@ -12893,7 +12892,7 @@ title: Changelog Archives
   <li class='major rfe'>
     Slaves can now have labels, and jobs can be tied to labels.
 </ul>
-<h3 id=v106>What's new in 1.106</h3>
+<h3 id=v106>What's new in 1.106 (05-14-2007)</h3>
 <ul class=image>
   <li class='major bug'>
     Trying to update a module in a native m2 project fails with NPE.
@@ -12949,7 +12948,7 @@ title: Changelog Archives
     Jar/war/ear built by Maven now includes the Hudson version number
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=526">issue 526</a>)
 </ul>
-<h3 id=v105>What's new in 1.105</h3>
+<h3 id=v105>What's new in 1.105 (04-29-2007)</h3>
 <ul class=image>
   <li class="bug">
     Fixed a bug where the native m2 support doesn't honor the JDK setting.
@@ -12995,7 +12994,7 @@ title: Changelog Archives
     [JIRA 1.2] JIRA plugin now works with the native m2 support.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=465">issue 465</a>)
 </ul>
-<h3 id=v104>What's new in 1.104</h3>
+<h3 id=v104>What's new in 1.104 (04-22-2007)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed NPE with the clean goal is run with the native m2 support.
@@ -13052,7 +13051,7 @@ title: Changelog Archives
   <li class="major rfe">
     [JABBER 0.2] Jabber plugin 0.2 release
 </ul>
-<h3 id=v103>What's new in 1.103</h3>
+<h3 id=v103>What's new in 1.103 (04-17-2007)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a security hole where Hudson allowed anyone to tag the workspace.
@@ -13081,7 +13080,7 @@ title: Changelog Archives
     RSS/ATOM feeds now have more information
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=461">issue 461</a>)
 </ul>
-<h3 id=v102>What's new in 1.102</h3>
+<h3 id=v102>What's new in 1.102 (04-16-2007)</h3>
 <ul class=image>
   <li class="major bug">
     Improved the fix for <a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=389">#389</a>
@@ -13115,7 +13114,7 @@ title: Changelog Archives
     JNLP slave agent TCP listener port is now configurable when the security is enabled.
     (<a href="http://www.nabble.com/distributed-build-with-slaves-in-vpn-tf3553582.html">discussion</a>)
 </ul>
-<h3 id=v101>What's new in 1.101</h3>
+<h3 id=v101>What's new in 1.101 (04-12-2007)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a bug where a long path name in javadoc or archived artifact causes the build to fail
@@ -13142,7 +13141,7 @@ title: Changelog Archives
     <a href="/remote-api.html">Remote API</a> is reimplemented so that Hudson
     can generate schema and documentation for the structure of JSON later.
 </ul>
-<h3 id=v100>What's new in 1.100</h3>
+<h3 id=v100>What's new in 1.100 (04-11-2007)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a bug in running Subversion SCM on a slave.
@@ -13162,7 +13161,7 @@ title: Changelog Archives
   <li class="major rfe">
     [POLARION 1.0] <a href="http://www.polarion.com/">Polarion for Subversion</a> plugin released. Kudos to Jonny Wray.
 </ul>
-<h3>What's new in 1.99</h3>
+<h3>What's new in 1.99 (04-10-2007)</h3>
 <ul class=image>
   <li class="major bug">
     JNLP slave agent stopped working as of 1.97 is now fixed.
@@ -13185,7 +13184,7 @@ title: Changelog Archives
     In the native m2 support, test results of modules are now aggregated and
     displayed in the project build page.
 </ul>
-<h3>What's new in 1.98</h3>
+<h3>What's new in 1.98 (04-07-2007)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a <b>critical bug</b> that crippled many parts of the Hudson UI.
@@ -13206,7 +13205,7 @@ title: Changelog Archives
     Native m2 builds now record Maven plugins that were used during the build.
     (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=297">issue 297</a>)
 </ul>
-<h3>What's new in 1.97</h3>
+<h3>What's new in 1.97 (04-07-2007)</h3>
 <ul>
   <li><b>Hudson now requires Java 1.5</b>
   <li>Native m2 support can now work with Maven 2.0.6.
@@ -13230,7 +13229,7 @@ title: Changelog Archives
       even though the submission fails.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=413">issue 413</a>)
 </ul>
-<h3>What's new in 1.96</h3>
+<h3>What's new in 1.96 (04-03-2007)</h3>
 <ul>
   <li>[TRAC 1.3] Added the repository browser support so that changelogs can be linked
       to Trac.
@@ -13246,7 +13245,7 @@ title: Changelog Archives
   <li>Fixed a bug where not all files in CVS projects get hyperlinked by a repository browser
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=417">issue 417</a>)
 </ul>
-<h3>What's new in 1.95</h3>
+<h3>What's new in 1.95 (03-31-2007)</h3>
 <ul>
   <li>Performance improvement in the master/slave communciation.
   <li>Fixed JavaScript errors that occure when there's no entries for repetable form fields
@@ -13269,7 +13268,7 @@ title: Changelog Archives
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=373">issue 373</a>)
   <li>[TEXT-FINDER 1.2] Added on-the-fly regular expression validation.
 </ul>
-<h3>What's new in 1.94</h3>
+<h3>What's new in 1.94 (03-29-2007)</h3>
 <ul>
   <li>M2 project now shows build queue for modules.
   <li>Improved exception propagation with master/slave mode.
@@ -13287,7 +13286,7 @@ title: Changelog Archives
   <li>"log rotation" is changed to "discard old builds"
       (<a href="http://www.nabble.com/Deleting-old-builds-tf3485486.html">report</a>)
 </ul>
-<h3>What's new in 1.93</h3>
+<h3>What's new in 1.93 (03-28-2007)</h3>
 <ul>
   <li>Fixed a bug where people working on the native m2 projects don't show up in the
       "people" links.
@@ -13303,7 +13302,7 @@ title: Changelog Archives
   <li>Native m2 projects now support <tt>MAVEN_OPTS</tt> setting.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=396">issue 396</a>)
 </ul>
-<h3>What's new in 1.92</h3>
+<h3>What's new in 1.92 (03-27-2007)</h3>
 <ul>
   <li>Fixed a config page rendering bug where sometimes all the repository browser configurations
       were displayed.
@@ -13313,7 +13312,7 @@ title: Changelog Archives
       n &gt; 1000.
   <li>Started adding remote access API via XML and JSON.
 </ul>
-<h3>What's new in 1.91</h3>
+<h3>What's new in 1.91 (03-26-2007)</h3>
 <ul>
   <li>Fixed a bug where ViewCVS support doesn't point to the correct path.
   <li>Improved the UI of project changelog list.
@@ -13335,7 +13334,7 @@ title: Changelog Archives
   <li>Fixed a upgrade problem to some old versions of Hudson to a new one (introduced in 1.87)
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=362">issue 362</a>)
 </ul>
-<h3>What's new in 1.90</h3>
+<h3>What's new in 1.90 (03-24-2007)</h3>
 <ul>
   <li>Fixed a bug where 'people' link doesn't show up if there are only m2 projects.
       (<a href="http://www.nabble.com/Email-addresses-of-users-whose-commits-broke-the-build--tf3455200.html">report</a>)
@@ -13349,7 +13348,7 @@ title: Changelog Archives
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=376">issue 376</a>)
   <li>Implemented FishEye support for Subversion.
 </ul>
-<h3>What's new in 1.89</h3>
+<h3>What's new in 1.89 (03-23-2007)</h3>
 <ul>
   <li>Added extension hooks for supporting repository browsers like ViewCVS/FishEye, etc.
   <li>Implemented preliminary ViewCVS support.
@@ -13366,7 +13365,7 @@ title: Changelog Archives
   <li>Fixed a bug where SCM configuration didn't work with Safari due to DOM issue.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=381">issue 381</a>)
 </ul>
-<h3>What's new in 1.88</h3>
+<h3>What's new in 1.88 (03-16-2007)</h3>
 <ul>
   <li>Fixed a bug where the job properties like trac URL doesn't show up in the native
       m2 build.
@@ -13378,7 +13377,7 @@ title: Changelog Archives
   <li>Fixed an IllegalArgumentException in the native m2 build when ~/.m2 doesn't exist.
       (<a href="http://www.nabble.com/BUG-Report-tf3401736.html">report</a>)
 </ul>
-<h3>What's new in 1.87</h3>
+<h3>What's new in 1.87 (03-13-2007)</h3>
 <ul>
   <li>[TRAC 1.2] Fixed an NPE when configuring the native maven2 project.
   <li>If there's only one Maven installation in the system, don't present a combobox
@@ -13391,7 +13390,7 @@ title: Changelog Archives
   <li>[JIRA 1.1] Improved the compatibility with different versions of JIRA.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=359">issue 359</a>)
 </ul>
-<h3>What's new in 1.86</h3>
+<h3>What's new in 1.86 (03-12-2007)</h3>
 <ul>
   <li>Disabled maven modules are now displayed in a different tab
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=355">issue 355</a>)
@@ -13414,7 +13413,7 @@ title: Changelog Archives
   <li>[EMMA 1.5] fixed a bug in parsing emma output without line coverage.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=350">issue 350</a>)
 </ul>
-<h3>What's new in 1.85</h3>
+<h3>What's new in 1.85 (03-06-2007)</h3>
 <ul>
   <li>Fixed a bug where incrementally updated build queue and executor list
       breaks tooltip.
@@ -13438,7 +13437,7 @@ title: Changelog Archives
   <li>Fixed a bug where the native m2 support didn't handle &lt;module>../foo/&lt;/module> correctly
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=342">issue 342</a>)
 </ul>
-<h3>What's new in 1.84</h3>
+<h3>What's new in 1.84 (02-27-2007)</h3>
 <ul>
   <li>Fixed a NPE in computing Subversion changelog with JDK 1.4
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=306">issue 306</a>)
@@ -13457,7 +13456,7 @@ title: Changelog Archives
   <li>Fixed a bug where slaves launched by JNLP agents cause LinkageError
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=320">issue 320</a>)
 </ul>
-<h3>What's new in 1.83</h3>
+<h3>What's new in 1.83 (02-21-2007)</h3>
 <ul>
   <li>Fixed a problem where Firefox may ends up using stale cache.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=272">issue 272</a>)
@@ -13474,7 +13473,7 @@ title: Changelog Archives
   <li>Modified not to display javadoc link when no javadoc is built yet.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=318">issue 316</a>)
 </ul>
-<h3>What's new in 1.82</h3>
+<h3>What's new in 1.82 (02-15-2007)</h3>
 <ul>
   <li>Fixed the initial welcome text for the native m2 support
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=296">issue 296</a>)
@@ -13491,7 +13490,7 @@ title: Changelog Archives
   <li>Fixed a bug where textbox expansion by drop-down arrow didn't work in IE7
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=303">issue 303</a>)
 </ul>
-<h3>What's new in 1.81</h3>
+<h3>What's new in 1.81 (02-12-2007)</h3>
 <ul>
   <li>Fixed a bug where Hudson doesn't run on <a href="http://winstone.sourceforge.net/">Winstone</a>
       when the temporary directory contains whitespace in path name (such as on Windows.)
@@ -13507,7 +13506,7 @@ title: Changelog Archives
   <li>Fixed a bug where the native maven2 support doesn't display the next scheduled build
       number correctly for the project.
 </ul>
-<h3>What's new in 1.80</h3>
+<h3>What's new in 1.80 (02-10-2007)</h3>
 <ul>
   <li>Fixed a bug in launching Ant on Windows slave from Unix master
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=280">issue 280</a>)
@@ -13520,7 +13519,7 @@ title: Changelog Archives
       you choose the job type.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=283">issue 283</a>)
 </ul>
-<h3>What's new in 1.79</h3>
+<h3>What's new in 1.79 (02-07-2007)</h3>
 <ul>
   <li>A whole bunch of bug fixes in the native maven2 support.
   <li>Javadoc archiver implemented for maven2.
@@ -13531,7 +13530,7 @@ title: Changelog Archives
   <li>Fixed a problem where progressive text is apparently not handled by IE as expected.
   (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=274">issue 274</a>)
 </ul>
-<h3>What's new in 1.78</h3>
+<h3>What's new in 1.78 (02-02-2007)</h3>
 <ul>
   <li>[JAVANET-UPLOADER 1.4] Supported wildcards and multiple file match.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=258">issue 258</a>)
@@ -13543,7 +13542,7 @@ title: Changelog Archives
   <li>Fixed a bug in handling M2_HOME path with whitespace
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=270">issue 270</a>)
 </ul>
-<h3>What's new in 1.77</h3>
+<h3>What's new in 1.77 (01-30-2007)</h3>
 <ul>
   <li>Modified to display plugin version numbers in the management screen.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=251">issue 251</a>)
@@ -13557,7 +13556,7 @@ title: Changelog Archives
   <li>Supported file exclusions in the artifact archiving
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=257">issue 257</a>)
 </ul>
-<h3>What's new in 1.76</h3>
+<h3>What's new in 1.76 (01-25-2007)</h3>
 <ul>
   <li>Fixed a bug where custom cvs path was not taking effect in changelog computation
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=242">issue 242</a>)
@@ -13569,7 +13568,7 @@ title: Changelog Archives
   <li>Fixed a bug where Subversion initialization wasn't done early enough.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=245">issue 245</a>)
 </ul>
-<h3>What's new in 1.75</h3>
+<h3>What's new in 1.75 (01-24-2007)</h3>
 <ul>
   <li>Fixed a memory leak in the slave agent program.
   <li>Made cvs binary location configurable.
@@ -13587,7 +13586,7 @@ title: Changelog Archives
   <li>Fixed a bug where a shutdown of Hudson doesn't terminate ssh used for slave agents
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=246">issue 246</a>)
 </ul>
-<h3>What's new in 1.74</h3>
+<h3>What's new in 1.74 (01-17-2007)</h3>
 <ul>
   <li>Fixed a page rendering bug when reporting a dependency change from an unknown revision
       to a known revision.
@@ -13600,7 +13599,7 @@ title: Changelog Archives
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=226">issue 226</a>)
   <li>Hudson now uses the integrated <a href="http://www.svnkit.org/">Java subversion client implementation</a>.
 </ul>
-<h3>What's new in 1.73</h3>
+<h3>What's new in 1.73 (01-12-2007)</h3>
 <ul>
   <li>[IRCBOT] Fixed a build issue that causes NoSuchFieldError. It's now built with the correct Hudson version.
   <li>Fixed a bug in links from artifacts/workspace views to fingerprint records.
@@ -13616,14 +13615,14 @@ title: Changelog Archives
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=230">issue 230</a>)
   <li>Fixed a bug in the remoting mechanism where the exception handling doesn't work correctly.
 </ul>
-<h3>What's new in 1.72</h3>
+<h3>What's new in 1.72 (01-07-2007)</h3>
 <ul>
   <li>Added a new extension point <tt>JobProperty</tt> so that plugins can add additional
       properties to <tt>Job</tt>.
   <li>Breadcrumbs now include views so that users can easily go back to the view that contained the job.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=154">issue 154</a>)
 </ul>
-<h3>What's new in 1.71</h3>
+<h3>What's new in 1.71 (01-07-2007)</h3>
 <ul>
   <li>Modified to create a shell script file in the system-specific temporary directory
       on each node, instead of the workspace.
@@ -13634,7 +13633,7 @@ title: Changelog Archives
       you can work around this problem by making changes, submitting it, then reopen
       the config page and submit that one more time.
 </ul>
-<h3>What's new in 1.70</h3>
+<h3>What's new in 1.70 (01-06-2007)</h3>
 <ul>
   <li>Added a new listerner <tt>SCMListener</tt> so that plugins can do something
       when change set is determined for a build. This is useful for integration with other systems.
@@ -13643,7 +13642,7 @@ title: Changelog Archives
       like hyperlinking to issue tracker.
   <li>Fixed a packaging problem of <tt>slave.jar</tt>. It was missing dependency jars.
 </ul>
-<h3>What's new in 1.69</h3>
+<h3>What's new in 1.69 (01-03-2007)</h3>
 <ul>
   <li>Modified not to show the complete build records in case you have a large history.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=212">issue 212</a>)
@@ -13666,7 +13665,7 @@ title: Changelog Archives
       doesn't cause the rescheduling of builds if builds are already in queue.
   <li><b>Be sure to also update your plugins if you are using any.</b>
 </ul>
-<h3>What's new in 1.68</h3>
+<h3>What's new in 1.68 (12-20-2006)</h3>
 <ul>
   <li>Fixed a bug where help links in a form set dynamically added don't work.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=168">issue 168</a>)
@@ -13681,7 +13680,7 @@ title: Changelog Archives
   <li>Fixed a bug in cvs update wrt time zone
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=209">issue 209</a>)
 </ul>
-<h3>What's new in 1.67</h3>
+<h3>What's new in 1.67 (12-15-2006)</h3>
 <ul>
   <li>The build history panel now shows build descriptions, if any
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=148">issue 148</a>)
@@ -13703,7 +13702,7 @@ title: Changelog Archives
   <li>Fixed a problem so that form pages are not auto-refreshed regardless of the current user setting.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=193">issue 193</a>)
 </ul>
-<h3>What's new in 1.66</h3>
+<h3>What's new in 1.66 (12-11-2006)</h3>
 <ul>
   <li>Fixed a packaging error where <tt>hudson</tt> and <tt>slave</tt> script files were missing
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=188">issue 188</a>)
@@ -13721,7 +13720,7 @@ title: Changelog Archives
   <li>Fixed an NPE that happens when Hudson tries to send e-mails to individuals, when
       the default domain suffix is not configured.
 </ul>
-<h3>What's new in 1.65</h3>
+<h3>What's new in 1.65 (12-07-2006)</h3>
 <ul>
   <li>Hudson's ATOM feeds are now ATOM 1.0 compliant
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=170">issue 170</a>)
@@ -13750,7 +13749,7 @@ title: Changelog Archives
   <li>Fixed CVS update bug introduced in 1.64.
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=190">issue 190</a>)
 </ul>
-<h3>What's new in 1.64</h3>
+<h3>What's new in 1.64 (11-21-2006)</h3>
 <ul>
   <li>Fixed a data-loss issue discovered in 1.63. Users upgrading from
       older versions to 1.63 loses the Ant and Maven configurations.
@@ -13767,7 +13766,7 @@ title: Changelog Archives
       additional modules as part of its build, changes in these extra modules will be reported in
       the changelog for subsequent builds.
 </ul>
-<h3>What's new in 1.63</h3>
+<h3>What's new in 1.63 (11-18-2006)</h3>
 <p>
   1.63 was taken off from the download because of the data loss issue fixed in 1.64.
   Please use 1.64 instead.
@@ -13792,7 +13791,7 @@ title: Changelog Archives
   <li>[JAVANET-UPLOADER] fixed broken links to help pages.
   <li>[JAVANET-UPLOADER] added macro substitution support for configuration.
 </ul>
-<h3>What's new in 1.62</h3>
+<h3>What's new in 1.62 (11-17-2006)</h3>
 <ul>
   <li>Fixed a bug where empty list of recipients of build notification messages
       causes NPE in Mailer component.
@@ -13809,7 +13808,7 @@ title: Changelog Archives
   <li>Fixed the checkbox out-of-sync behavior when configuration page is reloaded
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=145">issue 145</a>)
 </ul>
-<h3>What's new in 1.61</h3>
+<h3>What's new in 1.61 (11-13-2006)</h3>
 <ul>
   <li>Fixed a bug where removing the slave from configuration causes NPE
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=149">issue 149</a>)
@@ -13821,7 +13820,7 @@ title: Changelog Archives
   <li>Added <tt>EXECUTOR_NUMBER</tt> environment variable so that scripts can coordinate
       allocation of machine local resources.
 </ul>
-<h3>What's new in 1.60</h3>
+<h3>What's new in 1.60 (11-08-2006)</h3>
 <ul>
   <li>Fixed one horrible synchronization bottle-neck
       (<a href="https://hudson.dev.java.net/issues/show_bug.cgi?id=142">issue 142</a>)


### PR DESCRIPTION
Obtained from the `META-INF/MANIFEST.MF` file modification date inside the respective `.war` file from Artifactory. This is the date format `unzip -v` uses, and I didn't care enough to fix them.