### PR TITLE
Bump up to Ruby 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'colorize'
 gem 'awestruct', '~> 0.5.7'
 gem 'awestruct-ibeams', '~> 0.4'
 gem 'asciidoctor-jenkins-extensions'
-gem 'asciidoctor', '~> 1.5.5'
+gem 'asciidoctor', '~> 1.5.8'
 
 # Support for various template engines we use
 gem 'haml', '~> 4.0.7'
@@ -19,7 +19,7 @@ group :fetcher do
 end
 
 group :pdfs do
-  gem 'asciidoctor-pdf', '1.5.0.alpha.15'
+  gem 'asciidoctor-pdf', '1.5.0.alpha.16'
 end
 
 gem "concurrent-ruby", "~> 1.1"

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME=ruby:2.3
+CONTAINER_NAME=ruby:2.6
 source ./scripts/docker-env
 
 if [ ! -z ${LISTEN+x} ]; then


### PR DESCRIPTION
According to https://www.ruby-lang.org/en/downloads/branches/ ,
ruby 2.3 is nearing EOL, so bump up version used for building docs at jenkins.io