### PR TITLE
[WEBSITE-206] Move guest post disclaimer to the front matter

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -162,7 +162,7 @@ author: yourgithubname
 description: "Short summary for search engines and social media" # optional
 opengraph:
   image: /images/folder/icon.png # optional
-disclaimer: "Here you can mention that this is a guest post" # optional
+note: "Here you can mention that this is a guest post" # optional
 ---
 ----
 
@@ -223,7 +223,7 @@ with more than 200px in each dimension and preferred aspect ratio about 2:1. For
 more information see the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook],
 and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
 
-The `disclaimer` will be shown as a note at the top of the post,
+The `note` will be shown as a note at the top of the post,
 but will be omitted from the post summary on the blog front page. 
 It is intended for identifying posts by guest authors and posts that were also published somewhere else.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -162,6 +162,7 @@ author: yourgithubname
 description: "Short summary for search engines and social media" # optional
 opengraph:
   image: /images/folder/icon.png # optional
+disclaimer: "Here you can mention that this is a guest post" # optional
 ---
 ----
 
@@ -221,6 +222,10 @@ the article for social media. The `image` attribute should be a PNG or JPEG imag
 with more than 200px in each dimension and preferred aspect ratio about 2:1. For
 more information see the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook],
 and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
+
+The `disclaimer` will be shown as a note at the top of the post,
+but will be omitted from the post summary on the blog front page. 
+It is intended for identifying posts by guest authors and posts that were also published somewhere else.
 
 Once you have everything ready, you may
 link:https://help.github.com/articles/creating-a-pull-request/[create a pull

--- a/content/_ext/asciidocrender.rb
+++ b/content/_ext/asciidocrender.rb
@@ -1,0 +1,8 @@
+module AsciidocRender
+  include Asciidoctor
+
+  def asciidoc(text)
+    Asciidoctor.convert(text, :attributes => {'icons' => 'font'})
+  end
+end
+

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -61,6 +61,7 @@ Awestruct::Extensions::Pipeline.new do
   helper ActiveNav
   helper Authorship
   helper Legacy
+  helper AsciidocRender
 
   helper Awestruct::Extensions::GoogleAnalytics
   helper Awestruct::IBeams::AsciidocSections

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -36,7 +36,8 @@ layout: default
                 %li
                   %a.tag-link{:href => expand_link("node/tags/#{tag}")}
                     = tag
-
+      - if page.disclaimer
+        = asciidoc("NOTE: #{page.disclaimer}")
       = content
       
       - if page.author 

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -36,8 +36,8 @@ layout: default
                 %li
                   %a.tag-link{:href => expand_link("node/tags/#{tag}")}
                     = tag
-      - if page.disclaimer
-        = asciidoc("NOTE: #{page.disclaimer}")
+      - if page.note
+        = asciidoc("NOTE: #{page.note}")
       = content
       
       - if page.author 

--- a/content/blog/2018/01/2018-01-17-jenkins-world-cfp-open.adoc
+++ b/content/blog/2018/01/2018-01-17-jenkins-world-cfp-open.adoc
@@ -5,7 +5,7 @@ tags:
 - event
 - jenkinsworld
 author: alyssat
-disclaimer: "This is a guest post by link:https://github.com/alyssat[Alyssa Tong], who runs
+note: "This is a guest post by link:https://github.com/alyssat[Alyssa Tong], who runs
   the link:/projects/jam[Jenkins Area Meetup] program and is also responsible for
   Marketing & Community Programs at link:https://cloudbees.com[CloudBees, Inc.]"
 ---

--- a/content/blog/2018/01/2018-01-17-jenkins-world-cfp-open.adoc
+++ b/content/blog/2018/01/2018-01-17-jenkins-world-cfp-open.adoc
@@ -5,14 +5,10 @@ tags:
 - event
 - jenkinsworld
 author: alyssat
+disclaimer: "This is a guest post by link:https://github.com/alyssat[Alyssa Tong], who runs
+  the link:/projects/jam[Jenkins Area Meetup] program and is also responsible for
+  Marketing & Community Programs at link:https://cloudbees.com[CloudBees, Inc.]"
 ---
