### PR TITLE
[GSoC 2019] - Embed the draft google Docs in project idea pages

### DIFF
--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -20,15 +20,21 @@ layout: project
     Details
   = content
 - else
-  %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
-    - if page.links
-      - if page.links.draft
-        This project idea is under review, see the
+  - if page.links
+    - if page.links.draft
+      %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+        This project idea is under review.
+        You are welcome to comment on the proposal or to suggest changes in the draft embedded below
+        (
         %a{:href => page.links.draft, :target => "_blank"}
-          the project idea draft
-      - else
-        ERROR: The project idea draft link is missing, please report an error to GSoC org admins
+          Google Doc
+        )
+      %iframe{:src => "#{page.links.draft}?embedded=true", :width => "100%", :height => "600px"}
     - else
+      %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+        ERROR: The project idea draft link is missing, please report an error to GSoC org admins
+  - else
+    %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
       ERROR: The project links are not defined in the document, please report an error to GSoC org admins
 
 %h2.title

--- a/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
@@ -16,7 +16,7 @@ mentors:
   id: "oleg_nenashev"
   github: "oleg-nenashev"
 links:
-  draft: https://docs.google.com/document/d/1UYi0jIYsKHE5IGS84B5W0XBoeMyF4yY_exu-21O99U8/edit
+  draft: https://docs.google.com/document/d/1UYi0jIYsKHE5IGS84B5W0XBoeMyF4yY_exu-21O99U8
 ---
 
 TODO: add content once published

--- a/content/projects/gsoc/2019/project-ideas/ath-improvements.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ath-improvements.adoc
@@ -14,7 +14,7 @@ mentors:
   id: "deepchip"
   github: "martinda"
 links:
-  draft: https://docs.google.com/document/d/1M15rktOEOIPlDrlS13f42bSJLbI0P47hplBIAL_FX_g/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1M15rktOEOIPlDrlS13f42bSJLbI0P47hplBIAL_FX_g
   gitter: jenkinsci/acceptance-test-harness
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -19,7 +19,7 @@ mentors:
 - name: "Supun Wanniarachchi"
   github: "Supun94"
 links:
-  draft: https://docs.google.com/document/d/1CYzV_w5SrA-npXEMwTkJ4E2QyJdd2cJm7eDpwhg4XPk/edit#
+  draft: https://docs.google.com/document/d/1CYzV_w5SrA-npXEMwTkJ4E2QyJdd2cJm7eDpwhg4XPk
 ---
 
 TODO: add content once published

--- a/content/projects/gsoc/2019/project-ideas/bitbucket-rest-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/bitbucket-rest-plugin.adoc
@@ -14,7 +14,7 @@ mentors:
 - name: "Christopher Dancy"
   github: "cdancy"
 links:
-  draft: https://docs.google.com/document/d/191aCm6zNLJxItQ5ebOKht3Ov46yqfZ73GlnvYiLOFTk/edit?usp=sharing
+  draft: https://docs.google.com/document/d/191aCm6zNLJxItQ5ebOKht3Ov46yqfZ73GlnvYiLOFTk
 ---
 
 TODO: DRAFT

--- a/content/projects/gsoc/2019/project-ideas/discard-builds-step-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/discard-builds-step-plugin.adoc
@@ -12,7 +12,7 @@ mentors:
   id: "deepchip"
   github: "martinda"
 links:
-  draft: https://docs.google.com/document/d/1W7YX4Y6PhIhraEQc9G-PKLSheJ6jXKgy8HmKVz1lCqs/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1W7YX4Y6PhIhraEQc9G-PKLSheJ6jXKgy8HmKVz1lCqs
 ---
 
 The idea behind this plugin is to give users more options to manage and implement a data retention policy that covers their build histories, artifacts

--- a/content/projects/gsoc/2019/project-ideas/docker-registries-polling-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/docker-registries-polling-plugin.adoc
@@ -14,7 +14,7 @@ mentors:
 - name: "Justin Harringa"
   github: "justinharringa"
 links:
-  draft: https://docs.google.com/document/d/1r_wOqtzmiIyiNWri6U3FKINWdnyHWEMF_lbSCa4jPiw/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1r_wOqtzmiIyiNWri6U3FKINWdnyHWEMF_lbSCa4jPiw
 ---
 
 Keeping Docker images up-to-date is important to keep systems patched from known security vulnerabilities.

