### PR TITLE
Fix newbie-friendly query URL in blog post

### DIFF
--- a/content/blog/2019/05/2019-05-30-becoming-contributor-newbie-tickets.adoc
+++ b/content/blog/2019/05/2019-05-30-becoming-contributor-newbie-tickets.adoc
@@ -36,7 +36,7 @@ Visiting the https://issues.jenkins-ci.org/projects/JENKINS/issues[Jenkins issue
 step, since it is full of potential bugs and enhancements that have already been reported by the community. However, it
 is quite easy to feel overwhelmed by the possibilities listed there. Bear in mind that in a 10+-year-old project like
 this, most of the things that are reported are tricky for a newcomer to work on. For that reason, filtering by
-https://issues.jenkins-ci.org/browse/WEBSITE-625?jql=labels%20%3D%20newbie-friendly[newbie-friendly tickets] is probably
+https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly)[newbie-friendly tickets] is probably
 the best idea.
 
 .Screenshot displaying the list of newbie-friendly tickets in the Jenkins Jira
@@ -247,7 +247,7 @@ process from the very beginning, picking a ticket from the Jenkins issue tracker
 change released in a new Jekins version.
 
 If you have never contributed but are willing to do so, I hope this article motivates you to go back to the list of
-https://issues.jenkins-ci.org/browse/WEBSITE-625?jql=labels%20%3D%20newbie-friendly[`newbie-friendly` tickets], find one that looks interesting to you, and follow the steps described above, until you see
+https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly)[`newbie-friendly` tickets], find one that looks interesting to you, and follow the steps described above, until you see
 your own change released in a new Jenkins version.
 
 Remember, don’t try to solve a complicated issue as your first ticket, there are plenty of easier ways in which you can


### PR DESCRIPTION
The newbie-friendly bug query in the Jenkins CONTRIBUTING file is a
good choice.  Use it instead of the earlier URL.