### PR TITLE
Announce Docs SIG with SIG page and blog post

### DIFF
--- a/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
+++ b/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
@@ -1,0 +1,41 @@
+---
+:layout: post
+:title: "Jenkins Documentation Special Interest Group"
+:tags:
+- documentation
+- docs
+- community
+:author: markewaite
+:sig: docs
+---
+
+image:/images/logos/256.png[Jenkins, role=center, float=right]
+
+We're pleased to announce the formation of the Jenkins Documentation Special Interest Group.
+The Docs SIG will encourage, create, and review documentation contributions and improve documentation with contributors and external communities.
+
+See the link:/sigs/docs[Special Interest Group Overview] for more details and plans.
+
+== How can I help?
+
+The Jenkins Documentation SIG would love to have your help with:
+
+* reviewing and fixing link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20%22Jenkins%20Website%22%20AND%20status%20!%3D%20Done[open bug reports]
+* reviewing link:https://github.com/jenkins-infra/jenkins.io/pulls[Jenkins documentation pull requests]
+* reviewing link:https://github.com/jenkins-x/jx-docs/pulls[Jenkins X documentation pull requests]
+
+== How can I fix a documentation bug?
+
+Instructions for contributing to the Jenkins documentation are in the link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#getting-started[CONTRIBUTING file] of the site repository.
+Follow the instructions in that file and submit pull requests for review.
+
+Instructions for contributing to the Jenkins X documentation are on the link:https://jenkins-x.io/contribute/documentation/[Jenkins X documentation site].
+Follow those instructions and submit pull requests for review.
+
+== How can I evaluate a pull request?
+
+Pull requests for the Jenkins project are reviewed in the link:https://github.com/jenkins-infra/jenkins.io/pulls[Jenkins documentation repository].
+Login to GitHub with your credentials and add your review comments to pull requests.
+
+Pull requests for the Jenkins X project are reviewed in the link:https://github.com/jenkins-x/jx-docs/pulls[Jenkins X documentation repository].
+Login to GitHub with your credentials and add your review comments to pull requests.

--- a/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
+++ b/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
@@ -30,7 +30,7 @@ Instructions for contributing to the Jenkins documentation are in the link:https
 Follow the instructions in that file and submit pull requests for review.
 
 Instructions for contributing to the Jenkins X documentation are on the link:https://jenkins-x.io/contribute/documentation/[Jenkins X documentation site].
-Follow those instructions and submit pull requests for review.
+Follow the instructions in that file and submit pull requests for review.
 
 == How can I evaluate a pull request?
 

--- a/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
+++ b/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
@@ -35,7 +35,7 @@ Follow those instructions and submit pull requests for review.
 == How can I evaluate a pull request?
 
 Pull requests for the Jenkins project are reviewed in the link:https://github.com/jenkins-infra/jenkins.io/pulls[Jenkins documentation repository].
-Login to GitHub with your credentials and add your review comments to pull requests.
+Log in to GitHub with your credentials and add your review comments to pull requests.
 
 Pull requests for the Jenkins X project are reviewed in the link:https://github.com/jenkins-x/jx-docs/pulls[Jenkins X documentation repository].
 Login to GitHub with your credentials and add your review comments to pull requests.

--- a/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
+++ b/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
@@ -12,7 +12,7 @@
 image:/images/logos/256.png[Jenkins, role=center, float=right]
 
 We're pleased to announce the formation of the Jenkins Documentation Special Interest Group.
-The Docs SIG will encourage, create, and review documentation contributions and improve documentation with contributors and external communities.
+The Docs SIG encourages contributors and external communities to create and review Jenkins documentation. 
 
 See the link:/sigs/docs[Special Interest Group Overview] for more details and plans.
 

--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -77,6 +77,21 @@ notitle: true
                   14h UTC
               %h5.title
                 Google Summer of Code Office Hours
