### PR TITLE
Hacktoberfest 2019 - Switch the Core CONTRIBUTING page link to Asciidoc

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -69,7 +69,7 @@ who have committed to assist contributors and to provide quick turnaround in pul
   You can address various issues, improve the codebase,
   and add new features there.
 
-  link:https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md[Contributing],
+  link:https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.adoc[Contributing],
   link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newbie-friendly issues]
 
 | link:https://github.com/jenkinsci/configuration-as-code-plugin[Jenkins Configuration-as-Code]


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/4241