### PR TITLE
Fix invalid URL in 2.73.1 changelog (Hacktoberfest 2019)

### DIFF
--- a/content/_data/upgrades/2-73-1.adoc
+++ b/content/_data/upgrades/2-73-1.adoc
@@ -91,7 +91,7 @@ This feature has been implemented in Authorize Project Plugin version 1.2.0.
 link:https://issues.jenkins-ci.org/browse/JENKINS-44108[JENKINS-44108],
 link:https://issues.jenkins-ci.org/browse/JENKINS-44112[JENKINS-44112]
 
-The embedded link:https:/projects/remoting/[Jenkins Remoting] version has been updated from 3.7 to 3.10.
+The embedded link:https://jenkins.io/projects/remoting/[Jenkins Remoting] version has been updated from 3.7 to 3.10.
 It introduces support of work directories, which may be used by Remoting to store caches, logs and other metadata.
 
 Once work directory mode is enabled, Jenkins agents start writing logs to the disk and change the default destination of the filesystem JAR Cache.

--- a/content/_data/upgrades/2-73-1.adoc
+++ b/content/_data/upgrades/2-73-1.adoc
@@ -91,7 +91,7 @@ This feature has been implemented in Authorize Project Plugin version 1.2.0.
 link:https://issues.jenkins-ci.org/browse/JENKINS-44108[JENKINS-44108],
 link:https://issues.jenkins-ci.org/browse/JENKINS-44112[JENKINS-44112]
 
-The embedded link:https://jenkins.io/projects/remoting/[Jenkins Remoting] version has been updated from 3.7 to 3.10.
+The embedded link:/projects/remoting/[Jenkins Remoting] version has been updated from 3.7 to 3.10.
 It introduces support of work directories, which may be used by Remoting to store caches, logs and other metadata.
 
 Once work directory mode is enabled, Jenkins agents start writing logs to the disk and change the default destination of the filesystem JAR Cache.


### PR DESCRIPTION
The current URL resolves to "https:/projects/remoting/", which is kind of working in browser, but does not look good to me. Looks like relative URLs do not resolve properly in changelogs.