### PR TITLE
Add Open API to skills list.

### DIFF
--- a/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -9,7 +9,7 @@ showGoogleDoc: true
 skills:
 - Java
 - REST API
-- Swagger
+- OpenAPI / Swagger
 mentors:
 - name: "Martin d'Anjou"
   github: "martinda"


### PR DESCRIPTION
Since OpenAPI has a wider reach beyond Swagger spec, it's worth mentioning that OpenAPI is a skill that students would pick up.
Note: Swagger spec was donated to OpenAPI https://smartbear.com/news/news-releases/smartbear-launches-open-api-initiative-with-key-in/ .