### PR TITLE
[WEBSITE-405] Plugin site: configurable title, description and OG image

### DIFF
--- a/content/_ext/validator.rb
+++ b/content/_ext/validator.rb
@@ -73,7 +73,6 @@ class Validator
 
   def check_file(path, context)
     full = "#{File.dirname(__FILE__)}/..#{path}"
-    puts File.expand_path(full)
     if !File.file?(full)
       warning "Invalid file path #{path} for #{context}"
     end

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -8,6 +8,13 @@
         - description = page.overview
       - else
         - description = "Jenkins – an open source automation server which enables developers around the world to reliably build, test, and deploy their software"
+    - if page.opengraph.nil?
+      - opengraph_image = "images/logo-title-opengraph.png"
+    - else 
+      - opengraph_image = page.opengraph[:image]
+    - unless opengraph_image.start_with? "{{"
+      - opengraph_image = expand_link(opengraph_image)
+
     %title
       = page.title
     %meta{:'http-equiv' => 'Content-Type', :content => 'text/html; charset=UTF-8'}/
@@ -36,20 +43,14 @@
     %meta{:content => "@JenkinsCI", :name => "twitter:creator"}/
 
     / Twitter Summary card images must be at least 120x120px
-    - if page.opengraph.nil?
-      %meta{:content => expand_link("images/logo-title-opengraph.png"), :name => "twitter:image"}/
-    - else
-      %meta{:content => expand_link(page.opengraph[:image]), :name => "twitter:image"}/
+    %meta{:content => opengraph_image, :name => "twitter:image"}/
     / Open Graph data
     %meta{:content => page.title, :property => "og:title"}/
     %meta{:content => "article", :property => "og:type"}/
     %meta{:content => expand_link(page.output_path), :property => "og:url"}/
     %meta{:content => description, :name => "og:description"}/
     %meta{:content => page.title, :property => "og:site_name"}/
-    - if page.opengraph.nil?
-      %meta{:content => expand_link("images/logo-title-opengraph.png"), :name => "og:image"}/
-    - else
-      %meta{:content => expand_link(page.opengraph[:image]), :property => "og:image"}/
+    %meta{:content => opengraph_image, :name => "og:image"}/
 
     - if page.css
       - for style in page.css

--- a/content/template.html.haml
+++ b/content/template.html.haml
@@ -1,0 +1,14 @@
+---
+layout: default
+title: "{{ title }}"
+description: "{{ description }}"
+opengraph:
+  image: "{{ opengraphImage }}"
+section: plugins
+uneditable: true
+---
+
+- # This page is required by the plugins site at plugins.jenkins.io --
+- # it's periodically pulled in by that site to always show an up to date frame (download links etc.)
+
+%div#grid-box


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-405 and https://gitter.im/jenkinsci/docs?at=5ddaf97ec52bc74c9685740f

To use this the plugin site can download `jenkins.io/template` instead of `jenkins.io/plugins`, the latter can be removed after the switch.

CC @timja @halkeye 