### PR TITLE
Fix asciidoc heading warnings in blog post

### DIFF
--- a/content/blog/2019/05/2019-05-09-templating-engine.adoc
+++ b/content/blog/2019/05/2019-05-09-templating-engine.adoc
@@ -25,7 +25,7 @@ Most pipelines are going to follow the same generic workflow regardless of which
 As technology consultants with clients in both the public and private sectors, at Booz Allen we found ourselves building DevSecOps pipelines from scratch for every new project.  Through developing the Jenkins Templating Engine, we’ve seen pipeline development decrease from months to days now that we can reuse tool integrations while bringing a new level of governance to Jenkins pipelines. 
 
 
-= Pipeline Templating 
+== Pipeline Templating
 
 Organizations benefit from letting application developers focus on what they do best: building applications. Supporting this means building a centralized DevOps team responsible for maintaining platform infrastructure and creating CI/CD pipelines utilized by development teams.  
 
@@ -35,7 +35,7 @@ While the tools may differ between development teams, the workflow is often the 
 
 NOTE: The Templating Engine Plugin allows you to remove the Jenkinsfile from each repository by defining a common workflow for teams to inherit.  Instead of an entire pipeline definition in each repository, teams supply a configuration file specifying which tools to use for the workflow. 
 
-= JTE in Action
+== JTE in Action
 
 Let's walk through a bare bones example to demonstrate the reusability of templates: 
 
@@ -55,7 +55,7 @@ significantly easier to manage when supporting multiple teams simultaneously.
 
 The steps outlined by this template (``unit_test``, ``build``, and ``static_code_analysis``) have been named generically on purpose. This way teams can specify __different__ libraries to use while sharing the __same__ pipeline.
 
-== Implementing the Template
+=== Implementing the Template
 
 Implementing a shareable pipeline with the Templating Engine requires a few key components:   
 
@@ -63,7 +63,7 @@ Implementing a shareable pipeline with the Templating Engine requires a few key 
 . **Libraries**: __Provide technical implementations of the steps of the workflow__ +
 . **Configuration Files**: __Specify which libraries to use and their configuration__ 
 
-=== Step 1: Create a Pipeline Configuration Repository
+==== Step 1: Create a Pipeline Configuration Repository
 
 A __Pipeline Configuration Repository__ is used to store common configurations and pipeline templates inherited by teams. 
 
@@ -79,7 +79,7 @@ NOTE: The pipeline templates and the configuration file for a Governance Tier ar
 
 When configuring the Governance Tier in Jenkins, you will provide a source code management location for a repository that contains the above components as well as the base directory where these artifacts can be found. 
 
-=== Step 2: Create the Pipeline Template 
+==== Step 2: Create the Pipeline Template
 
 Next, we'll create a ``Jenkinsfile`` for the Governance Tier.  In JTE, the ``Jenkinsfile`` is the default pipeline template that an execution will use. 
 
@@ -91,7 +91,7 @@ build()
 static_code_analysis() 
 ----
 
-=== Step 3: Create the Libraries
+==== Step 3: Create the Libraries
 
 The Templating Engine Plugin has implemented a version of Jenkins Shared Libraries to enhance the reusability of libraries.  A library is a root directory within a source code repository that has been configured as a Library Source on a Governance Tier.  
 
@@ -112,7 +112,7 @@ In this scenario, we should create ``gradle``, ``maven``, and ``sonarqube`` libr
   \-- static_code_analysis.groovy 
 ----
 
-=== Step 4: Implement the Steps
+==== Step 4: Implement the Steps
 
 Implementing a library step is exactly the same as just writing regular global variables as part of the default Jenkins Shared Libraries. 
 