-
-[NOTE]
-====
-This is a guest post by link:https://github.com/alyssat[Alyssa Tong], who runs
-the link:/projects/jam[Jenkins Area Meetup] program and is also responsible for
-Marketing & Community Programs at link:https://cloudbees.com[CloudBees, Inc.]
-====
 
 image:/images/post-images/JW2018.png[Jenkins World 2018, role=center]
 

--- a/content/blog/2018/02/2018-02-22-cheetah.adoc
+++ b/content/blog/2018/02/2018-02-22-cheetah.adoc
@@ -6,7 +6,7 @@ tags:
 - performance
 - scalability
 author: svanoort
-disclaimer: "This is a guest post by link:https://github.com/svanoort[Sam Van Oort],
+note: "This is a guest post by link:https://github.com/svanoort[Sam Van Oort],
   Software Engineer at link:https://cloudbees.com[CloudBees], and contributor to
   the Jenkins project, and maintainer of the Pipeline Plugins."
 ---

--- a/content/blog/2018/02/2018-02-22-cheetah.adoc
+++ b/content/blog/2018/02/2018-02-22-cheetah.adoc
@@ -1,21 +1,17 @@
 ---
-:layout: post
-:title: "Project Cheetah - Faster, Leaner Pipeline That Can Keep Up With Demand"
-:tags:
+layout: post
+title: "Project Cheetah - Faster, Leaner Pipeline That Can Keep Up With Demand"
+tags:
 - pipeline
 - performance
 - scalability
-:author: svanoort
+author: svanoort
+disclaimer: "This is a guest post by link:https://github.com/svanoort[Sam Van Oort],
+  Software Engineer at link:https://cloudbees.com[CloudBees], and contributor to
+  the Jenkins project, and maintainer of the Pipeline Plugins."
 ---
 
 :toc: 
-
-[NOTE]
-====
-This is a guest post by link:https://github.com/svanoort[Sam Van Oort],
-Software Engineer at link:https://cloudbees.com[CloudBees], and contributor to
-the Jenkins project, and maintainer of the Pipeline Plugins.
-====
 
 Since it launched, Pipeline has had a bit of a Dr. Jekyll and Mr. Hyde performance problem.  In certain circumstances, Pipeline can turn from a mild-mannered CI/CD assistant into a monster.  It will happily eat storage read/write capacity like popcorn without caring about the other concerns of our friendly butler.  When combined with other additional factors, this can result in real-world stability problems.  For example, combining slow storage with a spike in running Pipelines has brought down production Jenkins at more than one organization.  Similarly, users see issues if a busy master gets hit with an extra source of stress; past culprits have been heavy automated (ab)use of Jenkins APIs, now-solved user lookup bugs, backup jobs, and plugins run crazy that load excessive numbers of builds.  Symptoms ranged from visible slowdowns in the UI to unresponsive jobs and "hung" masters.
 

--- a/content/blog/2018/04/2018-04-25-configuring-jenkins-pipeline-with-yaml-file.adoc
+++ b/content/blog/2018/04/2018-04-25-configuring-jenkins-pipeline-with-yaml-file.adoc
@@ -7,7 +7,7 @@ tags:
 - yaml
 - sharedlibrary
 author: mdesanti
-disclaimer: "This guest post was originally published on Wolox's Medium account 
+note: "This guest post was originally published on Wolox's Medium account 
   link:https://medium.com/wolox-driving-innovation/dynamic-jenkins-pipelines-b04066371fbc[here]."
 ---
 

--- a/content/blog/2018/04/2018-04-25-configuring-jenkins-pipeline-with-yaml-file.adoc
+++ b/content/blog/2018/04/2018-04-25-configuring-jenkins-pipeline-with-yaml-file.adoc
@@ -7,9 +7,9 @@ tags:
 - yaml
 - sharedlibrary
 author: mdesanti
+disclaimer: "This guest post was originally published on Wolox's Medium account 
+  link:https://medium.com/wolox-driving-innovation/dynamic-jenkins-pipelines-b04066371fbc[here]."
 ---
