### PR TITLE
Use direct links for the wiki

### DIFF
--- a/content/blog/2019/04/2019-04-03-security-advisory.adoc
+++ b/content/blog/2019/04/2019-04-03-security-advisory.adoc
@@ -18,4 +18,4 @@ In such cases, we publish https://jenkins.io/security/#vulnerabilities-in-plugin
 Doing so allows administrators to make an informed decision about the continued use of plugins with unresolved security vulnerabilities.
 Today's advisory is overwhelmingly such an advisory.
 
-See a plugin you love on this list and want to help out? https://wiki.jenkins-ci.org/display/JENKINS/Adopt+a+Plugin[Learn about adopting plugins].
+See a plugin you love on this list and want to help out? https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Learn about adopting plugins].

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -53,7 +53,7 @@ We use the *jenkins-admin* bot to automate common administrative operations.
 Its use is limited to users with _voice_ or _op_ in this channel.
 link:/projects/infrastructure/ircbot/[Learn more].
 
-https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Board members and officers] typically have _op_ (@) in this channel.
+https://wiki.jenkins.io/display/JENKINS/Governance+Board[Board members and officers] typically have _op_ (@) in this channel.
 Established contributors typically have _voice_ (+) in this channel.
 
 [[meeting]]
@@ -65,7 +65,7 @@ link:/project/governance/#meeting[Learn more about the project governance meetin
 
 Meetings are logged, and the channel is unused the rest of the time.
 We use the *robobutler* to run these meetings.
-See the link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda[about project meetings] for more details.
+See the link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[about project meetings] for more details.
 
 === `#jenkins-community`
 

--- a/content/doc/upgrade-guide/2.19.adoc
+++ b/content/doc/upgrade-guide/2.19.adoc
@@ -50,7 +50,7 @@ A memory leak on the dashboard (view pages) was fixed, so that browser memory us
 
 ==== Expansion of the serialization blacklist
 
-https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-11-16[Security Advisory 2016-11-16]
+https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2016-11-16[Security Advisory 2016-11-16]
 
 The major part of the security fix is an expansion of the serialization blacklist used for remoting (Jenkins CLI and master/agent communication) and XStream (XML configuration and data files).
 

--- a/content/doc/upgrade-guide/2.32.adoc
+++ b/content/doc/upgrade-guide/2.32.adoc
@@ -24,10 +24,10 @@ To restore the previous behavior, set the system property `hudson.security.Acces
 
 ==== Console notes security fix
 
-https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-382]
+https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-382]
 
 Console notes, the often bold or colored additions to build logs by plugins such as plugin:timestamper[Timestamper] or plugin:ansicolor[AnsiColor], that were created before you upgrade to Jenkins 2.43 or 2.32.2 will no longer be loaded for security reasons.
-To restore the previous (unsafe) behavior, set the system property `hudson.console.ConsoleNote.INSECURE` to `true` as described on link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[this wiki page].
+To restore the previous (unsafe) behavior, set the system property `hudson.console.ConsoleNote.INSECURE` to `true` as described on link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[this wiki page].
 
 Maven projects in plugin:maven-plugin[Maven Integration Plugin] 2.14 and earlier that use Maven 3.0.x to build will create console notes that can no longer be read by Jenkins, therefore parts of their build output will not be colored/bold.
 This does not affect freestyle projects.
@@ -35,7 +35,7 @@ This does not affect freestyle projects.
 
 ==== New encrypted secrets format
 
-https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-304]
+https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-304]
 
 Encrypted secrets are no AES-128 CBC with random IV instead of AES-128 ECB without IV. Therefore the format of encrypted secrets has been changed.
 While existing secrets can still be read, saving configuration files will result in re-encryption of stored secrets in the new format.
@@ -44,7 +44,7 @@ Repeatedly submitting the same form by clicking _Apply_ after changing a passwor
 
 ==== Re-keying backup files removed
 
-https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-376]
+https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-376]
 
 Re-keying, a process implemented for the Jenkins 1.480.2 security update, and performed only when upgrading Jenkins from versions 1.480.1 or 1.497 or earlier, left behind backup files with no restrictive file access permissions.
 On the first restart after applying the 2.32.2 update, Jenkins will remove these backup files, if present.
@@ -55,7 +55,7 @@ If you are relying on file system permissions to protect secrets stored in your 
 
 ==== Remoting blacklist addition
 
-https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-383]
+https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-383]
 
 The remoting blacklist of classes prohibited from being used in XStream and Java object serialization has been extended. These entries were added:
 
@@ -67,7 +67,7 @@ No legitimate use of these types is expected, but possible. Previous advice in t
 
 ==== User creation via GET no longer possible
 
-https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-406]
+https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[SECURITY-406]
 
 Jenkins administrators were able to create users by accessing the URL `/user/example`. Doing so would create (for this URL) a new user with the ID `example`, if it did not exist before.
 
@@ -76,7 +76,7 @@ Therefore this feature has been removed.
 
 When using the internal Jenkins user database, new users can be created via _Manage Jenkins » Manage Users_ instead.
 
-To restore the previous (unsafe) behavior, set the system property `hudson.model.User.allowUserCreationViaUrl` to `true` as described on link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[this wiki page].
+To restore the previous (unsafe) behavior, set the system property `hudson.model.User.allowUserCreationViaUrl` to `true` as described on link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[this wiki page].
 
 ==== Security warnings administrative monitor
 
@@ -109,7 +109,7 @@ If that happens, set the System property `jenkins.slaves.DefaultJnlpSlaveReceive
 
     java -Djenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification=true … -jar jenkins.war
 
-https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[Learn more about system properties in Jenkins.]
+https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[Learn more about system properties in Jenkins.]
 
 Additionally, this is the first remoting release that requires Java 7. While agents have needed Java 7 for a while now, remoting is also used to communicate with the Maven process in the Maven project type in the Maven Integration Plugin. These builds now needs a JDK 7 or newer to run. Use toolchains to compile with an older version of Java.
 

--- a/content/doc/upgrade-guide/2.60/windows.adoc
+++ b/content/doc/upgrade-guide/2.60/windows.adoc
@@ -13,7 +13,7 @@ The following features can be enabled after upgrading Jenkins to 2.60.1:
 * Automatic termination of Jenkins master processes
 
 NOTE: The described features and guidelines apply to classic JNLP agents installed as services.
-Plugins like link:https://plugins.jenkins.io/windows-slaves[Windows Agents Plugin] do not offer all features so far, see link:https://issues.jenkins-ci.org/browse/JENKINS-42743[JENKINS-42743].
+Plugins like plugin:windows-slaves[Windows Agents Plugin] do not offer all features so far, see link:https://issues.jenkins-ci.org/browse/JENKINS-42743[JENKINS-42743].
 
 === Upgrading old Jenkins agents
 

--- a/content/doc/upgrade-guide/2.7.adoc
+++ b/content/doc/upgrade-guide/2.7.adoc
@@ -36,7 +36,7 @@ Support for HTTP proxy exclusion in the build agent launcher was added. Build ag
 
 The new user experience for Jenkins 2 was overhauled, and instances now start with a setup wizard that sets up a very conservative security configuration and guides users through installation of a recommended set of plugins.
 
-For automatic deployments setting up a preconfigured environment e.g. using https://wiki.jenkins-ci.org/display/JENKINS/Post-initialization+script[`init.groovy` or `init.groovy.d/`], the System property https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[`jenkins.install.runSetupWizard`] allows skipping the setup wizard:
+For automatic deployments setting up a preconfigured environment e.g. using https://wiki.jenkins.io/display/JENKINS/Post-initialization+script[`init.groovy` or `init.groovy.d/`], the System property https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[`jenkins.install.runSetupWizard`] allows skipping the setup wizard:
 
  java -Djenkins.install.runSetupWizard=false -jar jenkins.war
 
@@ -81,7 +81,7 @@ One possible side effect is a memory leak described in JENKINS-33358 and https:/
 
 ==== Changes in UI theme
 
