### PR TITLE
[WEBSITE-654] - Move the plugin documentation hosting info from Wiki to jenkins.io

### DIFF
--- a/content/doc/developer/publishing/_chapter.yml
+++ b/content/doc/developer/publishing/_chapter.yml
@@ -3,7 +3,8 @@ sections:
 - style-guides
 - source-code-hosting
 - artifact-repository
-- wiki-page
+- documentation
+# - wiki-page
 #- issue-tracker
 #- update-center
 - plugin-site

--- a/content/doc/developer/publishing/_chapter.yml
+++ b/content/doc/developer/publishing/_chapter.yml
@@ -4,7 +4,7 @@ sections:
 - source-code-hosting
 - artifact-repository
 - documentation
-# - wiki-page
+- wiki-page
 #- issue-tracker
 #- update-center
 - plugin-site

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -137,5 +137,4 @@ Some notes:
 * Jenkins has a link:https://jenkins.io/project/conduct/[Code of Conduct] which applies to any contributor and to any component hosted by the project.
   It is defined for all repositories using the link:https://github.com/jenkinsci/.github[jenkinsci/.github] repository,
   plugin maintainers do not need to set it up.
-* Pull request templates can be created by plugin maintainers if needed.
-  See link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository].
+* Pull request templates: see link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository].

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -147,6 +147,21 @@ add a link to releases page to your documentation page
 * create a CHANGELOG file (Markdown, Asciidoc) in the repository root and link it from the documentation page
 * include the changelog content in the documentation page
 
+== Contributor documentation
+
+For open-source plugins it is important to have contributor guidelines to attract more contributors.
+GitHub offers standard ways to define guidelines and to show them to contributors,
+including contributing guidelines, code of conduct, pull request templates, etc.
+
+Some notes:
+
+* `CONTRIBUTING` guidelines can be defined by plugin maintainers, we do not set a default guide at the moment.
+  See link:https://help.github.com/en/articles/setting-guidelines-for-repository-contributors[Setting guidelines for repository contributors] for more information
+* Jenkins has a link:https://jenkins.io/project/conduct/[Code of Conduct] which applies to any contributor and to any component hosted by the project.
+  It is defined for all repositories using the link:https://github.com/jenkinsci/.github[jenkinsci/.github] repository,
+  plugin maintainers do not need to set it up
+* Pull request templates can be created by plugin maintainers if needed.
+  See link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository]
 
 == Useful links
 

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -46,7 +46,7 @@ relative links
 . Modify your project URL to point to the GitHub repository, e.g. `http://github.com/jenkinsci/your-plugin`.
   See the guidelines for Maven and Gradle below.
 . Release the new plugin version.
-  After several hours, the link:https://plugins.jenkins.io/[Plugin site] with start using it as a documentation source.
+  Once the link:https://plugins.jenkins.io/[plugin site] picks up the release (which can take up to a few hours) it will also display the documentation from GitHub.
 
 Documentation examples:
 

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -117,9 +117,9 @@ In your POM, make sure to include developer information, such as:
   ...
   <developers>
     <developer>
