### PR TITLE
[WEBSITE-497] Explain how to run Jenkins on Java 11 and recent improvements

### DIFF
--- a/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
+++ b/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
@@ -14,6 +14,14 @@ links:
   sig: platform
 ---
 
+[WARNING]
+--
+Guidelines in this blogpost are rendered obsolete link:/blog/2019/02/04/running-jenkins-with-java-11/[by the Java 11 Support Availability
+announcement] on February 4th, 2019.
+See the link:/doc/administration/requirements/java/[Java support page]
+for up-to-date information about running Jenkins with Java 11.
+--
+
 NOTE: This is a joint blogpost prepared by the link:https://github.com/orgs/jenkinsci/teams/java11-support[Java 11 Support Team].
 On Dec 18 (4PM UTC) we will be also presenting the Java 11 Preview Support at the Jenkins Online Meetup
 (link:https://www.meetup.com/Jenkins-online-meetup/events/257008190/[link])

--- a/content/blog/2019/02/2019-02-04-running-jenkins-with-java-11.adoc
+++ b/content/blog/2019/02/2019-02-04-running-jenkins-with-java-11.adoc
@@ -1,0 +1,105 @@
+---
+layout: post
+title: "Running Jenkins with Java 11"
+tags:
+- core
+- developer
+- java11
+author: alecharp
+---
+
+NOTE: This is a joint blogpost prepared by the link:https://github.com/orgs/jenkinsci/teams/java11-support[Java 11 Support Team].
+On Dec 18 (4PM UTC) we will be also presenting the Java 11 Preview Support at the Jenkins Online Meetup (link:https://www.meetup.com/Jenkins-online-meetup/events/257008190/[link]).
+
+image:/images/logos/formal/256.png[Jenkins Java, role=center, float=right]
+
+We recently made some improvement on the requirement to run Jenkins with Java 11.
+Since Jenkins core `2.163`, it is not necessary to download JAXB libraries nor add `java.xml.bind` or `java.activation` modules to the JVM. 
+This reduce the pre-requisite list to run Jenkins on Java 11.
+The JAXB libraries were extracted to the link:https://plugins.jenkins.io/jaxb[jaxb-plugin], so that plugin still requiring the libraries can use them through the plugins' dependencies mechanism.
+
+As part of the simplification, we also removed the requirement to use the Java 11 experimental update-center.
+This update center was mainly created to hold the plugins' releases which were made to try to solve issues reported specifically to Java 11 support. 
+This was the case for `workflow-support`, for example, which was solved in the release `3.1` of the plugin.
+
+=== Running Jenkins and Java 11 in Docker
+
+Starting from Jenkins `2.155`, we provide Docker images for the Jenkins master and agent.
+All these images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
+There were discussions about migrating to other base images, but we decided to exclude it from the Preview Availability scope.
+
+==== Jenkins master image
+
+As announced previously, Java 11 support is now provided as a part of the official link:https://hub.docker.com/r/jenkins/jenkins/[jenkins/jenkins] image.
+You can run the Jenkins with Java 11 simply as:
+
+[source, shell]
+----
+docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:jdk11
+----
+
+The following tags are available:
+
+* `jdk11` - Latest weekly release with Java 11 support
+* `2.155-jdk11` - Weekly releases packaged with Java 11.
+
+NOTE: Since the weekly release `2.155`, each weekly was also released with the suffix `-jdk11`.
+So you can use `2.163-jdk11`, for example.
+
+==== Agent images
+
+If you use containerized agents via Docker or Kubernetes plugins, we have also released official Docker images for Jenkins agents:
+
+* link:https://hub.docker.com/r/jenkins/slave/[jenkins/slave]
+* link:https://hub.docker.com/r/jenkins/jnlp-slave/[jenkins/jnlp-slave]
+* link:https://hub.docker.com/r/jenkins/ssh-slave/[jenkins/ssh-slave]
+
+All images use the `latest-jdk11` image tag for JDK11 bundles.
+And sorry for the obsolete names!
+
+=== Known compatibility issues
+
+To help users to track down the compatibility issues, we have created a new link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues] Wiki page.
+
+=== Reporting compatibility issues
+
+If you discover any Java 11 incompatibilities, please link:https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue[report issues in our bugtracker].
+Please set `java11-compatibility` labels for such issues so that they automatically appear on the Wiki page and get triaged.
+
+For the security issues please use the standard link:https://jenkins.io/security/#reporting-vulnerabilities[vulnerability reporting process].
+Although we will be fixing Java 11 specific issues in public while it is in the preview, following the security process will help us to investigate impact on Java 8 users.
+
+=== Java 11 Support Team
+
+Once Java 11 support is released, we expect reports of regressions in plugins and Jenkins core.
+One of the concerns are exotic platforms with native libraries, and of course other Java versions.
+There is also a risk of 3rd-party library incompatibilities with Java 11.
+To mitigate the risks, we have created a link:https://github.com/orgs/jenkinsci/teams/java11-support[Java 11 Support Team].
+This team will be focusing on triaging the incoming issues, helping to review pull requests and, in some cases, delivering the fixes.
+The process for this team is link:https://github.com/jenkinsci/jep/tree/master/jep/211#post-release-support[documented] in JEP-211.
+
+We do not expect the _Java 11 Support Team_ to be able to fix all discovered issues, and we will be working with Jenkins core and plugin maintainers to get the fixes delivered.
+If you are interested to join the team, reach out to us in the link:https://gitter.im/jenkinsci/platform-sig[Platform SIG Gitter Channel].
+
+=== Contributing
+
+We will appreciate any kind of contributions in the Java 11 effort, including trying out Jenkins with Java 11, reporting and fixing compatibility issues.
+
+* If you want to do the exploratory testing, we recommend to try out Java 11 support at one of your test instances.
+Such testing will be much appreciated, especially if you use some service integration plugins or exotic platforms.
+The issue reporting guidelines are provided link:/blog/2018/12/14/java11-preview-availability/#reporting-compatibility-issues[above]
+* If you are a plugin developer/maintainer, we would appreciate if you could test your plugin with Java 11.
+In order to help with that, we have created a Wiki page with link:https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines[Java 11 Developer guidelines].
+This page explains how to build and test plugins with Java 11, and it also lists known issues in development tools
+
+Whatever you do, please let us know about your experience by sending a message to the link:https://groups.google.com/forum/#!forum/jenkins-platform-sig[Platform SIG mailing list].
+Such information will help us a lot to track changes and contributions.
+Any other feedback about the migration complexity will be appreciated!
+
+=== Links
+
+* link:https://github.com/jenkinsci/jep/tree/master/jep/211[JEP-211: Java 11 support in Jenkins]
+* link:/doc/administration/requirements/java/[Java requirements in Jenkins]
+* link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues]
+* link:https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines[Java 11 Developer guidelines]
+* link:/sigs/platform/[Platform Special Interest Group]

