### PR TITLE
[JENKINS-59115] Documentation for branch when condition with comparator

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1145,8 +1145,15 @@ Nesting conditions may be nested to any arbitrary depth.
 ===== Built-in Conditions
 
 branch:: Execute the stage when the branch being built matches the branch
-pattern given, for example: `when { branch 'master' }`. Note that this only works on
-a multibranch Pipeline.
+pattern given.  Note that this only works on a multibranch Pipeline.
+Example: `when { branch "master-*" }`.
++
+The optional parameter `comparator` may be added after an attribute
+to specify how any patterns are evaluated for a match:
+`EQUALS` for a simple string comparison,
+`GLOB` (the default) for an ANT style path glob (same as for example `changeset`), or
+`REGEXP` for regular expression matching.
+For example: `when { branch pattern: "release-\\d+", comparator: "REGEXP"}`
 
 buildingTag:: Execute the stage when the build is building a tag.
 Example: `when { buildingTag() }`


### PR DESCRIPTION
See [JENKINS-59115](https://issues.jenkins-ci.org/browse/JENKINS-59115).

Documentation for the `branch` when condition with comparator. Similar to:
- https://github.com/jenkins-infra/jenkins.io/pull/1430

Downstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/351

## Tasks
- [ ] Declarative X.Y is released.