### PR TITLE
Add communication channel links to projects and SIGs

### DIFF
--- a/content/projects/blueocean/roadmap/index.html.haml
+++ b/content/projects/blueocean/roadmap/index.html.haml
@@ -5,6 +5,7 @@ css:
   - '/assets/bower/bootstrap/css/bootstrap.min.css'
   - '/css/blueocean-animate.css'
   - '/css/blueocean-roadmap-style.css'
+project: blueocean
 ---
 %header#header.header
   .skew

--- a/content/projects/evergreen/index.adoc
+++ b/content/projects/evergreen/index.adoc
@@ -8,6 +8,8 @@ tags:
 
 links:
   gitter: 'jenkins-infra/evergreen'
+  twitter: 'evergreenbutler'
+  github: 'jenkins-infra/evergreen'
 ---
 
 image:/images/evergreen/magician_256.png[Jenkins Evergreen, role=center, float=right]

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -5,6 +5,9 @@ section: projects
 tags:
 - infra
 - infrastructure
+links:
+  chat: "/chat/#jenkins-infra"
+  mailinglist: "/mailing-lists/#infralists-jenkins-ci-org"
 ---
 
 As an independent open source project, Jenkins maintains most of its own

--- a/content/projects/infrastructure/ircbot.adoc
+++ b/content/projects/infrastructure/ircbot.adoc
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 title: "IRC Bot"
+project: infrastructure
 ---
 
 :toc:

--- a/content/projects/jam/index.adoc
+++ b/content/projects/jam/index.adoc
@@ -5,6 +5,9 @@ section: projects
 tags:
 - jam
 - jams
+links:
+  googlegroup: 'jenkinsci-jam'
+  gitter: 'jenkinsci/advocacy-and-outreach-sig'
 ---
 
 Jenkins Area Meetups (JAMs) are local meetups intended to bring Jenkins users

--- a/content/projects/jam/suggest.html.haml
+++ b/content/projects/jam/suggest.html.haml
@@ -1,6 +1,7 @@
 ---
 layout: simplepage
 title: Suggest a presentation
+project: jam
 ---
 
 :css

--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -7,8 +7,7 @@ tags:
 - jcasc
 links:
   gitter: 'jenkinsci/configuration-as-code-plugin'
-
-
+  github: 'jenkinsci/configuration-as-code-plugin'
 
 ---
 

--- a/content/projects/jenkins-x/index.adoc
+++ b/content/projects/jenkins-x/index.adoc
@@ -5,6 +5,12 @@ section: projects
 tags:
 - jenkins-x
 - kubernetes
+links:
+  github: 'jenkins-x'
+  chat: 'https://jenkins-x.io/community/#slack'
+  twitter: jenkinsxio
+  meetings: 'https://jenkins-x.io/community/#office-hours'
+  mailinglist: 'https://jenkins-x.io/community/#email'
 ---
 
 Jenkins X is a CI/CD solution for modern cloud applications on Kubernetes and is being proposed as a sub-project via JEP-400. 

--- a/content/projects/remoting/index.adoc
+++ b/content/projects/remoting/index.adoc
@@ -8,6 +8,7 @@ tags:
 - agents
 links:
   gitter: 'jenkinsci/remoting'
+  googlegroup: 'jenkinsci-dev'
 ---
 
 Jenkins Remoting is a library, and executable Java archive, which implements the communication layer in Jenkins. 

--- a/content/sigs/chinese-localization/index.adoc
+++ b/content/sigs/chinese-localization/index.adoc
@@ -30,9 +30,8 @@ organizations:
 links:
   gitter: jenkinsci/chinese-localization-sig
   googlegroup: jenkins-chinese-localization-sig
-meetings:
-  text: Every month, to be announced
-  link: TODO
+  meetings: "/projects/sigs/chinese-localization/#meetings"
+
 overview: >
   The Chinese Localization group of contributors and collaborators focuses on
   improving Jenkins experience for Chinese users. The scope covered include:

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -80,9 +80,8 @@ organizations:
 links:
   gitter: jenkinsci/cloud-native-sig
   googlegroup: jenkins-cloud-native-sig
-meetings:
-  text: To be announced
-  link: TODO
+  meetings: "/projects/sigs/cloud-native/#meetings"
+
 overview: >
   The Cloud Native group of contributors and collaborators focuses on
   improving Jenkins to run on Cloud environments as a "Cloud Native" application.

--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -66,9 +66,8 @@ organizations:
 links:
   gitter: jenkinsci/pipeline-authoring-sig
   googlegroup: jenkins-pipeline-authoring-sig
-meetings:
-  text: To be announced
-  link: TODO
+  meetings: "/projects/sigs/pipeline-authoring/#meetings"
+
 overview: >
   This special interest group aims to improve and curate the
   experience of authoring Jenkins Pipelines. This includes the syntax
@@ -99,3 +98,6 @@ best practices, and examples.
   basic or starter `Jenkinsfile`s for common patterns that can be used
   as jumping-off points by new users.
 
+=== Meetings
+
+SIG meetings are announced in the Gitter channel and in the mailing list.


### PR DESCRIPTION
This PR is an addition to #2014. Once both are integrated, it will be possible to add connect links to blogposts and project pages. Also, the contacts will show up on the landing pages now. This PR addresses all projects and SIGs except GSoC which is handled in #2014 

CC leaders of SIGs/Projects: @carlossg @jstrachan @rtyler @batmat @michaelneale @MarkEWaite @ewelinawilkosz @alyssat @LinuxSuRen @abayer 
 

