### PR TITLE
Move Javadoc links into description text

### DIFF
--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -34,40 +34,33 @@ title: Javadoc
   Stapler Javadoc
 
 %p
-  Stapler is the framework used by Jenkins to route requests to the objects handling them.
+  %a{:href => 'http://stapler.kohsuke.org/apidocs/', :target => '_blank'}
+    Stapler Javadoc
+  is hosted on the Stapler site.
+  It describes the framework used by Jenkins to route requests to the objects handling them.
   %a{:href => '/doc/developer/architecture/web/'}
     Learn more.
-
-%p
-  %a{:href => 'http://stapler.kohsuke.org/apidocs/', :target => '_blank'}
-    Stapler Javadoc on the Stapler site
 
 %h2
   Components Javadoc
 
 %p
-  Components Javadoc is all about Jenkins components and libraries (currently a partial list of components).
-
-%p
   %a{:href => 'http://javadoc.jenkins.io/component/', :target => '_blank'}
     Components Javadoc
+  describes Jenkins components and libraries (currently a partial list of components).
 
 %h2
   Modules Javadoc
 
 %p
-  Modules Javadoc is for latest version of Jenkins Core modules (Jenkins releases may use earlier versions)
-
-%p
   %a{:href => 'http://javadoc.jenkins.io/module/', :target => '_blank'}
     Modules Javadoc
+  describes the latest versions of Jenkins Core modules (Jenkins releases may use earlier versions)
 
 %h2
   Plugins Javadoc
 
 %p
-  This site collects and the Javadoc for the newest releases of all Jenkins plugins, if available.
-
-%p
   %a{:href => 'http://javadoc.jenkins.io/plugin/', :target => '_blank'}
     Plugins Javadoc
+  describes the newest releases of all Jenkins plugins, if available.


### PR DESCRIPTION
Rather than use a trailing hyperlink, reuse the opening phrase of the description sentence to also include a hyperlink to the javadoc.

Also fix a minor phrasing problem.  It was:

> This site collects and the Javadoc for the newest releases of all Jenkins plugins, if available.