### PR TITLE
Update default body styles

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1187,7 +1187,8 @@ z.f9f9f9.section .ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.
 /*----plugin site----*/
 body {
   font-family: 'lato', Roboto, 'Open Sans', sans-serif;
-  font-size: 14px;
+  font-size: 1rem;
+  color: #4a5568;
   line-height: 1.5;
   margin: 0;
   background-color: #fff;


### PR DESCRIPTION
I've found the paragraph text of the current docs very hard to read—I'm nearsighted and the 14px font-size really forces me to get close to see what I'm reading. Upping the size to 16px (or 1rem) is pretty standard for readability purposes, and improves site accessibility for the visually impaired. I also changed to color to a warm gray to give the paragraph text contrast from the headlines so everything is easily distinguishable at first glance.