### PR TITLE
Add event locations to website and metadata

### DIFF
--- a/content/_data/events/2019-08-23-jom-summer-projects-1.adoc
+++ b/content/_data/events/2019-08-23-jom-summer-projects-1.adoc
@@ -1,5 +1,6 @@
 ---
-title: "Online: Summer Project Demos. Part 1"
+title: "Summer Project Demos. Part 1"
+location: Online
 date: "2019-08-23T14:00:00"
 link: "https://www.meetup.com/Jenkins-online-meetup/events/264171002/"
 ---

--- a/content/_data/events/2019-08-26-jom-summer-projects-2.adoc
+++ b/content/_data/events/2019-08-26-jom-summer-projects-2.adoc
@@ -1,5 +1,6 @@
 ---
-title: "Online: Summer Project Demos. Part 2"
+title: "Summer Project Demos. Part 2"
+location: Online
 date: "2019-08-26T15:00:00"
 link: "https://www.meetup.com/Jenkins-online-meetup/events/264171091/"
 ---

--- a/content/_data/events/2019-10-25-hackathon-beijing.adoc
+++ b/content/_data/events/2019-10-25-hackathon-beijing.adoc
@@ -1,5 +1,6 @@
 ---
 title: "Open Source DevOps Hackathon"
+location: Beijing, China
 date: "2019-10-25T19:30:00"
 link: "https://jenkins-zh.cn/event/beijing-2019-10-25/"
 ---

--- a/content/_data/events/2019-12-02-devops-world-jenkins-world-lisbon.adoc
+++ b/content/_data/events/2019-12-02-devops-world-jenkins-world-lisbon.adoc
@@ -1,5 +1,6 @@
 ---
-title: "DW|JW Lisbon"
+title: "Devops World | Jenkins World"
+location: Lisbon, Portugal
 date: "2019-12-02T9:00:00"
 link: "https://www.cloudbees.com/devops-world"
 ---

--- a/content/_partials/events.html.haml
+++ b/content/_partials/events.html.haml
@@ -30,7 +30,8 @@
 
             %h5.title
               = data.title
-
+            = data.location
+          
           %p.teaser
             = data.raw_content
             .more

--- a/content/events.html.haml
+++ b/content/events.html.haml
@@ -136,6 +136,7 @@ notitle: true
 
                 %h5.title
                   = data.title
+                = data.location
 
               %p.teaser
                 = data.raw_content


### PR DESCRIPTION
Historically we had issues with events which did not explicitly specify locations, e.g. see the Beijing hackathon where the location is not visible on the front page. The header row was also pretty short in some cases to display enough information about an event.

In this change I suggest to explicitly add a 'location' metadata which gets displayed under the event title. We can also add some geolocation later if we want, but even the current state should be helpful for users.

## Now

![now](https://user-images.githubusercontent.com/3000480/63430454-e6186e80-c41c-11e9-810c-4149c69aeede.PNG)
![now 2](https://user-images.githubusercontent.com/3000480/63430453-e6186e80-c41c-11e9-9a67-8b05411953bc.PNG)

## Was

![was](https://user-images.githubusercontent.com/3000480/63430479-f3cdf400-c41c-11e9-95e1-dd9907d29b89.PNG)
![was2](https://user-images.githubusercontent.com/3000480/63430484-f6304e00-c41c-11e9-9149-6c90303821b2.PNG)