--- a/content/blog/2019/02/2019-02-04-running-jenkins-with-java-11.adoc
+++ b/content/blog/2019/02/2019-02-04-running-jenkins-with-java-11.adoc
@@ -15,7 +15,7 @@ image:/images/logos/formal/256.png[Jenkins Java, role=center, float=right]
 
 We recently made some improvement on the requirement to run Jenkins with Java 11.
 Since Jenkins core `2.163`, it is not necessary to download JAXB libraries nor add `java.xml.bind` or `java.activation` modules to the JVM. 
-This reduce the pre-requisite list to run Jenkins on Java 11.
+This reduces the pre-requisite list to run Jenkins on Java 11.
 The JAXB libraries were extracted to the link:https://plugins.jenkins.io/jaxb[jaxb-plugin], so that plugin still requiring the libraries can use them through the plugins' dependencies mechanism.
 
 As part of the simplification, we also removed the requirement to use the Java 11 experimental update-center.
@@ -41,7 +41,9 @@ docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:jdk11
 The following tags are available:
 
 * `jdk11` - Latest weekly release with Java 11 support
-* `2.155-jdk11` - Weekly releases packaged with Java 11.
+* `${jenkins.version}-jdk11` - Weekly releases packaged with Java 11, e.g. `2.163-jdk11`
+* `latest` - Latest weekly release with Java 8
+* `${jenkins.version}` - Weekly releases packaged with Java 8
 
 NOTE: Since the weekly release `2.155`, each weekly was also released with the suffix `-jdk11`.
 So you can use `2.163-jdk11`, for example.


### PR DESCRIPTION
[WEBSITE-497](https://issues.jenkins-ci.org/browse/WEBSITE-497)

This blog entry comes to explain the improvments done by @jenkinsci/java11-support team to be able to run Jenkins on Java 11.

cc @jenkins-infra/java11-support-reviewer 