### PR TITLE
Add disclaimer to the internal timeline

### DIFF
--- a/content/projects/gsoc/2019/schedule.adoc
+++ b/content/projects/gsoc/2019/schedule.adoc
@@ -8,6 +8,10 @@ tags:
 
 = Jenkins year-round GSoC schedule
 
+NOTE: The link:https://developers.google.com/open-source/gsoc/timeline[Official Timeline] from Google always takes precedence over the
+timeline posted here. The timeline posted here maps the Google Summer of Code Timeline to the GSoC related Jenkins organization events
+and activities. It is not an official timeline for the program.
+
 == AUG 2018 - FEB 2019
 **Call for GSoC project proposals/mentors**
 


### PR DESCRIPTION
@oleg-nenashev @lloydchang @jeffpearce 

Added a disclaimer to the timeline that we published, spelling out that the official timeline is the one from Google.