### PR TITLE
Build a Node.js and React app with npm tutorial fix.

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -36,6 +36,7 @@ docker volume create jenkins-data
   link:https://docs.docker.com/engine/reference/commandline/container_run/[`docker container run`]
   command:
 +
+ifeval::["{tutorial-for}" == "node"]
 [source,bash]
 ----
 docker container run --name jenkins-docker --rm --detach \
@@ -46,6 +47,18 @@ docker container run --name jenkins-docker --rm --detach \
   --volume "$HOME":/home \
   --publish 3000:3000 docker:dind
 ----
+endif::[]
+ifeval::["{tutorial-for}" != "node"]
+[source,bash]
+----
+docker container run --name jenkins-docker --rm --detach \
+  --privileged --network jenkins --network-alias docker \
+  --env DOCKER_TLS_CERTDIR=/certs \
+  --volume jenkins-docker-certs:/certs/client \
+  --volume jenkins-data:/var/jenkins_home \
+  --volume "$HOME":/home docker:dind
+----
+endif::[]
 . Run the `jenkinsci/blueocean` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/commandline/container_run/[`docker container run`]

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -48,7 +48,7 @@ docker container run --name jenkins-docker --rm --detach \
   --publish 3000:3000 docker:dind
 ----
 endif::[]
-ifeval::["{tutorial-for}" != "node"]
+ifndef::tutorial-for[]
 [source,bash]
 ----
 docker container run --name jenkins-docker --rm --detach \

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -44,7 +44,7 @@ docker container run --name jenkins-docker --rm --detach \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
   --volume "$HOME":/home \
-  docker:dind
+  --publish 3000:3000 docker:dind
 ----
 . Run the `jenkinsci/blueocean` image as a container in Docker using the
   following

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -7,6 +7,8 @@ section: doc
 :toc:
 :toclevels: 3
 :imagesdir: ../../book/resources
+:tutorial-for: node
+
 
 This tutorial shows you how to use Jenkins to orchestrate building a simple
 https://nodejs.org/en/[Node.js] and https://reactjs.org/[React] application


### PR DESCRIPTION
Hi, I followed the [Build a Node.js and React app with npm tutorial](https://jenkins.io/doc/tutorials/build-a-node-js-and-react-app-with-npm/), and I got stuck in the delivering stage when trying to access localhost:3000 for the loaded React app.
This took me quite sometime to figure out that I have to expose the 3000 port when start up the docker:dind image.

This is a draft PR since the adoc is used for multiple tutorials and I'm not sure how to make it DRY.
Is there a mechanism in asciidoctor that let you include a doc with parameters?