### PR TITLE
[WEBSITE-700] - Move the Governance Meeting agenda to jenkins.io and Google Docs

### DIFF
--- a/content/blog/2012/2012-09-24-jenkins-project-meeting-in-the-meat-space-call-for-agenda.md
+++ b/content/blog/2012/2012-09-24-jenkins-project-meeting-in-the-meat-space-call-for-agenda.md
@@ -15,7 +15,7 @@ As you may or may not know, the Jenkins project has a [bi-weekly IRC meeting](ht
 
 Next Sunday, we'll bring this project meeting live to [Jenkins User Conference San Francisco](https://www.cloudbees.com/jenkins-user-conference-2012-san-francisco.cb).
 
-Since this is an unique opportunity to engage people who don't normally come to these meetings, I'd like to encourage everyone to propose agenda items and add it to [the agenda page](https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda#GovernanceMeetingAgenda-JenkinsUserConferenceMeeting@SanFrancisco).
+Since this is an unique opportunity to engage people who don't normally come to these meetings, I'd like to encourage everyone to propose agenda items and add it to [the agenda page](https://jenkins.io/project/governance-meeting).
 
 The Wiki page lists all the past meetings, so you can get a sense of what it is like. But this time, we hope to have a good number of users to the meeting, not just project insiders. So if you have things you'd like to get users feedback on, or if you like project insiders to update you on things, please don't hesitate to add them.
 

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -1,0 +1,435 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2011"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2011-Dec14thMeeting]]
+== Dec 14th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20111214T11&p1=224&ah=1&sort=1[December
+14th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's action items
+* Infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+* Add https://wiki.jenkins.io/display/~aheritier[Unknown User
+(aheritier)] to the "users-core" puppet module, giving him administrator
+access on all Jenkins infrastructure machines.
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-12-14-19.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-12-14-19.03.log.html[raw]
+
+[[GovernanceMeetingArchive2011-Nov30thMeeting]]
+== Nov 30th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20111130T11&p1=224&ah=1&sort=1[November
+30th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting action items
+* infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+* Discuss plans for exhibiting at
+http://www.socallinuxexpo.org/scale10x/jenkins-ci[SCALE 10x] on January
+20-22 in Los Angeles, CA.
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Discuss plans for http://www.fosdem.org/2012/[FOSDEM 2012]. What
+should we do (dev room talk? lightning talk? Jenkins stand?), and who
+will be going? (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+* Jenkins CIA program https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)]
+* Context: people like http://t.co/CYzvqOUB[those Jenkins stickers].
+We'd like to use them well to spread words about Jenkins.
+* LTS 1.424.1 release (vjuranek)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-11-30-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-11-30-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2011-Nov9thMeeting]]
+== Nov 9th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Governance+Meeting&iso=20111109T11&p1=283[November
+9th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 3am Tokyo.
+
+* Recap last meeting action items
+* (*This was unaddressed in the last meeting*) State of the Jenkins
+development environment (@kutzi)
+** the environment makes it hard for part time developers to work in the
+free time on Jenkins, because it's often broken. See
+http://jenkins.361315.n4.nabble.com/Error-running-mvn-hudson-dev-run-td3906244.html[here]
+or
+http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuchMethodError-org-codehaus-groovy-ast-ModuleNode-getStarIm-td3868116.html[here] or
+http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
+** What can we do about it?
+* Add https://wiki.jenkins.io/display/~jieryn[Unknown User (jieryn)] to
+the "users-core" puppet module, giving him administrator access on all
+Jenkins infrastructure machines.
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Appprove CloudBees request for the "Jenkins Enterprise from CloudBees"
+use request as per
+https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
+Document] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+* LTS discussion. Branch is ready, I say time for RC
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+** Augmenting LTS Test Matrix with written test plans
+(https://wiki.jenkins.io/display/~ryan[Unknown User (ryan)])
+** Backport of JENKINS-10989 and SECURITY-17 as
+http://jenkins.361315.n4.nabble.com/LTS-1-424-1-RC-td4015360.html#a4015852[suggested
+by Romain] (https://wiki.jenkins.io/display/~vjuranek[Unknown User
+(vjuranek)])
+** Security advisory handling.
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-11-09-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-11-09-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2011-Oct26thMeeting]]
+== Oct 26th Meeting
+
+WHEN http://permatime.com/GMT/2011-10-26/18:00[October 26th 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* State of the Jenkins development environment (@kutzi)
+** the environment makes it hard for part time developers to work in the
+free time on Jenkins, because it's often broken. See
+http://jenkins.361315.n4.nabble.com/Error-running-mvn-hudson-dev-run-td3906244.html[here]
+or
+http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuchMethodError-org-codehaus-groovy-ast-ModuleNode-getStarIm-td3868116.html[here] or
+http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
+** What can we do about it?
+* Bringing old Jenkins plugins up to a common requiredCore (@jieryn)
+* Infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+** SPI donation status for cucumber
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-10-26-18.04.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-10-26-18.04.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForOct12thMeeting]]
+== For Oct 12th Meeting
+
+WHEN http://permatime.com/GMT/2011-10-12/18:00[October 12th 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap of last meeting's action items
+
+[[GovernanceMeetingArchive2011-ForSept28thMeeting]]
+== For Sept 28th Meeting
+
+WHEN http://permatime.com/GMT/2011-09-28/18:00[September 28th 18:00
+UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap of last meeting's action items
+* Donation status update (@orrc)
+** Awesome progress towards
+https://wiki.jenkins-ci.org/display/JENKINS/Donation[the goal]
+** Can we make donating easier for companies/Europeans/recurring
+payments? (see
+http://groups.google.com/group/jenkinsci-users/browse_thread/thread/9a21a1ec4ea2a1cd#6cd5e5a4aa5b0776[this
+thread])
+* Choosing next LTS baseline candidate (Yahoo! folk?)
+* https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
+document] review/approval
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-09-28-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-09-28-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForSept14thMeeting]]
+== For Sept 14th Meeting
+
+WHEN http://permatime.com/GMT/2011-09-14/18:00[September 14th 18:00
+UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap of last meeting's action items (@rtyler)
+* Donation status update
+* https://groups.google.com/group/jenkinsci-dev/browse_frm/thread/04bbf72c3911ec99#[governance
+document review]
+* Choosing next LTS baseline candidate
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-09-14-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-09-14-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForAug31stMeeting(rescheduledfromAugust24th)]]
+== For Aug 31st Meeting (rescheduled from August 24th)
+
+WHEN http://permatime.com/GMT/2011-08-31/18:00[August 31st 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Plugin deprecations
+https://wiki.jenkins-ci.org/display/JENKINS/Proposed+Plugin+Deprecation
+* Jenkins User Conference
+http://jenkins-ci.org/content/jenkins-user-conference
+* Jenkins Mailing List SPAM - can we enable spam protection? This would
+require some trusted people to authorize first-time mail sources.
+See http://groups.google.com/support/bin/answer.py?hl=en&answer=186997 for
+further information. @jieryn
+* There are about a dozen plugins with pull requests in excess of 30
+days - what should we do about this? See
+https://wiki.jenkins-ci.org/display/JENKINS/Pending+Pull+Requests
+@jieryn
+* LTS 1.409.2 - test status, ready to release?, if yes, when will be
+release @vjuranek
+* Official commit workflow for core committers @dty
+* Can we link this
+page https://wiki.jenkins.io/display/JENKINS/Issue+Tracking[Issue
+Tracking] on a prominent place to get better bug reports? @kutzi
+* Feedback on the request for official definitions of stable, unstable,
+failure: https://issues.jenkins-ci.org/browse/JENKINS-10763 @kutzi
+* Donation drive to refill rtyler's pocketbook @rtyler
+* Infra update from rtyler
+** status of mirrors.jenkins-ci.org
+** cabbage update
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-08-31-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-08-31-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForAug11thMeeting]]
+== For Aug 11th Meeting
+
+WHEN http://permatime.com/GMT/2011-08-11/18:00[August 11th 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Plugin deprecations
+https://wiki.jenkins-ci.org/display/JENKINS/Proposed+Plugin+Deprecation
+* Jenkins User Conference
+http://jenkins-ci.org/content/jenkins-user-conference
+* Trademark Registration Status
+* Kohsuke wanted to discuss this (JENKINS-9488 - align topbar colors):
+https://github.com/jenkinsci/jenkins/pull/179
+* Adding olamy as an owner for jenkinsci on GitHub for additional
+coverage/redundancy.
+* When is it time to release a new LTS release?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-08-11-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-08-11-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForJul20thMeeting]]
+== For Jul 20th Meeting
+
+WHEN http://permatime.com/GMT/2011-07-20/18:00[July 20th 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+*
+
+[[GovernanceMeetingArchive2011-ForJul6thMeeting]]
+== For Jul 6th Meeting
+
+WHEN http://permatime.com/GMT/2011-07-06/18:00[July 6th 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* How do we handle pull requests which are pending for a long time
+** see http://echelog.matzon.dk/logs/browse/jenkins/1309816800 (since
+~19:40) for a related discussion
+* What is the current state of the
+'https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new
+EMailer]' ?
+** Maybe to get things going again, deprecate the built-in EMailer and
+deliver email-ext bundled?
+* Infra update from https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)] regarding new machines at the http://osuosl.org/[OSUOSL]
+* CLA discussion. We should start collecting CLA for core, and our
+current plan on the record was to reuse Apache CLA.
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-07-06-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-07-06-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForJun22ndMeeting]]
+== For Jun 22nd Meeting
+
+WHEN http://permatime.com/GMT/2011-06-22/18:00[June 22nd 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Commit message formatting
+* Talk about
+the https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2011#[Test
+Support Proposal] by Christoph Kutzinski
+* What is the current state of the
+'https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new
+EMailer]' ?
+** Maybe to get things going again, deprecate the built-in EMailer and
+deliver email-ext bundled?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-06-22-18.05.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-06-22-18.05.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForJun8thMeeting]]
+== For Jun 8th Meeting
+
+WHEN http://permatime.com/GMT/2011-06-08/18:00[June 8th 18:00 UTC],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Foundation update
+* LTS update
+* Discussion: fixing the test harness
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-06-08-18.04.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-06-08-18.04.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForMay24thMeeting]]
+== For May 24th Meeting
+
+WHEN http://permatime.com/UTC/2011-05-24/16:00[May 24th 16:00 UTC],
+which is 9am PDT, 12pm EDT, 6pm CEST, 1am Tokyo.
+
+* Recap of
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-05-11-18.01.html[Action
+items] from last meeting
+* Discussion of
+https://wiki.jenkins.io/display/JENKINS/Possible+Jenkins+Umbrella+Foundations[Possible
+Jenkins Umbrella Foundations] and
+https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2011#[Jenkins
+Hudson Reconciliation Requirements] community input, and what the next
+steps are in both areas.
+* Discuss state of the Jenkins test harness:
+** Tests take ages to finish
+** fail locally - with cryptic error messages - while succeeding on
+Jenkins-on-Jenkins. See e.g. http://pastebin.com/49N472Xu 
+** unit testing often isn't possible because of the Hudson god-class
+resp. final classes
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-05-24-16.09.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-05-24-16.09.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForMay11thMeeting]]
+== For May 11th Meeting
+
+WHEN: http://permatime.com/GMT/2011-05-11/18:00[May 11th 6pm GMT], which
+should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Discuss progress with SFC/SPI/ASF/EF regarding an umbrella
+organization
+* Decide whether a permalink from
+http://www.jenkins-ci.org/node[jenkins-ci.org] to John Smart's "Jenkins:
+The Definitive Guide" book is okay
+* Discuss hardware access for drulli and olamy (primarily eggplant)
+* Can the localization committers push their changes directly? If so,
+please put the approval in the record(from tyuki39)
+* Discuss status on the http://www.cafepress.com/jenkinsci[JenkinsCI
+cafe press] store
+* Discuss whether to add the git plugin to the core release bundle.
+* Updates:
+** Infra update from rtyler
+*** Status of new machines at the OSUOSL
+*** Status of MirrorBrain fixes/bandwidth allocation
+*** Status of proper backups at Contegix
+*** Discuss dealing with bandwidth issues and Debian APT clients (DNS
+round robin to OSUOSL?)
+
+MINUTES:
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-05-11-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-05-11-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForApril27thmeeting]]
+== For April 27th meeting
+
+WHEN: http://permatime.com/GMT/2011-04-27/18:00[April 27th 6pm GMT],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Updates
+** fcamblor to report the progress/status on plugin compat tester
+** Trademark registration status
+** Infra updates from rtyler
+
+MINUTES:
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-04-27-18.04.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-04-27-18.04.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForApril13thmeeting]]
+== For April 13th meeting
+
+WHEN: http://permatime.com/GMT/2011-04-13/18:00[April 13th 6pm GMT],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Review/discussion of aheritier's upcoming proposal for details of JIRA
+project split.
+* Updates:
+** "ULTIMATE ROBO LOGO SHOWDOWN" results
+** Trademark registration status
+** SFC/SPI/Apache status
+
+MINUTES:
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-04-13-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-04-13-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForMarch30thmeeting]]
+== For March 30th meeting
+
+WHEN: http://permatime.com/GMT/2011-03-30/18:00[March 30th 6pm GMT],
+which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
+
+* Review/discussion of aheritier's upcoming proposal for details of JIRA
+project split.
+* Updates:
+** Logo contest status
+** Trademark registration status
+** SFC response?
+* CLA discussion continued
+* Discussion on the way we can strengthen plugins and avoid unnecessary
+duplication/forks
+
+MINUTES:
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-03-30-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-03-30-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2011-ForMarch16thmeeting]]
+== For March 16th meeting
+
+* WHEN: March 16th, 2pm PST/4pm EST/9pm GMT/10pm CET
+
+* Review/discussion of aheritier's upcoming proposal for details of JIRA
+project split.
+* Updates:
+** Trademark registration status
+** SFC response?
+* Discussion whether requiring a CLA is beneficial or not.
+* Logo contest status
+* Infra hardware status
+
+[[GovernanceMeetingArchive2011-ForMarch2ndMeeting]]
+== For March 2nd Meeting
+
+* Discuss what updates should be made to
+https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2011#[Copyright
+on source code]
+* Any conclusions to the
+http://groups.google.com/group/jenkinsci-dev/browse_thread/thread/6896f52428556beb[stable-branch/endorsed-release]
+discussion
+** QA processes in core, e.g. introduction of code review?
+* Update on the long-term governance plans / progress on umbrella
+organisation

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -1,0 +1,546 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2012"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2012-December12thMeeting]]
+== December 12th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20121212T11&p1=224&ah=1&sort=1[December
+12th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's items
+* Authorizing SSL certificate renewal
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Renewing jenkins-ci.org domain
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Website banner usage guideline for people in the events list.
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+** like maybe giving automatic 1 week access to future events
+* Donation status and what can we do more?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Adding https://wiki.jenkins.io/display/~larrys[Unknown User (larrys)]
+to the admin to combat spam.
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-12-12-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-12-12-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-November14thMeeting]]
+== November 14th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20121114T11&p1=224&ah=1&sort=1[November
+14th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's items
+* Balancing personal information of JUC attendees vs cost
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+** https://docs.google.com/spreadsheet/ccc?key=0ApE2WVyiXL0hdGZSRTZVQmdTN2VnVWdJMWZCNEJqa1E[financial
+report of past JUCs]
+* Forming the Events subgroup in the community for the purpose of
+coordinating and running event
+(https://wiki.jenkins.io/display/~lisawells[Unknown User
+(lisawells)]/https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+** Initial task – define model for user events so we can attract others
+to run them
+** Improve oversight of JUC – define conditions, expectations, involve
+community
+** Streamline approvals for event publications on Jenkins-ci.org, blog,
+& Twitter
+** let this group handle CIA program
+* Status of moving Jenkins to java 6 as minimal runtime
+(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-11-14-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-11-14-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-October31thMeeting]]
+== October 31th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20121031T11&p1=224&ah=1&sort=1[October
+31th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's items
+* Take over http://www.meetup.com/jenkinsmeetup/["Jenkins users and
+developers" group] at meetup.com? (costs $144 per year)
+* Check on budget for buying stickers for next year's SCaLE11x and
+FOSDEM conferences (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+* Accepting donations in Europe
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** I spoke to the
+http://www.ffis.de/Verein/spi-en.html[Euro-friends-of-SPI] and it seems
+we could become affiliated. Would be nice to get working before FOSDEM
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-31-18.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-31-18.03.log.html[raw]
+
+[[GovernanceMeetingArchive2012-October17thMeeting]]
+== October 17th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20121017T11&p1=224&ah=1&sort=1[October
+17th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's items
+* Picking next LTS (https://wiki.jenkins.io/display/~vjuranek[Unknown
+User (vjuranek)])
+* Advertising http://jenkins-ci.org/survey[survey] on
+http://jenkins-ci.org/ (for 2 more weeks until it closes)
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-17-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-17-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2012-JenkinsUserConferenceMeeting@SanFrancisco]]
+== Jenkins User Conference Meeting @ San Francisco
+
+We'll have the project meeting in the meat-space at
+http://www.cloudbees.com/jenkins-user-conference-2012-san-francisco.cb[Jenkins
+User Conference San Francisco]. While we are still working on logistics,
+the event will be transcribed to IRC and
+http://www.ustream.tv/channel/jenkins-ci[get broadcasted live]. So if
+you aren't physically in the event, please join us in our usual IRC
+channel.
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120930T18&p1=224&ah=1[September
+30th 18:00 PDT], which should be 9pm EDT, Oct 1st 1am UTC, Oct 1st 10am
+Tokyo.
+
+Please suggest your agenda. Unlike regular project meetings, order here
+is irrelevant because we'll decide what to cover before the meeting.
+Please try to come up with the agenda items that take advantages of
+unusual audience demographic.
+
+* Discussion about future funding source/plan / fiance report
+* What are the pain points? (from 10000ft perspective, not individual
+bugs or features.)
+* What should the development team focus on? Are we working on the right
+things? (from 10000ft perspective, not individual bugs or features.)
+* What are the barriers to participation?
+
+Topic suggestions
+
+[width="100%",cols="34%,33%,33%",options="header",]
+|===
+|who + |suggestion + |first thoughts +
+|https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+|Decommissioning "cabbage" and migrating some new services to OSUOSL VMs
+|
+
+|Domi + |There are to many plugins doing (nearly) the same, its really
+hard for users to decide which one fits his need the best |_- although
+we want to keep the barriers for new participants low, we should not
+blindly clone every repo._ +
+_- The ones allowed to do this, should act as some kind of gatekeepers,
+I know this sounds hard but I really think we should encourage people to
+enhance/improve existing plugins._ +
+_- I'd rather have more people working on the same plugin then adding a
+new one which looses its maintainer afar the first couple releases._
+
+|Domi + |Think bigger… many features are implemented in a way they work
+with small to midrange side installations, but when you have 100+
+Salves, 1000+ Users, 1000+ Jobs - things get more complicated. e.g.: +
+|_- which plugins are actually in use? how many times? where?_ +
+_- listing of all users in the security config gets too big_ +
+_- plugins should think about what is really a global config what should
+be on job level. (e.g. global acts as default only)_
+
+|Domi + |Think security… plugin developers should think about what
+features compromise security. |_- e.g. blindly providing groovy access
+to Jenkins internals is a security hole_ +
+_- maybe it makes sense for an administrator to disable single features
+in a plugin or he should be the one to decide whether his users are
+allowed to configure something instead of him._ +
+_- also keep the size of an installation in mind_
+
+|Domi + |There is more work done to improve the UI (separate branch):
+[https://github.com/jenkinsci/jenkins/tree/ui-changes +
+] |_- we should reactivate that work_
+
+|Tonylampada + |Speaking of funding, please don't forget mention
+http://www.freedomsponsors.org/[FreedomSponsors] |_- If people there
+have any feedback about the JIRA plugin, or the platform in general, I'm
+very interested!_ +
+_- Also, if Kohsuke is planning to mention FreedomSponsors in a slide,
+could someone please take a picture?_
+image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/smile.svg[(smile)]
+|===
+
+[[GovernanceMeetingArchive2012-September19thMeeting]]
+== September 19th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120919T11&p1=224&ah=1&sort=1[September
+19th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's items
+* Discussion about future funding source/plan
+* Add more hackers to the SECURITY project to give more
+visibility/opportunity for security issues to be addressed
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Review survey questions for JUC San Francisco (Lisa Wells)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-09-19-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-09-19-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2012-September5thMeeting]]
+== September 5th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120905T11&p1=224&ah=1&sort=1[September
+5th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Should the "Sponsor this issue" link be
+https://github.com/freedomsponsors/freedomsponsors-jira-plugin/issues/4[ommited
+for closed issues]?
+(https://wiki.jenkins.io/display/~tonylampada[Unknown User
+(tonylampada)])
+* Discussion about the
+https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
+Election Process] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+* Help wanted: spams are on the rise
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* FOSDEM travel grant
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-09-05-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-09-05-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2012-August22thMeeting]]
+== August 22th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120822T11&p1=224&ah=1&sort=1[August
+22nd 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[action
+items]
+* Travel grant for FOSDEM?
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[context]
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-22-18.06.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-22-18.06.log.html[raw]
+
+[[GovernanceMeetingArchive2012-August8thMeeting]]
+== August 8th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120822T11&p1=224&ah=1&sort=1[August
+8th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
+use of the name "Jenkins"]. Do we need to take any actions?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Demoing the
+http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
+JIRA plugin] - http://ambtest.freedomsponsors.org:8080/browse/TLM-1[live
+demo] /
+https://github.com/freedomsponsors/freedomsponsors-jira-plugin[installation
+instructions] (https://wiki.jenkins.io/display/~tonylampada[Unknown User
+(tonylampada)])
+* Upcoming event planning and brainstorming
+https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/bokUEoheAAs%5B1-25%5D[link1]
+https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/eFawHz1JWYg%5B1-25%5D[link2]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]).
+* Documentation of jenkins-admin IRC-bot infra, so that community can
+manage restart. (https://wiki.jenkins.io/display/~ndeloof[Unknown User
+(ndeloof)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-July25thMeeting]]
+== July 25th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120725T11&p1=224&ah=1&sort=1[July
+25th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
+use of the name "Jenkins"]. Do we need to take any actions?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Installing the
+http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
+JIRA plugin] - when it's finished development.
+(https://wiki.jenkins.io/display/~tonylampada[Unknown User
+(tonylampada)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-07-25-18.05.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-07-25-18.05.log.html[raw]
+
+[[GovernanceMeetingArchive2012-July11thMeeting]]
+== July 11th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120711T11&p1=224&ah=1&sort=1[July
+11th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-06-27-18.01.html[action
+items]
+* How much if any advertisement is acceptable on plugin pages (ex.
+https://wiki.jenkins.io/display/JENKINS/Warnings+Plugin[Warnings
+Plugin]) (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-07-11-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-07-11-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2012-June27thMeeting]]
+== June 27th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120627T11&p1=224&ah=1&sort=1[June
+27th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Baseline for next major LTS release
+(https://wiki.jenkins.io/display/~vjuranek[vjuranek]) 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-06-27-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-06-27-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-June13thMeeting]]
+== June 13th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120613T11&p1=224&ah=1&sort=1[June
+13th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Selenium tests, switch to Cucumber/Capybara (vjuranek)
+* New home for wiki.jenkins-ci.org
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* maven.jenkins-ci.org to repo.jenkins-ci.org switch voer
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+[[GovernanceMeetingArchive2012-May30thMeeting]]
+== May 30th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120530T11&p1=224&ah=1&sort=1[May
+30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Moving Subversion repository to GitHub
+https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]
+* Improving JonJ and IRC bot stability - JonJ gets stuck very often
+recently, IRC bot also seems to get stuck when forking repo (vjuranek,
+unfortunately cannot attend but can offer some help) 
+* Plugin JonJ on DEV@ or BuildHive
+https://wiki.jenkins.io/display/~jieryn[Unknown User (jieryn)]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-30-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-30-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-May2ndMeeting]]
+== May 2nd Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120502T11&p1=224&ah=1&sort=1[May
+2nd 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-14-04.02.html[action
+items]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-02-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-02-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Apr14thMeeting]]
+== Apr 14th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120414T21&p1=224&ah=1&sort=1[April
+14th 04:00 UTC], which should be 13th Fri 9pm PDT, 13th Fri midnight
+EDT, 14th Sat 5am CEST, 14th Sat 1pm Tokyo. +
+*This is a one off time different from the usual schedule*
+
+* Recap last meeting's action items
+* JUC Tokyo status updates
+(https://wiki.jenkins.io/display/~ikikko[Unknown User (ikikko)],
+https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)], and
+others)
+* Anything we can do for bridging the Japanese community?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-14-04.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-14-04.02.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Apr4thMeeting]]
+== Apr 4th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120404T11&p1=224&ah=1&sort=1[April
+4th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's action items
+* Move plugin CI jobs to jenkins.ci.cloudbees.com
+(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+* Proposal : ask for FOSS JProfiler licenses ->
+http://www.ej-technologies.com/buy/jprofiler/openSource
+(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+* Migrate plugins to get rid of glassfish repo
+(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-04-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-04-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Mar21stMeeting]]
+== Mar 21st Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120321T11&p1=224&ah=1&sort=1[March
+21st 18:00 UTC], which should be 11am PDT, 2pm EDT, 7pm CET, 3am Tokyo.
+
+* Recap last meeting's action items
+* Please sign CLAs (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+* Officially launching
+https://wiki.jenkins.io/display/JENKINS/Jenkins+CIA+Program[Jenkins CIA
+Program] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+* "Jenkins@cloud for GitHub" and "Jenkins@cloud by CloudBees" name usage
+approval (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-21-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-21-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Mar7thMeeting]]
+== Mar 7th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120307T11&p1=224&ah=1&sort=1[March
+7th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's action items
+* Review current status and plans for
+https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
+(https://wiki.jenkins.io/display/~slide.o.mix@gmail.com[Unknown User
+(slide.o.mix@gmail.com)])
+* Last-minute discussion on Google SoC mentors
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Baseline for next major LTS release
+(https://wiki.jenkins.io/display/~vjuranek[vjuranek])
+* Cut-over from http://maven.jenkins-ci.org/ to
+http://repo.jenkins-ci.org/ : PoC demo
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-07-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-07-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Feb22ndMeeting]]
+== Feb 22nd Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120222T11&p1=224&ah=1&sort=1[Feburary
+22nd 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's action items
+* Proposal: Move away from Drupal to a Git repository powered by Jekyll
+for the community site (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+* It's been a year, should we elect a new board, how/when/etc?
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* JUC promotion ideas
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-02-22-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-02-22-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Feb8thMeeting]]
+== Feb 8th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120208T11&p1=224&ah=1&sort=1[Feburary
+8th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's action items
+* Pull requests and inbound contributor funnel discussion
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-02-08-19.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-02-08-19.03.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Jan25thMeeting]]
+== Jan 25th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120125T11&p1=224&ah=1&sort=1[January
+25th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's action items
+* #jenkins IRC status update - @jieryn
+** please review Cloaks section of
+https://wiki.jenkins-ci.org/display/JENKINS/IRC+Channel
+* Consider using cloudbees FOSS, http://www.cloudbees.com/foss/ -
+@jieryn
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-01-25-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-01-25-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2012-Jan11thMeeting]]
+== Jan 11th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20120111T11&p1=224&ah=1&sort=1[January
+11th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's action items
+* Would it make sense to populate the *Affects Version/s* and *Fix
+Version/s* fields in the Jenkins JIRA (automatically)? (Might include
+talking about the long pending plan of separating core and plugins in
+JIRA) (https://wiki.jenkins.io/display/~fredg[Unknown User (fredg)])
+* Funding for give-aways in events (stickers and T-shirts)
+* Start collecting CLAs
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-01-11-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-01-11-19.00.log.html[raw]

--- a/content/project/governance-meeting/archives/2013.adoc
+++ b/content/project/governance-meeting/archives/2013.adoc
@@ -1,0 +1,352 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2019"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2013-Dec11thMeeting]]
+== Dec 11th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20131211T11&p1=224&ah=1&sort=1[Dec
+11th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Advertisements on jenkins-ci.org?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* JUC 2014 brainstorming (Alyssa Tong)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-12-11-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-12-11-19.01.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2013-Nov13thMeeting]]
+== Nov 13th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20131113T11&p1=224&ah=1&sort=1[Nov
+13th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Name approval request take 2 "Jenkins Operations Center by CloudBees"
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* LTS status
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-11-13-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-11-13-19.01.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2013-Oct30thMeeting]]
+== Oct 30th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20131030T11&p1=224&ah=1&sort=1[Oct
+30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* LTS status (https://wiki.jenkins.io/display/~jglick[Unknown User
+(jglick)])
+* Name approval request for "Jenkins Multi-master by CloudBees"
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Jenkins User Conference Recap (autojack)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-30-18.05.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-30-18.05.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2013-Oct16thMeeting]]
+== Oct 16th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20131016T11&p1=224&ah=1&sort=1[Oct
+16th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-16-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-16-18.01.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2013-Sep18thMeeting]]
+== Sep 18th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130918T11&p1=224&ah=1&sort=1[Sep
+18th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* JUC Palo Alto discussion and feedback (Alyssa)
+* Event coordination for winter — SCALE? FOSDEM?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-02-18.04.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-02-18.04.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2013-Sep4thMeeting]]
+== Sep 4th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130904T11&p1=224&ah=1&sort=1[Sep
+4th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+(Cancelled)
+
+[[GovernanceMeetingArchive2013-Aug21thMeeting]]
+== Aug 21th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130821T11&p1=224&ah=1&sort=1[Aug
+21th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+[[GovernanceMeetingArchive2013-Aug7thMeeting]]
+== Aug 7th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130807T11&p1=224&ah=1&sort=1[Aug
+7th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Backporting of support for Maven 3.1 into upcoming  LTS release
+(vjuranek)
+* Schedule Credentials:1.6, SSH Credentials 1.0, SSH Slaves 1.0 for
+integration in 1.509.4 if there is one (stephenconnolly)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-08-07-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-08-07-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2013-Jul24thMeeting]]
+== Jul 24th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130724T11&p1=224&ah=1&sort=1[Jul
+24th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Next LTS plan and start lifting Java 6 dependency
+https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-24-18.05.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-24-18.05.log.html[raw]
+
+[[GovernanceMeetingArchive2013-Jul10thMeeting]]
+== Jul 10th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130710T11&p1=224&ah=1&sort=1[Jul
+10th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Improving out of the box experience: bundle more plugins
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Pull request greeting bot rollout
+(https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/5[example])
+(https://github.com/jenkinsci/nant-plugin/pull/2[why we need it])
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-10-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-10-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2013-Jun26thMeeting]]
+== Jun 26th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130626T11&p1=224&ah=1&sort=1[Jun
+26th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Highlighting LTS releases more
+(https://wiki.jenkins.io/display/~domi[Unknown User (domi)])
+* Travel grant to JUC (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-26-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-26-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2013-Jun12thMeeting]]
+== Jun 12th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130612T11&p1=224&ah=1&sort=1[Jun
+12th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's actions
+* Jenkins certification from the Japanese community
+https://docs.google.com/file/d/18sXYsZJrvkSECZKYfxLFkyDKlnlQTCvpaigY9BW_PTX4pJeEWu2iJyBBQ90S/edit?usp=sharing
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-12-18.14.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-12-18.14.log.html[raw]
+
+[[GovernanceMeetingArchive2013-May29thMeeting]]
+== May 29th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130529T11&p1=224&ah=1&sort=1[May
+29th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's actions
+
+[[GovernanceMeetingArchive2013-May15thMeeting]]
+== May 15th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130515T11&p1=224&ah=1&sort=1[May
+15th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's actions
+* LTS 1.509.2 (vjuranek)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-05-15-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-05-15-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2013-May1stMeeting]]
+== May 1st Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130501T11&p1=224&ah=1&sort=1[May
+1st 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's actions
+* mirroring artifacts to Central (jglick)
+* 1.509.1 status update (jglick)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-05-01-18.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-05-01-18.03.log.html[raw]
+
+[[GovernanceMeetingArchive2013-April17thMeeting]]
+== April 17th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130417T11&p1=224&ah=1&sort=1[April
+17th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's actions
+
+This meeting was kipped
+
+[[GovernanceMeetingArchive2013-April3rdMeeting]]
+== April 3rd Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130403T11&p1=224&ah=1&sort=1[April
+3rd 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
+
+* Recap last meeting's actions
+* https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
+Election Process]
+* next LTS candidate
+* problem with granting commit access to plugin devs
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-04-03-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-04-03-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2013-March20thMeeting]]
+== March 20th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130320T11&p1=224&ah=1&sort=1[March
+20th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's actions
+* Clean up changelog handling (jglick)
+
+* Meeting did not take place; agenda moved to April 3rd.
+
+[[GovernanceMeetingArchive2013-March6thMeeting]]
+== March 6th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130306T11&p1=224&ah=1&sort=1[March
+6th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's actions
+* Change LTS backport procedure: use labeling
+as http://groups.google.com/group/jenkinsci-dev/msg/6f513f00c607eed0[proposed] https://groups.google.com/d/msg/jenkinsci-dev/aUAd_QwbAdE/0O4HxgA_UW8J[(alt)]by
+Jesse (vjuranek)
+* Notification of issues included in a release and Use of release
+numbers in JIRA (mc1arke)
+* Next LTS rebump?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-03-06-19.13.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-03-06-19.13.log.html[raw]
+
+[[GovernanceMeetingArchive2013-Feburary20thMeeting]]
+== Feburary 20th Meeting
+
+WHEN http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130220T11&p1=224&ah=1&sort=1[Feburary
+20th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's actions
+* SCALE 11x prep
+* Change LTS backport procedure: use labeling
+as http://groups.google.com/group/jenkinsci-dev/msg/6f513f00c607eed0[proposed] https://groups.google.com/d/msg/jenkinsci-dev/aUAd_QwbAdE/0O4HxgA_UW8J[(alt)]by
+Jesse (vjuranek)
+* Notification of issues included in a release and Use of release
+numbers in JIRA (mc1arke)
+* Failed to achieve quorum to hold meeting. Agenda moved to 3/6.
+
+[[GovernanceMeetingArchive2013-Feburary6thMeeting]]
+== Feburary 6th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130206T11&p1=224&ah=1&sort=1[Feburary
+6th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Failed to achieve quorum to hold meeting. Agenda moved to 2/20.
+
+[[GovernanceMeetingArchive2013-January23rdMeeting]]
+== January 23rd Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130123T11&p1=224&ah=1&sort=1[January
+23rd 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Recap last meeting's actions
+* FOSDEM prep discussion?
+* Confirm European donation status (would be good to mention in all our
+talks/stands/flyers at FOSDEM)
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+* Authorize another sticker batch purchase of $500
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* SSL certificate renewal
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-01-23-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-01-23-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2013-January9thMeeting]]
+== January 9th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20130109T11&p1=224&ah=1&sort=1[January
+9th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Meeting canceled per IRC discussion due to lack of agenda items.

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -1,0 +1,409 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2019"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2014-Dec24meeting]]
+== Dec 24 meeting
+
+* Cancelled. Happy holidays!
+
+[[GovernanceMeetingArchive2014-Dec10meeting]]
+== Dec 10 meeting
+
+* 1.580.2 status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+
+[[GovernanceMeetingArchive2014-Nov26meeting]]
+== Nov 26 meeting
+
+* 1.580.2 RC status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
+usage request from CloudBees]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Can we improve the Jenkins release process?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* INFRA components
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Migration of repositories to https://github.com/jenkins-infra/
+(INFRA-169)
+** Test environment: Confluence clone for plugins testing (macros, etc.)
+** Guidelines describing current INFRA permissions and contacts
+*** Currently, INFRA activities require much time/efforts due to unknown
+contacts (or 1-person bottlenecks)
+*** Example 1: Access to TEST project on JIRA for IRCBot testing
+(INFRA-170)
+*** Example 2: Confluence plugin update for components renaming
+(INFRA-147)
+* https://github.com/jenkinsci/patron/pull/2/files[Patron message
+changes from CloudBees]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+[[GovernanceMeetingArchive2014-Nov12meeting]]
+== Nov 12 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20141112T11&p1=224&ah=1&sort=1[Nov
+12th 11:00 Pacific], which should be 6pm UTC, 2pm Eastern, 8pm Central
+Europe, 4am Tokyo.
+
+[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
+#
+
+It's DST change season: Make sure you're not
+https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
+
+* https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
+usage request from CloudBees]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Decision on further component renames in Jira
+(https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk[https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk|https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk])
+(https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk[https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk|https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk])
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Oct29meeting]]
+== Oct 29 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20141029T11&p1=224&ah=1&sort=1[Oct
+29th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 7pm Central
+Europe, 3am Tokyo.
+
+* LTS release status check
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+[[GovernanceMeetingArchive2014-Oct15meeting]]
+== Oct 15 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20141015T11&p1=224&ah=1&sort=1[Oct
+15th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* Using `+stable+` vs `+stable-+`__x__ branch for core LTS.  
+** Using `+stable+` provides convenient way to access latest stable
+commit for client but requires either force pushing or ours merging.
+`+stable-+`__x__ requires neither, though someone have to remember
+updating all automation.
+* Update on plugins not getting forked into jenkinsci, or not getting
+released from there (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+
+[[GovernanceMeetingArchive2014-Oct1meeting]]
+== Oct 1 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20141001T11&p1=224&ah=1&sort=1[Oct
+1st 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* Q4 patron ads on Jenkins Wiki
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Plugins not getting forked into jenkinsci, or not getting released
+from there (https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(danielbeck)])
+* GitHub private repositories for security work
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* New LTS base line (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Sep17meeting]]
+== Sep 17 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140917T11&p1=224&ah=1&sort=1[Sep
+17th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* Travel grant for JUC Tokyo 2015
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]). As
+of Jun 30th we have
+http://www.spi-inc.org/meetings/minutes/2014/2014-07-10/[$14K+ in the
+bank]. Can we spend some of it (proposal:$2K) to send spekaers to the
+upcoming JUC Tokyo?
+* Cease support for native Solaris packages
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Improvements to JENKINS project in JIRA
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(danielbeck)]):
+** Set the default priority to 'Minor'
+** Remove the 'Patch' issue type
+** Make closed issues editable
+** Already implemented (but can be reversed): Hide 'Due Date, 'Affects
+Version' and 'Fix Version' fields, add specific instructions for some
+fields when creating an issue.
+* Can we improve the Jenkins release process?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Sep3meeting]]
+== Sep 3 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140903T11&p1=224&ah=1&sort=1[Sep
+3rd 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* LTS status check (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+* How do we run the "Ask the Experts" section in JUC?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Decision on implementing
+https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[Browser
+Compatibility Matrix]
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* https://wiki.jenkins.io/display/JENKINS/2014+JIRA+Components+Refactoring[2014
+JIRA Components Refactoring]
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** Decision on adding `+-plugin+` suffix and rename/merge of other
+components (table in _Modification of existing components_)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-03-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-03-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Aug20meeting]]
+== Aug 20 meeting
+
+Canceled.
+
+[[GovernanceMeetingArchive2014-Aug06meeting]]
+== Aug 06 meeting
+
+Canceled.
+
+[[GovernanceMeetingArchive2014-Jul23thMeeting]]
+== Jul 23th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140723T11&p1=224&ah=1&sort=1[Jul
+23rd 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* JUC
+** Date set: Oct 23, Hyatt Burlingame by San Francisco Airport
+** Schedule a Jenkins meet-up around same time?
+** CD Summit scheduled for Oct 22nd in San Francisco
+** Sponsor contact details - ok to also share "job title" details with
+Gold & Platinum sponsors? Their sales teams will care about this.
+
+(No Kohsuke; jglick will try to drive the bot.)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-07-23-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-07-23-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Jul9thMeeting]]
+== Jul 9th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140709T11&p1=224&ah=1&sort=1[Jul
+9th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* Brainstorming on improving the sponsor contact opt-in ratio: only 20%
+of the attendees opted in to the sponsor contact. What can we do to
+improve that (or make it up in another way)?
+* Next Jenkins newsletter - Call for Content
+* 1.565.1 RC status check
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-07-09-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-07-09-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Jun25thMeeting]]
+== Jun 25th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140625T11&p1=224&ah=1&sort=1[Jun
+25th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* 1.554.3 release status check
+* What's the next LTS baseline?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-06-25-18.11.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-06-25-18.11.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Jun11thMeeting]]
+== Jun 11th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140611T11&p1=224&ah=1&sort=1[Jun
+11th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* 1.554.3 RC status check
+* JUC (https://wiki.jenkins.io/display/~lisawells[Unknown User
+(lisawells)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-06-11-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-06-11-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2014-May28thMeeting]]
+== May 28th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140528T11&p1=224&ah=1&sort=1[May
+28th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* comission to build 3D model of Mr.Jenkins?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* 1.554.2 LTS release status check
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* JUC
+
+[[GovernanceMeetingArchive2014-May14thMeeting]]
+== May 14th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140514T11&p1=224&ah=1&sort=1[May
+14th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+[[GovernanceMeetingArchive2014-Apr30thMeeting]]
+== Apr 30th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140430T11&p1=224&ah=1&sort=1[Apr
+30th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* 1.554.1 release status
+* Jenkins joining http://www.openinventionnetwork.com/[the software
+patent non-aggression community]?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Permanently switch to acceptance-tests for LTS testing. (ogondza)
+
+[[GovernanceMeetingArchive2014-Apr16thMeeting]]
+== Apr 16th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140416T11&p1=224&ah=1&sort=1[Apr
+16th 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
+Europe, 3am Tokyo.
+
+* JUC status update / travel grant?
+(https://wiki.jenkins.io/display/~lisawells[Unknown User
+(lisawells)]/Alyssa)
+** how to reach German Jenkins community?
+* 1.554.1 RC status (https://wiki.jenkins.io/display/~jglick[Unknown
+User (jglick)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-16-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-16-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2014-Apr2ndMeeting]]
+== Apr 2nd Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140402T11&p1=224&ah=1&sort=1[Apr
+2nd 18:00 UTC], which should be 11am PDT, 2pm EDT, 9pm CEST, 4am Tokyo.
+
+* 1.554 go or no-go (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+* https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[Patron
+of Jenkins program] approval
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* JIRA Versions backend application
+(https://wiki.jenkins.io/display/~slide_o_mix[slide_o_mix])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-02-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-02-18.02.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2014-Mar19thMeeting]]
+== Mar 19th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140319T11&p1=224&ah=1&sort=1[Mar
+19th 19:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CET, 4am Tokyo.
+
+* Pick new LTS baseline
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Review of the
+https://wiki.jenkins.io/display/JENKINS/2014+Jenkins+Infrastructure+Roadmap[2014
+Jenkins Infrastructure Roadmap]
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-19-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-19-18.01.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2014-Mar5thMeeting]]
+== Mar 5th Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140305T11&p1=224&ah=1&sort=1[Mar
+5h 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* Moving cucumber from Contegix to the OSUOSL data centers
+* Moving Confluence to a new VM
+* Switching from masterless Puppet to a Puppet master.
+* Approval to order more stickers
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-05-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-05-19.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2014-Jan22ndMeeting]]
+== Jan 22nd Meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140122T11&p1=224&ah=1&sort=1[Jan
+22nd 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
+
+* FOSDEM planning
+* LTS.next planning and its scheduled cadence
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* https://wiki.jenkins.io/pages/viewpage.action?pageId=71435396["Patron
+of Jenkins" proposal] (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-01-22-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-01-22-19.01.log.html[raw]

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -1,0 +1,712 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2015"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2015-Dec23meeting]]
+== Dec 23 meeting
+
+*This meeting will be skipped.*
+
+[[GovernanceMeetingArchive2015-Dec9meeting]]
+== Dec 9 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20151209T11&p1=224&ah=1&sort=1[Dec
+9 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* Next LTS baseline selection
+* (*hopefully*) Final review/adoption of
+https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
+Election Process] (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+* Review/adopt a
+https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* *NOT* tweet anymore plugins w/o a wiki page
+(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]) (for
+https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/qR8WqJZmNZs/1a9Zd3F0DAAJ[reference])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Nov25meeting]]
+== Nov 25 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20151125T11&p1=224&ah=1&sort=1[Nov
+25 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS RC status check
+* Announce Security Officer
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-25-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-25-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Nov11meeting]]
+== Nov 11 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20151111T11&p1=224&ah=1&sort=1[Nov
+11 11:00 Pacific].
+
+* Recap last meeting's actions
+* Review proposed www site change from Drupal to static site generation
+(current https://github.com/rtyler/jenkins.io[repo] and
+http://jenkins.lasagna.io/[generated version of site])
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* CERT membership requests from
+https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/UMBz91HMAgAJ[Ivan
+Meredith] and
+https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/v2sG6UvPAgAJ[Ben
+Walding] (https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(danielbeck)])
+* Review
+https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
+Election Process] and either move forward with the proposal or take
+feedback so we can have elections next year
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Jenkins 2.0 proposal recap
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Oct28meeting]]
+== Oct 28 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20151028T11&p1=224&ah=1&sort=1[Oct
+28 11:00 Pacific].
+
+[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
+#
+
+*It is the end of daylight savings time season. The meeting will be held
+at 11 am Pacific time, adjust accordingly.*
+
+* Recap last meeting's actions
+** https://wiki.jenkins.io/display/JENKINS/Rewards+for+reporting+security+issues[Rewards
+for reporting security issues]
+* LTS status check
+* https://wiki.jenkins.io/display/JENKINS/Proposal+-+Revisiting+JUC+in+2016[Proposal
+- Revisiting JUC in 2016]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Sticker purchase approval
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Voting: Should we require squashing commits in the core?
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Related discussion:
+https://groups.google.com/forum/#\!searchin/jenkinsci-dev/squash/jenkinsci-dev/kqvuDqXwPZw/oF-KMdNbCwAJ
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-28-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-28-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Oct14meeting]]
+== Oct 14 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20151014T11&p1=224&ah=1&sort=1[Oct
+14th 11:00 Pacific].
+
+* Recap last meeting's actions
+** https://wiki.jenkins.io/display/JENKINS/Approved+Trademark+Usage[Approved
+Trademark Usage] has been updated.
+* Quick announcement of `+#jenkins-community+`
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* LTS status check
+** https://github.com/jenkinsci/jenkins/pull/1812/files#diff-600376dffeb79835ede4a0b285078036R850[Link
+to changelog-stable when building]?
+* New Website JIRA project to organize website efforts under
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Approval of new Q4 patron messages by CloudBees
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* https://wiki.jenkins.io/display/JENKINS/Proposal+-+Project+sub-teams[Proposal
+- Project sub-teams] (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+* https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[Permission
+request] - Admin access to jenkinsci org
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* JIRA project for plugin hosting (and possibly similar) requests
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-14-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-14-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Sep30meeting]]
+== Sep 30 meeting
+
+[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
+#
+
+*This is the first meeting to be held in #jenkins-meeting.*
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150930T11&p1=224&ah=1&sort=1[Sep
+30th 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+** No RC posted two weeks ago?
+** https://issues.jenkins-ci.org/browse/JENKINS-29876[JENKINS-29876]
+* Q4
+https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[patron
+program] messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+** Same as for Q3, with same pre-approved message pending:
+https://github.com/jenkinsci/patron/pull/4
+* Time to think about Jenkins board elections?
+https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)]
+** This was vaguely discussed in the 100k podcast in February, and soon
+2/3 of the board will be CloudBees employees
+** The most recent proposal seems to be
+https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[proposal
+from April 2013]
+* Time to move to Java 8 and servlet 3.1?
+https://wiki.jenkins.io/display/~teilo[Unknown User (teilo)] for core?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Sep16meeting]]
+== Sep 16 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150916T11&p1=224&ah=1&sort=1[Sep
+16th 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS backporting status check
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Protect master branches of repositories
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA[https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA|https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-16-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-16-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Sep2meeting]]
+== Sep 2 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150902T11&p1=224&ah=1&sort=1[Sep
+2nd 11:00 Pacific].
+
+* Recap last meeting's actions
+** Travel grant blog post:
+http://jenkins-ci.org/content/announcing-travel-grant-program
+** Botbot.me logging for #jenkins: https://botbot.me/freenode/jenkins/
+** #jenkins-meeting: Waiting for
+https://github.com/jenkins-infra/jenkins-infra/pull/152 to be merged
+into prod
+** Infra access list:
+https://wiki.jenkins.io/display/JENKINS/Infrastructure+Admins[Infrastructure
+Admins] (still missing Artifactory)
+* LTS RC status check
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* LTS baseline selection
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
+grant program] blessing
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Process for merging PRs with multiple commits
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
+but it was really https://wiki.jenkins.io/display/~integer[Unknown User
+(integer)] and https://wiki.jenkins.io/display/~tfennelly[Unknown User
+(tfennelly)] who brought it up)
+* Clarification what requires a CLA and what does not
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* CERT Team membership request for
+https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[Unknown User
+(vlatombe)] and https://wiki.jenkins.io/display/~varmenise[Unknown User
+(varmenise)] (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-02-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-02-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Aug19meeting]]
+== Aug 19 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150819T11&p1=224&ah=1&sort=1[Aug
+19th 11:00 Pacific].
+
+* Recap last meeting's actions
+** https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
+grant program draft]
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* LTS RC status check / LTS baseline selection
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** What about
+https://issues.jenkins-ci.org/browse/JENKINS-29936[JENKINS-29936]?
+* Revisiting bundled plugins
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+** See
+https://groups.google.com/forum/#!topic/jenkinsci-dev/kRobm-cxFw8[mailing
+list post]
+* Allow file browsing in artifactory for ability view javadocs, add link
+in confluence macros live link, send request to jfrog support to get
+newer artifactory
+version.  (https://wiki.jenkins.io/display/~integer[Unknown User
+(integer)])
+* Provide public list of JIRA/confluence/artifactory admins in wiki
+(https://wiki.jenkins.io/display/~integer[Unknown User (integer)])
+* https://github.com/jenkinsci/jenkins/pull/1774[HTMLUnit update]
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-19-18.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-19-18.03.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Aug5meeting]]
+== Aug 5 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150805T11&p1=224&ah=1&sort=1[Aug
+5th 11:00 Pacific].
+
+* Recap last meeting's actions
+* Jenkins certification
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Approval of new
+https://wiki.jenkins-ci.org/display/JENKINS/Patron+of+Jenkins+program[Patron
+program] messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+* JUC travel grant (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+** (http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.log.html[previous
+discussion])
+** The Jenkins project currently has
+~http://permalink.gmane.org/gmane.org.spi.general/1507[$24k] in the bank
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-05-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-05-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Jul22meeting]]
+== Jul 22 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=201507022T11&p1=224&ah=1&sort=1[Jul
+22th 11:00 Pacific].
+
+* LTS 1.609 RC status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-07-22-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-07-22-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Jul8meeting]]
+== Jul 8 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150708T11&p1=224&ah=1&sort=1[Jul
+8th 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS 1.609.2 RC status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-07-08-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-07-08-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-June10meeting]]
+== June 10 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150610T11&p1=224&ah=1&sort=1[June
+10th 11:00 Pacific].
+
+* Recap last meeting's actions
+* Can we start to look at fixing the
+https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20INFRA%20AND%20component%20%3D%20spof%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC[single
+points of failure]? (https://wiki.jenkins.io/display/~orrc[Unknown User
+(orrc)])
+** e.g. https://issues.jenkins-ci.org/browse/INFRA-225[INFRA-225] was
+recently broken for a month; related
+https://issues.jenkins-ci.org/browse/INFRA-75[INFRA-75] is one year old
+* Using labels for pull requests to core (instead of renaming to
+something like "[WIP] [JENKINS-12345] Foo").
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* "Action items are https://issues.jenkins-ci.org/browse/MEETING[tracked
+in JIRA]" — can we agree to do this?
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** People miss meetings or forget action items, and there's usually no
+follow-up and the actions never get done
+* Time to move to Servlet 3.0 (3.1?) as
+http://jenkins-ci.org/content/good-bye-java6[announced]?
+(https://wiki.jenkins.io/display/~teilo[Unknown User (teilo)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-06-10-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-06-10-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-May27meeting]]
+== May 27 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150527T11&p1=224&ah=1&sort=1[May
+27th 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS RC status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* When to flip the switch on
+https://github.com/jenkinsci/backend-update-center2/pull/20[plugins
+without wiki pages]? (https://wiki.jenkins.io/display/~orrc[Unknown User
+(orrc)])
+** https://groups.google.com/forum/#!msg/jenkinsci-dev/dfvRxvCv7Mg/jIailHDwY2EJ[Mailing
+list thread]
+* Can we start to look at fixing the
+https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20INFRA%20AND%20component%20%3D%20spof%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC[single
+points of failure]? (https://wiki.jenkins.io/display/~orrc[Unknown User
+(orrc)])
+** e.g. https://issues.jenkins-ci.org/browse/INFRA-225[INFRA-225] is
+currently (again) a visible problem; related
+https://issues.jenkins-ci.org/browse/INFRA-75[INFRA-75] is one year old
+today
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-05-27-18.19.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-05-27-18.19.log.html[raw]
+
+[[GovernanceMeetingArchive2015-May13meeting]]
+== May 13 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150513T11&p1=224&ah=1&sort=1[May
+13th 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS RC status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* #jenkins-meeting (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+* Should we only include plugins in the Update Centre if they have a
+wiki page? (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)],
+https://wiki.jenkins.io/display/~evernat[Unknown User (evernat)])
+** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
+discussion];
+https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/S_uQ_C_7NMQJ[more
+details]
+** 47+ POMs have no `+url+` value, or a value with typos (which we can
+https://github.com/jenkinsci/backend-update-center2/pull/14/files[override]
+for now)
+** 60+ plugins https://gist.github.com/orrc/2995a31028a27f9765d1[have no
+wiki page at all] (not including workflow-*)
+** 20+ plugins have no source code in github.com/jenkinsci (or at all);
+at least 1 is closed-source
+(http://maven.jenkins-ci.org/content/repositories/releases/com/antelink/reporter/jenkins/plugin/AntepediaReporter-CI-plugin/1.8/AntepediaReporter-CI-plugin-1.8.pom[private
+repo, Java source excluded from release]: AntepediaReporter — orrc
+contacted them and they're considering open-sourcing)
+* Infra training/handover/expansion? (Was mentioned a while back and
+more recently, but can't find the link)
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+* Using a CDN with HTTPS / removing need for mirrorbrain?
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** https://issues.jenkins-ci.org/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
+on INFRA-266]
+* Further requirements for plugins published in the community update
+center (https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(danielbeck)])
+** To allow review, inspection and collaboration:
+*** Require a valid SCM URL for new plugin releases inside
+@jenkinsci/svn.jenkins-ci.org (that must exist) – needs to handle
+plugins not bundled with Gradle
+** To protect users:
+*** Require that the uploader of the binary is the same user who created
+the tag (we have the data in LDAP, see jenkins-ci.org/account)
+*** Remove the commit permissions from 'everyone', it's reckless
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-05-13-18.07.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-05-13-18.07.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Apr29meeting]]
+== Apr 29 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150429T11&p1=224&ah=1&sort=1[Apr
+29th 11:00 Pacific].
+
+* Recap last meeting's actions
+* Carryover from last meeting w.r.t. SECURITY bounties. Anything for
+historical submitters? Who has the action item?
+* Trademark usage approval for "CloudBees Jenkins Platform"
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* We only allow OSS plugins to be distributed via the update center, but
+what about closed source plugins which are documented on our wiki? (e.g.
+https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[CxSuite
+Jenkins Plugin])
+* Should we only include plugins in the Update Centre if they have a
+wiki page? (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
+discussion]
+* #jenkins-meeting (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+* LTS.next (https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Infra training? (Was mentioned a while back and more recently, but
+can't find the link) (https://wiki.jenkins.io/display/~orrc[Unknown User
+(orrc)])
+* Using a CDN with HTTPS / removing need for mirrorbrain?
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** https://issues.jenkins-ci.org/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
+on INFRA-266]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-29-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-29-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Apr15meeting]]
+== Apr 15 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150415T11&p1=224&ah=1&sort=1[Apr
+15th 11:00 Pacific].
+
+* Recap last meeting's actions
+* Migrate Jenkins-on-Jenkins jobs onto jenkins.ci.cloudbees.com
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Carryover from last meeting w.r.t. SECURITY bounties. Anything for
+historical submitters? Who has the action item?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-15-18.05.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-15-18.05.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Apr1meeting]]
+== Apr 1 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150401T11&p1=224&ah=1&sort=1[Apr
+1st 11:00 Pacific].
+
+[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
+#
+
+It's DST change season: Make sure you're not
+https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
+
+* Recap last meeting's actions
+* JUC 2015 - obtain approval for a Mobile Morning mini-track that focus
+on Jenkins mobile development (Alyssa)
+* Build/publisher steps & AbortException
+handling (https://wiki.jenkins.io/display/~integer[Unknown User
+(integer)])
+** https://github.com/jenkinsci/jenkins/pull/1577
+* Defining guidelines on expected behavior and/or structure for plugins?
+If so, should we enforce them?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** https://groups.google.com/d/msg/jenkinsci-dev/OHjuxTD1W9k/d4dRBtR_vFQJ
+** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html
+Item 3
+** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-15-18.02.html
+Item 3
+* Would changing the meeting time to 10 AM PST/PDT allow overruns?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Who gets voice on IRC? "Committers"... to any plugin? To core?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* https://issues.jenkins-ci.org/browse/JENKINS-27268[JENKINS-27268]
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Bug bounties/rewards for security issues?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Resurrecting the MEETING Jira project (maybe even have the bot create
+issues for action items automatically)
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* The important content of the Wiki is difficult to find (between
+outdated or even empty pages), and there's no real introduction to
+Jenkins – What can we do about it?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Proposal: move Jenkins
+https://github.com/cloudbees/jenkins-ci.org-docker[official image
+repo] to jenkinsci org so enhancement / version updates can be managed
+by the community (https://wiki.jenkins.io/display/~ndeloof[Unknown User
+(ndeloof)])
+* Disabling "Clone" feature in JIRA
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* The Chinese mirror is a mess
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** http://mirrors.jenkins-ci.org/status.html
+** https://issues.jenkins-ci.org/browse/INFRA-260
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-01-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-01-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Mar18meeting]]
+== Mar 18 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150318T11&p1=224&ah=1&sort=1[Mar
+18th 11:00 Pacific].
+
+Canceled.
+
+[[GovernanceMeetingArchive2015-Mar4meeting]]
+== Mar 4 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150304T11&p1=224&ah=1&sort=1[Mar
+4th 11:00 Pacific].
+
+* LTS RC status check
+* Recap last meeting's actions
+* Are there new "Patron of Jenkins" sponsors? No messages have been
+shown in 2015. (https://wiki.jenkins.io/display/~orrc[Unknown User
+(orrc)])
+** Maybe there was supposed to be one in Q1?
+https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ[https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ|https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ]
+** Also, the wiki states that
+"https://wiki.jenkins-ci.org/display/JENKINS/Patron+of+Jenkins+program[the
+program will be reviewed and changes might be made]" in March 2015
+* Workflow specific mailing lists
+(https://wiki.jenkins-ci.org/display/~dty[Dean Yu])
+* New release process? (i.e. release from master; no more RC branch)
+(discussed by https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)], https://wiki.jenkins.io/display/~jglick[Unknown User
+(jglick)] & https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(danielbeck)] in IRC)
+* Governance Document Updates
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** As per the Jenkins 100K podcast, we now have a trademark?
+** More information about the board; there appears to be no information
+about _who_ that is, how to "contact the board", and if/when the board
+changes (see also: the podcast)
+** Release process needs updating, if we decide to kill off RCs
+** Broken or no-longer-updated links, e.g. Sun coding style, GitHub repo
+wiki page, pull request wiki page
+** Other stuff we want to review, that's changed in the past three
+years? e.g. at least simple text updates like "500+ repos" is now
+"1000+"...
+* Build/publisher steps & AbortException
+handling (https://wiki.jenkins.io/display/~integer[Unknown User
+(integer)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-03-04-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-03-04-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Feb18meeting]]
+== Feb 18 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150218T11&p1=224&ah=1&sort=1[Feb
+18th 11:00 Pacific].
+
+* Approving another batch of stickers
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* https://groups.google.com/forum/?hl=en#!topic/jenkinsci-dev/oDXLTVcy56Y[IDEA
+licenses] (https://wiki.jenkins.io/display/~integer[Unknown User
+(integer)])
+* Should we have an "ops lead"? Adding more infra team members?
+Moderator teams?
+https://groups.google.com/forum/#!topic/jenkinsci-dev/046RwHh3Nko[mailing
+list discussion] (https://wiki.jenkins.io/display/~orrc[Unknown User
+(orrc)])
+* Who should we reach out for JUC speakers?
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* LTS status check (https://wiki.jenkins.io/display/~kohsuke[Unknown
+User (kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Feb4meeting]]
+== Feb 4 meeting
+
+WHEN
+http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150204T11&p1=224&ah=1&sort=1[Feb
+4th 11:00 Pacific].
+
+* Jenkins 100K PR planning (hgilmore)
+* LTS RC status (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)]/https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[~ogondza])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-04-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-04-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Jan21meeting]]
+== Jan 21 meeting
+
+* Releases of Windows libraries: winp and winsw
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** winp: https://github.com/kohsuke/winp/pull/12 - option to disable the
+DLL unpacking
+** winsw:
+https://issues.jenkins-ci.org/browse/JENKINS-10547[JENKINS-10547],
+https://issues.jenkins-ci.org/browse/JENKINS-22685[JENKINS-22685]
+correct properties handling, log rotation fix
+** A decision on MVS version would be useful for both projects. Proposed
+version - *Visual Studio Community 2013* (free for FOSS projects)
+* Jenkins at 100K active users (Heidi Gilmore)
+* INFRA (https://wiki.jenkins.io/display/~integer[Unknown User
+(integer)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-21-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-21-19.01.log.html[raw]
+
+[[GovernanceMeetingArchive2015-Jan7meeting]]
+== Jan 7 meeting
+
+* JUC post-mortem (https://wiki.jenkins.io/display/~atong[Unknown User
+(atong)]/https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-07-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-07-19.01.log.html[raw]

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -1,0 +1,709 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2016"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2016-Dec21meeting]]
+== Dec 21 meeting
+
+WHEN Dec 21 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* FOSDEM 2017 Plans (https://wiki.jenkins.io/display/~atong[Unknown User
+(atong)])
+** https://wiki.jenkins-ci.org/display/JENKINS/FOSDEM+2017
+* Infra update
+* JDK8 baseline upgrade followup,
+https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
+proposed by Oliver] https://wiki.jenkins.io/display/~batmat[Unknown User
+(batmat)] (will be absent
+image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/sad.svg[(sad)]
+)
+** https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/uh3IK_fzEAAJ[Plan/timeline
+to fix Windows issue compatible with Oliver's ^]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-21-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-21-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Dec7meeting]]
+== Dec 7 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20161207T18&p1=1440&ah=1[Dec
+7 18:00 UTC].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+** Is Kohsuke OK releasing 2.32.1 on 2016-12-21 or should we postpone to
+2017-01-04?
+** Should we just skip two weeks around Christmas like we did last year,
+postpone .2 RC from Jan 4 to Jan 18?
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* JDK8 as baseline, with the
+https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
+proposed by Oliver] https://wiki.jenkins.io/display/~batmat[Unknown User
+(batmat)]
+* New Security Officer announcement
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-07-18.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-07-18.03.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Nov23meeting]]
+== Nov 23 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20161123T18&p1=1440&ah=1[Nov
+23 18:00 UTC].
+
+* LTS base line selection
+* Revival of the Klocwork plugin
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** The plugin is hosted outside jenkinsci org, but it seems to be
+abandoned by maintainers
+** There is a ownership request:
+https://groups.google.com/forum/#!search/klocwork/jenkinsci-dev/U7SFVsjsHHQ/cA8SlsTgBQAJ[https://groups.google.com/forum/#!search/klocwork/jenkinsci-dev/U7SFVsjsHHQ/cA8SlsTgBQAJ|https://groups.google.com/forum/#!search/klocwork/jenkinsci-dev/U7SFVsjsHHQ/cA8SlsTgBQAJ]
+** We need to discuss if we can just proceed with plugin process and to
+grant the access to the requester
+* GSoC2017 sync-up
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Do we participate in it? If yes, should we schedule office hours?
+** Who will be Jenkins org admins this time?
+https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] will need some help
+* Azure migration / Infrastructure update
+https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-23-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-23-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Nov9meeting]]
+== Nov 9 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20161109T18&p1=1440&ah=1[Nov
+9 18:00 UTC].
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-09-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-09-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2016-October26meeting]]
+== October 26 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20161026T18&p1=1440&ah=1[October
+26 18:00 UTC].
+
+[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
+#
+
+We decided to switch to a fixed UTC-based time for the project meeting.
+It's now always at 18:00 UTC. This is the first meeting at this new
+time.
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-10-26-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-10-26-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-October12meeting]]
+== October 12 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20161012T11&p1=224&ah=1&sort=1[October
+12 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Bumping Jenkins core to Remoting 3
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Remoting 3 offers a new JNLP4 protocol (Adds Java NIO compared to
+JNLP3 + stability fixes)
+** Remoting 3 is formally incompatible: Java 6 support drop from slaves,
+also JnlpServerHandshake rework:
+https://github.com/jenkinsci/jenkins/pull/2492
+** https://wiki.jenkins.io/display/~stephenc[~stephenc] checked known
+OSS and closed-source implementations, no real compatibility issues
+** Question for voting: Do we want to go forward?
+* Out-of-order Jenkins Weekly release in order to get better soak
+testing for 2.19.3
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Question for voting: Do we want to release it if kohsuke is available?
+** https://issues.jenkins-ci.org/browse/JENKINS-38814[JENKINS-38814],
+https://github.com/jenkinsci/jenkins/commit/a04e2f9836263f7ae5e68617f5bafde18e594446
+* IntelliJ license handling
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Moving Governance Meetings to UTC
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Plugin site deployment to Jenkins project infra
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Allowing interface implementations as Extension points in Jenkins
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Background: https://github.com/jenkinsci/jenkins/pull/2566
+** ** Question for voting: Do we want to allow such use-case?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-10-12-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-10-12-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-September28meeting]]
+== September 28 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160928T11&p1=224&ah=1&sort=1[September
+28 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Discuss
+https://groups.google.com/forum/#!topic/jenkinsci-users/hP8uwU0y8K4[name
+use for Jenkins-LSCI] (Life Science Continuous Integration)
+(https://wiki.jenkins.io/display/~ioannis[Unknown User (ioannis)])
+* Patron messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-09-28-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-09-28-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-September14meeting]]
+== September 14 meeting
+
+*Skipped due to Jenkins World.*
+
+[[GovernanceMeetingArchive2016-August31meeting]]
+== August 31 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160831T11&p1=224&ah=1&sort=1[August
+31 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Pick new LTS version
+(﻿https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-08-31-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-08-31-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-August17meeting]]
+== August 17 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160817T11&p1=224&ah=1&sort=1[August
+17 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-08-17-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-08-17-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-August3meeting]]
+== August 3 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160803T11&p1=224&ah=1&sort=1[August
+3 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-08-03-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-08-03-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2016-July20meeting]]
+== July 20 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160720T11&p1=224&ah=1&sort=1[July
+20 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Obtain permission to post Jenkins World banner
+on http://issues.jenkins-ci.org/[issues.jenkins-ci.org] and
+wiki.jenkins-ci.org (https://wiki.jenkins.io/display/~atong[Unknown User
+(atong)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-07-20-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-07-20-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-July6meeting]]
+== July 6 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160706T11&p1=224&ah=1&sort=1[July
+6 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-07-06-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-07-06-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-June22meeting]]
+== June 22 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160622T11&p1=224&ah=1&sort=1[June
+22 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Officer updates
+** Security status update
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** Events status update (https://wiki.jenkins.io/display/~atong[Unknown
+User (atong)])
+** Release status update
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)])
+* Licensing and unrestricted access of
+https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
+Statistics] (aka "census data")
+http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
+context here] https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)]
+* Approval of new Q3 patron messages
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-22-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-22-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-June8meeting]]
+== June 8 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160608T11&p1=224&ah=1&sort=1[June
+8 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* Next LTS baseline selection
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Q3 patron messages
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Licensing and unrestricted access of
+https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
+Statistics] (aka "census data")
+http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
+context here] https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-08-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-08-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-May25meeting]]
+== May 25 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160525T11&p1=224&ah=1&sort=1[May
+25 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-05-25-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-05-25-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2016-May11meeting]]
+== May 11 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160511T11&p1=224&ah=1&sort=1[May
+11 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Infrastructure status update
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Security status update
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Events status update (https://wiki.jenkins.io/display/~atong[Unknown
+User (atong)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-05-11-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-05-11-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Apr27meeting]]
+== Apr 27 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160427T11&p1=224&ah=1&sort=1[Apr
+27 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* 2.0 status check
+* Approval of Q2 patron messages
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** https://github.com/jenkinsci/patron/pull/11
+* CERT membership request process changes
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+* Approval of CERT membership requests
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** Andres Rodriguez:
+https://groups.google.com/d/msg/jenkinsci-dev/WQO16ziPoCA/E9lmmKeiFAAJ
+** Antonio Muñiz:
+https://groups.google.com/d/msg/jenkinsci-dev/5_k8Uj5rErA/vTOyPnsZBwAJ
+* GSoC status check (https://wiki.jenkins.io/display/~batmat[Unknown
+User (batmat)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-04-27-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-04-27-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Apr13meeting]]
+== Apr 13 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160413T11&p1=224&ah=1&sort=1[Apr
+13 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* 2.0 status check
+* CERT membership request by Yoann Dubreuil
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** https://groups.google.com/d/msg/jenkinsci-dev/M9GeJFo_qcg/4Wax34DrBAAJ
+* Jenkins 2.0 launch - go over activities of what has been planned for
+this release (R. Tyler
+Croy/https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+** https://wiki.jenkins-ci.org/display/JENKINS/2.0+Launch+Marketing
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-04-13-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-04-13-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Mar30meeting]]
+== Mar 30 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160330T11&p1=224&ah=1&sort=1[Mar
+30 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* 2.0 status check
+* Check status for
+http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[action
+3d] - JetBrains licenses
+(https://wiki.jenkins.io/display/~integer[Unknown User (integer)])
+* https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
+Summer Of Code 2016] update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig[https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig|https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig]
+* Release officer announcement
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Major infrastructure opportunity
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Update to CD Summit & Jenkins Days wiki
+page (https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+* Advance notice: Privacy affecting bug, 1.642.4 release
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-30-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-30-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Mar16meeting]]
+== Mar 16 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160316T11&p1=224&ah=1&sort=1[Mar
+16 11:00 Pacific].
+
+[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
+#
+
+It's DST change season: Make sure you're not
+https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
+
+* Recap last meeting's actions
+* LTS status check
+* Next LTS baseline selection
+* Seek trademark usage approval for "Jenkins Days"
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+* Infrastructure status update
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Events status update (https://wiki.jenkins.io/display/~atong[Unknown
+User (atong)])
+* Security status update
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-16-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-16-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Mar2meeting]]
+== Mar 2 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160302T11&p1=224&ah=1&sort=1[Mar
+2 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* Board Election update (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+* 2.0 status check (https://wiki.jenkins.io/display/~danielbeck[Unknown
+User (danielbeck)])
+* Certification update from beta exams
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Conversion of
+https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2016#[Office
+Hours] to Jenkins Online meetup
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY[https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY|https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY]
+* Planning of GSoC office hours
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Application draft:
+https://docs.google.com/document/d/1dv9UXyT_FPukJXrBYauIKvxrZeEU6BT7v90LSQX36MU/edit#
+** We need: 1 public office hours, 1 bi-weekly mentor meeting
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-02-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-02-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Feb17meeting]]
+== Feb 17 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160203T11&p1=224&ah=1&sort=1[Feb
+17 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* https://wiki.jenkins.io/display/JENKINS/Jenkins+Certification[Jenkins
+Certification] update and trademark approval request
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* New team lead positions: *Events* and *Release* (see
+https://wiki.jenkins.io/display/JENKINS/Team+Leads[Team Leads])
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* (2nd run
+image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/smile.svg[(smile)]
+) Discussion: clarify that plugins available through the update center
+are required to have their source code canonical repository hosted under
+the Jenkinsci GitHub organization
+https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
+** For context
+https://groups.google.com/forum/#!topic/jenkinsci-dev/IoRmYHNn3Q4[the
+last thread about it]
+* (_time permitting_)
+https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
+Summer Of Code 2016] application progress -
+https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)]
+** Mailing list:
+https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0[https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0|https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0]
+** Application draft:
+https://docs.google.com/document/d/1dv9UXyT_FPukJXrBYauIKvxrZeEU6BT7v90LSQX36MU/edit#
+** Wiki:
+https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
+Summer Of Code 2016]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-02-17-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-02-17-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Feb3meeting]]
+== Feb 3 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160203T11&p1=224&ah=1&sort=1[Feb
+3 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check
+* Seek
+https://wiki.jenkins.io/display/JENKINS/Governance+Document#GovernanceDocument-Trademark[trademark
+approval] for
+https://wiki.jenkins-ci.org/download/attachments/54722987/Jenkins-World-revised-logo.jpg?version=1&modificationDate=1453408974536[Jenkins
+World 2016 logo] (https://wiki.jenkins.io/display/~atong[Unknown User
+(atong)])
+* Infrastructure status report -
+https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+* Should Jenkins be a mentor organisation for Google Summer of Code?
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Deadline is
+https://developers.google.com/open-source/gsoc/timeline[19th February]
+** Summary
+slides: https://speakerdeck.com/onenashev/jenkins-2-dot-0-google-code-of-summer-proposals
+* Do we have a timeline for the Governance Board elections?
+(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+* Discussion: clarify that plugins available through the update center
+are required to have their source code canonical repository hosted under
+the Jenkinsci GitHub organization
+https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
+** As a first step, only discuss the matter (hopefully with the board).
+Only potentially on a future meeting may we want to settle on something
+and act upon it.
+** For context
+https://groups.google.com/forum/#!topic/jenkinsci-dev/IoRmYHNn3Q4[the
+last thread about it]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-02-03-19.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-02-03-19.00.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Jan20meeting]]
+== Jan 20 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160120T11&p1=224&ah=1&sort=1[Jan
+20 11:00 Pacific].
+
+* Recap last meeting's actions
+* Approving Jenkins Press page and assigned contacts:
+https://jenkins-ci.org/press/&nbsp;
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Reworking / Shutting down the Jenkins CIA program
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY[https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY|https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY]
+* Follow-up to the unofficial Jenkins-related Twitter account
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://twitter.com/LearningJenkins
+** Aim: agree if "Learning Jenkins" with the unofficial resource notice
+is fine
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/VhEGPZ9_IzA[Thread
+in DEV mailing list]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-20-19.03.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-20-19.03.log.html[raw]
+
+[[GovernanceMeetingArchive2016-Jan6meeting]]
+== Jan 6 meeting
+
+WHEN
+https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160106T11&p1=224&ah=1&sort=1[Jan
+6 11:00 Pacific].
+
+* Recap last meeting's actions
+* LTS status check - discuss baseline change:
+https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM
+(https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM)
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Q1 Patron messages approval
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** PR: https://github.com/jenkinsci/patron/pull/8
+* Review/adopt a
+https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Discuss requiring pull requests for all non-release-process changes to
+core/master (https://wiki.jenkins.io/display/~abayer[Unknown User
+(abayer)])
+* Spam problems on wiki and possible solutions
+(https://wiki.jenkins.io/display/~lshatzer[Unknown User (lshatzer)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.log.html[raw]

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -1,0 +1,569 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2017"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2017-December20thmeeting]]
+== [line-through]*December 20th meeting*
+
+[line-through]**https://groups.google.com/d/msg/jenkinsci-dev/LmzleFNKecY/IBokx8ZwCAAJ[Skipped
+due to lack of agenda items and revised LTS schedule.]**
+
+[line-through]*WHEN: December 20th 18:00 UTC*
+
+* [line-through]*Recap last meeting's actions*
+* [line-through]*No LTS status check due to holiday schedule change*
+
+[[GovernanceMeetingArchive2017-December6thmeeting]]
+== December 6th meeting
+
+WHEN: December 6th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-12-06-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-12-06-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-November22ndmeeting]]
+== November 22nd meeting
+
+WHEN: November 22nd 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Planned release schedule for holiday season (topic for discussion
+proposed by https://wiki.jenkins.io/display/~andresrc[Unknown User
+(andresrc)])
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-11-22-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-11-22-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-November8thmeeting]]
+== November 8th meeting
+
+[.aui-icon .aui-icon-small .aui-iconfont-error .confluence-information-macro-icon]#
+#
+
+Note that the meeting time is in UTC, due to daylight savings time the
+start time for you may have changed recently.
+
+WHEN November 8th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* LTS baseline selection
+* Jenkins Enhancement Proposals
+(https://github.com/jenkinsci/jep/tree/jep-1/jep/1[JEP-1])
+( https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)] and https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(bitwiseman)] )
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-11-08-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-11-08-18.00.log.html[raw]
+
+ 
+
+[[GovernanceMeetingArchive2017-October25thmeeting]]
+== October 25th meeting
+
+WHEN October 25th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Q4 patron messages (Daniel) +
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-10-25-17.59.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-10-25-17.59.log.html[raw]
+
+ 
+
+[[GovernanceMeetingArchive2017-October11thmeeting]]
+== October 11th meeting
+
+WHEN October 11th 18:00 UTC
+
+ 
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-10-11-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-10-11-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-September27thmeeting]]
+== September 27th meeting
+
+WHEN September 27th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Huayou Tech request for mark usage for events "Jenkins User Conference
+China" (Forest Jing)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-09-27-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-09-27-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-September13thmeeting]]
+== September 13th meeting
+
+WHEN September 13th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* CloudBees request for mark usage for events  “Jenkins Days by
+CloudBees” (https://github.com/alyssat[Alyssa Tong])
+* TechMatrix request for mark usage for events "Jenkins Day Japan"
+(Kohsuke)
+* Introduction to Forest Jing - JAM Shanghai & Beijing organizer  +
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-09-13-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-09-13-18.00.log.html[raw]
+
+ 
+
+[[GovernanceMeetingArchive2017-August16thmeeting]]
+== August 16th meeting
+
+WHEN August 16th 18:00 UTC
+
+* Recap last meeting's actions
+* [line-through]*LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] will not make it to the meeting)*
+* next LTS baseline selection
+(https://wiki.jenkins.io/display/~jglick[Unknown User (jglick)])
+* Vote on proposal:[.F0XO1GC-mb-Y]# Add optional "Released as" and
+"Stage Release" states to JIRA#
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** JIRA ticket: [.jira-issue .conf-macro .output-block]#
+https://issues.jenkins-ci.org/browse/INFRA-1301[[.aui-icon .aui-icon-wait .issue-placeholder]##
+##INFRA-1301] - [.summary]#Getting issue details...#
+[.aui-lozenge .aui-lozenge-subtle .aui-lozenge-default .issue-placeholder]#STATUS#
+#
+** https://groups.google.com/forum/#%21topic/jenkinsci-dev/wzc4VLplHvs[https://groups.google.com/forum/#!topic/jenkinsci-dev/wzc4VLplHvs]
+** Proposal Text with
+Edits: https://docs.google.com/document/d/1EIRuCMOjmPgpxybkWRPHfx1f1yglcuYlqPWN8K1Ni28/edit?usp=sharing
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-08-16-17.59.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-08-16-17.59.log.html[raw]
+
+[[GovernanceMeetingArchive2017-August2meeting]]
+== August 2 meeting
+
+WHEN August 2nd 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] )
+* Jenkins World organization update (https://github.com/alyssat[Alyssa
+Tong])
+* Infra status update (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+* https://groups.google.com/d/msg/jenkinsci-dev/PoxnVCKa9NM/2F2iLlDuBwAJ[Jenkins
+mark usage request from CloudBees]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)] but
+ https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)] will
+proxy)
+* Deprecate Remoting CLI1/JNLP1/JNLP2/JNLP3 protocol - sign-off
+https://issues.jenkins-ci.org/browse/JENKINS-45841[JENKINS-45841]
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)]) +
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/sN2wHHFOJPg[Discussion
+in the Mailing List] (see compatibility notes and the rollout plan)
+** https://github.com/jenkinsci/jenkins/pull/2950[Main pull-request]
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-08-02-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-08-02-18.00.log.html[raw]
+
+ 
+
+[[GovernanceMeetingArchive2017-July19meeting]]
+== July 19 meeting
+
+WHEN July 19th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] )
+* https://github.com/docker-library/docs/pull/948[Deprecate] "jenkins"
+official docker image (that we don't control) and "jenkinsci/*" and
+start deploying our own stuff under
+"https://hub.docker.com/r/jenkins/[jenkins]/*" docker registry (ndeloof)
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-07-19-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-07-19-18.01.log.html[raw]
+
+ 
+
+[[GovernanceMeetingArchive2017-July5meeting]]
+== July 5 meeting
+
+WHEN July 5th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] )
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-07-05-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-07-05-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-June21stmeeting]]
+== June 21st meeting
+
+WHEN June 21st 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] )
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-06-21-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-06-21-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-June7thmeeting]]
+== June 7th meeting
+
+WHEN June 7th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] )
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-06-07-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-06-07-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-May24thmeeting]]
+== May 24th meeting
+
+WHEN May 24th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)] )
+** Next LTS baseline selection ([~olivergondza])
+* Purchasing a SendGrid account to send project emails from Azure-based
+applications - https://wiki.jenkins.io/display/~rtyler[Unknown User
+(rtyler)], https://wiki.jenkins.io/display/~olblak[Unknown User
+(olblak)]
+* Adding https://wiki.jenkins.io/display/~olblak[Unknown User
+(olblak)] as an admin in LDAP and provide access to jenkins-keys
+(provides puppet dashboard, account admin access, ability to encrypt
+secrets, etc)
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-05-24-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-05-24-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-May10thmeeting]]
+== May 10th meeting
+
+WHEN: May 10th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Infrastructure update (JIRA, Confluence, accounts, etc) (
+https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)],
+https://wiki.jenkins.io/display/~olblak[Unknown User (olblak)])
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-05-10-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-05-10-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-April26thmeeting]]
+== April 26th meeting
+
+WHEN: April 12th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Jenkins Ambassador program heads up (https://github.com/alyssat[Alyssa
+Tong])
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-04-26-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-04-26-18.01.log.html[raw]
+
+ 
+
+[[GovernanceMeetingArchive2017-April12thmeeting]]
+== April 12th meeting
+
+WHEN: April 12th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Google Groups issues (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+
+ 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-04-12-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-04-12-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-March29meeting]]
+== March 29 meeting
+
+WHEN: March 29 18:00 UTC
+
+* Recap last meeting's actions
+* LTS Status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Sublicense request, on behalf of JFrog, "Jenkins Community Day" event
+in Paris (Alyssa Tong)
+* Java 8 baseline bump heads up
+(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-29-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-29-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2017-March15meeting]]
+== March 15 meeting
+
+WHEN: March 15 18:00 UTC
+
+* Recap last meeting's actions
+* LTS Status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* The "Day of Jenkins" events (in
+http://www.code-conf.com/doj/doj-gbg/[GOT] and
+http://www.code-conf.com/doj/doj-osl/[OSL]) needs a sub license
+(https://wiki.jenkins-ci.org/display/~lars_kruse[Lars Kruse])
+* Obtain sub license for "DevOps Connect & Jenkins Days" events (Alyssa
+Tong)
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-15-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-15-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-March1meeting]]
+== March 1 meeting
+
+WHEN: March 1 18:00 UTC
+
+* Recap last meeting's actions
+* LTS Status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* Pick new LTS line
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+** https://jenkins.io/changelog/
+* The future of the patron program
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+** It doesn't make sense in its current form with the wiki slowly
+getting replaced
+** Do we want to just end it (for now), or implement e.g. on the site,
+on JIRA, …?
+* Obtain clearance on trademark usage "CloudBees Jenkins X" (Alyssa
+Tong)
+* GSoC 2017 update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-01-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-01-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-Feb15meeting]]
+== Feb 15 meeting
+
+WHEN: Feb 15 18:00 UTC
+
+* Recap last meeting's actions
+* LTS Status check
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)])
+* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)])
+* Infrastructure update (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+* Should we host plugins with closed-source dependencies?
+(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)],
+https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+** https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
+brought up the point after
+https://issues.jenkins-ci.org/browse/HOSTING-271[HOSTING-271]
+** Closed-source plugins are explicitly banned in the
+https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
+Document] ("But no such [proprietary] plugins will be hosted by the
+Jenkins project.") and on
+https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[Hosting Plugins]
+** Should we add a clarification that the source of all dependencies
+(which implies transient?) must also be open source? Or are binary blobs
+(so long as they're accessible) ok?
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-02-15-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-02-15-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2017-Feb1meeting]]
+== Feb 1 meeting
+
+WHEN: Feb 01 18:00 UTC
+
+* Recap last meeting's actions
+* LTS Status check
+* GSoC update
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/cPN7IZHGDWE[Status
+update]
+** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
+draf]
+* Infrastructure update (https://wiki.jenkins.io/display/~rtyler[Unknown
+User (rtyler)])
+* https://groups.google.com/forum/#!topic/jenkinsci-dev/1jZmjgSDcqM[Trademark
+usage approval] for upcoming "CloudBees Jenkins" product names
+(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+* Request for 50 private repos in the jenkinsci-cert GitHub org (1200
+USD/year, up from 20 repos for 600 USD/year)
+(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+
+Part 1:
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-02-01-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-02-01-18.00.log.html[raw]
+
+
+Part 2:
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-02-01-18.27.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-02-01-18.27.log.html[raw]
+
+[[GovernanceMeetingArchive2017-Jan18meeting]]
+== Jan 18 meeting
+
+WHEN Jan 18 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* Review GSoC project application status'
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/cPN7IZHGDWE[Status
+update]
+** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
+draf]
+* Bug Triage Team Idea
+(https://wiki.jenkins.io/display/~slide_o_mix[Unknown User
+(slide_o_mix)])
+* JDK8 baseline upgrade news
+(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)])
+** Jenkins https://github.com/jenkinsci/jenkins/pull/2698[core now
+builds on Windows] and is green \o/ (err, blue)
+** https://github.com/jenkins-infra/jenkins.io/pull/545[PR] for the
+public announcement is up for review
+* FOSDEM planning update
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-01-18-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-01-18-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2017-Jan4meeting]]
+== Jan 4 meeting
+
+WHEN Jan 4 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+** This should be quick as we postponed the .2 release
+image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/smile.svg[(smile)]
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-01-04-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-01-04-18.00.log.html[raw]

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -1,0 +1,511 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2018"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingArchive2018-Dec19]]
+== Dec 19
+
+WHEN December 19, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* https://groups.google.com/d/msg/jenkinsci-dev/MGZDWfhFaZI/Q6HdjOcHCQAJ[Trademark
+sublicensing request "CloudBees Jenkins X
+Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((https://wiki.jenkins.io/display/~bitwiseman[Unknown
+User (bitwiseman)] )
+* https://groups.google.com/d/msg/jenkinsci-dev/jv8oFl9PMM4/HvGw7ksICQAJ[Trademark
+sublicensing requests]
+(https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(bitwiseman)] ) +
+** Jenkins CI/CD Workshop by CloudBees
+** Jenkins Jumpstart by CloudBees +
+** Jenkins Virtuoso Workshop by CloudBees +
+** Jenkins X Cloud Native CI/CD Workshop by CloudBees
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-12-19-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-12-19-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-Dec5]]
+== Dec 5
+
+WHEN December 5, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ[Trademark
+sublicensing request
+"]https://groups.google.com/d/msg/jenkinsci-dev/5uFXdnr6-k0/tHjewODYBgAJ[CloudBees
+Jenkins X
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+* Java 11 preview availability - status update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+* GSoC status Update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-12-05-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-12-05-18.01.log.html[raw]
+
+[[GovernanceMeetingArchive2018-Nov21]]
+== Nov 21
+
+WHEN November 21, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* GSoC Update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)])
+* Platform SIG update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+*  Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-11-21-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-11-21-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2018-Nov7]]
+== Nov 7
+
+WHEN November 7, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* LTS next baseline selection
+* Trademark sublicensing
+request(https://wiki.jenkins.io/display/~surenpi[Unknown User
+(surenpi)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/UveOvVO-gwQhttps://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion[/discussion]
+*  Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-11-07-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-11-07-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2018-October10]]
+== October 10
+
+WHEN: October 10, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* Participating in
+Outreachy (https://wiki.jenkins.io/display/~tmiranda[Unknown User
+(tmiranda)])
+** https://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion
+* Trademark sublicensing request
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)] )
+** https://groups.google.com/d/topic/jenkinsci-dev/VysVavIJCnc/discussion
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-10-10-17.59.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-10-10-17.59.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-September12]]
+== September 12
+
+WHEN: September 12, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* Participating in Hacktoberfest
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/YYG1CyvcbgE
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-09-26-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-09-26-18.02.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-August29meeting]]
+== August 29 meeting
+
+WHEN August 29, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* GSoC Summer of Code: Results
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Cloud Native SIG update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Platform SIG update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Jenkins Ambassador applicants: Request to approve 2 new applicants
+(https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-08-29-18.04.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-08-29-18.04.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-August15meeting]]
+== August 15 meeting
+
+WHEN August 15, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* LTS next baseline selection
+* GSoC end-of-summer check
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-08-15.18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-08-15.18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2018-August1stmeeting]]
+== August 1st meeting
+
+WHEN: August 1st, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* GSoC status check
+* Travel grant request to DevOps World - Jenkins World SF
+(https://wiki.jenkins.io/display/~mandyhubbard[Unknown User
+(mandyhubbard)])
+** https://docs.google.com/document/d/1xbK9hbEMzg2oXNdxPDA6K-u3IWzbyVs2atqmzHu6VDE/edit?usp=sharing
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-08-01.18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-08-01.18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-Jul18thmeeting]]
+== Jul 18th meeting
+
+WHEN: July 18th, 18:00 UTC
+
+* Recap last meeting's actions
+** http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-20-18.10.html
+* LTS status check
+* Vote for mass adding Jenkinsfiles
+(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(olivergondza)]) +
+** https://groups.google.com/d/topic/jenkinsci-dev/6f_wKvfpESk/discussion
+* Growing community via a stronger Twitter presence
+(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)]) +
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/gqR_ee5grtM +
+* Jenkins Ambassader
+applicants (https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(bitwiseman)] & https://wiki.jenkins.io/display/~atong[Unknown User
+(atong)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
+* GSoC status update and travel grants budget request
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/zS1jzYRoF08
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-07-18-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-07-18-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-Jul4thmeeting]]
+== Jul 4th meeting
+
+*Meeting has been cancelled.*
+
+No agenda due to
+https://groups.google.com/forum/#!msg/jenkinsci-dev/oNzKUQcFik4/_6318kdAAAAJ[postponed
+LTS schedule].
+
+https://groups.google.com/d/msg/jenkinsci-dev/s_N84I1OwK8/GfmYA61PAgAJ[Proposed
+meeting cancellation].
+
+[[GovernanceMeetingArchive2018-Jun20thmeeting]]
+== Jun 20th meeting
+
+WHEN: June 20th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* https://groups.google.com/forum/#!topic/jenkinsci-dev/bmd6ooZZ7wI[Trademark
+Sublicensing Request]:
+https://www.code-conf.com/2018/day-of-jenkins-as-code/[Day of
+Jenkins [as code]] (https://wiki.jenkins.io/display/~ewel[Unknown User
+(ewel)] & Jasmine Crozier)
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Update: Jenkins & Java 10 Online
+Hackathon (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)]) +
+** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-20-18.10.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-20-18.10.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-Jun6thmeeting]]
+== Jun 6th meeting
+
+WHEN: June 6th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ[Trademark
+sublicensing request
+"]https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/jenkinsci-dev/dvnua3N32C0[CloudBees
+Jenkins
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+* https://github.com/jenkinsci/jep/edit/master/jep/5/README.adoc[Jenkins
+Ambassador program update]
+(https://wiki.jenkins.io/display/~bitwiseman[Unknown User (bitwiseman)]
+& https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/12D2tWxO6mM
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Update: Jenkins & Java 10 Online
+Hackathon (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-06-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-06-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-May23rdmeeting]]
+== May 23rd meeting
+
+WHEN: May 23rd, 18:00 UTC
+
+* LTS status check
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-05-23-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-05-23-18.02.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-May9thmeeting]]
+== May 9th meeting
+
+WHEN: May 9th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* LTS next baseline selection
+* GSoC status check
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-05-09-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-05-09-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-April25thmeeting]]
+== April 25th meeting
+
+WHEN: April 25th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* JEP-200 status update (https://wiki.jenkins.io/display/~jglick[Unknown
+User (jglick)])
+** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/AUdrTLmezgU
+* GSoC status update (https://wiki.jenkins.io/display/~deepchip[Unknown
+User (deepchip)])
+** Announcement:
+https://groups.google.com/forum/#!topic/jenkinsci-dev/92wY9hBW1Vo
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-04-25-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-04-25-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-April11thmeeting]]
+== April 11th meeting
+
+WHEN: April 11th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* GSoC status check
+* https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ[Trademark
+sublicensing request "DevOps World - Jenkins
+World"] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(kohsuke)])
+* SPI financial request for review
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-04-11-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-04-11-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-March28thmeeting]]
+== March 28th meeting
+
+WHEN: March 28th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* JEP-200 update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)])
+* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)])
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-03-28-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-03-28-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-March14thmeeting]]
+== March 14th meeting
+
+WHEN: March 14th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* https://groups.google.com/d/msg/jenkinsci-dev/7m9bz6KkVv4/gd8qhk6cAQAJ[Trademark
+sublicensing request "CloudBees Jenkins Metrics"]
+(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-03-14-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-03-14-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingArchive2018-February28thmeeting]]
+== February 28th meeting
+
+WHEN: February 28th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-02-28-18.02.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-02-28-18.02.log.html[raw]
+
+[[GovernanceMeetingArchive2018-February14thmeeting]]
+== February 14th meeting
+
+WHEN: February 14th, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* LTS baseline selection
+* Quick GSoC update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-02-14-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-02-14-18.00.log.html[raw]
+
+[[GovernanceMeetingArchive2018-January31stmeeting]]
+== January 31st meeting
+
+WHEN: January 31st, 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+
+*This meeting was skipped.*
+
+[[GovernanceMeetingArchive2018-January17thmeeting]]
+== January 17th meeting
+
+WHEN: January 17th 18:00 UTC
+
+* Recap last meeting's actions
+* LTS status check
+* JEP-200 status update / Q&A
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/EALjDtS4riU
+** https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins
+affected by fix for JEP-200]
+** Agenda: Answer any questions, agree on the out-of-order weekly
+release if needed
+* GSoC 2018: Discussion - Do we want to kick-it off?
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!searchin/jenkinsci-dev/Gsoc%7Csort:date/jenkinsci-dev/We-14-z_YXU/NgmQbPeFCwAJ
+** Current project
+ideas: https://docs.google.com/document/d/1q2p_XZEdbkcVDMpEPTtjPS15i2Oq3CQgH_geJjPhofY/edit
+* Request for mark usage, "JUC Paris" by JFrog (Katrin Runser)
+* FOSDEM planning update (Alyssa Tong)
+
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-01-17-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-01-17-18.01.log.html[raw]

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -1,0 +1,293 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting Archive 2019"
+section: project
+---
+
+This page is an archive of past meeting agendas, their minutes and IRC logs, for the year shown above.
+For current information, see the link:/project/governance-meeting[Governance Meeting] page.
+
+[[GovernanceMeetingAgenda-November20]]
+=== November 20
+
+* LTS status check
+* Event updates: FOSDEM, Jenkins World, etc.
+* Trademark usage request: Jenkins Master Class (Parker Ennis)
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/Cq_NQwyLD5s
+* Budget request: Hacktoberfest swag
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/k5KICbRDoz4
+* Approving Browser Support Policy update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/TV_pLEah9B4
+** https://github.com/jenkins-infra/jenkins.io/pull/2659
+* Approving the OS X packaging deprecation
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/xc-lDVsr0bQ
+
+[[GovernanceMeetingAgenda-September25]]
+=== September 25
+
+* Last meeting actions
+* Motions to vote on:
+** Request for trademark approval to use the name "Jenkins Health
+Advisor by CloudBees" instead of "CloudBees Jenkins Advisor".
+
+[[GovernanceMeetingAgenda-September11]]
+=== September 11
+
+* Last meeting actions
+* LTS status check
+* Jenkins Board & Officer Elections 2019
+(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)])
+** Dev list
+thread: https://groups.google.com/d/msg/jenkinsci-dev/vKi9JpxTQxY/pBidPImHAQAJ
+** Links:
+*** https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
+Election Process] (2015 base edition)
+*** https://wiki.jenkins.io/display/JENKINS/Governance+Board[Governance
+Board]
+** Motions to vote on: +
+*** All officer positions will be voted on in 2019
+(https://wiki.jenkins.io/display/JENKINS/Team+Leads[Team Leads])
+*** 3 Board positions instead of 2 in the proposal will be voted on in
+2019 (Dean Yu's seat + 2 new seats). 2 will be voted on in 2020
+*** CDF will supervise the election and run the voting
+using https://civs.cs.cornell.edu/[The Condorcet Internet voting
+system] instead
+of https://en.wikipedia.org/wiki/Single_transferable_vote[Single
+Transferable Vote]
+*** The election cut-off date for valid jenkins.io accounts for the 2019
+election is 1st September 2019
+*** The proposed election schedule will start on 13 September 2019 and
+conclude on 4 November 2019 with intermediate dates as per dev list
+thread
+*** Adding new officer role: Documentation officer (content officer from
+the
+2015 https://wiki.jenkins.io/display/JENKINS/Proposal+-+Project+sub-teams[Proposal
+- Project sub-teams])
+** Voting on a final proposal
+
+[[GovernanceMeetingAgenda-August28]]
+=== August 28
+
+* Last meeting actions
+* LTS status check
+
+[[GovernanceMeetingAgenda-July31]]
+=== July 31
+
+* Weekly Release delay
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+* LTS status check
+* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)] )
+** Part 1 demos: https://www.youtube.com/watch?v=tnoObQqGhyM
+** Part 2 demos:  https://www.youtube.com/watch?v=HlENuZZq7zc
+* GSoC budgeting (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)] )
+** Blanket approval for using GSoC budget for GSoC in 2019
+*** https://groups.google.com/forum/#!topic/jenkinsci-dev/MaFMYoo8Nxg
+*** https://github.com/jenkinsci/jep/tree/master/jep/8
+** If not approved, Budget approvals for GSoC: Swag and Travel grants
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] https://wiki.jenkins.io/display/~markyjackson5[Unknown
+User (markyjackson5)] https://wiki.jenkins.io/display/~deepchip[Unknown
+User (deepchip)] )
+*** Earmarking swag, swag shipping budget and community/contributors
+poster
+requests: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
+*** Dev list
+thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
+* Budget approvals for the Community Bridge dry-run
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+** Dev List
+thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/ZyLV-FTPbcM
+* SIG status reports
+( https://wiki.jenkins.io/display/~markewaite[Unknown User
+(markewaite)])
+** Process change - use e-mail or blog posts for
+https://github.com/jenkinsci/jep/tree/master/jep/4#specification[JEP-4
+status reports]
+** Platform SIG status
+** Docs SIG status 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-18.01.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-18.01.log.html[raw]
+
+[[GovernanceMeetingAgenda-June05]]
+=== June 05
+
+* Recap last meeting actions
+* LTS status check
+* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)] )
+* Platform SIG and Java 11 support status update
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+** https://github.com/jenkinsci/jep/tree/master/jep/211
+* Introducing global configurations in jenkinsci GitHub org
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] )
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQwQiI
+* Docs SIG update ( https://wiki.jenkins.io/display/~markewaite[Unknown
+User (markewaite)])
+
+[[GovernanceMeetingAgenda-May22]]
+=== May 22
+
+* Recap last meeting actions
+* LTS status check
+* Docs SIG update (https://wiki.jenkins.io/display/~markewaite[Unknown
+User (markewaite)])
+
+[[GovernanceMeetingAgenda-May8]]
+=== May 8
+
+* Recap last meeting actions
+* LTS status check
+* LTS baseline selection
+* GSoC Update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)] )
+* Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+* CDF update (https://wiki.jenkins.io/display/~tmiranda[Unknown User
+(tmiranda)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingAgenda-April24]]
+=== April 24
+
+* Recap last meeting actions
+* LTS status check
+* Google Summer of Code update (as needed)
+* Google Season of Docs update
+(https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)]
+)
+* Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingAgenda-April10]]
+=== April 10
+
+* Recap last meeting actions
+* LTS status check
+* Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+User (tmiranda)])
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-10-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-10-18.00.log.html[raw]
+
+
+
+[[GovernanceMeetingAgenda-Mar27]]
+=== Mar 27
+
+
+
+* Recap last meeting actions
+* LTS status checks
+* Google Season of Docs discussion +
+
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-18.24.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-18.24.log.html[raw]
+
+
+
+[[GovernanceMeetingAgenda-Feb13]]
+=== Feb 13
+
+* Recap last meeting actions
+* LTS status check and baseline selection
+* Java 11 Support Update && GA support in the new LTS baseline
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Outreachy update & next application period
+(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)])
+** https://groups.google.com/d/msg/jenkinsci-dev/yaPrguId_sY/lSs7mHaxAAAJ
+* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)] )
+
+Meeting bot was unavailable during the meeting, so minutes are here:
+https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+2019-02-13+Notes+and+Log[Governance
+Meeting 2019-02-13 Notes and Log]
+
+[[GovernanceMeetingAgenda-Jan30]]
+=== [line-through]*Jan 30*
+
+[line-through]*WHEN January 30, 18:00 UTC*
+
+* [line-through]*Recap last meeting actions*
+
+[[GovernanceMeetingAgenda-Jan16]]
+=== Jan 16
+
+WHEN January 16, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* Platform SIG status report - Java 11 and more
+(https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)])
+* GSoC status report
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+* Status report: Advocacy and Outreach SIG
+(https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(bitwiseman)] or https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+User (oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/84vjWz_Ho1k
+* Update: Hardware&EDA and Embedded SIGs
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)])
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/a69DXm6qQms
+* Request for https://github.com/LinuxSuRen[Rick] to be listed as
+Jenkins press contact for China
+(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)]) 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-16-18.00.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-16-18.00.log.html[raw]
+
+[[GovernanceMeetingAgenda-Jan2]]
+=== Jan 2
+
+WHEN January 2, 18:00 UTC
+
+* Recap last meeting actions
+* LTS status check
+* Jenkins GSoC: 500USD budget approval for swag
+(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(oleg_nenashev)] or https://wiki.jenkins.io/display/~lloydchang[Unknown
+User (lloydchang)] or [.fabric]#@deepchip#)
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw 
+
+MINUTES
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-02-18.06.html[summary]
+and
+http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-02-18.06.log.html[raw]

