### PR TITLE
Introduce a listing of solution pages

### DIFF
--- a/content/doc/index.adoc
+++ b/content/doc/index.adoc
@@ -48,7 +48,7 @@ through the installation of plugins.
 
 There are a vast array of plugins available to Jenkins. However, the
 documentation covered in the <<doc/pipeline/tour/getting-started#,Guided Tour>>,
-<<doc/tutorials#,Tutorials>> and <<doc/book/getting-started#,User Handbook>> of
+<<doc/tutorials#,Tutorials>>, <</solutions#,Solution pages>> and <<doc/book/getting-started#,User Handbook>> of
 this documentation are based on a <<doc/book/installing#,Jenkins installation>>
 with the <<doc/book/blueocean/getting-started#,Blue Ocean plugins installed>>,
 as well as the "suggested plugins", which are specified when running through the

--- a/content/solutions/index.html.haml
+++ b/content/solutions/index.html.haml
@@ -1,0 +1,11 @@
+---
+layout: simplepage
+title: "Jenkins use-cases"
+---
+
+%ul
+  - site.solutions.keys.sort.each do |key|
+  - link = expand_link("solutions/#{key}")
+    %li
+      %a{:href => link}
+        = site.solutions[key].usecase

--- a/content/solutions/index.html.haml
+++ b/content/solutions/index.html.haml
@@ -1,6 +1,6 @@
 ---
 layout: simplepage
-title: "Jenkins use-cases"
+title: "Jenkins Use-cases"
 ---
 
 %ul


### PR DESCRIPTION
Just a stub page for the list of solutions. We can use this stub in order to reference all solution pages at once. Looks terrible at the moment, but better than nothing IMHO

![image](https://user-images.githubusercontent.com/3000480/68604840-a1482500-04ab-11ea-8087-2a975de662ff.png)
