### PR TITLE
[WEBSITE-623] Change plugin:jdk-tool by jdk tool (it's not the same)

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -33,7 +33,7 @@ Generally, Jenkins allows ANY version of JRE/JDK to be invoked during the build.
 It includes:
 
 * Execution of Java commands from CLI
-* Installation and execution of build steps based on the plugin:jdk-tool plugin
+* Installation and execution of build steps based on the jdk tool
 
 In the case of particular plugins, there are still Java requirements:
 

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -33,7 +33,7 @@ Generally, Jenkins allows ANY version of JRE/JDK to be invoked during the build.
 It includes:
 
 * Execution of Java commands from CLI
-* Installation and execution of build steps based on the jdk tool
+* Installation and execution of build steps using JDK managed by JDK tool installers
 
 In the case of particular plugins, there are still Java requirements:
 


### PR DESCRIPTION
See [[WEBSITE-623] Change jdk-tool-plugin by jdk tool in Java requirements page](https://issues.jenkins-ci.org/browse/WEBSITE-623)

The jdk-tool-plugin is a plugin to add an automatic installer for JDKs downloading them from Oracle web site based on a crawler that relies on the structure of the Oracle Web Site. 

It's not a recommended approach to use this way of installing JDKs, so the official documentation can't talk about this plugin as the main way of executing builds with different Java versions.

Just **change** the use of the **jdk-tool-plugin by jdk tool**, slight difference but important.

@jenkins-infra/java11-support  