### PR TITLE
Change level of section title (minor markup fix)

### DIFF
--- a/content/blog/2019/08/2019-08-23-introducing-gitlab-branch-source-plugin.adoc
+++ b/content/blog/2019/08/2019-08-23-introducing-gitlab-branch-source-plugin.adoc
@@ -199,7 +199,7 @@ You can also use `JCasC` to directly create job from a Job DSL script. For examp
 * Actively maintain `GitLab Branch Source Plugin` and take feedbacks from users to improve the plugin's user experience.
 * Extend support for GitLab Pipeline to Blueocean.
 
-= Resources
+== Resources
 
 * link:https://github.com/jenkinsci/gitlab-api-plugin[GitLab API Plugin]
 * link:https://wiki.jenkins.io/display/JENKINS/GitLab+API+Plugin[GitLab API Plugin Wiki]


### PR DESCRIPTION
The top level heading is causing error message in console of CI builds. Even though  these errors have no impact on the generated site, they make the log harder to read.