### PR TITLE
Update 'Chat' page

### DIFF
--- a/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
+++ b/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
@@ -19,7 +19,7 @@ image:pipeline/realworld-pipeline-flow.png[alt="Pipeline Flow",width=100%]
 
 _Source of image: link:/doc/book/pipeline/[https://jenkins.io/doc/book/pipeline/]_
 
-# Jenkins Pipelines
+## Jenkins Pipelines
 
 https://jenkins.io/[Jenkins] is a well-known open source continuous integration and continuous deployment automation tool. With the latest 2.0 release, Jenkins introduced the Pipeline plugin that implements Pipeline-as-code. This plugin lets you define delivery pipelines using concise scripts which deal elegantly with jobs involving persistence and asynchrony. 
 
@@ -27,11 +27,11 @@ The Pipeline-as-code's script is also known as a _Jenkinsfile_.
 
 Jenkinsfiles uses a domain specific language syntax based on the http://groovy-lang.org/[Groovy] programming language. They are persistent files which can be checked in and version-controlled along with the rest of their project source code. This file can contain the complete set of encoded steps (steps, nodes, and stages) necessary to define the entire application life-cycle, becoming the intersecting point between development and operations.
 
-## Missing piece of the puzzle 
+### Missing piece of the puzzle
 
 One of the most common steps defined in a basic pipeline job is the _Deploy_ step. The deployment stage encompasses everything from publishing build artifacts to pushing code into pre-production and production environments. This deployment stage usually involves both development and operations teams logging onto various remote nodes to run commands and/or scripts to deploy code and configuration. While there are a couple of existing ssh plugins for Jenkins, they currently don't support the functionality such as logging into nodes for pipelines. Thus, there was a need for a plugin that supports these steps.
 
-# Introducing SSH Steps
+## Introducing SSH Steps
 
 image::/images/post-images/2019-02-06-ssh-steps/JenkinsPlusSSH.png[SSH Steps, role=center]
 
@@ -45,7 +45,7 @@ The initial version of this new plugin SSH Steps supports the following:
 * `sshPut`: Puts a file/directory from the current workspace to remote node. 
 * `sshRemove`: Removes a file/directory from the remote node.
 
-## Usage 
+### Usage
 
 Below is a simple demonstration on how to use above steps. More documentation can be found on https://github.com/jenkinsci/ssh-steps-plugin/blob/master/README.adoc[GitHub].
 
@@ -72,7 +72,7 @@ node {
 }
 ```
 
-## Configuring via YAML
+### Configuring via YAML
 
 At Cerner, we always strive to have simple configuration files for CI/CD pipelines whenever possible. With that in mind, my team built a wrapper on top of these steps from this plugin. After some design and analysis, we came up with the following YAML structure to run commands across various remote groups:
 
@@ -121,7 +121,7 @@ steps:
 
 The above example runs commands from `c_group_1` on remote nodes within `r_group_1` in parallel before it moves on to the next group using `sshUserAcct` (from the https://jenkins.io/doc/book/using/using-credentials/[Jenkins Credentials] store) to logon to nodes.
 
-## Shared Pipeline Library
+### Shared Pipeline Library
 
 We have created a shared pipeline library that contains a `sshDeploy` step to support the above mentioned YAML syntax. Below is the code snippet for the sshDeploy step from the library. The full version can be found https://github.com/nrayapati/ssh-deploy-library[here] on Github.
 
@@ -190,7 +190,7 @@ An example execution of the above pipeline code in Blue Ocean looks like this:
 
 image::/images/post-images/2019-02-06-ssh-steps/jenkins-ssh-deploy.png[SSH Deploy BlueOcean View, width=80%, role=center]
 
-## Wrapping up
+### Wrapping up
 
 Steps from the https://github.com/jenkinsci/ssh-steps-plugin[SSH Steps Plugin] are deliberately generic enough that they can be used for various other use-cases as well, not just for deploying code. Using SSH Steps has significantly reduced the time we spend on deployments and has given us the possibility of easily scaling our deployment workflows to various environments. 
 

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -7,25 +7,14 @@ title: Chat
 
 The Jenkins community discusses various topics in multiple rooms on https://gitter.im/jenkinsci/home[Gitter]
 
-=== https://gitter.im/jenkinsci/jenkins[Jenkins]
+=== https://gitter.im/jenkinsci/jenkins[jenkinsci/jenkins]
 
-General discussion about the Jenkins Continuous Integration Server
+General discussions about Jenkins.
 
-=== https://gitter.im/jenkinsci/advocacy-and-outreach-sig[Jenkins Advocacy and Outreach]
+=== https://gitter.im/jenkinsci/advocacy-and-outreach-sig[jenkinsci/advocacy-and-outreach-sig]
 
 Discuss community topics such as jenkins.io, events, process, and how we collaborate.
 
-=== https://gitter.im/jenkinsci/blueocean-plugin[Blue Ocean Plugin]
-
-Discuss the new Jenkins UI: Blue Ocean.
-
-=== https://gitter.im/jenkinsci/gsoc-sig[Google Summer of Code]
-
-Discuss the Google Summer of Code projects.
-
-=== https://gitter.im/jenkinsci/configuration-as-code-plugin[Jenkins Configuration-as-Code Plugin]
-
-Discuss the new Jenkins Configuration As Code Plugin
 
 == Internet Relay Chat (IRC)
 
@@ -87,14 +76,6 @@ See the link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agen
 === `#jenkins-infra`
 
 Discussions of the Jenkins project infrastructure, i.e. most services running on `jenkins.io`, `jenkins-ci.org`, and related domains.
-
-=== `#jenkins-cert`
-
-Invitation-only IRC channel for link:/security/#team[the Jenkins security team].
-
-=== `#jenkins-commits`
-
-Commit messages of commits pushed to GitHub will be posted here by *github-jenkins*. _Note that this channel may be empty most of the time, but messages still are posted._
 
 === `#jenkins-hackhouse`
 

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -3,11 +3,9 @@ layout: simplepage
 title: Chat
 ---
 
-= Gitter
+== Gitter
 
 The Jenkins community discusses various topics in multiple rooms on https://gitter.im/jenkinsci/home[Gitter]
-
-== Gitter Rooms
 
 === https://gitter.im/jenkinsci/jenkins[Jenkins]
 
@@ -29,7 +27,7 @@ Discuss the Google Summer of Code projects.
 
 Discuss the new Jenkins Configuration As Code Plugin
 
-= Internet Relay Chat (IRC)
+== Internet Relay Chat (IRC)
 
 The Jenkins community discusses various project-related topics in multiple channels on the http://www.freenode.net[Freenode] IRC network.
 
@@ -49,8 +47,6 @@ That means you basically need to create a reserved nick for you, link:https://fr
 Once done, you will be able to connect to `#jenkins` even if that channel is undergoing a spam attack.
 Note that even without this, this is a recommended practice so that people *know* this is you, and cannot be someone else, when a given nick is online.
 ====
-
-== IRC Channels
 
 === `#jenkins`
 
@@ -104,7 +100,7 @@ Commit messages of commits pushed to GitHub will be posted here by *github-jenki
 
 Channel for Jenkins hackathons and other similar non-regular events.
 
-== Cloaks
+=== Cloaks
 
 #jenkins is not only a registered channel, but the Jenkins project has an official relationship with Freenode (see https://freenode.net/groupreg[the Freenode site] for more details).
 Because of this, we can provide IRC cloaks for developers.

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -4,7 +4,7 @@ title: Chat
 ---
 
 The Jenkins project meets to discuss various topics on Gitter and IRC.
-In addition to the general purpose rooms and channels listed below, link:../sigs/[special interest groups] have their own spaces, and you will see chat rooms linked from the SIGs overview page.
+In addition to the general purpose rooms and channels listed below, link:../sigs/[special interest groups] and link:/projects[sub-projects] have their own spaces, and you will see chat rooms linked from their pages.
 
 == Gitter
 

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -57,11 +57,6 @@ link:/projects/infrastructure/ircbot/[Learn more].
 https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Board members and officers] typically have _op_ (@) in this channel.
 Established contributors typically have _voice_ (+) in this channel.
 
