### PR TITLE
Fix shared library documentation formatting

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -670,7 +670,7 @@ def call(int buildNumber) {
 evenOrOdd(currentBuild.getNumber())
 ----
 
-Only entire `pipeline`s can be defined in shared libraries as of this time.
+Only entire ``pipeline``s can be defined in shared libraries as of this time.
 This can only be done in `vars/*.groovy`, and only in a `call` method. Only one
 Declarative Pipeline can be executed in a single build, and if you attempt to
 execute a second one, your build will fail as a result.


### PR DESCRIPTION
👋I noticed that the formatting for this paragraph was a bit off on the website:
![image](https://user-images.githubusercontent.com/2644787/52149527-fca2d800-263a-11e9-9754-5f827c089be1.png)