### PR TITLE
[WEBSITE-497] Add documentation to run Jenkins on Java 11

### DIFF
--- a/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
+++ b/content/blog/2018/06/2018-06-17-running-jenkins-with-java10-11.adoc
@@ -11,6 +11,11 @@ author: oleg_nenashev
 
 [WARNING]
 --
+Please refer to link:/doc/administration/requirements/jenkins-on-java-11[Running Jenkins on Java 11] documentation to have the up-to-date details on how to run Jenkins on Java 11.
+--
+
+[WARNING]
+--
 Guidelines in this blogpost are rendered obsolete link:/blog/2018/12/14/java11-preview-availability/[by the Java 11 Support Preview Availability
 announcement] on Dec 13, 2018 and by the Java 11 GA release on Sep 25, 2018.
 See the link:/doc/administration/requirements/java/[Java support page]

--- a/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
+++ b/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
@@ -14,6 +14,11 @@ links:
   sig: platform
 ---
 
+[WARNING]
+--
+Please refer to link:/doc/administration/requirements/jenkins-on-java-11[Running Jenkins on Java 11] documentation to have the up-to-date details on how to run Jenkins on Java 11.
+--
+
 NOTE: This is a joint blogpost prepared by the link:https://github.com/orgs/jenkinsci/teams/java11-support[Java 11 Support Team].
 On Dec 18 (4PM UTC) we will be also presenting the Java 11 Preview Support at the Jenkins Online Meetup
 (link:https://www.meetup.com/Jenkins-online-meetup/events/257008190/[link])

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -10,7 +10,7 @@ There are separate run and job execution requirements for Jenkins installations.
 Modern Jenkins versions have the following Java requirements:
 
 * Java 8 runtime environments, both 32-bit and 64-bit versions are supported
-* Since Jenkins `2.163` footnote:[since `2.155` but it was made easier in `2.163`], Java 11 runtime environments is supported
+* Since Jenkins `2.164` footnote:[since `2.155` but it was made easier in `2.164`], Java 11 runtime environments is supported
 ** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed link:/doc/administration/requirements/jenkins-on-java-11[here].
 ** if you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
 * Older versions of Java are not supported

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -10,7 +10,7 @@ There are separate run and job execution requirements for Jenkins installations.
 Modern Jenkins versions have the following Java requirements:
 
 * Java 8 runtime environments, both 32-bit and 64-bit versions are supported
-* Since Jenkins `2.155`, Java 11 runtime environments is supported
+* Since Jenkins `2.163` footnote:[since `2.155` but it was made easier in `2.163`], Java 11 runtime environments is supported
 ** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed link:/doc/administration/requirements/jenkins-on-java-11[here].
 ** if you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
 * Older versions of Java are not supported

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -9,11 +9,12 @@ There are separate run and job execution requirements for Jenkins installations.
 
 Modern Jenkins versions have the following Java requirements:
 
-* Java 8 is the **ONLY** currently supported runtime environment, both 32-bit and 64-bit versions are supported
+* Java 8 runtime environments, both 32-bit and 64-bit versions are supported
+* Since Jenkins `2.155`, Java 11 runtime environments is supported
+** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed link:/doc/administration/requirements/jenkins-on-java-11[here].
+** if you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
 * Older versions of Java are not supported
 * Java 9 and Java 10 are not supported
-* Java 11 preview support is available in Jenkins 2.155+
-** link:/blog/2018/12/14/java11-preview-availability/[This page] provides guidelines about running Jenkins with these versions
 * Java 12 is not supported
 
 These requirements apply to all components of the Jenkins system including Jenkins master,
@@ -22,6 +23,7 @@ all types of agents, CLI clients, and other components.
 Jenkins project performs a full test flow with the following JDK/JREs:
 
 * OpenJDK JDK / JRE 8 - 64 bits
+* OpenJDK JDK / JRE 11 - 64 bits
 
 JRE/JDKs from other vendors are supported and may be used.
 See link:/redirect/issue-tracker[our Issue tracker] for known Java compatibility issues.

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -10,7 +10,7 @@ There are separate run and job execution requirements for Jenkins installations.
 Modern Jenkins versions have the following Java requirements:
 
 * Java 8 runtime environments, both 32-bit and 64-bit versions are supported
-* Since Jenkins `2.164` footnote:[since `2.155` but it was made easier in `2.164`], Java 11 runtime environments is supported
+* Since Jenkins `2.164` footnote:[since `2.155` but it was made easier in `2.164`], Java 11 runtime environments are supported
 ** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed in the link:/doc/administration/requirements/jenkins-on-java-11[Running Jenkins on Java 11] documentation.
 ** if you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
 * Older versions of Java are not supported

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -11,8 +11,8 @@ Modern Jenkins versions have the following Java requirements:
 
 * Java 8 runtime environments, both 32-bit and 64-bit versions are supported
 * Since Jenkins `2.164` footnote:[since `2.155` but it was made easier in `2.164`], Java 11 runtime environments are supported
-** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed in the link:/doc/administration/requirements/jenkins-on-java-11[Running Jenkins on Java 11] documentation.
-** if you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
+** Running Jenkins with Java 11 is documented link:/doc/administration/requirements/jenkins-on-java-11[here] 
+** There are some precautions to take when upgrading from Java 8 to Java 11 in Jenkins, please link:/doc/administration/requirements/upgrade-java-guidelines[follow these guidelines].
 * Older versions of Java are not supported
 * Java 9 and Java 10 are not supported
 * Java 12 is not supported

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -11,7 +11,7 @@ Modern Jenkins versions have the following Java requirements:
 
 * Java 8 runtime environments, both 32-bit and 64-bit versions are supported
 * Since Jenkins `2.164` footnote:[since `2.155` but it was made easier in `2.164`], Java 11 runtime environments is supported
-** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed link:/doc/administration/requirements/jenkins-on-java-11[here].
+** in order to run Jenkins on Java 11, there are few precautions to take, which are detailed in the link:/doc/administration/requirements/jenkins-on-java-11[Running Jenkins on Java 11] documentation.
 ** if you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
 * Older versions of Java are not supported
 * Java 9 and Java 10 are not supported

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -53,4 +53,3 @@ If you discover any Java 11 incompatibilities, please link:https://wiki.jenkins.
 Please set `java11-compatibility` labels for such issues so that they automatically appear on the Wiki page and get triaged.
 
 For the security issues please use the standard link:https://jenkins.io/security/#reporting-vulnerabilities[vulnerability reporting process].
-Although we will be fixing Java 11 specific issues in public while it is in the preview, following the security process will help us to investigate impact on Java 8 users.

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -8,7 +8,7 @@ If you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 1
 NOTE: At this moment, it is not required to upgrade the JVM version in order to run a Jenkins core more recent than `2.155`.
 
 Since Jenkins `2.155`, it is possible to run Jenkins with Java 11.
-However, it was greatly simplified since version `2.163`. 
+However, it was greatly simplified since version `2.164`. 
 For the sake of simplicity, we will describe next how to run Jenkins on Java 11 with the most recent version of Jenkins.
 
 NOTE: We do encourage you to only use LTS versions for production purposes. 

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -11,6 +11,9 @@ Since Jenkins `2.155`, it is possible to run Jenkins with Java 11.
 However, it was greatly simplified since version `2.163`. 
 For the sake of simplicity, we will describe next how to run Jenkins on Java 11 with the most recent version of Jenkins.
 
+NOTE: We do encourage you to only use LTS versions for production purpose. 
+At the time this documentation is writen, there is no LTS version with Java 11 Support.
+
 == Running Jenkins with Docker
 
 The easiest way to run Jenkins on Java 11 is to use the Docker image.

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -5,10 +5,8 @@ title: Running Jenkins on Java 11
 
 If you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
 
-NOTE: At this moment, it is not required to upgrade the JVM version in order to run a Jenkins core more recent than `2.155`.
+NOTE: At this moment, it is not required to upgrade the JVM version in order to run a Jenkins core more recent than ``2.164+``footnote:[It was possible to run Jenkins on Java 11 since the version `2.155` but its usage was then more complex. We do not recommend to use any version prior to `2.164`.].
 
-Since Jenkins `2.155`, it is possible to run Jenkins with Java 11.
-However, it was greatly simplified since version `2.164`. 
 For the sake of simplicity, we will describe next how to run Jenkins on Java 11 with the most recent version of Jenkins.
 
 NOTE: We do encourage you to only use LTS versions for production purposes. 
@@ -17,10 +15,9 @@ At the time of this writing, there is no LTS version with Java 11 Support.
 == Running Jenkins with Docker
 
 The easiest way to run Jenkins on Java 11 is to use the Docker image.
-Since the weekly release `2.155`, each weekly release has also been packaged on a Java 11 ready Docker image.
 All these images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
 
-You can choose these Java 11 based images by using the `jdk11` tag (for the latest weekly release) or by suffixing the tag to use with `-jdk11` (eg. `2.163-jdk11`).
+You can choose these Java 11 based images by using the `jdk11` tag (for the latest weekly release) or by suffixing the tag to use with `-jdk11` (eg. `2.164-jdk11`).
 
 This is the command to use, in order to start a Jenkins running on Java 11: 
 
@@ -37,18 +34,11 @@ docker run --rm -ti \
 
 It is also possible to run Jenkins using the `java` command.
 
-However, we need to take some precaution with this method, because some plugins are using classes in the package `java.sql.*`.
-This package was modularized since Java 9, which means the classes inside this package are not accessible out-of-the-box.
-We need to open this module with the `java` parameter `--add-modules java.sql`.
-It is the case for example of plugin:pipeline-maven[Pipeline Maven integration] plugin but others are using classes from this package as well.
-
 Starting Jenkins would be:
 
 [source, shell]
 ----
-java \
-  --add-modules java.sql \
-  -jar jenkins.war
+java -jar jenkins.war
 ----
 
 == Discovering issues with Java 11

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -33,18 +33,11 @@ docker run --rm -ti \
 == Running Jenkins with Java
 
 It is also possible to run Jenkins using the `java` command.
-At the time those lines are writen, the support of Java 11 is a opt-in.
-It means that it's a feature we need to activate when Jenkins is started.
 
-To do so, we have two options:
-
-* using the `--enable-future-java` option on the `jenkins.war` binary
-* using the `ENABLE_FUTURE_JAVA=true` environment variable.
-
-NOTE: the `--enable-future-java` option is part of the Jenkins configuration. 
-It needs to be after the `-jar jenkins.jar`.
-
-Also, because some plugins are using classes in the package `java.sql`, which is not public since Java 9, we need to open this module with the `java` parameter `--add-modules java.sql`.
+However, we need to take some precaution with this method, because some plugins are using classes in the package `java.sql.*`.
+This package was modularized since Java 9, which means the claases inside this package are not accessible out-of-the-box.
+We need to open this module with the `java` parameter `--add-modules java.sql`.
+It is the case for example of plugin:pipeline-maven[Pipeline Maven integration] plugin but others are using classes from this package as well.
 
 Starting Jenkins would be:
 
@@ -52,8 +45,7 @@ Starting Jenkins would be:
 ----
 java \
   --add-modules java.sql \
-  -jar jenkins.war \
-  --enable-future-java
+  -jar jenkins.war
 ----
 
 == Discovering issues with Java 11

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -11,8 +11,8 @@ Since Jenkins `2.155`, it is possible to run Jenkins with Java 11.
 However, it was greatly simplified since version `2.163`. 
 For the sake of simplicity, we will describe next how to run Jenkins on Java 11 with the most recent version of Jenkins.
 
-NOTE: We do encourage you to only use LTS versions for production purpose. 
-At the time this documentation is writen, there is no LTS version with Java 11 Support.
+NOTE: We do encourage you to only use LTS versions for production purposes. 
+At the time of this writing, there is no LTS version with Java 11 Support.
 
 == Running Jenkins with Docker
 
@@ -54,7 +54,7 @@ java \
 == Discovering issues with Java 11
 
 Between June 2018 and February 2019, the community performed many exploratory tests to try to discover as many issues related to Java 11 as possible.
-The result of this is that the community solved a lot of problem before anouncing the support of Java 11 by Jenkins.
+The result of this is that the community solved a lot of problems before announcing the support of Java 11 by Jenkins.
 However, it is still possible that some plugins are not yet compatible with Java 11.
 
 In order to track this, we have created a new link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues] Wiki page.

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -3,23 +3,22 @@ layout: documentation
 title: Running Jenkins on Java 11
 ---
 