-=== `#jenkins-community`
-
-The channel to help organize events, documentation and more "meta conversations" around the Jenkins project.
-We don't discuss Jenkins -- the software -- here. You can find conversation logs on https://botbot.me/freenode/jenkins-community/[botbot.me].
-
 [[meeting]]
 === `#jenkins-meeting`
 
@@ -73,13 +68,14 @@ Meetings are logged, and the channel is unused the rest of the time.
 We use the *robobutler* to run these meetings.
 See the link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda[about project meetings] for more details.
 
+=== `#jenkins-community`
+
+The channel to help organize events, documentation and more "meta conversations" around the Jenkins project.
+We don't discuss Jenkins -- the software -- here. You can find conversation logs on https://botbot.me/freenode/jenkins-community/[botbot.me].
+
 === `#jenkins-infra`
 
 Discussions of the Jenkins project infrastructure, i.e. most services running on `jenkins.io`, `jenkins-ci.org`, and related domains.
-
-=== `#jenkins-hackhouse`
-
-Channel for Jenkins hackathons and other similar non-regular events.
 
 === Cloaks
 

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -3,9 +3,13 @@ layout: simplepage
 title: Chat
 ---
 
+The Jenkins project meets to discuss various topics on Gitter and IRC.
+In addition to the general purpose rooms and channels listed below, link:../sigs/[special interest groups] have their own spaces, and you will see chat rooms linked from the SIGs overview page.
+
 == Gitter
 
-The Jenkins community discusses various topics in multiple rooms on https://gitter.im/jenkinsci/home[Gitter]
+The Jenkins community discusses various topics in multiple rooms on https://gitter.im/jenkinsci/home[Gitter].
+Various link:../sigs/[special interest groups] also use Gitter to meet, and you will find their rooms linked on the SIGs overview page.
 
 === https://gitter.im/jenkinsci/jenkins[jenkinsci/jenkins]
 

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -11,11 +11,6 @@ The Jenkins community discusses various topics in multiple rooms on https://gitt
 
 General discussions about Jenkins.
 
-=== https://gitter.im/jenkinsci/advocacy-and-outreach-sig[jenkinsci/advocacy-and-outreach-sig]
-
-Discuss community topics such as jenkins.io, events, process, and how we collaborate.
-
-
 == Internet Relay Chat (IRC)
 
 The Jenkins community discusses various project-related topics in multiple channels on the http://www.freenode.net[Freenode] IRC network.


### PR DESCRIPTION
* Use unambiguous Gitter room identifiers as they (also) appear on the UI.
* Remove some of the more specialized, or obsolete, chats. We don't need everything here, just those we can reasonable expect people to be interested in coming through the generic 'chat' page. Otherwise it's just too long of a list.
* Fix formatting based on errors printed during build

Also updates formatting of a blog post the build also complained about.