### PR TITLE
[Docs SIG] - Add plugin docs and plugin site as SIG projects + Hacktoberfest featured project

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -78,6 +78,16 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[Contributing guidelines],
   link:https://issues.jenkins-ci.org/issues/?filter=18650&jql=project%20%3D%20WEBSITE%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[newbie-friendly issues]
 
+| link:/sigs/docs/#plugin-documentation-on-github[Plugin docs on GitHub]
+| Markdown, Asciidoc
+| We are currently moving plugin documentation from https://wiki.jenkins.io/ to GitHub, 
+  and it is a great opportunity to create small pull requests which benefit all Jenkins users.
+  You can move the existing documentation, improve it, or just improve the existing docs.  
+  The documentation will be also made available on the link:https://plugins.jenkins.io/[plugin site].
+  
+  link:https://issues.jenkins-ci.org/browse/JENKINS-59467[Template issue for plugin docs migration],
+  link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[GitHub support announcement]
+
 | link:https://jenkins-x.io/[Jenkins X]
 | Kubernetes, Go
 | Try out the project and create new demos,

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -67,13 +67,51 @@ on platform topics.
 
 === Ongoing projects
 
+This sections lists some of the projects being done under umbrella of this SIG.
+See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
+
+==== Plugin site integration with GitHub
+
+link:https://plugins.jenkins.io/[Jenkins Plugin Site] currently uses Jenkins update center and link:https://wiki.jenkins.io/[Jenkins Wiki] as a main source of information to be displayed on the website.
+We have recently added support of plugin documentation from GitHub (link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]), 
+but there is still a lot of improvement areas: visualizing changelogs, pulling plugin tags and maintainers list from GitHub, etc.
+This project is tracked in the jira:WEBSITE-637[] EPIC.
+
+Useful links:
+
+* link:https://github.com/jenkins-infra/plugin-site[Plugin Site Frontend]
+* link:https://github.com/jenkins-infra/plugin-site-api[Plugin Site Backend] (exposes REST API for the frontend)
+* link:https://github.com/jenkins-infra/update-center2[Jenkins Update Center] (serves plugin metadata)
+* link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20WEBSITE%20AND%20component%20%3D%20plugin-site%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Newbie-friendly issues for the plugin site]
+* link:https://issues.jenkins-ci.org/browse/JENKINS-59467[Template issue for plugin documentation migration to GitHub] (newbie-friendly)
+* link:https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Hostingthepluginpage[Wiki: Hosting the plugin page]
+
+==== Plugin documentation on GitHub
+
+Currently the SIG is working on migrating plugin documentation from https://wiki.jenkins.io/ to GitHub.
+By supporting such source in plugin site we provide good user experience to Jenkins users who look for documentation. 
+At the same time, plugin maintainers now can follow the documentation-as-code approach and make documentation changes a part of the pull requests. 
+It also gives an opportunity to review the documentation changes and to add documentation contributor recognition, 
+especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation]. 
+
+We have more than 50 plugins which already use GitHub as a documentation source,
+but there are still hundreds of plugins to migrate.
+We invite contributors to participate in the project and to help us with migrating the docs.
+It is also a great opportunity to update and copy-edit the documentation.
+
+Useful links:
+
+* link:https://issues.jenkins-ci.org/browse/JENKINS-59467[Template issue for plugin documentation migration to GitHub]
+* link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[Announcement in the developer mailing list]
+* link:https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-UsingGitHubasasourceofdocumentation[Wiki: Using GitHub as a source of plugin documentation]
+
+==== Documentation Reviews
+
 * Reviewing Jenkins documentation link:https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=18640[bug reports]
 * Identifying link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20%22Jenkins%20Website%22%20and%20status%20!%3D%20done%20and%20labels%20%3D%20newbie-friendly%20ORDER%20BY%20%20%20type%20asc%2C%20status%2C%20updatedDate[newbie-friendly documentation bug reports]
 * Reviewing Jenkins documentation link:https://github.com/jenkins-infra/jenkins.io/pulls[pull requests]
 * Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
 * link:https://plugins.jenkins.io/[Plugins site] improvements
-
-See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
 === Meetings
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -74,7 +74,7 @@ See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD
 
 link:https://plugins.jenkins.io/[Jenkins Plugin Site] currently uses Jenkins update center and link:https://wiki.jenkins.io/[Jenkins Wiki] as a main source of information to be displayed on the website.
 We have recently added support of plugin documentation from GitHub (link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]), 
-but there is still a lot of improvement areas: visualizing changelogs, pulling plugin tags and maintainers list from GitHub, etc.
+but there are still many improvement areas: visualizing changelogs, pulling plugin tags and maintainers list from GitHub, etc.
 This project is tracked in the jira:WEBSITE-637[] EPIC.
 
 Useful links:
@@ -88,8 +88,8 @@ Useful links:
 
 ==== Plugin documentation on GitHub
 
-Currently the SIG is working on migrating plugin documentation from https://wiki.jenkins.io/ to GitHub.
-By supporting such source in plugin site we provide good user experience to Jenkins users who look for documentation. 
+Currently the SIG is migrating plugin documentation from https://wiki.jenkins.io/ to GitHub.
+Documentation in the plugin GitHub repository provides a good user experience for Jenkins users seeking documentation. 
 At the same time, plugin maintainers now can follow the documentation-as-code approach and make documentation changes a part of the pull requests. 
 It also gives an opportunity to review the documentation changes and to add documentation contributor recognition, 
 especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation]. 


### PR DESCRIPTION
Adds Plugin documentation and Plugin site as SIG projects + adds the GitHub plugin documentation as a featured project.

Screenshots:

![image](https://user-images.githubusercontent.com/3000480/65817752-4fa14f00-e20b-11e9-9e32-af9c72d1d698.png)

![image](https://user-images.githubusercontent.com/3000480/65817756-5def6b00-e20b-11e9-8858-7a3333d0c46f.png)


Hacktoberfest page:

![image](https://user-images.githubusercontent.com/3000480/65817743-39938e80-e20b-11e9-8f81-59630fc8c2d7.png)
