### PR TITLE
Fix typo in Adoc syntax

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -1,4 +1,4 @@
-n---
+---
 layout: developer
 title: Create a Plugin
 ---


### PR DESCRIPTION
Fix a small typo that changes the layout of
https://jenkins.io/doc/developer/tutorial/create/