-If you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
+If you are upgrading the Jenkins JVM version from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow these guidelines].
 
-NOTE: At this moment, it is not required to upgrade the JVM version in order to run a Jenkins core more recent than ``2.164+``footnote:[It was possible to run Jenkins on Java 11 since the version `2.155` but its usage was then more complex. We do not recommend to use any version prior to `2.164`.].
+NOTE: As of February 2019, Jenkins cores more recent than ``2.164+``footnote:[Although it's technically been possible to run Jenkins on Java 11 since version `2.155`, doing so is far more complex. Running any Jenkins version prior to `2.164` on Java 11 *is not recommended*] do not require a JVM upgrade.
 
-For the sake of simplicity, we will describe next how to run Jenkins on Java 11 with the most recent version of Jenkins.
+For simplicity, this document describes how to run the most recent version of Jenkins on Java 11.
 
-NOTE: We do encourage you to only use LTS versions for production purposes. 
-At the time of this writing, there is no LTS version with Java 11 Support.
+NOTE: Production deployments should use only LTS versions of Jenkins. As of February 2019, there are no LTS versions with Java 11 support.
 
 == Running Jenkins with Docker
 
-The easiest way to run Jenkins on Java 11 is to use the Docker image.
-All these images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
+The easiest way to run Jenkins on Java 11 is with a Docker image.
+These images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
 
-You can choose these Java 11 based images by using the `jdk11` tag (for the latest weekly release) or by suffixing the tag to use with `-jdk11` (eg. `2.164-jdk11`).
+To use the latest weekly release of the Java 11-based images, use the `jdk11` tag. For other releases, append the `-jdk11` tag to the version (for exanple,`2.164-jdk11`).
 
-This is the command to use, in order to start a Jenkins running on Java 11: 
+For exanple, this command starts Jenkins on Java 11 using the latest weekly release: 
 
 [source, shell]
 ----
@@ -32,9 +31,7 @@ docker run --rm -ti \
 
 == Running Jenkins with Java
 
-It is also possible to run Jenkins using the `java` command, just like with Java 8.
-
-Starting Jenkins would be:
+As with Java 8, you can start Jenkins using the `java` command:
 
 [source, shell]
 ----
@@ -43,13 +40,12 @@ java -jar jenkins.war
 
 == Discovering issues with Java 11
 
-Between June 2018 and February 2019, the community performed many exploratory tests to try to discover as many issues related to Java 11 as possible.
-The result of this is that the community solved a lot of problems before announcing the support of Java 11 by Jenkins.
-However, it is still possible that some plugins are not yet compatible with Java 11.
+Between June 2018 and February 2019, the community performed many exploratory tests to discover as many Java 11 issues as possible.
 
-In order to track this, we have created a new link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues] Wiki page.
+As a result, the community solved a lot of problems before announcing Java 11 support in Jenkins. However, it's still possible that some plugins haven't been updated to support Java 11.
 
