### PR TITLE
Changelog - Noting JENKINS-47896 in 2.175

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -4325,7 +4325,8 @@
       pull: 3980
       message: |-
         Ensure that Remoting objects are being serialized only through Remoting channels.
-        Classes like <code>hudson.FilePath</code> will not longer be serialized to the disk.
+        Certain classes which were never designed for persistence in XML will no longer be serialized to disk:
+        <code>FilePath</code>, <code>[Stream]TaskListener</code>, and <code>ProcessTree</code>.
     - type: bug
       pull: 3987
       issue: 57071

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -4330,12 +4330,17 @@
       message: |-
         Make Debian/Ubuntu launcher script work with Java 11.
     - type: rfe
+      issue: 47896
+      pull: 3980
+      message: |-
+        Ensure that Remoting objects are being serialized only through Remoting channels.
+        Classes like <code>hudson.FilePath</code> will not longer be serialized to the disk.
+    - type: rfe
       pull: 3984
       message: |-
         Developer: Make <code>${port}</code> be honored by <code>mvn -f war hudson-dev:run</code>.
     # pull: 3873 ([JENKINS-55829] New getter method in AbstractCIBase)
     # pull: 3978 (Update Dockerfile)
-    # pull: 3980 ([JENKINS-47896] SerializableOnlyOverRemoting)
     # pull: 3986 (Making ConfidentialKey instances safe to keep in static fields even across JenkinsRule starts)
     # pull: 3990 (Bump to more recent tip of ATH)
     # pull: 3995 (Add section for agent to master configuration)

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -4320,6 +4320,12 @@
       pull: 3999
       message: |-
         Re-enable Stapler request dispatching telemetry.
+    - type: rfe
+      issue: 47896
+      pull: 3980
+      message: |-
+        Ensure that Remoting objects are being serialized only through Remoting channels.
+        Classes like <code>hudson.FilePath</code> will not longer be serialized to the disk.
     - type: bug
       pull: 3987
       issue: 57071
@@ -4329,12 +4335,6 @@
       issue: 57096
       message: |-
         Make Debian/Ubuntu launcher script work with Java 11.
-    - type: rfe
-      issue: 47896
-      pull: 3980
-      message: |-
-        Ensure that Remoting objects are being serialized only through Remoting channels.
-        Classes like <code>hudson.FilePath</code> will not longer be serialized to the disk.
     - type: rfe
       pull: 3984
       message: |-


### PR DESCRIPTION
It is no longer minor since we have 4 plugin regressions after https://github.com/jenkinsci/jenkins/pull/3980

CC @daniel-beck @batmat @jglick 