### PR TITLE
Fix link to org admins. Clarify comment process.

### DIFF
--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -78,7 +78,7 @@ proposal through the process. The acceptance process includes the following step
   link:https://docs.google.com/document/d/14N6kCShmxy4SumT0khuEFxXYZE4v1_bimK66PJuBHzM/edit#heading=h.o5kqo7p5rgto[project
     table in the projects doc],
   giving it a status of "NEW"
-. The link:/projects/gsoc/#mentors-and-org-admins[GSoC org admins] discuss the the proposal with the champion and provide initial feedback
+. The link:/projects/gsoc/2019/#org-admins[GSoC org admins] and other mentors discuss the the proposal with the champion and provide initial feedback via the link:https://gitter.im/jenkinsci/gsoc-sig[gitter chat] and as comments to the proposal document.
 . Once the proposal is consistent with the GSoC template requirements, a GSoC org admin will change the status to "DRAFT"
 . An org admin publishes the draft project idea on link:/projects/gsoc/2019/project-ideas/#draft-project-ideas[jenkins.io]
 . The project champion reaches out to the community to get additional feedback about the proposal


### PR DESCRIPTION
Minor fix: Fixed the link to the list of org admins, and clarified the commenting process for proposals.

@lloydchang @jeffpearce @oleg-nenashev 