### PR TITLE
[GSoC 2019] - Link Ext Workspace Manager Cloud Features to the Cloud Native SIG

### DIFF
--- a/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
@@ -5,6 +5,7 @@ goal: "Add support of provisioning workspaces from cloud services"
 category: Plugins
 year: 2019
 status: published
+sig: cloud-native
 skills:
 - Java
 - Cloud-based storage (e.g. Amazon EFS)


### PR DESCRIPTION
Just to follow-up on the SIG discussions we had. This project maps the Cloud Native SIG well, but it needs explicit +1 from @martinda before merging.

Also CC @carlossg 