### PR TITLE
Add last confirmed version to 2019-04-03 advisory

### DIFF
--- a/content/security/advisory/2019-04-03.adoc
+++ b/content/security/advisory/2019-04-03.adoc
@@ -21,7 +21,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.ircbot.IrcPublisher.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: ircbot # 2.30 (current)
+  - name: ircbot
+    previous: 2.30
 
 
 - id: SECURITY-831
@@ -35,7 +36,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.awsbeanstalkpublisher.AWSEBPublisher.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: aws-beanstalk-publisher-plugin # 1.7.4 (current)
+  - name: aws-beanstalk-publisher-plugin
+    previous: 1.7.4
 
 
 - id: SECURITY-839
@@ -49,7 +51,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: hockeyapp # 1.2.2 (confirmed in 1.4.0)
+  - name: hockeyapp
+    previous: 1.4.0
 
 
 - id: SECURITY-837
@@ -63,7 +66,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: jenkins-jira-issue-updater # 1.18 (current) (4900 installs)
+  - name: jenkins-jira-issue-updater
+    previous: 1.18 # (4900 installs)
 
 
 - id: SECURITY-954
@@ -77,7 +81,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.zanox.hudson.plugins.FTPPublisher.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: ftppublisher # 1.2 (current) (3800 installs)
+  - name: ftppublisher
+    previous: 1.2 # (3800 installs)
 
 
 - id: SECURITY-956
@@ -91,7 +96,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: websphere-deployer # 1.6.1 (current)
+  - name: websphere-deployer
+    previous: 1.6.1
 
 
 - id: SECURITY-965
@@ -105,7 +111,8 @@ issues:
     Bitbucket Approve Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.bitbucket_approve.BitbucketApprover.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: bitbucket-approve # 1.0.3 (current) (3000 installs)
+  - name: bitbucket-approve
+    previous: 1.0.3 # (3000 installs)
 
 
 - id: SECURITY-974
@@ -120,7 +127,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: ftppublisher # 1.2 (current)
+  - name: ftppublisher
+    previous: 1.2
 
 
 - id: SECURITY-1041
@@ -134,7 +142,8 @@ issues:
     PLUGIN_NAME stores Jira credentials unencrypted in its global configuration file `org.jenkinsci.plugins.zap.ZAPBuilder.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: zap # 1.1.0 (current)
+  - name: zap
+    previous: 1.1.0
 
 
 - id: SECURITY-1042
@@ -148,7 +157,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: jenkins-cloudformation-plugin # 1.2 (current)
+  - name: jenkins-cloudformation-plugin
+    previous: 1.2
 
 
 # 100+
@@ -165,7 +175,8 @@ issues:
     AWS CloudWatch Logs Publisher Plugin stores credentials unencrypted in its global configuration file `jenkins.plugins.awslogspublisher.AWSLogsConfig.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: aws-cloudwatch-logs-publisher # 1.2.0 (current)
+  - name: aws-cloudwatch-logs-publisher
+    previous: 1.2.0
 
 
 - id: SECURITY-832
@@ -179,7 +190,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.snsnotify.AmazonSNSNotifier.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: snsnotify # 1.13 (current)
+  - name: snsnotify
+    previous: 1.13
 
 
 - id: SECURITY-835
@@ -193,7 +205,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.awsdevicefarm.AWSDeviceFarmRecorder.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: aws-device-farm # 1.15 (confirmed in 1.25)
+  - name: aws-device-farm
+    previous: 1.25
 
 
 - id: SECURITY-838
