### PR TITLE
Revert Stapler from the list of useful skills outside of Jenkins.

### DIFF
--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -10,7 +10,6 @@ skills:
 - Java
 - REST API
 - Swagger
-- Stapler
 mentors:
 - name: "Martin d'Anjou"
   github: "martinda"


### PR DESCRIPTION
As discussed on https://github.com/jenkins-infra/jenkins.io/pull/2157