### PR TITLE
Office Hours info added to JCasC project

### DIFF
--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -13,30 +13,43 @@ links:
 
 The ‘as code’ paradigm is about being able to reproduce and/or restore a full environment within minutes based on recipes and automation, managed as code.
 
-== Manage configuration as human-readable config file(s)
+=== Manage configuration as human-readable config file(s)
 
 Setting up Jenkins is a complex process, as both Jenkins and its plugins require some tuning and configuration,
 with dozens of parameters to set within the web UI manage section.
 
 Jenkins Configuration as Code allows to define this whole configuration as a simple, human-friendly, plain text yaml syntax. Without any manual step this configuration can be validated and applied to a Jenkins master in fully a reproducible way. With JCasC setting up a new Jenkins master will become a no-brainer event.
 
-== Configure ALL jenkins initial setup
+=== Configure ALL jenkins initial setup
 
 Fully working Jenkins master with:
 
 * **no hands** on keyboard
 * **no click** on UI
 
-== Support most plugins without extra development effort
+=== Support most plugins without extra development effort
 
 * No need to write glue code for every supported plugin
 * Most plugins supported out of the box
 * Others can bundle adapter code
 
-== Getting started
+=== Getting started
 
 * link:https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md[*Documentation and getting started*]
 * You can ask questions about it on the regular Jenkins Developer mailing list (just prefix with [JCasC]).
 * The link:https://github.com/jenkinsci/configuration-as-code-plugin[source code]
 * Feature requests, bugs and so on are currently tracked via the github link:https://github.com/jenkinsci/configuration-as-code-plugin/issues[issue tracker]
 
+=== Office Hours meeting
+
+The purpose of JCasC Office Hours meeting is to discuss current issues but also short and long term future of the plugin
+
+==== Time and location
+The meeting takes place on Wednesdays, 9am (UTC+1) every two weeks. 
+
+Meetings will be announced at link:https://jenkins.io/event-calendar/[*Event Calendar*]
+
+Hangouts On Air is used to host and stream the meeting on link:https://www.youtube.com/channel/UC5JBtmoz7ePk-33ZHimGiDQ[*Jenkins Youtube channel*].
+Link to the actual meeting is always shared a few minutes before the meeting at link:http://gitter.im/jenkinsci/configuration-as-code-plugin[*configuration-as-code-plugin*] gitter channel
+
+link:https://docs.google.com/document/d/1Hm07Q1egWL6VVAqNgu27bcMnqNZhYJmXKRvknVw4Y84/edit?usp=sharing[*Minutes of Meeting*] are available for everyone interested

--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -8,6 +8,7 @@ tags:
 links:
   gitter: 'jenkinsci/configuration-as-code-plugin'
   github: 'jenkinsci/configuration-as-code-plugin'
+  meetings: "/projects/projects/jcasc/#office-hours-meeting"
 
 ---
 


### PR DESCRIPTION
adding short info regarding Office Hours meeting so it can be announced with https://jenkins.io/event-calendar/

@oleg-nenashev please comment once you have time