### PR TITLE
[WEBSITE-702] - Update the donations status on the jenkins.io/donate page

### DIFF
--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -4,7 +4,6 @@ title: "Donate to Jenkins"
 ---
 
 WARNING: Jenkins donations flow is being redesigned at the moment.
-At the moment there is no reliable way to donate money to the project, but we are working on it.
 See jira:INFRA-2396[Jenkins Donations flow update] for more information about the current status.
 If you want to make a donation, please contact the link:mailto://jenkinsci-board@googlegroups.com[Jenkins Board].
 
@@ -22,11 +21,17 @@ Your contribution is *not* used for paying personnel.
 
 == Ways to donate
 
+There are multiple ways to donate money to the Jenkins project.
+
 === Donations through SPI
 
-The Jenkins project used to accept donations through link:http://www.spi-inc.org/[Software in the Public Interest (SPI)].
-Due to the ongoing migration to link:https://cd.foundation/[Continuous Delivery Foundation],
-SPI will no longer accept donations to the Jenkins project. 
+Before the transition to link:https://cd.foundation/[Continuous Delivery Foundation] in 2019,
+Jenkins project was under the umbrella of link:http://www.spi-inc.org/[Software in the Public Interest (SPI)].
+At the moment of this page update (Dec 26, 2019), SPI still accepts donations to the Jenkins project.
+In the future SPI will stop accepting donations.
+
+* You can do a link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[donation online] in USD
+* For other ways to donate, refer to the link:https://spi-inc.org/donations[donations page on the SPI website]
 
 === Donations through ffis.de
 

--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -3,19 +3,10 @@ layout: simplepage
 title: "Donate to Jenkins"
 ---
 
-NOTE: You can donate directly through the link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[SPI donation page] (donation in USD)
-or via the link:http://www.ffis.de/Verein/donations.html[ffis.de donation page] (donation in EUR) if you do not need the context below
-
-The Jenkins project is affiliated with link:https://www.spi-inc.org[Software in the Public Interest], a non-profit organization.
-Via SPI we can accept link:https://co.clickandpledge.com/advanced/default.aspx?wid=46160[donations online] in USD.
-For other ways to donate, refer to the link:https://spi-inc.org/donations[donations page on the SPI website].
-
-
-For European residents, we can also accept donations through link:http://www.ffis.de/Verein/donations.html[ffis.de] via bank transfer in EUR.
-As ffis.de is a charitable association, this donation is tax deductible in Germany.
-
-NOTE: If you donate via ffis.de, please write to `donation[at]ffis.de` to ensure that your donation will be earmarked for the Jenkins project.
-
+WARNING: Jenkins donations flow is being redesigned at the moment.
+At the moment there is no reliable way to donate money to the project, but we are working on it.
+See jira:INFRA-2396[Jenkins Donations flow update] for more information about the current status.
+If you want to make a donation, please contact the link:mailto://jenkinsci-board@googlegroups.com[Jenkins Board].
 
 == Why donate?
 
@@ -27,9 +18,24 @@ Your contributions help us keep Jenkins going by paying project expenses, such a
 * Covering network transit costs (not including that incurred by mirrors)
 * Equipment/replacement hardware
 
-A portion of contributions help fund SPI, Inc, which acts as the legal umbrella organization for holding copyrights, etc.
-
 Your contribution is *not* used for paying personnel.
+
+== Ways to donate
+
+=== Donations through SPI
+
+The Jenkins project used to accept donations through link:http://www.spi-inc.org/[Software in the Public Interest (SPI)].
+Due to the ongoing migration to link:https://cd.foundation/[Continuous Delivery Foundation],
+SPI will no longer accept donations to the Jenkins project. 
+
+=== Donations through ffis.de
+
+WARNING: Status of this donation way is not clear, see jira:WEBSITE-703[]
+
+For European residents, we can also accept donations through link:http://www.ffis.de/Verein/donations.html[ffis.de] via bank transfer in EUR.
+As ffis.de is a charitable association, this donation is tax deductible in Germany.
+
+NOTE: If you donate via ffis.de, please write to `donation[at]ffis.de` to ensure that your donation will be earmarked for the Jenkins project.
 
 == Friend of Jenkins
 


### PR DESCRIPTION
This pull request updates the donations status, as discussed with the Jenkins Board and @tracymiranda in the Governance mailing list. See [INFRA-2396](https://issues.jenkins-ci.org/browse/INFRA-2396) for the EPIC which summarizes this discussion.

I will start the discussion in the dev list about the next steps. This is rather an immediate actions to turn off the broken documentation which may mislead users.

Changes summary:

- [x] - Add a banner which indicates the WIP status of the page
- [x] - Explicitly deprecate the SPI dontaions flow
- [x] - Add a warning for the ffis.de flow (status is unknown)


