### PR TITLE
Correct the wording about 'when' before 'input'

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1231,7 +1231,7 @@ condition evaluates to true.
 
 ===== Evaluating `when` before the `input` directive
 
-By default, the when condition for a stage will be evaluated before the input, if one is defined.
+By default, the when condition for a stage will not be evaluated before the input, if one is defined.
 However, this can be changed by specifying the `beforeInput` option within the when block. If `beforeInput` is set to true,
 the when condition will be evaluated first, and the input will only be entered if the when condition evaluates to true.
 


### PR DESCRIPTION
When setting up a 'when' condition in a stage with an 'input' I found that the default behaviour was for the 'input' to run before the 'when' condition.  This document states that the default is the 'when' before the 'input'
This edit changes that logic