--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -44,8 +44,7 @@ Older agendas, minutes and IRC logs are archived on these pages:
 
 == Useful links
 
-* http://webchat.freenode.net/?channels=jenkins&uio=OT10cnVlde[Direct IRC Webchat link]
-* http://permatime.com/UTC[Permatime]
+* https://webchat.freenode.net/#jenkins-meeting[Direct IRC Webchat link]
 
 == IRC Tips
 

--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -5,24 +5,29 @@ section: project
 ---
 
 As per the Jenkins link:/project/governance/[Governance Document],
-the project holds a bi-weekly meeting on the `#jenkins-meeting` link:/chat[IRC Channel] on Freenode,
-open for everyone to participate, where we can make decisions about the project.
-In case of doubt, the project's link:/project/board[governance board] takes priority.
+the project holds a bi-weekly governance meeting on the `#jenkins-meeting` link:/chat[IRC Channel] on Freenode.
+Jenkins Governance Meeting is open for everyone to participate and vote.
+The meetings calendar is available link:/event-calendar[here].
 
-The meeting is run with http://meetbot.debian.net/Manual.html[the moderation of a bot].
-You can use the `+#info+` and `+#idea+` commands to flag info and ideas as such, which will be noted in the meeting minutes. 
-Further commands are documented http://meetbot.debian.net/Manual.html#commands[here].
-
-Minutes for each meeting should be linked with each past meeting below, and can be otherwise found in full on
-http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
-Action items are https://issues.jenkins-ci.org/browse/MEETING[tracked in JIRA].
+This meeting is used to make decisions about the project: budget approvals, key decisions sign-off, voting on proposals if there is no consensus, etc.
+The topics are usually discussed in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[developer mailing list], and contributors can cast their votes there ahead of the meeting.
+This meeting is rarely used for technical decisions, for that purpose we use the developer mailing list and link:https://github.com/jenkinsci/jep/[Jenkins Enhancement Proposals].
+If a decision cannot be made at the governance meeting, the project's link:/project/board[governance board] takes priority.
 
 === Agenda
 
