### PR TITLE
Use adoc link markup in contributing file

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,7 +1,6 @@
 :toc:
 :toclevels: 3
 
-
 = Contributing to jenkins.io
 
 toc::[]
@@ -220,8 +219,8 @@ write your blog post!
 The `opengraph` section is optional. It allows you to define a preview of
 the article for social media. The `image` attribute should be a PNG or JPEG image
 with more than 200px in each dimension and preferred aspect ratio about 2:1. For
-more information see the documentation for [Facebook](https://developers.facebook.com/docs/sharing/webmasters/images/),
-and [Twitter](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html).
+more information see the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook],
+and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
 
 Once you have everything ready, you may
 link:https://help.github.com/articles/creating-a-pull-request/[create a pull
@@ -543,7 +542,7 @@ Some tips:
 * If you need help with reviews for documentation changes,
   you can in the link:https://gitter.im/jenkinsci/docs[Documentation SIG Gitter channel].
 * If you are interested to join the Copy Editors team, 
-  you can request membership in the link:[Jenkins Developer mailing list](https://groups.google.com/d/forum/jenkinsci-dev).
+  you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list].
   Such membership requires a track of contributions to Jenkins, and also a signed link:https://github.com/jenkinsci/infra-cla[Contributor License Agreement]
 
 [[user-site]]


### PR DESCRIPTION
Markdown does not convert to links inside an adoc file.