### PR TITLE
Add support of multiple authors to the blogposts + fix the Pipeline Config History post

### DIFF
--- a/content/_data/authors/jochenafuerbacher.adoc
+++ b/content/_data/authors/jochenafuerbacher.adoc
@@ -1,0 +1,7 @@
+---
+name: "Jochen A. Fürbacher"
+github: "Jochen-A-Fuerbacher"
+---
+
+Jochen is a software developer for development infrastructure at 1&1 Telecommunication.
+He has been working with Jenkins for many years and develop some Jenkins plugins.

--- a/content/_data/authors/pch-maintainers.adoc
+++ b/content/_data/authors/pch-maintainers.adoc
@@ -1,7 +1,0 @@
----
-name: "Jochen A. Fürbacher, Stefan Brausch, and Robin Schulz, 1&1 Telecommunication"
----
-https://github.com/Jochen-A-Fuerbacher[Jochen],
-https://github.com/stefanbrausch[Stefan], and
-https://github.com/RobinRSchulz[Robin] are software developers for development infrastructure at 1&1 Telecommunication.
-They have been working with Jenkins for many years and develop some Jenkins plugins.

--- a/content/_data/authors/robinrschulz.adoc
+++ b/content/_data/authors/robinrschulz.adoc
@@ -1,0 +1,7 @@
+---
+name: "Robin Schulz"
+github: "RobinRSchulz"
+---
+
+Robin is a software developer for development infrastructure at 1&1 Telecommunication.
+He has been working with Jenkins for many years and develop some Jenkins plugins.

--- a/content/_data/authors/stefanbrausch.adoc
+++ b/content/_data/authors/stefanbrausch.adoc
@@ -1,0 +1,7 @@
+---
+name: "Stefan Brausch"
+github: "stefanbrausch"
+---
+
+Stefan is a software developer for development infrastructure at 1&1 Telecommunication.
+He has been working with Jenkins for many years and develop some Jenkins plugins.

--- a/content/_ext/authorlist.rb
+++ b/content/_ext/authorlist.rb
@@ -30,6 +30,13 @@ class AuthorList
          @authors[author] ||= Awestruct::Extensions::Tagger::TagStat.new( author, [] )
          @authors[author].pages << page
        end
+       if page.authors
+        page.authors.each { |coauthor|
+          author = coauthor.to_s
+          @authors[author] ||= Awestruct::Extensions::Tagger::TagStat.new( author, [] )
+          @authors[author].pages << page
+        }
+       end
      end
 
      ordered_authors = @authors.values

--- a/content/_ext/authorship.rb
+++ b/content/_ext/authorship.rb
@@ -1,16 +1,28 @@
 # The authorship helper helps display authorship for a given entity
 #
-# This only renders something if the author has put information in
-# content/_data/authors and the document has an `author` attribute in its
+# This only renders something if the author(s) has put information in
+# content/_data/authors and the document has an `author` or `authors` attribute in its
 # front-matter
 require 'authorlist.rb'
 module Authorship
   include AuthorList::AuthorLink
 
   def display_author_for(node)
-    # bail early if what we were given doesn't even respond
-    return unless node.author
-    display_user(node.author)
+    if node.author
+      display_user(node.author)
+    elsif node.authors
+      display_users(node.authors)
+    else
+      return
+    end
+  end
+
+  def display_users(users)
+    res = Array.new
+    users.each { |user|
+      res << display_user(user)
+    }
+    return res.join(', ')
   end
 
   def display_user(author)

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -38,4 +38,8 @@ layout: default
                     = tag
 
       = content
-      = partial("author.html.haml", :author => page.author)
+      - if page.author 
+        = partial("author.html.haml", :author => page.author)
+      - if page.authors
+        - page.authors.each do |author|
+          = partial("author.html.haml", :author => author)

--- a/content/blog/2019/07/2019-07-15-pipeline-config-history-plugin.adoc
+++ b/content/blog/2019/07/2019-07-15-pipeline-config-history-plugin.adoc
@@ -4,7 +4,10 @@ title: "Introducing the Pipeline Configuration History Plugin"
 tags:
 - pipeline
 - plugins
-author: pch-maintainers
+authors:
+- jochenafuerbacher
+- stefanbrausch
+- robinrschulz
 opengraph:
   image: /images/post-images/2019-07-pipeline-config-history/Diff_2.6.png
 ---


### PR DESCRIPTION
As a follow-up to External Workspace Storage blogposts for GSoC in #2365 and #2366, we need to support multiple authors. So I tried implementing it here. In parallel I have fixed the post from @Jochen-A-Fuerbacher @stefanbrausch @RobinRSchulz which had a hack to support multiple authors. CC @zbynek who was the author of the original logic.

Probably we need to rework the author.html.haml to avoid duplicate headers, but it can be done in a follow-up IMHO
Screenshots:

![image](https://user-images.githubusercontent.com/3000480/64898616-0e943100-d688-11e9-8ff3-a4b81134fd07.png)

![image](https://user-images.githubusercontent.com/3000480/64898681-55822680-d688-11e9-9491-ba62ce55225d.png)


![image](https://user-images.githubusercontent.com/3000480/64898599-020fd880-d688-11e9-93fe-2be67df88d7e.png)