-Jenkins 2 introduced changes to the UI of the New Item page and various configuration pages that may impact custom CSS/JS (injected e.g. using the https://wiki.jenkins-ci.org/display/JENKINS/Simple+Theme+Plugin[Simple Theme Plugin]) relying on the DOM or other features of the Jenkins UI.
+Jenkins 2 introduced changes to the UI of the New Item page and various configuration pages that may impact custom CSS/JS (injected e.g. using the https://wiki.jenkins.io/display/JENKINS/Simple+Theme+Plugin[Simple Theme Plugin]) relying on the DOM or other features of the Jenkins UI.
 
 Please note that we do not guarantee any UI level backwards compatibility for custom themes.
 

--- a/content/friend.adoc
+++ b/content/friend.adoc
@@ -1,4 +1,4 @@
 ---
 layout: refresh
-refresh_to_post_id: 'https://wiki.jenkins-ci.org/display/JENKINS/Donation'
+refresh_to_post_id: 'https://wiki.jenkins.io/display/JENKINS/Donation'
 ---

--- a/content/jenkins-20-proposals.adoc
+++ b/content/jenkins-20-proposals.adoc
@@ -4,7 +4,7 @@
 :created: 1446595678
 :author: rtyler
 ---
-This page contains an overview of some of the **key** proposals for link:https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+2.0[Jenkins 2.0].
+This page contains an overview of some of the **key** proposals for link:https://wiki.jenkins.io/display/JENKINS/Jenkins+2.0[Jenkins 2.0].
 
 
 Below are a list of the blog posts summarizing the proposals, with their associated issue tracker links where you can provide more feedback:

--- a/content/merchandise.adoc
+++ b/content/merchandise.adoc
@@ -15,7 +15,7 @@ Cafepress hosts a link:https://www.cafepress.com/jenkinsci[Jenkins store] for va
 The link:https://www.shapeways.com/shops/jenkins[Jenkins 3D Shop] offers 3D printed figures of Mr. Jenkins.
 
 The model for these figures was created by link:https://www.fast-d.com/search/engineers/2798[akiki] and is licensed as CC-BY-SA.
-It can be be downloaded from the link:https://wiki.jenkins-ci.org/display/JENKINS/Logo[logo] wiki page.
+It can be be downloaded from the link:https://wiki.jenkins.io/display/JENKINS/Logo[logo] wiki page.
 
 // https://jenkins.io/blog/2014/07/28/jenkins-figure-is-available-in-shapeways/
 

--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -11,19 +11,19 @@ This page is still a work in progress.
 
 Check out these existing resources for contributors:
 
-* link:https://wiki.jenkins-ci.org/display/JENKINS/Beginners+Guide+to+Contributing#BeginnersGuidetoContributing-Areyouinterestedinwritingcode%3F[Beginners Guide to Contributing].
-* https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins[The complete guide to hosting and publishing plugins]
-* https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial[The plugin tutorial will get you started with Jenkins plugin development]
-* https://wiki.jenkins-ci.org/display/JENKINS/Adopt+a+Plugin[Adopt a plugin]
-* https://wiki.jenkins-ci.org/display/JENKINS/Before+starting+a+new+plugin[Advice before creating a new plugin]
-* https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories[How we handle pull requests to plugin repositories]
+* link:https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing#BeginnersGuidetoContributing-Areyouinterestedinwritingcode%3F[Beginners Guide to Contributing].
+* https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[The complete guide to hosting and publishing plugins]
+* https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial[The plugin tutorial will get you started with Jenkins plugin development]
+* https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopt a plugin]
+* https://wiki.jenkins.io/display/JENKINS/Before+starting+a+new+plugin[Advice before creating a new plugin]
+* https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[How we handle pull requests to plugin repositories]
 * Check out the https://github.com/jenkinsci[jenkinsci] organization on GitHub for plugins and other components to contribute to.
 * link:https://issues.jenkins-ci.org/issues/?jql=labels+%3D+newbie-friendly[Jira query for issues we believe are beginner-friendly]
 
 ////
 
-* https://wiki.jenkins-ci.org/display/JENKINS/Instructions+for+Committers[Instructions for committers]
-* https://wiki.jenkins-ci.org/display/JENKINS/GitHub+commit+messages[On writing GitHub commit messages]
-* https://wiki.jenkins-ci.org/display/JENKINS/Introduction
+* https://wiki.jenkins.io/display/JENKINS/Instructions+for+Committers[Instructions for committers]
+* https://wiki.jenkins.io/display/JENKINS/GitHub+commit+messages[On writing GitHub commit messages]
+* https://wiki.jenkins.io/display/JENKINS/Introduction
 
 ////

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -68,7 +68,7 @@ To run pipelines, you need to have a Jenkins instance that is set up with the ap
 The Pipeline plugin is installed in the same way as other Jenkins plugins. Installing the Pipeline plugin also installs the suite of related plugins on which it depends:
 Open Jenkins in your web browser.
 On the Manage Jenkins page for your installation, navigate to Manage Plugins.
-Find link:https://plugins.jenkins.io/workflow-aggregator[Pipeline Plugin] from among the plugins listed on the Available tab.
+Find plugin:workflow-aggregator[Pipeline Plugin] from among the plugins listed on the Available tab.
  (You can do this by scrolling through the plugin list or by using “Pipeline” as a term to filter results)
 Select the checkbox for Pipeline Plugin.
 Select either *Install without restart* or *Download now and install after restart*. Pipeline plugin installation automatically includes all necessary dependencies.

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -68,8 +68,8 @@ To run pipelines, you need to have a Jenkins instance that is set up with the ap
 The Pipeline plugin is installed in the same way as other Jenkins plugins. Installing the Pipeline plugin also installs the suite of related plugins on which it depends:
 Open Jenkins in your web browser.
 On the Manage Jenkins page for your installation, navigate to Manage Plugins.
-Find Pipeline Plugin from among the plugins listed on the Available tab.
-https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin (You can do this by scrolling through the plugin list or by using “Pipeline” as a term to filter results)
+Find link:https://plugins.jenkins.io/workflow-aggregator[Pipeline Plugin] from among the plugins listed on the Available tab.
+ (You can do this by scrolling through the plugin list or by using “Pipeline” as a term to filter results)
 Select the checkbox for Pipeline Plugin.
 Select either *Install without restart* or *Download now and install after restart*. Pipeline plugin installation automatically includes all necessary dependencies.
 Restart Jenkins.
@@ -299,7 +299,7 @@ Pipeline-related plugins other than those listed above are regularly “whitelis
 * Build Flow Plugin - introduces a job type that lets you define an orchestration process as a script.
 
 === More Information
-As with any Jenkins plugin, you have the option of installing the Pipeline plugin from the Plugins web page at https://wiki.jenkins-ci.org/display/JENKINS/Plugins, but using the Plugin Manager interface is preferred because you do not then have to make allowances for plugin dependencies or compatibility issues.
+As with any Jenkins plugin, you have the option of installing the Pipeline plugin from the Plugins web page at https://plugins.jenkins.io , but using the Plugin Manager interface is preferred because you do not then have to make allowances for plugin dependencies or compatibility issues.
 To investigate Pipeline without installing Jenkins separately or accessing your production system, you can run a link:https://github.com/jenkinsci/workflow-plugin/blob/master/demo/README.md[Docker demo] of Pipeline functionality.
 
 == Approaches to Defining Pipeline Script

--- a/content/press.adoc
+++ b/content/press.adoc
@@ -32,7 +32,7 @@ Our
 link:/project/governance/[Governance
 Document] outlines the project's philosophy, structure and guidelines. This
 also includes information on the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance
+link:https://wiki.jenkins.io/display/JENKINS/Governance+Board[Governance
 Board], which is the group with acting executive authority. While board members
 are available for comment, we encourage you to reach out to our <<Press Contacts>>
 as an initial point of contact for press inquiries.
@@ -63,7 +63,7 @@ writing about the Jenkins project:
 
 image::/images/logo_128.png[title="Jenkins", float=right]
 
-On our link:https://wiki.jenkins-ci.org/display/JENKINS/Logo[Logo] page we have
+On our link:https://wiki.jenkins.io/display/JENKINS/Logo[Logo] page we have
 documented some versions of our logo, including the color palette our branding
 uses. Our logos can be downloaded in a number of sizes, or as vector graphics,
 from link:http://mirrors.jenkins-ci.org/art/[here]. Please do not use any of

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -54,7 +54,7 @@ when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Jenkins
+link:https://wiki.jenkins.io/display/JENKINS/Governance+Board[Jenkins
 board] at jenkinsci-board@googlegroups.com.  All complaints will be reviewed
 and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. The board is obligated to maintain
@@ -89,7 +89,7 @@ Technical criticism is always appreciated, but avoid destructive behavior such a
 Everything hosted under link:https://jenkins-ci.org/[jenkins-ci.org] and its sub-domains such as:
 
 * link:https://issues.jenkins-ci.org/[issues.jenkins-ci.org]
-* link:https://wiki.jenkins-ci.org/[wiki.jenkins-ci.org]
+* link:https://wiki.jenkins.io/[wiki.jenkins.io]
 * link:http://lists.jenkins-ci.org/mailman/listinfo[lists.jenkins-ci.org]
 
 ==== Mailing lists
@@ -125,7 +125,7 @@ page, e.g.
 If you feel somebody has breached this code, please send an email with the
 relevant information (links, etc) to jenkinsci-board@googlegroups.com. This
 email list is only readable by the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance
+link:https://wiki.jenkins.io/display/JENKINS/Governance+Board[Governance
 Board] members.
 
 Please understand that the board may not have all of the necessary context and
@@ -135,7 +135,7 @@ matters.
 If you believe one of the members of the board has violated the code of conduct
 above, please email one of the other members of the Governance Board with the
 details (their emails are visible on the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance
+link:https://wiki.jenkins.io/display/JENKINS/Governance+Board[Governance
 Board] page).
 
 == Handling of violations
@@ -180,7 +180,7 @@ The ban will include but is not limited to:
 
 
 NOTE: This page has been imported from the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Code+of+Conduct[Code of
+link:https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of
 Conduct] wiki page, which, as of `v15`, was approved by the project governance
 meeting on
 link:https://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[2016-01-06]

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -100,7 +100,7 @@ in order to protect the project and users from confusing use of the term. To
 reduce the process overhead and uphold our open-source spirit, we adopt the
 Linux kernel policy on trademark usage.
 
-You need to apply for a link:https://wiki.jenkins-ci.org/display/JENKINS/Trademark+Sublicense[sublicense] if you are using the term "Jenkins" as part of your own trademark or brand identifier for Jenkins-based software goods or services. It doesn’t matter if your trademark is unregistered, or if you do not plan to make any money using the mark.
+You need to apply for a link:https://wiki.jenkins.io/display/JENKINS/Trademark+Sublicense[sublicense] if you are using the term "Jenkins" as part of your own trademark or brand identifier for Jenkins-based software goods or services. It doesn’t matter if your trademark is unregistered, or if you do not plan to make any money using the mark.
 
 Answering the following questions (which break out each of the key issues) may help you determine if you need a sublicense. If you are still in doubt, please contact the board and we will work with you to determine whether you need to apply for a sublicense.
 
@@ -110,7 +110,7 @@ If the answer to all three of the following questions is "yes," then you need to
 - Does my mark contain the following string of adjacent letters, in this order: "Jenkins"? These letters may or may not be capitalized, and in the case of foreign characters, phonetic translations also apply.
 - Do I use my mark to identify software-related goods or services (see how that phrase is link:https://www.linuxfoundation.org/programs/legal/trademark/faq[defined] again in LF)?
 
-A list of trademark usages approved by the project can be found on the link:https://wiki.jenkins-ci.org/display/JENKINS/Approved+Trademark+Usage[Approved Trademark Usage] page.
+A list of trademark usages approved by the project can be found on the link:https://wiki.jenkins.io/display/JENKINS/Approved+Trademark+Usage[Approved Trademark Usage] page.
 
 
 === Trademark Attribution
@@ -170,9 +170,9 @@ The governance board consists of three people who act as public representatives 
 
 The board also acts as the ultimate decision-making authority in case disputes cannot be resolved via the regular project community meeting. The decision-making ability of the board is more symbolic and honorific, and it “rules” like British queens rather than a dictatorship.
 
-The link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board[Governance Board] page provides further information, including a list of current board members, and how to contact the board.
+The link:https://wiki.jenkins.io/display/JENKINS/Governance+Board[Governance Board] page provides further information, including a list of current board members, and how to contact the board.
 
-The process by which the Governance Board is elected can be reviewed in the link:https://wiki.jenkins-ci.org/display/JENKINS/Board+Election+Process[Board Election Process]
+The process by which the Governance Board is elected can be reviewed in the link:https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board Election Process]
 
 
 === Infrastructure admins
@@ -181,7 +181,7 @@ Infrastructure administrators have root access to the various servers and build 
 
 Because of the sensitive nature of this work, infrastructure admins are by invitation only, and some of the activity happen behind closed doors. Infrastructure admins often appoint others to delegate some partial access to the system to complete some tasks.
 
