### PR TITLE
GSoC - Remove the 2018 project reference from the Projects page

### DIFF
--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -46,9 +46,6 @@ project.  In exchange, numerous Jenkins community members volunteer as "mentors"
 for students to help integrate them into the open source community and succeed
 in completing their summer projects.
 
-The Jenkins project participated in the Google Summer of Code 2018 with
-link:https://summerofcode.withgoogle.com/archive/2018/organizations/5245157809061888/[two student projects].
-
 link:gsoc[*Learn more*]
 
 ---


### PR DESCRIPTION
subj. Just noticed some obsolete information