### PR TITLE
Fix CODEOWNERS for GSoC entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 content/ @jenkins-infra/copy-editors
 
 # GSoC
-content/projects/gsoc @jenkins-infra/gsoc
-content/*gsoc* @jenkins-infra/gsoc
+content/projects/gsoc/ @jenkins-infra/gsoc
+*gsoc* @jenkins-infra/gsoc
 
 # Hacktoberfest
 *hacktoberfest* @jenkins-infra/hacktoberfest


### PR DESCRIPTION
Apparently it does not work due to whatever reason