### PR TITLE
[JENKINS-52850] Improve credentials helper section and add SSH support

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -493,10 +493,16 @@ and `MYVARNAME_PSW` respectively.
 SSH with Private Key:: 
 the environment variable specified will be set to the location of the SSH key 
 file that is temporarily created and two additional environment variables may
-be automatically defined: `MYVARNAME_USR` and `MYVARNAME_PSW` respectively.
+be automatically defined: `MYVARNAME_USR` and `MYVARNAME_PSW` (holding the 
+passphrase).
+
+[NOTE]
+====
+Unsupported credentials type causes the pipeline to fail with the message: `org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException: No suitable binding handler could be found for type <unsupportedType>.`
+====
 
 [[environment-example]]
-===== Example
+===== Examples
 
 [pipeline]
 ----
@@ -526,6 +532,37 @@ given environment variables to steps within the `stage`.
 <3> The `environment` block has a helper method `credentials()` defined which
 can be used to access pre-defined Credentials by their identifier in the
 Jenkins environment.
+
+[pipeline]
+----
+// Declarative //
+pipeline {
+    agent any
+    stages {
+        stage('Example Username/Password') {
+            environment {
+                SERVICE_CREDS = credentials('my-prefined-username-password')
+            }
+            steps {
+                sh 'echo "Service user is $SERVICE_CREDS_USR"'
+                sh 'echo "Service password is $SERVICE_CREDS_PSW"'
+                sh 'curl -u $SERVICE_CREDS https://myservice.example.com'
+            }
+        }
+        stage('Example Username/Password') {
+            environment {
+                SSH_CREDS = credentials('my-prefined-ssh-creds')
+            }
+            steps {
+                sh 'echo "SSH private key is located at $SSH_CREDS"'
+                sh 'echo "SSH user is $SSH_CREDS_USR"'
+                sh 'echo "SSH passphrase is $SSH_CREDS_PSW"'
+            }
+        }
+    }
+}
+// Script //
+----
 
 ==== options
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -465,13 +465,7 @@ depending on where the `environment` directive is located within the Pipeline.
 
 This directive supports a special helper method `credentials()` which can be
 used to access pre-defined Credentials by their identifier in the Jenkins
-environment. For Credentials which are of type "Secret Text", the
-`credentials()` method will ensure that the environment variable specified
-contains the Secret Text contents. For Credentials which are of type "Standard
-username and password", the environment variable specified will be set to
-`username:password` and two additional environment variables will be
-automatically be defined: `MYVARNAME_USR` and `MYVARNAME_PSW` respectively.
-
+environment. 
 
 [cols="^10h,>90a",role=syntax]
 |===
@@ -484,6 +478,22 @@ automatically be defined: `MYVARNAME_USR` and `MYVARNAME_PSW` respectively.
 | Allowed
 | Inside the `pipeline` block, or within `stage` directives.
 |===
+
+===== Supported Credentials Type
+
+Secret Text:: 
+the environment variable specified will be set to the Secret Text content
+Secret File::
+the environment variable specified will be set to the location of the File
+file that is temporarily created
+Username and password:: 
+the environment variable specified will be set to `username:password` and two
+additional environment variables will be automatically defined: `MYVARNAME_USR`
+and `MYVARNAME_PSW` respectively.
+SSH with Private Key:: 
+the environment variable specified will be set to the location of the SSH key 
+file that is temporarily created and two additional environment variables may
+be automatically defined: `MYVARNAME_USR` and `MYVARNAME_PSW` respectively.
 
 [[environment-example]]
 ===== Example


### PR DESCRIPTION
[JENKINS-52850](https://issues.jenkins-ci.org/browse/JENKINS-52850)

* Add support for SSH with Private Key credentials in the `environment` block of declarative pipeline.
* Improve the current documentation for credentials helper.