-A list of admins of some of the public infrastructure components can be found here: link:https://wiki.jenkins-ci.org/display/JENKINS/Infrastructure+Admins[Infrastructure Admins]
+A list of admins of some of the public infrastructure components can be found here: link:https://wiki.jenkins.io/display/JENKINS/Infrastructure+Admins[Infrastructure Admins]
 
 
 === Core committers
@@ -223,7 +223,7 @@ link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account o
 
 === Source code
 
-The link:https://github.com/jenkinsci/[GitHub JenkinsCI organization] is where we host most of our code (see link:https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Repositories[the list of repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have link:https://svn.jenkins-ci.org/[the subversion repository] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
+The link:https://github.com/jenkinsci/[GitHub JenkinsCI organization] is where we host most of our code (see link:https://wiki.jenkins.io/display/JENKINS/GitHub+Repositories[the list of repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have link:https://svn.jenkins-ci.org/[the subversion repository] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
 
 To aid classifying our 1000+ Git repositories, some naming conventions have been adopted:
 
@@ -231,7 +231,7 @@ To aid classifying our 1000+ Git repositories, some naming conventions have been
 * libraries are named "lib-*"
 * backend infrastructure programs are named "backend-*"
 
-To encourage migration of plugins from Subversion to Git, a daemon is used to mirror plugins individually to GitHub. See link:https://wiki.jenkins-ci.org/display/JENKINS/Moving+from+Subversion+%28svn%29+to+Github[this page] for more about how to migrate your plugin to GitHub.
+To encourage migration of plugins from Subversion to Git, a daemon is used to mirror plugins individually to GitHub. See link:https://wiki.jenkins.io/display/JENKINS/Moving+from+Subversion+%28svn%29+to+Github[this page] for more about how to migrate your plugin to GitHub.
 
 === User Accounts
 
@@ -254,7 +254,7 @@ We link:https://ci.jenkins-ci.org/[run Jenkins for our own development] and to a
 
 The Jenkins project uses biweekly project meetings as the primary forum of decision making for matters that need consensus.
 The meeting is link:/chat/#meeting[conducted on IRC] and open to anyone.
-Agenda items can be added by anyone by simply adding your topic to link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda[the Governance Meeting Agenda wiki page].
+Agenda items can be added by anyone by simply adding your topic to link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[the Governance Meeting Agenda wiki page].
 Be sure to include your user name (so we know who proposed a topic).
 
 The meeting minutes are public:
@@ -282,7 +282,7 @@ Every weekend a new release is built from the master branch and released, in var
 
 === LTS Releases
 
-Every three months or so we pick a prior release as the new long-term support (LTS) release and then create the ‘stable’ branch, from that release point. This branch gets important bug fixes backported from the master branch, and further patch releases are built roughly every two weeks until the next LTS baseline is chosen. See link:https://wiki.jenkins-ci.org/JENKINS/LTS+Release+Line[LTS Release Line] for more details.
+Every three months or so we pick a prior release as the new long-term support (LTS) release and then create the ‘stable’ branch, from that release point. This branch gets important bug fixes backported from the master branch, and further patch releases are built roughly every two weeks until the next LTS baseline is chosen. See link:https://wiki.jenkins.io/JENKINS/LTS+Release+Line[LTS Release Line] for more details.
 
 === Core Coding Convention
 
@@ -303,7 +303,7 @@ Maintainer information should be listed in the info box of the plugin's wiki pag
 
 === Plugin Wiki Page
 
-Each plugin has its own Wiki page in https://wiki.jenkins-ci.org/, such as link:https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin[this]. Plugin wiki pages should the macro that produces the stock header table, describing what the plugin does, along with the release history / changelog. Take a look at some plugin wiki pages as a guideline of what you should do.
+Each plugin has its own Wiki page in https://wiki.jenkins.io/, such as link:https://wiki.jenkins.io/display/JENKINS/Git+Plugin[this]. Plugin wiki pages should the macro that produces the stock header table, describing what the plugin does, along with the release history / changelog. Take a look at some plugin wiki pages as a guideline of what you should do.
 
 These wiki pages are referenced from the update center built in to Jenkins, and they are the primary means through which users discover information about plugins.
 
@@ -339,7 +339,7 @@ In some cases, the supposed "temporary" patch sets became more permanent for var
 
 === Bringing in new plugins/tools/libraries
 
-If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See link:https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins[Hosting Plugins] for more details.
+If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See link:https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[Hosting Plugins] for more details.
 
 === Making changes to existing plugins
 
@@ -365,7 +365,7 @@ When making changes, use your common sense. For example, if you are thinking abo
 
 === Contributing localizations
 
-We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see link:https://wiki.jenkins-ci.org/display/JENKINS/Internationalization[Internationalization] for the details of how to make changes.
+We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see link:https://wiki.jenkins.io/display/JENKINS/Internationalization[Internationalization] for the details of how to make changes.
 
 [[pull-request]]
 
@@ -376,12 +376,12 @@ As discussed above, Jenkins project uses pull requests as one of the main workfl
 * See link:https://help.github.com/articles/creating-a-pull-request/[the github online help] for how to create a pull request
 * We encourage you to file a ticket in link:https://issues.jenkins-ci.org/[the issue tracker] to describe the bug that you are fixing or the feature you are implementing. This creates a permanent record on our system that allows future developers to understand how the code came into the current shape. This is not a requirement (especially for small changes), but we appreciate if you do that.
 * Refer to the ticket in your commit message by using the notation `[JENKINS-1234]` where _JENKINS-1234_ is the ticket ID. This allows our scripts to understand the history and generate changelogs without human help. If you use the notation `[FIX JENKINS-1234]`, our bot will close the ticket automatically when the change is merged into the repository, and when the change is tested in our CI server. These notations create useful cross-references across systems, and are therefore highly recommended.
-* We encourage you to have a test case for the code you added to avoid future regressions. See link:https://wiki.jenkins-ci.org/display/JENKINS/Unit+Test[Unit Test] for more details about how to write tests.
+* We encourage you to have a test case for the code you added to avoid future regressions. See link:https://wiki.jenkins.io/display/JENKINS/Unit+Test[Unit Test] for more details about how to write tests.
 * Try to describe your changes so that other people understand what you did.
 * Make sure you didn’t modify portions that aren’t related to your changes (most often caused by IDE auto-fixing import statements and other code formats.)
 
-We do try to be attentive to inbound pull requests, but as you can see link:https://wiki.jenkins-ci.org/display/JENKINS/Pending+Pull+Requests[here], unfortunately we can fail to resolve some of them in a timely fashion. If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list, and please consider becoming a committer and push the changes directly. See link:https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories[Pull Request to Repositories] for more.
+We do try to be attentive to inbound pull requests, but as you can see link:https://wiki.jenkins.io/display/JENKINS/Pending+Pull+Requests[here], unfortunately we can fail to resolve some of them in a timely fashion. If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list, and please consider becoming a committer and push the changes directly. See link:https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[Pull Request to Repositories] for more.
 
 == This document
 
