### PR TITLE
Move Adding a Logo guideline in Artwork page to contributing guidelines

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -549,6 +549,12 @@ would create the directory `content/my-clean-url` and if I were creating an
 Asciidoc file, I would then create the file `content/my-clean-url/index.adoc`.
 (Advanced Haml users would create `content/my-clean-url/index.html.haml`).
 
+=== Adding a Logo
+
+In order to add a new logo, please submit a pull request, 
+adding a new `.yml` file in `content/_data/logo` and a 
+new directory containing the logo assets into `content/images/logos/`.
+
 [[reviewing]]
 == Reviewing changes
 

--- a/content/artwork/index.html.haml
+++ b/content/artwork/index.html.haml
@@ -73,13 +73,7 @@ title: Jenkins Artwork
       %h3
         Adding a Logo
       %p
-        In order to add a new logo, please submit a pull request, adding a new
-        %code
-          \.yml
-        file in
-        %code
-          content/_data/logo
-        and a new directory containing the logo assets into
-        %code
-          content/images/logos/<logoname>
+        In order to add a new logo, please refer to the 
+        %a{:href => 'https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-a-logo'}
+          CONTRIBUTING guidelines.
 


### PR DESCRIPTION
Resolves [WEBSITE-671](https://issues.jenkins-ci.org/browse/WEBSITE-671).

**Summary**
- Moved `Adding a Logo` info from the artwork page to `CONTRIBUTING.adoc`
- Refer to `CONTRIBUTING.adoc` in the artwork page

<img width="553" alt="Screen Shot 2019-10-08 at 10 37 48 pm" src="https://user-images.githubusercontent.com/8002179/66392753-8140c400-ea1c-11e9-9b34-33dbbb1f6ee5.png">
