### PR TITLE
[WEBSITE-474] Use Official Jenkins docker image in documentation

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -11,7 +11,7 @@ the sibling file _docker.adoc (used in index.adoc).
 ==== On macOS and Linux
 
 . Open up a terminal window.
-. Run the `jenkinsci/blueocean` image as a container in Docker using the
+. Run the `jenkinsci/jenkins` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
   command (bearing in mind that this command automatically downloads the image
@@ -26,7 +26,7 @@ docker run \
   -v jenkins-data:/var/jenkins_home \ # <1>
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$HOME":/home \ # <2>
-  jenkinsci/blueocean
+  jenkinsci/jenkins
 ----
 <1> Maps the `/var/jenkins_home` directory in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
@@ -48,7 +48,7 @@ docker run \
   -v jenkins-data:/var/jenkins_home \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$HOME":/home \
-  jenkinsci/blueocean
+  jenkinsci/jenkins
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.
 
@@ -56,7 +56,7 @@ docker run \
 ==== On Windows
 
 . Open up a command prompt window.
-. Run the `jenkinsci/blueocean` image as a container in Docker using the
+. Run the `jenkinsci/jenkins` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
   command (bearing in mind that this command automatically downloads the image
@@ -70,24 +70,24 @@ docker run ^
   -v jenkins-data:/var/jenkins_home ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v "%HOMEPATH%":/home ^
-  jenkinsci/blueocean
+  jenkinsci/jenkins
 ----
 For an explanation of these options, refer to the <<on-macos-and-linux,macOS
 and Linux>> instructions above.
 . Proceed to the <<setup-wizard,Setup wizard>>.
 
 
-==== Accessing the Jenkins/Blue Ocean Docker container
+==== Accessing the Jenkins Docker container
 
 If you have some experience with Docker and you wish or need to access the
-Jenkins/Blue Ocean Docker container through a terminal/command prompt using the
+Jenkins Docker container through a terminal/command prompt using the
 link:https://docs.docker.com/engine/reference/commandline/exec/[`docker exec`]
 command, you can add an option like `--name jenkins-tutorials` (with the
 link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
-above), which would give the Jenkins/Blue Ocean Docker container the name
+above), which would give the Jenkins Docker container the name
 "jenkins-tutorials".
 
-This means you could access the Jenkins/Blue Ocean container (through a separate
+This means you could access the Jenkins container (through a separate
 terminal/command prompt window) with a `docker exec` command like:
 
 `docker exec -it jenkins-tutorials bash`

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -11,7 +11,7 @@ the sibling file _docker.adoc (used in index.adoc).
 ==== On macOS and Linux
 
 . Open up a terminal window.
-. Run the `jenkinsci/jenkins` image as a container in Docker using the
+. Run the `jenkins/jenkins` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
   command (bearing in mind that this command automatically downloads the image
@@ -26,7 +26,7 @@ docker run \
   -v jenkins-data:/var/jenkins_home \ # <1>
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$HOME":/home \ # <2>
-  jenkinsci/jenkins
+  jenkins/jenkins
 ----
 <1> Maps the `/var/jenkins_home` directory in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
@@ -48,7 +48,7 @@ docker run \
   -v jenkins-data:/var/jenkins_home \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$HOME":/home \
-  jenkinsci/jenkins
+  jenkins/jenkins
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.
 
@@ -56,7 +56,7 @@ docker run \
 ==== On Windows
 
 . Open up a command prompt window.
-. Run the `jenkinsci/jenkins` image as a container in Docker using the
+. Run the `jenkins/jenkins` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
   command (bearing in mind that this command automatically downloads the image
@@ -70,7 +70,7 @@ docker run ^
   -v jenkins-data:/var/jenkins_home ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v "%HOMEPATH%":/home ^
-  jenkinsci/jenkins
+  jenkins/jenkins
 ----
 For an explanation of these options, refer to the <<on-macos-and-linux,macOS
 and Linux>> instructions above.

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -13,10 +13,7 @@ _run-jenkins-in-docker.adoc).
 ===== On macOS and Linux
 
 . Open up a terminal window.
-. Download the `jenkinsci/blueocean` image and run it as a container in Docker
-  using the following
-  link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
-  command:
+. Download the `jenkinsci/jenkins` image and run it as a container in Docker using the following link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`] command:
 +
 [source,bash]
 ----
@@ -28,24 +25,24 @@ docker run \
   -p 50000:50000 \ # <4>
   -v jenkins-data:/var/jenkins_home \ # <5>
   -v /var/run/docker.sock:/var/run/docker.sock \ # <6>
-  jenkinsci/blueocean # <7>
+  jenkinsci/jenkins # <7>
 ----
 <1> ( _Optional_ ) Automatically removes the Docker container (which is the
-instantiation of the `jenkinsci/blueocean` image below) when it is shut down.
+instantiation of the `jenkinsci/jenkins` image below) when it is shut down.
 This keeps things tidy if you need to quit Jenkins.
-<2> ( _Optional_ ) Runs the `jenkinsci/blueocean` container in the background
+<2> ( _Optional_ ) Runs the `jenkinsci/jenkins` container in the background
 (i.e. "detached" mode) and outputs the container ID. If you do not specify this
 option, then the running Docker log for this container is output in the terminal
 window.
-<3> Maps (i.e. "publishes") port 8080 of the `jenkinsci/blueocean` container to
+<3> Maps (i.e. "publishes") port 8080 of the `jenkinsci/jenkins` container to
 port 8080 on the host machine. The first number represents the port on the host
 while the last represents the container's port. Therefore, if you specified `-p
 49000:8080` for this option, you would be accessing Jenkins on your host machine
 through port 49000.
-<4> ( _Optional_ ) Maps port 50000 of the `jenkinsci/blueocean` container to
+<4> ( _Optional_ ) Maps port 50000 of the `jenkinsci/jenkins` container to
 port 50000 on the host machine. This is only necessary if you have set up one or
 more JNLP-based Jenkins agents on other machines, which in turn interact with
-the `jenkinsci/blueocean` container (acting as the "master" Jenkins server, or
+the `jenkinsci/jenkins` container (acting as the "master" Jenkins server, or
 simply "Jenkins master"). JNLP-based Jenkins agents communicate with the Jenkins
 master through TCP port 50000 by default. You can change this port number on
 your Jenkins master through the <<managing/security#,Configure Global Security>>
@@ -78,14 +75,14 @@ directory on your local machine, which would typically be
 `/Users/<your-username>/jenkins` or `/home/<your-username>/jenkins`.
 <6> ( _Optional_ ) `/var/run/docker.sock` represents the Unix-based socket
 through which the Docker daemon listens on. This mapping allows the
-`jenkinsci/blueocean` container to communicate with the Docker daemon, which is
-required if the `jenkinsci/blueocean` container needs to instantiate other
+`jenkinsci/jenkins` container to communicate with the Docker daemon, which is
+required if the `jenkinsci/jenkins` container needs to instantiate other
 Docker containers. This option is necessary if you run declarative Pipelines
 whose syntax contains the <<pipeline/syntax#agent,`agent`>> section with the
 `docker` parameter - i.e. +
 `agent { docker { ... } }`. Read more about this on the
 <<pipeline/syntax#,Pipeline Syntax>> page.
-<7> The `jenkinsci/blueocean` Docker image itself. If this image has not already
+<7> The `jenkinsci/jenkins` Docker image itself. If this image has not already
 been downloaded, then this `docker run` command will automtically download the
 image for you. Furthermore, if any updates to this image were published since
 you last ran this command, then running this command again will automatically
@@ -94,7 +91,7 @@ download these published image updates for you. +
 using the
 link:https://docs.docker.com/engine/reference/commandline/pull/[`docker pull`]
 command: +
-`docker pull jenkinsci/blueocean`
+`docker pull jenkinsci/jenkins`
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
@@ -109,7 +106,7 @@ docker run \
   -p 50000:50000 \
   -v jenkins-data:/var/jenkins_home \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  jenkinsci/blueocean
+  jenkinsci/jenkins
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
@@ -117,7 +114,7 @@ docker run \
 ===== On Windows
 
 . Open up a command prompt window.
-. Download the `jenkinsci/blueocean` image and run it as a container in Docker
+. Download the `jenkinsci/jenkins` image and run it as a container in Docker
   using the following
   link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
   command:
@@ -132,28 +129,27 @@ docker run ^
   -p 50000:50000 ^
   -v jenkins-data:/var/jenkins_home ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
-  jenkinsci/blueocean
+  jenkinsci/jenkins
 ----
 For an explanation of each of these options, refer to the <<on-macos-and-linux,
 macOS and Linux>> instructions above.
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
 
-==== Accessing the Jenkins/Blue Ocean Docker container
+==== Accessing the Jenkins Docker container
 
 If you have some experience with Docker and you wish or need to access the
-`jenkinsci/blueocean` container through a terminal/command prompt using the
+`jenkinsci/jenkins` container through a terminal/command prompt using the
 link:https://docs.docker.com/engine/reference/commandline/exec/[`docker exec`]
-command, you can add an option like `--name jenkins-blueocean` (with the
+command, you can add an option like `--name jenkins-master` (with the
 link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
-above), which would give the `jenkinsci/blueocean` container the name
-"jenkins-blueocean".
+above), which would give the `jenkinsci/jenkins` container the name
+"jenkins-master".
 
 This means you could access the container (through a separate terminal/command
 prompt window) with a `docker exec` command like:
 
-`docker exec -it jenkins-blueocean bash`
-
+`docker exec -it jenkins-master bash`
 
 ==== Accessing the Jenkins console log through Docker logs
 
@@ -168,19 +164,18 @@ which you ran this Docker command.
 
 Otherwise, you can access the Jenkins console log through the
 link:https://docs.docker.com/engine/reference/commandline/logs/[Docker logs] of
-the `jenkinsci/blueocean` container using the following command:
+the `jenkinsci/jenkins` container using the following command:
 
 `docker logs <docker-container-name>`
 
 Your `<docker-container-name>` can be obtained using the
 link:https://docs.docker.com/engine/reference/commandline/ps/[`docker ps`]
 command. If you specified the +
-`--name jenkins-blueocean` option in the `docker run ...` command above (see
+`--name jenkins-master` option in the `docker run ...` command above (see
 also
-<<accessing-the-jenkins-blue-ocean-docker-container,Accessing the Jenkins/Blue
-Ocean Docker container>>), you can simply use the `docker logs` command:
+<<accessing-the-jenkins-docker-container,Accessing the Jenkins Docker container>>), you can simply use the `docker logs` command:
 
-`docker logs jenkins-blueocean`
+`docker logs jenkins-master`
 
 
 ==== Accessing the Jenkins home directory
@@ -196,7 +191,7 @@ contents of this directory through your machine's usual terminal/command prompt.
 
 Otherwise, if you specified the `-v jenkins-data:/var/jenkins_home` option in
 the `docker run ...` command, you can access the contents of the Jenkins home
-directory through the `jenkinsci/blueocean` container's terminal/command prompt
+directory through the `jenkinsci/jenkins` container's terminal/command prompt
 using the
 link:https://docs.docker.com/engine/reference/commandline/exec/[`docker exec`]
 command:
@@ -207,22 +202,22 @@ As mentioned <<accessing-the-jenkins-console-log-through-docker-logs,above>>,
 your `<docker-container-name>` can be obtained using the
 link:https://docs.docker.com/engine/reference/commandline/ps/[`docker ps`]
 command. If you specified the +
-`--name jenkins-blueocean` option in the `docker run ...`
+`--name jenkins-master` option in the `docker run ...
 command above (see also
-<<accessing-the-jenkins-blue-ocean-docker-container,Accessing the Jenkins/Blue
-Ocean Docker container>>), you can simply use the `docker exec` command:
+<<accessing-the-jenkins-docker-container,Accessing the Jenkins Docker container>>), 
+you can simply use the `docker exec` command:
 
-`docker exec -it jenkins-blueocean bash`
+`docker exec -it jenkins-master bash`
 
 ////
 Might wish to add explaining the `docker run -t` option, which was covered in
 the old installation instructions but not above.
 
-Also mention that spinning up a container of the `jenkinsci/blueocean` Docker
+Also mention that spinning up a container of the `jenkinsci/jenkins` Docker
 image can be done so with all the same
 https://github.com/jenkinsci/docker#usage[configuration options] available to
 the other images published by the Jenkins project.
 
 Explain colon syntax on Docker image references like
-`jenkinsci/blueocean:latest'.
+`jenkinsci/jenkins:latest'.
 ////

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -13,7 +13,7 @@ _run-jenkins-in-docker.adoc).
 ===== On macOS and Linux
 
 . Open up a terminal window.
-. Download the `jenkinsci/jenkins` image and run it as a container in Docker using the following link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`] command:
+. Download the `jenkins/jenkins` image and run it as a container in Docker using the following link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`] command:
 +
 [source,bash]
 ----
