### PR TITLE
[WEBSITE-610] Clarify credential masking limitations

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -521,12 +521,17 @@ Pipeline's <<syntax#environment,`environment`>> directive), within this stage's
 steps using the syntax `$AWS_ACCESS_KEY_ID` and `$AWS_SECRET_ACCESS_KEY`. For
 example, here you can authenticate to AWS using the secret text credentials
 assigned to these credential variables. +
-To maintain the security and anonymity of these credentials, if you attempt to
-retrieve the value of these credential variables from within the Pipeline (e.g.
+To maintain the security and anonymity of these credentials, if the job
+displays the value of these credential variables from within the Pipeline (e.g.
 `echo $AWS_SECRET_ACCESS_KEY`), Jenkins only returns the value "`+****+`" to
-prevent secret information from being written to the console output and any
+reduce the risk of secret information being disclosed to the console output and any
 logs. Any sensitive information in credential IDs themselves (such as usernames)
-are also returned as "`+****+`" in the Pipeline run's output.
+are also returned as "`+****+`" in the Pipeline run's output. +
+This only reduces the risk of **accidental exposure**.  It does
+not prevent a malicious user from capturing the credential value
+by other means. A Pipeline that uses credentials can also disclose
+those credentials.  Don't allow untrusted Pipeline jobs to use trusted
+credentials.
 <2> In this Pipeline example, the credentials assigned to the two `AWS_...`
 environment variables are scoped globally for the entire Pipeline, so these
 credential variables could also be used in this stage's steps. If, however, the
@@ -612,10 +617,15 @@ stage's steps and can be referenced using the syntax:
 +
 For example, here you can authenticate to Bitbucket with the username and
 password assigned to these credential variables. +
-To maintain the security and anonymity of these credentials, if you attempt to
-retrieve the value of these credential variables from within the Pipeline, the
+To maintain the security and anonymity of these credentials, if the job
+displays the value of these credential variables from within the Pipeline the
 same behavior described in the <<#secret-text,Secret text>> example above
-applies to these username and password credential variable types too.
+applies to these username and password credential variable types too. +
+This only reduces the risk of **accidental exposure**.  It does
+not prevent a malicious user from capturing the credential value
+by other means. A Pipeline that uses credentials can also disclose
+those credentials.  Don't allow untrusted Pipeline jobs to use trusted
+credentials.
 <2> In this Pipeline example, the credentials assigned to the three
 `COMMON_BITBUCKET_CREDS...` environment variables are scoped only to `Example
 stage 1`, so these credential variables are not available for use in this
@@ -784,7 +794,12 @@ To maintain the security and anonymity of these credentials, if you attempt to
 retrieve the value of these credential variables from within these
 `withCredentials( ... ) { ... }` steps, the same behavior described in the
 <<#secret-text,Secret text>> example (above) applies to these SSH public/private
-key pair credential and certificate variable types too.
+key pair credential and certificate variable types too. +
+This only reduces the risk of **accidental exposure**.  It does
+not prevent a malicious user from capturing the credential value
+by other means. A Pipeline that uses credentials can also disclose
+those credentials.  Don't allow untrusted Pipeline jobs to use trusted
+credentials.
 
 [NOTE]
 ====


### PR DESCRIPTION
Credential masking is a reasonable attempt to prevent accidental disclosure of credentials.  It does not (and cannot) prevent those with malicious intent from disclosing credentials which their Pipeline is allowed to access.  If a Pipeline can use a credential, it has the values of the credential and can leak those values if it chooses to do so.

See [WEBSITE-610](https://issues.jenkins-ci.org/browse/WEBSITE-610) for more details