### PR TITLE
Clarify developer use of Experimental Update Center

### DIFF
--- a/content/doc/developer/publishing/releasing-experimental-updates.adoc
+++ b/content/doc/developer/publishing/releasing-experimental-updates.adoc
@@ -4,14 +4,19 @@ layout: developerguide
 ---
 
 To simplify delivery of beta versions of plugins to interested users, the Jenkins project published an _experimental update center_.
-It will include alpha and beta versions of plugins, which aren't usually included in the regular update sites.
+It includes alpha and beta versions of plugins, which aren't usually included in the regular update center.
 
 == Creating Experimental Plugin Releases
 
-Plugin releases that contain `alpha` or `beta` in their version number will only show up in the experimental update site.
-Note that it also serves regular releases, so the release of version `1.4` will result in `1.3-beta-2` no longer being available.
+Plugin releases that contain `alpha` or `beta` in their version number will only appear in the experimental update site, not in the regular update center.
+The experimental update center also serves regular releases.
+Newer releases hide older releases in all update centers.
+For example, the release of version `1.4` will hide `1.3-beta-2` from the experimental update center.
 
-== Configuring Jenkins to Use Experimental Update Center
+Note that **only** `alpha` and `beta` strings in the version number will publish to the experimental update center.
+Other version strings like `proto`, `rc`, and `unstable` **will appear** in the regular update center.
+
+== Using the Experimental Update Center
 
 Users who are interested in downloading experimental plugin releases can go to _Plugin Manager_, then to the _Advanced_ tab, and configure the update center URL `\https://updates.jenkins.io/experimental/update-center.json`.
 Submit, and then select _Check Now_.


### PR DESCRIPTION
Consider this part of my apology for releasing git plugin 4.0.0-rc to the entire community when I had intended that it would only be released to the experimental update center.