--- a/content/projects/gsoc/2019/project-ideas/eda-coverage-adapters.adoc
+++ b/content/projects/gsoc/2019/project-ideas/eda-coverage-adapters.adoc
@@ -22,7 +22,7 @@ mentors:
   twitter: "oleg_nenashev"
 links:
   gitter: "jenkinsci/hw-and-eda-sig"
-  draft: https://docs.google.com/document/d/1pW9cSPTSekhMirHWKGnchmsDGsGLeN8MBEpMyN9HDEo/edit
+  draft: https://docs.google.com/document/d/1pW9cSPTSekhMirHWKGnchmsDGsGLeN8MBEpMyN9HDEo
 ---
 
 TODO: add content once published

--- a/content/projects/gsoc/2019/project-ideas/eda-plugins.adoc
+++ b/content/projects/gsoc/2019/project-ideas/eda-plugins.adoc
@@ -19,7 +19,7 @@ mentors:
   twitter: "oleg_nenashev"
 links:
   gitter: "jenkinsci/hw-and-eda-sig"
-  draft: https://docs.google.com/document/d/1v54zvQVp2HqWyxZ5b4QZ-THeTRQYiIAsIOX4hbvGPa0/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1v54zvQVp2HqWyxZ5b4QZ-THeTRQYiIAsIOX4hbvGPa0
 ---
 
 The idea is to create a Jenkins plugin for one of widely used EDA tools.

--- a/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
@@ -18,7 +18,7 @@ mentors:
   github: "hynespm"
 links:
   gitter: "jenkinsci/external-workspace-manager-plugin"
-  draft: https://docs.google.com/document/d/12qsvHSJpDaYALQQgzWpWw0-cmu6QOAmhr5THK3T1U0M/edit?usp=sharing
+  draft: https://docs.google.com/document/d/12qsvHSJpDaYALQQgzWpWw0-cmu6QOAmhr5THK3T1U0M
 ---
 
 We wish to add Cloud features to the Jenkins External Workspace Manager Plugin.

--- a/content/projects/gsoc/2019/project-ideas/gitlab-support-for-multibranch-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/gitlab-support-for-multibranch-pipeline.adoc
@@ -13,7 +13,7 @@ mentors:
   id: "linuxsuren"
   github: "linuxsuren"
 links:
-  draft: https://docs.google.com/document/d/1Gqz4LyU5sw6I50OdAVsQSW_WPNDlvXg4Ic9NdcYj4Ts/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1Gqz4LyU5sw6I50OdAVsQSW_WPNDlvXg4Ic9NdcYj4Ts
 ---
 
 TODO: DRAFT

--- a/content/projects/gsoc/2019/project-ideas/jenkins-rest-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/jenkins-rest-plugin.adoc
@@ -14,7 +14,7 @@ mentors:
 - name: "Christopher Dancy"
   github: "cdancy"
 links:
-  draft: https://docs.google.com/document/d/1Xz3I02T-QxlJW-1nt_CofF2I6se3hztF9ZsHqxu55nU/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1Xz3I02T-QxlJW-1nt_CofF2I6se3hztF9ZsHqxu55nU
 ---
 
 TODO: DRAFT

--- a/content/projects/gsoc/2019/project-ideas/working-hours-improvements.adoc
+++ b/content/projects/gsoc/2019/project-ideas/working-hours-improvements.adoc
@@ -14,7 +14,7 @@ mentors:
   id: "jeffpearce"
   github: "jeffpearce"
 links:
-  draft: https://docs.google.com/document/d/1tEFPL2VDJmsdyq5aacbvW4Hm1XFByQNNGIP_UeaHNJk/edit?usp=sharing
+  draft: https://docs.google.com/document/d/1tEFPL2VDJmsdyq5aacbvW4Hm1XFByQNNGIP_UeaHNJk
 ---
 
 TODO: add content once published


### PR DESCRIPTION
Just a proposal for review. We can embed Google Docs into the project idea draft pages so that the idea is shown in the Web UI. Not sure whether it is good or bad from the UX perspective, would appreciate feedback

<img width="1089" alt="screenshot 2019-01-03 at 01 04 11" src="https://user-images.githubusercontent.com/3000480/50618554-ec8cc100-0ef3-11e9-86e4-8bec655dc33d.png">