-This document is owned by the community and substantial changes are approved via the project meeting. Send your questions to the dev list, or add an item to the link:https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda[next meeting's agenda].
+This document is owned by the community and substantial changes are approved via the project meeting. Send your questions to the dev list, or add an item to the link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[next meeting's agenda].

--- a/content/projects/gsoc/gsoc2016.adoc
+++ b/content/projects/gsoc/gsoc2016.adoc
@@ -114,5 +114,5 @@ use and ranking the users.
 
 * link:https://summerofcode.withgoogle.com/organizations/5668199471251456/[Jenkins GSoC organization profile]
 * link:https://groups.google.com/forum/#!forum/jenkinsci-dev[jenkinsci-dev@ mailing list]
-* link:https://wiki.jenkins-ci.org/display/JENKINS/Google+Summer+Of+Code+2016[GSoC
+* link:https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[GSoC
   wiki page 2016] with more organizational information: project ideas, mentors, etc.

--- a/content/projects/gsoc/gsoc2017.adoc
+++ b/content/projects/gsoc/gsoc2017.adoc
@@ -52,7 +52,7 @@ Potential mentors: link:https://github.com/martinda[Martin d'Anjou], link:https:
 
 It is often difficult for plugins developers to diagnose issues and analyse the user environment.
 
-The link:https://wiki.jenkins-ci.org/display/JENKINS/Support+Core+Plugin[Support Core plugin] allows users to generate a bundle to help on this but it is nowadays rarely used because it is isn't user friendly.
+The link:https://wiki.jenkins.io/display/JENKINS/Support+Core+Plugin[Support Core plugin] allows users to generate a bundle to help on this but it is nowadays rarely used because it is isn't user friendly.
 Various fixes and improvements may help our community a lot. 
 
 Few ideas of new features to add:

--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -7,7 +7,7 @@ noblogs: true
 
 At the heart of the Jenkins project exists the automation engine's
 link:https://github.com/jenkinsci/jenkins[core] and hundreds of
-link:https://wiki.jenkins-ci.org/display/JENKINS/Plugins[plugins]. There are
+link:https://plugins.jenkins.io[plugins]. There are
 however other collaborative initiatives going on under the umbrella of the
 Jenkins project which grow or expand the project in new ways.
 

--- a/content/redirect/api-token.adoc
+++ b/content/redirect/api-token.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Remote+access+API
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Remote+access+API
+  ja: https://wiki.jenkins.io/display/JA/Remote+access+API
 ---

--- a/content/redirect/build-record-migration.adoc
+++ b/content/redirect/build-record-migration.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/JENKINS-24380+Migration
+redirect_url: https://wiki.jenkins.io/display/JENKINS/JENKINS-24380+Migration
 ---

--- a/content/redirect/cli-https-proxy-tunnel.adoc
+++ b/content/redirect/cli-https-proxy-tunnel.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Jenkins+CLI
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Jenkins+CLI
+  ja: https://wiki.jenkins.io/display/JA/Jenkins+CLI
 ---

--- a/content/redirect/configuring-servlet-containers.adoc
+++ b/content/redirect/configuring-servlet-containers.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Containers
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Containers
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Containers
+  ja: https://wiki.jenkins.io/display/JA/Containers
 ---

--- a/content/redirect/dangerous-permissions.adoc
+++ b/content/redirect/dangerous-permissions.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Matrix-based+security
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Matrix-based+security
 ---

--- a/content/redirect/developer/class-is-missing-descriptor.adoc
+++ b/content/redirect/developer/class-is-missing-descriptor.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/My+class+is+missing+descriptor
+redirect_url: https://wiki.jenkins.io/display/JENKINS/My+class+is+missing+descriptor
 ---

--- a/content/redirect/developer/extension-points.adoc
+++ b/content/redirect/developer/extension-points.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Extension+points
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Extension+points
 ---

--- a/content/redirect/developer/index.adoc
+++ b/content/redirect/developer/index.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Extend+Jenkins
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Extend+Jenkins
 ---

--- a/content/redirect/developer/structured-form-submission.adoc
+++ b/content/redirect/developer/structured-form-submission.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Structured+Form+Submission
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Structured+Form+Submission
 ---

--- a/content/redirect/find-jenkins-logs.adoc
+++ b/content/redirect/find-jenkins-logs.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Logging
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Logging
 ---

--- a/content/redirect/fingerprint.adoc
+++ b/content/redirect/fingerprint.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Fingerprint
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Fingerprint
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Fingerprint
+  ja: https://wiki.jenkins.io/display/JA/Fingerprint
 ---

--- a/content/redirect/installation-wizard.adoc
+++ b/content/redirect/installation-wizard.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins#InstallingJenkins-InstallationWizard
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins#InstallingJenkins-InstallationWizard
 ---

--- a/content/redirect/log-levels.adoc
+++ b/content/redirect/log-levels.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Logger+Configuration
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Logger+Configuration
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Logger+Configuration
+  ja: https://wiki.jenkins.io/display/JA/Logger+Configuration
 ---

--- a/content/redirect/log-recorders.adoc
+++ b/content/redirect/log-recorders.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Logger+Configuration
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Logger+Configuration
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Logger+Configuration
+  ja: https://wiki.jenkins.io/display/JA/Logger+Configuration
 ---

--- a/content/redirect/logging.adoc
+++ b/content/redirect/logging.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Logging
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Logging
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Logger+Configuration
+  ja: https://wiki.jenkins.io/display/JA/Logger+Configuration
 ---

--- a/content/redirect/migrate-jenkins-home.adoc
+++ b/content/redirect/migrate-jenkins-home.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Administering+Jenkins
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Administering+Jenkins
+  ja: https://wiki.jenkins.io/display/JA/Administering+Jenkins
 ---

--- a/content/redirect/offline-installation.adoc
+++ b/content/redirect/offline-installation.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Offline+Jenkins+Installation
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Offline+Jenkins+Installation
 ---

--- a/content/redirect/oracle-account-signup.adoc
+++ b/content/redirect/oracle-account-signup.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins-ci.org/oracleAccountSignup # TODO get rid of double redirect
+redirect_url: https://jenkins.io/oracleAccountSignup # TODO get rid of double redirect
 ---

--- a/content/redirect/parameterized-builds.adoc
+++ b/content/redirect/parameterized-builds.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Build
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Parameterized+Build
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Parameterized+Build
+  ja: https://wiki.jenkins.io/display/JA/Parameterized+Build
 ---

--- a/content/redirect/remote-api.adoc
+++ b/content/redirect/remote-api.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Remote+access+API
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Remote+access+API
+  ja: https://wiki.jenkins.io/display/JA/Remote+access+API
 ---

--- a/content/redirect/report-an-issue.adoc
+++ b/content/redirect/report-an-issue.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/How+to+report+an+issue
+redirect_url: https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue
 ---

--- a/content/redirect/scm-change-trigger.adoc
+++ b/content/redirect/scm-change-trigger.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Building+a+software+project
 ---

--- a/content/redirect/search-box.adoc
+++ b/content/redirect/search-box.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Search+Box
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Search+Box
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Search+Box
+  ja: https://wiki.jenkins.io/display/JA/Search+Box
 ---

--- a/content/redirect/securing-jenkins.adoc
+++ b/content/redirect/securing-jenkins.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Securing+Jenkins
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Securing+Jenkins
 ---

--- a/content/redirect/security-144.adoc
+++ b/content/redirect/security-144.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Slave+To+Master+Access+Control
 ---

--- a/content/redirect/setting-system-properties.adoc
+++ b/content/redirect/setting-system-properties.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties
 ---

--- a/content/redirect/troubleshooting/broken-reverse-proxy.adoc
+++ b/content/redirect/troubleshooting/broken-reverse-proxy.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+says+my+reverse+proxy+setup+is+broken
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Jenkins+says+my+reverse+proxy+setup+is+broken
 ---

--- a/content/redirect/troubleshooting/disable-security-manager.adoc
+++ b/content/redirect/troubleshooting/disable-security-manager.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Containers
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Containers
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Containers
+  ja: https://wiki.jenkins.io/display/JA/Containers
 ---

--- a/content/redirect/troubleshooting/executor-starvation.adoc
+++ b/content/redirect/troubleshooting/executor-starvation.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Executor+Starvation
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Executor+Starvation
 ---

--- a/content/redirect/troubleshooting/java.awt.headless.adoc
+++ b/content/redirect/troubleshooting/java.awt.headless.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+got+java.awt.headless+problem
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Jenkins+got+java.awt.headless+problem
 ---

--- a/content/redirect/troubleshooting/jna-already-loaded.adoc
+++ b/content/redirect/troubleshooting/jna-already-loaded.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/JNA+is+already+loaded
+redirect_url: https://wiki.jenkins.io/display/JENKINS/JNA+is+already+loaded
 ---

--- a/content/redirect/troubleshooting/process-leaked-file-descriptors.adoc
+++ b/content/redirect/troubleshooting/process-leaked-file-descriptors.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Spawning+processes+from+build
 ---

--- a/content/redirect/troubleshooting/utf8-url-decoding.adoc
+++ b/content/redirect/troubleshooting/utf8-url-decoding.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Tomcat#Tomcat-i18n
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Tomcat#Tomcat-i18n
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Tomcat#Tomcat-i18n
+  ja: https://wiki.jenkins.io/display/JA/Tomcat#Tomcat-i18n
 ---

--- a/content/redirect/troubleshooting/windows-agent-restart.adoc
+++ b/content/redirect/troubleshooting/windows-agent-restart.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Windowsslaveserviceupgrades
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Distributed+builds#Distributedbuilds-Windowsslaveserviceupgrades
 # This page exists in the Japanese wiki, but is missing the referenced section
 ---

--- a/content/redirect/troubleshooting/windows-service-fails-to-start.adoc
+++ b/content/redirect/troubleshooting/windows-service-fails-to-start.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+windows+service+fails+to+start
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Jenkins+windows+service+fails+to+start
 localized_urls:
-  ja: https://wiki.jenkins-ci.org/display/JA/Jenkins+windows+service+fails+to+start
+  ja: https://wiki.jenkins.io/display/JA/Jenkins+windows+service+fails+to+start
 ---

--- a/content/redirect/user-content-directory.adoc
+++ b/content/redirect/user-content-directory.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins-ci.org/display/JENKINS/User+Content
+redirect_url: https://wiki.jenkins.io/display/JENKINS/User+Content
 ---

--- a/content/security/advisory/2013-02-16.adoc
+++ b/content/security/advisory/2013-02-16.adoc
@@ -34,8 +34,8 @@ All the prior versions are affected by these vulnerabilities.
 
 As a part of the fix, these versions contain the following incompatible changes. Administrators of Jenkins need to be aware of the following implications of the upgrade:
 
-* JSONP support in link:https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API[Remote access API] is removed. If you have other programs that depend on this behavior, you can set the `hudson.model.Api.INSECURE` system property to `true` to resurrect behaviour. However, this is highly discouraged.
-* If your Jenkins does not have the security enabled, some of the link:https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API[Remote access API] calls that previously didn't  require `POST` now requires it. See the "CSRF Protection" section of the remote access API page for how to add necessary header.
+* JSONP support in link:https://wiki.jenkins.io/display/JENKINS/Remote+access+API[Remote access API] is removed. If you have other programs that depend on this behavior, you can set the `hudson.model.Api.INSECURE` system property to `true` to resurrect behaviour. However, this is highly discouraged.
+* If your Jenkins does not have the security enabled, some of the link:https://wiki.jenkins.io/display/JENKINS/Remote+access+API[Remote access API] calls that previously didn't  require `POST` now requires it. See the "CSRF Protection" section of the remote access API page for how to add necessary header.
 
 == Other resources
 * link:https://www.cloudbees.com/jenkins-advisory/jenkins-security-advisory-2013-02-16.cb[Corresponding security advisory on CloudBees regarding DEV@cloud and Jenkins Enterprise by CloudBees]

--- a/content/security/advisory/2015-10-01.adoc
+++ b/content/security/advisory/2015-10-01.adoc
@@ -11,7 +11,7 @@ kind: other
 
 The Jenkins project has received multiple credible reports indicating that unsecured, publicly accessible instances of Jenkins are being targeted and infected with malware. This advisory publishes the information we have about this situation and may be updated once we learn more.
 
-By default, Jenkins listens to all interfaces and does not require user authentication, allowing anyone on the network to run arbitrary processes as the user running Jenkins. *If you're running a Jenkins instance on a public network, make sure security is enabled, and that anonymous users have read access at most.* To do this, link:https://wiki.jenkins-ci.org/display/JENKINS/Standard+Security+Setup[follow the instructions in the Jenkins wiki].
+By default, Jenkins listens to all interfaces and does not require user authentication, allowing anyone on the network to run arbitrary processes as the user running Jenkins. *If you're running a Jenkins instance on a public network, make sure security is enabled, and that anonymous users have read access at most.* To do this, link:https://wiki.jenkins.io/display/JENKINS/Standard+Security+Setup[follow the instructions in the Jenkins wiki].
 
 While this is not a bug in Jenkins, we are planning to change the Jenkins setup in a future release to be secure by default to prevent something like this from occurring in the future.
 
@@ -29,7 +29,7 @@ We currently neither know the exact nature of this malware, nor how to remove it
 
 ===  Fix
 
-If you're running a Jenkins instance on a public network, link:https://wiki.jenkins-ci.org/display/JENKINS/Standard+Security+Setup[follow the instructions in the Jenkins wiki] to set up security on your Jenkins instance.
+If you're running a Jenkins instance on a public network, link:https://wiki.jenkins.io/display/JENKINS/Standard+Security+Setup[follow the instructions in the Jenkins wiki] to set up security on your Jenkins instance.
 
 It is important that it is _not_ possible for anonymous users to perform administrative actions or run scripts. This means:
 

--- a/content/security/advisory/2015-12-09.adoc
+++ b/content/security/advisory/2015-12-09.adoc
@@ -15,7 +15,7 @@ This advisory announces multiple vulnerabilities in Jenkins.
 
 In certain configurations, low privilege users were able to create e.g. HTML files in workspaces and archived artifacts that could result in XSS when accessed by other users. Jenkins now sends `Content-Security-Policy` headers that enables sandboxing and prohibits script execution by default.
 
-NOTE: If you rely on the previous behavior, or in case of compatibility problems with certain plugins, you can modify the header sent by Jenkins. Learn more: link:https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy].
+NOTE: If you rely on the previous behavior, or in case of compatibility problems with certain plugins, you can modify the header sent by Jenkins. Learn more: link:https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy].
 
 === CSRF vulnerability in some administrative actions
 *SECURITY-225 / CVE-2015-7537*

