### PR TITLE
Fix PLUGIN_NAME in advisories

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -60,7 +60,7 @@ notitle: true
     Descriptions
   - described_issues.each do | issue |
     - if issue.plugins && issue.plugins[0]
-      - plugin_name = site._generated[:update_center].plugins[issue.plugins[0].name]&.title || issue.plugins[0].name
+      - plugin_name = site._generated[:update_center].plugins[issue.plugins[0].name]&.title || issue.plugins[0]&.title || issue.plugins[0].name
     %h3{:id => issue.id}
       - if plugin_name
         = issue.title.gsub(/PLUGIN_NAME/, "#{plugin_name} Plugin")


### PR DESCRIPTION
This is the first advisory since I introduced this placeholder that depublished plugins, so this problem didn't show up before.

----

# Before

> ![Screenshot](https://user-images.githubusercontent.com/1831569/62702286-9e3e2400-b9e6-11e9-815e-53ae567840c3.png)

# After

> ![Screenshot](https://user-images.githubusercontent.com/1831569/62702296-a4340500-b9e6-11e9-8a35-ad9c4d6aad15.png)
