### PR TITLE
Jenkins Infra: Rework the services list

### DIFF
--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -54,6 +54,7 @@ Here is a non-exhaustive list of services that we provide and maintain.
 
 === Self-hosted services
 
+[%header]
 |===
 | Service                                                | JIRA component(s) | Repository
 | https://accounts.jenkins.io[Accounts]                  | `account`, `accountapp` | https://github.com/jenkins-infra/account-app[Code] 
@@ -72,9 +73,10 @@ Here is a non-exhaustive list of services that we provide and maintain.
 
 === SaaS
 
+[%header]
 |===
 | Service                                                | Provided by  | JIRA component(s) | Repository
-| https://repo.jenkins-ci.org/webapp/#/home[Artifactory] | JFrog | `artifactory` | JFrog
+| https://repo.jenkins-ci.org/webapp/#/home[Artifactory] | JFrog | `artifactory` | -
 | https://github.com/jenkins-infra[GitHub]               | GitHub | `github` | -
 | https://jenkins.datadoghq.com[Monitoring]              | Datadog | `datadog` | https://github.com/jenkins-infra/jenkins-infra-monitoring[Code]
 | https://www.pagerduty.com[Pagerduty]                   | Pagerduty | N/A | - 
@@ -84,6 +86,7 @@ Here is a non-exhaustive list of services that we provide and maintain.
 
 Jenkins infrastructure also hosts some services for sub-projects and special interest groups:
 
+[%header]
 |===
 | Service | Owner Sub-project/SIG | JIRA component(s) | Repository
 | https://cn.jenkins.io[Website in Chinese] | link:/sigs/chinese-localization/[Chinese Localization] | `cn.jenkins.io` | https://github.com/jenkins-infra/cn.jenkins.io[Code]

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -52,25 +52,42 @@ we have a follow the sun policy where we try to only be on call during our "avai
 Another major aspect of the Jenkins Infrastructure project, is the maintenance of all services either provided by us or third parties.
 Here is a non-exhaustive list of services that we provide and maintain.
 
+=== Self-hosted services
+
 |===
