### PR TITLE
Add CVEs assigned so far in January 2019

### DIFF
--- a/content/security/advisory/2018-09-25.adoc
+++ b/content/security/advisory/2018-09-25.adoc
@@ -10,7 +10,7 @@ issues:
 - id: SECURITY-1101
   title: CSRF vulnerability in JUnit Plugin
   reporter: Oleg Nenashev, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000411
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
@@ -26,7 +26,7 @@ issues:
 - id: SECURITY-1029
   title: CSRF vulnerability and missing permission checks in Jira Plugin allowed capturing credentials
   reporter: Wadeck Follonier, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000412
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N
@@ -45,7 +45,7 @@ issues:
 - id: SECURITY-1080
   title: Stored XSS vulnerability in Config File Provider Plugin
   reporter: Zhouyuan Yang of Fortinet's FortiGuard Labs
-  cve: CVE pending
+  cve: CVE-2018-1000413
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N
@@ -61,7 +61,7 @@ issues:
 - id: SECURITY-938
   title: CSRF vulnerability in Config File Provider Plugin
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000414
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
@@ -77,7 +77,7 @@ issues:
 - id: SECURITY-130
   title: Stored XSS vulnerability in Rebuild Plugin
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000415
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
@@ -93,7 +93,7 @@ issues:
 - id: SECURITY-1130
   title: Reflected XSS vulnerability in Job Config History Plugin
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000416
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
@@ -112,7 +112,7 @@ issues:
 - id: SECURITY-1125
   title: CSRF vulnerability in Email Extension Template Plugin
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000417
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
@@ -130,7 +130,7 @@ issues:
 - id: SECURITY-984 (1) # capture
   title: CSRF vulnerability and missing permission checks in HipChat Plugin allowed capturing credentials
   reporter: Viktor Gazdag
-  cve: CVE pending
+  cve: CVE-2018-1000418
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
@@ -148,7 +148,7 @@ issues:
 
 - id: SECURITY-984 (2) # disclose
   title: Unprivileged users with Overall/Read access are able to enumerate credential IDs in HipChat Plugin
-  cve: CVE pending
+  cve: CVE-2018-1000419
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
@@ -169,7 +169,7 @@ issues:
 - id: SECURITY-1013 (1) # credentials
   title: Unprivileged users with Overall/Read access are able to enumerate credential IDs in Mesos Plugin
   reporter: Oleg Nenashev, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000420
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -188,7 +188,7 @@ issues:
 - id: SECURITY-1013 (2) # SSRF
   title: Server-side request forgery vulnerability in Mesos Plugin
   reporter: Oleg Nenashev, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000421
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
@@ -206,7 +206,7 @@ issues:
 - id: SECURITY-1067
   title: Server-side request forgery vulnerability in Crowd 2 Integration Plugin
   reporter: Viktor Gazdag
-  cve: CVE pending
+  cve: CVE-2018-1000422
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
@@ -225,7 +225,7 @@ issues:
 - id: SECURITY-1068
   title: Crowd 2 Integration Plugin stored credentials in plain text
   reporter: Viktor Gazdag
-  cve: CVE pending
+  cve: CVE-2018-1000423
   cvss:
     severity: low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -244,7 +244,6 @@ issues:
 - id: SECURITY-972
   title: CSRF vulnerability and missing permission checks in MQ Notifier Plugin
   reporter: Viktor Gazdag
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
@@ -262,7 +261,6 @@ issues:
 - id: SECURITY-1075
   title: Stored XSS vulnerability in Metadata Plugin
   reporter: Zhouyuan Yang of Fortinet's FortiGuard Labs
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N
@@ -278,7 +276,6 @@ issues:
 - id: SECURITY-1135
   title: Missing permission check in Metadata Plugin allows unauthorized users to change Metadata Plugin configuration
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N
@@ -300,7 +297,7 @@ issues:
 - id: SECURITY-265
   title: Artifactory Plugin stored old directly entered credentials unencrypted on disk
   reporter: Steve Marlowe <smarlowe@cisco.com> of Cisco ASIG
-  cve: CVE pending
+  cve: CVE-2018-1000424
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -332,7 +329,7 @@ issues:
 - id: SECURITY-1163
   title: SonarQube Scanner Plugin stored server authentication token in plain text
   reporter: The CJE team from ABN-AMRO
-  cve: CVE pending
+  cve: CVE-2018-1000425
   cvss:
     severity: low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -352,7 +349,7 @@ issues:
 - id: SECURITY-1122
   title: Stored XSS vulnerability in Git Changelog Plugin
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000426
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N
@@ -370,7 +367,6 @@ issues:
 - id: SECURITY-948
   title: Arachni Scanner Plugin stored credentials in plain text
   reporter: Viktor Gazdag
