### PR TITLE
[WEBSITE-270] allow colon in section titles

### DIFF
--- a/content/_ext/validator.rb
+++ b/content/_ext/validator.rb
@@ -6,8 +6,8 @@ class Validator
       next unless page.output_path =~ /\.html?/i
       if !page.layout
          warning "Missing layout for #{page.output_path}"
-      elsif page.layout != "redirect" && page.layout != "refresh" && !page.title
-         warning "Missing title for #{page.output_path}"
+      elsif page.layout != "redirect" && page.layout != "refresh"
+         validate_title page
       end
     end
 
@@ -33,6 +33,21 @@ class Validator
     end
   end
 
+  def validate_title(page)
+    if !page.title
+      warning "Missing title for #{page.output_path}"
+    else
+      # Workaround for title parsing bug
+      # https://issues.jenkins-ci.org/browse/WEBSITE-270
+      if page.title.is_a?(Hash) and page.title.keys.length == 1
+        page.title.each do |key, val|
+          page.title = "#{key}: #{val}"
+        end
+      end
+      warning "Invalid title #{page.title} for #{page.output_path}" unless page.title.is_a?(String)
+    end
+  end
+  
   def warning(message)
     puts "WARNING: #{message}"
     @warnings += 1


### PR DESCRIPTION
See [WEBSITE-270](https://issues.jenkins-ci.org/browse/WEBSITE-270)
The PR does not fix the parsing problem as I couldn't find it (probably somewhere in Awestruct), but at least it corrects the wrongly parsed titles.

Note that the issue also impacts existing pages like
https://jenkins.io/doc/developer/extensions/workflow-cps/