@@ -25,24 +25,24 @@ docker run \
   -p 50000:50000 \ # <4>
   -v jenkins-data:/var/jenkins_home \ # <5>
   -v /var/run/docker.sock:/var/run/docker.sock \ # <6>
-  jenkinsci/jenkins # <7>
+  jenkins/jenkins # <7>
 ----
 <1> ( _Optional_ ) Automatically removes the Docker container (which is the
-instantiation of the `jenkinsci/jenkins` image below) when it is shut down.
+instantiation of the `jenkins/jenkins` image below) when it is shut down.
 This keeps things tidy if you need to quit Jenkins.
-<2> ( _Optional_ ) Runs the `jenkinsci/jenkins` container in the background
+<2> ( _Optional_ ) Runs the `jenkins/jenkins` container in the background
 (i.e. "detached" mode) and outputs the container ID. If you do not specify this
 option, then the running Docker log for this container is output in the terminal
 window.
-<3> Maps (i.e. "publishes") port 8080 of the `jenkinsci/jenkins` container to
+<3> Maps (i.e. "publishes") port 8080 of the `jenkins/jenkins` container to
 port 8080 on the host machine. The first number represents the port on the host
 while the last represents the container's port. Therefore, if you specified `-p
 49000:8080` for this option, you would be accessing Jenkins on your host machine
 through port 49000.
-<4> ( _Optional_ ) Maps port 50000 of the `jenkinsci/jenkins` container to
+<4> ( _Optional_ ) Maps port 50000 of the `jenkins/jenkins` container to
 port 50000 on the host machine. This is only necessary if you have set up one or
 more JNLP-based Jenkins agents on other machines, which in turn interact with
-the `jenkinsci/jenkins` container (acting as the "master" Jenkins server, or
+the `jenkins/jenkins` container (acting as the "master" Jenkins server, or
 simply "Jenkins master"). JNLP-based Jenkins agents communicate with the Jenkins
 master through TCP port 50000 by default. You can change this port number on
 your Jenkins master through the <<managing/security#,Configure Global Security>>
@@ -75,14 +75,14 @@ directory on your local machine, which would typically be
 `/Users/<your-username>/jenkins` or `/home/<your-username>/jenkins`.
 <6> ( _Optional_ ) `/var/run/docker.sock` represents the Unix-based socket
 through which the Docker daemon listens on. This mapping allows the
-`jenkinsci/jenkins` container to communicate with the Docker daemon, which is
-required if the `jenkinsci/jenkins` container needs to instantiate other
+`jenkins/jenkins` container to communicate with the Docker daemon, which is
+required if the `jenkins/jenkins` container needs to instantiate other
 Docker containers. This option is necessary if you run declarative Pipelines
 whose syntax contains the <<pipeline/syntax#agent,`agent`>> section with the
 `docker` parameter - i.e. +
 `agent { docker { ... } }`. Read more about this on the
 <<pipeline/syntax#,Pipeline Syntax>> page.
-<7> The `jenkinsci/jenkins` Docker image itself. If this image has not already
+<7> The `jenkins/jenkins` Docker image itself. If this image has not already
 been downloaded, then this `docker run` command will automtically download the
 image for you. Furthermore, if any updates to this image were published since
 you last ran this command, then running this command again will automatically
@@ -91,7 +91,7 @@ download these published image updates for you. +
 using the
 link:https://docs.docker.com/engine/reference/commandline/pull/[`docker pull`]
 command: +
-`docker pull jenkinsci/jenkins`
+`docker pull jenkins/jenkins`
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
@@ -106,7 +106,7 @@ docker run \
   -p 50000:50000 \
   -v jenkins-data:/var/jenkins_home \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  jenkinsci/jenkins
+  jenkins/jenkins
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
@@ -114,7 +114,7 @@ docker run \
 ===== On Windows
 
 . Open up a command prompt window.
-. Download the `jenkinsci/jenkins` image and run it as a container in Docker
+. Download the `jenkins/jenkins` image and run it as a container in Docker
   using the following
   link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
   command:
@@ -129,7 +129,7 @@ docker run ^
   -p 50000:50000 ^
   -v jenkins-data:/var/jenkins_home ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
-  jenkinsci/jenkins
+  jenkins/jenkins
 ----
 For an explanation of each of these options, refer to the <<on-macos-and-linux,
 macOS and Linux>> instructions above.
@@ -139,11 +139,11 @@ macOS and Linux>> instructions above.
 ==== Accessing the Jenkins Docker container
 
 If you have some experience with Docker and you wish or need to access the
-`jenkinsci/jenkins` container through a terminal/command prompt using the
+`jenkins/jenkins` container through a terminal/command prompt using the
 link:https://docs.docker.com/engine/reference/commandline/exec/[`docker exec`]
 command, you can add an option like `--name jenkins-master` (with the
 link:https://docs.docker.com/engine/reference/commandline/run/[`docker run`]
-above), which would give the `jenkinsci/jenkins` container the name
+above), which would give the `jenkins/jenkins` container the name
 "jenkins-master".
 
 This means you could access the container (through a separate terminal/command
@@ -164,7 +164,7 @@ which you ran this Docker command.
 
 Otherwise, you can access the Jenkins console log through the
 link:https://docs.docker.com/engine/reference/commandline/logs/[Docker logs] of
-the `jenkinsci/jenkins` container using the following command:
+the `jenkins/jenkins` container using the following command:
 
 `docker logs <docker-container-name>`
 
@@ -191,7 +191,7 @@ contents of this directory through your machine's usual terminal/command prompt.
 
 Otherwise, if you specified the `-v jenkins-data:/var/jenkins_home` option in
 the `docker run ...` command, you can access the contents of the Jenkins home
-directory through the `jenkinsci/jenkins` container's terminal/command prompt
+directory through the `jenkins/jenkins` container's terminal/command prompt
 using the
 link:https://docs.docker.com/engine/reference/commandline/exec/[`docker exec`]
 command:
@@ -213,11 +213,11 @@ you can simply use the `docker exec` command:
 Might wish to add explaining the `docker run -t` option, which was covered in
 the old installation instructions but not above.
 
-Also mention that spinning up a container of the `jenkinsci/jenkins` Docker
+Also mention that spinning up a container of the `jenkins/jenkins` Docker
 image can be done so with all the same
 https://github.com/jenkinsci/docker#usage[configuration options] available to
 the other images published by the Jenkins project.
 
 Explain colon syntax on Docker image references like
-`jenkinsci/jenkins:latest'.
+`jenkins/jenkins:latest'.
 ////

--- a/content/doc/book/installing/_run-jenkins-in-docker.adoc
+++ b/content/doc/book/installing/_run-jenkins-in-docker.adoc
@@ -8,7 +8,7 @@ Docker instructions documented in the sibling 'index.adoc' file.
 === Run Jenkins in Docker
 
 In this tutorial, you'll be running Jenkins as a Docker container from the
-link:https://hub.docker.com/r/jenkinsci/jenkins/[`jenkinsci/jenkins`] Docker
+link:https://hub.docker.com/r/jenkins/jenkins/[`jenkins/jenkins`] Docker
 image.
 
 To run Jenkins in Docker, follow the relevant instructions below for either

--- a/content/doc/book/installing/_run-jenkins-in-docker.adoc
+++ b/content/doc/book/installing/_run-jenkins-in-docker.adoc
@@ -8,7 +8,7 @@ Docker instructions documented in the sibling 'index.adoc' file.
 === Run Jenkins in Docker
 
 In this tutorial, you'll be running Jenkins as a Docker container from the
-link:https://hub.docker.com/r/jenkinsci/blueocean/[`jenkinsci/blueocean`] Docker
+link:https://hub.docker.com/r/jenkinsci/jenkins/[`jenkinsci/jenkins`] Docker
 image.
 
 To run Jenkins in Docker, follow the relevant instructions below for either

--- a/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
+++ b/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
@@ -65,15 +65,15 @@ Finally, Jenkins asks you to create your first administrator user.
 
 ==== Stopping and restarting Jenkins
 
-Throughout the remainder of this tutorial, you can stop the Jenkins/Blue Ocean
+Throughout the remainder of this tutorial, you can stop the Jenkins
 Docker container by typing `Ctrl-C` in the terminal/command prompt window from
 which you ran the `docker run ...` command <<run-jenkins-in-docker,above>>.
 
-To restart the Jenkins/Blue Ocean Docker container:
+To restart the Jenkins Docker container:
 
 . Run the same `docker run ...` command you ran for <<on-macos-and-linux,macOS,
   Linux>> or <<on-windows,Windows>> above. +
-  *Note:* This process also updates the `jenkinsci/blueocean` Docker image, if
+  *Note:* This process also updates the `jenkinsci/jenkins` Docker image, if
   an updated one is available.
 . Browse to `\http://localhost:8080`.
 . Wait until the log in page appears and log in.