-If you discover any Java 11 incompatibilities, please link:https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue[report issues in our bugtracker].
-Please set `java11-compatibility` labels for such issues so that they automatically appear on the Wiki page and get triaged.
+Compatibility issues are being tracked by the link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues Wiki page].
 
-For the security issues please use the standard link:https://jenkins.io/security/#reporting-vulnerabilities[vulnerability reporting process].
+If you discover a Java 11 incompatibility, please link:https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue[report the issues in the Jenkins bug tracker] using the `java11-compatibility` label. This helps us organize these issues so that they automatically appear on the Wiki page and get triaged.
+
+For security issues, please use the standard link:https://jenkins.io/security/#reporting-vulnerabilities[vulnerability reporting process].

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -14,7 +14,7 @@ For the sake of simplicity, we will describe next how to run Jenkins on Java 11 
 == Running Jenkins with Docker
 
 The easiest way to run Jenkins on Java 11 is to use the Docker image.
-Since the weekly release `2.155`, each weekly releases were also packaged on a Java 11 ready Docker image.
+Since the weekly release `2.155`, each weekly release has also been packaged on a Java 11 ready Docker image.
 All these images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
 
 You can choose these Java 11 based images by using the `jdk11` tag (for the latest weekly release) or by suffixing the tag to use with `-jdk11` (eg. `2.163-jdk11`).
