### PR TITLE
Added Gitter to "Participate and contribute". Only IRC was there.

### DIFF
--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -41,7 +41,10 @@ section: participate
             jenkinsci-users mailing list
         %li
           %a{:href => '/chat'}
-            \#jenkins IRC channel on Freenode
+            jenkinsci/jenkins room on Gitter
+        %li
+          %a{:href => '/chat'}
+            #jenkins IRC channel on Freenode
         %li
           %a{:href => 'https://reddit.com/r/jenkinsci'}
             \/r/jenkins on Reddit
@@ -57,7 +60,7 @@ section: participate
             Mailing lists
         %li
           %a{:href => '/chat'}
-            IRC channels
+            Gitter rooms and IRC channels
 
       %h3
         Review changes


### PR DESCRIPTION
The anchor text of links to the /chat page were only mentioning IRC, even though Gitter was included in its content; so I modified the corresponding links to add it