### PR TITLE
[WEBSITE-711] - Add changelog attribution with minor change support

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -5201,27 +5201,58 @@
       - issue: 53462
       - url: https://bugzilla.mozilla.org/show_bug.cgi?id=1370630
         title: Firefox issue 1370630
+    authors:
+      - thomasgl-orange
     message: |-
       Revert changes in forms submission in Jenkins classic UI with Firefox have caused a regression on forms with "file" inputs.
       These were made to anticipate a bugfix in Firefox which has been backed out since.
       (regression in 2.173)
   - type: rfe
     pull: 3894
+    authors:
+      - daniel-beck
     message: |-
       Add telemetry on the use of the 'auto refresh' feature.
   - type: rfe
     pull: 4300
+    authors:
+      - anafke
     message: |-
       Add <code>java.util.concurrent.ConcurrentLinkedDeque</code> to the JEP-200 deserialization whitelist.
   - type: rfe
     pull: 4259
+    authors:
+      - jsoref
     message: |-
       Developer: Introduce <code>Run#getBuildsOverThreshold()</code> method for getting runs above the desired execution result.
-  # pull: 4155 (PR title: Revert "Disable Windows builds and ATH to mitigate the ongoing INFRA issue")
-  # pull: 4253 (PR title: Replace ACL.impersonate with ACL.as)
-  # pull: 4292 (PR title: Update at-since in Javadoc, make script work on Mac OS X)
-  # pull: 4303 too minor (PR title: Use actual logger to record Jenkins home and where it was found)
-  # pull: 4313 (PR title: [JENKINS-58625] Cancel older builds of a given branch)
+
+  - type: minor rfe
+    pull: 4313
+    issue: 58625
+    authors:
+      - jglick
+    message: |-
+      Jenkinsfile: Cancel older builds of a given branch.
+  - type: minor bug
+    references:
+      - pull: 4155
+      - pull: 4316
+    authors:
+      - oleg-nenashev
+    message: |-
+      Jenkinsfile: Skip ATH and Windows builds while there are infra problems.
+  - type: minor rfe
+    pull: 4253
+    authors:
+      - res0nance
+    message: |-
+      Replace <code>ACL#impersonate</code> with <code>ACL#as</code>.
+  - type: minor rfe
+    pull: 4292
+    authors:
+      - daniel-beck
+    message: |-
+      Update <code>@since</code> in Javadoc, make script for these update work on Mac OS X.
 
 - version: '2.203'
   date: 2019-11-05

--- a/content/_partials/changelog-changes.html.haml
+++ b/content/_partials/changelog-changes.html.haml
@@ -1,36 +1,53 @@
 - if page.changes.empty?
   %em
     No notable changes in this release.
+- minor_authors = []
 - page.changes.each do | change |
-  %li{:class => change.type }
-    = change.message
-    - if change.references
-      - change.references.each_with_index do | reference, index |
-        - if index == 0
-          (
-        - else
-          ,&nbsp;
-        - if reference.issue
-          %a{:href => "https://issues.jenkins-ci.org/browse/JENKINS-#{reference.issue}" }<>
-            = "issue #{reference.issue}"
-        - if reference.pull
-          %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{reference.pull}" }<>
-            = "pull #{reference.pull}"
-        - else
-          %a{:href => reference.url }<>
-            - if reference.title
-              = reference.title
-            - else
-              = reference.url
-        - if index == change.references.count - 1
-          )
-    - elsif change.issue
-      (
-      %a{:href => "https://issues.jenkins-ci.org/browse/JENKINS-#{change.issue}" }<>
-        = "issue #{change.issue}"
-      )
-    - elsif change.pull
-      (
-      %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{change.pull}" }<>
-        = "pull #{change.pull}"
-      )
+  - if change.type =~ /minor/
+    - if change.authors
+      - minor_authors += change.authors
+  - else
+    %li{:class => change.type }
+      = change.message
+      - if change.references
+        - change.references.each_with_index do | reference, index |
+          - if index == 0
+            (
+          - else
+            ,&nbsp;
+          - if reference.issue
+            %a{:href => "https://issues.jenkins-ci.org/browse/JENKINS-#{reference.issue}" }<>
+              = "issue #{reference.issue}"
+          - if reference.pull
+            %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{reference.pull}" }<>
+              = "pull #{reference.pull}"
+          - else
+            %a{:href => reference.url }<>
+              - if reference.title
+                = reference.title
+              - else
+                = reference.url
+          - if index == change.references.count - 1
+            )
+      - elsif change.issue
+        (
+        %a{:href => "https://issues.jenkins-ci.org/browse/JENKINS-#{change.issue}" }<>
+          = "issue #{change.issue}"
+        )
+      - elsif change.pull
+        (
+        %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{change.pull}" }<>
+          = "pull #{change.pull}"
+        )
+      - if change.authors
+        by
+        - change.authors.each do | author |
+          %a{:href => "https://github.com/#{author}" }<>
+            = " @#{author}"
+- if !minor_authors.empty?
+  - # TODO sort and uniq
+  %p
+    We'd also like to thank the following contributors for further contributions to this release:
+    - minor_authors.each do | author |
+      %a{:href => "https://github.com/#{author}" }<>
+        = " @#{author}"


### PR DESCRIPTION
Alternative/extended proposal to https://github.com/jenkins-infra/jenkins.io/pull/2620 taking care of attribution for minor changes not making the changelog.

Also takes care of the weird not-actually-data approach of changes by marking them as minor, and just skipping them in the changelog (for now).

TODO:
- [ ] Sort and uniq the list
- [ ] Add attribution to RSS, ignore minor changes there
- [ ] Add retroactive credits?

> ![Screenshot](https://user-images.githubusercontent.com/1831569/68166432-a1ec3300-ff62-11e9-9aa8-4a1269b5cf84.png)

