### PR TITLE
Add support of project/sig inheritance in Connect links, add Twitter support

### DIFF
--- a/content/_layouts/gsocproject.html.haml
+++ b/content/_layouts/gsocproject.html.haml
@@ -1,5 +1,6 @@
 ---
 layout: project
+sig: gsoc
 ---
 
 %p
@@ -25,14 +26,7 @@ layout: project
 %h3.title
   Links
 %ul
-  - if page.links.gitter
-    %li
-      %a{:href => "https://gitter.im/#{page.links.gitter}?utm_source=share-link&utm_medium=link&utm_campaign=share-link", :target => "_blank"}
-        %img{:title => "Gitter", :src => "https://badges.gitter.im/#{page.links.gitter}.svg"}
-  - if page.links.github
-    %li
-      %a{:href => "https://github.com/#{page.links.github}", :target => "_blank"}
-        Github repository
+  = partial("connect-links.html.haml", :links => page.links, :sig => page.sig, :project => page.project)
   %li
     %a{:href => "/projects/gsoc", :target => "_blank"}
       Jenkins GSoC page

--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -51,9 +51,9 @@ sig: gsoc
 %ul
   = partial("connect-links.html.haml", :links => page.links, :sig => page.sig, :project => page.project)
   - if page.links && page.links.draft
-  %li
-    %a{:href => page.links.draft, :target => "_blank"}
-      Project idea draft
+    %li
+      %a{:href => page.links.draft, :target => "_blank"}
+        Project idea draft
   %li
     %a{:href => "/projects/gsoc", :target => "_blank"}
       Jenkins GSoC page

--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -1,5 +1,6 @@
 ---
 layout: project
+sig: gsoc
 ---
 
 %p
@@ -48,19 +49,11 @@ layout: project
 %h2.title
   Links
 %ul
-  - if page.links
-    - if page.links.gitter
-      %li
-        %a{:href => "https://gitter.im/#{page.links.gitter}?utm_source=share-link&utm_medium=link&utm_campaign=share-link", :target => "_blank"}
-          %img{:title => "Gitter", :src => "https://badges.gitter.im/#{page.links.gitter}.svg"}
-    - if page.links.github
-      %li
-        %a{:href => "https://github.com/#{page.links.github}", :target => "_blank"}
-          Github repository
-    - if page.links.draft
-      %li
-        %a{:href => page.links.draft, :target => "_blank"}
-          Project idea draft
+  = partial("connect-links.html.haml", :links => page.links, :sig => page.sig, :project => page.project)
+  - if page.links && page.links.draft
+  %li
+    %a{:href => page.links.draft, :target => "_blank"}
+      Project idea draft
   %li
     %a{:href => "/projects/gsoc", :target => "_blank"}
       Jenkins GSoC page

--- a/content/_layouts/project.html.haml
+++ b/content/_layouts/project.html.haml
@@ -38,24 +38,8 @@ layout: default
 
         = document.converter.convert document, 'outline'
 
-      - if page.links
-        %div
-          %h4
-            Connect
+        = partial("connect-h4-div.html.haml", :links => page.links, :sig => page.sig, :project => page.project)
 
-          %ul
-            - if page.links.googlegroup
-              %li
-                %a{:href => "https://groups.google.com/forum/#!forum/#{page.links.googlegroup}", :target => "_blank"}
-                  Mailing List
-            - if page.links.gitter
-              %li
-                %a{:href => "https://gitter.im/#{page.links.gitter}", :target => "_blank"}
-                  %img{:title => "Gitter", :src => "https://badges.gitter.im/#{page.links.gitter}.svg"}
-            - if page.links.github
-              %li
-                %a{:href => "https://github.com/#{page.links.github}", :target => "_blank"}
-                  Github repository
         %div
           - # Only render articles if we have them
           - if articles.size > 0

--- a/content/_partials/connect-h4-div.html.haml
+++ b/content/_partials/connect-h4-div.html.haml
@@ -1,0 +1,7 @@
+- if page.links || page.sig || page.project
+  %div
+    %h4
+      Connect
+
+  %ul
+    = partial("connect-links.html.haml", :links => page.links, :sig => page.sig, :project => page.project)

