### PR TITLE
try to avoid anchoring trailing whitespace

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -82,12 +82,12 @@
             - unless page.uneditable
               %p.box
                 %a{:href => "https://github.com/jenkins-infra/jenkins.io/edit/master/content/#{page.relative_source_path}",
-                :title => "Edit #{page.relative_source_path} on GitHub"}
-                  Improve this page
+                :title => "Edit #{page.relative_source_path} on GitHub",
+                } Improve this page
                 |
                 %a{:href => "https://github.com/jenkins-infra/jenkins.io/commits/master/content/#{page.relative_source_path}",
-                :title => "View #{page.relative_source_path} history on GitHub"}
-                  Page history
+                :title => "View #{page.relative_source_path} history on GitHub",
+                } Page history
 
             .license-box
               #creativecommons


### PR DESCRIPTION
The current content renders like this when hovered:
![image](https://user-images.githubusercontent.com/2119212/55286385-5426a100-5369-11e9-968d-387dc65984f9.png)

Because the haml to html is:
```
<a href='https://github.com/jenkins-infra/jenkins.io/edit/master/content//index.html.haml' title='Edit /index.html.haml on GitHub'>
Improve this page
</a>
|
<a href='https://github.com/jenkins-infra/jenkins.io/commits/master/content//index.html.haml' title='View /index.html.haml history on GitHub'>
Page history
</a>
```

Browsers used to have some fairly interesting whitespace collapsing rules.  But, at this point the general rule is that whitespace will be part of your link if it's there.

here's a data url you can load in a browser to get a sense of the general behavior:
```
data:text/html,<title>test</title>pure inline: <a href="http://example.com"> a </a>b;<p>new blocks:<p><a href="http://example.com"> a </a><p>b;<p>not the real beginning of a block:<p>&nbsp;<a href="http://example.com"> a </a><p>b
```
