### PR TITLE
Fix parsing

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1120,7 +1120,7 @@ For example: `when { anyOf { branch 'master'; branch 'staging' } }`
 triggeredBy:: Execute the stage when the current build has been triggered by the param given.
 For example: `when { triggeredBy 'SCMTrigger' }`
 
-===== Evaluating `when` before entering the `stage`'s `agent`
+===== Evaluating `when` before entering `agent` in a `stage`
 
 By default, the `when` condition for a `stage` will be evaluated after
 entering the `agent` for that `stage`, if one is defined. However, this can


### PR DESCRIPTION
The previous version resulted in:
> Evaluating when before entering the stage’s `agent