### PR TITLE
Remove docs sig blog image

### DIFF
--- a/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
+++ b/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc
@@ -9,7 +9,7 @@
 :sig: docs
 ---
 
-image:/images/logos/256.png[Jenkins, role=center, float=right]
+image:/images/logos/needs-you/Jenkins_Needs_You-02.png[Jenkins Needs You, role=center, float=right, height=256]
 
 We're pleased to announce the formation of the Jenkins Documentation Special Interest Group.
 The Docs SIG encourages contributors and external communities to create and review Jenkins documentation. 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -77,7 +77,7 @@ The group focuses on documentation for Jenkins and Jenkins X, including:
 ** link:/doc/developer/book/[Developer Reference]
 ** link:/doc/developer/guides/[How-To Guides]
 * Solution documentation - Specific Solutions with Jenkins
-** Language solutions like link:/solutions/c/[C/C\+\+], link:/solutions/java/[Java], link:/solutions/php/[PHP], link:/solutions/python/[Python], and link:/solutions/c/[Ruby]
+** Language solutions like link:/solutions/c/[C/C++], link:/solutions/java/[Java], link:/solutions/php/[PHP], link:/solutions/python/[Python], and link:/solutions/c/[Ruby]
 ** Platform solutions like link:/solutions/android/[Android], link:/solutions/docker[Docker], and link:/solutions/embedded[Embedded]
 ** Implementation solutions like link:/solutions/pipeline[Pipeline]
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -3,6 +3,7 @@ layout: sig
 title: "Documentation"
 section: sigs
 sigId: "docs"
+logo: /images/logos/needs-you/Jenkins_Needs_You-02.png
 tags:
   - docs
   - docs_sig

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -103,7 +103,7 @@ on platform topics.
 * Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
 * link:https://plugins.jenkins.io/[Plugins site] improvements
 
-See the SIG meeting notes for more information about the ongoing projects.
+See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
 === Meetings
 

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -105,7 +105,7 @@ ARM architecture support, adapting RedHat packaging to best practices, etc.)
 * Enabling continuous delivery for Jenkins packaging
 ** Experimental DockerHub organization and deployments from ci.jenkins.io (jep:217[])
 
-See the SIG meeting notes for more information about the ongoing projects.
+See the link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y/edit?usp=sharing[SIG meeting notes] for more information about the ongoing projects.
 
 === Meetings
 


### PR DESCRIPTION
Don't include a broken image reference, better to wait until a specific image is selected or provided.  That image should not be the same image as any other SIG and preferably would be unique to the Docs SIG.