### PR TITLE
[WEBSITE-520] add OpenGraph image to SIGs and projects

### DIFF
--- a/content/projects/evergreen/index.adoc
+++ b/content/projects/evergreen/index.adoc
@@ -5,6 +5,7 @@ section: projects
 tags:
 - evergreen
 - evergreen
+
 opengraph:
   image: /images/logos/evergreen/evergreen.png
 links:

--- a/content/projects/evergreen/index.adoc
+++ b/content/projects/evergreen/index.adoc
@@ -5,7 +5,8 @@ section: projects
 tags:
 - evergreen
 - evergreen
-
+opengraph:
+  image: /images/logos/evergreen/evergreen.png
 links:
   gitter: 'jenkins-infra/evergreen'
   twitter: 'evergreenbutler'

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -5,6 +5,8 @@ section: projects
 tags:
 - gsoc
 sig: gsoc
+opengraph:
+  image: /images/gsoc/jenkins-gsoc-logo_small.png
 links:
   meetings: "/projects/gsoc/#office-hours"
 ---
@@ -49,7 +51,7 @@ Projects may also have their own mailing lists, chats and meetings.
 See details on project pages.
 * We use link:https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public[mailing list] for discussions.
   This is the **recommended** channel for communications
-* There is also a [GSoC Gitter channel](https://gitter.im/jenkinsci/gsoc-sig) for real-time communications,
+* There is also a link:https://gitter.im/jenkinsci/gsoc-sig:[GSoC Gitter channel] for real-time communications,
    but it is better to use mailing lists to request technical feedback or to have long discussions
 
 === Mailing lists

--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -5,11 +5,12 @@ section: projects
 tags:
 - jenkins-configuration-as-code
 - jcasc
+opengraph:
+  image: /images/logos/JCasC/JCasC.png
 links:
   gitter: 'jenkinsci/configuration-as-code-plugin'
   github: 'jenkinsci/configuration-as-code-plugin'
   meetings: "/projects/projects/jcasc/#office-hours-meeting"
-
 ---
 
 The ‘as code’ paradigm is about being able to reproduce and/or restore a full environment within minutes based on recipes and automation, managed as code.

--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -11,6 +11,7 @@ links:
   gitter: 'jenkinsci/configuration-as-code-plugin'
   github: 'jenkinsci/configuration-as-code-plugin'
   meetings: "/projects/projects/jcasc/#office-hours-meeting"
+
 ---
 
 The ‘as code’ paradigm is about being able to reproduce and/or restore a full environment within minutes based on recipes and automation, managed as code.

--- a/content/projects/jenkins-x/index.adoc
+++ b/content/projects/jenkins-x/index.adoc
@@ -5,6 +5,8 @@ section: projects
 tags:
 - jenkins-x
 - kubernetes
+opengraph:
+  image: /images/logos/jenkins-x/jenkins-x.png
 links:
   github: 'jenkins-x'
   chat: 'https://jenkins-x.io/community/#slack'

--- a/content/sigs/chinese-localization/index.adoc
+++ b/content/sigs/chinese-localization/index.adoc
@@ -4,6 +4,8 @@ title: "Chinese Localization"
 section: sigs
 sigId: "chinese-localization"
 logo: /images/logos/kongfu/256.png
+opengraph:
+  image: /images/logos/kongfu/kongfu.png
 tags:
 - chinese
 - localization

--- a/content/sigs/gsoc/index.adoc
+++ b/content/sigs/gsoc/index.adoc
@@ -4,6 +4,8 @@ title: "Google Summer of Code"
 section: sigs
 sigId: "platform"
 logo: /images/gsoc/jenkins-gsoc-logo_small.png
+opengraph:
+  image: /images/gsoc/jenkins-gsoc-logo_small.png
 tags:
   - gsoc
 leads:

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -4,6 +4,8 @@ title: "Platform"
 section: sigs
 sigId: "platform"
 logo: /images/logos/formal/256.png
+opengraph:
+  image: /images/logos/formal/formal.png
 tags:
   - java
   - windows


### PR DESCRIPTION
Adds the `og:image` meta  tag to pages that have a unique logo.

Also fixes a minor typo in adoc syntax for GSoC.