-      <id>devguy</id>
-      <name>Developer Guy</name>
-      <email>devguy@developerguy.blah</email>
+      <id>exampleauthor</id>
+      <name>Author Name</name>
+      <email>author@example.com</email>
     </developer>
   </developers>
 </project>

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -94,17 +94,6 @@ jenkinsPlugin {
 }
 ```
 
-Or if you have a plugin written in
-https://wiki.jenkins.io/display/JENKINS/Jenkins+plugin+development+in+Ruby[Ruby],
-you must edit your `+.pluginspec+` file like so:
-
-```ruby
-Jenkins::Plugin::Specification.new do |plugin|
-  # ...
-  plugin.url = 'http://github.com/jenkinsci/your-plugin'
-  # ...
-end
-```
 
 This ensures that the update center will list your plugin correctly once
 the new plugin version is released. If this is missing, or does not
@@ -167,7 +156,3 @@ Some notes:
   plugin maintainers do not need to set it up.
 * Pull request templates can be created by plugin maintainers if needed.
   See link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository].
-
-== Useful links
-
-

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -2,8 +2,10 @@
 title: Plugin Documentation
 layout: developersection
 references:
+- url: https://plugins.jenkins.io/
+  title: Plugin site
 - url: ../plugin-site/
-  title: Plugin Site Documentation
+  title: Plugin site documentation
 - url: ../wiki-page/
   title: Hosting plugin documentation on Jenkins Wiki
 ---
@@ -18,45 +20,32 @@ This section provides overview of these documentation types.
 Plugin pages are hosted on the link:https://plugins.jenkins.io/[Plugin Site].
 These pages are generated automatically using the metadata from the latest plugin release and an external documentation page.
 External documentation can be retrieved from GitHub or from the https://wiki.jenkins.io[Jenkins Wiki].
-Since the introduction of GitHub documentation support in September 2019
-(https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]),
-this is the *recommended way* to host documentation.
+GitHub documentation support was introduced in September 2019
+(https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]).
 
-In Jenkins we recommend storing documentation in the plugin repository.
-It allows plugin maintainers to provide the same documentation from GitHub README pages and the Jenkins plugin site,
+For new plugins we recommend storing documentation in the GitHub repositories.
+It allows plugin maintainers to provide the same documentation from README pages and the Jenkins plugin site,
 and at the same time it allows using the Documentation-as-Code techniques when the documentation is a part of the
 repository and hence all common practices can be applied 
 (versioning, pull requests and reviews, creating documentation in parallel with features, editing docs from GitHub Web UI).
 
 === Using GitHub as a source of documentation
 
-Since the introduction of GitHub documentation support in September 2019
-(https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]),
-this is the *recommended way* to host documentation. It allows plugin
-maintainers to provide the same documentation from GitHub pages and the
-Jenkins plugin site, and at the same time it allows using the
-Documentation-as-Code techniques when the documentation is a part of the
-repository and hence all common practices can be applied (versioning,
-pull requests and reviews, creating documentation in parallel with
-features, editing docs from GitHub Web UI).
+The plugin site can pull documentation from the root README pages or from other locations defined by the plugin URL (see below).
+Multiple formats are supported: GitHub Markdown, Asciidoc or raw text.
 
-The plugin site can pull documentation from the root README pages and
-from other locations. For new plugins it is recommended to use README
-pages as a source of documentation, preferably in Markdown or Asciidoc
-format (TXT is also supported in such case).
+To publish the plugin documentation on GitHub...
 
-How to publish the plugin documentation from GitHub?
-
-* Create a README page and put the plugin documentation there
-** This page will become a landing page for https://plugins.jenkins.io/
+. Create a README page and put the plugin documentation there.
+  This page will become a landing page for the link:https://plugins.jenkins.io/[Plugin site].
 ** More documentation pages can be introduced inside the repository and
 linked from the README, the plugin site will display both absolute and
 relative links
 ** Images from pages will be displayed by the plugin site as well
-* Modify your project URL to point to the GitHub repository,
-e.g. http://github.com/jenkinsci/your-plugin
-** See the guidelines for Maven and Gradle below
-* Once the new plugin version is released, link:https://plugins.jenkins.io/[Plugin site] with start using it as a documentation source
+. Modify your project URL to point to the GitHub repository, e.g. `http://github.com/jenkinsci/your-plugin`.
+  See the guidelines for Maven and Gradle below.
+. Release the new plugin version.
+  After several hours, the link:https://plugins.jenkins.io/[Plugin site] with start using it as a documentation source.
 
 Documentation examples:
 
@@ -66,14 +55,12 @@ Documentation examples:
 
 === Using Jenkins Wiki as source of documentation
 
-Even though for new plugins it is recommended to just use GitHub README files, 
-link:https://wiki.jenkins.io[Jenkins Wiki] can still be used if there are strong reasons to do so.
+link:https://wiki.jenkins.io[Jenkins Wiki] can still be used for previously created plugins or for new plugins if there are reasons to do so.
 See link:../wiki-page[this page] for more information.
 
 === Referencing the documentation page from the project file
 