-| Service                                                | Provided by  | Repository
-| https://accounts.jenkins.io[Accounts]                  | Jenkins-infra | https://github.com/jenkins-infra/account-app[Code] 
-| https://repo.jenkins-ci.org/webapp/#/home[Artifactory] | Jfrog | Jfrog
-| https://evergreen.jenkins.io[Evergreen]                | Jenkins-infra | https://github.com/jenkins-infra/evergreen[Repository]
-| https://github.com/jenkins-infra[Github]               | Github | -
-| IRC Bot                                                | Jenkins-infra | https://github.com/jenkins-infra/ircbot[Code]
-| https://javadoc.jenkins.io[Javadoc]                    | Jenkins-infra | https://github.com/jenkins-infra/javadoc[Code]
-| https://issues.jenkins-ci.org[Jira]                    | Jenkins-infra | https://github.com/jenkins-infra/jira[Docker] 
-| https://ci.jenkins.io[Jenkins]                         | Jenkins-infra | 
-| Ldap                          | Jenkins-infra | https://github.com/jenkins-infra/ldap[Docker]
-| https://jenkins.io[Main Website]                       | Jenkins-infra | https://github.com/jenkins-infra/jenkins.io[English] https://github.com/jenkins-infra/cn.jenkins.io[Chinese]
-| https://jenkins.datadoghq.com[Monitoring]              | Datadog       | https://github.com/jenkins-infra/jenkins-infra-monitoring[Code]
-| Vpn          | Jenkins-infra | https://github.com/jenkins-infra/openvpn[Code]
-| https://www.pagerduty.com[Pagerduty]                   | Pagerduty     | - 
-| https://plugins.jenkins.io[Plugin Site]                       | Jenkins-infra | https://github.com/jenkins-infra/plugin-site[Frontend ] https://github.com/jenkins-infra/plugin-site-api[Backend]
-| http://stats.jenkins.io/jenkins-stats/svg/svgs.html[Stats] | Jenkins-infra | https://github.com/jenkins-infra/infra-statistics[Scripts]
-| https://uplink.jenkins.io[UpLink]                | Jenkins-infra | https://github.com/jenkins-infra/uplink[Code] 
-| https://wiki.jenkins.io[Wiki]                          | Jenkins-infra | https://github.com/jenkins-infra/confluence[Docker]
+| Service                                                | JIRA component(s) | Repository
+| https://accounts.jenkins.io[Accounts]                  | `account`, `accountapp` | https://github.com/jenkins-infra/account-app[Code] 
+| link:./ircbot[IRC Bot]                                                | `ircbot` | https://github.com/jenkins-infra/ircbot[Code]
+| https://javadoc.jenkins.io[Javadoc]                    | `javadoc` | https://github.com/jenkins-infra/javadoc[Code]
+| https://issues.jenkins-ci.org[Jira]                    | `jira` | https://github.com/jenkins-infra/jira[Docker] 
+| https://ci.jenkins.io[Jenkins]                         | `ci.jenkins.io`, `ci` | https://github.com/jenkins-infra/jenkins-infra[Deployment scripts]
+| LDAP                          | `ldap` | https://github.com/jenkins-infra/ldap[Docker]
+| https://jenkins.io[Main Website]                       | `jenkins.io` | https://github.com/jenkins-infra/jenkins.io[Code]
+| VPN          | `vpn` | https://github.com/jenkins-infra/openvpn[Code]
+| https://plugins.jenkins.io[Plugin Site]                       | `plugins.jenkins.io` | https://github.com/jenkins-infra/plugin-site[Frontend], https://github.com/jenkins-infra/plugin-site-api[Backend]
+| http://stats.jenkins.io/jenkins-stats/svg/svgs.html[Stats] | N/A | https://github.com/jenkins-infra/infra-statistics[Scripts]
+| https://uplink.jenkins.io[UpLink]                | `uplink` | https://github.com/jenkins-infra/uplink[Code] 
+| https://wiki.jenkins.io[Wiki]                          | `wiki` | https://github.com/jenkins-infra/confluence[Docker]
+|===
+
+=== SaaS
+
+|===
+| Service                                                | Provided by  | JIRA component(s) | Repository
+| https://repo.jenkins-ci.org/webapp/#/home[Artifactory] | JFrog | `artifactory` | JFrog
+| https://github.com/jenkins-infra[GitHub]               | GitHub | `github` | -
+| https://jenkins.datadoghq.com[Monitoring]              | Datadog | `datadog` | https://github.com/jenkins-infra/jenkins-infra-monitoring[Code]
+| https://www.pagerduty.com[Pagerduty]                   | Pagerduty | N/A | - 
+|===
+
+=== Sub-project/SIG services
+
+Jenkins infrastructure also hosts some services for sub-projects and special interest groups:
+
+|===
+| Service | Owner Sub-project/SIG | JIRA component(s) | Repository
+| https://cn.jenkins.io[Website in Chinese] | link:/sigs/chinese-localization/[Chinese Localization] | `cn.jenkins.io` | https://github.com/jenkins-infra/cn.jenkins.io[Code]
+| https://evergreen.jenkins.io[Evergreen] | link:/projects/evergreen/[Evergreen] | `evergreen` | https://github.com/jenkins-infra/evergreen[Repository]
 |===
 
 == Contributing


### PR DESCRIPTION
This change splits the list of services to 3 categories: self-hosted, SaaS, and also sub-project/SIG services hosted by the project. Some links are fixed, and I have also added JIRA component IDs. But I did not add other services to the list yet, some of them are missing. 

P.S: Tables on jenkins.io are just ugly, we need to update CSS IMHO

Before:

![image](https://user-images.githubusercontent.com/3000480/68669685-6c8baa80-054b-11ea-9a1c-7858055139dc.png)


After:

![image](https://user-images.githubusercontent.com/3000480/68669715-7d3c2080-054b-11ea-9632-dcec4ae077fe.png)
