### PR TITLE
Docs SIG should not use the Platform SIG logo

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -3,7 +3,6 @@ layout: sig
 title: "Documentation"
 section: sigs
 sigId: "docs"
-logo: /images/logos/formal/256.png
 tags:
   - docs
   - docs_sig


### PR DESCRIPTION
I suggest that there is another logo chosen for the Docs SIG.

CC @MarkEWaite 