### PR TITLE
[GSoC 2019] - Add /participate and newbie-friendly issues to the project ideas

### DIFF
--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -56,16 +56,29 @@ project: gsoc
         = mentor.name
 
 %h2.title
-  Links
+  Project Links
 %ul
   = partial("connect-links.html.haml", :links => page.links, :sig => page.sig, :project => page.project)
   - if page.links && page.links.draft
     %li
       %a{:href => page.links.draft, :target => "_blank"}
         Project idea draft
+
+%h2.title
+  Organization Links
+%ul
   %li
     %a{:href => "/projects/gsoc", :target => "_blank"}
       Jenkins GSoC page
+    \- documentation, application guidelines
+  %li
+    %a{:href => "/participate", :target => "_blank"}
+      Participate and contribute to Jenkins
+    \- landing page for newcomer contributors
+  %li
+    %a{:href => "https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20%3D%20newbie-friendly%20", :target => "_blank"}
+      Newbie-friendly issues
+    \- list of organization-wide newbie-friendly issues (use them if there is no links in the project idea)
 
 %p
   %a{:href => "/projects/gsoc/#{page.year}/project-ideas", :target => "_blank"}


### PR DESCRIPTION
As @kwhetstone suggested, added some organization-wide links to the project idea pages.

<img width="765" alt="screenshot 2019-01-18 at 23 12 34" src="https://user-images.githubusercontent.com/3000480/51415675-eeeb4e00-1b76-11e9-9913-f666940077f1.png">


@jenkins-infra/gsoc @kwhetstone 