-  cve: CVE pending
   cvss:
     severity: low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -389,7 +385,6 @@ issues:
 - id: SECURITY-1011 (1) # SSRF
   title: CSRF vulnerability and missing permission checks in Argus Notifier Plugin allowed capturing credentials
   reporter: Oleg Nenashev, CloudBees, Inc.
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N
@@ -409,7 +404,6 @@ issues:
 - id: SECURITY-1011 (2) # credentials
   title: Unprivileged users with Overall/Read access are able to enumerate credential IDs  in Argus Notifier Plugin
   reporter: Oleg Nenashev, CloudBees, Inc.
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -428,7 +422,6 @@ issues:
 - id: SECURITY-1050 (1) # SSRF
   title: CSRF vulnerability and missing permission checks in Chatter Notifier Plugin allowed capturing credentials
   # reporter: Uncredited
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N
@@ -448,7 +441,6 @@ issues:
 - id: SECURITY-1050 (2) # credential enumeration
   title: Unprivileged users with Overall/Read access are able to enumerate credential IDs  in Chatter Notifier Plugin
   # reporter: Uncredited
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -467,7 +459,6 @@ issues:
 - id: SECURITY-1065
   title: Dimensions Plugin stored credentials in plain text
   reporter: Viktor Gazdag
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -484,7 +475,6 @@ issues:
 - id: SECURITY-1108
   title: CSRF vulnerability and missing permission checks in Dimensions Plugin
   reporter: Daniel Beck, CloudBees, Inc.
-  cve: CVE pending
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
@@ -502,7 +492,6 @@ issues:
 - id: SECURITY-845 # and SECURITY-851
   title: Publish Over Dropbox Plugin stored credentials in plain text
   reporter: Viktor Gazdag
-  cve: CVE pending
   cvss:
     severity: low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N

--- a/content/security/advisory/2018-10-10.adoc
+++ b/content/security/advisory/2018-10-10.adoc
@@ -15,7 +15,7 @@ issues:
 - id: SECURITY-867
   title: Path traversal vulnerability in Stapler allowed accessing internal data
   reporter: Apple Information Security
-  cve: CVE pending
+  cve: CVE pending # TODO
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
@@ -26,7 +26,7 @@ issues:
 - id: SECURITY-1074
   title: Arbitrary file write vulnerability using file parameter definitions
   reporter: Oleg Nenashev
-  cve: CVE pending
+  cve: CVE-2018-1000406
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N
@@ -40,7 +40,7 @@ issues:
 - id: SECURITY-1129
   title: Reflected XSS vulnerability
   reporter: Evan Grant of Tenable
-  cve: CVE pending
+  cve: CVE-2018-1000407
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
@@ -69,7 +69,7 @@ issues:
 - id: SECURITY-1128
   title: Ephemeral user record creation
   reporter: Evan Grant of Tenable
-  cve: CVE pending
+  cve: CVE-2018-1000408
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L
@@ -83,7 +83,7 @@ issues:
 - id: SECURITY-1158
   title: Session fixation vulnerability on user signup
   reporter: Wadeck Follonier, CloudBees, Inc.
-  cve: CVE pending
+  cve: CVE-2018-1000409
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
@@ -96,7 +96,7 @@ issues:
 - id: SECURITY-765
   title: Failures to process form submission data could result in secrets being displayed or written to logs
   reporter: Sam Gleske
-  cve: CVE pending
+  cve: CVE-2018-1000410
   cvss:
     severity: low
     vector: CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N

--- a/content/security/advisory/2019-01-08.adoc
+++ b/content/security/advisory/2019-01-08.adoc
@@ -8,7 +8,8 @@ issues:
 - id: SECURITY-1266
   title: Sandbox Bypass in Script Security and Pipeline Plugins
   reporter: Orange Tsai(@orange_8361) from DEVCORE
-  cve: CVE pending
+  cve: > # https://github.com/CVEProject/cvelist/pull/1478
+    CVE-2019-1003000 (Script Security), CVE-2019-1003001 (Pipeline: Groovy), CVE-2019-1003002 (Pipeline: Declarative)
   cvss:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H

--- a/content/security/advisory/2019-01-16.adoc
+++ b/content/security/advisory/2019-01-16.adoc
@@ -11,11 +11,11 @@ core:
     previous: 2.159
     fixed: "2.160"
 issues:
-
+# CVEs via https://github.com/CVEProject/cvelist/pull/1479
 - id: SECURITY-868
   title: Administrators could persist access to Jenkins using crafted 'Remember me' cookie
   reporter: Apple Information Security
-  cve: CVE pending
+  cve: CVE-2019-1003003
   cvss:
     severity: high
     vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
@@ -30,7 +30,7 @@ issues:
 - id: SECURITY-901
   title: Deleting a user in an external security realm did not invalidate their session or 'Remember me' cookie
   reporter: Nimrod Stoler of CyberArk Labs
-  cve: CVE pending
+  cve: CVE-2019-1003004
   cvss:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H


### PR DESCRIPTION
Some 'CVE pending' are removed because I ended up not requesting CVEs due to low install counts of the affected plugins.

**DO NOT MERGE, I will merge this when ready.**