+    .col-md-6.text-center
+      %ul.ji-item-list
+        %li.post.event.floating
+          %a.body{:href => 'https://jenkins.io/sigs/docs#meetings', :target => '_blank'}
+            .header.time
+              .date-time
+                .date
+                  .day.small
+                    Every other Fri
+                  .dow
+                    Fri
+                .time
+                  13h UTC
+              %h5.title
+                Docs SIG Meeting
 
   .row
     .col

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -1,0 +1,124 @@
+---
+layout: sig
+title: "Documentation"
+section: sigs
+sigId: "docs"
+logo: /images/logos/formal/256.png
+tags:
+  - docs
+  - docs_sig
+  - docs-sig
+  - documentation
+leads:
+- name: "Mark Waite"
+  id: "markewaite"
+  github: "markewaite"
+  irc: "markewaite"
+  twitter: "MarkEWaite"
+participants:
+- name: "Oleg Nenashev"
+  id: "oleg_nenashev"
+  github: "oleg-nenashev"
+  irc: "oleg_nenashev"
+  twitter: "oleg_nenashev"
+- name: "Tracy Miranda"
+  id: "tracymiranda"
+  github: "tracymiranda"
+  irc: "tracymiranda"
+  twitter: "tracymiranda"
+- name: "Tammy Fox"
+  id: "tfoxnc"
+  github: "tfoxnc"
+- name: "Kristin Whetstone"
+  id: "kwhetstone"
+  github: "kwhetstone"
+  twitter: "lighteningdrake"
+- name: "Radek Antoniuk"
+  id: "warden"
+  github: "warden"
+  irc: "warden"
+- name: "John Ha"
+  id: "jha-cloudbees"
+  github: "jha-cloudbees"
+- name: "Petra Sargent"
+  id: "petra-sargent"
+  github: "petra-sargent"
+  twitter: "momsthatcode"
+- name: "Owen Mehegan"
+  id: "omehegan"
+  github: "omehegan"
+  twitter: "literatesavant"
+- name: "Meg McRoberts"
+  id: "stackscribe"
+  github: "stackscribe"
+- name: "Zhao Xiaojie (Rick)"
+  id: "surenpi"
+  github: "LinuxSuRen"
+links:
+  gitter: "jenkinsci/docs"
+  googlegroup: "jenkinsci-docs"
+  meetings: "https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#"
+overview: >
+  This special interest group improves Jenkins use and adoption through documentation.
+  The SIG encourages, creates, and reviews documentation contributions and improves documentation with contributors and external communities.
+---
+
+The Documentation special interest group offers a venue for all kinds of documentation creation, improvement, and delivery.
+
+The group focuses on documentation for Jenkins and Jenkins X, including:
+
+* link:/doc/[User documentation] - Using Jenkins
+** link:/doc/tutorials[Tutorials]
+** link:/doc/book/[User Handbook]
+** References like link:/doc/book/pipeline/syntax/[Pipeline Syntax] and link:/doc/pipeline/steps/[Pipeline Steps]
+** How-to Guides
+* link:/doc/developer/[Extension documentation] - Extending Jenkins
+** link:/doc/developer/tutorial/[Tutorials]
+** link:/doc/developer/book/[Developer Reference]
+** link:/doc/developer/guides/[How-To Guides]
+* Solution documentation - Specific Solutions with Jenkins
+** Language solutions like link:/solutions/c/[C/C\+\+], link:/solutions/java/[Java], link:/solutions/php/[PHP], link:/solutions/python/[Python], and link:/solutions/c/[Ruby]
+** Platform solutions like link:/solutions/android/[Android], link:/solutions/docker[Docker], and link:/solutions/embedded[Embedded]
+** Implementation solutions like link:/solutions/pipeline[Pipeline]
+
+Documentation SIG may cooperate with other groups.
+For example, we will be cooperating with the link:/sigs/cloud-native[Cloud-Native Jenkins SIG]
+on topics related to Cloud-Native documentation efforts and
+with the link:/sigs/platform[Platform SIG].
+on platform topics.
+
+=== Topics
+
+* Creating new documentation
+* Improving existing documentation
+* Reviewing documentation contributions
+* Coordinating documentation initiatives
+* Reviewing JEPs related to documentation
+
+=== Ongoing projects
+
+* Reviewing Jenkins documentation link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20%22Jenkins%20Website%22%20and%20status%20!%3D%20done%20ORDER%20BY%20%20type%20asc%2C%20status%2C%20updatedDate[bug reports]
+* Identifying link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20%22Jenkins%20Website%22%20and%20status%20!%3D%20done%20and%20labels%20%3D%20newbie-friendly%20ORDER%20BY%20%20%20type%20asc%2C%20status%2C%20updatedDate[newbie-friendly documentation bug reports]
+* Reviewing Jenkins documentation link:https://github.com/jenkins-infra/jenkins.io/pulls[pull requests]
+* Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
+* link:https://plugins.jenkins.io/[Plugins site] improvements
+
+See the SIG meeting notes for more information about the ongoing projects.
+
+=== Meetings
+
+We have regular meetings on Fridays every two weeks, at *1PM UTC*.
+See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
+At these meetings we discuss projects and do presentations/demos.
+You can find and contribute to the agenda for the incoming meetings
+link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[here].
+
+Meetings will be conducted and recorded via Zoom.
+Participant links will be posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+
+==== 2019-05-10
+
+Initial organizing meeting
+
+* link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#heading=h.g4afeqolzwpj[Meeting notes]
+* Youtube recording to be added later

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -63,7 +63,7 @@ overview: >
   The SIG encourages, creates, and reviews documentation contributions and improves documentation with contributors and external communities.
 ---
 
-The Documentation special interest group offers a venue for all kinds of documentation creation, improvement, and delivery.
+The SIG offers a venue for all kinds of documentation creation, improvement, and delivery.
 
 The group focuses on documentation for Jenkins and Jenkins X, including:
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -113,8 +113,8 @@ At these meetings we discuss projects and do presentations/demos.
 You can find and contribute to the agenda for the incoming meetings
 link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[here].
 
-Meetings will be conducted and recorded via Zoom.
-Participant links will be posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+Meetings are conducted and recorded using Zoom.
+Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
 
 ==== 2019-05-10
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -93,7 +93,7 @@ on platform topics.
 * Improving existing documentation
 * Reviewing documentation contributions
 * Coordinating documentation initiatives
-* Reviewing JEPs related to documentation
+* Reviewing Jenkins Enhancement Proposals (JEPs) related to documentation
 
 === Ongoing projects
 


### PR DESCRIPTION
Include links to existing documentation like:

* Using Jenkins
* Extending Jenkins
* Solution documentation

Include participants from the initial meeting and individuals that have expressed willingness to contribute to documentation.

Also adds the Docs SIG to the repeating events list and provides a blog entry for the Docs SIG.
