### PR TITLE
Update stages directive doc

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -463,8 +463,6 @@ pipeline {
 }
 // Script //
 ----
-<1> The `stages` section will typically follow the directives such as `agent`,
-`options`, etc.
 
 ==== steps
 


### PR DESCRIPTION
IIUC it's not supported when using something like:

```
  stages {
    options { skipDefaultCheckout() }
```

Throws the below error:

```
 org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
 WorkflowScript: 36: Expected a stage @ line 36, column 5.
        options { skipDefaultCheckout() }
```

I don't see any references in the AST definition:
- https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/94fa840c38a407e48eb37510273afc63d25fd6b4/pipeline-model-api/src/main/resources/ast-schema.json#L538