### PR TITLE
Declarative Pipeline post failure conditions now run even if the result is set manually

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -332,10 +332,7 @@ was successful.
 run has an "aborted" status, usually due to the Pipeline being manually aborted.
 This is typically denoted by gray in the web UI.
 `failure`:: Only run the steps in `post` if the current Pipeline's or stage's
-run has a "failed" status, typically denoted by red in the web UI. Note that if
-you manually set `currentBuild.result = 'FAILURE'` in a stage and have a
-`failure` `post` condition on that stage, the `failure` will not fire for that
-stage.
+run has a "failed" status, typically denoted by red in the web UI.
 `success`:: Only run the steps in `post` if the current Pipeline's or stage's
 run has a "success" status, typically denoted by blue or green in the web UI.
 `unstable`:: Only run the steps in `post` if the current Pipeline's or stage's


### PR DESCRIPTION
As of at least jenkinsci/pipeline-model-definition-plugin/pull/322 (released in Pipeline: Declarative 1.3.7), but probably as early as jenkinsci/pipeline-model-definition-plugin/pull/313 (released in Pipeline: Declarative 1.3.5), failure conditions _are_ executed even if the result is set to FAILURE manually. I added a test confirming the behavior in https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/322/commits/3beec5b76ff0e4c901d6446f60b3774ace5c5536.

CC @abayer