### PR TITLE
Added note specifying that PRs listed for review only visible to those in the GitHub Teams

### DIFF
--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -76,6 +76,9 @@ section: participate
             %strong
               copy editing
             has been requested
+      %p
+        Note that you will only be able to see the open pull requests linked above if you belong to the corresponding
+        GitHub Team.
 
       %h3
         Provide feedback


### PR DESCRIPTION
In the "Participate and contribute" page, if the reader is not part of the "code-reviewers" or "copy-editors" GitHub teams, a "No results marched your search" message will be displayed when clicking the links. Without the note, it might be confusing for a newcomer.