### PR TITLE
Use minified version of jQuery

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -76,7 +76,7 @@
       :media => 'screen'}/
 
   %body
-    %script{:src => expand_link("/assets/bower/jquery/jquery.js")}
+    %script{:src => expand_link("/assets/bower/jquery/jquery.min.js")}
 
     = content
 

--- a/content/projects/blueocean/roadmap/index.html.haml
+++ b/content/projects/blueocean/roadmap/index.html.haml
@@ -32,7 +32,6 @@ project: blueocean
               %th Released
           %tbody
 
-%script{:src => "#{site.base_url}/assets/bower/jquery/jquery.min.js"}
 %script{:src => expand_link('js/blueocean-roadmap-script.js'), :type => "text/javascript"}
 %script{:src => expand_link('js/wow.js'), :type => "text/javascript"}
 :javascript


### PR DESCRIPTION
Currrently bower assets contain both full and minified version of jQuery. Most pages load the full one, Blue Ocean roadmap loads both. This PR loads the minified version everywhere.