### PR TITLE
Remove Blue Ocean Information from the Press landing page

### DIFF
--- a/content/press.adoc
+++ b/content/press.adoc
@@ -74,62 +74,6 @@ to be used over the `headshot.png` image.
 
 If you have any questions about artwork, please ask one of the <<Press Contacts>>.
 
-== About Blue Ocean
-
-.Elevator Pitch
-""
-Blue Ocean is a new user experience for Jenkins based on a personalizable,
-modern design that allows users to graphically create, visualize and diagnose
-Continuous Delivery (CD) Pipelines
-""
-
-=== Screenshots
-
-.Pipeline Editor
-
-""
-Developers of any skill level can create Continuous Delivery pipelines from start to finish using the intuitive and visual pipeline editor.
-""
-image:/images/blueocean/press/pipeline-editor.png[Editor, role=center]
-image:/images/blueocean/press/pipeline-editor-step.png[Editor with open step, role=center]
-
-.Pipeline visualization
-""
-Enables developers to visually represent pipelines in a way even their boss's boss can understand, improving clarity into the CD process for the whole organization
-""
-image:/images/blueocean/press/pipeline-visualization.png[Pipeline visualization, role=center]
-
-.Pipeline diagnosis
-""
-Developers locate automation problems instantly without endlessly scanning through logs or navigating through many screens.
-""
-image:/images/blueocean/press/pipeline-diagnosis.png[Pipeline diagnosis, role=center]
-
-.Personalized dashboard
-
-""
-Developers can make Jenkins their own by customizing their dashboard so that they only see the Pipelines that matter to them.
-""
-image:/images/blueocean/press/personalization.png[Personalized dashboard, role=center]
-
-.Github integration
-
-""
-Pipelines are run for all feature branches and pull requests, with their status reported back to Github, so the whole team knows if your changes need work or are good to go.
-""
-image:/images/blueocean/press/github-status.png[Github integration, role=center]
-
-=== Video
-
-Also available for download in link:https://www.dropbox.com/s/1824kdeh0czdgna/Blue_Ocean_01_End_Bumper.mov?dl=0[full high definition].
-++++
-<center>
-<iframe width="853" height="480"
-src="https://www.youtube-nocookie.com/embed/k_fVlU1FwP4?rel=0" frameborder="0"
-allowfullscreen></iframe>
-</center>
-++++
-
 == Press Contacts
 
 The following individuals can be reached out to for comment, clarification

--- a/content/projects/blueocean/about/index.adoc
+++ b/content/projects/blueocean/about/index.adoc
@@ -2,7 +2,9 @@
 layout: project
 title: "About Blue Ocean"
 section: projects
-noblogs: true
+tags:
+- blueocean
+project: blueocean
 ---
 
 .Elevator Pitch

--- a/content/projects/blueocean/about/index.adoc
+++ b/content/projects/blueocean/about/index.adoc
@@ -1,0 +1,60 @@
+---
+layout: project
+title: "About Blue Ocean"
+section: projects
+noblogs: true
+---
+
+.Elevator Pitch
+""
+Blue Ocean is a new user experience for Jenkins based on a personalizable,
+modern design that allows users to graphically create, visualize and diagnose
+Continuous Delivery (CD) Pipelines
+""
+
+=== Screenshots
+
+.Pipeline Editor
+
+""
+Developers of any skill level can create Continuous Delivery pipelines from start to finish using the intuitive and visual pipeline editor.
+""
+image:/images/blueocean/press/pipeline-editor.png[Editor, role=center]
+image:/images/blueocean/press/pipeline-editor-step.png[Editor with open step, role=center]
+
+.Pipeline visualization
+""
+Enables developers to visually represent pipelines in a way even their boss's boss can understand, improving clarity into the CD process for the whole organization
+""
+image:/images/blueocean/press/pipeline-visualization.png[Pipeline visualization, role=center]
+
+.Pipeline diagnosis
+""
+Developers locate automation problems instantly without endlessly scanning through logs or navigating through many screens.
+""
+image:/images/blueocean/press/pipeline-diagnosis.png[Pipeline diagnosis, role=center]
+
+.Personalized dashboard
+
+""
+Developers can make Jenkins their own by customizing their dashboard so that they only see the Pipelines that matter to them.
+""
+image:/images/blueocean/press/personalization.png[Personalized dashboard, role=center]
+
+.Github integration
+
+""
+Pipelines are run for all feature branches and pull requests, with their status reported back to Github, so the whole team knows if your changes need work or are good to go.
+""
+image:/images/blueocean/press/github-status.png[Github integration, role=center]
+
+=== Video
+
+Also available for download in link:https://www.dropbox.com/s/1824kdeh0czdgna/Blue_Ocean_01_End_Bumper.mov?dl=0[full high definition].
+++++
+<center>
+<iframe width="853" height="480"
+src="https://www.youtube-nocookie.com/embed/k_fVlU1FwP4?rel=0" frameborder="0"
+allowfullscreen></iframe>
+</center>
+++++

--- a/content/projects/blueocean/contribute/index.adoc
+++ b/content/projects/blueocean/contribute/index.adoc
@@ -3,6 +3,7 @@ layout: project
 title: "Contributing to Blue Ocean"
 section: projects
 noblogs: true
+project: blueocean
 ---
 
 == Releases

--- a/content/projects/blueocean/index.html.haml
+++ b/content/projects/blueocean/index.html.haml
@@ -23,6 +23,8 @@ links:
             = partial('logo.html.haml')
           %h1.intro-title
             Blue Ocean for Jenkins Pipelines
+          %a.btn.btn-secondary{:href => expand_link('projects/blueocean/about')}
+            Overview
           %a.btn.btn-secondary{:href => expand_link('doc/book/blueocean')}
             Documentation
           %a.btn.btn-secondary{:href => 'https://github.com/jenkinsci/blueocean-plugin/releases'}


### PR DESCRIPTION
Blue Ocean overview consumes more than 50% of the page due to screenshots and embedded video. Taking the current status and https://groups.google.com/forum/#!msg/jenkinsci-dev/zO9VFNxhF-o/EpjdA8-jCgAJ from @jphartley, I believe we do not want to have this information on the page at all.

This change introduces a new "Overview" page inside the Blue Ocean Folder and moves all the content there. 

## New pages

![image](https://user-images.githubusercontent.com/3000480/72161624-c16b6600-33c0-11ea-8e8a-6bbbf5aba70b.png)


![image](https://user-images.githubusercontent.com/3000480/72161590-b31d4a00-33c0-11ea-89b0-9b5f0580f28a.png)
 
CC @i386 @slide @uhafner @rtyler @kohsuke (the page is within the governance space)