### PR TITLE
Remove outdated info from Platform SIG page

### DIFF
--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -72,6 +72,7 @@ ARM architecture support, adapting RedHat packaging to best practices, etc.)
 * Rework of Windows installers
 ** New version of installers for 64bit platforms
 ** Removal of Java bundling
+** Creating an official link:https://chocolatey.org/packages/jenkins[Jenkins Chocolatey package]
 * Enabling continuous delivery for Jenkins packaging
 ** Experimental DockerHub organization and deployments from ci.jenkins.io (jep:217[])
 

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -85,53 +85,6 @@ At these meetings we discuss project statuses and do presentations/demos.
 You can find and contribute to the agenda for the incoming meetings
 link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y/edit?usp=sharing[here].
 
-Meetings will be conducted and recorded via Jenkins Hangouts-on-Air.
-Participant links will be posted in the SIG Gitter Chat within 10 minutes before the meeting starts.
-
-==== 2018-12-04
-
-Java 11 preview availability sign-off and Docker packaging
-
-* link:https://docs.google.com/document/d/1s4XhfmhgVa6ZHcwGhOIrwL-6wc9v9qXhym96BiwWUrQ/edit?usp=sharing[Meeting notes]
-* link:https://www.youtube.com/watch?v=RohXaGiDViw[Youtube recording]
-
-==== 2018-11-19. Project sync-up
-
-Project sync-ups: Windows Installers, Java 11 packaging, Multi-architecture Docker images.
-
-* link:https://docs.google.com/document/d/1FARi55vDjsdzi6Nj9ZB9e1wh2dU8nyWK6mq_cge0ceg/edit?usp=sharing[Meeting notes]
-* link:https://youtu.be/Rv-KvlGvnio[Youtube recording]
-* link:https://docs.google.com/presentation/d/1lw4unaFhsQk7a8HzhxhgTK4X2X2ocv_W_VW7aoH2WkM/edit?usp=sharing[Slides: Java 11 Status update]
-
-==== 2018-09-27. Project sync-up
-
-Project sync-ups: Java 11 packaging, Multi-architecture Docker images.
-
-* link:https://docs.google.com/document/d/1nIz1STmwOVMJ3vx68m6Xc4pv2oEKDRdyeYUNI8zZJsg/edit?usp=sharing[Meeting notes]
-* link:https://www.youtube.com/watch?v=JmOnJopFix0[Video recording]
-
-==== 2018-08-29. Multi-architecture Docker images
-
-Sync-up call about jira:52785[Support of Multi-Architecture Docker images in Jenkins].
-We discussed ways to get these images built and/or hosted within Jenkins project.
-
-* link:https://docs.google.com/document/d/1YofL2uhy7xAa1mx_qFdDvDg4P-molmhDwFD0-8xX8mI/edit?usp=sharing[Meeting notes]
-* link:https://www.youtube.com/watch?v=6SeDJXgzUCA[Youtube video]
-
-==== 2018-08-23. Eclipse OpenJ9 and Jenkins
-
-This online meetup is about Eclipse OpenJ9 and Jenkins.
-The discussion will be led by Steve Poole (Eclipse Openj9), and Tracy Miranda where they aim to shed light on some questions.
-Can Jenkins stand to gain any performance boosts by taking advantage of Eclipse OpenJ9 and its optimizations?
-How can the two open source communities collaborate to drive improvements for Jenkins running in the cloud?
-
-* link:https://www.meetup.com/Jenkins-online-meetup/events/253769950/[Jenkins Online Meetup page]
-* link:https://docs.google.com/document/d/1RuD5f78bpakBmWy0bwap424IysxV1B3uj2-NbkTC9E0/edit#[Meeting notes]
-
-==== 2018-08-15. Status meeting
-
-Status sync-up: Java 10+ support in Jenkins (JEP-211),
-64-bit Windows installers, Chocolatey packaging, and other topics.
-
-* link:https://www.youtube.com/watch?v=bbWO89HPMUM[Youtube video]
-* link:https://docs.google.com/document/d/1OgQCeyHNEV2GVx6phsNX_RtzpAiJWtKLUdAm1NDF6vY/edit[Meeting Agenda and Notes]
+Meetings are conducted and recorded via Zoom.
+Participant links are posted in the link:https://gitter.im/jenkinsci/platform-sig[SIG Gitter Chat] within 10 minutes before the meeting starts.
+Meeting recordings are posted to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -67,13 +67,11 @@ ARM architecture support, adapting RedHat packaging to best practices, etc.)
 
 === Ongoing projects
 
-* Java 11 support in Jenkins (jep:211[])
 * Multi-architecture Docker images
 ** Enabling official images to run on Arm, IBM s390x, and other platforms
 * Rework of Windows installers
 ** New version of installers for 64bit platforms
 ** Removal of Java bundling
-** Creating an official link:https://chocolatey.org/packages/jenkins[Jenkins Chocolatey package]
 * Enabling continuous delivery for Jenkins packaging
 ** Experimental DockerHub organization and deployments from ci.jenkins.io (jep:217[])
 

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -54,7 +54,7 @@ The group focuses on technologies used in Jenkins:
 
 Platform SIG may be cooperating with other groups.
 For example, we will be cooperating with the link:/sigs/cloud-native[Cloud-Native Jenkins group]
-if the topics related to Cloud-Native platforms like Kubernetes or Docker.
+on topics related to Cloud-Native platforms like Kubernetes or Docker.
 
 === Topics
 


### PR DESCRIPTION
## Remove outdated info from Platform SIG page

* Old meeting notes are in the meeting notes file, not needed on the page
* Remove completed projects from ongoing projects list
* Minor phrasing improvement