### PR TITLE
Embed Platform and Docs SIG meeting agendas

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -121,9 +121,15 @@ Useful links:
 
 We have regular meetings on Fridays every two weeks, at *1PM UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
-At these meetings we discuss projects and do presentations/demos.
-You can find and contribute to the agenda for the incoming meetings
-link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[here].
-
-Meetings are conducted and recorded using Zoom.
+At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
+Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+
+==== Meeting Agendas
+
+Meeting agendas and meeting notes for the SIG are posted in link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c[this Google Document].
+Anyone is welcome to add a topic for an upcoming meeting by suggesting a change in the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c[agenda].
+
+++++
+<iframe src="https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c?embedded=true" width="100%" height="600px"></iframe>
+++++

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -82,10 +82,15 @@ See the link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8t
 
 We have regular meetings on Thursdays every two weeks, at *12:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
-At these meetings we discuss project statuses and do presentations/demos.
-You can find and contribute to the agenda for the incoming meetings
-link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y/edit?usp=sharing[here].
+At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
+Meetings are conducted and recorded via Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].
+Participant links are posted in the link:https://gitter.im/jenkinsci/platform-sig[SIG Gitter Chat] 10 minutes before the meeting starts.
 
-Meetings are conducted and recorded via Zoom.
-Participant links are posted in the link:https://gitter.im/jenkinsci/platform-sig[SIG Gitter Chat] within 10 minutes before the meeting starts.
-Meeting recordings are posted to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].
+==== Meeting Agendas
+
+Meeting agendas and meeting notes for the SIG are posted in link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y[this Google Document].
+Anyone is welcome to add a topic for an upcoming meeting by suggesting a change in the link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y[agenda].
+
+++++
+<iframe src="https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y?embedded=true" width="100%" height="600px"></iframe>
+++++


### PR DESCRIPTION
## Embed Platform and Docs SIG meeting agendas

Consistent with other uses of embedded Google documents and easier for contirbutors to find them and help with them.