-When adding agenda items, please add them to the to the *end of the list*
-(i.e. first-come, first-served), and place your Jenkins user ID next to it.
+Starting from 12.12.2019, the governance meeting agenda is posted in link:http://bit.ly/jenkins-governance-meeting[this Google Document].
+Everyone is welcome to add a topic for one of the incoming meetings by suggesting a change in this Google document.
 
-[[GovernanceMeetingAgenda-ArchivedMeetings]]
+++++
+<iframe src="https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg?embedded=true" width="100%" height="600px"></iframe>
+++++
+
+=== Meeting notes
+
+Minutes and raw conversation history for each meeting can be found in full on link:http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
+The meeting minutes also contain the list of action items defined at the meeting.
+
 === Archived Meetings
 
 Older agendas, minutes and IRC logs are archived on these pages:
@@ -37,8 +42,13 @@ Older agendas, minutes and IRC logs are archived on these pages:
 * link:./archives/2012[Governance Meeting Archive 2012]
 * link:./archives/2011[Governance Meeting Archive 2011]
 
-[[GovernanceMeetingAgenda-GeneralMeetingResources]]
-== General Meeting Resources
+== Useful links
 
 * http://webchat.freenode.net/?channels=jenkins&uio=OT10cnVlde[Direct IRC Webchat link]
 * http://permatime.com/UTC[Permatime]
