### PR TITLE
Update GSoC Role Strategy Project page

### DIFF
--- a/content/projects/gsoc/2019/role-strategy-performance.adoc
+++ b/content/projects/gsoc/2019/role-strategy-performance.adoc
@@ -39,3 +39,13 @@ You can find more details at the project proposal link:https://docs.google.com/d
 Project Specific meetings: Tuesdays and Fridays at 7:00 AM UTC
 
 Jenkins GSoC Office Hours: Wednesdays at 2:00 PM UTC
+
+===== Performance Testing for Jenkins using JMH
+A demo was held on May 31 for the Performance Testing framework for Jenkins can be found
+at: https://www.youtube.com/watch?v=sr28UADG1AE .
+Another demo was held at the Platform SIG meeting on June 6, this can be found at
+https://www.youtube.com/watch?v=lyfbmhQd0Ag
+
+The presentation slides are available at:  https://drive.google.com/file/d/1gig6u64rzvSzGKjN_PTTXTkSXQ9Ah7E5/view?usp=sharing
+
+The framework is about to be merged in to link:https://github.com/jenkinsci/jenkins-test-harness/pull/135[Jenkins Test Harness]

--- a/content/projects/gsoc/2019/role-strategy-performance.adoc
+++ b/content/projects/gsoc/2019/role-strategy-performance.adoc
@@ -48,4 +48,4 @@ https://www.youtube.com/watch?v=lyfbmhQd0Ag
 
 The presentation slides are available at:  https://drive.google.com/file/d/1gig6u64rzvSzGKjN_PTTXTkSXQ9Ah7E5/view?usp=sharing
 
-The framework is about to be merged in to link:https://github.com/jenkinsci/jenkins-test-harness/pull/135[Jenkins Test Harness]
+The framework is about to be merged in to link:https://github.com/jenkinsci/jenkins-test-harness/pull/135[Jenkins Test Harness] and would soon be available for everyone to use. Please follow our link:https://gitter.im/jenkinsci/role-strategy-plugin[Gitter chat] for more details.


### PR DESCRIPTION
Update GSoC Role Strategy Project page to add links to demos and presentation slides.

@oleg-nenashev @runzexia @supun94