### PR TITLE
Reset parallelism setting for site generation

### DIFF
--- a/content/_config/site.yml
+++ b/content/_config/site.yml
@@ -28,6 +28,8 @@ asciidoctor:
     prewrap: null
     fragment: ''
     notitle: ''
+generation:
+  :in_threads: null
 profiles:
   production:
     base_url: https://jenkins.io/


### PR DESCRIPTION
Since a bugfix in Awestruct the parallelization settings changed. The last few builds were slower (5min->9min) and had some unexpected failures. This PR will set the parallelization back from threads to processes.