--- a/content/_partials/connect-links.html.haml
+++ b/content/_partials/connect-links.html.haml
@@ -1,0 +1,87 @@
+- if page.project
+  - project = site.pages.find { |p| p.source_path.include? "/content/projects/#{page.project}/index.adoc" }
+
+- if page.sig
+  - sig = site.pages.find { |p| p.source_path.include? "/content/sigs/#{page.sig}/index.adoc" }
+- elsif project && project.sig
+  - sig = site.pages.find { |p| p.source_path.include? "/content/sigs/#{project.sig}/index.adoc" }
+
+- ####
+- # Mailing lists
+- ####
+- if page.links && page.links.googlegroup
+  - googlegroup = page.links.googlegroup
+- elsif page.links && page.links.mailinglist
+  - mailinglist = page.links.mailinglist
+- elsif project && project.links && project.links.googlegroup
+  - googlegroup = project.links.googlegroup
+- elsif project && project.links && project.links.mailinglist
+  - mailinglist = project.links.mailinglist
+- elsif sig && sig.links && sig.links.googlegroup
+  - googlegroup = sig.links.googlegroup
+- elsif sig && sig.links && sig.links.mailinglist
+  - mailinglist = sig.links.mailinglist
+
+-if googlegroup
+  %li
+    %a{:href => "https://groups.google.com/forum/#!forum/#{googlegroup}", :target => "_blank"}
+      Mailing List
+-elsif mailinglist
+  %li
+    %a{:href => expand_link(mailinglist), :target => "_blank"}
+      Mailing List
+
+- ####
+- # Chats
+- ####
+- if page.links && page.links.gitter
+  - gitter = page.links.gitter
+- elsif page.links && page.links.chat
+  - chat = page.links.chat
+- elsif project && project.links && project.links.gitter
+  - gitter = project.links.gitter
+- elsif project && project.links && project.links.chat
+  - chat = project.links.chat
+- elsif sig && sig.links && sig.links.gitter
+  - gitter = sig.links.gitter
+- elsif sig && sig.links && sig.links.chat
+  - chat = sig.links.chat
+
+- if gitter
+  %li
+    %a{:href => "https://gitter.im/#{gitter}", :target => "_blank"}
+      %img{:title => "Gitter", :src => "https://badges.gitter.im/#{gitter}.svg"}
+-elsif chat
+  %li
+    %a{:href => expand_link(chat), :target => "_blank"}
+      Chat
+
+- ####
+- # GitHub
+- ####
+- if page.links && page.links.github
+  - github = page.links.github
+- elsif project && project.links && project.links.github
+  - github = project.links.github
+- elsif sig && sig.links && sig.links.github
+  - github = sig.links.github
+
+- if github
+  %li
+    %a{:href => "https://github.com/#{github}", :target => "_blank"}
+      Github
+
+- ####
+- # Twitter
+- ####
+- if page.links && page.links.twitter
+  - twitter = page.links.twitter
+- elsif project && project.links && project.links.twitter
+  - twitter = project.links.twitter
+- elsif sig && sig.links && sig.links.twitter
+  - twitter = sig.links.twitter
+
+- if twitter
+  %li
+    %a{:href => "https://twitter.com/#{twitter}", :target => "_blank"}
+      Twitter

--- a/content/projects/gsoc/2019/project-ideas.html.haml
+++ b/content/projects/gsoc/2019/project-ideas.html.haml
@@ -5,10 +5,7 @@ year: 2019
 tags:
 - gsoc
 - gsoc2019
-links:
-- gitter: jenkinsci/gsoc-sig
-- googlegroup: jenkinsci-gsoc-all-public
-- sig: gsoc
+project: gsoc
 ---
 
 :css

--- a/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
@@ -5,6 +5,7 @@ goal: "Create a new highly anticipated engine for managing promotions in Jenkins
 category: Plugins
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 - JavaScript

--- a/content/projects/gsoc/2019/project-ideas/ath-improvements.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ath-improvements.adoc
@@ -5,6 +5,7 @@ goal: "Improve performance of the framework for WebUI and Integration testing"
 category: Dev Tools
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 - Docker

--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -5,6 +5,7 @@ goal: "Find and implement the extraction of the REST APIs from the sources and g
 category: Plugins
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 - REST API

