### PR TITLE
Add a page for Jenkins structure and governance

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -147,6 +147,9 @@
 
                     %ul.project
                       %li
+                        %a{:href => expand_link("project")}
+                          Structure and governance
+                      %li
                         %a{:href => 'https://issues.jenkins-ci.org'}
                           Issue tracker
                       %li

--- a/content/project/index.adoc
+++ b/content/project/index.adoc
@@ -1,0 +1,26 @@
+---
+layout: simplepage
+title: "Project structure and governance"
+section: project
+---
+
+The Jenkins project as a community revolves around Jenkins as a piece of software.
+We are a group of open-source developers and users who develop, use, promote Jenkins, software around Jenkins, and other related activities for our mutual benefit.
+
+This page provides some links to pages describing the project structure and its governance.
+
+### Project governance
+
+* link:./governance[Jenkins Governance Document] - overview of the project's governance model, philosophy, project roles, decision making process, etc.
+* link:./conduct[Code of Conduct]
+* link:./board-election-process[Jenkins Board election process]
+
+### Project structure
+
+* link:./board[Governance Board members and current officers]
+* link:./team-leads[Team leaders]
+* Teams:
+** link:/security/#team[Security Team]
+** link:/projects/infrastructure/[Infrastructure]
+* link:/sigs/[Special Interest Groups]
+* link:/projects/[Sub-projects]

--- a/content/project/index.adoc
+++ b/content/project/index.adoc
@@ -20,7 +20,7 @@ This page provides some links to pages describing the project structure and its 
 * link:./board[Governance Board members and current officers]
 * link:./team-leads[Team leaders]
 * Teams:
-** link:/security/#team[Security Team]
+** link:/security/#team[Security]
 ** link:/projects/infrastructure/[Infrastructure]
 * link:/sigs/[Special Interest Groups]
 * link:/projects/[Sub-projects]


### PR DESCRIPTION
For better transparency, it would be great to have a landing page which lists the current project structure and links to other related pages. This pull requests adds such page and also adds a link to it in the global jenkins.io footer

![image](https://user-images.githubusercontent.com/3000480/68602307-64c5fa80-04a6-11ea-8bc6-a8afc2e6a282.png)
