### PR TITLE
[WEBSITE-666] - Hacktoberfest: Update the /participate/code page

### DIFF
--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -1,27 +1,100 @@
 ---
-layout: simplepage
+layout: project
 title: Contribute code
 section: participate
+tags:
+  - outreach-programs
+  - developer
 ---
 
-[NOTE]
-====
-This page is still a work in progress.
-====
+Jenkins project includes a lot of code, and we invite everyone to contribute to the project.
+There is a diverse set of programming languages used in Jenkins,
+including but not limited to: Java, JavaScript, Groovy, Golang, Ruby, Shell scripts.
+And, since Jenkins is an automation server with hundreds of plugins, there is a huge number of technologies involved.
+If you are an expert or just want to study something new while contributing,
+you may find interesting opportunities in our project.
 
-Check out these existing resources for contributors:
+== Where to contribute?
 
-* link:https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing#BeginnersGuidetoContributing-Areyouinterestedinwritingcode%3F[Beginners Guide to Contributing].
-* https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[The complete guide to hosting and publishing plugins]
+The Jenkins project is spread across multiple organizations on GitHub.
+You are welcome to contribute to **any** repository in **any** of those organizations, or to any other Jenkins-related repository on GitHub.
+
+* https://github.com/jenkinsci[jenkinsci] - Main organization. Jenkins core, plugins and libraries reside there
+* https://github.com/jenkins-infra[jenkins-infra] - Jenkins infrastructure, including the website and other services
+* https://github.com/stapler/[stapler] - Stapler Web Framework which is currently maintained by the Jenkins community
+* https://github.com/jenkins-zh[jenkins-zh] - organization of the link:/sigs/chinese-localization/[Chinese Localization SIG]
+
+Various components in Jenkins have differing review and delivery policies,
+so please see the repositories for specific contributing guidelines.
+
+=== Plugins
+
+There are more than link:https://plugins.jenkins.io[1500 plugins] in Jenkins,
+and these plugins implement the most of the Jenkins functionality.
+Every plugin is a isolated component which can be developed independently of other parts of the project,
+with help of the APIs and development tools provided by the project.
+
+The most of Jenkins contributors work on plugins, and it might be the best way to start contributing to the project.
+Here are some documentation links:
+
+* link:/doc/developer/[Jenkins developer documentation]
 * https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial[The plugin tutorial will get you started with Jenkins plugin development]
+* https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[The complete guide to hosting and publishing plugins]
 * https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopt a plugin]
 * https://wiki.jenkins.io/display/JENKINS/Before+starting+a+new+plugin[Advice before creating a new plugin]
 * https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[How we handle pull requests to plugin repositories]
-* Check out the https://github.com/jenkinsci[jenkinsci] organization on GitHub for plugins and other components to contribute to.
-* link:https://issues.jenkins-ci.org/issues/?jql=labels+%3D+newbie-friendly[Jira query for issues we believe are beginner-friendly]
+
+=== Jenkins core
+
+Jenkins core is the heart of any Jenkins installation which provides the kernel functionality and extension APIs being used by Jenkins plugins.
+Written mostly in Java, it includes multiple components and frameworks.
+The core also includes the standard Web container and acts as an executable WAR file which can be run in the instance.
+
+See the link:https://github.com/jenkinsci/jenkins[jenkinsci/jenkins] repository for the overview and documentation links.
+
+=== Infrastructure
+
+As an independent open source project, the Jenkins project maintains most of its own infrastructure including services which help to keep the project running. 
+The kind of things that fall into "infrastructure" can span from operating virtual machines, containers, configuring network or developing and maintaining project-specific applications to make the development of Jenkins core and plugins more efficient.
+
+Because we strongly believe in Open Source principles, we also apply them to our infrastructure. 
+As such we consider ourself as an open infrastructure project where everybody is invited to learn, share, contribute.
+
+See the link:/projects/infrastructure/[Infrastructure sub-project] for more information and contributing guidelines.
+
+=== Other components
+
+There are hundreds of repositories which do not fall under categories below:
+libraries, packaging, developer tools, etc.
+You can discover these components by looking into link:/sigs[special interest groups] and link:/projects[sub-projects] pages.
 
 ////
+TODO(oleg_nenashev): Expand this section?
+////
 