+
+== IRC Tips
+
+The meeting is run with http://meetbot.debian.net/Manual.html[the moderation of a bot].
+You can use the `+#info+` and `+#idea+` commands to flag info and ideas as such, which will be noted in the meeting minutes. 
+Further commands are documented http://meetbot.debian.net/Manual.html#commands[here].

--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -1,0 +1,44 @@
+---
+layout: simplepage
+title: "Jenkins Governance Meeting"
+section: project
+---
+
+As per the Jenkins link:/project/governance/[Governance Document],
+the project holds a bi-weekly meeting on the `#jenkins-meeting` link:/chat[IRC Channel] on Freenode,
+open for everyone to participate, where we can make decisions about the project.
+In case of doubt, the project's link:/project/board[governance board] takes priority.
+
+The meeting is run with http://meetbot.debian.net/Manual.html[the moderation of a bot].
+You can use the `+#info+` and `+#idea+` commands to flag info and ideas as such, which will be noted in the meeting minutes. 
+Further commands are documented http://meetbot.debian.net/Manual.html#commands[here].
+
+Minutes for each meeting should be linked with each past meeting below, and can be otherwise found in full on
+http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
+Action items are https://issues.jenkins-ci.org/browse/MEETING[tracked in JIRA].
+
+=== Agenda
+
+When adding agenda items, please add them to the to the *end of the list*
+(i.e. first-come, first-served), and place your Jenkins user ID next to it.
+
+[[GovernanceMeetingAgenda-ArchivedMeetings]]
+=== Archived Meetings
+
+Older agendas, minutes and IRC logs are archived on these pages:
+
+* link:./archives/2019[Governance Meeting Archive 2019]
+* link:./archives/2018[Governance Meeting Archive 2018]
+* link:./archives/2017[Governance Meeting Archive 2017]
+* link:./archives/2016[Governance Meeting Archive 2016]
+* link:./archives/2015[Governance Meeting Archive 2015]
+* link:./archives/2014[Governance Meeting Archive 2014]
+* link:./archives/2013[Governance Meeting Archive 2013]
+* link:./archives/2012[Governance Meeting Archive 2012]
+* link:./archives/2011[Governance Meeting Archive 2011]
+
+[[GovernanceMeetingAgenda-GeneralMeetingResources]]
+== General Meeting Resources
+
+* http://webchat.freenode.net/?channels=jenkins&uio=OT10cnVlde[Direct IRC Webchat link]
+* http://permatime.com/UTC[Permatime]

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -254,7 +254,7 @@ We link:https://ci.jenkins-ci.org/[run Jenkins for our own development] and to a
 
 The Jenkins project uses biweekly project meetings as the primary forum of decision making for matters that need consensus.
 The meeting is link:/chat/#meeting[conducted on IRC] and open to anyone.
