### PR TITLE
Add a direct link to the .ics URL

### DIFF
--- a/content/event-calendar.html.haml
+++ b/content/event-calendar.html.haml
@@ -39,6 +39,10 @@ notitle: true
         About this calendar
       %p
         This page tracks the upcoming events related to Jenkins.
+        (
+        %a{:href => 'https://calendar.google.com/calendar/ical/4ss12f0mqr3tbp1t2fe369slf4%40group.calendar.google.com/public/basic.ics'}
+          .ics format
+        )
 
       %h3
         Making changes


### PR DESCRIPTION
At least in my browse the calendar widget from Google no longer shares the direct ICS link, but instead has an "Add to Google" button :disappointed: