### PR TITLE
fix syntax.adoc

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1066,7 +1066,7 @@ pipeline {
 The `input` directive on a `stage` allows you to prompt for input, using the
 link:https://jenkins.io/doc/pipeline/steps/pipeline-input-step/#input-wait-for-interactive-input[`input` step].
 The `stage` will pause after any `options` have been applied, and before
-entering the ``stage``s `agent` or evaluating its `when` condition. If the `input`
+entering the `agent` block for that `stage` or evaluating the `when` condition of the `stage`. If the `input`
 is approved, the `stage` will then continue. Any parameters provided as part of
 the `input` submission will be available in the environment for the rest of the
 `stage`.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -938,9 +938,9 @@ The `H` symbol can be thought of as a random value over a range,
 but it actually is a hash of the job name, not a random function, so that
 the value remains stable for any given project.
 
-Beware that for the day of month field, short cycles such as `*/3`
+Beware that for the day of month field, short cycles such as `\*/3`
 or `H/3` will not work consistently near the end of most months,
-due to variable month lengths.  For example, `*/3`j will run on the
+due to variable month lengths.  For example, `*/3` will run on the
 1st, 4th, …31st days of a long month, then again the next day of
 the next month.  Hashes are always chosen in the 1-28 range, so
 `H/3` will produce a gap between runs of between 3 and 6 days at
@@ -1066,7 +1066,7 @@ pipeline {
 The `input` directive on a `stage` allows you to prompt for input, using the
 link:https://jenkins.io/doc/pipeline/steps/pipeline-input-step/#input-wait-for-interactive-input[`input` step].
 The `stage` will pause after any `options` have been applied, and before
-entering the `stage`s `agent` or evaluating its `when` condition. If the `input`
+entering the ``stage``s `agent` or evaluating its `when` condition. If the `input`
 is approved, the `stage` will then continue. Any parameters provided as part of
 the `input` submission will be available in the environment for the rest of the
 `stage`.


### PR DESCRIPTION
couple fixes in syntax.adoc

before:
![image](https://user-images.githubusercontent.com/6235822/68251477-42f6ee80-0034-11ea-8981-9afd09d8b047.png)
![image](https://user-images.githubusercontent.com/6235822/68251507-5bff9f80-0034-11ea-87f3-a31ee9db87af.png)
after:
![image](https://user-images.githubusercontent.com/6235822/68251563-79cd0480-0034-11ea-9249-3ed87c300855.png)
![image](https://user-images.githubusercontent.com/6235822/68251534-6883f800-0034-11ea-853f-c5a91d738bd8.png)