--- a/content/projects/gsoc/2019/project-ideas/bitbucket-rest-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/bitbucket-rest-plugin.adoc
@@ -5,6 +5,7 @@ goal: "Create a new plugin to give Jenkins users the ability to make REST API ca
 category: Plugin
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 mentors:

--- a/content/projects/gsoc/2019/project-ideas/discard-builds-step-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/discard-builds-step-plugin.adoc
@@ -5,6 +5,7 @@ goal: "Create a new plugin to give Jenkins users more options to manage and impl
 category: Plugins
 year: 2019
 status: published
+project: gsoc
 skills:
 - Java
 mentors:

--- a/content/projects/gsoc/2019/project-ideas/docker-registries-polling-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/docker-registries-polling-plugin.adoc
@@ -5,6 +5,7 @@ goal: "Create a new Jenkins plugin to automate polling of image changes and secu
 category: Plugins
 year: 2019
 status: published
+project: gsoc
 skills:
 - Java
 - Docker

--- a/content/projects/gsoc/2019/project-ideas/eda-coverage-adapters.adoc
+++ b/content/projects/gsoc/2019/project-ideas/eda-coverage-adapters.adoc
@@ -5,13 +5,14 @@ goal: "Create Jenkins plugins for various Electronic Design Automation coverage 
 category: Plugins
 year: 2019
 status: draft
+project: gsoc
+sig: hw-and-eda
 skills:
 - Java
 - EDA Tools
 - FPGA
 - ASIC
 - Coverage
-sig: hw-and-eda
 mentors:
 - name: "Martin d'Anjou"
   id: "deepchip"

--- a/content/projects/gsoc/2019/project-ideas/eda-plugins.adoc
+++ b/content/projects/gsoc/2019/project-ideas/eda-plugins.adoc
@@ -5,10 +5,11 @@ goal: "Create a new Jenkins plugin for one of widely used EDA tools"
 category: Plugins
 year: 2019
 status: published
+project: gsoc
+sig: hw-and-eda
 skills:
 - Java
 - EDA Tools
-sig: hw-and-eda
 mentors:
 - name: "Martin d'Anjou"
   id: "deepchip"

--- a/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
@@ -5,6 +5,7 @@ goal: "Add support of provisioning workspaces from cloud services"
 category: Plugins
 year: 2019
 status: published
+project: gsoc
 skills:
 - Java
 - Cloud-based storage (e.g. Amazon EFS)

--- a/content/projects/gsoc/2019/project-ideas/gitlab-support-for-multibranch-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/gitlab-support-for-multibranch-pipeline.adoc
@@ -5,6 +5,7 @@ goal: "Add Multi-branch Pipeline support for Gitlab SCM private and SaaS instanc
 category: Plugin
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 - Gitlab SCM

--- a/content/projects/gsoc/2019/project-ideas/jenkins-rest-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/jenkins-rest-plugin.adoc
@@ -5,6 +5,7 @@ goal: "Create a new plugin to give Jenkins users the ability to make calls to ot
 category: Plugin
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 mentors:

--- a/content/projects/gsoc/2019/project-ideas/role-strategy-performance.adoc
+++ b/content/projects/gsoc/2019/project-ideas/role-strategy-performance.adoc
@@ -5,6 +5,7 @@ goal: "Improve performance of one of the most popular authorization plugins in J
 category: Plugins
 year: 2019
 status: published
+project: gsoc
 skills:
 - Java
 - Performance Testing

--- a/content/projects/gsoc/2019/project-ideas/role-strategy-ux.adoc
+++ b/content/projects/gsoc/2019/project-ideas/role-strategy-ux.adoc
@@ -5,6 +5,7 @@ goal: "Improve UI and REST APIs using new technologies to make it more user-frie
 category: Plugins
 year: 2019
 status: published
+project: gsoc
 skills:
 - Java
 - JavaScript

--- a/content/projects/gsoc/2019/project-ideas/working-hours-improvements.adoc
+++ b/content/projects/gsoc/2019/project-ideas/working-hours-improvements.adoc
@@ -5,6 +5,7 @@ goal: "Rewrite Working Hours plugin UI in React, providing much needed usability
 category: Plugins
 year: 2019
 status: draft
+project: gsoc
 skills:
 - Java
 - JavaScript

