### PR TITLE
Fail build on Asciidoctor errors

### DIFF
--- a/scripts/awestruct
+++ b/scripts/awestruct
@@ -8,7 +8,7 @@ else
         cat build/error.txt >&2
         exit 1
     }
-    if [[ -n "$( grep --fixed-strings WARNING build/error.txt )" ]] ; then
+    if [[ -n "$( grep '\(ERROR\|WARNING\)' build/error.txt )" ]] ; then
         echo "Failing build due to warnings in log output:" >&2
         sort -u build/error.txt >&2
 


### PR DESCRIPTION
Syntax problems reported as ERRORs don't break the build, but WARNINGs do. So the only way to detect ERROR (e.g. the one fixed in #2717) is to introduce a WARNING (as I did in the first commit of #2716).

This PR makes sure both are handled the same way.