### PR TITLE
[JEP-211] - Update the warning in the June 2018 blogpost

### DIFF
--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -9,7 +9,14 @@ tags:
 author: oleg_nenashev
 ---
 
-CAUTION: See link:/doc/administration/requirements/java/[the dedicated about Java support on Jenkins for more up-to-date information.]
+[WARNING]
+--
+Guidelines in this blogpost are rendered obsolete link:/blog/2018/12/14/java11-preview-availability/[by the Java 11 Support Preview Availability
+announcement] on Dec 13, 2018 and by the Java 11 GA release on Sep 25, 2018.
+See the link:/doc/administration/requirements/java/[Java support page]
+for up-to-date information about running Jenkins with Java 11.
+The Jenkins project also no longer ships preview versions for Java 10.
+--
 
 As you probably know, we will have a
 link:/blog/2018/06/08/jenkins-java10-hackathon/[Jenkins and Java 10+ online hackathon] this week.
@@ -22,14 +29,6 @@ the packages are ready for evaluation and exploratory testing.
 
 This article explains how to run Jenkins with Java 10 and 11 using Docker images and WAR files.
 It also lists known issues and provides contributor guidelines.
-
-[WARNING]
---
-Update from the author: OpenJDK 11 has been released on September 25, 2018.
-Starting from this date, Java 10 is in the "end of life" state.
-The Jenkins project no longer ships preview versions for Java 10,
-please use these guidelines only for Java 11 preview builds.
---
 
 === Running in Docker
 


### PR DESCRIPTION
The change makes the support status reference explicit. We will no longer need references in this blogpost, because all the new updates refer the Java support page.

CC @MRamonLeon @batmat @alecharp 
