### PR TITLE
Add GSoC to the list of events

### DIFF
--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -62,6 +62,21 @@ notitle: true
                   14h UTC
               %h5.title
                 Platform SIG Meeting
+    .col-md-6.text-center
+      %ul.ji-item-list
+        %li.post.event.floating
+          %a.body{:href => 'https://jenkins.io/projects/gsoc#office-hours', :target => '_blank'}
+            .header.time
+              .date-time
+                .date
+                  .day.small
+                    Wednesdays
+                  .dow
+                    Wed
+                .time
+                  14h UTC
+              %h5.title
+                Google Summer of Code Office Hours
 
   .row
     .col

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -88,7 +88,9 @@ we also have regular "office hours" video calls.
 During these timeslots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
 
 Before the announcement of accepted projects,
-we will be using a weekly link:sigs/gsoc[GSoC SIG] meeting as the office hours slot (2PM UTC on Wednesdays).
+we will be using a weekly link:/sigs/gsoc[GSoC SIG] meeting as the office hours slot (2PM UTC on Wednesdays).
+You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
+
 More slots may be added in the future.
 We post links in link:https://gitter.im/jenkinsci/gsoc-sig[our Gitter channel]
 before the meeting starts.


### PR DESCRIPTION
I would like to add GSoC to the list of recurring [events](https://jenkins.io/events/).
