### PR TITLE
Add CDF to the submission

### DIFF
--- a/content/projects/gsoc/2020/application.md
+++ b/content/projects/gsoc/2020/application.md
@@ -188,7 +188,10 @@ https://github.com/jenkins-infra/ ,
 https://github.com/jenkins-zh/
 
 #### Are you part of a foundation/umbrella organization?
-Yes, Software in the Public Interest, Inc. (https://spi-inc.org) a 501 (c) (3) non-profit organization
+Yes, Jenkins is transitioning between two organizations at this time:
+
+* Software in the Public Interest, Inc. (https://spi-inc.org) a 501 (c) (3) non-profit organization
+* Continuous Delivery foundation (https://cd.foundation/about/), a non-profit Linux Foundation organization
 
 #### Anything else we should know (optional)?
 


### PR DESCRIPTION
When Jenkins applies to Google for the Google Summer of Code project, we must list the organization under which we operate. Since we are transitioning to CDF, I thought we might want to list it.

@tracymiranda 