### PR TITLE
Added hardware recommendations to several pages

### DIFF
--- a/content/doc/book/architecting-for-manageability.adoc
+++ b/content/doc/book/architecting-for-manageability.adoc
@@ -310,5 +310,4 @@ this level.
 More information on Metrics basic and advanced usages can be found
 link:https://documentation.cloudbees.com/docs/cje-user-guide/monitoring-sect-getting-started.html[here].
 
-Additional information on hardware recommendations can be be found 
-link:/doc/hardware-recommendations.adoc]
+Additional information on hardware recommendations can be be found on the https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page

--- a/content/doc/book/architecting-for-manageability.adoc
+++ b/content/doc/book/architecting-for-manageability.adoc
@@ -310,4 +310,4 @@ this level.
 More information on Metrics basic and advanced usages can be found
 link:https://documentation.cloudbees.com/docs/cje-user-guide/monitoring-sect-getting-started.html[here].
 
-Additional information on hardware recommendations can be be found on the link:https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
+Additional information on hardware recommendations can be be found on the link:/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page

--- a/content/doc/book/architecting-for-manageability.adoc
+++ b/content/doc/book/architecting-for-manageability.adoc
@@ -310,4 +310,4 @@ this level.
 More information on Metrics basic and advanced usages can be found
 link:https://documentation.cloudbees.com/docs/cje-user-guide/monitoring-sect-getting-started.html[here].
 
-Additional information on hardware recommendations can be be found on the https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
+Additional information on hardware recommendations can be be found on the link:https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page

--- a/content/doc/book/architecting-for-manageability.adoc
+++ b/content/doc/book/architecting-for-manageability.adoc
@@ -309,3 +309,6 @@ this level.
 
 More information on Metrics basic and advanced usages can be found
 link:https://documentation.cloudbees.com/docs/cje-user-guide/monitoring-sect-getting-started.html[here].
+
+Additional information on hardware recommendations can be be found 
+link:/doc/hardware-recommendations.adoc]

--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -270,7 +270,7 @@ resources together with their destruction when they are not needed anymore:
 
 Comprehensive hardware recommendations:
 
-* Hardware: see the link:https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
+* Hardware: see the link:/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
 
 ==== Master division strategies
 

--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -270,7 +270,7 @@ resources together with their destruction when they are not needed anymore:
 
 Comprehensive hardware recommendations:
 
-* Hardware: see the link:/doc/hardware-recommendations.adoc] page
+* Hardware: see the https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
 
 ==== Master division strategies
 

--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -270,7 +270,7 @@ resources together with their destruction when they are not needed anymore:
 
 Comprehensive hardware recommendations:
 
-* Hardware: see the https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
+* Hardware: see the link:https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
 
 ==== Master division strategies
 

--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -268,6 +268,10 @@ resources together with their destruction when they are not needed anymore:
 
 === Right-sizing Jenkins masters
 
+Comprehensive hardware recommendations:
+
+* Hardware: see the link:/doc/hardware-recommendations.adoc] page
+
 ==== Master division strategies
 
 Designing the best Jenkins architecture for your organization is dependent on

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -47,7 +47,7 @@ Recommended hardware configuration for a small team:
 
 Comprehensive hardware recommendations:
 
-* Hardware: see the link:https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
+* Hardware: see the link:/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
 
 Software requirements:
 

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -45,6 +45,10 @@ Recommended hardware configuration for a small team:
 * 1 GB+ of RAM
 * 50 GB+ of drive space
 
+Comprehensive hardware recommendations:
+
+* Hardware: see the link:/doc/hardware-recommendations.adoc] page
+
 Software requirements:
 
 * Java: see the link:/doc/administration/requirements/java[Java Requirements] page

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -47,7 +47,7 @@ Recommended hardware configuration for a small team:
 
 Comprehensive hardware recommendations:
 
-* Hardware: see the link:/doc/hardware-recommendations.adoc] page
+* Hardware: see the link:https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations[Hardware Recommendations] page
 
 Software requirements:
 

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -35,7 +35,7 @@ title: Jenkins installation and setup
           %p
             Before downloading, please take a moment to review hardware recommendations
             %strong
-              %a{:href => 'https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations'}
+              %a{:href => '/doc/book/hardware-recommendations/#hardware-recommendations'}
                 Hardware Recommendations
             section of the User Handbook.
         .row

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -33,12 +33,12 @@ title: Jenkins installation and setup
             %span.icon-gear-menu-o
             gear icon are maintained by third parties.
           %p
-           Before downloading, please take a moment to review hardware recommendations
-           %strong
-                %a{:href => '/doc/book/hardware-recommendations.adoc'}
-                  Hardware Recommendations
-              section of the User Handbook.
-         .row
+            Before downloading, please take a moment to review hardware recommendations
+            %strong
+              %a{:href => 'https://jenkins.io/doc/book/hardware-recommendations/#hardware-recommendations'}
+                Hardware Recommendations
+            section of the User Handbook.
+        .row
           .col-md-6
             %h4
               Long-term Support (LTS)

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -32,7 +32,13 @@ title: Jenkins installation and setup
             files, native packages, installers, and Docker containers. Packages with the
             %span.icon-gear-menu-o
             gear icon are maintained by third parties.
-        .row
+          %p
+           Before downloading, please take a moment to review hardware recommendations
+           %strong
+                %a{:href => '/doc/book/hardware-recommendations.adoc'}
+                  Hardware Recommendations
+              section of the User Handbook.
+         .row
           .col-md-6
             %h4
               Long-term Support (LTS)


### PR DESCRIPTION
Added hardware recommendations to:

-  Installation
- Downloads
- content/doc/book/architecting-for-manageability.adoc
- content/doc/book/architecting-for-scale.adoc

Couldn't get Cross references working so I went with external links