### PR TITLE
Chat page: remove botbotme, link the project infrastructure

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -47,7 +47,7 @@ NOTE: if you have a question about Jenkins, just ask it -- don't ask whether you
 It's common to not receive an answer for quite a while if no active contributors are currently checking IRC.
 In that case, just stick around, and periodically (every few hours) ask your question again.
 
-Conversations in this channel are automatically archived to both https://echelog.com/?jenkins[echelog] and https://botbot.me/freenode/jenkins/[botbot.me].
+Conversations in this channel are automatically archived to https://echelog.com/?jenkins[echelog].
 
 We use the *jenkins-admin* bot to automate common administrative operations.
 Its use is limited to users with _voice_ or _op_ in this channel.
@@ -74,7 +74,7 @@ We don't discuss Jenkins -- the software -- here. You can find conversation logs
 
 === `#jenkins-infra`
 
-Discussions of the Jenkins project infrastructure, i.e. most services running on `jenkins.io`, `jenkins-ci.org`, and related domains.
+Discussions of the link:/projects/infrastructure/[Jenkins project infrastructure], i.e. most services running on `jenkins.io`, `jenkins-ci.org`, and related domains.
 
 === Cloaks
 


### PR DESCRIPTION
CC @timja , follow-up to the https://issues.jenkins-ci.org/browse/INFRA-2346 investigation.
BotBotMe is defunct, see https://lincolnloop.com/blog/saying-goodbye-botbotme/