### PR TITLE
Add GSoC 2020 project ideas for git plugin

### DIFF
--- a/content/_data/authors/fcojfernandez.adoc
+++ b/content/_data/authors/fcojfernandez.adoc
@@ -1,0 +1,6 @@
+---
+name: "Francisco Fernandez"
+github: fcojfernandez
+---
+
+Francisco is one of the maintainers of the Jenkins git plugin.

--- a/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
+++ b/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
@@ -9,6 +9,7 @@ sig: platform
 mentors:
 - "markewaite"
 - "fcojfernandez"
+- "rsandell"
 skills:
 - Java
 - Git

--- a/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
+++ b/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
@@ -1,0 +1,33 @@
+---
+layout: gsocprojectidea
+title: "Git repository caching on agents"
+goal: "Cache git repositories on agents for faster checkout"
+category: Plugins
+year: 2020
+status: draft
+sig: platform
+mentors:
+- "markewaite"
+- "fcojfernandez"
+skills:
+- Java
+- Git
+links:
+  gitter: "jenkinsci/git-plugin"
+  draft: https://docs.google.com/document/d/1M9Na1eJxwGZ7fY1L-PsBGv62jL_pPBtqmGePpwogUBw
+---
+
+The Jenkins git plugin clones remote git repositories into Jenkins workspaces on agents.
+The Jenkins agents frequently have other copies of the remote git repository which could be used as a local cache to reduce network data transfer from the remote git server to the local workspace.
+Those local copies could be in workspaces for previous builds of this job or they could be in workspaces for other branches of the same repository.
+Those local copies might also be maintained by administrators with periodic updates from the central repository.
+
+Identify and use a well-chosen existing copy of the remote git repository as a reference repository for the git fetch that is being performed in the workspace.
+Default to dissociate the workspace repository from the reference repository during the fetch so that deletion of the reference repository will not harm the workspace repository.
+
+Refer to link:[pull request 502] for discussions and alternatives which can be considered.
+Stephen Connolly recommends that the capability be created as a separate plugin which extends the git plugin.
+That would avoid the risk of users seeing this new feature without intentionally installing a new plugin specifically for the feature.
+If a separate plugin is the path that is chosen, then Mark Waite will need additional help from other mentors that are more familiar with the Jenkins extension mechanisms.
+
+See Google Doc

--- a/content/projects/gsoc/2020/project-ideas/git-plugin-performance.adoc
+++ b/content/projects/gsoc/2020/project-ideas/git-plugin-performance.adoc
@@ -1,0 +1,75 @@
+---
+layout: gsocprojectidea
+title: "Git plugin performance improvements"
+goal: "Improve git plugin performance"
+category: Plugins
+year: 2020
+status: draft
+sig: platform
+mentors:
+- "markewaite"
+- "fcojfernandez"
+skills:
+- Java
+- Git
+links:
+  gitter: "jenkinsci/git-plugin"
+  draft: https://docs.google.com/document/d/1bmpgW_8cg38ulp0uFdn2BRfVlIrZ03FFhWpe0MVHyyI
+---
+
+Improve Jenkins git plugin performance by fixing known issues in performance critical areas.
+Implement performance comparisons between the command line git and JGit implementations using the Java Microbenchmark Harness.
+Improve the performance of git operations that use the command line git implementation by selectively replacing CLI implementations with JGit when benchmarks show a significant performance gain.
+
+=== Fix Known Issues - Avoid Redundant Fetch
+
+The Jenkins git plugin copies remote git repositories into Jenkins workspaces on agents as part of a 'checkout'.
+The checkout creates an empty git repository in the workspace, configures it with 'git config', and populates it with 'git fetch'.
+Unfortunately, the most commonly used path through the code will call 'git fetch' twice.
+
+The second call to 'git fetch' is useless when it is using the same arguments as the first call.
+It wastes server time, network bandwidth, and job time.
+With large repositories, that waste of time may be a minute or more.
+
+. Implement at least one automated test to detect the redundant fetch
+. Implement changes in the git plugin and the git client plugin to avoid the second call to 'git fetch' when using the same arguments as the first call to 'git fetch'.
+
+=== Performance Comparisons
+
+. Compare link:https://github.com/jenkinsci/git-client-plugin/blob/master/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java[CliGitAPIImpl] and link:https://github.com/jenkinsci/git-client-plugin/blob/master/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java[JGitAPIImpl] using the link:https://jenkins.io/blog/2019/06/21/performance-testing-jenkins/[Java Microbenchmark Harness] by writing benchmark tests that compare performance of the same operations using the two different implementations.
+. Present the results of those comparisons.
+. Use the results of the comparisons and common use cases to prioritize operations for performance improvement.
+
+=== Performance Improvements
+
+. Confirm that existing automated tests adequately verify the existing implementations.
+If they do not adequately verify implementation behaviors, write additional automated tests to verify the existing implementations.
+. Replace a command line git implementation with a JGit implementation in cases where benchmarks show JGit is faster.
+. Confirm that benchmark tests show the performance improvement.
+. Confirm that automated tests confirm no loss of functionality.
+
+=== Quickstart
+
+The project idea is expected to require changes in both the git client plugin and the git plugin.
+
+Install a git client plugin development environment by following the link:https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc[contributing instructions].
+Compile the plugin, run its automated tests, and confirm that the automated tests are passing.
+Enable coverage reporting and review the coverage report.
+
+Install a git plugin development environment by following the link:https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc[contributing instructions].
+Compile the plugin, run its automated tests, and confirm that the automated tests are passing.
+Enable coverage reporting and review the coverage report.
+
+Consider implementing a fix for one of the link:https://issues.jenkins-ci.org/issues/?jql=(component%3Dgit-plugin%20OR%20component%20%3D%20git-client-plugin)%20and%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2CReopened)[newbie friendly issues].
+
+=== Links
+
+* link:https://groups.google.com/d/msg/jenkinsci-gsoc-all-public/bJUtxIxcT64/0Ddt_LZvCQAJ[Jenkins GSoC mailing list discussion of redundant fetch removal idea]
+* link:https://groups.google.com/d/msg/jenkinsci-gsoc-all-public/SXeSeo3yRl4/I8QeJYVvCQAJ[Jenkins GSoC mailing list discussion of JMH benchmark idea]
+* link:https://issues.jenkins-ci.org/browse/JENKINS-49757[JENKINS-49757] - Git plugin calls fetch twice per checkout
+* link:https://issues.jenkins-ci.org/browse/JENKINS-56404[JENKINS-56404] - Exclude redundant fetch
+
+=== Google Doc Draft Idea
+
+See Google Doc
+


### PR DESCRIPTION
## GSoC 2020 project ideas for git plugin

Proposes two project ideas for the git plugin, one for general performance improvements, the other for repository caching on agents.

I was surprised that all my edits to the adoc file were ignored when I viewed the page from `make run`. I applied the adoc changes to the Google docs so that reviewers can comment in either location.