### PR TITLE
Correct the description of SECURITY-1434

### DIFF
--- a/content/security/advisory/2019-10-16.adoc
+++ b/content/security/advisory/2019-10-16.adoc
@@ -246,7 +246,7 @@ issues:
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME stores an access token unencrypted in the global `config.xml` configuration file on the Jenkins master.
-    This token can be viewed by users with Extended Read permission or access to the master file system.
+    This token can be viewed by users with access to the master file system.
 
     As of publication of this advisory there is no fix.
   plugins:


### PR DESCRIPTION
This is correct in https://github.com/CVEProject/cvelist/blob/e92196fd4eae5e899de8bed7812ce727c38e68bb/2019/10xxx/CVE-2019-10450.json#L37 but was wrong in this advisory.

Score was correct, at least.