-You should link to your plugin's documentation, whether on the wiki or
-elsewhere, in your plugin's pom.xml, like this:
+You should link to your plugin's documentation, whether on the wiki or elsewhere, in your plugin's pom.xml, like this:
 
 ```xml
 <project>

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -11,8 +11,7 @@ references:
 ---
 
 Documentation is an important part of any Jenkins plugin.
-It includes user documentation (plugin pages, changelogs, user guidelines, etc.)
-and the contributor documentation (how to contribute, developer guidelines, etc.).
+It includes user documentation (plugin pages, changelogs, user guidelines, etc.) and the contributor documentation (how to contribute, developer guidelines, etc.).
 This section provides overview of these documentation types.
 
 == Plugin pages
@@ -20,14 +19,17 @@ This section provides overview of these documentation types.
 Plugin pages are hosted on the link:https://plugins.jenkins.io/[Plugin Site].
 These pages are generated automatically using the metadata from the latest plugin release and an external documentation page.
 External documentation can be retrieved from GitHub or from the https://wiki.jenkins.io[Jenkins Wiki].
-GitHub documentation support was introduced in September 2019
-(https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]).
+GitHub documentation support was introduced in September 2019 (https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]).
 
 For new plugins we recommend storing documentation in the GitHub repositories.
 It allows plugin maintainers to provide the same documentation from README pages and the Jenkins plugin site,
 and at the same time it allows using the Documentation-as-Code techniques when the documentation is a part of the
-repository and hence all common practices can be applied 
-(versioning, pull requests and reviews, creating documentation in parallel with features, editing docs from GitHub Web UI).
+repository and hence all common practices can be applied:
+
+* Pull requests and reviews
+* Creating documentation in parallel with features
+* Editing docs from GitHub Web UI, with preview support
+* Versioning, documentation for previous plugin versions can be easily accessed 
 
 === Using GitHub as a source of documentation
 
@@ -81,19 +83,13 @@ jenkinsPlugin {
 }
 ```
 
-
-This ensures that the update center will list your plugin correctly once
-the new plugin version is released. If this is missing, or does not
-point to your Jenkins wiki page, your plugin will not be included in the
-update center.
-
 == Maintainer Information
 
 Maintainer information is listed for every plugin on the https://plugins.jenkins.io/[plugin site].
 It is currently sourced from the Maven metadata.
 
 WARNING: There is a plan to use link:https://github.com/jenkins-infra/repository-permissions-updater[repository-permissions-updater],
-See jira:WEBSITE-658[] for the task in the bugtracker.
+See jira:WEBSITE-658[] in the issue tracker.
 Once it is implemented, the guidelines below will changed.
 
 In your POM, make sure to include developer information, such as:
@@ -132,8 +128,7 @@ add a link to releases page to your documentation page
 == Contributor documentation
 
 For open-source plugins it is important to have contributor guidelines to attract more contributors.
