### PR TITLE
escape-by-default XSS is no longer a vulnerability

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -40,6 +40,7 @@ The following components are out of scope:
 
 We do not consider the following issues to be vulnerabilities in Jenkins:
 
+* Cross-site scripting (XSS) vulnerabilities due to lack of `escape-by-default` XML processing instruction, as these are only exploitable on Jenkins before than 2.146 and 2.138.2.
 * Vulnerabilities in dependencies without a plausible or demonstrated exploit will not be treated as vulnerabilities.
   While we inform maintainers about the need to update their dependencies, and may track progress in the SECURITY Jira project, no security advisory will be published for these.
 * Cookies not set to `Secure` due to misconfiguration of Jenkins.


### PR DESCRIPTION
This hasn't affected any Jenkins release for more than a year