### PR TITLE
Clarify Shared Library documentation re: user-provided docs

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -76,9 +76,8 @@ This directory is added to the classpath when executing Pipelines.
 The `vars` directory hosts script files that are exposed as a variable in Pipelines. The name of the file is the name of the variable in the Pipeline. 
 So if you had a file called `vars/log.groovy` with a function like `def info(message)...` in it, you can access this function like `log.info "hello world"` in the Pipeline. You can put as many functions as you like inside this file. Read on below for more examples and options. 
 
-The basename of each `*.groovy` file should be a Groovy (~ Java) identifier, conventionally `camelCased`.
-The matching `*.txt`, if present, can contain documentation, processed through the system’s configured markup formatter
-(so may really be HTML, Markdown, etc., though the `txt` extension is required).
+The basename of each `.groovy` file should be a Groovy (~ Java) identifier, conventionally `camelCased`.
+The matching `.txt`, if present, can contain documentation, processed through the system’s configured https://wiki.jenkins.io/display/JENKINS/Markup+formatting[markup formatter] (so may really be HTML, Markdown, etc., though the `.txt` extension is required). This documentation will only be visible on the https://jenkins.io/doc/book/pipeline/getting-started/#global-variable-reference[Global Variable Reference] pages that are accessed from the navigation sidebar of Pipeline jobs that import the shared library. In addition, those jobs must run successfully once before the shared library documentation will be generated.
 
 The Groovy source files in these directories get the same “CPS transformation”
 as in Scripted Pipeline.


### PR DESCRIPTION
Added some text to explain where and when user-provided documentation of shared libraries will be visible in the Jenkins UI.