@@ -207,7 +220,8 @@ issues:
     CloudShare Docker-Machine Plugin stores credentials unencrypted in its global configuration file `com.cloudshare.jenkins.CloudShareConfiguration.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: cloudshare-docker # 1.1.0 (current)
+  - name: cloudshare-docker
+    previous: 1.1.0
 
 
 - id: SECURITY-841
@@ -221,7 +235,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.bugzilla.BugzillaProjectProperty.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: bugzilla # 1.5 (current)
+  - name: bugzilla
+    previous: 1.5
 
 
 - id: SECURITY-842
@@ -235,7 +250,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: trac-publisher-plugin # 1.3 (current)
+  - name: trac-publisher-plugin
+    previous: 1.3
 
 
 - id: SECURITY-945
@@ -249,7 +265,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: vmware-vrealize-automation-plugin # unspecified version but 1.2.3 is current, released 3 years ago
+  - name: vmware-vrealize-automation-plugin
+    previous: 1.2.3
 
 
 - id: SECURITY-949
@@ -263,7 +280,8 @@ issues:
     Aqua Security Scanner Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.aquadockerscannerbuildstep.AquaDockerScannerBuilder.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: aqua-security-scanner # 3.0.6 (confirmed in 3.0.15)
+  - name: aqua-security-scanner
+    previous: 3.0.15
 
 
 - id: SECURITY-952
@@ -277,7 +295,8 @@ issues:
     veracode-scanner Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.veracodescanner.VeracodeNotifier.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: veracode-scanner # 1.6 (current)
+  - name: veracode-scanner
+    previous: 1.6
 
 
 - id: SECURITY-957
@@ -291,7 +310,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.octopusdeploy.OctopusDeployPlugin.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: octopusdeploy # 1.8.1 (confirmed in 1.9.0)
+  - name: octopusdeploy
+    previous: 1.9.0
 
 
 - id: SECURITY-961
@@ -305,7 +325,8 @@ issues:
     PLUGIN_NAME stores deployment credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: wildfly-deployer # 1.0.2 (current)
+  - name: wildfly-deployer
+    previous: 1.0.2
 
 
 - id: SECURITY-962
@@ -319,7 +340,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: vsts-cd # 1.3 (current)
+  - name: vsts-cd
+    previous: 1.3
 
 
 - id: SECURITY-964
@@ -333,7 +355,8 @@ issues:
     Hyper.sh Commons Plugin stores credentials unencrypted in its global configuration file `sh.hyper.plugins.hypercommons.Tools.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: hyper-commons # 0.1.5 (current)
+  - name: hyper-commons
+    previous: 0.1.5
 
 
 - id: SECURITY-966
@@ -347,7 +370,8 @@ issues:
     Audit to Database Plugin stores database credentials unencrypted in its global configuration file `audit2db.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: audit2db # 0.5 (current)
+  - name: audit2db
+    previous: 0.5
 
 
 - id: SECURITY-977
@@ -362,7 +386,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: audit2db # 0.5 (current)
+  - name: audit2db
+    previous: 0.5
 
 
 - id: SECURITY-979
@@ -377,7 +402,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: labmanager # 0.2.8 (current)
+  - name: labmanager
+    previous: 0.2.8
 
 
 - id: SECURITY-981
@@ -392,7 +418,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: openshift-deployer # 1.2.0 (current)
+  - name: openshift-deployer
+    previous: 1.2.0
 
 
 - id: SECURITY-991
@@ -407,7 +434,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: gearman-plugin # 0.2.0 (current)
+  - name: gearman-plugin
+    previous: 0.2.0
 
 
 - id: SECURITY-993
@@ -422,7 +450,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: zephyr-enterprise-test-management # 1.4 (confirmed in 1.6)
+  - name: zephyr-enterprise-test-management
+    previous: 1.6
 
 
 - id: SECURITY-1037
@@ -437,7 +466,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: sinatra-chef-builder # 1.20 (current)
+  - name: sinatra-chef-builder
+    previous: 1.20
 
 
 - id: SECURITY-1043
@@ -451,7 +481,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: fabric-beta-publisher # 2.0 (confirmed in 2.1)
+  - name: fabric-beta-publisher
+    previous: 2.1
 
 
 - id: SECURITY-1044
@@ -465,7 +496,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: upload-pgyer # 1.31 (current)
+  - name: upload-pgyer
+    previous: 1.31
 
 
 - id: SECURITY-1054
@@ -480,7 +512,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: cloudtest # 2.25 (current)
+  - name: cloudtest
+    previous: 2.25
 
 
 - id: SECURITY-1058
@@ -495,7 +528,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: nomad # 0.4 (current)
+  - name: nomad
+    previous: 0.4
 
 
 - id: SECURITY-1059
@@ -509,7 +543,8 @@ issues:
     Open STF Plugin stores credentials unencrypted in its global configuration file `hudson.plugins.openstf.STFBuildWrapper.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: open-stf # 1.0.8 (confirmed in 1.0.9)
+  - name: open-stf
+    previous: 1.0.9
 
 
 - id: SECURITY-1061
@@ -523,7 +558,8 @@ issues:
     Perfecto Mobile Plugin stores credentials unencrypted in its global configuration file `com.perfectomobile.jenkins.ScriptExecutionBuilder.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: perfectomobile # 2.62.0.3 (current)
+  - name: perfectomobile
+    previous: 2.62.0.3
 
 
 - id: SECURITY-1062
@@ -537,7 +573,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: TestFairy # 4.16 (current)
+  - name: TestFairy
+    previous: 4.16
 
 
 - id: SECURITY-1069
@@ -551,7 +588,8 @@ issues:
     Crowd Integration Plugin stores credentials unencrypted in the global configuration file `config.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: crowd # 1.2 (current)
