### PR TITLE
Rework the jenkins.io footer links for better navigation

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -121,25 +121,23 @@
 
                     %ul.resources
                       %li
-                        %a{:href => expand_link("events")}
-                          Events
+                        %a{:href => expand_link("download")}
+                          Downloads
+                      %li
+                        %a{:href => expand_link("node")}
+                          Blog
                       %li
                         %a{:href => expand_link("doc")}
                           Documentation
                       %li
-                        %a{:href => expand_link("node")}
-                          Blog
-
-                .area.col-md-3
-                  .div-mar
-                    %h5 Solutions
-
-                    %ul
-                      - site.solutions.keys.sort.each do |key|
-                        - link = expand_link("solutions/#{key}")
-                        %li
-                          %a{:href => link}
-                            = site.solutions[key].usecase
+                        %a{:href => 'https://plugins.jenkins.io/'}
+                          Plugins    
+                      %li
+                        %a{:href => expand_link("security")}
+                          Security
+                      %li
+                        %a{:href => expand_link("participate")}
+                          Contributing
 
                 .area.col-md-3
                   .div-mar
@@ -165,11 +163,14 @@
 
                     %ul.community
                       %li
-                        %a{:href => 'https://groups.google.com/forum/#!forum/jenkinsci-users'}
-                          Users mailing list
+                        %a{:href => expand_link("events")}
+                          Events
                       %li
-                        %a{:href => 'https://groups.google.com/forum/#!forum/jenkinsci-dev'}
-                          Developers mailing list
+                        %a{:href => expand_link("mailing-lists")}
+                          Mailing lists
+                      %li
+                        %a{:href => expand_link("chat")}
+                          Chats
                       %li
                         %a{:href => expand_link("sigs")}
                           Special Interest Groups
@@ -179,9 +180,23 @@
                       %li
                         %a{:href => 'https://reddit.com/r/jenkinsci'}
                           Reddit
+                .area.col-md-3
+                  .div-mar
+                    %h5 Other
+
+                    %ul.other
+                      %li
+                        %a{:href => expand_link("conduct")}
+                          Code of Conduct
+                      %li
+                        %a{:href => expand_link("press")}
+                          Press information
                       %li
                         %a{:href => expand_link("merchandise")}
                           Merchandise
+                      %li
+                        %a{:href => expand_link("artwork")}
+                          Artwork
                       %li
                         %a{:href => expand_link("awards")}
                           Awards


### PR DESCRIPTION
This change replaces the obsolete "solutions" column in order to inject more meaningful information for users and contributors. Solutions are generally not maintained well, and I doubt we should keep it in spotlight. We have them in the navigation bar anyway

The footer has been also made shorter by this change

Before:
![image](https://user-images.githubusercontent.com/3000480/68604302-74dfd900-04aa-11ea-8aaa-8638da9c45b9.png)

After:
![image](https://user-images.githubusercontent.com/3000480/68604273-672a5380-04aa-11ea-9219-333685c75e2f.png)
