### PR TITLE
Update plugin build process recommendation

### DIFF
--- a/content/doc/developer/publishing/continuous-integration.adoc
+++ b/content/doc/developer/publishing/continuous-integration.adoc
@@ -9,7 +9,7 @@ It will build all plugin repositories in the `jenkinsci` organization that have 
 The typical plugin build (Maven or Gradle) can be run by just having the following statement in the `Jenkinsfile`:
 
 ----
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())
 ----
 
 To learn more about the Pipeline library providing this functionality, see https://github.com/jenkins-infra/pipeline-library[its GitHub repository].


### PR DESCRIPTION
The recommended configuration builds a matrix of Jenkins versions and JDK to build the plugin against and validate its support.