### PR TITLE
[WEBSITE-641] Specify valid formats for GitHub documentation

### DIFF
--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -43,7 +43,7 @@ To publish the plugin documentation on GitHub:
 linked from the README, the plugin site will display both absolute and
 relative links
 ** Images from pages will be displayed by the plugin site as well
-. Modify your project URL to point to the GitHub repository, e.g. `http://github.com/jenkinsci/your-plugin`.
+. Modify your project URL to point to the GitHub repository, e.g. `https://github.com/jenkinsci/your-plugin`.
   See the guidelines for Maven and Gradle below.
 . Release the new plugin version.
   Once the link:https://plugins.jenkins.io/[plugin site] picks up the release (which can take up to a few hours) it will also display the documentation from GitHub.
@@ -53,6 +53,17 @@ Documentation examples:
 * https://plugins.jenkins.io/configuration-as-code
 * https://plugins.jenkins.io/gradle
 * https://plugins.jenkins.io/mailer
+
+Valid URL formats for GitHub based documentation are
+
+https&#58;//github.com/jenkinsci/YOUR-PLUGIN::
+Loads README located in the root of `YOUR-PLUGIN` repository from the master branch
+https&#58;//github.com/jenkinsci/YOUR-PLUGIN/tree/REF:: 
+Load README located in the root of `YOUR-PLUGIN` repository from the tag or branch `REF`
+https&#58;//github.com/jenkinsci/YOUR-PLUGIN/blob/REF/path/to/readme.md::
+Loads a Markdown or AsciiDoc file specified by path from `YOUR-PLUGIN` repository's tag or branch `REF`.
+
+If you use git tag for releases, you can make sure the plugin site loads a snapshot of your README relevant for the last release by setting the URL to e.g. `\https://github.com/jenkinsci/${project.artifactId}/tree/${project.artifactId}-${revision}`.
 
 === Using Jenkins Wiki as source of documentation
 
@@ -67,7 +78,7 @@ You should link to your plugin's documentation, whether on the wiki or elsewhere
 ```xml
 <project>
   ...
-  <url>http://github.com/jenkinsci/your-plugin</url>
+  <url>https://github.com/jenkinsci/your-plugin</url>
   ...
 </project>
 ```
@@ -78,7 +89,7 @@ you can set the URL in your `+build.gradle+` like so:
 ```groovy
 jenkinsPlugin {
   // ...
-  url = 'http://github.com/jenkinsci/your-plugin'
+  url = 'https://github.com/jenkinsci/your-plugin'
   // ...
 }
 ```

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -63,7 +63,7 @@ Load README located in the root of `YOUR-PLUGIN` repository from the tag or bran
 https&#58;//github.com/jenkinsci/YOUR-PLUGIN/blob/REF/path/to/readme.md::
 Loads a Markdown or AsciiDoc file specified by path from `YOUR-PLUGIN` repository's tag or branch `REF`.
 
-If you use git tag for releases, you can make sure the plugin site loads a snapshot of your README relevant for the last release by setting the URL to e.g. `\https://github.com/jenkinsci/${project.artifactId}/tree/${project.artifactId}-${revision}`.
+If you use git tag for releases, you can make sure the plugin site loads a snapshot of your README relevant for the last release by setting the URL to e.g. `+https://github.com/jenkinsci/${project.artifactId}/tree/${project.artifactId}-${revision}+`.
 
 === Using Jenkins Wiki as source of documentation
 


### PR DESCRIPTION
The list of valid formats explains how to use the URL to load any branch or tag of a readme file.
See also https://issues.jenkins-ci.org/browse/WEBSITE-641