### PR TITLE
[WEBSITE-662] - Cleanup jenkins.io/participate pages and tags, add WIP warnings for pages which are not complete yet

### DIFF
--- a/content/participate/design.adoc
+++ b/content/participate/design.adoc
@@ -3,12 +3,12 @@ layout: project
 title: Art and Design
 section: participate
 tags:
-  - outreach-programs
-  - designer
+  - design
+  - user-experience
 ---
 
-
-== Contribute
+As it is intended for daily use by finicky web developers, Jenkins design and user experience are essential.
+We invite designers to improve Jenkins, its website, and to create new artwork for the project.
 
 === Artwork
 

--- a/content/participate/document.adoc
+++ b/content/participate/document.adoc
@@ -4,7 +4,13 @@ title: Document
 section: participate
 tags:
   - help
+  - documentation
 ---
+
+NOTE: This page is under development, there will be more content added soon. 
+See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
+
+Improve the documentation to make it easier for others to get started and to use Jenkins.
 
 - We coordinate and discuss documenting efforts using the https://groups.google.com/forum/#!forum/jenkinsci-docs[jenkinsci-docs] mailing list and the https://jenkins.io/chat/[jenkins-community IRC channel]
 - Learn how to https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-documentation[contribute documentation to jenkins.io]

--- a/content/participate/help.adoc
+++ b/content/participate/help.adoc
@@ -4,9 +4,11 @@ title: Help
 section: participate
 tags:
   - help
+  - community
 ---
 
-== Contribute
+NOTE: This page is under development, there will be more content added soon.
+See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
 
 There are many platforms and channels where you can help jenkins users.
 

--- a/content/participate/review-changes.adoc
+++ b/content/participate/review-changes.adoc
@@ -4,8 +4,14 @@ title: Review Changes
 section: participate
 tags:
   - developer
+  - contributing
   - review
 ---
+
+NOTE: This page is under development, there will be more content added soon.
+See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
+
+Help us to review changes to code or documentation!
 
 == Code Reviews and Copy Editing
 

--- a/content/participate/test.adoc
+++ b/content/participate/test.adoc
@@ -9,6 +9,7 @@ tags:
 ---
 
 NOTE: This page is under development, there will be more content added soon.
+See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
 
 === Automated Testing
 

--- a/content/participate/test.adoc
+++ b/content/participate/test.adoc
@@ -4,9 +4,11 @@ title: Testing
 section: participate
 tags:
   - developer
+  - testing
+  - contributing
 ---
 
-== Contribute
+NOTE: This page is under development, there will be more content added soon.
 
 === Automated Testing
 


### PR DESCRIPTION
Not all pages are fully finished at the moment, and some pages need serious updates. This pull request does some minor cleanup, fixes labels for blogposts, and adds disclaimers for pages which have not been updated yet.

Sample:

![image](https://user-images.githubusercontent.com/3000480/68861720-64b73c00-06ec-11ea-9ed1-b9f2ba9d0ea0.png)

CC @MarkEWaite @urwa 
