### PR TITLE
fixed link to gitlab

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -116,7 +116,7 @@ who have committed to assist contributors and to provide quick turnaround in pul
   Markdown
 | Let's make Jenkins integration with Gitlab better!
   We invite everyone to work on
-  plugin:gitlab[Gitlab], plugin:gitlab-api[Gitlab API], plugin:gitlab-branch-source[Gitlab Branch Source] and other plugins for Jenkins to add new features, fix issues and improve documentation.
+  plugin:gitlab-plugin[Gitlab], plugin:gitlab-api[Gitlab API], plugin:gitlab-branch-source[Gitlab Branch Source] and other plugins for Jenkins to add new features, fix issues and improve documentation.
 
   link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20newbie-friendly%20and%20component%20in%20(gitlab-plugin%2C%20gitlab-api-plugin%2C%20gitlab-branch-source-plugin)%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Newbie-friendly issues in JIRA],
   link:https://github.com/jenkinsci/gitlab-plugin/issues?q=is%3Aissue+is%3Aopen+label%3Anewbie-friendly[GitHub issues for the Gitlab plugin]


### PR DESCRIPTION
fixed link to gitlab plugin

I'm not sure that this minor change qualifies for Hacktoberfest, but I found a dead link ;)