### PR TITLE
Replaced broken link to Awestruct site with link to its GitHub (README)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = jenkins.io
 
 This repository is what powers the link:https://jenkins.io/[Jenkins
-website]. This uses link:http://awestruct.org[awestruct]
+website]. This uses link:https://github.com/awestruct/awestruct[Awestruct]
 with link:https://asciidoctor.org[Asciidoctor] under the hood to provide a very
 useful and compelling web presence for the link:https://jenkins.io/[Jenkins
 automation server].


### PR DESCRIPTION
This change has already been made and merged in the CONTRIBUTING file ([see](https://github.com/jenkins-infra/jenkins.io/pull/2181)), so it seems the README file should follow the same path