### PR TITLE
Hacktoberfest - Make the event teaser collapsable

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -915,6 +915,31 @@ z.f9f9f9.section .ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.
   line-height: 1.1rem;
 }
 
+.event .teaser {
+  position: relative;
+  overflow: hidden;
+  text-align: justify;
+}
+
+.event .teaser.collapsed {
+  max-height: 4rem;
+}
+
+.event .teaser:not(.collapsed) {
+  max-height: unset;
+}
+
+.event .teaser.collapsed::before {
+  content: "";
+  position: absolute; 
+  bottom: 0; 
+  left: 0;
+  width: 100%;
+  padding: 3em 0; 
+  
+  background-image: linear-gradient(to bottom, transparent, white);
+}
+
 .events .ji-blog-list>.event>.body>.teaser:after {
   height: 1.1rem
 }

--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -138,8 +138,8 @@ notitle: true
                   = data.title
                 = data.location
 
-              %p.teaser
-                = data.raw_content
-                .more
+            %p.teaser.collapsed{:onclick => "this.classList.toggle('collapsed')"}
+              = data.raw_content
+              .more
 
             .attrs


### PR DESCRIPTION
My proposition to solve https://issues.jenkins-ci.org/browse/WEBSITE-660

Events start as collapsed, displaying only a few lines; clicking toggles the full text.
I have not managed to add a nice css transition because the box height is not fixed.

By clicking an item's teaser you switch from this...
![image](https://user-images.githubusercontent.com/7082839/66002853-edfc1180-e4a4-11e9-959e-2d378de898c6.png)

...To this!
![image](https://user-images.githubusercontent.com/7082839/66002907-0c620d00-e4a5-11e9-9ce9-828d937a41e1.png)
