### PR TITLE
Press - Add explicit section about trademarks + reference CDF

### DIFF
--- a/content/press.adoc
+++ b/content/press.adoc
@@ -41,14 +41,14 @@ as an initial point of contact for press inquiries.
 The Jenkins project is part of link:https://spi-inc.org/[Software in the Public
 Interest], a 501 (c) (3) non-profit organization, which holds the Jenkins
 trademark and acts as a legal umbrella organization.
-The project transitions to link:https://cd.foundation/[Continuous Delivery Foundation] at the moment,
+The project is transitioning to the link:https://cd.foundation/[Continuous Delivery Foundation]
 and it is also considered as a part of this foundation.
 
 === Trademark
 
 The name "Jenkins" is a registered trademark in the USA (link:https://trademarks.justia.com/854/47/jenkins-85447465.html[#4664929],
 held by link:https://spi-inc.org[Software in the Public Interest, Inc.]) in order to protect the project and users from confusing use of the term.
-For more info about trademark and its usage see the link:/project/governance/#trademark[Trademark] and link:/project/governance/#trademark-attribution[Trademark Attribution] sections of the GGovernance document. 
+For more info about trademark and its usage see the link:/project/governance/#trademark[Trademark] and link:/project/governance/#trademark-attribution[Trademark Attribution] sections of the Governance document.
 
 === Branding
 
@@ -165,4 +165,3 @@ volunteers so availability and time may be limited.
 === Security related contacts
 
 If your press request involves any security related matter please also include `jenkinsci-cert[at]googlegroups.com`
-

--- a/content/press.adoc
+++ b/content/press.adoc
@@ -42,7 +42,7 @@ The Jenkins project is part of link:https://spi-inc.org/[Software in the Public
 Interest], a 501 (c) (3) non-profit organization, which holds the Jenkins
 trademark and acts as a legal umbrella organization.
 The project is transitioning to the link:https://cd.foundation/[Continuous Delivery Foundation]
-and it is also considered as a part of this foundation.
+and is an official [Continuous Delivery Foundation founding project](https://cd.foundation/projects/).
 
 === Trademark
 

--- a/content/press.adoc
+++ b/content/press.adoc
@@ -41,6 +41,14 @@ as an initial point of contact for press inquiries.
 The Jenkins project is part of link:https://spi-inc.org/[Software in the Public
 Interest], a 501 (c) (3) non-profit organization, which holds the Jenkins
 trademark and acts as a legal umbrella organization.
+The project transitions to link:https://cd.foundation/[Continuous Delivery Foundation] at the moment,
+and it is also considered as a part of this foundation.
+
+=== Trademark
+
+The name "Jenkins" is a registered trademark in the USA (link:https://trademarks.justia.com/854/47/jenkins-85447465.html[#4664929],
+held by link:https://spi-inc.org[Software in the Public Interest, Inc.]) in order to protect the project and users from confusing use of the term.
+For more info about trademark and its usage see the link:/project/governance/#trademark[Trademark] and link:/project/governance/#trademark-attribution[Trademark Attribution] sections of the GGovernance document. 
 
 === Branding
 


### PR DESCRIPTION
Press often misuses the trademark when writing about Jenkins (e.g. google for "Apache Jenkins"). Wishful thinking, but maybe an explicit trademark section will help a bit.

Also referenced CDF since it is not mentioned on the press page ATM