-NOTE: This guest post was originally published on Wolox's Medium account 
-link:https://medium.com/wolox-driving-innovation/dynamic-jenkins-pipelines-b04066371fbc[here].
 
 A few years ago our CTO wrote about building a
 link:https://medium.com/wolox-driving-innovation/ruby-on-rails-continuous-integration-with-jenkins-and-docker-compose-8dfd24c3df57[Continuous Integration server for Ruby On Rails using Jenkins and docker]. 

--- a/content/blog/2018/07/2018-07-13-jenkins-user-conference-china.adoc.adoc
+++ b/content/blog/2018/07/2018-07-13-jenkins-user-conference-china.adoc.adoc
@@ -5,13 +5,9 @@ tags:
 - event
 - juc
 author: fjing
+disclaimer: "This is a guest post by link:https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/members/226406250/[Forest Jing], who runs
+  the https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/[Shanghai Jenkins Area Meetup]"
 ---
-
-[NOTE]
-====
-This is a guest post by link:https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/members/226406250/[Forest Jing], who runs
-the https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/[Shanghai Jenkins Area Meetup]
-====
 
 image::/images/post-images/2018-07-13/697401A7-21B5-4E10-A931-EBF00064951C.jpg[width=800,role=center]
 

--- a/content/blog/2018/07/2018-07-13-jenkins-user-conference-china.adoc.adoc
+++ b/content/blog/2018/07/2018-07-13-jenkins-user-conference-china.adoc.adoc
@@ -5,7 +5,7 @@ tags:
 - event
 - juc
 author: fjing
-disclaimer: "This is a guest post by link:https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/members/226406250/[Forest Jing], who runs
+note: "This is a guest post by link:https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/members/226406250/[Forest Jing], who runs
   the https://www.meetup.com/Shanghai-Jenkins-Area-Meetup/[Shanghai Jenkins Area Meetup]"
 ---
 

--- a/content/blog/2018/08/2018-08-17-speaker-blog-brent-laster.adoc
+++ b/content/blog/2018/08/2018-08-17-speaker-blog-brent-laster.adoc
@@ -8,9 +8,9 @@ tags:
 - pipeline
 - docker
 author: brentlaster
+disclaimer: "This a guest post by Brent Laster, DevOps World | Jenkins World 2018 Speaker and author of 
+  \"link:https://www.amazon.com/Jenkins-Deployment-Pipeline-Generation-Automation/dp/1491979593[Jenkins 2 – Up and Running:  Evolve Your Pipeline for Next-Generation Automation]\"."
 ---
-
-NOTE: This a guest post by Brent Laster, DevOps World | Jenkins World 2018 Speaker and author of "link:https://www.amazon.com/Jenkins-Deployment-Pipeline-Generation-Automation/dp/1491979593[Jenkins 2 – Up and Running:  Evolve Your Pipeline for Next-Generation Automation]".
 
 image:/images/conferences/devops-world-2018.jpg[DevOps World | Jenkins World 2018, float="right", link="https://www.cloudbees.com/devops-world"]
 

--- a/content/blog/2018/08/2018-08-17-speaker-blog-brent-laster.adoc
+++ b/content/blog/2018/08/2018-08-17-speaker-blog-brent-laster.adoc
@@ -8,7 +8,7 @@ tags:
 - pipeline
 - docker
 author: brentlaster
-disclaimer: "This a guest post by Brent Laster, DevOps World | Jenkins World 2018 Speaker and author of 
+note: "This a guest post by Brent Laster, DevOps World | Jenkins World 2018 Speaker and author of 
   \"link:https://www.amazon.com/Jenkins-Deployment-Pipeline-Generation-Automation/dp/1491979593[Jenkins 2 – Up and Running:  Evolve Your Pipeline for Next-Generation Automation]\"."
 ---
 

--- a/content/blog/2018/09/2018-09-11-speaker-blog-warnings-plugin.adoc
+++ b/content/blog/2018/09/2018-09-11-speaker-blog-warnings-plugin.adoc
@@ -6,7 +6,7 @@ tags:
 - jenkinsworld
 - jenkinsworld2018
 author: uhafner
