### PR TITLE
Update 2.175 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -4329,6 +4329,10 @@
       pull: 3984
       message: |-
         Developer: Make <code>${port}</code> be honored by <code>mvn -f war hudson-dev:run</code>.
+    - type: bug
+      issue: 57096
+      message: |-
+        Fix Debian/Ubuntu launcher script for Java 11 support.
     # pull: 3873 ([JENKINS-55829] New getter method in AbstractCIBase)
     # pull: 3978 (Update Dockerfile)
     # pull: 3980 ([JENKINS-47896] SerializableOnlyOverRemoting)


### PR DESCRIPTION
Includes the fix for [JENKINS-57096](https://issues.jenkins-ci.org/browse/JENKINS-57096) in the changelog:

![2019-04-29-12-22-17_727x340](https://user-images.githubusercontent.com/985955/56890368-8cf58b00-6a79-11e9-8297-62137b43e609.png)

@jenkins-infra/java11-support-maintainer @daniel-beck 