### PR TITLE
fix golang image name in scripted pipeline example

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -202,7 +202,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('go').inside {
+        docker.image('golang').inside {
             sh 'go version'
         }
     }


### PR DESCRIPTION
the docker image name is "golang" and not "go" (https://hub.docker.com/_/golang)