### PR TITLE
[INFRA-2337] - Update Wiki export guidelines in CONTRIBUTING to reference Jenkins Wiki exporter

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -418,13 +418,13 @@ C++/Windows specific content.
 Jenkins project still hosts a lot of documentation pages on link:https://wiki.jenkins.io[Jenkins Wiki].
 Some documentation sections in this repository are marked as "work-in-progress", and they just refer Wiki.
 It is recommended to move such pages to jenkins.io,
-and it can be done in a semi-automated way using the link:https://pandoc.org[Pandoc] tool for Wiki->Asciidoc conversion.
+and it can be done in a semi-automated way using the link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter] tool which is based on link:https://pandoc.org/[Pandoc].
 
-. Open the Wiki page page you want to migrate
-. In the "..." button in the top right corner click the _View Source_ action. A new window will open
-. Save the document as HTML to a temporary folder, e.g. as
-`mypage.html`
-. Call `pandoc -o mypage.adoc --extract-media=todo-replace-by-actual-path mypage.html`
+. Open the Wiki page page you want to migrate, copy its URL
+. Go to the link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter] web page
+. Paste the URL of the Wiki page you want to export
+. Select the export option. Use __Asciidoc_ for pages without images or _Asciidoc Zip_ if you want to export images as well
+. Click the _Convert_ button and wait till the files are generated
 . Put the content and images to the right destinations in the repository
 . Review/edit the exported file formatting
 ** Remove the macro references in the top of the document
@@ -433,9 +433,8 @@ and it can be done in a semi-automated way using the link:https://pandoc.org[Pan
 . Review the content. 
 ** If there are any images in the exported pages, replace `todo-replace-by-actual-path` by the actual directory path (`/images/...`)
 ** Wiki pages are often outdated, and it is nice to review them before submitting (e.g. rename "slave" to "agent", "workflow" to "pipeline", "Hudson" to "Jenkins", etc.)
-. Commit changes and create a pull request against the repository
-. Once the pull request is merged, replace the content on Wiki by a link to the new jenkins.io locations 
-  (use warning boxes to do that)
+. Commit changes, push them to your fork and create a pull request against link:https://github.com/jenkins-infra/jenkins.io[the repository]
+. Once the pull request is merged, create an `INFRA` Jenkins JIRA ticket to replace the content on Wiki by a link to the new jenkins.io locations 
 
 === Adding an event
 

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -108,6 +108,5 @@ The link:https://jenkins-wiki-exporter.g4v.dev/[Jenkins Wiki Exporter] can expor
 ** Verify formatting and spelling
 ** Wiki pages are often outdated, and it is nice to review them before submitting 
    (e.g. rename "slave" to "agent", "workflow" to "pipeline", "Hudson" to "Jenkins", etc.)
-
-. Once the pull request is merged, replace the content on Wiki by a link to the new GitHub location
-  (use info boxes to do that).
+. Commit changes, push them to your fork and create a pull request against the plugin repository
+. Once the pull request is merged, create an `INFRA` Jenkins JIRA ticket to replace the content on Wiki by a link to the new jenkins.io locations 


### PR DESCRIPTION
Now we can use https://jenkins-wiki-exporter.jenkins.io/ for any Wiki page, so let's simplify the guidelines

Fixes https://issues.jenkins-ci.org/browse/INFRA-2337

CC @halkeye @zbynek @timja 
