### PR TITLE
[JENKINS-60381] - Update the Remoting protocol deprecation announcement

### DIFF
--- a/content/blog/2017/08/2017-08-11-remoting-update.adoc
+++ b/content/blog/2017/08/2017-08-11-remoting-update.adoc
@@ -9,6 +9,9 @@ tags:
 author: oleg_nenashev
 ---
 
+NOTE: Updated on Jan 10, 2019: The deprecated protocols were removed in Remoting 3.40+ and Jenkins 2.214+. 
+See issue:JENKINS-60381[Remove old, deprecated Remoting protocols] for more information and links.
+
 There are upcoming changes in Jenkins "core" which **may** require extra steps
 when upgrading Jenkins.  If you use configuration management for Jenkins
 agents, please read this announcement carefully.


### PR DESCRIPTION
This update is needed, because the guidelines are linked from administrative monitors.

CC @jeffret-b @Wadeck @MarkEWaite 