--- a/content/security/advisory/2016-05-11.adoc
+++ b/content/security/advisory/2016-05-11.adoc
@@ -27,7 +27,7 @@ To allow specific, known safe parameter names to be passed to builds, set the sy
 java -Dhudson.model.ParametersAction.safeParameters=FOO,BAR_BAZ,qux -jar jenkins.war
 ----
 
-NOTE: For an overview of impacted plugins and the current status of their fixes, see: link:https://wiki.jenkins-ci.org/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170[Plugins affected by fix for SECURITY-170]
+NOTE: For an overview of impacted plugins and the current status of their fixes, see: link:https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170[Plugins affected by fix for SECURITY-170]
 
 
 === Malicious users with multiple user accounts can prevent other users from logging in

--- a/content/security/advisory/2016-06-20.adoc
+++ b/content/security/advisory/2016-06-20.adoc
@@ -36,7 +36,7 @@ The plugin did not escape a parameter echoed on an HTML page, resulting in a ref
 === Async HTTP Client Plugin does not properly validate certificates
 *SECURITY-305 / CVE-2013-7397 and CVE-2013-7398*
 
-Async HTTP Client Plugin provides the Async HTTP Client Java library to other plugins. It is based on the 1.7.x line of AHC, which by default is vulnerable to link:https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-7397[CVE-2013-7397] and link:https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-7398[CVE-2013-7398], allowing man-in-the-middle attacks. The fixes for these vulnerabilities were backported. The system property `jenkins.plugins.asynchttpclient.AHC.acceptAnyCertificate` can temporarily be set to `true` to disable these new validity checks. link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[Learn more about system properties in Jenkins].
+Async HTTP Client Plugin provides the Async HTTP Client Java library to other plugins. It is based on the 1.7.x line of AHC, which by default is vulnerable to link:https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-7397[CVE-2013-7397] and link:https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-7398[CVE-2013-7398], allowing man-in-the-middle attacks. The fixes for these vulnerabilities were backported. The system property `jenkins.plugins.asynchttpclient.AHC.acceptAnyCertificate` can temporarily be set to `true` to disable these new validity checks. link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[Learn more about system properties in Jenkins].
 
 == Severity
 

--- a/content/security/advisory/2016-07-27.adoc
+++ b/content/security/advisory/2016-07-27.adoc
@@ -13,11 +13,11 @@ This advisory announces a vulnerability in the link:https://plugins.jenkins.io/c
 === Cucumber Reports Plugin disables Content-Security-Policy for archived and workspace files
 *SECURITY-309*
 
-Jenkins 1.641 and 1.625.3 introduced `Content-Security-Policy` HTTP headers as protection against Cross-Site Scripting attacks using workspace files and archived artifacts served using `DirectoryBrowserSupport` (link:https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-12-09[SECURITY-95]).
+Jenkins 1.641 and 1.625.3 introduced `Content-Security-Policy` HTTP headers as protection against Cross-Site Scripting attacks using workspace files and archived artifacts served using `DirectoryBrowserSupport` (link:https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2015-12-09[SECURITY-95]).
 
 The Cucumber Reports Plugin disabled this XSS protection until Jenkins was restarted whenever a Cucumber Report was viewed by any user to work around the `Content-Security-Policy` limitations.
 
-While disabling this protection mechanism temporarily may be necessary to make plugins work that haven't been adapted to work with the Content-Security-Policy restriction, this should only be done by administrators, as doing so may result in a security issue (see https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy]).
+While disabling this protection mechanism temporarily may be necessary to make plugins work that haven't been adapted to work with the Content-Security-Policy restriction, this should only be done by administrators, as doing so may result in a security issue (see https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy]).
 
 
 == Severity

--- a/content/security/advisory/2017-02-01.adoc
+++ b/content/security/advisory/2017-02-01.adoc
@@ -84,7 +84,7 @@ The method `Jenkins#getItems()` included a performance optimization that resulte
 
 Jenkins allows plugins to annotate build logs, adding new content or changing the presentation of existing content while the build is running. Popular examples include the highlighting of sections by plugin:ant[Ant Plugin], or the timestamp metadata from plugin:timestamper[Timestamper]. Malicious Jenkins users, or users with SCM access, could configure jobs or modify build scripts such that they print serialized console notes that perform cross-site scripting attacks on Jenkins users viewing the build logs.
 
-To prevent this, console notes are now signed by Jenkins when created, and Jenkins will only deserialize correctly signed console notes. *As a side effect, console notes created before updating to a release containing this fix will no longer be deserialized.* To restore the previous (unsafe) behavior, set the system property `hudson.console.ConsoleNote.INSECURE` to `true` as described on link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[Features controlled by system properties].
+To prevent this, console notes are now signed by Jenkins when created, and Jenkins will only deserialize correctly signed console notes. *As a side effect, console notes created before updating to a release containing this fix will no longer be deserialized.* To restore the previous (unsafe) behavior, set the system property `hudson.console.ConsoleNote.INSECURE` to `true` as described on link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[Features controlled by system properties].
 
 
 === XStream remote code execution vulnerability
@@ -124,7 +124,7 @@ Jenkins allows administrators to enter their username and password to the Oracle
 
 When administrators accessed a URL like `/user/example` via HTTP GET, a user with the ID `example` was created if it did not exist. While this user record was only retained until restart in most cases, administrators' web browsers could be manipulated to create a large number of user records.
 
-Accessing these URLs now no longer results in a user record getting created, Jenkins will respond with 404 Not Found if no such user exists. When using the internal Jenkins user database, new users can be created via _Manage Jenkins » Manage Users_. To restore the previous (unsafe) behavior, set the system property `hudson.model.User.allowUserCreationViaUrl` to `true` as described on link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[Features controlled by system properties].
+Accessing these URLs now no longer results in a user record getting created, Jenkins will respond with 404 Not Found if no such user exists. When using the internal Jenkins user database, new users can be created via _Manage Jenkins » Manage Users_. To restore the previous (unsafe) behavior, set the system property `hudson.model.User.allowUserCreationViaUrl` to `true` as described on link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[Features controlled by system properties].
 
 
 

--- a/content/security/advisory/2017-03-20.adoc
+++ b/content/security/advisory/2017-03-20.adoc
@@ -11,7 +11,7 @@ This advisory announces vulnerabilities in these Jenkins plugins:
 * plugin:distfork[DistFork]
 * plugin:email-ext[Email Extension (Email-ext)]
 * plugin:mailer[Mailer]
-* link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Classpath+Step+Plugin[Pipeline: Classpath Step]
+* link:https://wiki.jenkins.io/display/JENKINS/Pipeline+Classpath+Step+Plugin[Pipeline: Classpath Step]
 * plugin:ssh-slaves[SSH Slaves]
 
 == Description

--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -16,41 +16,41 @@ kind: plugins
 
 This advisory announces vulnerabilities or security-related fixes in these Jenkins plugins:
 
-* https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Adaptive+Plugin[Adaptive DSL]
-* https://wiki.jenkins-ci.org/display/JENKINS/Application+Detector+Plugin[Application Detector]
-* https://wiki.jenkins-ci.org/display/JENKINS/ArtifactDeployer+Plugin[Artifact Deployer]
-* https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin[Build Flow]
-* https://wiki.jenkins-ci.org/display/JENKINS/CAS+Plugin[CAS]
-* https://wiki.jenkins-ci.org/display/JENKINS/CAS1+Plugin[CAS protocol version 1]
+* https://wiki.jenkins.io/display/JENKINS/Jenkins+Adaptive+Plugin[Adaptive DSL]
+* https://wiki.jenkins.io/display/JENKINS/Application+Detector+Plugin[Application Detector]
+* https://wiki.jenkins.io/display/JENKINS/ArtifactDeployer+Plugin[Artifact Deployer]
+* https://wiki.jenkins.io/display/JENKINS/Build+Flow+Plugin[Build Flow]
+* https://wiki.jenkins.io/display/JENKINS/CAS+Plugin[CAS]
+* https://wiki.jenkins.io/display/JENKINS/CAS1+Plugin[CAS protocol version 1]
 * plugin:claim[Claim]
-* https://wiki.jenkins-ci.org/display/JENKINS/CVS+Tagging+Plugin[CVS Tagging]
-* https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Parameter+Plug-in[Dynamic Parameter]
+* https://wiki.jenkins.io/display/JENKINS/CVS+Tagging+Plugin[CVS Tagging]
+* https://wiki.jenkins.io/display/JENKINS/Dynamic+Parameter+Plug-in[Dynamic Parameter]
 * plugin:email-ext[Email Extension (Email-ext)]
 * plugin:envinject[Environment Injector (EnvInject)] (2 vulnerabilities)
 * plugin:extensible-choice-parameter[Extensible Choice Parameter]
 * plugin:extreme-notification[Extreme Notification]
-* https://wiki.jenkins-ci.org/display/JENKINS/Grails+Plugin[Grails]
+* https://wiki.jenkins.io/display/JENKINS/Grails+Plugin[Grails]
 * plugin:groovy[Groovy]
-* https://wiki.jenkins-ci.org/display/JENKINS/GroovyAxis[GroovyAxis]
+* https://wiki.jenkins.io/display/JENKINS/GroovyAxis[GroovyAxis]
 * plugin:job-dsl[Job DSL] (2 vulnerabilities)
 * plugin:lockable-resources[Lockable Resources]
 * plugin:matrix-auth[Matrix Authorization Strategy]