@@ -128,7 +128,7 @@ void call(){
 
 TIP: Read more about link:https://boozallen.github.io/jenkins-templating-engine/pages/Library_Development/index.html[Library Development within JTE].
 
-=== Step 5: Create the Configuration Files 
+==== Step 5: Create the Configuration Files
 
 The configuration file for JTE is named ``pipeline_config.groovy``.  
 
@@ -163,7 +163,7 @@ libraries{
 }
 ----
 
-=== Step 6: Configure the Governance Tier in Jenkins
+==== Step 6: Configure the Governance Tier in Jenkins
 
 Now that we have a link:https://github.com/steven-terrana/example-jte-configuration[Pipeline Configuration Repository] and a link:https://github.com/steven-terrana/example-jte-libraries[Library Source Repository], we can configure a link:https://boozallen.github.io/jenkins-templating-engine/pages/Governance/index.html#governance-tier[Governance Tier] in Jenkins:
 
@@ -173,7 +173,7 @@ NOTE: This configuration shown in the image above can be found under ``Manage Je
 
 TIP: Through the Templating Engine, you can create a pipeline governance hierarchy matching your organization's taxonomy by representing this structure via Folders in Jenkins. 
 
-=== Step 7: Create a Multibranch Pipeline for Both Applications 
+==== Step 7: Create a Multibranch Pipeline for Both Applications
 
 When creating Multibranch Pipeline Projects for each app, the Templating Engine plugin supplies a new ``Project Recognizer`` 
 called **Jenkins Templating Engine**.  This sets the project to use the Templating Engine framework for all branches within the
@@ -183,7 +183,7 @@ image:/images/post-images/2019-05-09-templating-engine/project_recognizer.png[ro
 
 NOTE: You can also set the **Jenkins Templating Engine** project recognizer for a GitHub Organization project, enabling you to easily share the same pipeline across an entire Github Organization! 
 
-=== Step 8: Run the Pipelines
+==== Step 8: Run the Pipelines
 
 That's it!  Now, both applications will leverage the exact same pipeline template while having the flexibility to select which 
 tools should be used during each phase of the workflow. 
@@ -231,36 +231,36 @@ sonarqube: static_code_analysis()
 ----
 
 
-= Benefits of the Templating Engine 
+== Benefits of the Templating Engine
 
 image:/images/post-images/2019-05-09-templating-engine/jte_benefits.png[role=center]
 
-== Apply Organizational Governance
+=== Apply Organizational Governance
 
 Leveraging the Templating Engine Plugin will allow you to define enterprise-scale, approved 
 workflows that can be used by teams regardless of what tools are being used.  This top-down 
 approach makes scaling and enforcing DevSecOps principles significantly easier within your organization.  
 
-== Optimize Code Reuse
+=== Optimize Code Reuse
 
 There's really no need for every team in your organization to figure out how to do the same things over
 and over again.  At Booz Allen, we have seen pipeline development time decrease from months to days as 
 we have continuously reused and expanded upon our Templating Engine library portfolio as part of our Solutions
 Delivery Platform. 
 
-== Simplify Pipeline Maintainability
+=== Simplify Pipeline Maintainability
 
 Often DevOps engineers find themselves building and supporting pipelines for multiple development teams at
 the same time.  By decoupling the workflow from the technical implementation and consolidating the pipeline 
 definition to a centralized location, the Templating Engine plugin allows DevOps engineers to scale much faster. 
 
-= Get Involved! 
+== Get Involved!
 
 The plugin:templating-engine[Templating Engine Plugin] has been open sourced and made available in the Jenkins Update Center.
 
 We always appreciate feedback and contributions! If you have an interesting use case or would like to ask questions, try the link:https://gitter.im/jenkinsci/templating-engine-plugin[templating-engine-plugin on Gitter]. 
 
-= Advanced Features 
+== Advanced Features
 
 * link:https://boozallen.github.io/jenkins-templating-engine/pages/Governance/conditional_inheritance.html[Configuration File Conditional Inheritance]
 * link:https://boozallen.github.io/jenkins-templating-engine/pages/Library_Development/externalizing_config.html[Externalize Library Configurations]
@@ -269,16 +269,16 @@ We always appreciate feedback and contributions! If you have an interesting use 
 * link:https://boozallen.github.io/jenkins-templating-engine/pages/Templating/configuration_files/default_step_implementation.html[Default Step Implementation]
 * link:https://boozallen.github.io/jenkins-templating-engine/pages/Templating/configuration_files/sandboxing.html[Configuration File DSL Sandboxing]
 
-= More Resources
+== More Resources
 
-== For this Demonstration 
+=== For this Demonstration
 
 * link:https://github.com/steven-terrana/example-jte-configuration[Pipeline Configuration Repository]
 * link:https://github.com/steven-terrana/example-jte-libraries[Sample Libraries]
 * link:https://github.com/steven-terrana/example-jte-app-maven[Sample Maven Repository]
 * link:https://github.com/steven-terrana/example-jte-app-gradle[Sample Gradle Repository]
 
-== Additional Resources
+=== Additional Resources
 * link:https://boozallen.github.io/jenkins-templating-engine/[Templating Engine Documentation]
 * link:https://github.com/jenkinsci/templating-engine-plugin[Source Code]
 * link:https://github.com/boozallen/sdp-libraries[Booz Allen's SDP Pipeline Libraries]


### PR DESCRIPTION
Use consistent heading levels to match with other blog posts.  The asciidoc warnings note that the original heading levels in the blog post were one level higher than is allowed.  They were also one level higher than those in other blog posts.  This change will make the blog post presentation consistent with other blog posts and remove the surprising message from the output.