### PR TITLE
Replaced broken link to Awestruct site with a link to its GitHub repo

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -52,7 +52,7 @@ When they are ready you will push your changes to your your fork and submit a pu
 This project uses GNU/Make and Docker in order to generate the fully statically
 generated link:https://jenkins.io[jenkins.io] web site. The key tool for
 converting source code into the site is the
-link:http://awestruct.org[Awestruct] static site generator,
+link:https://github.com/awestruct/awestruct[Awestruct] static site generator,
 which is downloaded automatically as part of the build process.
 
 Ensure you have GNU/Make and Docker available on your machine:


### PR DESCRIPTION
The http://awestruct.org/ domain has expired. Linking [Awestruct's repository](https://github.com/awestruct/awestruct) in GitHub seems like the safest replacement.