-* https://wiki.jenkins-ci.org/display/JENKINS/Ontrack+Plugin[Ontrack]
-* https://wiki.jenkins-ci.org/display/JENKINS/PostBuildScript+Plugin[Post-Build Script]
-* https://wiki.jenkins-ci.org/display/JENKINS/Process+Cleaner+Plugin[Process Cleaner]
-* https://wiki.jenkins-ci.org/display/JENKINS/PTC+Integrity+Plugin[PTC Integrity CM]
-* https://wiki.jenkins-ci.org/display/JENKINS/Reactor+Plugin[Reactor]
+* https://wiki.jenkins.io/display/JENKINS/Ontrack+Plugin[Ontrack]
+* https://wiki.jenkins.io/display/JENKINS/PostBuildScript+Plugin[Post-Build Script]
+* https://wiki.jenkins.io/display/JENKINS/Process+Cleaner+Plugin[Process Cleaner]
+* https://wiki.jenkins.io/display/JENKINS/PTC+Integrity+Plugin[PTC Integrity CM]
+* https://wiki.jenkins.io/display/JENKINS/Reactor+Plugin[Reactor]
 * plugin:role-strategy[Role-based Authorization Strategy]
-* https://wiki.jenkins-ci.org/display/JENKINS/Script+SCM+Plugin[Script SCM]
-* https://wiki.jenkins-ci.org/display/JENKINS/Scriptler+Plugin[Scriptler] (5 vulnerabilities)
-* https://wiki.jenkins-ci.org/display/JENKINS/ScriptTrigger+Plugin[scripttrigger]
+* https://wiki.jenkins.io/display/JENKINS/Script+SCM+Plugin[Script SCM]
+* https://wiki.jenkins.io/display/JENKINS/Scriptler+Plugin[Scriptler] (5 vulnerabilities)
+* https://wiki.jenkins.io/display/JENKINS/ScriptTrigger+Plugin[scripttrigger]
 * plugin:shared-objects[Shared Objects]
 * plugin:splunk-devops[Splunk]
-* https://wiki.jenkins-ci.org/display/JENKINS/Splunk+Plugin+for+Pipeline+Job+Support[Splunk Extension]
-* https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Tagging+Plugin[Subversion Tagging]
-* https://wiki.jenkins-ci.org/display/JENKINS/Tcl+plugin[tcl]
+* https://wiki.jenkins.io/display/JENKINS/Splunk+Plugin+for+Pipeline+Job+Support[Splunk Extension]
+* https://wiki.jenkins.io/display/JENKINS/Subversion+Tagging+Plugin[Subversion Tagging]
+* https://wiki.jenkins.io/display/JENKINS/Tcl+plugin[tcl]
 * plugin:warnings[Warnings] (2 vulnerabilities)
-* https://wiki.jenkins-ci.org/display/JENKINS/YouTrack+Plugin[youtrack-plugin]
+* https://wiki.jenkins.io/display/JENKINS/YouTrack+Plugin[youtrack-plugin]
 
 Additionally, the following plugins had their vulnerability published and fixed in the past, but haven't been included in a security advisory:
 
@@ -734,44 +734,44 @@ The plugin retains permissions configured before upgrading, so there should be n
 == Affected versions
 
 * plugin:uno-choice[Active Choices] up to and including version 1.4
-* https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Adaptive+Plugin[Adaptive DSL] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Application+Detector+Plugin[Application Detector] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/ArtifactDeployer+Plugin[Artifact Deployer] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin[Build Flow] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/CAS1+Plugin[CAS protocol version 1] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/CAS+Plugin[CAS] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Jenkins+Adaptive+Plugin[Adaptive DSL] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Application+Detector+Plugin[Application Detector] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/ArtifactDeployer+Plugin[Artifact Deployer] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Build+Flow+Plugin[Build Flow] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/CAS1+Plugin[CAS protocol version 1] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/CAS+Plugin[CAS] (all versions)
 * plugin:claim[Claim] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/CVS+Tagging+Plugin[CVS Tagging] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Parameter+Plug-in[Dynamic Parameter] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/CVS+Tagging+Plugin[CVS Tagging] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Dynamic+Parameter+Plug-in[Dynamic Parameter] (all versions)
 * plugin:email-ext[Email Extension (Email-ext)] up to and including version 2.57.1
 * plugin:envinject[Environment Injector (EnvInject)] up to and including version 1.93.1
 * plugin:extended-choice-parameter[Extended Choice Parameter] up to and including version 0.61
 * plugin:extensible-choice-parameter[Extensible Choice Parameter] up to and including version 1.3.4
 * plugin:extreme-notification-plugin[Extreme Notification] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Grails+Plugin[Grails] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Grails+Plugin[Grails] (all versions)
 * plugin:groovy[Groovy] up to and including version 1.31
 * plugin:groovy-label-assignment[Groovy Label Assignment] up to and including version 1.1.1
 * plugin:groovy-postbuild[Groovy Postbuild] up to and including version 1.10
-* https://wiki.jenkins-ci.org/display/JENKINS/GroovyAxis[GroovyAxis] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/GroovyAxis[GroovyAxis] (all versions)
 * plugin:job-dsl[Job DSL] up to and including version 1.59
 * plugin:lockable-resources[Lockable Resources] up to and including version 1.11.2
 * plugin:matrix-auth[Matrix Authorization Strategy] up to and including version 1.4
-* https://wiki.jenkins-ci.org/display/JENKINS/Ontrack+Plugin[Ontrack] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/PostBuildScript+Plugin[Post-Build Script] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Process+Cleaner+Plugin[Process Cleaner] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/PTC+Integrity+Plugin[PTC Integrity CM] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Reactor+Plugin[Reactor] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Ontrack+Plugin[Ontrack] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/PostBuildScript+Plugin[Post-Build Script] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Process+Cleaner+Plugin[Process Cleaner] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/PTC+Integrity+Plugin[PTC Integrity CM] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Reactor+Plugin[Reactor] (all versions)
 * plugin:role-strategy[Role-based Authorization Strategy] up to and including version 2.3.2
-* https://wiki.jenkins-ci.org/display/JENKINS/Script+SCM+Plugin[Script SCM] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Scriptler+Plugin[Scriptler] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/ScriptTrigger+Plugin[scripttrigger] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Script+SCM+Plugin[Script SCM] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Scriptler+Plugin[Scriptler] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/ScriptTrigger+Plugin[scripttrigger] (all versions)
 * plugin:shared-objects[Shared Objects] (all versions)
 * plugin:splunk-devops[Splunk] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Splunk+Plugin+for+Pipeline+Job+Support[Splunk Extension] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Tagging+Plugin[Subversion Tagging] (all versions)
-* https://wiki.jenkins-ci.org/display/JENKINS/Tcl+plugin[tcl] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Splunk+Plugin+for+Pipeline+Job+Support[Splunk Extension] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Subversion+Tagging+Plugin[Subversion Tagging] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/Tcl+plugin[tcl] (all versions)
 * plugin:warnings[Warnings] up to and including version 4.60
-* https://wiki.jenkins-ci.org/display/JENKINS/YouTrack+Plugin[youtrack-plugin] (all versions)
+* https://wiki.jenkins.io/display/JENKINS/YouTrack+Plugin[youtrack-plugin] (all versions)
 
 
 == Fix
@@ -801,7 +801,7 @@ Listed versions include fixes to the vulnerabilities described above.
 All prior versions containing the affected features are considered affected by these vulnerabilities unless otherwise noted.
 
 Plugins not listed above have not been fixed in time for this security advisory.
-The link:https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Support+in+Plugins[Jenkins wiki] tracks the current state of these plugins.
+The link:https://wiki.jenkins.io/display/JENKINS/Script+Security+Support+in+Plugins[Jenkins wiki] tracks the current state of these plugins.
 
 == Credit
 

--- a/content/security/advisory/2017-08-07.adoc
+++ b/content/security/advisory/2017-08-07.adoc
@@ -51,7 +51,7 @@ The Deploy to container Plugin now integrates with plugin:credentials[Credential
 === Blue Ocean Plugin did not check the optional Run/Artifacts permission before granting access to archived artifacts
 *SECURITY-564 / CVE-2017-1000105*
 
-The optional Run/Artifacts permission can be enabled by setting link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[a Java system property].
+The optional Run/Artifacts permission can be enabled by setting link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[a Java system property].
 
 Blue Ocean did not check this permission before providing access to archived artifacts, Item/Read permission was sufficient.
 

--- a/content/security/advisory/2017-10-11.adoc
+++ b/content/security/advisory/2017-10-11.adoc
@@ -9,7 +9,7 @@ This advisory announces multiple vulnerabilities in Jenkins (weekly and LTS), an
 
 * plugin:maven-plugin[Maven Plugin]
 * plugin:swarm[Swarm Plugin] Client
-* link:https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Speaks!+Plugin[Speaks! Plugin]
+* link:https://wiki.jenkins.io/display/JENKINS/Hudson+Speaks!+Plugin[Speaks! Plugin]
 
 == Description
 

--- a/content/security/advisory/2018-03-26.adoc
+++ b/content/security/advisory/2018-03-26.adoc
@@ -62,7 +62,7 @@ issues:
 
     Cucumber Living Documentation Plugin disabled this XSS protection until Jenkins was restarted whenever a Cucumber Report was viewed by any user to work around the `Content-Security-Policy` limitations.
 
-    While disabling this protection mechanism temporarily may be necessary to make plugins work that haven't been adapted to work with the Content-Security-Policy restriction, this should only be done by administrators, as doing so may result in a security issue (see https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy]).
+    While disabling this protection mechanism temporarily may be necessary to make plugins work that haven't been adapted to work with the Content-Security-Policy restriction, this should only be done by administrators, as doing so may result in a security issue (see https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy]).
 
     This has been addressed in version 1.1.0 of the plugin, and it will now request that users change the Content-Security-Policy option in Jenkins.
 

--- a/content/security/advisory/2018-12-05.adoc
+++ b/content/security/advisory/2018-12-05.adoc
@@ -103,7 +103,7 @@ issues:
 
     In rare cases, it may be desirable to disable this fix.
     To do so, set the Java system property `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape` to `true`.
-    link:https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties[Learn more about system properties in Jenkins].
+    link:https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties[Learn more about system properties in Jenkins].
 
     NOTE: While the same component allows browsing archived artifacts, this fix does not apply to archived artifacts.
     Valid symbolic links are archived as the files and directories they point to on the agent, while invalid symlinks cannot escape the root directory for archived artifacts on the Jenkins master.

--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -36,7 +36,7 @@ We provide issue reporting guidelines and an overview of our process on link:rep
 If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
 `jenkinsci-cert@googlegroups.com`
 
-To show our appreciation for your help, we'll send you link:https://wiki.jenkins-ci.org/display/JENKINS/Rewards+for+reporting+security+issues[a small reward] for privately reported, valid vulnerability reports.
+To show our appreciation for your help, we'll send you link:https://wiki.jenkins.io/display/JENKINS/Rewards+for+reporting+security+issues[a small reward] for privately reported, valid vulnerability reports.
 
 [[cna]]
 == CVE Numbers Authority
@@ -47,7 +47,7 @@ Contact us at `jenkinsci-cert@googlegroups.com` if you have questions about the 
 [[team]]
 == About the Jenkins Security Team
 
-The Jenkins Security Team is a group of volunteers lead by the link:https://wiki.jenkins-ci.org/display/JENKINS/Team+Leads[Jenkins Security Officer] who triage and fix security vulnerabilities.
+The Jenkins Security Team is a group of volunteers lead by the link:https://wiki.jenkins.io/display/JENKINS/Team+Leads[Jenkins Security Officer] who triage and fix security vulnerabilities.
 
 Membership is generally open to anyone with a history of positive contributions to the Jenkins project and subject to approval by the Jenkins Security Officer.
 In order to join, you'll need to:

--- a/content/solutions/android.adoc
+++ b/content/solutions/android.adoc
@@ -7,12 +7,11 @@ As one of the predominant mobile platforms, Android is attractive to a number
 of developers, but it does bring it's own set of challenges with it. With an
 extremely broad set of devices available on the market, building and testing
 for the matrix of device configurations can be very challenging. With the
-link:https://plugins.jenkins.io/android-emulator[Android
-emulator plugin]
+plugin:android-emulator[Android emulator plugin]
 however, it is possible to build and test on a myriad of emulated devices.
 
 When combined with the
