### PR TITLE
Fix typo 'commannds' to 'commands'

### DIFF
--- a/content/doc/developer/cli/writing-cli-commands.adoc
+++ b/content/doc/developer/cli/writing-cli-commands.adoc
@@ -1,5 +1,5 @@
 ---
-title: Writing CLI commannds
+title: Writing CLI commands
 layout: developerguide
 ---
 


### PR DESCRIPTION
Cause: noticed this typo in "How-To Guides" page in https://jenkins.io/doc/developer/guides/