### PR TITLE
Add the instruction after Installation for MacOS

### DIFF
--- a/content/_partials/osx-brew-installer.html.haml
+++ b/content/_partials/osx-brew-installer.html.haml
@@ -39,6 +39,8 @@ Sample commands:
     %code
       = "brew upgrade #{page.tag}" 
 
+After starting the Jenkins service, browse to http://localhost:8080 and follow the instructions to complete the installation.
+
 Also see the external materials for installation guidelines. For example,
 %a{:href => "https://www.macminivault.com/installing-jenkins-on-macos/"}
   this blogpost


### PR DESCRIPTION
I've installed Jenkins for MacOS with https://jenkins.io/download/lts/macos/.
After `$ brew services start jenkins-lts` there was no information about access to the service.

Proposal:
Pick up No. 4 and 5 from https://jenkins.io/doc/pipeline/tour/getting-started/#download-and-run-jenkins for MacOS users