-link:https://plugins.jenkins.io/google-play-android-publisher[Google
-Play Publisher plugin], Android developers can build true continuous delivery
+plugin:google-play-android-publisher[Google Play Publisher plugin],
+Android developers can build true continuous delivery
 pipeline, sending builds to an alpha channel in Google Play for release or
 further testing.

--- a/content/solutions/android.adoc
+++ b/content/solutions/android.adoc
@@ -7,12 +7,12 @@ As one of the predominant mobile platforms, Android is attractive to a number
 of developers, but it does bring it's own set of challenges with it. With an
 extremely broad set of devices available on the market, building and testing
 for the matrix of device configurations can be very challenging. With the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Android+Emulator+Plugin[Android
+link:https://plugins.jenkins.io/android-emulator[Android
 emulator plugin]
 however, it is possible to build and test on a myriad of emulated devices.
 
 When combined with the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Google+Play+Android+Publisher+Plugin[Google
+link:https://plugins.jenkins.io/google-play-android-publisher[Google
 Play Publisher plugin], Android developers can build true continuous delivery
 pipeline, sending builds to an alpha channel in Google Play for release or
 further testing.

--- a/content/solutions/embedded.adoc
+++ b/content/solutions/embedded.adoc
@@ -30,8 +30,8 @@ environments, a few of the following approaches can be considered:
   Variables_ section. Once the variable is modified, the build agent should be
   reconnected.
 . In order to integrate setup the tool environment, consider
-  link:https://plugins.jenkins.io/custom-tools-plugin[Custom Tools Plugin].
-. link:https://plugins.jenkins.io/envinject[EnvInject Plugin] allows to setup custom environments at the job level.
+  plugin:custom-tools-plugin[Custom Tools Plugin].
+. plugin:envinject[EnvInject Plugin] allows to setup custom environments at the job level.
 
 === Working with FPGA boards and hardware peripherals
 
@@ -41,9 +41,9 @@ attempting to access the same shared external peripherals at the same time.
 There are a few plugins which can help manage concurrent peripherals access
 such as the:
 
-. link:https://plugins.jenkins.io/throttle-concurrents[Throttle Concurrent Builds Plugin] allows preventing hardware and license usage conflicts.
-. link:https://plugins.jenkins.io/build-timeout[Build Timeout Plugin] helps prevent tools (e.g. cable drives) which might hang for whatever reason, blocking a Jenkins build indefinitely.
-. link:https://plugins.jenkins.io/naginator[Naginator Plugin] enables conditional restarting of builds in case of flakey hardware issues.
+. plugin:throttle-concurrents[Throttle Concurrent Builds Plugin] allows preventing hardware and license usage conflicts.
+. plugin:build-timeout[Build Timeout Plugin] helps prevent tools (e.g. cable drives) which might hang for whatever reason, blocking a Jenkins build indefinitely.
+. plugin:naginator[Naginator Plugin] enables conditional restarting of builds in case of flakey hardware issues.
 
 
 === Working with computing grids
@@ -77,15 +77,11 @@ supported by exising Jenkins plugins.
 For tools which generate some form of XML-based reports, formatting of those
 reports can be implemented with an XSLT converter. Consider the following plugins for incorporating generated reports into Jenkins:
 
-* Unit testing results: link:https://plugins.jenkins.io/xunit[xUnit
-  Plugin], which
+* Unit testing results: plugin:xunit[xUnit Plugin], which
   provides a "Custom report" handler to convert any XML to JUnit formatted reports for Jenkins
-* Timing analysis reports: link:https://plugins.jenkins.io/performance[Performance
-  plugin]
+* Timing analysis reports: plugin:performance[Performance plugin]
   (support JMeter-alike reports)
-* Code coverage: link:https://plugins.jenkins.io/cobertura[Cobertura
-  Plugin] or
-  link:https://plugins.jenkins.io/emma[Emma Plugin]
+* Code coverage: plugin:cobertura[Cobertura Plugin] or plugin:emma[Emma Plugin]
 
 
 == Presentations

--- a/content/solutions/embedded.adoc
+++ b/content/solutions/embedded.adoc
@@ -30,8 +30,8 @@ environments, a few of the following approaches can be considered:
   Variables_ section. Once the variable is modified, the build agent should be
   reconnected.
 . In order to integrate setup the tool environment, consider
-  link:https://wiki.jenkins-ci.org/display/JENKINS/Custom+Tools+Plugin[Custom Tools Plugin].
-. link:https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin[EnvInject Plugin] allows to setup custom environments at the job level.
+  link:https://plugins.jenkins.io/custom-tools-plugin[Custom Tools Plugin].
+. link:https://plugins.jenkins.io/envinject[EnvInject Plugin] allows to setup custom environments at the job level.
 
 === Working with FPGA boards and hardware peripherals
 
@@ -41,9 +41,9 @@ attempting to access the same shared external peripherals at the same time.
 There are a few plugins which can help manage concurrent peripherals access
 such as the:
 
-. link:https://wiki.jenkins-ci.org/display/JENKINS/Throttle+Concurrent+Builds+Plugin[Throttle Concurrent Builds Plugin] allows preventing hardware and license usage conflicts.
-. link:https://wiki.jenkins-ci.org/display/JENKINS/Timeout+Plugin[Timeout Plugin] helps prevent tools (e.g. cable drives) which might hang for whatever reason, blocking a Jenkins build indefinitely.
-. link:https://wiki.jenkins-ci.org/display/JENKINS/Naginator+Plugin[Naginator Plugin] enables conditional restarting of builds in case of flakey hardware issues.
+. link:https://plugins.jenkins.io/throttle-concurrents[Throttle Concurrent Builds Plugin] allows preventing hardware and license usage conflicts.
+. link:https://plugins.jenkins.io/build-timeout[Build Timeout Plugin] helps prevent tools (e.g. cable drives) which might hang for whatever reason, blocking a Jenkins build indefinitely.
+. link:https://plugins.jenkins.io/naginator[Naginator Plugin] enables conditional restarting of builds in case of flakey hardware issues.
 
 
 === Working with computing grids
@@ -53,7 +53,7 @@ parallelized tests and builds it would be useful to provision Jenkins agents
 from computing grids
 
 There is a
-link:https://wiki.jenkins-ci.org/display/JENKINS/lsf-cloud+Plugin[LSF Cloud
+link:https://wiki.jenkins.io/display/JENKINS/lsf-cloud+Plugin[LSF Cloud
 Plugin] for link:https://en.wikipedia.org/wiki/Platform_LSF[LSF], but for other
 grids there is no open source plugins currently available.
 
@@ -77,15 +77,15 @@ supported by exising Jenkins plugins.
 For tools which generate some form of XML-based reports, formatting of those
 reports can be implemented with an XSLT converter. Consider the following plugins for incorporating generated reports into Jenkins:
 
-* Unit testing results: link:https://wiki.jenkins-ci.org/display/JENKINS/xUnit+Plugin[xUnit
+* Unit testing results: link:https://plugins.jenkins.io/xunit[xUnit
   Plugin], which
   provides a "Custom report" handler to convert any XML to JUnit formatted reports for Jenkins
-* Timing analysis reports: link:https://wiki.jenkins-ci.org/display/JENKINS/Performance+Plugin[Performance
+* Timing analysis reports: link:https://plugins.jenkins.io/performance[Performance
   plugin]
   (support JMeter-alike reports)
-* Code coverage: link:https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin[Cobertura
+* Code coverage: link:https://plugins.jenkins.io/cobertura[Cobertura
   Plugin] or
-  link:https://wiki.jenkins-ci.org/display/JENKINS/Emma+Plugin[Emma Plugin]
+  link:https://plugins.jenkins.io/emma[Emma Plugin]
 
 
 == Presentations

--- a/content/solutions/github.adoc
+++ b/content/solutions/github.adoc
@@ -12,12 +12,11 @@ The primary avenues for integrating your Jenkins instance with GitHub are:
 
 == Build integration
 
-With the help of the link:https://plugins.jenkins.io/git[Git plugin]
+With the help of the plugin:git[Git plugin]
 Jenkins can easily pull source code from any Git repository that the Jenkins
 build node can access.
 
-The link:https://plugins.jenkins.io/github[GitHub
-plugin] extends
+The plugin:github[GitHub plugin] extends
 upon that integration further by providing improved bi-directional
 integration with GitHub. Allowing you to set up a link:https://developer.github.com/webhooks/#service-hooks[Service
 Hook] which will hit
@@ -33,12 +32,11 @@ link:https://stackoverflow.com/questions/14274293/show-current-state-of-jenkins-
 
 == Authenticating with GitHub
 
-Using the
-link:https://plugins.jenkins.io/github-oauth[GitHub
-Authentication plugin] it is possible to use GitHub's own authentication scheme
+Using the plugin:github-oauth[GitHub Authentication plugin]
+it is possible to use GitHub's own authentication scheme
 for implementing authentication in your Jenkins instance.
 
