### PR TITLE
Remove Feb 2019 disclaimers on Java 11 LTS support

### DIFF
--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -5,11 +5,11 @@ title: Running Jenkins on Java 11
 
 If you are upgrading the Jenkins JVM version from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow these guidelines].
 
-NOTE: As of February 2019, Jenkins cores more recent than ``2.164+``footnote:[Although it's technically been possible to run Jenkins on Java 11 since version `2.155`, doing so is far more complex. Running any Jenkins version prior to `2.164` on Java 11 *is not recommended*] do not require a JVM upgrade.
+NOTE: Jenkins cores more recent than ``2.164+``footnote:[Although it's technically been possible to run Jenkins on Java 11 since version `2.155`, doing so is far more complex. Running any Jenkins version prior to `2.164` on Java 11 *is not recommended*] do not require a JVM upgrade.
 
 For simplicity, this document describes how to run the most recent version of Jenkins on Java 11.
 
-NOTE: Production deployments should use only LTS versions of Jenkins. As of February 2019, there are no LTS versions with Java 11 support.
+NOTE: Production deployments should use only LTS versions of Jenkins.
 
 == Running Jenkins with Docker
 

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -13,7 +13,9 @@ As with any upgrade, we recommend backing up `JENKINS_HOME` and testing the upgr
 
 == Upgrading Jenkins
 
-NOTE: In production environments, you should use only LTS versions of Jenkins. As of February 2019, *there are no LTS versions that support Java 11*.
+NOTE: In production environments, you should use only LTS versions of Jenkins.
+Java 11 support was first included in a Long Term Support release beginning with Jenkins 2.164.1.
+All Jenkins LTS versions since 2.164.1 support Java 11.
 
 If you need to upgrade Jenkins as well as the JVM, we recommand that you:
 
@@ -61,7 +63,7 @@ Java Web Start has been removed in Java 11.
 When a Jenkins master is running on Java 11, the Java Web Start button will no longer appear in the Web UI.
 Agents for a Java 11 Jenkins server can't be launched from a `*.jnlp` file downloaded to a web browser.
 
-As of February 2019, there are no plans to replace this functionality.
+There are no plans to replace this functionality.
 Connect agents to Jenkins on Java 11 with plugins like plugin:ssh-slaves[SSH Slaves Plugin], with operating system command line calls to `java -jar agent.jar`, or by using containers.
 
 == JDK Tool Automatic installer


### PR DESCRIPTION
## Remove Java 11 LTS support disclaimers

Java 11 support has been available long enough that we can remove the February 2019 disclaimer.  Simpler to discuss the Java 11 support as a "given".