### PR TITLE
Make Java Web Start explanation more visible

### DIFF
--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -55,14 +55,17 @@ All agents must be running on the same JVM version as the master (because of how
 
 You can validate the version of each agent with the plugin:versioncolumn[Versions Node Monitors] plugin. This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins instance. This plugin can also be configured to automatically disconnect any agent with an incorrect JVM version.
 
-Java Web Start has been removed in Java 11, which means that you can no longer start an agent using a `*.jnlp` file.
-When a Jenkins master is running on Java 11, the Java Web Start button will no longer appear in the Web UI.
+== Java Web Start
 
-As of February 2019, there are no plans to replace this functionality: instead, you should connect agents with the Jenkins CLI, through plugins like plugin:ssh-slaves[SSH Slaves Plugin], or by using containers.
+Java Web Start has been removed in Java 11.
+When a Jenkins master is running on Java 11, the Java Web Start button will no longer appear in the Web UI.
+Agents for a Java 11 Jenkins server can't be launched from a `*.jnlp` file downloaded to a web browser.
+
+As of February 2019, there are no plans to replace this functionality.
+Connect agents to Jenkins on Java 11 with plugins like plugin:ssh-slaves[SSH Slaves Plugin], with operating system command line calls to `java -jar agent.jar`, or by using containers.
 
 == JDK Tool Automatic installer
 
-As of Jenkins 11, Oracle licensing prevents the Jenkins community from listing the JDKs distributed by Oracle. Because of this restriction, it's not possible to automatically install of a JDK in version 11.
-This problem is tracked in the issue link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
+As of Java 11, Oracle licensing prevents the Jenkins community from listing the JDKs distributed by Oracle. Because of this licensing restriction, Oracle JDK 11 can't be automatically installed by Jenkins. This problem is tracked in the issue link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
 
 As an alternative, we encourage you to use containers based on images that contain all the tooling needed for your builds.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -66,6 +66,6 @@ Connect agents to Jenkins on Java 11 with plugins like plugin:ssh-slaves[SSH Sla
 
 == JDK Tool Automatic installer
 
-As of Java 11, Oracle licensing prevents the Jenkins community from listing the JDKs distributed by Oracle. Because of this licensing restriction, Oracle JDK 11 can't be automatically installed by Jenkins. This problem is tracked in the issue link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
+Oracle JDK 11 licensing prevents the Jenkins community from listing the Oracle JDKs. Because of this licensing restriction, Oracle JDK 11 can't be automatically installed by Jenkins. This problem is tracked in the issue link:https://issues.jenkins-ci.org/browse/JENKINS-54305[JENKINS-54305].
 
 As an alternative, we encourage you to use containers based on images that contain all the tooling needed for your builds.


### PR DESCRIPTION
Java 11 does not include Java Web Start.

Also corrects an incorrect attribution of the JDK 11 licensing problem.  Earlier it said that Jenkins 11 was the cause of the issue.  There is no Jenkins 11, only Java 11.

Navigation path for the user to reach this page is longer than I would like, but that would require larger changes than I can make at this time.