### PR TITLE
Old description was misleading of variables

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -73,8 +73,9 @@ The directory structure of a Shared Library repository is as follows:
 The `src` directory should look like standard Java source directory structure.
 This directory is added to the classpath when executing Pipelines.
 
-The `vars` directory hosts scripts that define global variables accessible from
-Pipeline.
+The `vars` directory hosts script files that are exposed as a variable in Pipelines. The name of the file is the name of the variable in the Pipeline. 
+So if you had a file called `vars/log.groovy` with a function like `def info(message)...` in it, you can access this function like `log.info "hello world"` in the Pipeline. You can put as many functions as you like inside this file. Read on below for more examples and options. 
+
 The basename of each `*.groovy` file should be a Groovy (~ Java) identifier, conventionally `camelCased`.
 The matching `*.txt`, if present, can contain documentation, processed through the system’s configured markup formatter
 (so may really be HTML, Markdown, etc., though the `txt` extension is required).


### PR DESCRIPTION
Variables in those files are not included in the pipeline, only functions. The simple example makes it explicit.