--- a/content/projects/gsoc/2019/schedule.adoc
+++ b/content/projects/gsoc/2019/schedule.adoc
@@ -4,10 +4,7 @@ title: "Jenkins year-round GSoC schedule"
 tags:
 - gsoc
 - gsoc2019
-links:
-  gitter: jenkinsci/gsoc-sig
-  googlegroup: jenkinsci-gsoc-all-public
-  sig: gsoc
+sig: gsoc
 ---
 
 = Jenkins year-round GSoC schedule

--- a/content/projects/gsoc/gsoc2016.adoc
+++ b/content/projects/gsoc/gsoc2016.adoc
@@ -4,6 +4,7 @@ title: "Jenkins in Google Summer of Code 2016"
 tags:
 - gsoc
 - gsoc2016
+project: gsoc
 ---
 
 WARNING: This is an archived page about Jenkins project participation in Google Summer of Code 2016.

--- a/content/projects/gsoc/gsoc2017.adoc
+++ b/content/projects/gsoc/gsoc2017.adoc
@@ -4,6 +4,7 @@ title: "Jenkins in Google Summer of Code 2017"
 tags:
 - gsoc
 - gsoc2017
+project: gsoc
 ---
 
 WARNING: This is an archived page about Jenkins project participation in Google Summer of Code 2017.

--- a/content/projects/gsoc/gsoc2018-project-ideas.adoc
+++ b/content/projects/gsoc/gsoc2018-project-ideas.adoc
@@ -4,6 +4,7 @@ title: "GSoC 2018 Project Ideas"
 tags:
 - gsoc
 - gsoc2018
+project: gsoc
 ---
 
 WARNING: This is an archived page about Jenkins project participation in Google Summer of Code 2016.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -4,10 +4,7 @@ title: "Google Summer of Code in Jenkins"
 section: projects
 tags:
 - gsoc
-links:
-  gitter: jenkinsci/gsoc-sig
-  googlegroup: jenkinsci-gsoc-all-public
-  sig: gsoc
+sig: gsoc
 ---
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -3,10 +3,7 @@ layout: project
 title: "Google Summer of Code. Information for mentors"
 tags:
 - gsoc
-links:
-  gitter: jenkinsci/gsoc-sig
-  googlegroup: jenkinsci-gsoc-all-public
-  sig: gsoc
+project: gsoc
 ---
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -3,10 +3,7 @@ layout: project
 title: "Proposing new project ideas"
 tags:
 - gsoc
-links:
-  gitter: jenkinsci/gsoc-sig
-  googlegroup: jenkinsci-gsoc-all-public
-  sig: gsoc
+project: gsoc
 ---
 
 :toc:

--- a/content/projects/gsoc/roles-and-responsibilities.adoc
+++ b/content/projects/gsoc/roles-and-responsibilities.adoc
@@ -3,10 +3,7 @@ layout: project
 title: "Google Summer of Code. Roles and Responsibilities"
 tags:
 - gsoc
-links:
-  gitter: jenkinsci/gsoc-sig
-  googlegroup: jenkinsci-gsoc-all-public
-  sig: gsoc
+project: gsoc
 ---
 
 *Roles and Responsibilities*

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -3,10 +3,7 @@ layout: project
 title: "Google Summer of Code. Information for students"
 tags:
 - gsoc
-links:
-  gitter: jenkinsci/gsoc-sig
-  googlegroup: jenkinsci-gsoc-all-public
-  sig: gsoc
+project: gsoc
 ---
 
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]


### PR DESCRIPTION
This pull request allows referencing SIGs or Projects on `project`, `gsocproject`, `gsocprojectidea` pages and layouts (and on all pages inheriting them). Once the reference is added, the pages will automatically include SIG/project chats and mailing lists in the _Connect_ section on the panel.

Such change should make channels more visible and help visitors to use proper channels.

Changes:

- [x] - introduce a new `connect-links` partial which now includes all the logic
- [x] - Connect links can be inherited from SIGs or projects. Local links still have a priority
- [x] - Add Twitter to the Connect layout
- [x] - Adapt GSoC pages and templates to demo the layout

Other SIGs and subprojects will be updated in follow-up pull requests, because I will need reviews from the project leads

@jenkins-infra/gsoc @jenkins-infra/copy-editors 