-GitHub offers standard ways to define guidelines and to show them to contributors,
-including contributing guidelines, code of conduct, pull request templates, etc.
+GitHub offers standard ways to define guidelines and to show them to contributors, including contributing guidelines, code of conduct, pull request templates, etc.
 
 Some notes:
 

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -1,0 +1,154 @@
+---
+title: Plugin Documentation
+layout: developersection
+---
+
+Documentation is an important part of any Jenkins plugin.
+It includes user documentation (plugin pages, changelogs, user guidelines, etc.)
+and the contributor documentation (how to contribute, developer guidelines, etc.).
+This section provides overview of these documentation types.
+
+== Plugin pages
+
+Plugin pages are hosted on the link:https://plugins.jenkins.io/[Plugin Site],
+these pages are being generated automatically using the metadata from the latest plugin release and an external documentation page.
+External documentation can be retrieved from GitHub or from https://wiki.jenkins.io[Jenkins Wiki].
+Since the introduction of GitHub documentation support in September 2019
+(https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]),
+this is the *recommended way* to host documentation.
+
+In Jenkins we recommend storing documentation in the plugin repository.
+It allows plugin maintainers to provide the same documentation from GitHub README pages and the Jenkins plugin site,
+and at the same time it allows using the Documentation-as-Code techniques when the documentation is a part of the
+repository and hence all common practices can be applied 
+(versioning, pull requests and reviews, creating documentation in parallel with features, editing docs from GitHub Web UI).
+
+=== Using GitHub as a source of documentation
+
+Since the introduction of GitHub documentation support in September 2019
+(https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]),
+this is the *recommended way* to host documentation. It allows plugin
+maintainers to provide the same documentation from GitHub pages and the
+Jenkins plugin site, and at the same time it allows using the
+Documentation-as-Code techniques when the documentation is a part of the
+repository and hence all common practices can be applied (versioning,
+pull requests and reviews, creating documentation in parallel with
+features, editing docs from GitHub Web UI).
+
+The plugin site can pull documentation from the root README pages and
+from other locations. For new plugins it is recommended to use README
+pages as a source of documentation, preferably in Markdown or Asciidoc
+format (TXT is also supported in such case).
+
+How to publish the plugin documentation from GitHub?
+
+* Create a README page and put the plugin documentation there
+** This page will become a landing page for https://plugins.jenkins.io/
+** More documentation pages can be introduced inside the repository and
+linked from the README, the plugin site will display both absolute and
+relative links
+** Images from pages will be displayed by the plugin site as well
+* Modify your project URL to point to the GitHub repository,
+e.g. http://github.com/jenkinsci/your-plugin
+** See the guidelines for Maven and Gradle below
+* Once the new plugin version is released, link:https://plugins.jenkins.io/[Plugin site] with start using it as a documentation source
+
+Documentation examples:
+
+* https://plugins.jenkins.io/configuration-as-code
+* https://plugins.jenkins.io/gradle
+* https://plugins.jenkins.io/mailer
+
+=== Using Jenkins Wiki as source of documentation
+
+Even though for new plugins it is recommended to just use GitHub README files, 
+link:https://wiki.jenkins.io[Jenkins Wiki] can still be used if there are strong reasons to do so.
+See link:../wiki-page[this page] for more information.
+
+=== Referencing the documentation page from the project file
+
+You should link to your plugin's documentation, whether on the wiki or
+elsewhere, in your plugin's pom.xml, like this:
+
+```xml
+<project>
+  ...
+  <url>http://github.com/jenkinsci/your-plugin</url>
+  ...
+</project>
+```
+
+If you're building your plugin with https://github.com/jenkinsci/gradle-jpi-plugin[Gradle], 
+you can set the URL in your `+build.gradle+` like so:
+
+```groovy
+jenkinsPlugin {
+  // ...
+  url = 'http://github.com/jenkinsci/your-plugin'
+  // ...
+}
+```
+
+Or if you have a plugin written in
+https://wiki.jenkins.io/display/JENKINS/Jenkins+plugin+development+in+Ruby[Ruby],
+you must edit your `+.pluginspec+` file like so:
+
+```ruby
+Jenkins::Plugin::Specification.new do |plugin|
+  # ...
+  plugin.url = 'http://github.com/jenkinsci/your-plugin'
+  # ...
+end
+```
+
+This ensures that the update center will list your plugin correctly once
+the new plugin version is released. If this is missing, or does not
+point to your Jenkins wiki page, your plugin will not be included in the
+update center.
+
+== Adding Maintainer Information
+
+Maintainer information is listed for every plugin on the https://plugins.jenkins.io/[plugin site].
+
+In your POM, make sure to include developer information, such as:
+
+```xml
+<project>
+  ...
+  <developers>
+    <developer>
+      <id>devguy</id>
+      <name>Developer Guy</name>
+      <email>devguy@developerguy.blah</email>
+    </developer>
+  </developers>
+</project>
+```
+
+
+The ID is your jenkins-ci.org account. The name is a human readable
+display name. This ensures that the update center and related tools are
+able to properly display the maintainer for your plugin. +
+It's highly advisable to include an email address so that people can
+contact you (this will be shown in the plugin infobox on the wiki), but
+it's optional. If pull requests go unmerged for a long time, and there's
+no way of contacting you, the maintainer, others will be encouraged to
+take over maintainership.
+
+== Changelogs
+
+Once you have made your first release, you should add release notes to your plugin. 
+You have many options how to do it:
+
+* use GitHub Releases (possibly with the help of
+https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[Release Drafter]), 
+add a link to releases page to your documentation page
+(recommended)
+* create a CHANGELOG file (Markdown, Asciidoc) in the repository root and link it from the documentation page
+* include the changelog content in the documentation page
+
+
+== Useful links
+
+* link:../plugin-site[Plugin Site Documentation]
+* link:../wiki-page[Hosting plugin documentation on Jenkins Wiki (deprecated)]

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -87,9 +87,14 @@ the new plugin version is released. If this is missing, or does not
 point to your Jenkins wiki page, your plugin will not be included in the
 update center.
 
-== Adding Maintainer Information
+== Maintainer Information
 
 Maintainer information is listed for every plugin on the https://plugins.jenkins.io/[plugin site].
+It is currently sourced from the Maven metadata.
+
+WARNING: There is a plan to use link:https://github.com/jenkins-infra/repository-permissions-updater[repository-permissions-updater],
+See jira:WEBSITE-658[] for the task in the bugtracker.
+Once it is implemented, the guidelines below will changed.
 
 In your POM, make sure to include developer information, such as:
 
