### PR TITLE
Correcting multibranch link

### DIFF
--- a/content/doc/book/pipeline/running-pipelines.adoc
+++ b/content/doc/book/pipeline/running-pipelines.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 === Multibranch
 
-See <<multibranch, the Multibranch documentation>> for more information.
+See <<multibranch#, the Multibranch documentation>> for more information.
 
 === Parameters
 


### PR DESCRIPTION
Originally it resulted in a section link within the same document instead of linking to a different document, effectively linking to itself.