### PR TITLE
Doc ref to localhost assumes a local server

### DIFF
--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -272,7 +272,7 @@ on the plugins installed which explicitly expose steps for use in Pipeline.
 
 To generate a step snippet with the Snippet Generator:
 
-. Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline, or at `\$\{YOUR_JENKINS_URL}/pipeline-syntax[localhost:8080/pipeline-syntax`.
+. Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline, or at `\$\{YOUR_JENKINS_URL}/pipeline-syntax`.
 . Select the desired step in the *Sample Step* dropdown menu
 . Use the dynamically populated area below the *Sample Step* dropdown to configure the selected step.
 . Click *Generate Pipeline Script* to create a snippet of Pipeline which can be

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -272,7 +272,7 @@ on the plugins installed which explicitly expose steps for use in Pipeline.
 
 To generate a step snippet with the Snippet Generator:
 
-. Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline, or at link:http://localhost:8080/pipeline-syntax[localhost:8080/pipeline-syntax].
+. Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline, or at `\$\{YOUR_JENKINS_URL}/pipeline-syntax[localhost:8080/pipeline-syntax`.
 . Select the desired step in the *Sample Step* dropdown menu
 . Use the dynamically populated area below the *Sample Step* dropdown to configure the selected step.
 . Click *Generate Pipeline Script* to create a snippet of Pipeline which can be
@@ -305,8 +305,8 @@ The variables provided by default in Pipeline are:
 env::
 
 Environment variables accessible from Scripted Pipeline, for example:
-`env.PATH` or `env.BUILD_ID`. Consult the built-in
-link:http://localhost:8080/pipeline-syntax/globals#env[Global Variable Reference]
+`env.PATH` or `env.BUILD_ID`. Consult the built-in global variable reference at
+`\$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
 for a complete, and up to date, list of environment variables
 available in Pipeline.
 
@@ -320,8 +320,8 @@ currentBuild::
 
 May be used to discover information about the currently executing Pipeline,
 with properties such as `currentBuild.result`, `currentBuild.displayName`,
-etc. Consult the built-in
-link:http://localhost:8080/pipeline-syntax/globals#currentBuild[Global Variable Reference]
+etc. Consult the built-in global variable reference at
+`\$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
 for a complete, and up to date, list of properties available on `currentBuild`.
 
 
@@ -341,7 +341,7 @@ To generate a Declarative directive using the Declarative Directive Generator:
 
 . Navigate to the *Pipeline Syntax* link (referenced above) from a configured Pipeline,
   and then click on the *Declarative Directive Generator* link in the sidepanel,
-  or go directly to link:http://localhost:8080/directive-generator[localhost:8080/directive-generator].
+  or go directly to `\$\{YOUR_JENKINS_URL}/directive-generator`.
 . Select the desired directive in the dropdown menu
 . Use the dynamically populated area below the dropdown to configure the selected directive.
 . Click *Generate Directive* to create the directive's configuration to copy


### PR DESCRIPTION
[Documentation feedback](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) on this page said:

> Update the Global Variable Reference links that point to localhost to point to a real page.

> The "Global Variable Reference" on this page point to "localhost:8080". Please fix or remove this link.

We can't point to a real page because the user needs to consult the content on their specific Jenkins server. Compromise by mentioning the assumption in more places.