### PR TITLE
Hacktoberfest 2019: Add Hacktoberfest issue queries and the experienced developers section

### DIFF
--- a/content/blog/2019/10/2019-10-01-hacktoberfest.adoc
+++ b/content/blog/2019/10/2019-10-01-hacktoberfest.adoc
@@ -53,9 +53,14 @@ The Jenkins project is spread across multiple organizations on GitHub (jenkinsci
 You are welcome to contribute to **any** repository in **any** of these organizations,
 or to any other Jenkins-related repository on GitHub.
 If you adopt Jenkins in your own open-source projects (e.g. Jenkins Pipeline or Configuration as Code),
-it counts as well!
+it counts as well! Some useful queries:
 
-If you are a newcomer contributor, we have prepared a link:/events/hacktoberfest/#featured-projects[list of featured projects/components] where you will get a warm welcome.
+* link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20hacktoberfest%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened)[Jenkins JIRA issues suggested for Hacktoberfest]
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Aissue+is%3Aopen+label%3Ahacktoberfest[GitHub issues suggested for Hacktoberfest]
+* link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened)[Newbie-friendly issues in Jenkins JIRA]
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues on GitHub]
+
+**Featured projects**. If you are a newcomer contributor, we have prepared a link:/events/hacktoberfest/#featured-projects[list of projects/components] where you will get a warm welcome.
 All these projects have newbie-friendly tasks, contributing guidelines, and active maintainers
 who have committed to assist contributors and to quickly review pull requests.
 The list of featured projects will be updated during the event,

--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -43,11 +43,20 @@ See the link:/participate/[Contribute and Participate] page for more information
 
 == Where to contribute?
 
-The Jenkins project is spread across several organizations on GitHub (jenkinsci, jenkins-x, jenkins-infra).
+The Jenkins project is spread across several organizations on GitHub (`jenkinsci`, `jenkins-infra`, `jenkins-zh`).
 You are welcome to contribute to **any** repository in **any** of those organizations, or to any other Jenkins-related repository on GitHub.
 However various components in Jenkins have differing review and delivery velocity.
 If you adopt Jenkins in your own open-source projects (e.g. Jenkins Pipeline or Configuration as Code),
 it counts as well!
+
+=== Issue queries
+
+We have marked some issues in Jenkins JIRA and GitHub issues which can be handled by contributors during Hacktoberfest:
+
+* link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20hacktoberfest%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened)[Jenkins JIRA issues suggested for Hacktoberfest]
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Aissue+is%3Aopen+label%3Ahacktoberfest[GitHub issues suggested for Hacktoberfest]
+* link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened)[Newbie-friendly issues in Jenkins JIRA]
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues on GitHub]
 
 === Featured projects
 
@@ -173,10 +182,15 @@ who have committed to assist contributors and to provide quick turnaround in pul
 
 |=========================================================
 
-Note that this is not a full list,
-and the list will be extended depending on the interest from maintainers.
-You are welcome to contribute to any of existing Jenkins plugins...
-and even to create new ones.
+=== Experienced developers
+
+If you are an established developer and want to create something new, 
+please don't let yourself to be blocked by the suggested topics!
+Feel free to contribute to any area of Jenkins.
+If you see any major functionality missing in Jenkins,
+we invite you to create new plugins.
+See the link:https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial[Plugin Tutorial] and
+link:https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[Hosting Plugins] guidelines for more information.
 
 == Local events
 


### PR DESCRIPTION
Just to simplify the search for Hacktoberfest issues...

Right now we have around 80 Hacktoberfest issues and also 200+ newbie-friendly ones, so it should be helful for those ones who look for issues outside featured projects

