### PR TITLE
Corrected the description in section Building containers

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -396,7 +396,7 @@ It is possible to pass other arguments to
 link:https://docs.docker.com/engine/reference/commandline/build/[docker build]
 by adding them to the second argument of the `build()` method.
 When passing arguments this way, the last value in the that string must be 
-the path to the docker file.
+the path to the docker file and should end with the folder to use as the build context)
 
 This example overrides the default `Dockerfile` by passing the `-f`
 flag:


### PR DESCRIPTION
When using a Dockerfile in a sub-directory from root directory, the description says docker.build should end with the path where Dockerfile is found, but it should end with the path of folder to consider the build context for this command to succeed.