@@ -35,7 +35,7 @@ docker run --rm -ti \
 It is also possible to run Jenkins using the `java` command.
 
 However, we need to take some precaution with this method, because some plugins are using classes in the package `java.sql.*`.
-This package was modularized since Java 9, which means the claases inside this package are not accessible out-of-the-box.
+This package was modularized since Java 9, which means the classes inside this package are not accessible out-of-the-box.
 We need to open this module with the `java` parameter `--add-modules java.sql`.
 It is the case for example of plugin:pipeline-maven[Pipeline Maven integration] plugin but others are using classes from this package as well.
 
@@ -50,7 +50,7 @@ java \
 
 == Discovering issues with Java 11
 
-Since June 2018 to February 2019, the community performed many exploratory tests to try to discover as many issues related to Java 11 as possible.
+Between June 2018 and February 2019, the community performed many exploratory tests to try to discover as many issues related to Java 11 as possible.
 The result of this is that the community solved a lot of problem before anouncing the support of Java 11 by Jenkins.
 However, it is still possible that some plugins are not yet compatible with Java 11.
 

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -1,0 +1,71 @@
+---
+layout: documentation
+title: Running Jenkins on Java 11
+---
+
+If you need to upgrade the JVM version used to run Jenkins from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow this guidelines].
+
+NOTE: At this moment, it is not required to upgrade the JVM version in order to run a Jenkins core more recent than `2.155`.
+
+Since Jenkins `2.155`, it is possible to run Jenkins with Java 11.
+However, it was greatly simplified since version `2.163`. 
+For the sake of simplicity, we will describe next how to run Jenkins on Java 11 with the most recent version of Jenkins.
+
+== Running Jenkins with Docker
+
+The easiest way to run Jenkins on Java 11 is to use the Docker image.
+Since the weekly release `2.155`, each weekly releases were also packaged on a Java 11 ready Docker image.
+All these images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
+
+You can choose these Java 11 based images by using the `jdk11` tag (for the latest weekly release) or by suffixing the tag to use with `-jdk11` (eg. `2.163-jdk11`).
+
+This is the command to use, in order to start a Jenkins running on Java 11: 
+
+[source, shell]
+----
+docker pull jenkins/jenkins:jdk11
+docker run --rm -ti \
+  -p 8080:8080 -p 50000:50000
+  -v jenkins-home:/var/jenkins_home \
+  jenkins/jenkins:jdk11
+----
+
+== Running Jenkins with Java
+
+It is also possible to run Jenkins using the `java` command.
+At the time those lines are writen, the support of Java 11 is a opt-in.
+It means that it's a feature we need to activate when Jenkins is started.
+
+To do so, we have two options:
+
+* using the `--enable-future-java` option on the `jenkins.war` binary
+* using the `ENABLE_FUTURE_JAVA=true` environment variable.
+
+NOTE: the `--enable-future-java` option is part of the Jenkins configuration. 
+It needs to be after the `-jar jenkins.jar`.
+
+Also, because some plugins are using classes in the package `java.sql`, which is not public since Java 9, we need to open this module with the `java` parameter `--add-modules java.sql`.
+
+Starting Jenkins would be:
+
+[source, shell]
+----
+java \
+  --add-modules java.sql \
+  -jar jenkins.war \
+  --enable-future-java
+----
+
+== Discovering issues with Java 11
+
+Since June 2018 to February 2019, the community performed many exploratory tests to try to discover as many issues related to Java 11 as possible.
+The result of this is that the community solved a lot of problem before anouncing the support of Java 11 by Jenkins.
+However, it is still possible that some plugins are not yet compatible with Java 11.
+
+In order to track this, we have created a new link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues] Wiki page.
+
+If you discover any Java 11 incompatibilities, please link:https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue[report issues in our bugtracker].
+Please set `java11-compatibility` labels for such issues so that they automatically appear on the Wiki page and get triaged.
+
+For the security issues please use the standard link:https://jenkins.io/security/#reporting-vulnerabilities[vulnerability reporting process].
+Although we will be fixing Java 11 specific issues in public while it is in the preview, following the security process will help us to investigate impact on Java 8 users.

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -32,7 +32,7 @@ docker run --rm -ti \
 
 == Running Jenkins with Java
 
