### PR TITLE
Do not publish releases named 'null' in RSS

### DIFF
--- a/scripts/release.rss.groovy
+++ b/scripts/release.rss.groovy
@@ -42,7 +42,7 @@ xml.feed(xmlns:"http://www.w3.org/2005/Atom") {
 
   json.releaseHistory.reverse().subList(0,30).each { i ->
     i.releases.each { r ->
-      if (r.gav) {
+      if (r.gav && r.title) {
         entry {
           s = (first[toGA(r.gav)] == r.gav) ? " (new)" : ""
           title("${r.title} ${r.version}${s}")


### PR DESCRIPTION
An old optimization of the update center build was to not retrieve the plugin name and other metadata included in the manifest file for releases older than 31 days.

This script reads the last 31 per-day batches of plugin releases from that file. However, if no releases have happened yet today, then this will include dates older than the cutoff for retrieval of the plugin name.

For that reason, the oldest entries in release-history.json may lack the data required to have a title, so they show up as "null", e.g. in https://twitter.com/jenkins_release/status/1132456704027717633

Before and after: https://gist.github.com/daniel-beck/ed818b4597751ee9b93e5e48c8a79fd3

This is expected to only remove the oldest entries in some situations.