### PR TITLE
Updated the Error resolution for Ubuntu 18.04 Server Version

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -204,6 +204,15 @@ sudo apt-get update
 sudo apt-get install jenkins
 ----
 
+[NOTE]
+====
+If you face error "jenkins : Depends: daemon but it is not installable", execute following command after `sudo apt-get update` -
+[source,bash]
+----
+sudo add-apt-repository universe
+----
+====
+
 This package installation will:
 
 * Setup Jenkins as a daemon launched on start. See `/etc/init.d/jenkins` for more details.


### PR DESCRIPTION
Updated the resolution for the following common error -

Error -
The following packages have unmet dependencies:
 jenkins : Depends: daemon but it is not installable
E: Unable to correct problems, you have held broken packages.

Solution Updated -
sudo add-apt-repository universe