@@ -107,14 +112,10 @@ In your POM, make sure to include developer information, such as:
 ```
 
 
-The ID is your jenkins-ci.org account. The name is a human readable
-display name. This ensures that the update center and related tools are
-able to properly display the maintainer for your plugin. +
-It's highly advisable to include an email address so that people can
-contact you (this will be shown in the plugin infobox on the wiki), but
-it's optional. If pull requests go unmerged for a long time, and there's
-no way of contacting you, the maintainer, others will be encouraged to
-take over maintainership.
+The `id` is your jenkins.io account. 
+The `name` is a human readable display name.
+This ensures that the update center and related tools are able to properly display the maintainer for your plugin.
+It's advisable to include an email address so that people can contact you (this will be shown in the plugin infobox on the wiki), but it's optional. 
 
 == Changelogs
 

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -19,7 +19,6 @@ This section provides overview of these documentation types.
 Plugin pages are hosted on the link:https://plugins.jenkins.io/[Plugin Site].
 These pages are generated automatically using the metadata from the latest plugin release and an external documentation page.
 External documentation can be retrieved from GitHub or from the https://wiki.jenkins.io[Jenkins Wiki].
-GitHub documentation support was introduced in September 2019 (https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]).
 
 For new plugins we recommend storing documentation in the GitHub repositories.
 It allows plugin maintainers to provide the same documentation from README pages and the Jenkins plugin site,
@@ -34,9 +33,9 @@ repository and hence all common practices can be applied:
 === Using GitHub as a source of documentation
 
 The plugin site can pull documentation from the root README pages or from other locations defined by the plugin URL (see below).
-Multiple formats are supported: GitHub Markdown, Asciidoc or raw text.
+Multiple formats are supported: GitHub Flavored Markdown, Asciidoc or raw text.
 
-To publish the plugin documentation on GitHub...
+To publish the plugin documentation on GitHub:
 
 . Create a README page and put the plugin documentation there.
   This page will become a landing page for the link:https://plugins.jenkins.io/[Plugin site].
@@ -134,7 +133,7 @@ Some notes:
 
 * `CONTRIBUTING` guidelines can be defined by plugin maintainers, we do not set a default guide at the moment.
   See link:https://help.github.com/en/articles/setting-guidelines-for-repository-contributors[Setting guidelines for repository contributors] for more information
-* Jenkins has a link:https://jenkins.io/project/conduct/[Code of Conduct] which applies to any contributor and to any component hosted by the project.
+* Jenkins has a link:https://jenkins.io/project/conduct/[Code of Conduct] which applies to all contributors and to all components hosted by the project.
   It is defined for all repositories using the link:https://github.com/jenkinsci/.github[jenkinsci/.github] repository,
   plugin maintainers do not need to set it up.
 * Pull request templates: see link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository].

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -10,9 +10,9 @@ This section provides overview of these documentation types.
 
 == Plugin pages
 
-Plugin pages are hosted on the link:https://plugins.jenkins.io/[Plugin Site],
-these pages are being generated automatically using the metadata from the latest plugin release and an external documentation page.
-External documentation can be retrieved from GitHub or from https://wiki.jenkins.io[Jenkins Wiki].
+Plugin pages are hosted on the link:https://plugins.jenkins.io/[Plugin Site].
+These pages are generated automatically using the metadata from the latest plugin release and an external documentation page.
+External documentation can be retrieved from GitHub or from the https://wiki.jenkins.io[Jenkins Wiki].
 Since the introduction of GitHub documentation support in September 2019
 (https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]),
 this is the *recommended way* to host documentation.
@@ -159,9 +159,9 @@ Some notes:
   See link:https://help.github.com/en/articles/setting-guidelines-for-repository-contributors[Setting guidelines for repository contributors] for more information
 * Jenkins has a link:https://jenkins.io/project/conduct/[Code of Conduct] which applies to any contributor and to any component hosted by the project.
   It is defined for all repositories using the link:https://github.com/jenkinsci/.github[jenkinsci/.github] repository,
-  plugin maintainers do not need to set it up
+  plugin maintainers do not need to set it up.
 * Pull request templates can be created by plugin maintainers if needed.
-  See link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository]
+  See link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository].
 
 == Useful links
 

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -1,6 +1,11 @@
 ---
 title: Plugin Documentation
 layout: developersection
+references:
+- url: ../plugin-site/
+  title: Plugin Site Documentation
+- url: ../wiki-page/
+  title: Hosting plugin documentation on Jenkins Wiki
 ---
 
 Documentation is an important part of any Jenkins plugin.
@@ -165,5 +170,4 @@ Some notes:
 
 == Useful links
 
-* link:../plugin-site[Plugin Site Documentation]
-* link:../wiki-page[Hosting plugin documentation on Jenkins Wiki (deprecated)]
+

--- a/content/doc/developer/publishing/preparation.adoc
+++ b/content/doc/developer/publishing/preparation.adoc
@@ -25,7 +25,7 @@ We recommend use of the MIT license which is used for Jenkins core and most plug
 
 == Documentation
 
-It is highly recommended that the hosted plugins include user documentation so that the plugins can be easily adopted.
+We recommend that plugins include user documentation so users understand quickly what the plugin does and how to use it.
 We recommend following the documentation-as-code approach and keeping the documentation directly in the plugin repository.
 
 See link:../documentation[Documentation] for more information.

--- a/content/doc/developer/publishing/preparation.adoc
+++ b/content/doc/developer/publishing/preparation.adoc
@@ -28,7 +28,7 @@ We recommend use of the MIT license which is used for Jenkins core and most plug
 It is highly recommended that the hosted plugins include user documentation so that the plugins can be easily adopted.
 We recommend following the documentation-as-code approach and keeping the documentation directly in the plugin repository.
 
-See link:../documentation[Documentation] for more info.
+See link:../documentation[Documentation] for more information.
 
 == Signup Required
 

--- a/content/doc/developer/publishing/preparation.adoc
+++ b/content/doc/developer/publishing/preparation.adoc
@@ -23,6 +23,12 @@ Make sure to specify the license both in the `pom.xml` file, as well as a `LICEN
 
 We recommend use of the MIT license which is used for Jenkins core and most plugins and libraries, but any OSI-approved open source license will do.
 
