### PR TITLE
Add example to environment docs

### DIFF
--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -249,10 +249,8 @@ easier to create Pipelines of varying complexities. This built-in documentation
 is automatically generated and updated based on the plugins installed in the
 Jenkins instance.
 
-The built-in documentation can be found globally at:
-link:http://localhost:8080/pipeline-syntax/[localhost:8080/pipeline-syntax/],
-assuming you have a Jenkins instance running on localhost port 8080. The same
-documentation is also linked as *Pipeline Syntax* in the side-bar for any
+The built-in documentation can be found globally at `$\{YOUR_JENKINS_URL}/pipeline-syntax`.
+The same documentation is also linked as *Pipeline Syntax* in the side-bar for any
 configured Pipeline project.
 
 [.boxshadow]

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -272,7 +272,7 @@ on the plugins installed which explicitly expose steps for use in Pipeline.
 
 To generate a step snippet with the Snippet Generator:
 
-. Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline, or at `\$\{YOUR_JENKINS_URL}/pipeline-syntax`.
+. Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline, or at `$\{YOUR_JENKINS_URL}/pipeline-syntax`.
 . Select the desired step in the *Sample Step* dropdown menu
 . Use the dynamically populated area below the *Sample Step* dropdown to configure the selected step.
 . Click *Generate Pipeline Script* to create a snippet of Pipeline which can be
@@ -306,7 +306,7 @@ env::
 
 Environment variables accessible from Scripted Pipeline, for example:
 `env.PATH` or `env.BUILD_ID`. Consult the built-in global variable reference at
-`\$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
+`$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
 for a complete, and up to date, list of environment variables
 available in Pipeline.
 
@@ -321,7 +321,7 @@ currentBuild::
 May be used to discover information about the currently executing Pipeline,
 with properties such as `currentBuild.result`, `currentBuild.displayName`,
 etc. Consult the built-in global variable reference at
-`\$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
+`$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
 for a complete, and up to date, list of properties available on `currentBuild`.
 
 
@@ -341,7 +341,7 @@ To generate a Declarative directive using the Declarative Directive Generator:
 
 . Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline,
   and then click on the *Declarative Directive Generator* link in the sidepanel,
-  or go directly to `\$\{YOUR_JENKINS_URL}/directive-generator`.
+  or go directly to `$\{YOUR_JENKINS_URL}/directive-generator`.
 . Select the desired directive in the dropdown menu
 . Use the dynamically populated area below the dropdown to configure the selected directive.
 . Click *Generate Directive* to create the directive's configuration to copy

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -348,8 +348,7 @@ Pipeline's more advanced features.
 Jenkins Pipeline exposes environment variables via the global variable `env`,
 which is available from anywhere within a `Jenkinsfile`. The full list of
 environment variables accessible from within Jenkins Pipeline is documented at
-link:http://localhost:8080/pipeline-syntax/globals#env[localhost:8080/pipeline-syntax/globals#env],
-assuming a Jenkins master is running on `localhost:8080`, and includes:
+$\{YOUR_JENKINS_URL}/pipeline-syntax/globals#env and includes:
 
 BUILD_ID:: The current build ID, identical to BUILD_NUMBER for builds created in Jenkins versions 1.597+
 BUILD_NUMBER:: The current build number, such as "153"

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -353,7 +353,7 @@ assuming a Jenkins master is running on `localhost:8080`, and includes:
 
 BUILD_ID:: The current build ID, identical to BUILD_NUMBER for builds created in Jenkins versions 1.597+
 BUILD_NUMBER:: The current build number, such as "153"
