### PR TITLE
Fix display of videos in solution sites

### DIFF
--- a/content/_data/solutions/android.yml
+++ b/content/_data/solutions/android.yml
@@ -31,5 +31,5 @@ videos:
   title: 'Building, testing and deploying Android apps'
 -
   short:
-  id: EOogyOv79NE
+  id: 'zm6ntUt-vqY'
   title: 'Continuous Integration for Mobile Apps with Jenkins'

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -336,6 +336,8 @@ img.desaturate {
 }
 
 .media-row {
+    display: flex;
+    flex-wrap: wrap;
     background-color: #fff;
 }
 


### PR DESCRIPTION
* replace dead video link with a valid one
* make sure 'media-row' class is actually displayed as row and only wraps on small screens (currently displayed as column, see https://jenkins.io/solutions/docker/ )