### PR TITLE
[WEBSITE-706] Restore 'Handbook' heading to TOC

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -75,6 +75,8 @@ section: doc
           %li
             = active_href('doc/tutorials/build-a-multibranch-pipeline-project', 'End-to-End Multibranch Pipeline Project Creation')
 
+        %h4
+          Handbook
         %ul
           - site.handbook.chapters.each do |chapter|
             %li

--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -98,7 +98,7 @@ section: doc
             = active_href('doc/upgrade-guide', 'LTS Upgrade Guide', :fuzzy => true)
 
         %h5
-          Recent Tutorial Blog Posts
+          Tutorial Blog Posts
         %ul
           - tutorials[0...3].each do |t|
             %li


### PR DESCRIPTION
The 'Handbook' heading should be above the Handbook contents in the table of contents so that it matches with the tutorial section that precedes it and the resources section that follows it.

The tutorials header is easier to read as a single line rather than two lines.

## Before

![user-docs-entry-page-01](https://user-images.githubusercontent.com/156685/71389694-b4760680-25ba-11ea-88cf-f46a34e7d646.png)

## After

![user-docs-entry-page-02](https://user-images.githubusercontent.com/156685/71389703-b8098d80-25ba-11ea-9720-3db28dab2fd7.png)
