### PR TITLE
GSoC 2020 process simplifications for students and project ideas

### DIFF
--- a/content/projects/gsoc/2020/project-ideas.html.haml
+++ b/content/projects/gsoc/2020/project-ideas.html.haml
@@ -38,10 +38,19 @@ project: gsoc
   Other ideas may be proposed by interested mentors and students (e.g. new features in the core, "write a plugin for MY_TOOL_OR_SERVICE", etc.).
   Such project applications will be considered though applicants may need to work
   with the community and GSoC org admins to find potential mentors.
-  More info:
+  To add a new project idea:
   = succeed '.' do
     %a{:href => expand_link("/projects/gsoc/proposing-project-ideas/")}
       proposing project ideas
+
+%h3
+  Ideas accepted
+
+.markdown
+  Below you can see the list of project ideas that have been accepted.
+  The scope of these ideas is well known and we don't normally expect deep changes.
+  You are welcome to comment on these ideas. We welcome mentors to join the mentor teams,
+  and we invite students to submit project proposal applications in relation to these ideas.
 
 %table.pi_table{:border => 1}
   %tbody

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -11,20 +11,29 @@ project: gsoc
 New ideas for GSoC can be proposed by mentors, students and/or anyone in the Jenkins
 community with an idea they'd like to see implemented.
 
+Note: Project ideas should not be confused with link:../students#student-proposals[student proposals].
+
 == Proposal quick start
 
-If you have an interesting project that meets our requirements, you can kick off
-the process by:
+If you would like to propose a project idea to the Jenkins community for the GSoC program:
 
-. Making a copy of the
-  link:https://docs.google.com/document/d/1l5SdcLnlCwWA6qH8FKT9XC714Dl1XJ9lyy1CKDdKKAU[project proposal template]
-  and create a new Google Document describing the project proposal. Make sure to set the permissions so
-  members of the community can comment on it.
-. When the project is ready for consideration, contact the GSoC org admins via the
-  link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] or the
-  link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list].
+. share your idea on the
+link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list]
+. use `[GSOC 2020 PROJECT IDEA] Title of idea` as the subject
+. if you idea gets good feedback, create a pull-request:
+.. fork and clone the link:https://github.com/jenkins-infra/jenkins.io[jenkins.io] repository
+.. create a new `.adoc` file under the
+link:https://github.com/jenkins-infra/jenkins.io/tree/master/content/projects/gsoc/2020/project-ideas[project-ideas]
+folder with your project idea
+.. look at existing idea files for the format you should follow (many existing ideas contain a link to a google doc but this is optional)
+.. in the pull-request comment box
+... add `CC @jenkins-infra/gsoc` so we get a notification
+... add a link to the related mailing list thread
+.. post the pull-request link to the
+link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] and to the
+link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list] as a follow up to your original thread.
 
-The full proposal process is link:#acceptance-process[documented here].
+The goal when you submit a project idea is to attract attention and feedback from the community.
 
 == Requirements
 
@@ -53,60 +62,3 @@ that will find potential mentors for every proposal, especially for narrow areas
 During the selection phase we won't be able to accept proposals without mentors, so
 we highly recommend getting initial feedback in the mailing lists before spending too much
 time on such proposals.
-
-[#acceptance-process]
-== Acceptance process for new project proposals
-
-Project proposals are tracked in two places. When first proposed they are added to
-the link:https://docs.google.com/document/d/14N6kCShmxy4SumT0khuEFxXYZE4v1_bimK66PJuBHzM/edit#heading=h.o5kqo7p5rgto[project
-  table in the projects doc]. Once a project is accepted as a draft, it is also published to
-  link:/projects/gsoc/2019/project-ideas[jenkins.io].
-
-Projects are proposed by a project champion who is a potential mentor or interested student.
-Please see
-link:/projects/gsoc/roles-and-responsibilities[this list of roles] for
-more information about the different project roles.
-The champion will be responsible for shepherding the
-proposal through the process. The acceptance process includes the following steps:
-
-. The project champion makes a copy of the
-  link:https://docs.google.com/document/d/1l5SdcLnlCwWA6qH8FKT9XC714Dl1XJ9lyy1CKDdKKAU[project proposal template]
-  and creates a new Google Document describing the project proposal.
-. When the project is ready for consideration, the project champion contacts GSoC org admins via the
-  link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] or the
-  link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list].
-. An org admin will add the proposal to the
-  link:https://docs.google.com/document/d/14N6kCShmxy4SumT0khuEFxXYZE4v1_bimK66PJuBHzM/edit#heading=h.o5kqo7p5rgto[project
-    table in the projects doc],
-  giving it a status of "NEW"
-. The link:/projects/gsoc/2019/#org-admins[GSoC org admins] and other mentors discuss the the proposal with the champion and provide initial feedback via the link:https://gitter.im/jenkinsci/gsoc-sig[gitter chat] and as comments to the proposal document.
-. Once the proposal is consistent with the GSoC template requirements, a GSoC org admin will change the status to "DRAFT"
-. An org admin publishes the draft project idea on link:/projects/gsoc/2019/project-ideas/#draft-project-ideas[jenkins.io]
-. The project champion reaches out to the community to get additional feedback about the proposal
-  (Community channels include chats, mailing lists, and the SIG meetings).
-  NOTE: The champion should try to recruit one or more mentors from the community. Having
-  multiple mentors is crucial to the success of the project.
-  The proposal document should
-  be updated to reflect any changes suggested by the community.
-. Once the champion and org admins feel the proposal has been developed enough to be viable:
-  . The org admins change the status of the proposal to "ACCEPTED" in the summary table
-  . Contact Org admin publishes the current state of the document to the Jenkins website
-  . After this change, champions/mentors should synchronize the google doc with jenkins.io
-. The contact org admin updates the project at link:https://jenkins.io/projects/gsoc/2019/project-ideas[jenkins.io],
-  moving from the drafts table to the accepted table, and updates the status to "PUBLISHED"
-
-Project statuses:
-
-* NEW - a google doc exists for the project, but it is sill under development, and not not yet formally correct.
-* DRAFT - the proposal meets GSoC standards, and is ready for feeback from the community
-* ACCEPTED - the project has been accepted, but is not yet on jenkins.io
-* PUBLISHED - the project has been published to jenkins.io
-* REJECTED - project is not compliant with GSoC rules. Can be reworked and reconsidered as Draft
-* STALLED
-
-** champion cancels it or abandons it (becomes unresponsive). Anyone can pick up the
-    idea and become a new Champion.
-** The student leaves the project before the end of GSoC.
-
-* ARCHIVED - The project has been removed from jenkins.io. It can be picked up by a new champion.
-* DONE - The project is completed by the end of the program.

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -20,7 +20,7 @@ If you would like to propose a project idea to the Jenkins community for the GSo
 . share your idea on the
 link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list]
 . use `[GSOC 2020 PROJECT IDEA] Title of idea` as the subject
