### PR TITLE
[WEBSITE-676] - Move "Adopt a plugin" from Wiki to jenkins.io

### DIFF
--- a/content/blog/2015/2015-11-01-adopt-a-plugin.md
+++ b/content/blog/2015/2015-11-01-adopt-a-plugin.md
@@ -15,4 +15,4 @@ The major problem of course is that it's often difficult to tell whether a plugi
 
 To connect plugins that aren't actively maintained with potential maintainers, we recently implemented the "Adopt-a-plugin" initiative: We built a list of plugins that are up for "adoption", and display a prominent message on the plugins' wiki pages. Anyone interested in taking over as a plugin maintainer can then contact us, and we'll set you up.
 
-Are you interested in becoming a plugin maintainer? Maybe one of your favorite plugins isn't actively maintained right now. Check out the [Adopt a Plugin wiki page](https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin) for more details on this program, and a list of plugins that would benefit from your help.
+Are you interested in becoming a plugin maintainer? Maybe one of your favorite plugins isn't actively maintained right now. Check out the [Adopt a Plugin page](/doc/developer/plugin-governance/adopt-a-plugin/) for more details on this program, and a list of plugins that would benefit from your help.

--- a/content/blog/2015/2015-11-16-celebrating-hacksgiving.md
+++ b/content/blog/2015/2015-11-16-celebrating-hacksgiving.md
@@ -23,8 +23,8 @@ We'll be hosting Hacksgiving **Nov 23rd** and **Nov 24** from 7:00PST - 15:00PST
 We have a few goals for Hacksgiving:
 
 1. Introduce new contributors to the process of writing code and/or documentation ([documentation hacking details here](https://wiki.jenkins.io/display/JENKINS/Hacksgiving+2015#Hacksgiving2015-Documentationhacking)).
-1. Find some plugins which [are up for adoption](https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin#AdoptaPlugin-Whichpluginsarecurrentlyupforadoption%3F) new maintainers.
-1. Clean up or merge some existing plugins which need some care ([listed here](https://wiki.jenkins.io/display/JENKINS/Hacksgiving+2015#Hacksgiving2015-Pluginstocleanup)).
+2. Find some plugins which [are up for adoption](/doc/developer/plugin-governance/adopt-a-plugin#which-plugins-are-currently-up-for-adoption) new maintainers.
+3. Clean up or merge some existing plugins which need some care ([listed here](https://wiki.jenkins.io/display/JENKINS/Hacksgiving+2015#Hacksgiving2015-Pluginstocleanup)).
 <!--break-->
 ### Sessions to note
 

--- a/content/blog/2017/08/2017-08-23-pull-requests-and-more.adoc
+++ b/content/blog/2017/08/2017-08-23-pull-requests-and-more.adoc
@@ -100,12 +100,12 @@ The team at link:mailto:jenkinsci-jam@googlegroups.com[jenkinsci-jam@googlegroup
 The Jenkins plugin ecosystem covers a wide range of areas.
 Jenkins plugin maintainers come from many different backgrounds, with many different interests.
 Often, a plugin maintainer may find that they want to do something different on the project, or they may leave the project.
-When a plugin maintainer is no longer able to maintain a plugin, they can link:https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[place it for adoption].
+When a plugin maintainer is no longer able to maintain a plugin, they can link:/doc/developer/plugin-governance/adopt-a-plugin/[place it for adoption].
 
 Plugins placed for adoption range from very specific use cases (node stalker plugin) to very general use cases (Subversion plugin).
 
 Maintaining an orphan plugin is a great way to contribute to the project.
-Follow the instructions to "link:https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopt a Plugin]".
+Follow the instructions to "link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopt a Plugin]".
 
 === See You There!
 

--- a/content/blog/2019/04/2019-04-03-security-advisory.adoc
+++ b/content/blog/2019/04/2019-04-03-security-advisory.adoc
@@ -18,4 +18,4 @@ In such cases, we publish https://jenkins.io/security/#vulnerabilities-in-plugin
 Doing so allows administrators to make an informed decision about the continued use of plugins with unresolved security vulnerabilities.
 Today's advisory is overwhelmingly such an advisory.
 
-See a plugin you love on this list and want to help out? https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Learn about adopting plugins].
+See a plugin you love on this list and want to help out? link:/doc/developer/plugin-governance/adopt-a-plugin/[Learn about adopting plugins].

--- a/content/doc/developer/_book.yml
+++ b/content/doc/developer/_book.yml
@@ -15,6 +15,7 @@ chapters:
   - cli
   - testing
   - plugin-development
+  - plugin-governance
   - publishing
   - blueocean-plugin-development
   - building

--- a/content/doc/developer/plugin-governance/_chapter.yml
+++ b/content/doc/developer/plugin-governance/_chapter.yml
@@ -1,0 +1,3 @@
+---
+sections:
+- adopt-a-plugin

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -5,7 +5,7 @@ title: Adopt a Plugin
 
 We're looking for new maintainers of existing plugins!
 
-WARNING: The process documented on this page is a subject to change, and it cannot be used at te moment due to the read-only state of Jenkins Wiki.
+WARNING: The process documented on this page is a subject to change, and it cannot be used at the moment due to the read-only state of Jenkins Wiki.
 See the discussion link:https://groups.google.com/forum/#!topic/jenkinsci-dev/UoEqG5AaWJU[here].
 
 This page addresses cases when there is no active maintainer of a plugin:
@@ -32,7 +32,7 @@ Please provide the following things in the request:
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.
 The typical way to do that is to ping in GitHub and to add her/his/their email addresses in CC (hint: Git commits should have this information).
 We typically wait for about 2 weeks in normal work periods before proceeding, so please be patient.
-Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be fast-looped.
+Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be faster.
 
 Once granted access, you can file a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
 You're generally expected to start slowly, by filing PRs, and not commit directly.

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -1,0 +1,84 @@
+---
+layout: developersection
+title: Adopt a Plugin
+---
+
+*We're looking for new maintainers of existing plugins!*
+
+== A plugin I'm (planning on) using shows up as looking for a maintainer. Does that mean I shouldn't use it?
+
+*No.* Jenkins is designed with backward compatibility in mind, so it's rare that a plugin stops working.
+And even then there's often someone who can fix the bug and release a new version even if they wouldn't be considered a maintainer of the plugin.
+So if you're happy with what a plugin is offering, there's no reason not to use it just because it's up for adoption.
+
+== I want to help! How can I find a plugin to maintain?
+
+Check out the list of plugins up for adoption at the bottom of this page.
+If you see a plugin you like, visit its wiki page as it may contain additional information about the adoption request.
+
+== I know which plugin I want to help with, what should I do now?
+
+Once you've chosen a plugin, review the documentation on plugin maintainership in the Jenkins project. 
+This is especially important if you're not currently a plugin developer.
+
+As a new maintainer of a new plugin, you'll inherit its existing users, so be careful with breaking changes.
+https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-Compatibilitymatters[We
+value data compatibility highly], so any new releases should remain compatible with previous data and upgrade smoothly. 
+If you need help with this, don't hesitate to ask other Jenkins developers for help.
+And if all else fails,
+https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions[you can mark a new version as being incompatible with older releases] to warn users before they update.
+
+=== Request commit access
+
+Email the http://jenkins-ci.org/content/mailing-lists[Jenkins Developers mailing list] and request to be made a maintainer 
+(which usually means commit access to the plugin repository and being made default assignee for newly reported issues in JIRA).
+To that purpose, it's expected to try and reach out to existing maintainer(s) using a best effort.
+So, the typical way to do that is to put her/his/their email addresses in CC (hint: Git commits should have this information).
+
+We typically wait for about 2 weeks in normal work periods before proceeding, so please be patient.
+Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be fast-looped.
+
+*IMPORTANT: To speed up and ease the process, please provide the two following things:*
+
+* Your GitHub username/id (e.g. oleg-nenashev for https://github.com/oleg-nenashev/)
+* Your Jenkins infrastructure account id. Create https://jenkins-ci.org/account/[your account if you don't have one].
+
+Once granted access, you can file a PR (with your Jenkins infrastructure account id) against
+https://github.com/jenkins-infra/repository-permissions-updater to be
+able to deploy snapshots and releases for your plugin.
+You're generally expected to start slowly, by filing PRs, and not commit directly.
+Even more for plugins with a big number of installations for obvious reasons.
+
+== How can I mark a plugin for adoption?
+
+First, *make sure the plugin is not being actively maintained*.
+Even in actively maintained plugins, there may be periods of lower developer activity.
+Don't misinterpret failures to respond to questions or requests as the plugin being unmaintained!
+
+To mark a plugin for adoption, add the `+adopt-this-plugin+` label to the plugin's wiki page.
+This will cause the note to appear below the plugin info box.
+
+IMPORTANT: please use the _Comment:_ textfield of Confluence page edition to explain why you're marking that plugin as up for adoption.
+Ideally, link to a thread on the mailing-lists, GitHub or somewhere else with a message from the current maintainer(s) confirming that the plugin is indeed not maintained anymore.
+
+If you want to customize the message, use the `+adopt-message+` parameter to the `+jenkins-plugin-info+` macro, e.g. like this:
+
+```
+{jenkins-plugin-info:myplugin|adopt-message=The maintainer is looking
+for a co-maintainer.}
+```
+
+This message will replace the default _Want to help improve this plugin?_ text in the note.
+
+== I'm a plugin maintainer and my plugin shows as up for adoption, why?
+
+This status is based on the `+adopt-this-plugin+` label on the plugin wiki page.
+Plugin pages are labeled `+adopt-this-plugin+` manually, so it's likely a mistaken assumption that your plugin is unmaintained.
+If you remove the label from its wiki page, it'll disappear from the list again.
+
+== Which plugins are currently up for adoption?
+
+See the list of plugin pages with the `+adopt-this-plugin+` label.
+
+* link:https://wiki.jenkins.io/dosearchsite.action?cql=type%20in%20(%22page%22)%20AND%20label%20in%20(%22adopt-this-plugin%22)&includeArchivedSpaces=false[Jenkins Wiki Query]
+

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -27,7 +27,7 @@ Please provide the following things in the request:
 * Link to a plugin you want to adopt
 * Link(s) to pull requests you want to deliver, if applicable
 * Your GitHub username/id (e.g. oleg-nenashev for https://github.com/oleg-nenashev/)
-* Your Jenkins infrastructure account id. Create https://jenkins-ci.org/account/[your account if you don't have one].
+* Your Jenkins infrastructure account id. link:https://accounts.jenkins.io/[Create your account] if you don't have one.
 
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.
 The typical way to do that is to ping in GitHub and to add her/his/their email addresses in CC (hint: Git commits should have this information).

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -57,7 +57,7 @@ Once you've chosen a plugin, review the documentation on plugin maintainership i
 This is especially important if you're not currently a plugin developer.
 
 As a new maintainer of a new plugin, you'll inherit its existing users, so be careful with breaking changes.
-https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-Compatibilitymatters[We
+link:/project/governance/#compatibility-matters[We
 value data compatibility highly], so any new releases should remain compatible with previous data and upgrade smoothly. 
 If you need help with this, don't hesitate to ask other Jenkins developers for help.
 And if all else fails,

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -3,20 +3,55 @@ layout: developersection
 title: Adopt a Plugin
 ---
 
-*We're looking for new maintainers of existing plugins!*
+We're looking for new maintainers of existing plugins!
 
-== A plugin I'm (planning on) using shows up as looking for a maintainer. Does that mean I shouldn't use it?
+WARNING: The process documented on this page is a subject to change, and it cannot be used at te moment due to the read-only state of Jenkins Wiki.
+See the discussion link:https://groups.google.com/forum/#!topic/jenkinsci-dev/UoEqG5AaWJU[here].
+
+This page addresses cases when there is no active maintainer of a plugin:
+
+* **Adopting plugins marked for adoption.**
+  Plugin maintainers can mark plugins for adoption if they do not plan to maintain their plugins anymore.
+  In such case we have a low-barrier process for taking over plugins.
+* **Adopting abandoned plugins.** 
+  Sometimes plugin maintainers move on without marking plugins for adoption, due to various reasons.
+  In such case we can transfer ownership for plugins being hosted within the `jenkinsci` GitHub organization.
+  Such transfer may take a while.
+
+== Requesting commit access
+
+Email the http://jenkins-ci.org/content/mailing-lists[Jenkins Developers mailing list] and request to be made a maintainer 
+(which usually means commit access to the plugin repository and being made default assignee for newly reported issues in JIRA).
+Please provide the following things in the request:
+
+* Link to a plugin you want to adopt
+* Link(s) to pull requests you want to deliver, if applicable
+* Your GitHub username/id (e.g. oleg-nenashev for https://github.com/oleg-nenashev/)
+* Your Jenkins infrastructure account id. Create https://jenkins-ci.org/account/[your account if you don't have one].
+
+For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.
+The typical way to do that is to ping in GitHub and to add her/his/their email addresses in CC (hint: Git commits should have this information).
+We typically wait for about 2 weeks in normal work periods before proceeding, so please be patient.
+Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be fast-looped.
+
+Once granted access, you can file a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
+You're generally expected to start slowly, by filing PRs, and not commit directly.
+Even more for plugins with a big number of installations for obvious reasons.
+
+== FAQ
+
+=== A plugin I'm (planning on) using shows up as looking for a maintainer. Does that mean I shouldn't use it?
 
 *No.* Jenkins is designed with backward compatibility in mind, so it's rare that a plugin stops working.
 And even then there's often someone who can fix the bug and release a new version even if they wouldn't be considered a maintainer of the plugin.
 So if you're happy with what a plugin is offering, there's no reason not to use it just because it's up for adoption.
 
-== I want to help! How can I find a plugin to maintain?
+=== I want to help! How can I find a plugin to maintain?
 
 Check out the list of plugins up for adoption at the bottom of this page.
 If you see a plugin you like, visit its wiki page as it may contain additional information about the adoption request.
 
-== I know which plugin I want to help with, what should I do now?
+=== I know which plugin I want to help with, what should I do now?
 
 Once you've chosen a plugin, review the documentation on plugin maintainership in the Jenkins project. 
 This is especially important if you're not currently a plugin developer.
@@ -28,28 +63,7 @@ If you need help with this, don't hesitate to ask other Jenkins developers for h
 And if all else fails,
 https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions[you can mark a new version as being incompatible with older releases] to warn users before they update.
 
-=== Request commit access
-
-Email the http://jenkins-ci.org/content/mailing-lists[Jenkins Developers mailing list] and request to be made a maintainer 
-(which usually means commit access to the plugin repository and being made default assignee for newly reported issues in JIRA).
-To that purpose, it's expected to try and reach out to existing maintainer(s) using a best effort.
-So, the typical way to do that is to put her/his/their email addresses in CC (hint: Git commits should have this information).
-
-We typically wait for about 2 weeks in normal work periods before proceeding, so please be patient.
-Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be fast-looped.
-
-*IMPORTANT: To speed up and ease the process, please provide the two following things:*
-
-* Your GitHub username/id (e.g. oleg-nenashev for https://github.com/oleg-nenashev/)
-* Your Jenkins infrastructure account id. Create https://jenkins-ci.org/account/[your account if you don't have one].
-
-Once granted access, you can file a PR (with your Jenkins infrastructure account id) against
-https://github.com/jenkins-infra/repository-permissions-updater to be
-able to deploy snapshots and releases for your plugin.
-You're generally expected to start slowly, by filing PRs, and not commit directly.
-Even more for plugins with a big number of installations for obvious reasons.
-
-== How can I mark a plugin for adoption?
+=== How can I mark a plugin for adoption?
 
 First, *make sure the plugin is not being actively maintained*.
 Even in actively maintained plugins, there may be periods of lower developer activity.
@@ -70,13 +84,13 @@ for a co-maintainer.}
 
 This message will replace the default _Want to help improve this plugin?_ text in the note.
 
-== I'm a plugin maintainer and my plugin shows as up for adoption, why?
+=== I'm a plugin maintainer and my plugin shows as up for adoption, why?
 
 This status is based on the `+adopt-this-plugin+` label on the plugin wiki page.
 Plugin pages are labeled `+adopt-this-plugin+` manually, so it's likely a mistaken assumption that your plugin is unmaintained.
 If you remove the label from its wiki page, it'll disappear from the list again.
 
-== Which plugins are currently up for adoption?
+=== Which plugins are currently up for adoption?
 
 See the list of plugin pages with the `+adopt-this-plugin+` label.
 

--- a/content/doc/developer/plugin-governance/index.adoc
+++ b/content/doc/developer/plugin-governance/index.adoc
@@ -1,0 +1,5 @@
+---
+title: Plugin governance
+summary: About plugin governance, ownership, adoption, et.c
+layout: developerchapter
+---

--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -40,7 +40,7 @@ Here are some documentation links:
 * link:/doc/developer/[Jenkins developer documentation]
 * https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial[The plugin tutorial will get you started with Jenkins plugin development]
 * https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[The complete guide to hosting and publishing plugins]
-* https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopt a plugin]
+* link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopt a plugin]
 * https://wiki.jenkins.io/display/JENKINS/Before+starting+a+new+plugin[Advice before creating a new plugin]
 * https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[How we handle pull requests to plugin repositories]
 

--- a/content/projects/gsoc/gsoc2018-project-ideas.adoc
+++ b/content/projects/gsoc/gsoc2018-project-ideas.adoc
@@ -246,7 +246,7 @@ Need some hints? Here are examples of project ideas:
 
 * New plugin for integration with various external tools or services
 (e.g. link:/projects/gsoc/gsoc2018-project-ideas/#plugin-s-for-electronic-design-automation-tools[plugins for Electronic Design Automation Tool] proposal)
-* link:https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopting an existing plugin],
+* link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopting an existing plugin],
 extending it by adding new features like link:/doc/book/pipeline/[Jenkins Pipeline]
 * Working on major feature requests from the link:https://issues.jenkins-ci.org/secure/Dashboard.jspa[Jenkins bugtracker]
 * Creating new demo and reference setups,

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -40,7 +40,7 @@ link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide].
 Need some hints? Here are examples of project ideas:
 
 * A new plugin for integration with various development tools or services
-* link:https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Adopting an existing plugin],
+* link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopting an existing plugin],
 extending it by adding new features like link:/doc/book/pipeline/[Jenkins Pipeline]
 * Working on major feature requests from the link:https://issues.jenkins-ci.org/secure/Dashboard.jspa[Jenkins bugtracker]
 * Creating new demo and reference setups,


### PR DESCRIPTION
First step in reworking the plugin adoption documentation.
See https://groups.google.com/forum/#!topic/jenkinsci-dev/UoEqG5AaWJU for the context

- [x] - Add a new "Plugin Governance" section in Developer docs
- [x] - Move and copy-edit the documentation without introducing major changes
- [x] - Update links to guidelines inside the website