### PR TITLE
Fix simple typo - installing jenkins annotations

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -91,7 +91,7 @@ whose syntax contains the <<pipeline/syntax#agent,`agent`>> section with the
 `agent { docker { ... } }`. Read more about this on the
 <<pipeline/syntax#,Pipeline Syntax>> page.
 <8> The `jenkinsci/blueocean` Docker image itself. If this image has not already
-been downloaded, then this `docker run` command will automtically download the
+been downloaded, then this `docker run` command will automatically download the
 image for you. Furthermore, if any updates to this image were published since
 you last ran this command, then running this command again will automatically
 download these published image updates for you. +


### PR DESCRIPTION
Change "automtically" to "automatically"