### PR TITLE
Remove meeting notes from Docs SIG page

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -85,10 +85,3 @@ link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOE
 
 Meetings are conducted and recorded using Zoom.
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
-
-==== 2019-05-10
-
-Initial organizing meeting
-
-* link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#heading=h.g4afeqolzwpj[Meeting notes]
-* Youtube recording to be added later


### PR DESCRIPTION
Meeting notes are kept in a separate file, along with meeting recordings on YouTube channel.