### PR TITLE
Updated pipeline syntax for the lock resource

### DIFF
--- a/content/blog/2016/2016-10-16-stage-lock-milestone.adoc
+++ b/content/blog/2016/2016-10-16-stage-lock-milestone.adoc
@@ -60,12 +60,17 @@ stage('Build') {
 
 [source, groovy]
 ----
-lock('myResource') {
-  stage('Build') {
-    echo "Building"
+stage('Parent') {
+  options {
+    lock('myResource')
   }
-  stage('Test') {
-    echo "Testing"
+  stages {
+    stage('Build') {
+      echo "Building"
+    }
+    stage('Test') {
+      echo "Testing"
+    }
   }
 }
 ----


### PR DESCRIPTION
The declarative pipeline cannot lock multiple stages as shown previously in this document. The example has been fixed to achieve the intended outcome.