-. if you idea gets good feedback, create a pull-request:
+. if your idea gets good feedback, create a pull-request:
 .. fork and clone the link:https://github.com/jenkins-infra/jenkins.io[jenkins.io] repository
 .. create a new `.adoc` file under the
 link:https://github.com/jenkins-infra/jenkins.io/tree/master/content/projects/gsoc/2020/project-ideas[project-ideas]

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -32,6 +32,7 @@ We cannot make any exception. Please:
 
 . Check out the link:/projects/gsoc/2020/project-ideas[GSoC 2020 Project ideas]
 . Select an interesting project idea or draft your own proposal.
+. Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
 . Join the _jenkinsci-gsoc-all-public@googlegroups.com_ mailing list (link:https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public[archives]).
 . Join the link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC Gitter Chat]
@@ -109,11 +110,15 @@ development organization, where all proposals and ideas are debated
 in public and are visible to the entire community. There is always a
 public debate on ideas and proposals.
 
+[#student-proposals]
 ===== Student Proposals
 
-We expect proposals to contain all the sections discussed in the
+We expect proposals from students to contain all the sections discussed in the
 link:https://google.github.io/gsocguides/student/[GSoC Student Guide],
 specifically the link:https://google.github.io/gsocguides/student/writing-a-proposal#elements-of-a-quality-proposal[Elements of a Quality Proposal].
+
+Students need to use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template]
+to write their proposals. Student proposals should not be confused with link:../proposing-project-ideas[project ideas].
 
 We strongly encourage students to engage with the mentors as early as
 possible. If you wait until the last few days to submit a proposal,
@@ -145,8 +150,7 @@ It is required to join the mailing list for the initial review and feedback coll
 === First email to jenkinsci-gsoc-all-public
 
 * Selecting a thread subject
-** Please use the _[PROJECT_NAME]_ prefix in your email thread subjects.
-*** Creating personal intro thread is also fine.
+** Please use the _[GSOC2020 PROPOSAL] Name and Title_ subject in mailing lists.
 * Contents. In the first e-mail we would be interested to see the following information:
 ** A short self-introduction: your area of study, interests, background
 ** Motivation letter. Why are you interested in the Jenkins project? Which projects ideas do you want to work on?

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -149,8 +149,8 @@ It is required to join the mailing list for the initial review and feedback coll
 
 === First email to jenkinsci-gsoc-all-public
 
-* Selecting a thread subject
-** Please use the _[GSOC2020 PROPOSAL] Name and Title_ subject in mailing lists.
+* Please use the _[GSOC 2020 PROPOSAL] Your Name and Project Title_ subject in mailing lists.
+** If another student is interested in the same project idea, you can contribute to their thread, or start your own thread.
 * Contents. In the first e-mail we would be interested to see the following information:
 ** A short self-introduction: your area of study, interests, background
 ** Motivation letter. Why are you interested in the Jenkins project? Which projects ideas do you want to work on?


### PR DESCRIPTION
These are the changes I am proposing to the GSoC 2020 process. I think this makes things simpler.

* Provide a template for student proposals
* Simplify the idea proposal submission process
  * In this simpler process, project ideas are submitted in the mailing list
  * if they get a positive feedback, the champion creates pull-request
  * we no longer track them in the google table like in 2019
  * there are no "states", we simply review the idea proposal in the mailing list and in the pull-request