### PR TITLE
NY2020 Blog post - Link updates and copy-edits

### DIFF
--- a/content/blog/2020/01/2020-01-07-happy-new-year.adoc
+++ b/content/blog/2020/01/2020-01-07-happy-new-year.adoc
@@ -21,8 +21,8 @@ image:/images/post-images/2017-12-31-new-year/card.png[NewYear, role=center]
 * We released link:/blog/2019/03/11/let-s-celebrate-java-11-support/[Java 11 support in Jenkins]
 * link:https://jenkins-x.io/[Jenkins X] has graduated as a Jenkins sub-project and became a new project under umbrella of CDF
 * In October 2019 we reached the record high number of contributions: **915** unique contributors, **124** of them were first-timers
-* We started new special interest groups for link:/sigs/docs/[Documentation] and link:https://groups.google.com/forum/#!forum/jenkinsci-ux[User Experience].
-* A new position of the Documentation officer was also introduced to highlight an important role of documentation in the project
+* We started new special interest groups for link:/sigs/docs/[Documentation] and link:/sigs/ux/[User Experience].
+* A new position of the link:/project/team-leads/#documentation[Documentation officer] was introduced to highlight an important role of documentation in the project
 * We ran multiple mentorship programs with **12** mentees in total: link:/projects/gsoc/2019/[Google Summer of Code], link:/events/hacktoberfest/[Hacktoberfest] and link:/blog/2019/09/23/outreachy-audit-log-release/[Outreachy]
 
 If you are interested to know more about Jenkins features introduced in 2019,
@@ -33,7 +33,7 @@ stay tuned for a separate blog post about it (coming soon!).
 Highlights above do not cover all advancements we had in the project.
 Below you can find slides from the link:https://www.meetup.com/jenkinsmeetup/events/264795368/[Jenkins contributor summit] in Lisbon.
 There we had project updates by officers, SIG and sub-project leaders.
-See the slide deck to know about: Jenkins Core, Jenkins Pipeline, Configuration-as-Code, Security, UX Overhaul, Jenkins Infrastructure, platform support and documentation.
+See the slide deck to know about: Jenkins Core, Pipeline, Configuration-as-Code, Security, UX Overhaul, Jenkins Infrastructure, platform support and documentation.
 
 ++++
 <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTeUXM75UR8m_v5FbldYYNXeVW0CtXkpRydMRvQjBuew2vRyC4cjgLMSUEVNoonfYbKDSbOvasHPpxg/embed?start=false&loop=false&delayms=60000" width="100%" height="600px"></iframe>
@@ -42,7 +42,7 @@ See the slide deck to know about: Jenkins Core, Jenkins Pipeline, Configuration-
 
 ## Some stats and numbers
 
-If this section seems to be too long for you, here is some infographic prepared by link:https://github.com/tracymiranda[Tracy Miranda]: top-level Jenkins stats and comparison with other projects in link:https://cd.foundation/[Continuous Delivery Foundation] link:https://www.cncf.io/[Cloud Native Computing Foundation].
+If this section seems to be too long for you, here is some infographic prepared by link:https://github.com/tracymiranda[Tracy Miranda].
 As you may see, Jenkins is pretty big :)
 
 image:/images/post-images/2020/01-new-year-blogpost/jenkins_stats_2019.png[Jenkins 2019 in numbers, role=center, float=center,height=512]
@@ -62,7 +62,7 @@ There was also a lot of housekeeping work: better APIs, codebase refresh, cleani
 The core's components also got major updates.
 Only link:/projects/remoting/[Jenkins Remoting] got **11** releases with stability improvements and new features like support of inbound connections to headless Jenkins masters.
 There are also major incoming features like jep:222[WebSocket Services support], UI look&feel updates, jira:JENKINS-12548[Readonly system configuration support], Docker images for new platforms like Arm.
-On the community side a link:https://groups.google.com/forum/#!msg/jenkinsci-dev/0sdrcSOQW64/tD-IKDTsBQAJ[Core pull request reviewers team] and added **9** contributors there.
+To facilitate further changes we created a new link:https://groups.google.com/forum/#!msg/jenkinsci-dev/0sdrcSOQW64/tD-IKDTsBQAJ[Core pull request reviewers team] and added **9** contributors there.
 
 **Plugins**.
 There were **2654** plugin releases, and **157** NEW plugins have been hosted in the Update Center.
@@ -73,7 +73,7 @@ If you are afraid about such plugin numbers and dependency management, there is 
 **Security**.
 It was a hot year for the link:/security/[Jenkins Security Team].
 There were **5** link:/security/advisories/[security advisories] for the core and *20* - for plugins.
-In total we disclosed **288** security vulnerabilities across the project, including some backlog cleaning for unmaintained plugins.
+In total we disclosed **288** vulnerabilities across the project, including some backlog cleaning for unmaintained plugins.
 plugin:script-security[Script Security Plugin] was the hottest plugin with **10** critical fixes addressing various sandbox bypass vulnerabilities.
 Plain text storage and unprotected credentials were the most popular vulnerability type **120** disclosures in 2019.
 It was made possible by hundreds of reports submitted by contributors after code surveys,
@@ -115,8 +115,8 @@ and Outreachy resulted in a new link:/blog/2019/09/23/outreachy-audit-log-releas
 
 Where did we get those stats?
 GitHub stats came from the link:https://devstats.cd.foundation/[CDF DevStats] service.
-These stats include all repositories in the link:https://github.com/jenkinsci[jenkinsci organization] and most popular repositories in [link:https://github.com/jenkins-infra[jenkins-infra]], other organizations/repositories within the project are not included.
-Other stats came from link:https://docs.google.com/presentation/d/e/2PACX-1vTeUXM75UR8m_v5FbldYYNXeVW0CtXkpRydMRvQjBuew2vRyC4cjgLMSUEVNoonfYbKDSbOvasHPpxg[project reports], component changelogs, link:https://stats.jenkins.io/[Jenkins usage statistics service], link:https://updates.jenkins.io/current/release-history.jsonp[plugin releases history].
+These stats include all repositories in the link:https://github.com/jenkinsci[jenkinsci organization] and most popular repositories in link:https://github.com/jenkins-infra[jenkins-infra], Jenkins X and other organizations/repositories within the project are not included.
+Other stats came from link:https://docs.google.com/presentation/d/e/2PACX-1vTeUXM75UR8m_v5FbldYYNXeVW0CtXkpRydMRvQjBuew2vRyC4cjgLMSUEVNoonfYbKDSbOvasHPpxg[project reports], component changelogs, link:https://stats.jenkins.io/[Jenkins usage statistics service], link:https://updates.jenkins.io/current/release-history.json[plugin releases history].
 
 ## What's next?
 


### PR DESCRIPTION
Cleaning up text. Also, I have changed the link to Jenkins UX SIG so that it leads participants to the new page. Thanks @jphartley !