### PR TITLE
Use friendly label for CodeScan plugin (no longer published)

### DIFF
--- a/content/security/advisory/2019-09-25.adoc
+++ b/content/security/advisory/2019-09-25.adoc
@@ -485,6 +485,7 @@ issues:
     As of publication of this advisory, there is no fix.
   plugins:
   - name: codescan
+    title: CodeScan
     previous: 0.11
 
 


### PR DESCRIPTION
Lowercase "codescan" in https://jenkins.io/security/advisory/2019-09-25/ doesn't look great.