### PR TITLE
Modify the Java version.

### DIFF
--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -16,7 +16,7 @@ For this tour, you will require:
 ** 256 MB of RAM, although more than 512MB is recommended
 ** 10 GB of drive space (for Jenkins and your Docker image)
 * The following software installed:
-** Java 8 (either a JRE or Java Development Kit (JDK) is fine)
+** Java 8 or 11 (either a JRE or Java Development Kit (JDK) is fine)
 ** https://docs.docker.com/[Docker] (navigate to *Get Docker* at the top of the
    website to access the Docker download that's suitable for your platform)
 


### PR DESCRIPTION
When I tried to boot Jenkins with Java 13, I got the error message below.
Jenkins requires Java versions [8, 11]

When I tried to boot Jenkins with Java 11, there were no error messages.
But, the following documents are written only about Java 8. So I added Java 11 as well.
https://jenkins.io/doc/pipeline/tour/getting-started/
