### PR TITLE
Mention "Use SCM" option in normal Pipeline jobs in pipeline-as-code.adoc 

### DIFF
--- a/content/doc/book/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline-as-code.adoc
@@ -32,6 +32,7 @@ Additionally, one of the enabling jobs needs to be configured in Jenkins:
 * _Organization Folders_: scan a *GitHub Organization* or *Bitbucket Team* to
   discover an organization's repositories, automatically creating managed
   _Multibranch Pipeline_ jobs for them
+* _Pipeline_: Regular Pipeline jobs have an option when specifying the pipeline to "Use SCM".
 
 
 Fundamentally, an organization's repositories can be viewed as a hierarchy,


### PR DESCRIPTION
Just wanting to make it clear that one can use "Pipeline as Code" (PaC) concept outside the context of a Multibranch Pipeline or Organizational Folders job. This tripped me up as I was learning about PaC.