-disclaimer: "This is a guest post by Ullrich Hafner, professor for Software Engineering at the University of Applied Sciences Munich and Jenkins contributor.
+note: "This is a guest post by Ullrich Hafner, professor for Software Engineering at the University of Applied Sciences Munich and Jenkins contributor.
   He will be presenting *link:https://sched.co/F9NZ[Static Analysis Plugins - White Mountain Release for Pipelines]* at DevOps World | Jenkins World 2018."
 ---
 

--- a/content/blog/2018/09/2018-09-11-speaker-blog-warnings-plugin.adoc
+++ b/content/blog/2018/09/2018-09-11-speaker-blog-warnings-plugin.adoc
@@ -6,10 +6,9 @@ tags:
 - jenkinsworld
 - jenkinsworld2018
 author: uhafner
+disclaimer: "This is a guest post by Ullrich Hafner, professor for Software Engineering at the University of Applied Sciences Munich and Jenkins contributor.
+  He will be presenting *link:https://sched.co/F9NZ[Static Analysis Plugins - White Mountain Release for Pipelines]* at DevOps World | Jenkins World 2018."
 ---
-
-NOTE: This is a guest post by Ullrich Hafner, professor for Software Engineering at the University of Applied Sciences Munich and Jenkins contributor.
-He will be presenting *link:https://sched.co/F9NZ[Static Analysis Plugins - White Mountain Release for Pipelines]* at DevOps World | Jenkins World 2018.
 
 image::/images/conferences/devops-world-2018.jpg[DevOps World | Jenkins World 2018, float="right", link="https://www.cloudbees.com/devops-world"]
 

--- a/content/blog/2018/09/2018-09-12-2018-community-survey.adoc
+++ b/content/blog/2018/09/2018-09-12-2018-community-survey.adoc
@@ -6,14 +6,12 @@ tags:
 - devops
 - jenkinsworld2018
 author: bvdawson
+disclaimer: "This is a guest post by link:https://twitter.com/brianvdawson[Brian Dawson]
+  on behalf of CloudBees, where he works as a DevOps Evangelist
+  responsible for developing and sharing continuous delivery and DevOps best
+  practices. He also serves as the CloudBees Product Marketing Manager for
+  Jenkins."
 ---
-
-NOTE: This is a guest post by link:https://twitter.com/brianvdawson[Brian
-Dawson] on behalf of CloudBees, where he works as a DevOps Evangelist
-responsible for developing and sharing continuous delivery and DevOps best
-practices. He also serves as the CloudBees Product Marketing Manager for
-Jenkins.    
-  
       
 == Take the 5th Annual DevOps and Jenkins Community Survey 
 

--- a/content/blog/2018/09/2018-09-12-2018-community-survey.adoc
+++ b/content/blog/2018/09/2018-09-12-2018-community-survey.adoc
@@ -6,7 +6,7 @@ tags:
 - devops
 - jenkinsworld2018
 author: bvdawson
-disclaimer: "This is a guest post by link:https://twitter.com/brianvdawson[Brian Dawson]
+note: "This is a guest post by link:https://twitter.com/brianvdawson[Brian Dawson]
   on behalf of CloudBees, where he works as a DevOps Evangelist
   responsible for developing and sharing continuous delivery and DevOps best
   practices. He also serves as the CloudBees Product Marketing Manager for

--- a/content/blog/2018/09/2018-09-14-kubernetes-and-secret-agents.adoc
+++ b/content/blog/2018/09/2018-09-14-kubernetes-and-secret-agents.adoc
@@ -7,7 +7,7 @@ tags:
 - cloud-native
 - kubernetes
 author: devmandy
-disclaimer: "This is a guest post by _DevOps World | Jenkins World_ speaker
+note: "This is a guest post by _DevOps World | Jenkins World_ speaker
   link:https://devopsworldjenkinsworld2018.sched.com/speaker/mandy_hubbard.1y8j4r23[Mandy Hubbard]."
 ---
 

--- a/content/blog/2018/09/2018-09-14-kubernetes-and-secret-agents.adoc
+++ b/content/blog/2018/09/2018-09-14-kubernetes-and-secret-agents.adoc
@@ -7,10 +7,9 @@ tags:
 - cloud-native
 - kubernetes
 author: devmandy
