### PR TITLE
Stop crash when new files are added

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -71,8 +71,7 @@
             %strong
               Special Interest Groups
           - site.pages.map do |page|
-            - if page.url
-              - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
+            - if page.url && page.url.match(/\/sigs\/([^\/]+)\/$/)
               %a.dropdown-item.feature{:href => expand_link(page.url)}
                 = '&nbsp;-&nbsp;' + page.title
 
@@ -83,8 +82,7 @@
           %a.dropdown-item.feature{:href => expand_link('projects/')}
             Overview
           - site.pages.map do |page|
-            - if page.url
-              - next unless page.url.match(/\/projects\/([^\/]+)\/$/)
+            - if page.url && page.url.match(/\/projects\/([^\/]+)\/$/)
               %a.dropdown-item.feature{:href => expand_link(page.url)}
                 = page.title
 

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -71,9 +71,10 @@
             %strong
               Special Interest Groups
           - site.pages.map do |page|
-            - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
-            %a.dropdown-item.feature{:href => expand_link(page.url)}
-              = '&nbsp;-&nbsp;' + page.title
+            - if page.url
+              - next unless page.url.match(/\/sigs\/([^\/]+)\/$/)
+              %a.dropdown-item.feature{:href => expand_link(page.url)}
+                = '&nbsp;-&nbsp;' + page.title
 
       %li.dropdown.nav-item
         = partial("dropdown.html.haml", :name => "Subprojects")
@@ -82,9 +83,10 @@
           %a.dropdown-item.feature{:href => expand_link('projects/')}
             Overview
           - site.pages.map do |page|
-            - next unless page.url.match(/\/projects\/([^\/]+)\/$/)
-            %a.dropdown-item.feature{:href => expand_link(page.url)}
-              = page.title
+            - if page.url
+              - next unless page.url.match(/\/projects\/([^\/]+)\/$/)
+              %a.dropdown-item.feature{:href => expand_link(page.url)}
+                = page.title
 
       %li.nav-item.dropdown
         = partial("dropdown.html.haml", :name => "About")


### PR DESCRIPTION
Before this change any new page being added while using `make run` would
cause no page reload to be possible until `make run` was ran again.

This isn't a full fix as new pages won't show up till it's run, but it
means that you can iterate on other pages until you are ready to restart
it

Fixes this error:
![image](https://user-images.githubusercontent.com/21194782/67151077-6d1c8280-f2b8-11e9-9be6-773bc17db3dd.png)
