### PR TITLE
Add sections to navigation in developerbook

### DIFF
--- a/content/_layouts/developerbook.html.haml
+++ b/content/_layouts/developerbook.html.haml
@@ -34,8 +34,10 @@ layout: default
               - if chapter.page.wip
                 - if !chapter.page.references || chapter.page.references.length == 0
                   %i.icon-warning{:title => 'Early work in progress'}
+                    &nbsp;
                 - else
                   %i.icon-warning{:title => 'Partial work in progress', :style => 'opacity: 0.5;'}
+                    &nbsp;
               - if chapter.sections
                 %ol
                   - chapter.sections.each do |section|

--- a/content/_layouts/developerbook.html.haml
+++ b/content/_layouts/developerbook.html.haml
@@ -34,10 +34,13 @@ layout: default
               - if chapter.page.wip
                 - if !chapter.page.references || chapter.page.references.length == 0
                   %i.icon-warning{:title => 'Early work in progress'}
-                    &nbsp;
                 - else
                   %i.icon-warning{:title => 'Partial work in progress', :style => 'opacity: 0.5;'}
-                    &nbsp;
+              - if chapter.sections
+                %ol
+                  - chapter.sections.each do |section|
+                    %li 
+                      = active_href(File.join(File.join('doc/developer', chapter.key), section.key), section.title, :fuzzy => true)
 
         %h4
           = active_href('doc/developer/guides', 'How-To Guides', :fuzzy => true)


### PR DESCRIPTION
Adds sections to the developer book to make it easier to discover other pages, navigate to the next section and not get lost

Before:
![image](https://user-images.githubusercontent.com/21194782/67148362-d25f7c00-f296-11e9-99d3-e2c4d7a57c77.png)


After:
![image](https://user-images.githubusercontent.com/21194782/67148283-05edd680-f296-11e9-9ff5-2c9b06fdbca8.png)