-It is also possible to run Jenkins using the `java` command.
+It is also possible to run Jenkins using the `java` command, just like with Java 8.
 
 Starting Jenkins would be:
 

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -10,10 +10,10 @@ In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 t
 As for any upgrade, we recommend you to backup the `JENKINS_HOME`.
 It is also recommended to test the upgrade with the backup before performing it on the production instance.
 
-== Plugins upgrade
+== Upgrading Plugins
 
-First, we need to understand that some plugins were not directly compatible with Java 11.
-So, it is important you upgrade all the plugins to the latest version available at the time you are performing the upgrade.
+Some plugins were not previously compatible with Java 11.
+Therefore it is important that you upgrade all of your plugins.
 
 One of the most important upgrades is the plugin:workflow-support[Workflow Support plugin].
 We need to make sure that the version of the plugin is at least `3.0`.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -10,10 +10,34 @@ In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 t
 As for any upgrade, we recommend you to backup the `JENKINS_HOME`.
 It is also recommended to test the upgrade with the backup before performing it on the production instance.
 
+== Upgrading Jenkins
+
+If you need to upgrade Jenkins version as well, we recommand you to:
+
+. take a backup of the `JENKINS_HOME`
+. upgrade Jenkins to `2.164`+ version
+** To upgrade Jenkins, it depends on how you install Jenkins in the first place. 
+** We recommend you to use the package manager of your system (`apt`, `yum`, etc.).
+. validate the upgrade (all plugins and jobs are loaded)
+. upgrade the required plugins (see <<Upgrading Plugins>>)
+. take a backup of the `JENKINS_HOME`
+. stop the Jenkins instance
+. upgrade the JVM to run Jenkins
+** The installation of the new JVM should be perform by a package manager.
+** Make sure the newly installed JVM is the default one, if not, make sure to use the correct `java` command in the Jenkins startup scripts (`/etc/default/jenkins` or `/etc/init.d/jenkins`).
+
+NOTE: On production environment, make sure to only use LTS version of Jenkins.
+
+If you are using Docker containers to run Jenkins, we still recommand you to follow these steps.
+To change the JDK version, you can suffix the Docker image tag with `-jdk11`.
+
 == Upgrading Plugins
 
 Some plugins were not previously compatible with Java 11.
-Therefore it is important that you upgrade all of your plugins.
+You can find the list of plugins that were fixed on the link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues] Wiki page.
+Therefore it is important that you upgrade the plugins which were fixed to support Java 11.
+
+If you face an un-reported issue, please see <<./jenkins-on-java-11#discovering-issues-with-java-11,how to report a Java 11 Compatibility issue>>.
 
 One of the most important upgrades is the plugin:workflow-support[Pipeline: Support plugin].
 We need to make sure that the version of the plugin is at least `3.0`.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -1,0 +1,19 @@
+---
+layout: documentation
+title: Upgrading Jenkins Java version from 8 to 11
+---
+
+In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 to Java 11, there are few details and steps to take care.
+
+First, we need to understand that some plugins were not directly compatible with Java 11. 
+This means that the community had to fix those plugins and release them.
+So, we need to make sure that, if those plugins are installed in our instance, we need to make sure they are installed with those versions or more recent ones.
+
+
+== Workflow Support 3.0 
+
+One of the most important upgrade is about the plugin:workflow-support[Workflow Support plugin].
+We need to make sure that the version of the plugin is at least `3.0`.
+Because this upgrade changes the serialization of the Pipeline builds, it requires that no Pipeline jobs are running when upgrading this plugin. 
+
+Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin, it is always a better option to make sure that no Pipeline builds are in progress before restarting the instance.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -37,11 +37,12 @@ This means, as we are about to run Jenkins on Java 11, we need to make sure the 
 In order to validate the version of each agent, you can rely on plugin:versioncolumn[Versions Node Monitors] plugin.
 This plugin will provide a new information on the node management screen of our Jenkins instance.
 This will permit us to visualize which JVM version each agent is using.
+The plugin can also be configured to disconnect automatically any agents which would have incorrect JVMs versions.
 
 It is also very important to note that, since Java 9, Java Web Start is deprecated. 
-This means that it is  not possible to start an agent with the JWS anymore.
+This means that it is not possible to start an agent with the JWS anymore.
 At this moment, there is no plan to replace this. 
-We do encourage you to move to a SSH connection or to use containers instead.
+We do encourage you to move to an SSH connection or to use containers instead.
 
 == JDK Tool Automatic installer
 

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -3,16 +3,14 @@ layout: documentation
 title: Upgrading Jenkins Java version from 8 to 11
 ---
 
-In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 to Java 11, there are few details and steps to take care.
+In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 to Java 11, there are a few details and steps to take care.
 
 First, we need to understand that some plugins were not directly compatible with Java 11. 
