### PR TITLE
Fix hyperlinks to Jenkins test harness javadoc

### DIFF
--- a/content/blog/2017/08/2017-08-07-intro-to-plugin-development.adoc
+++ b/content/blog/2017/08/2017-08-07-intro-to-plugin-development.adoc
@@ -28,7 +28,7 @@ Here are some of my favorite plugin development topics and links.
 == Plugin tutorial pages
 
 * Tutorial on link:https://jenkins.io/doc/developer/tutorial/[jenkins.io]
-** Install the latest link:https://adoptopenjdk.net/[Java Development Kit 8 or 11]
+** Install a Java Development kit, for example link:https://adoptopenjdk.net/[AdoptOpenJDK 8 or 11]
 ** Install the latest link:https://maven.apache.org/download.cgi[maven release]
 ** Install your link:https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial#Plugintutorial-SettingupaproductiveenvironmentwithyourIDE[IDE] (I like Netbeans, has the Jenkins/Stapler plugin to make plugin creation as easy as menu:File[New Project > Maven > Jenkins Plugin])
 

--- a/content/blog/2017/08/2017-08-07-intro-to-plugin-development.adoc
+++ b/content/blog/2017/08/2017-08-07-intro-to-plugin-development.adoc
@@ -28,7 +28,7 @@ Here are some of my favorite plugin development topics and links.
 == Plugin tutorial pages
 
 * Tutorial on link:https://jenkins.io/doc/developer/tutorial/[jenkins.io]
-** Install the latest link:https://www.oracle.com/technetwork/java/javase/downloads/index.html[Java SE Development Kit 8]
+** Install the latest link:https://adoptopenjdk.net/[Java Development Kit 8 or 11]
 ** Install the latest link:https://maven.apache.org/download.cgi[maven release]
 ** Install your link:https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial#Plugintutorial-SettingupaproductiveenvironmentwithyourIDE[IDE] (I like Netbeans, has the Jenkins/Stapler plugin to make plugin creation as easy as menu:File[New Project > Maven > Jenkins Plugin])
 
@@ -49,10 +49,10 @@ Many of the Jenkins plugin development topics have dedicated pages of their own,
 === Testing a plugin
 
 * link:https://wiki.jenkins.io/display/JENKINS/Unit+Test[Unit test] from the Jenkins wiki
-* Jenkins test objects like link:https://javadoc.jenkins.io/archive/jenkins-1.642/org/jvnet/hudson/test/JenkinsRule.html[JenkinsRule] and the link:https://javadoc.jenkins.io/archive/jenkins-1.642/org/jvnet/hudson/test/WithoutJenkins.html[WithoutJenkins annotation]
+* Jenkins test objects like link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/JenkinsRule.html[JenkinsRule] and the link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/WithoutJenkins.html[WithoutJenkins annotation]
 * DataBoundConstructor in link:https://wiki.jenkins.io/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins[Basic Guide to Jelly usage]
 * DataBoundSetter in link:https://groups.google.com/d/msg/jenkinsci-dev/58-DEvuJZWI/5QrxBZRFJ6IJ[google groups]
-* Java unit testing tools like link:https://code.google.com/archive/p/hamcrest/wikis/Tutorial.wiki[Hamcrest] and link:https://joel-costigliola.github.io/assertj/assertj-core-quick-start.html[AssertJ] (and link:https://javadoc.jenkins.io/archive/jenkins-1.642/org/jvnet/hudson/test/JenkinsMatchers.html[JenkinsMatchers])
+* Java unit testing tools like link:https://code.google.com/archive/p/hamcrest/wikis/Tutorial.wiki[Hamcrest] and link:https://joel-costigliola.github.io/assertj/assertj-core-quick-start.html[AssertJ] (and link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/JenkinsMatchers.html[JenkinsMatchers])
 * Java unit testing rules like link:https://junit.org/junit4/javadoc/4.12/org/junit/rules/TemporaryFolder.html[TemporaryFolder], link:https://junit.org/junit4/javadoc/4.12/org/junit/rules/Timeout.html[Timeout], and link:https://junit.org/junit4/javadoc/4.12/org/junit/rules/DisableOnDebug.html[DisableOnDebug]
 * Java unit testing classes like link:https://junit.org/junit4/javadoc/4.12/org/junit/Assume.html[Assume] and link:https://junit.org/junit4/javadoc/4.12/org/junit/runners/Parameterized.html[Parameterized]
 * Java unit testing mock frameworks like link:https://site.mockito.org/[mockito] and link:https://powermock.github.io/[powermock]


### PR DESCRIPTION
Blog post was written at a time when the javadoc for the Jenkins Test Harness was not being regularly published to a standard URL.  Use the standard URL now.