### PR TITLE
[GSoC 2020] - Application: Jenkins X is no longer a Jenkins sub-project

### DIFF
--- a/content/projects/gsoc/2020/application.md
+++ b/content/projects/gsoc/2020/application.md
@@ -55,8 +55,9 @@ In total we have more than 2000 components including plugins, libraries, and var
 The main languages in the project are Java, Groovy and JavaScript, 
 but we also have components written in other languages (Go, C/C++, C#, etc.).
 Jenkins project also includes multiple 
-[sub-projects](https://jenkins.io/projects/) (including [Jenkins X](https://jenkins-x.io/), 
-[Configuration-as-Code](https://jenkins.io/projects/jcasc/) 
+[sub-projects](https://jenkins.io/projects/) (including 
+[Configuration-as-Code](https://jenkins.io/projects/jcasc/),
+[Infrastructure](https://jenkins.io/projects/infrastructure/)
 and [Remoting](https://jenkins.io/projects/remoting/)) and 
 [special interest groups](https://jenkins.io/sigs/).
 These projects and SIGs participate in GSoC as a part of the Jenkins project.


### PR DESCRIPTION
Jenkins X is no longer a sub-project of Jenkins, it graduated to a separate project under the CDF umbrella. As agreed with @MarckK, Jenkins X project plans to participate as a part of the Jenkins organization this year. Once we receive and publish project idea drafts, the text will need to be updated again to reference Jenkins X as a sister-project (or whatever it is called).