+== Newcomers
+
+The Jenkins project always welcomes newcomer contributors.
+We maintain lists of newbie-friendly issues which can be taken.
+
+* link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened)[Newbie-friendly issues in Jenkins JIRA]
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues on GitHub]
+
+Useful links:
+
+* link:https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing#BeginnersGuidetoContributing-Areyouinterestedinwritingcode%3F[Beginners Guide to Contributing]
+* Presentation: Contributing to Jenkins (link:https://docs.google.com/presentation/d/1JHgVzWZAx95IsUAZp8OoyCQGGkrCjzUd7eblwd1Y-hA/edit?usp=sharing[slides])
+* link:/sigs/advocacy-and-outreach/outreach-programs/[Outreach programs] - Google Summer of Code, Outreachy, Hacktoberfest may be a good opportunity to start contributing to the project
+
+== Experienced contributors
+
+Are you an established contributor to Jenkins and looking for a new challenge?
+The link:/security#team[Jenkins Security Team] is looking for members willing to help improve Jenkins security.
+Also, there are many link:/sigs[special interest groups] and link:/projects[sub-projects] which look for contributors 
+in order to push bigger projects forward.
+
+////
+TODO: delete?
 * https://wiki.jenkins.io/display/JENKINS/Instructions+for+Committers[Instructions for committers]
 * https://wiki.jenkins.io/display/JENKINS/GitHub+commit+messages[On writing GitHub commit messages]
 * https://wiki.jenkins.io/display/JENKINS/Introduction

--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -30,11 +30,11 @@ so please see the repositories for specific contributing guidelines.
 === Plugins
 
 There are more than link:https://plugins.jenkins.io[1500 plugins] in Jenkins,
-and these plugins implement the most of the Jenkins functionality.
-Every plugin is a isolated component which can be developed independently of other parts of the project,
+and these plugins implement the majority of Jenkins functionality.
+Every plugin is an isolated component which can be developed independently of other parts of the project,
 with help of the APIs and development tools provided by the project.
 
-The most of Jenkins contributors work on plugins, and it might be the best way to start contributing to the project.
+Most Jenkins contributors work on plugins and it is often the best way to start contributing to the project.
 Here are some documentation links:
 
 * link:/doc/developer/[Jenkins developer documentation]
@@ -46,7 +46,7 @@ Here are some documentation links:
 
 === Jenkins core
 
-Jenkins core is the heart of any Jenkins installation which provides the kernel functionality and extension APIs being used by Jenkins plugins.
+Jenkins core is the heart of any Jenkins installation. It provides the kernel functionality and extension APIs used by Jenkins plugins.
 Written mostly in Java, it includes multiple components and frameworks.
 The core also includes the standard Web container and acts as an executable WAR file which can be run in the instance.
 
@@ -75,7 +75,7 @@ TODO(oleg_nenashev): Expand this section?
 == Newcomers
 
 The Jenkins project always welcomes newcomer contributors.
-We maintain lists of newbie-friendly issues which can be taken.
+We maintain lists of newbie-friendly issues and encourage new contributors to work on those issues.
 
 * link:https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened)[Newbie-friendly issues in Jenkins JIRA]
 * link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues on GitHub]
@@ -90,7 +90,7 @@ Useful links:
 
 Are you an established contributor to Jenkins and looking for a new challenge?
 The link:/security#team[Jenkins Security Team] is looking for members willing to help improve Jenkins security.
-Also, there are many link:/sigs[special interest groups] and link:/projects[sub-projects] which look for contributors 
+Also, there are many link:/sigs[special interest groups] and link:/projects[sub-projects] which are seeking contributors 
 in order to push bigger projects forward.
 
 ////

--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -118,11 +118,6 @@ section: participate
         Do you enjoy writing code? There are numerous plugins and components for you to contribute to.
         %a{:href => 'code'}
           Learn more.
-      %p
-        Are you an established contributor to Jenkins and looking for a new challenge?
-        The Jenkins Security Team is looking for members willing to help improve Jenkins security.
-        %a{:href => expand_link('security#team')}
-          Learn more.
 
       %p
         Are you a student? You might be eligible to participate in Google Summer of Code.


### PR DESCRIPTION
Just started reworking the /participate/code page so that it looks less terrible. Still a lot to improve, but at least the change allows improving the situation and creating follow-up newbie-friendly tickets for Hacktoberfest

Also removed the Security team referece from /participate and moved it under /code . I consider it as a temporary solution until /participate is reworked

https://issues.jenkins-ci.org/browse/WEBSITE-666

Before:

![image](https://user-images.githubusercontent.com/3000480/66126849-a5e70700-e5ea-11e9-9f95-04eecc989874.png)


After:

![image](https://user-images.githubusercontent.com/3000480/66126820-910a7380-e5ea-11e9-8c7f-5aa47b6cf60a.png)