-BUILD_TAG:: String of jenkins-\$\{JOB_NAME}-\$\{BUILD_NUMBER}. Convenient to put into a resource file, a jar file, etc for easier identification
+BUILD_TAG:: String of jenkins-$\{JOB_NAME}-$\{BUILD_NUMBER}. Convenient to put into a resource file, a jar file, etc for easier identification
 BUILD_URL:: The URL where the results of this build can be found (for example \http://buildserver/jenkins/job/MyJobName/17/ )
 EXECUTOR_NUMBER:: The unique number that identifies the current executor (among executors of the same machine) performing this build. This is the number you see in the "build executor status", except that the number starts from 0, not 1
 JAVA_HOME:: If your job is configured to use a specific JDK, this variable is set to the JAVA_HOME of the specified JDK. When this variable is set, PATH is also updated to include the bin subdirectory of JAVA_HOME

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -430,7 +430,7 @@ given environment variables to steps within the `stage`.
 
 ==== Setting environment variables dynamically
 
-Environment variables can be set at run time with shell scripts (`sh`), Windows batch scripts (`bat`) and PowerShell scripts (`powershell`).
+Environment variables can be set at run time and can be used by shell scripts (`sh`), Windows batch scripts (`bat`) and PowerShell scripts (`powershell`).
 Each script can either `returnStatus` or `returnStdout`.
 link:https://jenkins.io/doc/pipeline/steps/workflow-durable-task-step[More information on scripts].
 

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -342,6 +342,7 @@ Understanding how to use string interpolation is vital for using some of
 Pipeline's more advanced features.
 
 
+[[using-environment-variables]]
 === Using environment variables
 
 Jenkins Pipeline exposes environment variables via the global variable `env`,
@@ -351,8 +352,15 @@ link:http://localhost:8080/pipeline-syntax/globals#env[localhost:8080/pipeline-s
 assuming a Jenkins master is running on `localhost:8080`, and includes:
 
 BUILD_ID:: The current build ID, identical to BUILD_NUMBER for builds created in Jenkins versions 1.597+
-JOB_NAME:: Name of the project of this build, such as "foo" or "foo/bar".
+BUILD_NUMBER:: The current build number, such as "153"
+BUILD_TAG:: String of jenkins-\$\{JOB_NAME}-\$\{BUILD_NUMBER}. Convenient to put into a resource file, a jar file, etc for easier identification
+BUILD_URL:: The URL where the results of this build can be found (for example \http://buildserver/jenkins/job/MyJobName/17/ )
+EXECUTOR_NUMBER:: The unique number that identifies the current executor (among executors of the same machine) performing this build. This is the number you see in the "build executor status", except that the number starts from 0, not 1
+JAVA_HOME:: If your job is configured to use a specific JDK, this variable is set to the JAVA_HOME of the specified JDK. When this variable is set, PATH is also updated to include the bin subdirectory of JAVA_HOME
 JENKINS_URL:: Full URL of Jenkins, such as https://example.com:port/jenkins/ (NOTE: only available if Jenkins URL set in "System Configuration")
+JOB_NAME:: Name of the project of this build, such as "foo" or "foo/bar".
+NODE_NAME:: The name of the node the current build is running on. Set to 'master' for master node.
+WORKSPACE:: The absolute path of the workspace
 
 Referencing or using these environment variables can be accomplished like
 accessing any key in a Groovy
@@ -420,10 +428,10 @@ apply to all steps within the Pipeline.
 given environment variables to steps within the `stage`.
 
 
-==== Setting environment variables dynamically 
+==== Setting environment variables dynamically
 
-In the case where environment variable need to be set dynamically at run time this can be done with the use of a shell scripts (`sh`), Windows Batch Script (`bat`) or PowerShell Script (`powershell`). 
-Each script can either `returnStatus` or `returnStdout`.  
+Environment variables can be set at run time with shell scripts (`sh`), Windows batch scripts (`bat`) and PowerShell scripts (`powershell`).
+Each script can either `returnStatus` or `returnStdout`.
 link:https://jenkins.io/doc/pipeline/steps/workflow-durable-task-step[More information on scripts].
 
 Below is an example in a declarative pipeline using `sh` (shell) with both `returnStatus` and `returnStdout`.
@@ -459,7 +467,7 @@ pipeline {
 // Script //
 ----
 <1> An `agent` must be set at the top level of the pipeline. This will fail if agent is set as `agent none`.
-<2> When using `returnStdout` a trailing whitespace will be append to the returned string. Use `.trim()` to remove this. 
+<2> When using `returnStdout` a trailing whitespace will be appended to the returned string. Use `.trim()` to remove this.
 
 === Handling credentials
 
@@ -817,11 +825,11 @@ However, if you only need to handle these types of credentials, it is
 recommended you use the relevant procedure described in the section
 <<#for-secret-text-usernames-and-passwords-and-secret-files,above>> for improved
 Pipeline code readability.
-* The use of **single-quotes** instead of  **double-quotes** to define the `script` 
-(the implicit parameter to `sh`) in Groovy above. 
+* The use of **single-quotes** instead of  **double-quotes** to define the `script`
+(the implicit parameter to `sh`) in Groovy above.
 The single-quotes will cause the secret to be expanded by the shell as an environment variable.
-The double-quotes are potentially less secure as the secret is interpolated by Groovy, 
-and so typical operating system process listings (as well as Blue Ocean, 
+The double-quotes are potentially less secure as the secret is interpolated by Groovy,
+and so typical operating system process listings (as well as Blue Ocean,
 and the pipeline steps tree in the classic UI) will accidentally disclose it :
 ```
 node {

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -357,7 +357,7 @@ BUILD_TAG:: String of jenkins-$\{JOB_NAME}-$\{BUILD_NUMBER}. Convenient to put i
 BUILD_URL:: The URL where the results of this build can be found (for example \http://buildserver/jenkins/job/MyJobName/17/ )
 EXECUTOR_NUMBER:: The unique number that identifies the current executor (among executors of the same machine) performing this build. This is the number you see in the "build executor status", except that the number starts from 0, not 1
 JAVA_HOME:: If your job is configured to use a specific JDK, this variable is set to the JAVA_HOME of the specified JDK. When this variable is set, PATH is also updated to include the bin subdirectory of JAVA_HOME
-JENKINS_URL:: Full URL of Jenkins, such as https://example.com:port/jenkins/ (NOTE: only available if Jenkins URL set in "System Configuration")
+JENKINS_URL:: Full URL of Jenkins, such as \https://example.com:port/jenkins/ (NOTE: only available if Jenkins URL set in "System Configuration")
 JOB_NAME:: Name of the project of this build, such as "foo" or "foo/bar".
 NODE_NAME:: The name of the node the current build is running on. Set to 'master' for master node.
 WORKSPACE:: The absolute path of the workspace

--- a/content/doc/book/scaling/index.adoc
+++ b/content/doc/book/scaling/index.adoc
@@ -12,6 +12,8 @@ endif::[]
 
 = Scaling Jenkins
 
+See the current architectural scaling recommendations in *link:../architecting-for-scale[Architecting for Scale]*.
+
 This chapter will cover topics related to using and managing large scale Jenkins
 configurations: large numbers of users, nodes, agents, folders, projects,
 concurrent jobs, job results and logs, and even large numbers of masters.

--- a/content/doc/pipeline/tour/environment.adoc
+++ b/content/doc/pipeline/tour/environment.adoc
@@ -18,7 +18,9 @@ will only apply to the stage in which they're defined.
 ----
 // Declarative //
 pipeline {
-    agent any
+    agent {
+        label '!windows'
+    }
 
     environment {
         DISABLE_AUTH = 'true'
@@ -28,16 +30,20 @@ pipeline {
     stages {
         stage('Build') {
             steps {
+                echo "Database engine is ${DB_ENGINE}"
+                echo "DISABLE_AUTH is ${DISABLE_AUTH}"
                 sh 'printenv'
             }
         }
     }
 }
 // Scripted //
-node {
+node('!windows') {
     withEnv(['DISABLE_AUTH=true',
              'DB_ENGINE=sqlite']) {
         stage('Build') {
+            echo "Database engine is ${DB_ENGINE}"
+            echo "DISABLE_AUTH is ${DISABLE_AUTH}"
             sh 'printenv'
         }
     }
@@ -47,6 +53,11 @@ node {
 This approach to defining environment variables from within the `Jenkinsfile`
 can be very useful for instructing scripts, such as a `Makefile`, to configure
 the build or tests differently to run them inside of Jenkins.
+
+See *link:/doc/book/pipeline/jenkinsfile#using-environment-variables["Using Environment Variables"]* for more details on using environment variables in Pipelines.
+
+Environment variables may also be set by Jenkins plugins.
+Refer to the documentation of the specific plugins for environment variable names and descriptions for those plugins.
 
 Another common use for environment variables is to set or override "dummy"
 credentials in build or test scripts. Because it's (_obviously_) a bad idea to


### PR DESCRIPTION
[Reader feedback](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) from the jenkins.io site requested that an example referencing an environment variable be included in the environment step description.

Comment was:

> It shows how to declare variables, but doesn't show how to use them. Do I need a $ before the variable or not?

This example shows how to use defined environment variables in declarative and scripted pipeline.  Verified behavior on Jenkins 2.176.2 with latest Pipeline plugin releases.

Also added exclusion to prevent running the example on Windows, since it uses an `sh` step and that was failing on my Windows agents.