-The **link:https://plugins.jenkins.io/github-oauth#GithubOAuthPlugin-Setup[setup guide]**
+The **plugin:github-oauth#GithubOAuthPlugin-Setup[setup guide]**
 will help walk you through configuring the GitHub OAuth side, and your
 Jenkins instance, to provide easy authentication/authorization for users.
 

--- a/content/solutions/github.adoc
+++ b/content/solutions/github.adoc
@@ -12,11 +12,11 @@ The primary avenues for integrating your Jenkins instance with GitHub are:
 
 == Build integration
 
-With the help of the link:https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin[Git plugin]
+With the help of the link:https://plugins.jenkins.io/git[Git plugin]
 Jenkins can easily pull source code from any Git repository that the Jenkins
 build node can access.
 
-The link:https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Plugin[GitHub
+The link:https://plugins.jenkins.io/github[GitHub
 plugin] extends
 upon that integration further by providing improved bi-directional
 integration with GitHub. Allowing you to set up a link:https://developer.github.com/webhooks/#service-hooks[Service
@@ -34,11 +34,11 @@ link:https://stackoverflow.com/questions/14274293/show-current-state-of-jenkins-
 == Authenticating with GitHub
 
 Using the
-link:https://wiki.jenkins-ci.org/display/JENKINS/GitHub+OAuth+Plugin[GitHub
+link:https://plugins.jenkins.io/github-oauth[GitHub
 Authentication plugin] it is possible to use GitHub's own authentication scheme
 for implementing authentication in your Jenkins instance.
 
-The **link:https://wiki.jenkins-ci.org/display/JENKINS/Github+OAuth+Plugin#GithubOAuthPlugin-Setup[setup guide]**
+The **link:https://plugins.jenkins.io/github-oauth#GithubOAuthPlugin-Setup[setup guide]**
 will help walk you through configuring the GitHub OAuth side, and your
 Jenkins instance, to provide easy authentication/authorization for users.
 

--- a/content/solutions/java.adoc
+++ b/content/solutions/java.adoc
@@ -22,7 +22,7 @@ image::/images/solution-images/jenkins-maven-step.png['Jenkins Maven step', role
 == Gradle
 
 As the associated plugin is not installed by default, first install the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin[Gradle plugin].
+link:https://plugins.jenkins.io/gradle[Gradle plugin].
 Once done, you should be able to add a Gradle step.
 
 

--- a/content/solutions/java.adoc
+++ b/content/solutions/java.adoc
@@ -22,7 +22,7 @@ image::/images/solution-images/jenkins-maven-step.png['Jenkins Maven step', role
 == Gradle
 
 As the associated plugin is not installed by default, first install the
-link:https://plugins.jenkins.io/gradle[Gradle plugin].
+plugin:gradle[Gradle plugin].
 Once done, you should be able to add a Gradle step.
 
 

--- a/content/solutions/pipeline.adoc
+++ b/content/solutions/pipeline.adoc
@@ -14,8 +14,7 @@ best practices to the job configurations themselves.
 
 == Pipeline
 
-With the introduction of the link:https://plugins.jenkins.io/workflow-aggregator[Pipeline
-plugin],
+With the introduction of the plugin:workflow-aggregator[Pipeline plugin],
 users now can implement a project's entire build/test/deploy pipeline
 in a `Jenkinsfile` and store that alongside their code, treating their
 pipeline as another piece of code checked into source control.
@@ -32,15 +31,14 @@ features like:
   "link:/doc/book/pipeline/shared-libraries/[Shared Libraries]" feature.
 
 In an adjacent space is the
-link:https://plugins.jenkins.io/job-dsl[Job DSL plugin]
+plugin:job-dsl[Job DSL plugin]
 which is worth mentioning as well.
 
 
 == Getting Started
 
 * link:/doc/pipeline[Getting Started with Pipeline]
-* The link:https://plugins.jenkins.io/workflow-aggregator[Pipeline
-  plugin]
+* The plugin:workflow-aggregator[Pipeline plugin]
   has a fairly comprehensive
   link:https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md[tutorial]
   checked into its source tree too.
@@ -58,7 +56,7 @@ Demonstrations of Pipeline functionality you can run locally.
 
 == Additional resources
 
-* link:https://plugins.jenkins.io/workflow-aggregator[Pipeline Plugin page]
+* plugin:workflow-aggregator[Pipeline Plugin page]
 * link:https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md[Plugins compatible with Workflow]
 * link:https://stackoverflow.com/questions/tagged/jenkins-workflow[Stack Overflow "jenkins-workflow" tag]
 * link:https://github.com/jenkinsci/workflow-examples[Examples/snippets repository]
@@ -66,7 +64,7 @@ Demonstrations of Pipeline functionality you can run locally.
 
 == Presentations
 
-The presentations below were given by link:https://github.com/jglick[Jesse Glick], author of the link:https://plugins.jenkins.io/workflow-aggregator[Pipeline Plugin]
+The presentations below were given by link:https://github.com/jglick[Jesse Glick], author of the plugin:workflow-aggregator[Pipeline Plugin]
 
 ++++
 <center>

--- a/content/solutions/pipeline.adoc
+++ b/content/solutions/pipeline.adoc
@@ -14,14 +14,14 @@ best practices to the job configurations themselves.
 
 == Pipeline
 
-With the introduction of the link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin[Pipeline
+With the introduction of the link:https://plugins.jenkins.io/workflow-aggregator[Pipeline
 plugin],
 users now can implement a project's entire build/test/deploy pipeline
 in a `Jenkinsfile` and store that alongside their code, treating their
 pipeline as another piece of code checked into source control.
 
 The Pipeline plugin was inspired by the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin[Build Flow
+link:https://wiki.jenkins.io/display/JENKINS/Build+Flow+Plugin[Build Flow
 plugin] but aims to improve upon some concepts explored by Build Flow with
 features like:
 
@@ -32,14 +32,14 @@ features like:
   "link:/doc/book/pipeline/shared-libraries/[Shared Libraries]" feature.
 
 In an adjacent space is the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin[Job DSL plugin]
+link:https://plugins.jenkins.io/job-dsl[Job DSL plugin]
 which is worth mentioning as well.
 
 
 == Getting Started
 
 * link:/doc/pipeline[Getting Started with Pipeline]
-* The link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin[Pipeline
+* The link:https://plugins.jenkins.io/workflow-aggregator[Pipeline
   plugin]
   has a fairly comprehensive
   link:https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md[tutorial]
@@ -58,7 +58,7 @@ Demonstrations of Pipeline functionality you can run locally.
 
 == Additional resources
 
-* link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin[Pipeline Plugin page]
+* link:https://plugins.jenkins.io/workflow-aggregator[Pipeline Plugin page]
 * link:https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md[Plugins compatible with Workflow]
 * link:https://stackoverflow.com/questions/tagged/jenkins-workflow[Stack Overflow "jenkins-workflow" tag]
 * link:https://github.com/jenkinsci/workflow-examples[Examples/snippets repository]
@@ -66,7 +66,7 @@ Demonstrations of Pipeline functionality you can run locally.
 
 == Presentations
 
-The presentations below were given by link:https://github.com/jglick[Jesse Glick], author of the link:https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin[Pipeline Plugin]
+The presentations below were given by link:https://github.com/jglick[Jesse Glick], author of the link:https://plugins.jenkins.io/workflow-aggregator[Pipeline Plugin]
 
 ++++
 <center>

--- a/content/solutions/python.adoc
+++ b/content/solutions/python.adoc
@@ -12,7 +12,7 @@ for testing/reporting such as:
 
 * link:https://github.com/nose-devs/nose2[nose2] and link:https://docs.pytest.org/en/latest[pytest]
   for executing unit tests and generating JUnit-compatible XML test reports _and_
-  link:https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin[Cobertura]-compatible
+  link:https://plugins.jenkins.io/cobertura[Cobertura]-compatible
   code coverage reports.
 
 

--- a/content/solutions/python.adoc
+++ b/content/solutions/python.adoc
@@ -12,7 +12,7 @@ for testing/reporting such as:
 
 * link:https://github.com/nose-devs/nose2[nose2] and link:https://docs.pytest.org/en/latest[pytest]
   for executing unit tests and generating JUnit-compatible XML test reports _and_
-  link:https://plugins.jenkins.io/cobertura[Cobertura]-compatible
+  plugin:cobertura[Cobertura]-compatible
   code coverage reports.
 
 

--- a/content/solutions/ruby.adoc
+++ b/content/solutions/ruby.adoc
@@ -22,13 +22,13 @@ image::/images/solution-images/junit-rspec-postbuild-action.png[Configured JUnit
 
 By integrating the test reports into Jenkins, you can generate trends and
 reports. There are other plugins, such as the
-link:https://wiki.jenkins-ci.org/display/JENKINS/Email-ext+plugin[Email Ext
-plugin] which can also make use of these machine-readable test reports to send
+link:https://plugins.jenkins.io/email-ext[Email Ext plugin]
+which can also make use of these machine-readable test reports to send
 email notifications with only the failing test cases listed.
 
 image::/images/solution-images/junit-rspec-trend.png[Trending RSpec test reports, role=center]
 
-Using plugins such as the link:https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Test+Result+Plugin[Cucumber Test Result
+Using plugins such as the link:https://plugins.jenkins.io/cucumber-testresult-plugin[Cucumber Test Result
 plugin]
 improve the integration and discoverability of successful/unsuccessful
 Cucumber scenarios.

--- a/content/solutions/ruby.adoc
+++ b/content/solutions/ruby.adoc
@@ -22,14 +22,13 @@ image::/images/solution-images/junit-rspec-postbuild-action.png[Configured JUnit
 
 By integrating the test reports into Jenkins, you can generate trends and
 reports. There are other plugins, such as the
-link:https://plugins.jenkins.io/email-ext[Email Ext plugin]
+plugin:email-ext[Email Ext plugin]
 which can also make use of these machine-readable test reports to send
 email notifications with only the failing test cases listed.
 
 image::/images/solution-images/junit-rspec-trend.png[Trending RSpec test reports, role=center]
 
-Using plugins such as the link:https://plugins.jenkins.io/cucumber-testresult-plugin[Cucumber Test Result
-plugin]
+Using plugins such as the plugin:cucumber-testresult-plugin[Cucumber Test Result plugin]
 improve the integration and discoverability of successful/unsuccessful
 Cucumber scenarios.
 


### PR DESCRIPTION
Mostly just changing wiki.jenkins-ci.org to wiki.jenkins.io, where applicable also replacing links to the wiki with links to the plugin site (based on @MarkEWaite 's suggestion in #2221 )