### PR TITLE
[WEBSITE-670] - Document how to Migrate plugin from Wiki to GitHub

### DIFF
--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -58,6 +58,7 @@ Documentation examples:
 
 link:https://wiki.jenkins.io[Jenkins Wiki] can still be used for previously created plugins or for new plugins if there are reasons to do so.
 See link:../wiki-page[this page] for more information.
+It also include Wiki=>GitHub migration guidelines.
 
 === Referencing the documentation page from the project file
 

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -56,7 +56,7 @@ Document migration can be done in a semi-automated way using the link:https://pa
 This guide shows how to do so for a common case when the documentation page is going to be sourced from the README file inside the repository's root.
 
 NOTE: If there is no ticket for the documentation migration created by the current plugin maintainers,
-make sure to confirm it with them first.
+make sure to create one and then discuss with the plugin maintainers
 Similarly, Asciidoc/Markdown preferences should be also discussed with maintainers.
 
 . Fork the plugin repository in GitHub and clone it to the local machine.

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -56,7 +56,7 @@ Document migration can be done in a semi-automated way using the link:https://pa
 This guide shows how to do so for a common case when the documentation page is going to be sourced from the README file inside the repository's root.
 
 NOTE: If there is no ticket for the documentation migration created by the current plugin maintainers,
-make sure to create one and then discuss with the plugin maintainers
+make sure to create one and then discuss with the plugin maintainers.
 Similarly, Asciidoc/Markdown preferences should be also discussed with maintainers.
 
 . Fork the plugin repository in GitHub and clone it to the local machine.
@@ -64,7 +64,7 @@ Similarly, Asciidoc/Markdown preferences should be also discussed with maintaine
 . In the "..." button in the top right corner click the _View Source_ action. A new window will open.
 . Save the document as HTML to the repository, e.g. as `myplugin.html`.
 . Call `pandoc -o myplugin.md --extract-media=docs/images myplugin.html`.
-  Asciidoc format can be used as well. 
+  Asciidoc format can be used as well, with the `.adoc` extension.
 . Review/edit the exported file formatting
 ** Remove the macro references in the top of the document.
 ** If the document includes "Table of contents", remove this section in Markdown 
@@ -80,5 +80,5 @@ Similarly, Asciidoc/Markdown preferences should be also discussed with maintaine
    (e.g. rename "slave" to "agent", "workflow" to "pipeline", "Hudson" to "Jenkins", etc.)
 . Modify the URL documentation page reference in the project file so that it points to GitHub (link:/doc/developer/publishing/documentation/#referencing-the-documentation-page-from-the-project-file[documentation]).
 . Commit changes, push them to your fork and create a pull request against the repository.
-. Once the pull request is merged, replace the content on Wiki by a link to the new jenkins.io locations 
-  (use warning boxes to do that).
+. Once the pull request is merged, replace the content on Wiki by a link to the new GitHub location
+  (use info boxes to do that).

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -49,3 +49,36 @@ If a non-wiki URL is specified, for example to a GitHub repository, it will only
 Given the limitations inherent in including scraped content, many advanced macros will not show up properly on the plugin site:
 Basically every macro that uses AJAX to load data in the background will not work.
 Since Jenkins will link to the plugin's page on the plugin site from its plugin manager, this will result in a bad experience reading broken documentation for many users.
+
+== Migrating from Wiki to GitHub
+
+Document migration can be done in a semi-automated way using the link:https://pandoc.org[Pandoc] tool for Wiki->Asciidoc conversion.
+This guide shows how to do so for a common case when the documentation page is going to be sourced from the README file inside the repository's root.
+
+NOTE: If there is no ticket for the documentation migration created by the current plugin maintainers,
+make sure to confirm it with them first.
+Similarly, Asciidoc/Markdown preferences should be also discussed with maintainers.
+
+. Fork the plugin repository in GitHub and clone it to the local machine.
+. Open the plugin's Wiki page page you want to migrate.
+. In the "..." button in the top right corner click the _View Source_ action. A new window will open.
+. Save the document as HTML to the repository, e.g. as `myplugin.html`.
+. Call `pandoc -o myplugin.md --extract-media=docs/images myplugin.html`.
+  Asciidoc format can be used as well. 
+. Review/edit the exported file formatting
+** Remove the macro references in the top of the document.
+** If the document includes "Table of contents", remove this section in Markdown 
+   or replace it by `:toc:` macros in Asciidoc (link:https://raw.githubusercontent.com/jenkinsci/.github/master/.github/release-drafter.adoc[example]).
+** If the source Wiki page includes code blocks, they will need to be manually converted. 
+   Pandoc exports them as tables.
+. Merge the exported file with existing README file. 
+  If it does not exist, just rename the file.
+. Review the contents.
+** Plugin Wiki pages often contain changelogs.
+   It is recommended to extract them to a separate `CHANGELOG.md` file in the repository root.
+** Wiki pages are often outdated, and it is nice to review them before submitting 
+   (e.g. rename "slave" to "agent", "workflow" to "pipeline", "Hudson" to "Jenkins", etc.)
+. Modify the URL documentation page reference in the project file so that it points to GitHub (link:/doc/developer/publishing/documentation/#referencing-the-documentation-page-from-the-project-file[documentation]).
+. Commit changes, push them to your fork and create a pull request against the repository.
+. Once the pull request is merged, replace the content on Wiki by a link to the new jenkins.io locations 
+  (use warning boxes to do that).


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-670 . This PR includes some documentation for the migration process

CC @MarkEWaite @zbynek 