-Agenda items can be added by anyone by simply adding your topic to link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[the Governance Meeting Agenda wiki page].
+Agenda items can be added by anyone by simply adding your topic to link:/project/governance-meeting[the Governance Meeting Agenda].
 Be sure to include your user name (so we know who proposed a topic).
 
 The meeting minutes are public:

--- a/content/project/index.adoc
+++ b/content/project/index.adoc
@@ -12,6 +12,7 @@ This page provides some links to pages describing the project structure and its 
 ### Project governance
 
 * link:./governance[Jenkins Governance Document] - overview of the project's governance model, philosophy, project roles, decision making process, etc.
+* link:./governance-meeting[Jenkins Governance Meetings]
 * link:./conduct[Code of Conduct]
 * link:./board-election-process[Jenkins Board election process]
 


### PR DESCRIPTION
- [x] - Jenkins Governance meeting documentation was moved to jenkins.io and updated
- [x] - Meeting archives were moved to jenkins.io as well
- [x] - New meeting agenda is in Google Doc: https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit?usp=sharing

![image](https://user-images.githubusercontent.com/3000480/70725047-ffab3200-1cfb-11ea-9beb-65c22952d3e8.png)

![image](https://user-images.githubusercontent.com/3000480/70725091-0df94e00-1cfc-11ea-9f8a-33e860dc3c1e.png)



https://issues.jenkins-ci.org/browse/WEBSITE-700
