### PR TITLE
JSON Schema doc

### DIFF
--- a/content/projects/jcasc/json-schema.adoc
+++ b/content/projects/jcasc/json-schema.adoc
@@ -1,0 +1,46 @@
+---
+layout: project
+title: "Jenkins Configuration as Code"
+section: projects
+tags:
+- jenkins-configuration-as-code
+- jcasc
+opengraph:
+  image: /images/logos/JCasC/JCasC.png
+links:
+  gitter: 'jenkinsci/configuration-as-code-plugin'
+  github: 'jenkinsci/configuration-as-code-plugin'
+  meetings: "/projects/jcasc/#office-hours-meeting"
+
+---
+
+THe JSON Schema is structured to validate the yaml files that are loaded via JCasC.The structure and validation of the Schema is done based on the user-installed plugins.
+
+=== Version
+
+The Schema uses JSON draft v07. 
+http://json-schema.org/draft-06/schema#
+
+
+=== Progress
+
+* The JSON Schema is currently not working.
+* We are working on it and will release a beta version.
+
+=== Office Hours meeting
+
+The purpose of JCasC Office Hours meeting is to discuss current issues but also short and long term future of the plugin
+
+==== Time and location
+The meeting takes place on Wednesdays, 9am (UTC+1) every two weeks. 
+
+Meetings will be announced at link:https://jenkins.io/event-calendar/[*Event Calendar*]
+
+Hangouts On Air is used to host and stream the meeting on link:https://www.youtube.com/channel/UC5JBtmoz7ePk-33ZHimGiDQ[*Jenkins Youtube channel*].
+Link to the actual meeting is always shared a few minutes before the meeting at link:https://gitter.im/jenkinsci/configuration-as-code-plugin[*configuration-as-code-plugin*] gitter channel
+
+link:https://docs.google.com/document/d/1Hm07Q1egWL6VVAqNgu27bcMnqNZhYJmXKRvknVw4Y84/edit?usp=sharing[*Minutes of Meeting*] are available for everyone interested
+
+==== CommunityBridge
+
+link:dev-tools[JCasC development tools improvement] is a funded CommunityBridge project to improve the experience of administrators and developers creating and maintaining JCasC YAML files. 


### PR DESCRIPTION
This document is used to reference and announce the release the new Beta Version of the Schema.
The Template for the doc is the same as the index page for jcasc.