### PR TITLE
Fix the meetings hyperlinks on the SIG pages

### DIFF
--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -47,7 +47,7 @@ participants:
 links:
   gitter: "jenkinsci/advocacy-and-outreach-sig"
   googlegroup: "jenkins-advocacy-and-outreach-sig"
-  meetings: "/projects/sigs/advocacy-and-outreach/#meetings"
+  meetings: "https://docs.google.com/document/d/1K5dTSqe56chFhDSGNfg_MCy-LmseUs_S3ys_tg60sTs/edit#heading=h.9jh09t587y90"
 overview: >
   This special interest group offers a venue for discussions around
   advocacy and outreach in the Jenkins community.

--- a/content/sigs/chinese-localization/index.adoc
+++ b/content/sigs/chinese-localization/index.adoc
@@ -33,7 +33,7 @@ organizations:
 links:
   gitter: jenkinsci/chinese-localization-sig
   googlegroup: jenkins-chinese-localization-sig
-  meetings: "/projects/sigs/chinese-localization/#meetings"
+  meetings: "/sigs/chinese-localization/#meetings"
 
 overview: >
   The Chinese Localization group of contributors and collaborators focuses on

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -86,7 +86,7 @@ organizations:
 links:
   gitter: jenkinsci/cloud-native-sig
   googlegroup: jenkins-cloud-native-sig
-  meetings: "/projects/sigs/cloud-native/#meetings"
+  meetings: "/sigs/cloud-native/#meetings"
 
 overview: >
   The Cloud Native group of contributors and collaborators focuses on

--- a/content/sigs/hw-and-eda/index.adoc
+++ b/content/sigs/hw-and-eda/index.adoc
@@ -21,7 +21,7 @@ participants:
 links:
   gitter: jenkinsci/hw-and-eda-sig
   googlegroup: jenkins-hw-and-eda-sig
-  meetings: "/projects/sigs/hw-and-eda/#meetings"
+  meetings: "/sigs/hw-and-eda/#meetings"
 
 overview: >
   This special interest group of Jenkins users and practitioners

--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -71,7 +71,7 @@ organizations:
 links:
   gitter: jenkinsci/pipeline-authoring-sig
   googlegroup: jenkins-pipeline-authoring-sig
-  meetings: "/projects/sigs/pipeline-authoring/#meetings"
+  meetings: "/sigs/pipeline-authoring/#meetings"
 
 overview: >
   This special interest group aims to improve and curate the

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -61,7 +61,7 @@ participants:
 links:
   gitter: "jenkinsci/platform-sig"
   googlegroup: "jenkins-platform-sig"
-  meetings: "/projects/sigs/platform/#meetings"
+  meetings: "/sigs/platform/#meetings"
 overview: >
   This special interest group offers a venue for all kinds of platform support discussions:
   Java, Operating Systems, Architectures, Docker, Packaging, Web Containers, etc.


### PR DESCRIPTION
# SIG's not under projects

The 'Connect' links are intended to link to locations outside the page. They open a new browser tab when the link is clicked.

However, some of the special interest groups don't have a solo meeting URL that is external to the page.  Rather than remove the 'Meetings' link in the 'Connect' section for those pages, this change will resolve those links to the 'Meetings' heading inside the page.

### External meeting note locations:

* Advocacy and Outreach SIG links to external meeting notes
* Platform SIG links to external meeting notes

### Internal meeting note locations:

* Chinese localization SIG
* Cloud native SIG
* Hardware / EDA SIG
* Pipeline authoring SIG

![image](https://user-images.githubusercontent.com/156685/57565260-d0080600-7377-11e9-9c91-001563680ef9.png)
