### PR TITLE
Fix windows home path

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -69,7 +69,7 @@ docker run ^
   -p 8080:8080 ^
   -v jenkins-data:/var/jenkins_home ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
-  -v "%HOMEPATH%":/home ^
+  -v "%HOMEDRIVE%%HOMEPATH%":/home ^
   jenkinsci/blueocean
 ----
 For an explanation of these options, refer to the <<on-macos-and-linux,macOS


### PR DESCRIPTION
An error ('The source path is not a valid path') is thrown when trying to use just the %HOMEPATH% environment variable. Use %HOMEDRIVE%%HOMEPATH% for the full path to that directory in Windows.