-This means that the community had to fix those plugins and release them.
-So, we need to make sure that, if those plugins are installed in our instance, we need to make sure they are installed with those versions or more recent ones.
-
+So if those plugins are installed in our instance, we need to make sure they are installed with those versions or more recent ones.
 
 == Workflow Support 3.0 
 
-One of the most important upgrade is about the plugin:workflow-support[Workflow Support plugin].
+One of the most important upgrades is the plugin:workflow-support[Workflow Support plugin].
 We need to make sure that the version of the plugin is at least `3.0`.
 Because this upgrade changes the serialization of the Pipeline builds, it requires that no Pipeline jobs are running when upgrading this plugin. 
 

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -5,75 +5,64 @@ title: Upgrading Jenkins Java version from 8 to 11
 
 In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 to Java 11, there are a few details and steps to take care.
 
+If you're upgrading the JVM used to run Jenkins, and particularly if you're upgrading from Java 8 to Java 11, there are some details you should know and precautions you should take.
+
 == Backup
 
-As for any upgrade, we recommend you to backup the `JENKINS_HOME`.
-It is also recommended to test the upgrade with the backup before performing it on the production instance.
+As with any upgrade, we recommend backing up `JENKINS_HOME` and testing the upgrade with the backup before performing the upgrade on your production instance.
 
 == Upgrading Jenkins
 
-If you need to upgrade Jenkins version as well, we recommand you to:
+NOTE: In production environments, you should use only LTS versions of Jenkins. As of February 2019, *there are no LTS versions that support Java 11*.
 
-. take a backup of the `JENKINS_HOME`
-. upgrade Jenkins to `2.164`+ version
-** To upgrade Jenkins, it depends on how you install Jenkins in the first place. 
-** We recommend you to use the package manager of your system (`apt`, `yum`, etc.).
-. validate the upgrade (all plugins and jobs are loaded)
-. upgrade the required plugins (see <<Upgrading Plugins>>)
-. take a backup of the `JENKINS_HOME`
-. stop the Jenkins instance
-. upgrade the JVM to run Jenkins
-** The installation of the new JVM should be perform by a package manager.
-** Make sure the newly installed JVM is the default one, if not, make sure to use the correct `java` command in the Jenkins startup scripts (`/etc/default/jenkins` or `/etc/init.d/jenkins`).
+If you need to upgrade Jenkins as well as the JVM, we recommand that you:
 
-NOTE: On production environment, make sure to only use LTS version of Jenkins.
+. Back up `JENKINS_HOME`
+. Upgrade Jenkins to version `2.164` or higher
+** How you upgrade Jenkins depends on how you installed Jenkins in the first place. 
+** We recommend that you use the package manager of your system (such as `apt` or `yum`).
+. Validate the upgrade to confirm that all plugins and jobs are loaded
+. Upgrade the required plugins (see <<Upgrading Plugins>>)
+. Make a second backup of `JENKINS_HOME` after upgrading Jenkins and the required plugins 
+. Stop the Jenkins instance
+. Upgrade the JVM on which Jenkins is running
+** Use a package manager to install the new JVM
+** Make sure the default JVM is the newly installed version. If it is not, use the correct `java` command in the Jenkins startup scripts (`/etc/defaJVMult/jenkins` or `/etc/init.d/jenkins`)
 
-If you are using Docker containers to run Jenkins, we still recommand you to follow these steps.
-To change the JDK version, you can suffix the Docker image tag with `-jdk11`.
+If you are using Docker containers to run Jenkins, you should follow the same process, and change the Java version by appending `-jdk11` to the Docker image tag.
 
 == Upgrading Plugins
 
-Some plugins were not previously compatible with Java 11.
-You can find the list of plugins that were fixed on the link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues] Wiki page.
-Therefore it is important that you upgrade the plugins which were fixed to support Java 11.
+It's important to not just upgrade Jenkins and the JVM but also to upgrade the plugins which support Java 11.
 
-If you face an un-reported issue, please see <<./jenkins-on-java-11#discovering-issues-with-java-11,how to report a Java 11 Compatibility issue>>.
+The list of plugins that are compatible with Java 11 is on the link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues Wiki page].
 
-One of the most important upgrades is the plugin:workflow-support[Pipeline: Support plugin].
-We need to make sure that the version of the plugin is at least `3.0`.
-Because this upgrade changes the serialization of the Pipeline builds, it requires that no Pipeline jobs are running when upgrading this plugin. 
+NOTE: If you discover a previously unreported issue, please let us know: see <<./jenkins-on-java-11#discovering-issues-with-java-11,how to report a Java 11 Compatibility issue>> for guidance.
 
-Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin upgrade, it is always a better option to make sure that no Pipeline builds are in progress before the scheduled Jenkins maintenance.
+One of the most important plugin upgrades is the plugin:workflow-support[Pipeline: Support plugin]: make sure that the version of the plugin is at least `3.0`. 
+
+NOTE: Stop all Pipeline jobs before upgrading this plugin, because this upgrade changes the serialization of Pipeline builds. As a general rule,even though Pipeline jobs are supposed to survive a Jenkins restart, it's always a better option to make sure that no Pipeline builds are in progress before any scheduled Jenkins maintenance.
 
 == Javax XML Bind libraries
 
