### PR TITLE
Reduce the size of the "restart stage" animated png

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -21,6 +21,10 @@ h6[id]:before {
   opacity: 0;
 }
 
+img {
+  max-width: 100%;
+}
+
 .anchorjs-link:hover {
   opacity: 1;
 }


### PR DESCRIPTION
Reduces the size of the animated png that was added in https://github.com/jenkins-infra/jenkins.io/pull/2129 showing the "restart" stage functionality