### PR TITLE
Syntax highlighting typo in 2019-02-06-ssh-steps-for-jenkins-pipeline.

### DIFF
--- a/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
+++ b/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
@@ -76,7 +76,7 @@ node {
 
 At Cerner, we always strive to have simple configuration files for CI/CD pipelines whenever possible. With that in mind, my team built a wrapper on top of these steps from this plugin. After some design and analysis, we came up with the following YAML structure to run commands across various remote groups:
 
-```groovy
+```yaml
 config:
   credentials_id: sshUserAcct
 


### PR DESCRIPTION
Mistake in #2076. @nrayapati