+disclaimer: "This is a guest post by _DevOps World | Jenkins World_ speaker
+  link:https://devopsworldjenkinsworld2018.sched.com/speaker/mandy_hubbard.1y8j4r23[Mandy Hubbard]."
 ---
-
-NOTE: This is a guest post by _DevOps World | Jenkins World_ speaker
-link:https://devopsworldjenkinsworld2018.sched.com/speaker/mandy_hubbard.1y8j4r23[Mandy Hubbard].
 
 image::/images/conferences/devops-world-2018.jpg[DevOps World | Jenkins World 2018, float="right", link="https://www.cloudbees.com/devops-world"]
 

--- a/content/blog/2018/11/2018-11-12-inspecting-binaries-with-jenkins.adoc
+++ b/content/blog/2018/11/2018-11-12-inspecting-binaries-with-jenkins.adoc
@@ -9,12 +9,8 @@ tags:
 - compliance
 - twistlock
 author: michaelhuettermann
+disclaimer: "This is a guest post by link:https://github.com/michaelhuettermann[Michael Hüttermann]."
 ---
-
-[NOTE]
-====
-This is a guest post by link:https://github.com/michaelhuettermann[Michael Hüttermann].
-====
 
 In a past blog post,
 link:/blog/2017/04/18/continuousdelivery-devops-sonarqube/[Delivery Pipelines, with Jenkins 2, SonarQube, and Artifactory],

--- a/content/blog/2018/11/2018-11-12-inspecting-binaries-with-jenkins.adoc
+++ b/content/blog/2018/11/2018-11-12-inspecting-binaries-with-jenkins.adoc
@@ -9,7 +9,7 @@ tags:
 - compliance
 - twistlock
 author: michaelhuettermann
-disclaimer: "This is a guest post by link:https://github.com/michaelhuettermann[Michael Hüttermann]."
+note: "This is a guest post by link:https://github.com/michaelhuettermann[Michael Hüttermann]."
 ---
 
 In a past blog post,

--- a/content/blog/2019/01/2019-01-08-mpl-modular-pipeline-library.adoc
+++ b/content/blog/2019/01/2019-01-08-mpl-modular-pipeline-library.adoc
@@ -6,7 +6,7 @@ tags:
 - jenkinsfile
 - pipeline
 - sharedlibrary
-disclaimer: "This is a guest post by Sergei Parshev from link:https://www.griddynamics.com/[Grid Dynamics], originally posted on the
+note: "This is a guest post by Sergei Parshev from link:https://www.griddynamics.com/[Grid Dynamics], originally posted on the
   link:https://blog.griddynamics.com/developing-a-modular-pipeline-library-to-improve-devops-collaboration/[Grid Dynamics Blog]."
 ---
 

--- a/content/blog/2019/01/2019-01-08-mpl-modular-pipeline-library.adoc
+++ b/content/blog/2019/01/2019-01-08-mpl-modular-pipeline-library.adoc
@@ -6,10 +6,9 @@ tags:
 - jenkinsfile
 - pipeline
 - sharedlibrary
+disclaimer: "This is a guest post by Sergei Parshev from link:https://www.griddynamics.com/[Grid Dynamics], originally posted on the
+  link:https://blog.griddynamics.com/developing-a-modular-pipeline-library-to-improve-devops-collaboration/[Grid Dynamics Blog]."
 ---
-
-NOTE: This is a guest post by Sergei Parshev from link:https://www.griddynamics.com/[Grid Dynamics], originally posted on the
-link:https://blog.griddynamics.com/developing-a-modular-pipeline-library-to-improve-devops-collaboration/[Grid Dynamics Blog].
 
 Despite speeding up development with deployment automation, one of our clients
 was experiencing slow time-to-market due to a lack of collaboration in DevOps.

--- a/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
+++ b/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
@@ -7,7 +7,7 @@ tags:
 - ssh
 - steps
 author: nrayapati
