### PR TITLE
WIP. Add a dynamically generated list of mailing list of all SIGs

### DIFF
--- a/content/mailing-lists.adoc
+++ b/content/mailing-lists.adoc
@@ -121,3 +121,7 @@ Automated notifications from JIRA (JENKINS project only). +
 link:http://groups.google.com/group/jenkinsci-issues/topics[archive] |
 mailto:jenkinsci-issues+subscribe@googlegroups.com[subscribe] |
 mailto:jenkinsci-issues+unsubscribe@googlegroups.com[unsubscribe]
+
+== Special Interest Groups lists
+
+link:/sigs/mailing-lists[List of mailing lists of SIGs]

--- a/content/sigs/mailing-lists.html.haml
+++ b/content/sigs/mailing-lists.html.haml
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Jenkins Special Interest Groups
+---
+
+.container
+  .row.body
+    .col-lg-9
+      %h1
+        Special Interest Groups mailing lists
+
+      %p
+        This page contains all existing mailing lists for SIG.
+
+      - sigs = site.pages.select { |p| p.source_path =~ /\/content\/sigs\/[^\/]+\/index.adoc/ }
+      - sigs.each do |item|
+        - if item.links.googlegroup
+          - email = item.links.googlegroup + "@googlegroup.com"
+          %h3
+            %a{:href => "mailto:#{item.links.googlegroup}@googlegroup.com", :target => "_blank"}
+              = email
+          %p
+            Mailing list for
+            %a{:href => "#{item.url}", :target => "_blank"}
+              = item.title
+            %br
+            %a{:href => "http://groups.google.com/group/#{item.links.googlegroup}/topics", :target => "_blank"}
+              archive
+            |
+            %a{:href => "mailto:#{item.links.googlegroup}+subscribe@googlegroups.com", :target => "_blank"}
+              subscribe
+            |
+            %a{:href => "mailto:#{item.links.googlegroup}+unsubscribe@googlegroups.com", :target => "_blank"}
+              unsubscribe
+    .col-lg-3
+      .sidebar-nav


### PR DESCRIPTION
Cannot think of ideal solution.

Original page is written in adoc and dynamic generation require haml. But html generated from haml lacks some nice and useful features like:
- anchors for sections
- note/warning blocks
(And after all reading adoc is much more easy and pleasant)

For now I've ended with separate page (automatically generated): [gh-pages](https://sp1r.github.io/jenkins.io/sigs-mailing-lists-list/sigs/mailing-lists/)
And added a link to it from "mailing lists" page: [gh-pages](https://sp1r.github.io/jenkins.io/sigs-mailing-lists-list/mailing-lists/#special-interest-groups-lists)

Can someone help with this? How to do it better way?

ISSUE: [WEBSITE-588](https://issues.jenkins-ci.org/browse/WEBSITE-588)