### PR TITLE
[WEBSITE-683] - Revamp the participate/review-changes page

### DIFF
--- a/content/participate/review-changes.adoc
+++ b/content/participate/review-changes.adoc
@@ -9,15 +9,15 @@ tags:
 ---
 
 Help us to review changes to code or documentation!
-All pull requests within Jenkins GitHub organizations are publicly open for reviews, and any reviews will be much appreciated.
+All pull requests within Jenkins GitHub organizations are publicly open for reviews and any reviews are much appreciated.
 
 == Code Reviews and Copy Editing
 
-Contributors and component maintainers may explicitly request request reviews from other community members.
-Below there are some queries which can help to find such open pull requests where help is needed:
+Contributors and component maintainers may explicitly request reviews from other community members.
+Below there are some queries which can help to find open pull requests where help is needed:
 
-- link:https://github.com/search?q=is%3Aopen+is%3Apr+team-review-requested%3Ajenkins-infra%2Fcopy-editors[Open pull requests for copy editing], mostly for Jenkins website
-- link:https://github.com/search?q=is%3Aopen+is%3Apr+%22jenkinsci%2Fcode-reviewers%22&type=Issues[Open pull requests for code reviews] (https://github.com/orgs/jenkinsci/teams/code-reviewers[@jenkinsci/code-reviewers] team is mentioned)
+- link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+is%3Aopen+is%3Apr+team-review-requested%3Ajenkins-infra%2Fcopy-editors[Open pull requests for copy editing], mostly for Jenkins website
+- link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+is%3Aopen+is%3Apr+%22jenkinsci%2Fcode-reviewers%22&type=Issues[Open pull requests for code reviews] (https://github.com/orgs/jenkinsci/teams/code-reviewers[@jenkinsci/code-reviewers] team is mentioned)
 - link:https://github.com/search?q=is%3Aopen+is%3Apr+%22jenkinsci%core-pr-reviewers%22&type=Issues[Open pull requests for code reviews in the Jenkins Core] (https://github.com/orgs/jenkinsci/teams/core-pr-reviewers[@jenkinsci/core-pr-reviewers] team is mentioned)
 
 *NOTE:* You will only be able to see the linked teams if you belong to the corresponding GitHub Team.

--- a/content/participate/review-changes.adoc
+++ b/content/participate/review-changes.adoc
@@ -8,21 +8,30 @@ tags:
   - review
 ---
 
-NOTE: This page is under development, there will be more content added soon.
-See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
-
 Help us to review changes to code or documentation!
+All pull requests within Jenkins GitHub organizations are publicly open for reviews, and any reviews will be much appreciated.
 
 == Code Reviews and Copy Editing
 
-You can help review changes to the code and the documentation through following lists:
+Contributors and component maintainers may explicitly request request reviews from other community members.
+Below there are some queries which can help to find such open pull requests where help is needed:
 
-- link:https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+team%3Ajenkinsci%2Fcode-reviewers[Open pull requests for code reviews]
-- link:https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+team%3Ajenkins-infra%2Fcopy-editors[Open pull requests for copy editing]
+- link:https://github.com/search?q=is%3Aopen+is%3Apr+team-review-requested%3Ajenkins-infra%2Fcopy-editors[Open pull requests for copy editing], mostly for Jenkins website
+- link:https://github.com/search?q=is%3Aopen+is%3Apr+%22jenkinsci%2Fcode-reviewers%22&type=Issues[Open pull requests for code reviews] (https://github.com/orgs/jenkinsci/teams/code-reviewers[@jenkinsci/code-reviewers] team is mentioned)
+- link:https://github.com/search?q=is%3Aopen+is%3Apr+%22jenkinsci%core-pr-reviewers%22&type=Issues[Open pull requests for code reviews in the Jenkins Core] (https://github.com/orgs/jenkinsci/teams/core-pr-reviewers[@jenkinsci/core-pr-reviewers] team is mentioned)
 
-*NOTE:* You will only be able to see the open pull requests linked above if you belong to the corresponding GitHub Team.
+*NOTE:* You will only be able to see the linked teams if you belong to the corresponding GitHub Team.
 
 == Reviewer team membership
 
-If you are interested to join the link:https://[*Copy Editors team*] or link:https://[*Code Reviewers team*], you can request membership in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Jenkins Developer mailing list].
-Such membership requires a track of contributions to Jenkins, and also a signed link:https://github.com/jenkinsci/infra-cla[Contributor License Agreement].
+If you are interested to join a reviewers team,
+you can request membership in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Jenkins Developer mailing list].
+You can also request membership in the GitHub web interface if you are already a member of a retrospective GitHub organization.
+
+Reviewer team links:
+
+* link:https://github.com/orgs/jenkins-infra/teams/copy-editors[Copy Editors team] - Jenkins website and documentation hosted there
+* link:https://github.com/orgs/jenkinsci/teams/code-reviewers[Code Reviewers team] - Jenkins plugins and other components
+* link:https://github.com/orgs/jenkinsci/teams/core-pr-reviewers[Core Reviewers team] - Jenkins Core and its modules/libraries
+
+Membership in all teams requires a track of contributions to Jenkins, and also a signed link:https://github.com/jenkinsci/infra-cla[Contributor License Agreement].


### PR DESCRIPTION
Before:

* Links to not show the relevant content
* Links require authentication and GitHub org membership

Now:

* Anyone can see the pull requests in the links, they are more or less relevant
* More content

![image](https://user-images.githubusercontent.com/3000480/68949755-0e64fe80-07bb-11ea-8ae8-700fcad817e5.png)



