### PR TITLE
Move the Browser compatibility policy from Wiki to GitHub

### DIFF
--- a/content/doc/administration/requirements/web-browsers.adoc
+++ b/content/doc/administration/requirements/web-browsers.adoc
@@ -6,6 +6,9 @@ title:  Browser compatibility
 NOTE: This page documents the browser support policy in the Jenkins automation server.
 It does not apply to the Jenkins website or other services hosted by the Jenkins project.
 
+WARNING: This policy is outdated, and it is a subject to change.
+See the link:https://groups.google.com/forum/#!topic/jenkinsci-dev/TV_pLEah9B4[discussion in the developer mailing list].
+
 == Support model
 
 Jenkins web browser support falls into one of three classes:

--- a/content/doc/administration/requirements/web-browsers.adoc
+++ b/content/doc/administration/requirements/web-browsers.adoc
@@ -1,10 +1,57 @@
 ---
 layout: documentation
 title:  Browser compatibility
-wip: true
 ---
 
-This page is under development.
+NOTE: This page documents the browser support policy in the Jenkins automation server.
+It does not apply to the Jenkins website or other services hosted by the Jenkins project.
 
-See
-link:https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[this Wiki page].
+== Support model
+
+Jenkins web browser support falls into one of three classes:
+
+. Level 1:  Aim to proactively fix these browsers and provide an equal
+UX across all.
+. Level 2:  Accept patches to fix issues and make a best effort to
+ensure there is at least one way to do any action.
+. Level 3:  No guarantees. We will accept patches, but only if they are
+low risk. *This is the default unless a browser/version is listed
+below*.
+
+We do not claim any compatibility with, or accept bug reports and
+patches, for pre-release (e.g. alpha, beta or canary) versions of
+browsers.
+
+== Browser compatibility matrix
+
+[width="100%",cols="25%,25%,25%,25%",options="header",]
+|===
+|Browser |Level 1 |Level 2 |Comment(s)
+|Google Chrome |Latest regular release |  | +
+
+|Mozilla Firefox |Latest regular release +
+Latest
+https://www.mozilla.org/en-US/firefox/organizations/[ESR] release + | 
+| 
+
+|Microsoft Internet Explorer |Version 11 + |Versions 9 and 10 +
+|Specific OS Versions?
+
+|Apple Safari |Versions 6 and newer + |Version 5 release (OS X only) +
+| 
+|===
+
+These rules were
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-03-18.01.html[adopted
+on 2014-09-03] for Jenkins 1.579 and up.
+
+Unless otherwise noted, only the latest minor release / patch level of
+each version is supported.
+
+Support for mobile browsers (e.g. iOS Safari) has not yet been
+determined
+
+
+== Change history
+
+* 2014-09-03 - Original policy for for Jenkins 1.579 (http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-03-18.01.html[governance meeting notes])


### PR DESCRIPTION
This change moves the document to jenkins.io. The policy is obsolete. https://groups.google.com/forum/#!topic/jenkinsci-dev/TV_pLEah9B4 was created to discuss the changes