+  - name: crowd
+    previous: 1.2
 
 
 - id: SECURITY-1084
@@ -566,7 +604,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: openid # 2.2 (confirmed in 2.3)
+  - name: openid
+    previous: 2.3
 
 
 - id: SECURITY-1085
@@ -580,7 +619,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: starteam # 0.6.13 (current)
+  - name: starteam
+    previous: 0.6.13
 
 
 - id: SECURITY-1091
@@ -595,7 +635,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: jenkins-reviewbot # 2.4.6 (current)
+  - name: jenkins-reviewbot
+    previous: 2.4.6
 
 
 - id: SECURITY-1093
@@ -609,7 +650,8 @@ issues:
     Assembla Auth Plugin stores credentials unencrypted in the global configuration file `config.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: assembla-auth # 1.11 (current)
+  - name: assembla-auth
+    previous: 1.11
 
 
 # 10+
@@ -626,7 +668,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.relution_publisher.configuration.global.StoreConfiguration.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: relution-publisher # 1.24 (current)
+  - name: relution-publisher
+    previous: 1.24
 
 
 - id: SECURITY-843
@@ -640,7 +683,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: klaros-testmanagement # 2.0.0 (current)
+  - name: klaros-testmanagement
+    previous: 2.0.0
 
 
 - id: SECURITY-946
@@ -654,7 +698,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: mabl-integration # 0.0.8 (confirmed in 0.0.12)
+  - name: mabl-integration
+    previous: 0.0.12
 
 
 - id: SECURITY-947
@@ -668,7 +713,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: diawi-upload # 1.4 (current)
+  - name: diawi-upload
+    previous: 1.4
 
 
 - id: SECURITY-955
@@ -682,7 +728,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.minio.MinioUploader.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: minio-storage # 0.0.3 (current)
+  - name: minio-storage
+    previous: 0.0.3
 
 
 - id: SECURITY-959
@@ -696,7 +743,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: deployhub # 8.0.10 (confirmed in 8.0.13)
+  - name: deployhub
+    previous: 8.0.13
 
 
 - id: SECURITY-963
@@ -728,7 +776,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `de.e_nexus.jabber.JabberBuilder.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: jabber-server-plugin # 1.9 (current)
+  - name: jabber-server-plugin
+    previous: 1.9
 
 
 - id: SECURITY-1032
@@ -780,7 +829,8 @@ issues:
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
   plugins:
-  - name: kmap-jenkins # 1.6 (current)
+  - name: kmap-jenkins
+    previous: 1.6
 
 
 - id: SECURITY-1056
@@ -794,7 +844,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: kmap-jenkins # 1.6 (current)
+  - name: kmap-jenkins
+    previous: 1.6
 
 
 - id: SECURITY-1063
@@ -808,7 +859,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
     These credentials can be viewed by users with Extended Read permission, or access to the master file system.
   plugins:
-  - name: crittercism-dsym # 1.1 (current)
+  - name: crittercism-dsym
+    previous: 1.1
 
 
 - id: SECURITY-1066
@@ -822,7 +874,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.urbancode.ds.jenkins.plugins.serenarapublisher.UrbanDeployPublisher.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: sra-deploy # 1.4.2.4 (current)
+  - name: sra-deploy
+    previous: 1.4.2.4
 
 
 - id: SECURITY-1090
@@ -836,7 +889,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.sametime.im.transport.SametimePublisher.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: sametime # 0.4 (current)
+  - name: sametime
+    previous: 0.4
 
 
 - id: SECURITY-1092
@@ -850,7 +904,8 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.koji.KojiBuilder.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: koji # 0.3 (current)
+  - name: koji
+    previous: 0.3
 
 
 # 0+
@@ -867,4 +922,5 @@ issues:
     PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.cloudcoreo.plugins.jenkins.CloudCoreoBuildWrapper.xml` on the Jenkins master.
     These credentials can be viewed by users with access to the master file system.
   plugins:
-  - name: cloudcoreo-deploytime # 0.2.3 (current)
+  - name: cloudcoreo-deploytime
+    previous: 0.2.3


### PR DESCRIPTION
In previous advisories, we've always specified the latest known affected versions even for issues without a fix. This does not substantially change the content of the advisory in a way that would require an update notification, it may however limit confusion in the future once fixes are released.

This coupled with the statement that no fixes were available as the advisory was published should be good enough.

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/55674642-92671780-58b7-11e9-945a-9c58098f55e9.png)
