### PR TITLE
[GSoC 2019] - Support publishing GSoC projects as Google Docs

### DIFF
--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -15,11 +15,20 @@ project: gsoc
       Skills:
     = page.skills.join(", ")
 
-
 - if page.status == "published"
   %h2.title
     Details
-  = content
+  - if page.showGoogleDoc
+    %p
+      This project idea is published as a Google doc.
+      You are welcome to comment on the proposal or to suggest changes in the draft embedded below
+      (
+      %a{:href => page.links.draft, :target => "_blank"}
+        Google Doc
+      )
+    %iframe{:src => "#{page.links.draft}?embedded=true", :width => "100%", :height => "600px"}
+  - else
+    = content
 - else
   - if page.links
     - if page.links.draft

--- a/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
@@ -19,3 +19,5 @@ mentors:
 links:
   draft: https://docs.google.com/document/d/1UYi0jIYsKHE5IGS84B5W0XBoeMyF4yY_exu-21O99U8
 ---
+
+See Google Doc

--- a/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
@@ -19,5 +19,3 @@ mentors:
 links:
   draft: https://docs.google.com/document/d/1UYi0jIYsKHE5IGS84B5W0XBoeMyF4yY_exu-21O99U8
 ---
-
-TODO: add content once published

--- a/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/artifact-promotion-plugin-for-jenkins-pipeline.adoc
@@ -4,7 +4,8 @@ title: "Artifact Promotion plugin for Jenkins Pipeline"
 goal: "Create a new highly anticipated engine for managing promotions in Jenkins Pipeline, with modern UIs and REST APIs"
 category: Plugins
 year: 2019
-status: draft
+status: published
+showGoogleDoc: true
 skills:
 - Java
 - JavaScript

--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -4,7 +4,8 @@ title: "Automatic Specification Generator for Jenkins REST API"
 goal: "Find and implement the extraction of the REST APIs from the sources and generate and publish the REST APIs respective documentation"
 category: Plugins
 year: 2019
-status: draft
+status: published
+showGoogleDoc: true
 skills:
 - Java
 - REST API

--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -22,5 +22,3 @@ mentors:
 links:
   draft: https://docs.google.com/document/d/1CYzV_w5SrA-npXEMwTkJ4E2QyJdd2cJm7eDpwhg4XPk
 ---
-
-TODO: add content once published

--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -22,3 +22,5 @@ mentors:
 links:
   draft: https://docs.google.com/document/d/1CYzV_w5SrA-npXEMwTkJ4E2QyJdd2cJm7eDpwhg4XPk
 ---
+
+See Google Doc


### PR DESCRIPTION
Publish 2 project ideas as Google doc. In order to do that, I have added few flags

@jenkins-infra/gsoc 
