### PR TITLE
Reference contributing assistance channels in jenkins.io/participate and CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -15,6 +15,12 @@ from that branch to the `master` branch of this repository.
 Forking only needs to be done once, after which you can push changes to your fork
 using the GitHub website file editor or from a local clone, as described below.
 
+[[newcomers]]
+=== Information for newcomers
+
+The documentation below describes common cases for contributors.
+If you have any questions, please do not hesitate to ask in link:https://gitter.im/jenkinsci/newcomer-contributors[newcomers] or link:https://gitter.im/jenkinsci/docs[Documentation SIG] Gitter chats.
+If you have any feedback about your contributor experience, please also share it with us in these channels so that we can improve our guidelines.
 
 [[forking]]
 === Creating a fork

--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -12,6 +12,10 @@ section: participate
       margin-bottom: 1rem;
   }
 
+  .channels-help {
+      text-align: center;
+  }
+
   .card {
       border: 1px solid #d3d3d3;
       border-radius: .25rem;
@@ -194,3 +198,14 @@ section: participate
       %p Help review changes to code or documentation.
       %a.btn.btn-review{ :href => "/participate/review-changes"} Read More
  
+%p.channels-help
+  %b
+    Help and feedback. 
+  Please contact us in the 
+  %a{:href => 'https://gitter.im/jenkinsci/newcomer-contributors'}
+    Newcomer
+  or
+  %a{:href => 'https://gitter.im/jenkinsci/advocacy-and-outreach-sig'}
+    Advocacy and Outreach SIG
+  channels if you have any questions about contributing to Jenkins.
+  Any feedback about the guidelines will be appreciated.


### PR DESCRIPTION
Submitting the PR to get feedback about the change feasibility. The idea is to have https://gitter.im/jenkinsci/newcomer-contributors linked from few places where we have the most of the newcomer traffic

![image](https://user-images.githubusercontent.com/3000480/68869103-ee6d0680-06f8-11ea-8a92-aa9f01ce61c7.png)