-Some plugins are using JAXB libraries, provided by the JDK running Jenkins.
-`java.xml.bind` and `javax.activation` modules are no longer included into OpenJDK 11, and plugins might fail if there is no replacement offered
+Some plugins use JAXB libraries provided by the JDK. However, the `java.xml.bind` and `javax.activation` modules are no longer included in OpenJDK 11, and plugins might fail if no replacement is offered.
 
-In order to fix this, we bundled those libraries in a new detached plugin: plugin:jaxb[JAXB plugin].
-This new plugin will be automatically installed with Jenkins core more recent than `2.163` when running on Java 11.
-If you manage your plugins outside Jenkins (e.g. `plugins.txt` in Docker images), you might need to explicitly install the plugin.
+To fix this problem, we've bundled those libraries into a new detached plugin: plugin:jaxb[JAXB plugin]. When any Jenkins core more recent than `2.163` is running on Java 11, this plugin is automatically installed. However, if you manage your plugins outside Jenkins (fr example, if you use `plugins.txt` in your Docker images), you might need to explicitly install the plugin.
 
 == JVM version on agents
 
-It is important to know that because of the communication system between the master and its agents, all agents must be running on the same JVM version as the master.
-This means, as we are about to run Jenkins on Java 11, we need to make sure the agents JVM are upgraded as well.
+All agents must be running on the same JVM version as the master (because of how masters and agents communicate). If you're upgrading your Jenkins master to run on Java 11, you also need to upgrade the JVM on your agents. 
 
-In order to validate the version of each agent, you can rely on plugin:versioncolumn[Versions Node Monitors] plugin.
-This plugin will provide a new information on the node management screen of our Jenkins instance.
-This will permit us to visualize which JVM version each agent is using.
-The plugin can also be configured to disconnect automatically any agents which would have incorrect JVMs versions.
+You can validate the version of each agent with the plugin:versioncolumn[Versions Node Monitors] plugin. This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins instance. This plugin can also be configured to automatically disconnect any agent with an incorrect JVM version.
 
-It is also very important to note that Java Web Start was removed from Java 11. 
-This means that it is not possible to start an agent using a `*.jnlp` file anymore.
-When a Jenkins master runs with Java 11, it will no longer offer the Java Web Start button in the Web UI.
-At this moment, there is no plan to replace this. 
-We do encourage you to move to connect agents using CLI, plugins like plugin:ssh-slaves[SSH Slaves Plugin], or to use containers instead.
+Java Web Start has been removed in Java 11, which means that you can no longer start an agent using a `*.jnlp` file.
+When a Jenkins master is running on Java 11, the Java Web Start button will no longer appear in the Web UI.
+
+As of February 2019, there are no plans to replace this functionality: instead, you should connect agents with the Jenkins CLI, through plugins like plugin:ssh-slaves[SSH Slaves Plugin], or by using containers.
 
 == JDK Tool Automatic installer
 
-Since Java 11, the Oracle licensing prevent the Jenkins community to list JDK distributed by this company.
-Because of this, it is not possible, at this moment to have an automatic installation of a JDK in version 11.
-This problem is tracked with the ticket link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
+As of Jenkins 11, Oracle licensing prevents the Jenkins community from listing the JDKs distributed by Oracle. Because of this restriction, it's not possible to automatically install of a JDK in version 11.
+This problem is tracked in the issue link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
 
