### PR TITLE
Add title / layout validation, fix syntax erors

### DIFF
--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -53,6 +53,8 @@ Awestruct::Extensions::Pipeline.new do
 
   transformer VersionSwitcher.new
 
+  extension Validator.new
+
   helper AuthorList::AuthorLink
   helper ActiveNav
   helper Authorship

--- a/content/_ext/validator.rb
+++ b/content/_ext/validator.rb
@@ -1,0 +1,19 @@
+class Validator
+  def execute(site)
+    warnings = 0
+    layouts = []
+    site.pages.each do |page|
+      next unless page.output_path =~ /\.html?/i
+      if !page.layout
+         warnings += 1
+         puts "WARNING: Missing layout for #{page.output_path}"
+      elsif page.layout != "redirect" && page.layout != "refresh" && !page.title
+         warnings += 1
+         puts "WARNING: Missing title for #{page.output_path}"
+      end
+    end
+    if warnings > 0
+      raise "Found #{warnings} issues, see log messages above"
+    end
+  end
+end

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -251,7 +251,6 @@ For example:
 ----
 +
 Refer to the following example for reference: https://github.com/jenkinsci/kubernetes-plugin/blob/master/examples/kaniko.groovy
-----
 
 ===== Common Options
 

--- a/content/doc/book/system-administration/security/build-authorization.adoc
+++ b/content/doc/book/system-administration/security/build-authorization.adoc
@@ -1,8 +1,7 @@
 ---
+title: Access Control for Builds
 layout: documentation
 ---
-
-== Access Control for Builds
 
 Similar to access control for users, builds in Jenkins run with an associated user authorization.
 By default, builds run as the internal SYSTEM user that has full permissions to run on any node, create or delete jobs, start and cancel other builds, etc.

--- a/content/images/jams/ToulouseJam/README.asciidoc
+++ b/content/images/jams/ToulouseJam/README.asciidoc
@@ -1,4 +1,7 @@
-= Toulouse Jenkins Area Meetup
+---
+title: Toulouse Jenkins Area Meetup
+layout: default
+---
 
 * link:https://www.google.fr/maps/place/Toulouse/@43.6040986,1.440202,653m/data=!3m1!1e3!4m2!3m1!1s0x12aebb6fec7552ff:0x406f69c2f411030!6m1!1e1[located in the South of France].
-* link:meetup.com/fr/Toulouse-Jenkins-Area-Meetup/[Meetup link]
+* link:https://meetup.com/fr/Toulouse-Jenkins-Area-Meetup/[Meetup link]


### PR DESCRIPTION
This PR
* fixes recent Asciidoc syntax typo that got merged in #2353
* adds validation for title/layout to make sure we catch front matter typos
* adds missing title/layout for the two pages that were missing those

For the Toulouse meetup README page (https://jenkins.io/images/jams/ToulouseJam/README/ ) deletion might make more sense than the fix, but I wouldn't dare :) @batmat looped
