### PR TITLE
Document the Jenkins Wiki Exporter service for plugins

### DIFF
--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -103,6 +103,7 @@ The link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] can expor
    It allows tools like Dependabot to read changelog summaries
 ** Use versions as headers.
    Changelogs in Wiki often include release dates, but it is better to keep them in the text below the header.
+** Examples: link:https://github.com/jenkinsci/envinject-api-plugin/blob/master/CHANGELOG.md[EnvInject API Plugin], link:https://github.com/jenkinsci/aws-java-sdk-plugin/blob/master/CHANGELOG.md[AWS Java SDK Plugin]
 . Review the text
 ** Verify formatting and spelling
 ** Wiki pages are often outdated, and it is nice to review them before submitting 

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -4,6 +4,8 @@ layout: developersection
 references:
 - url: ../documentation/
   title: Plugin documentation
+- url: https://jenkins-wiki-exporter.g4v.dev/
+  title: Jenkins Wiki Exporter
 ---
 
 WARNING: This page describes hosting of plugin documentation on link:https://wiki.jenkins.io[the Jenkins wiki].
@@ -52,33 +54,59 @@ Since Jenkins will link to the plugin's page on the plugin site from its plugin 
 
 == Migrating from Wiki to GitHub
 
-Document migration can be done in a semi-automated way using the link:https://pandoc.org[Pandoc] tool for Wiki->Asciidoc conversion.
+Document migration can be done in a semi-automated way using the link:https://pandoc.org[Pandoc] tool for Wiki conversion to Markdown or Asciidoc.
 This guide shows how to do so for a common case when the documentation page is going to be sourced from the README file inside the repository's root.
 
 NOTE: If there is no ticket for the documentation migration created by the current plugin maintainers,
 make sure to create one and then discuss with the plugin maintainers.
 Similarly, Asciidoc/Markdown preferences should be also discussed with maintainers.
 
+There are the following migration steps:
+
 . Fork the plugin repository in GitHub and clone it to the local machine.
+. Export the documentation. It can be done in a manual or automated way, see below
+. Add the documentation and images to the repository
+** You can merge the exported file with existing README file or create a new one.
+. Copy-edit the documentation, see below
+. Modify the URL documentation page reference in the project file so that it points to GitHub (link:/doc/developer/publishing/documentation/#referencing-the-documentation-page-from-the-project-file[documentation]).
+. Commit changes, push them to your fork and create a pull request against the repository.
+
+=== Exporting Wiki documentation (automatic way)
+
+It is possible to use link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] in order to export plugin documentation to Markdown or Asciidoc.
+
+. Go to the service
+. Specify the plugin ID you want to export in the field
+. Select the export option. For plugins with images you will need to use _Markdown Zip_ or _Asciidoc Zip_  
+. Click _Convert_ to do the conversion. It will either show the converted file or provide the archive to download
+
+=== Exporting Wiki documentation (manual way)
+
 . Open the plugin's Wiki page page you want to migrate.
 . In the "..." button in the top right corner click the _View Source_ action. A new window will open.
 . Save the document as HTML to the repository, e.g. as `myplugin.html`.
-. Call `pandoc -o myplugin.md --extract-media=docs/images myplugin.html`.
+. Call `pandoc -o myplugin.md --extract-media=docs/images myplugin.html` to export Markdown.
   Asciidoc format can be used as well, with the `.adoc` extension.
+. Cleanup documentation. 
+  link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] does some bits automatically, but you may need to apply manual updates here.
+** Remove the macro references in the top of the document, if any.
+
+=== Reviewing the documentation
+
 . Review/edit the exported file formatting
-** Remove the macro references in the top of the document.
 ** If the document includes "Table of contents", remove this section in Markdown 
    or replace it by `:toc:` macros in Asciidoc (link:https://raw.githubusercontent.com/jenkinsci/.github/master/.github/release-drafter.adoc[example]).
 ** If the source Wiki page includes code blocks, they will need to be manually converted. 
    Pandoc exports them as tables.
-. Merge the exported file with existing README file. 
-  If it does not exist, just rename the file.
-. Review the contents.
-** Plugin Wiki pages often contain changelogs.
-   It is recommended to extract them to a separate `CHANGELOG.md` file in the repository root.
+. Extract changelogs to a separate file
+** It is recommended to extract changelogs to a separate `CHANGELOG.md` file in the repository root.
+   It will allows tools like Dependabot to pick up changelog summaries
+** Use versions as headers.
+   Changelogs in Wiki often include release dates, but it is better to keep them in the text below the header.
+. Review the text
+** Verify formatting and spelling
 ** Wiki pages are often outdated, and it is nice to review them before submitting 
    (e.g. rename "slave" to "agent", "workflow" to "pipeline", "Hudson" to "Jenkins", etc.)
-. Modify the URL documentation page reference in the project file so that it points to GitHub (link:/doc/developer/publishing/documentation/#referencing-the-documentation-page-from-the-project-file[documentation]).
-. Commit changes, push them to your fork and create a pull request against the repository.
+
 . Once the pull request is merged, replace the content on Wiki by a link to the new GitHub location
   (use info boxes to do that).

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -66,16 +66,16 @@ There are the following migration steps:
 . Fork the plugin repository in GitHub and clone it to the local machine.
 . Export the documentation. It can be done in a manual or automated way, see below
 . Add the documentation and images to the repository
-** You can merge the exported file with existing README file or create a new one.
+** You can merge the exported file with the existing README file or create a new one.
 . Copy-edit the documentation, see below
 . Modify the URL documentation page reference in the project file so that it points to GitHub (link:/doc/developer/publishing/documentation/#referencing-the-documentation-page-from-the-project-file[documentation]).
 . Commit changes, push them to your fork and create a pull request against the repository.
 
 === Exporting Wiki documentation (automatic way)
 
-It is possible to use link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] in order to export plugin documentation to Markdown or Asciidoc.
+The link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] can export plugin documentation to Markdown or Asciidoc.
 
-. Go to the service
+. Go to the link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] service
 . Specify the plugin ID you want to export in the field
 . Select the export option. For plugins with images you will need to use _Markdown Zip_ or _Asciidoc Zip_  
 . Click _Convert_ to do the conversion. It will either show the converted file or provide the archive to download
@@ -100,7 +100,7 @@ It is possible to use link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki E
    Pandoc exports them as tables.
 . Extract changelogs to a separate file
 ** It is recommended to extract changelogs to a separate `CHANGELOG.md` file in the repository root.
-   It will allows tools like Dependabot to pick up changelog summaries
+   It allows tools like Dependabot to read changelog summaries
 ** Use versions as headers.
    Changelogs in Wiki often include release dates, but it is better to keep them in the text below the header.
 . Review the text


### PR DESCRIPTION
Follow-up to the https://jenkins-wiki-exporter.g4v.dev/ service created by @halkeye 