-We do encourage you to use containers based on images containing all the tooling you need for your build.
+As an alternative, we encourage you to use containers based on images that contain all the tooling needed for your builds.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -19,7 +19,7 @@ One of the most important upgrades is the plugin:workflow-support[Workflow Suppo
 We need to make sure that the version of the plugin is at least `3.0`.
 Because this upgrade changes the serialization of the Pipeline builds, it requires that no Pipeline jobs are running when upgrading this plugin. 
 
-Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin, it is always a better option to make sure that no Pipeline builds are in progress before restarting the instance.
+Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin upgrade, it is always a better option to make sure that no Pipeline builds are in progress before restarting the instance.
 
 == JAXB libraries
 
@@ -27,7 +27,7 @@ Some plugins were using JAXB libraries, provided by the JDK running Jenkins.
 Those libraries are no longer provided, since Java 9.
 
 In order to fix this, we bundled those libraries in a new detached plugin: plugin:jaxb[JAXB plugin].
-This new plugin will be automatically installed with Jenkins core more recent than `2.163`.
+This new plugin will be automatically installed with Jenkins core more recent than `2.163` when running on Java 11.
 
 == JVM version on agents
 

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -5,13 +5,35 @@ title: Upgrading Jenkins Java version from 8 to 11
 
 In order to upgrade the JVM used to run Jenkins, more specifically from Java 8 to Java 11, there are a few details and steps to take care.
 
-First, we need to understand that some plugins were not directly compatible with Java 11. 
-So if those plugins are installed in our instance, we need to make sure they are installed with those versions or more recent ones.
+== Backup
 
-== Workflow Support 3.0 
+As for any upgrade, we recommend you to backup the `JENKINS_HOME`.
+It is also recommended to test the upgrade with the backup before performing it on the production instance.
+
+== Plugins upgrade
+
+First, we need to understand that some plugins were not directly compatible with Java 11.
+So, it is important you upgrade all the plugins to the latest version available at the time you are performing the upgrade.
 
 One of the most important upgrades is the plugin:workflow-support[Workflow Support plugin].
 We need to make sure that the version of the plugin is at least `3.0`.
 Because this upgrade changes the serialization of the Pipeline builds, it requires that no Pipeline jobs are running when upgrading this plugin. 
 
 Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin, it is always a better option to make sure that no Pipeline builds are in progress before restarting the instance.
+
+== JAXB libraries
+
+Some plugins were using JAXB libraries, provided by the JDK running Jenkins.
+Those libraries are no longer provided, since Java 9.
+
+In order to fix this, we bundled those libraries in a new detached plugin: plugin:jaxb[JAXB plugin].
+This new plugin will be automatically installed with Jenkins core more recent than `2.163`.
+
+== JVM version on agents
+
+It is important to know that because of the communication system between the master and its agents, all agents must be running on the same JVM version as the master.
+This means, as we are about to run Jenkins on Java 11, we need to make sure the agents JVM are upgraded as well.
+
+In order to validate the version of each agent, you can rely on plugin:versioncolumn[Versions Node Monitors] plugin.
+This plugin will provide a new information on the node management screen of our Jenkins instance.
+This will permit us to visualize which JVM version each agent is using.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -37,3 +37,15 @@ This means, as we are about to run Jenkins on Java 11, we need to make sure the 
 In order to validate the version of each agent, you can rely on plugin:versioncolumn[Versions Node Monitors] plugin.
 This plugin will provide a new information on the node management screen of our Jenkins instance.
 This will permit us to visualize which JVM version each agent is using.
+
+It is also very important to note that, since Java 9, Java Web Start is deprecated. 
+This means that it is  not possible to start an agent with the JWS anymore.
+At this moment, there is no plan to replace this. 
+We do encourage you to move to a SSH connection or to use containers instead.
+
+== JDK Tool Automatic installer
+
+Since Java 11, the Oracle licensing prevent the Jenkins community to list JDK distributed by this company.
+Because of this, it is not possible, at this moment to have an automatic installation of a JDK in version 11.
+
+We do encourage you to use containers based on images containing all the tooling you need for your build.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -15,19 +15,20 @@ It is also recommended to test the upgrade with the backup before performing it 
 Some plugins were not previously compatible with Java 11.
 Therefore it is important that you upgrade all of your plugins.
 
-One of the most important upgrades is the plugin:workflow-support[Workflow Support plugin].
+One of the most important upgrades is the plugin:workflow-support[Pipeline: Support plugin].
 We need to make sure that the version of the plugin is at least `3.0`.
 Because this upgrade changes the serialization of the Pipeline builds, it requires that no Pipeline jobs are running when upgrading this plugin. 
 
-Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin upgrade, it is always a better option to make sure that no Pipeline builds are in progress before restarting the instance.
+Even if Pipeline jobs are supposed to survive a Jenkins restart, when the restart of the instance is due to a Pipeline related plugin upgrade, it is always a better option to make sure that no Pipeline builds are in progress before the scheduled Jenkins maintenance.
 
-== JAXB libraries
+== Javax XML Bind libraries
 
-Some plugins were using JAXB libraries, provided by the JDK running Jenkins.
-Those libraries are no longer provided, since Java 9.
+Some plugins are using JAXB libraries, provided by the JDK running Jenkins.
+`java.xml.bind` and `javax.activation` modules are no longer included into OpenJDK 11, and plugins might fail if there is no replacement offered
 
 In order to fix this, we bundled those libraries in a new detached plugin: plugin:jaxb[JAXB plugin].
 This new plugin will be automatically installed with Jenkins core more recent than `2.163` when running on Java 11.
+If you manage your plugins outside Jenkins (e.g. `plugins.txt` in Docker images), you might need to explicitly install the plugin.
 
 == JVM version on agents
 
@@ -39,14 +40,16 @@ This plugin will provide a new information on the node management screen of our 
 This will permit us to visualize which JVM version each agent is using.
 The plugin can also be configured to disconnect automatically any agents which would have incorrect JVMs versions.
 
-It is also very important to note that, since Java 9, Java Web Start is deprecated. 
-This means that it is not possible to start an agent with the JWS anymore.
+It is also very important to note that Java Web Start was removed from Java 11. 
+This means that it is not possible to start an agent using a `*.jnlp` file anymore.
+When a Jenkins master runs with Java 11, it will no longer offer the Java Web Start button in the Web UI.
 At this moment, there is no plan to replace this. 
-We do encourage you to move to an SSH connection or to use containers instead.
+We do encourage you to move to connect agents using CLI, plugins like plugin:ssh-slaves[SSH Slaves Plugin], or to use containers instead.
 
 == JDK Tool Automatic installer
 
 Since Java 11, the Oracle licensing prevent the Jenkins community to list JDK distributed by this company.
 Because of this, it is not possible, at this moment to have an automatic installation of a JDK in version 11.
+This problem is tracked with the ticket link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
 
 We do encourage you to use containers based on images containing all the tooling you need for your build.


### PR DESCRIPTION
[WEBSITE-497](https://issues.jenkins-ci.org/browse/WEBSITE-497)

With description to upgrade the JVM used to run Jenkins.

@jenkins-infra/java11-support-reviewer 