### PR TITLE
Do not print ruby objects in HTML

### DIFF
--- a/content/_partials/pagination.html.haml
+++ b/content/_partials/pagination.html.haml
@@ -17,7 +17,7 @@
 %div
   %nav
     %ul.pagination
-      %li.page-item{:class => (page.posts.previous_page or 'disabled')}
+      %li.page-item{:class => ('disabled' unless page.posts.previous_page)}
         %a.page-link{:href => (page.posts.previous_page and expand_link(page.posts.previous_page.url))}
           &laquo;
       - previous_visible = false
@@ -62,7 +62,7 @@
               %a.page-link{:href => '#'}
                 \...
             - previous_visible = false
-      %li.page-item{:class => (page.posts.next_page or 'disabled')}
+      %li.page-item{:class => ('disabled' unless page.posts.next_page)}
         %a.page-link{:href => (page.posts.next_page and expand_link(page.posts.next_page.url))}
           &raquo;
 


### PR DESCRIPTION
This should not affect users at all, just makes the markup cleaner.

If a pagination link is not disabled, it should have no additional class. Currently a Ruby object is serialized to HTML, in the source of https://jenkins.io/node/ yo can see
```
<li class='47135220427120: 47135221800140: 47135222560800: 47135222767480: 47135223628660: 47135223869240: 47135224483480: 47135225221300: :change_frequency=&gt;"never", :lastmod=&gt;"2019-07-20", :layout=&gt;"default", :paginate_generated=&gt;true, :posts=&gt;[Awestruct::Page{ :priority=&gt;0.1, :section=&gt;"blog", :selected_tag=&gt;nil, :title=&gt;"Jenkins :url=&gt;"/node/page/2.html"} Awestruct::Page{ Blog", Community layout=&gt;post output_path=&gt;/blog/2019/04/03/security-advisory/index.html, output_path=&gt;/blog/2019/05/05/telemetry-success/index.html, output_path=&gt;/blog/2019/05/09/chinese-localization/index.html, output_path=&gt;/blog/2019/05/09/templating-engine/index.html, output_path=&gt;/blog/2019/05/11/docs-sig-announcement/index.html, output_path=&gt;/blog/2019/05/22/outreachy-audit-log-project/index.html, output_path=&gt;/blog/2019/05/30/becoming-contributor-newbie-tickets/index.html, output_path=&gt;/blog/2019/06/03/DevOps-World-Jenkins-World-2019-San-Francisco-Agenda-is-Live/index.html, page-item source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/04/2019-04-03-security-advisory.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/05/2019-05-05-telemetry-success.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/05/2019-05-09-chinese-localization.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/05/2019-05-09-templating-engine.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/05/2019-05-11-docs-sig-announcement.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/05/2019-05-22-outreachy-audit-log-project.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/05/2019-05-30-becoming-contributor-newbie-tickets.adoc, source_path=&gt;/home/jenkins/workspace/jenkins.io/content/blog/2019/06/2019-06-03-DevOps-World-Jenkins-World-2019-San-Francisco-Agenda-is-Live.adoc, {:__is_layout=&gt;false, }, }],'>
```