+== Documentation
+
+It is highly recommended that the hosted plugins include user documentation so that the plugins can be easily adopted.
+We recommend following the documentation-as-code approach and keeping the documentation directly in the plugin repository.
+
+See link:../documentation[Documentation] for more info.
 
 == Signup Required
 

--- a/content/doc/developer/publishing/requesting-hosting.adoc
+++ b/content/doc/developer/publishing/requesting-hosting.adoc
@@ -43,13 +43,6 @@ This means:
 - https://help.github.com/articles/searching-in-forks/[Source code search] will succeed even without a significant number of watchers on GitHub.
 - Others are more likely to file pull requests in the `jenkinsci` repository (which is ideal for collaboration).
 
-
-== Create a Wiki Page
-
-While not strictly necessary to release your plugin, it's a good idea to create a wiki page for your plugin to store documentation.
-See link:../wiki-page[the guide to plugin wiki pages] for details how to do this.
-
-
 == Enable CI Builds
 
 The Jenkins project hosts a Jenkins instance to perform continuous integration builds for plugins.

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -1,11 +1,14 @@
 ---
 title: Plugin Wiki Pages
 layout: developersection
+references:
+- url: ../documentation/
+  title: Plugin documentation
 ---
 
 WARNING: This page describes hosting of plugin documentation on link:https://wiki.jenkins.io[the Jenkins wiki].
-This approach is deprecated and not recommended for new plugins.
-See link:../documentation[this page] for the recent guidelines.
+For newly created plugins it is recommended to keep plugin documentation in GitHub repositories.
+See link:../documentation[this page] for the guidelines.
 
 Plugins should have user documentation outside the plugin itself so that potential users can learn about the plugin without installing it.
 A common way to do this is to create a plugin wiki page on link:https://wiki.jenkins.io[the Jenkins wiki].

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -3,6 +3,10 @@ title: Plugin Wiki Pages
 layout: developersection
 ---
 
+WARNING: This page describes hosting of plugin documentation on link:https://wiki.jenkins.io[the Jenkins wiki].
+This approach is deprecated and not recommended for new plugins.
+See link:../documentation[this page] for the recent guidelines.
+
 Plugins should have user documentation outside the plugin itself so that potential users can learn about the plugin without installing it.
 A common way to do this is to create a plugin wiki page on link:https://wiki.jenkins.io[the Jenkins wiki].
 


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-654

- [x] Documentation hosting sections were moved from Wiki to jenkins.io
- [x] Plugin Wiki documentation is marked as deprecated and removed from listing
- [x] Some tips about the Contributor documentation have been added to the page
- [ ] Remove references to the obsolete Ruby plugin flow

Wiki documentation will be replaced by a link once these docs are deployed

CC @MarkEWaite @zbynek @tracymiranda 