### PR TITLE
Correct min plugin-pom version for use-jenkins-bom profile

### DIFF
--- a/content/doc/developer/plugin-development/dependency-management.adoc
+++ b/content/doc/developer/plugin-development/dependency-management.adoc
@@ -64,7 +64,7 @@ For example:
 </dependencyManagement>
 ----
 
-Or, if you are using the plugin-pom (4.0 or later) as the parent, then things are even easier as there is a profile that will manage this for you.
+Or, if you are using the plugin-pom (3.52 or later) as the parent, then things are even easier as there is a profile that will manage this for you.
 The default behaviour of `plugin-pom` is to _not_ use the BOM, but you can switch on BOM support by setting the Maven property `use-jenkins-bom`.
 For example:
 


### PR DESCRIPTION
Updating ('downdating'?) minimum `plugin-pom` that contains the `use-jenkins-bom` profile to 3.52 as per comments in [jenkinsci/plugin-pom#/229](https://github.com/jenkinsci/plugin-pom/pull/229#discussion_r344701162).