-disclaimer: "This guest post was originally published on Cerner's Engineering blog
+note: "This guest post was originally published on Cerner's Engineering blog
   link:https://engineering.cerner.com/blog/ssh-steps-for-jenkins-pipeline/[here]."
 ---
 

--- a/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
+++ b/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
@@ -7,11 +7,9 @@ tags:
 - ssh
 - steps
 author: nrayapati
+disclaimer: "This guest post was originally published on Cerner's Engineering blog
+  link:https://engineering.cerner.com/blog/ssh-steps-for-jenkins-pipeline/[here]."
 ---
-
-NOTE: This guest post was originally published on Cerner's Engineering blog
-link:https://engineering.cerner.com/blog/ssh-steps-for-jenkins-pipeline/[here].
-
 
 **Pipeline-as-code** or defining the deployment pipeline through code rather than manual job creation through UI, provides tremendous benefits for teams automating builds and deployment infrastructure across their environments.
 

--- a/content/blog/2019/02/2019-02-26-jenkins-alexa-voice-controlled-cicd.adoc
+++ b/content/blog/2019/02/2019-02-26-jenkins-alexa-voice-controlled-cicd.adoc
@@ -5,7 +5,7 @@ author: keshawilliams
 tags:
 - jenkins
 - alexa
-disclaimer: This is a guest post by link:http://www.kesha.tech/[Kesha Williams].
+note: This is a guest post by link:http://www.kesha.tech/[Kesha Williams].
 ---
 
 Integrating Jenkins with Alexa to launch your pipelines and obtain results

--- a/content/blog/2019/02/2019-02-26-jenkins-alexa-voice-controlled-cicd.adoc
+++ b/content/blog/2019/02/2019-02-26-jenkins-alexa-voice-controlled-cicd.adoc
@@ -5,9 +5,8 @@ author: keshawilliams
 tags:
 - jenkins
 - alexa
+disclaimer: This is a guest post by link:http://www.kesha.tech/[Kesha Williams].
 ---
-
-NOTE: This is a guest post by link:http://www.kesha.tech/[Kesha Williams]. 
 
 Integrating Jenkins with Alexa to launch your pipelines and obtain results
 about your deployments through voice is easier than you think.  Learn how Alexa

--- a/content/blog/2019/03/2019-03-01-devops-world-jenkins-world-cfp-open.adoc
+++ b/content/blog/2019/03/2019-03-01-devops-world-jenkins-world-cfp-open.adoc
@@ -5,14 +5,10 @@ tags:
 - event
 - jenkinsworld
 author: svanalstine
+disclaimer: "This is a guest post by link:https://github.com/svanalstine[Skylar VanAlstine], who helps with
+  the link:/projects/jam[Jenkins Area Meetup] program and assists with
+  Marketing & Community Programs at link:https://cloudbees.com[CloudBees, Inc.]"
 ---
-
-[NOTE]
-====
-This is a guest post by link:https://github.com/svanalstine[Skylar VanAlstine], who helps with
-the link:/projects/jam[Jenkins Area Meetup] program and assists with
-Marketing & Community Programs at link:https://cloudbees.com[CloudBees, Inc.]
-====
 
 image:/images/post-images/JW2019.png[Jenkins World 2019, role=center]
 

--- a/content/blog/2019/03/2019-03-01-devops-world-jenkins-world-cfp-open.adoc
+++ b/content/blog/2019/03/2019-03-01-devops-world-jenkins-world-cfp-open.adoc
@@ -5,7 +5,7 @@ tags:
 - event
 - jenkinsworld
 author: svanalstine
-disclaimer: "This is a guest post by link:https://github.com/svanalstine[Skylar VanAlstine], who helps with
+note: "This is a guest post by link:https://github.com/svanalstine[Skylar VanAlstine], who helps with
   the link:/projects/jam[Jenkins Area Meetup] program and assists with
   Marketing & Community Programs at link:https://cloudbees.com[CloudBees, Inc.]"
 ---

--- a/content/blog/2019/05/2019-05-09-templating-engine.adoc
+++ b/content/blog/2019/05/2019-05-09-templating-engine.adoc
@@ -8,7 +8,7 @@
 - pipeline-authoring
 :author: steven-terrana
 :sig: pipeline-authoring
