### PR TITLE
Add opengraph image to Docs SIG

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -54,6 +54,8 @@ participants:
 - name: "Zhao Xiaojie (Rick)"
   id: "surenpi"
   github: "LinuxSuRen"
+opengraph:
+  image: /images/logos/needs-you/Jenkins_Needs_You-02.png
 links:
   gitter: "jenkinsci/docs"
   googlegroup: "jenkinsci-docs"

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -4,6 +4,8 @@ title: "Documentation"
 section: sigs
 sigId: "docs"
 logo: /images/logos/needs-you/Jenkins_Needs_You-02.png
+opengraph:
+  image: /images/logos/needs-you/Jenkins_Needs_You-02.png
 tags:
   - docs
   - docs_sig
@@ -54,8 +56,6 @@ participants:
 - name: "Zhao Xiaojie (Rick)"
   id: "surenpi"
   github: "LinuxSuRen"
-opengraph:
-  image: /images/logos/needs-you/Jenkins_Needs_You-02.png
 links:
   gitter: "jenkinsci/docs"
   googlegroup: "jenkinsci-docs"


### PR DESCRIPTION
Twitter and Facebook shares will use the OpenGraph image as part of their post.  Images in social media posts increase user engagement.