### PR TITLE
[WEBSITE-155] a11y: fix navigation by tab, add metadata

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{:lang => 'en'}
   %head
     - if not page.description.nil?
       - description = page.description
@@ -102,7 +102,7 @@
               #creativecommons
                 %a{:href => 'https://creativecommons.org/licenses/by-sa/4.0/'}
                   %p
-                    %img{:src => 'https://licensebuttons.net/l/by-sa/4.0/88x31.png'}/
+                    %img{:src => 'https://licensebuttons.net/l/by-sa/4.0/88x31.png', :alt => 'Creative Commons Attribution-ShareAlike license'}/
 
                 %p
                   The content driving this site is licensed under the Creative
@@ -184,6 +184,9 @@
 
     = google_analytics_universal
 
+    -# Add Twitter widget.
+    -# Hide outline for dropdowns when clicked, but show it when focused
+    -# by pressing Tab.
     :javascript
       !function(d,s,id) {
         var js, fjs=d.getElementsByTagName(s)[0];
@@ -194,3 +197,13 @@
           fjs.parentNode.insertBefore(js,fjs);
         }
       }(document,"script","twitter-wjs");
+
+      $(function(){
+        var $body = $(document.body);
+        $(".nav-link.dropdown-toggle").on("mousedown", function(){
+          $body.addClass("no-outline");
+        })
+        $body.on("keydown", function(){
+          $body.removeClass("no-outline");
+        })
+      })

--- a/content/_partials/dropdown.html.haml
+++ b/content/_partials/dropdown.html.haml
@@ -1,0 +1,2 @@
+%button.nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown"}
+  = page.name

--- a/content/_partials/projectcarousel.html.haml
+++ b/content/_partials/projectcarousel.html.haml
@@ -43,7 +43,7 @@
               .col-md-12.col-lg-8.order-first.order-lg-last
                 - if slide.image
                   - image_height = slide.image.height || '300px'
-                  %img{:src => slide.image.src, :style => "height: #{image_height};"}
+                  %img{:src => slide.image.src, :style => "height: #{image_height};", :role => "presentation"}
               .col-md-12.col-lg-4.order-last.order-lg-first
                 %a{:href => slide.href}
                   %h2

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -10,8 +10,7 @@
           Blog
 
       %li.nav-item.dropdown
-        .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-          Documentation
+        = partial("dropdown.html.haml", :name => "Documentation")
 
         .dropdown-menu
           %a.dropdown-item{:href => expand_link('doc')}
@@ -32,8 +31,7 @@
           Plugins
 
       %li.nav-item.dropdown
-        .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-          Community
+        = partial("dropdown.html.haml", :name => "Community")
 
         .dropdown-menu
           %a.dropdown-item.feature{:href => expand_link("participate")}
@@ -63,7 +61,8 @@
               = '&nbsp;-&nbsp;' + page.title
 
       %li.dropdown.nav-item
-        .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"} Sub-projects
+        = partial("dropdown.html.haml", :name => "Subprojects")
+
         .dropdown-menu
           %a.dropdown-item.feature{:href => expand_link('projects/')}
             Overview
@@ -73,8 +72,7 @@
               = page.title
 
       %li.nav-item.dropdown
-        .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-          About
+        = partial("dropdown.html.haml", :name => "About")
 
         .dropdown-menu
           %a.dropdown-item{:href => expand_link('security')}
@@ -89,8 +87,7 @@
             Artwork
 
       %li.nav-item.dropdown
-        .nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :role => "button"}
-          English
+        = partial("dropdown.html.haml", :name => "English")
 
         .dropdown-menu
           %a.dropdown-item{:href => expand_link('zh')}

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1614,6 +1614,23 @@ table.syntax > tbody > tr > th {
   .navbar-toggler-icon {
     font-size: 0.8em; }
 
+.nav-link.dropdown-toggle {
+    border: 0;
+    background-color: transparent;
+    font-size: inherit;
+    line-height: inherit;
+    font-family: inherit;
+}
+
+.navbar .navbar-brand:focus, .navbar .nav-link:focus{
+    outline-width: 1px;
+    outline-style: auto;
+    outline-color: rgba(255,255,255,0.5);
+}
+
+.no-outline .navbar .navbar-brand:focus, .no-outline .navbar .nav-link:focus {
+    outline-width: 0;
+}
 
 .banner-container .skew:before {
   content: '';


### PR DESCRIPTION
* Change the dropdowns from <div>s to <button>s to make them work with keyboard, add CSS to make sure this change does not alter their appearance. Use JS to hide the dropdown outline when used with mouse.
* Add missing `alt`-text and `lang` values
* Mark the image on the frontpage as `presentation` as it doesn't contain information not included in the text