### PR TITLE
Remove simplepage margins to improve visualization on mobile screens

### DIFF
--- a/content/_layouts/simplepage.html.haml
+++ b/content/_layouts/simplepage.html.haml
@@ -3,10 +3,6 @@ layout: default
 ---
 
 :css
-  .container .row.body {
-    margin-right: 5em;
-    margin-left: 5em;
-  }
   .toc {
       float: right;
   }


### PR DESCRIPTION
There is a number of jenkins.io pages inheriting `simplepage` due to some reasons. E.g. we use it for GSoC where we generate content by YAML. Unfortunately these pages look really bad on smartphones due to the hardcoded margins. Some pages are really critical to be viewable from mobile phones:

* Jenkins Changelog
* Security advisories
* GSoC 2019 Project ideas (students navigate by phone)

Other templates like `project` or `documentation` do not have such margins. Originally the margins in `simplepage` were introduced by @rtyler for BlueOcean pages: https://github.com/jenkins-infra/jenkins.io/pull/266 , but BlueOcean pages do not longer use this layout anymore.

I propose to just remove margins. The layouts stay bad, but they definitely get somewhat better after the change

### Before

<img width="379" alt="screenshot 2019-01-05 at 00 10 34" src="https://user-images.githubusercontent.com/3000480/50715837-4372d180-107f-11e9-840f-fce74465adc6.png">

<img width="385" alt="screenshot 2019-01-05 at 00 16 35" src="https://user-images.githubusercontent.com/3000480/50715856-4bcb0c80-107f-11e9-9e42-0cacaf6062ce.png">

<img width="395" alt="screenshot 2019-01-05 at 00 04 49" src="https://user-images.githubusercontent.com/3000480/50715867-54bbde00-107f-11e9-9acc-1da17fed0d8f.png">

### After

<img width="386" alt="screenshot 2019-01-05 at 00 10 59" src="https://user-images.githubusercontent.com/3000480/50715877-5be2ec00-107f-11e9-8df1-e6b47044d591.png">

<img width="380" alt="screenshot 2019-01-05 at 00 16 56" src="https://user-images.githubusercontent.com/3000480/50715886-656c5400-107f-11e9-9ee5-102ae670ab7b.png">

<img width="377" alt="screenshot 2019-01-05 at 00 04 59" src="https://user-images.githubusercontent.com/3000480/50715896-787f2400-107f-11e9-874a-bb21e2ddb98e.png">
