### PR TITLE
Security fixes aren't severe enough to make 'Important'

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -2652,7 +2652,7 @@
     We're providing an additional release of the 2.176.x LTS line to allow administrators to apply security updates without having to perform a major upgrade.
   changes:
     - type: security
-      message: Important security fixes.
+      message: Security fixes.
       references:
         - url: https://jenkins.io/security/advisory/2019-09-25/
           title: security advisory

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -4996,7 +4996,7 @@
   date: 2019-09-25
   changes:
     - type: security
-      message: Important security fixes.
+      message: Security fixes.
       references:
         - url: https://jenkins.io/security/advisory/2019-09-25/
           title: security advisory


### PR DESCRIPTION
We declare security fixes to be "Important" when at least one (core) vulnerability is severity "High" or "Critical". This wasn't the case last week.

Keep the label for 2.190.1, since it includes also the August advisory, in which there was such an issue.