### PR TITLE
[GSoC 2019] - Add contact links to all 2019 pages

### DIFF
--- a/content/projects/gsoc/2019/index.adoc
+++ b/content/projects/gsoc/2019/index.adoc
@@ -5,6 +5,8 @@ tags:
 - gsoc
 links:
   gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 In 2019 we plan to apply to Google Summer of Code.

--- a/content/projects/gsoc/2019/project-ideas.html.haml
+++ b/content/projects/gsoc/2019/project-ideas.html.haml
@@ -7,6 +7,8 @@ tags:
 - gsoc2019
 links:
 - gitter: jenkinsci/gsoc-sig
+- googlegroup: jenkinsci-gsoc-all-public
+- sig: gsoc
 ---
 
 :css

--- a/content/projects/gsoc/2019/schedule.adoc
+++ b/content/projects/gsoc/2019/schedule.adoc
@@ -4,6 +4,10 @@ title: "Jenkins year-round GSoC schedule"
 tags:
 - gsoc
 - gsoc2019
+links:
+  gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 = Jenkins year-round GSoC schedule

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -4,6 +4,10 @@ title: "Google Summer of Code in Jenkins"
 section: projects
 tags:
 - gsoc
+links:
+  gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -3,6 +3,10 @@ layout: project
 title: "Google Summer of Code. Information for mentors"
 tags:
 - gsoc
+links:
+  gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -3,6 +3,10 @@ layout: project
 title: "Proposing new project ideas"
 tags:
 - gsoc
+links:
+  gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 :toc:

--- a/content/projects/gsoc/roles-and-responsibilities.adoc
+++ b/content/projects/gsoc/roles-and-responsibilities.adoc
@@ -3,6 +3,10 @@ layout: project
 title: "Google Summer of Code. Roles and Responsibilities"
 tags:
 - gsoc
+links:
+  gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 *Roles and Responsibilities*

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -3,6 +3,10 @@ layout: project
 title: "Google Summer of Code. Information for students"
 tags:
 - gsoc
+links:
+  gitter: jenkinsci/gsoc-sig
+  googlegroup: jenkinsci-gsoc-all-public
+  sig: gsoc
 ---
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]


### PR DESCRIPTION
I am working on a generic solution so that the links can be inherited from the SIG metadata. But this one shoild at least make contacts visible everywhere for now.

@jenkins-infra/gsoc 