--- a/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
+++ b/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
@@ -73,7 +73,7 @@ To restart the Jenkins Docker container:
 
 . Run the same `docker run ...` command you ran for <<on-macos-and-linux,macOS,
   Linux>> or <<on-windows,Windows>> above. +
-  *Note:* This process also updates the `jenkinsci/jenkins` Docker image, if
+  *Note:* This process also updates the `jenkins/jenkins` Docker image, if
   an updated one is available.
 . Browse to `\http://localhost:8080`.
 . Wait until the log in page appears and log in.

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -108,26 +108,15 @@ information about how to configure Docker to start on boot.
 
 There are several Docker images of Jenkins available.
 
-The recommended Docker image to use is the
-link:https://hub.docker.com/r/jenkinsci/blueocean/[`jenkinsci/blueocean` image]
-(from the link:https://hub.docker.com/[Docker Hub repository]). This image
-contains the current link:/download[Long-Term Support (LTS) release of Jenkins]
-(which is production-ready) bundled with all Blue Ocean plugins and features.
-This means that you do not need to install the Blue Ocean plugins separately.
+The recommended Docker image to use is the link:https://hub.docker.com/r/jenkinsci/jenkins/[`jenkinsci/jenkins` image] (from the link:https://hub.docker.com/[Docker Hub repository]). 
+We do recommend to use the current link:/download[Long-Term Support (LTS) release of Jenkins] for production environment, and keep weekly and RC releases for testing purposes.
 
 [NOTE]
 ====
-A new `jenkinsci/blueocean` image is published each time a new release of Blue
-Ocean is published. You can see a list of previously published versions of the
-`jenkinsci/blueocean` image on the
-link:https://hub.docker.com/r/jenkinsci/blueocean/tags/[tags] page.
+A new `jenkinsci/jenkins` image is published each time a new release of Jenkins is published. 
+You can see a list of previously published versions of the `jenkinsci/jenkins` image on the link:https://hub.docker.com/r/jenkinsci/jenkins/tags/[tags] page.
 
-There are also other Jenkins Docker images you can use (accessible through
-link:https://hub.docker.com/r/jenkins/jenkins/[`jenkins/jenkins`] on Docker
-Hub). However, these do not come with Blue Ocean, which would need to be
-installed via the link:../managing[*Manage Jenkins*] >
-link:../managing/plugins[*Manage Plugins*] page in Jenkins. Read more
-about this in link:../blueocean/getting-started[Getting started with Blue Ocean].
+LTS versions can be identified as they are composed of 3 digits (eg. `2.138.4` or `2.164.1`), when weekly releases are composed of only 2 digits (eg. `2.158` or `2.166`).
 ====
 
 include::doc/book/installing/_docker.adoc[]
@@ -151,19 +140,8 @@ any operating system or platform that supports Java.
 
 *Notes:*
 
-* Unlike downloading and running Jenkins with Blue Ocean in Docker
-  (<<docker,above>>), this process does not automatically install the Blue Ocean
-  features, which would need to installed separately via the
-  link:../../book/managing[**Manage Jenkins**] >
-  link:../../book/managing/plugins/[**Manage Plugins**] page in Jenkins. Read
-  more about the specifics for installing Blue Ocean on the
-  link:../../book/blueocean/getting-started/[Getting started with Blue Ocean]
-  page.
-* You can change the port by specifying the `--httpPort` option when you run the
-  `java -jar jenkins.war` command. For example, to make Jenkins accessible
-  through port 9090, then run Jenkins using the command: +
-  `java -jar jenkins.war --httpPort=9090`
-
+* You can change the port by specifying the `--httpPort` option when you run the `java -jar jenkins.war` command. 
+  For example, to make Jenkins accessible through port 9090, then run Jenkins using the command: `java -jar jenkins.war --httpPort=9090`
 
 === macOS
 

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -108,13 +108,13 @@ information about how to configure Docker to start on boot.
 
 There are several Docker images of Jenkins available.
 
-The recommended Docker image to use is the link:https://hub.docker.com/r/jenkinsci/jenkins/[`jenkinsci/jenkins` image] (from the link:https://hub.docker.com/[Docker Hub repository]). 
+The recommended Docker image to use is the link:https://hub.docker.com/r/jenkins/jenkins/[`jenkins/jenkins` image] (from the link:https://hub.docker.com/[Docker Hub repository]). 
 We do recommend to use the current link:/download[Long-Term Support (LTS) release of Jenkins] for production environment, and keep weekly and RC releases for testing purposes.
 
 [NOTE]
 ====
-A new `jenkinsci/jenkins` image is published each time a new release of Jenkins is published. 
-You can see a list of previously published versions of the `jenkinsci/jenkins` image on the link:https://hub.docker.com/r/jenkinsci/jenkins/tags/[tags] page.
+A new `jenkins/jenkins` image is published each time a new release of Jenkins is published. 
+You can see a list of previously published versions of the `jenkins/jenkins` image on the link:https://hub.docker.com/r/jenkins/jenkins/tags/[tags] page.
 
 LTS versions can be identified as they are composed of 3 digits (eg. `2.138.4` or `2.164.1`), when weekly releases are composed of only 2 digits (eg. `2.158` or `2.166`).
 ====

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -109,7 +109,7 @@ information about how to configure Docker to start on boot.
 There are several Docker images of Jenkins available.
 
 The recommended Docker image to use is the link:https://hub.docker.com/r/jenkins/jenkins/[`jenkins/jenkins` image] (from the link:https://hub.docker.com/[Docker Hub repository]). 
-We do recommend to use the current link:/download[Long-Term Support (LTS) release of Jenkins] for production environment, and keep weekly and RC releases for testing purposes.
+We recommend the current link:/download[Long-Term Support (LTS) release of Jenkins] for production environments, and keep weekly releases and long term support release candidates for testing.
 
 [NOTE]
 ====


### PR DESCRIPTION
[WEBSITE-474](https://issues.jenkins-ci.org/browse/WEBSITE-474)

Replacing references to jenkins/blueocean image in the installation documentation to only use jenkins/jenkins image.