### PR TITLE
Hacktoberfest 2019 - Add keywords to the featured projects

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -50,10 +50,12 @@ If you are a newcomer contributor, we have prepared a list of projects/component
 All these projects have newbie-friendly tasks, contributing guidelines, and active maintainers
 who have committed to assist contributors and to provide quick turnaround in pull requests.
 
+[frame="topbot",grid="all",options="header",cols="30%,15%,55%"]
 |=========================================================
-|Project/component | Ideas and links
+|Project/component | Keywords | Ideas and links
 
 | link:https://github.com/jenkinsci/jenkins[Jenkins Core]
+| Java
 | There is always something to improve in Jenkins core itself.
   You can address various issues, improve the codebase,
   and add new features there.
@@ -61,7 +63,8 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md[Contributing],
   link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newbie-friendly issues]
 
-| link:https://github.com/jenkinsci/configuration-as-code-plugin[Jenkins Configuration-as-Code Plugin]
+| link:https://github.com/jenkinsci/configuration-as-code-plugin[Jenkins Configuration-as-Code]
+| Java, YAML
 | Contribute to the fresh new plugin: improve the codebase,
   add demos and link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(jcasc-compatibility)[plugin integrations].
 
@@ -70,12 +73,14 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:https://issues.jenkins-ci.org/issues/?filter=18649&jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20Reopened)%20AND%20labels%20%3D%20newbie-friendly%20AND%20(labels%20in%20(jcasc-compatibility%2C%20jcasc-devtools-compatibility)%20or%20component%20in%20(configuration-as-code-plugin%2C%20configuration-as-code-groovy-plugin%2C%20configuration-as-code-secret-ssm-plugin)%20)[newbie-friendly issues in Jenkins JIRA]
 
 | link:https://jenkins.io[Jenkins Website]
+| Documentation, Asciidoc, CSS, Ruby
 | Extend and improve Jenkins documentation, help to improve the website's look&feel, or create link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-a-blog-post[a new blogpost].
 
   link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[Contributing guidelines],
   link:https://issues.jenkins-ci.org/issues/?filter=18650&jql=project%20%3D%20WEBSITE%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[newbie-friendly issues]
 
 | link:https://jenkins-x.io/[Jenkins X]
+| Kubernetes, Go
 | Try out the project and create new demos,
   extend documentation, and create new builders for your toolchains.
 
@@ -85,13 +90,16 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:https://github.com/jenkins-x/jx/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[newbie-friendly issues]
 
 | link:/sigs/chinese-localization/[Chinese Localization SIG]
+| Documentation, Asciidoc, Java
 | Contribute to the new link:https://github.com/jenkins-infra/cn.jenkins.io[Website] and
   the link:https://github.com/jenkinsci/localization-zh-cn-plugin[Simplified Chinese Localization plugin].
 
 | link:https://github.com/jenkins-zh/jenkins-cli/[Jenkins CLI written in Go]
+| Go, REST API
 | Try to supplement the documents or start from the link:https://github.com/jenkins-zh/jenkins-cli/issues?q=is%3Aissue+is%3Aopen+label%3Anewbie[newbie-friendly issues].
 
 | link:/artwork[Jenkins Artwork]
+| Design
 | Create new images and logos for link:/projects/jam/[Jenkins area meetups],
   link:/projects/[subprojects], and plugins.
   You can also contribute new graphics to plugins.


### PR DESCRIPTION
After the change:

![image](https://user-images.githubusercontent.com/3000480/65365603-0bb2b680-dc1b-11e9-89c3-512fc298c608.png)

Unfortunately I cannot do a better layout with just Asciidoc, e.g. I cannot add Grid. The default styles seem to override the configurations in Awestruct. https://issues.jenkins-ci.org/browse/WEBSITE-656 for better defaults