-disclaimer: "This is a guest post by link:https://github.com/steven-terrana[Steven Terrana], a Lead Technologist at
+note: "This is a guest post by link:https://github.com/steven-terrana[Steven Terrana], a Lead Technologist at
   link:https://boozallen.com[Booz Allen Hamilton] and principal engineer working on the plugin:templating-engine[Templating Engine Plugin].
   He participates in the link:../../../../../sigs/pipeline-authoring[Pipeline Authoring  Special Interest Group]."
 ---

--- a/content/blog/2019/05/2019-05-09-templating-engine.adoc
+++ b/content/blog/2019/05/2019-05-09-templating-engine.adoc
@@ -8,15 +8,10 @@
 - pipeline-authoring
 :author: steven-terrana
 :sig: pipeline-authoring
+disclaimer: "This is a guest post by link:https://github.com/steven-terrana[Steven Terrana], a Lead Technologist at
+  link:https://boozallen.com[Booz Allen Hamilton] and principal engineer working on the plugin:templating-engine[Templating Engine Plugin].
+  He participates in the link:../../../../../sigs/pipeline-authoring[Pipeline Authoring  Special Interest Group]."
 ---
-
-[NOTE]
-====
-This is a guest post by link:https://github.com/steven-terrana[Steven Terrana], a Lead Technologist at
-link:https://boozallen.com[Booz Allen Hamilton] and principal engineer working on the plugin:templating-engine[Templating Engine Plugin]. 
-He participates in the link:../../../../../sigs/pipeline-authoring[Pipeline Authoring  Special Interest Group].
-====
-
 
 Implementing DevSecOps practices at the enterprise scale is challenging. With multiple programming languages, automated testing frameworks, and security compliance tools being used by different applications within your organization, it becomes difficult to build and maintain pipelines for each team. 
 

--- a/content/blog/2019/09/2019-09-10-introducing-the-jira-software-plugin-for-jenkins.adoc
+++ b/content/blog/2019/09/2019-09-10-introducing-the-jira-software-plugin-for-jenkins.adoc
@@ -6,7 +6,7 @@ tags:
 - plugin
 - pipeline
 author: rafalmyslek
-disclaimer: This is a guest post by Rafal Myslek from link:https://www.atlassian.com/jira[Atlassian].
+note: This is a guest post by Rafal Myslek from link:https://www.atlassian.com/jira[Atlassian].
 ---
 
 According to a link:https://www.atlassian.com/blog/software-teams/modern-software-development-trends[recent survey] we conducted, software & IT teams on average use 4+ tools to move code from development to customer-facing production. As a result, teams struggle with keeping the status of work updated and understanding the overall health of their delivery pipeline.

--- a/content/blog/2019/09/2019-09-10-introducing-the-jira-software-plugin-for-jenkins.adoc
+++ b/content/blog/2019/09/2019-09-10-introducing-the-jira-software-plugin-for-jenkins.adoc
@@ -6,9 +6,8 @@ tags:
 - plugin
 - pipeline
 author: rafalmyslek
+disclaimer: This is a guest post by Rafal Myslek from link:https://www.atlassian.com/jira[Atlassian].
 ---
-
-NOTE: This is a guest post by Rafal Myslek from link:https://www.atlassian.com/jira[Atlassian].
 
 According to a link:https://www.atlassian.com/blog/software-teams/modern-software-development-trends[recent survey] we conducted, software & IT teams on average use 4+ tools to move code from development to customer-facing production. As a result, teams struggle with keeping the status of work updated and understanding the overall health of their delivery pipeline.
 


### PR DESCRIPTION
The goal of [the ticket](https://issues.jenkins-ci.org/browse/WEBSITE-206) is to hide the initial NOTE from guest posts in the blog roll.

One way to do that would be to make the "summary" function smarter and detect parts of content that are not relevant. This PR proposes a simpler solution where the disclaimer is moved to the metadata and is only rendered in full view of the article, not in blog roll.

This approach requires changing the content of the articles, it's done for posts from the last two years.