### PR TITLE
Update styles for new navbar class

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1584,32 +1584,32 @@ table.syntax > tbody > tr > th {
 
 
 /** pilfered from blueocean-style.css **/
-.navbar.navbar-expand-md {
+.navbar.navbar-expand-lg {
   font-size: 0.875rem; }
-  .navbar.navbar-expand-md.bg-dark {
+  .navbar.navbar-expand-lg.bg-dark {
     background-color: #212529!important; }
-  .navbar.navbar-expand-md .navbar-brand {
+  .navbar.navbar-expand-lg .navbar-brand {
     font-family: Georgia,Times,Times New Roman,serif;
     font-weight: 600;
     font-size: 20px;
     padding: 2px 0; }
-  .navbar.navbar-expand-md .btn {
+  .navbar.navbar-expand-lg .btn {
     font-size: 0.875rem;
     margin-left: 8px;
     margin-top: 1px; }
-    .navbar.navbar-expand-md .btn.dropdown-toggle::after {
+    .navbar.navbar-expand-lg .btn.dropdown-toggle::after {
       margin: 0 0 0 8px; }
-    .navbar.navbar-expand-md .btn.btn-outline-secondary.active, .navbar.navbar-expand-md .btn.btn-outline-secondary.focus, .navbar.navbar-expand-md .btn.btn-outline-secondary:active, .navbar.navbar-expand-md .btn.btn-outline-secondary:focus,
-    .navbar.navbar-expand-md .btn .btn-outline-secondary.active,
-    .navbar.navbar-expand-md .btn .btn-outline-secondary:active {
+    .navbar.navbar-expand-lg .btn.btn-outline-secondary.active, .navbar.navbar-expand-lg .btn.btn-outline-secondary.focus, .navbar.navbar-expand-lg .btn.btn-outline-secondary:active, .navbar.navbar-expand-lg .btn.btn-outline-secondary:focus,
+    .navbar.navbar-expand-lg .btn .btn-outline-secondary.active,
+    .navbar.navbar-expand-lg .btn .btn-outline-secondary:active {
       background-color: rgba(255, 255, 255, 0.15); }
-    .navbar.navbar-expand-md .btn.btn-outline-secondary:hover, .navbar.navbar-expand-md .navbar-toggler:hover {
+    .navbar.navbar-expand-lg .btn.btn-outline-secondary:hover, .navbar.navbar-expand-lg .navbar-toggler:hover {
       background-color: rgba(255, 255, 255, 0.1); }
-  .navbar.navbar-expand-md .show > .btn-outline-secondary.dropdown-toggle {
+  .navbar.navbar-expand-lg .show > .btn-outline-secondary.dropdown-toggle {
     background-color: rgba(255, 255, 255, 0.15); }
-  .navbar.navbar-expand-md .nav-link.btn {
+  .navbar.navbar-expand-lg .nav-link.btn {
     color: rgba(255, 255, 255, 0.75); }
-  .navbar.navbar-expand-md .dropdown-menu {
+  .navbar.navbar-expand-lg .dropdown-menu {
     font-size: 0.875rem; }
   .navbar-toggler-icon {
     font-size: 0.8em; }


### PR DESCRIPTION
After #2405 the header reverted to default bootstrap color / font, which was not intentional. This PR makes sure the overrides from `jenkins.css` are actually used for the navbar.

@halkeye looped