### PR TITLE
Update link to documentation in older blog post 

### DIFF
--- a/content/blog/2019/05/2019-05-09-templating-engine.adoc
+++ b/content/blog/2019/05/2019-05-09-templating-engine.adoc
@@ -279,7 +279,7 @@ We always appreciate feedback and contributions! If you have an interesting use 
 * link:https://github.com/steven-terrana/example-jte-app-gradle[Sample Gradle Repository]
 
 === Additional Resources
-* link:https://boozallen.github.io/jenkins-templating-engine/[Templating Engine Documentation]
+* link:https://jenkinsci.github.io/templating-engine-plugin/[Templating Engine Documentation]
 * link:https://github.com/jenkinsci/templating-engine-plugin[Source Code]
 * link:https://github.com/boozallen/sdp-libraries[Booz Allen's SDP Pipeline Libraries]
 * link:https://boozallen.com[Booz Allen Hamilton]


### PR DESCRIPTION
Hey!  we've updated the documentation link for the Templating Engine Plugin - so i'd like to update this blog post to point to the correct site. 