### PR TITLE
Building and Debugging : add a blog on Netbeans

### DIFF
--- a/content/doc/developer/building/index.adoc
+++ b/content/doc/developer/building/index.adoc
@@ -8,6 +8,8 @@ references:
   title: Why Maven?
 - url: https://wiki.jenkins-ci.org/display/JENKINS/Debugging+native+Maven+jobs
   title: Debugging native Maven jobs # TODO convert to guide
+- url: https://www.jimklimov.com/2019/02/debugging-jenkins-plugins-and-core-with.html
+  title: One contributor's experience tracing Jenkins plugins and the Jenkins server itself under the Netbeans IDE # TODO convert to guide
 ---
 
 = Building and Debugging


### PR DESCRIPTION
While certainly worse than actually porting the blog content into the docs proper (planned "to do" when time allows), this gets the information out there in the interim. Tested during recent FOSDEM'19 meet-up.