### PR TITLE
GSoC 2020 - Move the Windows services project idea to Asciidoc && publish it

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/winsw-yaml-config-support.adoc
+++ b/content/projects/gsoc/2020/project-ideas/winsw-yaml-config-support.adoc
@@ -4,8 +4,7 @@ title: "Jenkins Windows Services: YAML Configuration Support"
 goal: "Enhance Jenkins master and agent service management on Windows by offering new configuration file formats and improving settings validation"
 category: Core, Tools
 year: 2020
-status: draft
-showGoogleDoc: true
+status: published
 sig: platform
 skills:
 - C#
@@ -21,4 +20,40 @@ links:
   draft: https://docs.google.com/document/d/16Aa3E9D_IYD-LO89bcInZQPwAfTOWfD_UrDbDxy8FKA
 ---
 
-See Google doc
+On Windows machines Jenkins master and agents can be installed as Windows Services in order to get better robustness and manageability within the system.
+This is a functionality bundled into the Jenkins core directly.
+When installed as a service, Jenkins uses the https://github.com/kohsuke/winsw[Windows Service Wrapper] executable (.NET, written in C#) which is being configured by XML config files.
+Currently there are only few configuration checks there (no XML Schema, limited validation, etc.),
+and it’s often that the service wrapper is misconfigured by Jenkins users.
+
+In this project we propose to update Windows Service Wrapper to support YAML files as configuration inputs and to introduce better configuration validation during the service installation and startup.
+Usage of YAML should simplify configuration management in Jenkins, especially when automated tools are used.
+On the Jenkins side, patches could be proposed to the Jenkins Core and Windows Agent Installer module to switch them from XML to YAML once the new version of WinSW is integrated.
+
+In this project students can also propose various extra enhancements to the Windows Service Wrapper project especially around logging and diagnosability.
+Students are welcome to explore the tool and to make other suggestions in their project proposal.
+
+== Links
+
+* Windows Service Wrapper: https://github.com/kohsuke/winsw[https://github.com/kohsuke/winsw]
+* Jenkins Windows Agent Installer Module: https://github.com/jenkinsci/windows-slave-installer-module[https://github.com/jenkinsci/windows-slave-installer-module]
+* Jenkins WMI Windows Agents Plugin: https://github.com/jenkinsci/windows-slaves-plugin[https://github.com/jenkinsci/windows-slaves-plugin]
+* Windows Service Lifecycle in the Jenkins core:
+https://github.com/jenkinsci/jenkins/blob/0795e89b308ec7fcbda097858d58763d8531be8c/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java[https://github.com/jenkinsci/jenkins/blob/0795e89b308ec7fcbda097858d58763d8531be8c/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java]
+
+== Special requirements
+
+* This project requires development on Windows, and hence the applicant should have access to a computer with Windows 10 or other recent Windows versions (`amd64` is recommended)
+* Microsoft Visual Studio Community Edition will be enough for this project 
+
+== Quick Start
+
+* Download WinSW (link:https://github.com/kohsuke/winsw#download[guidelines]), then try it with some demo services
+* Try building and testing WinSW locally (link:https://github.com/kohsuke/winsw/blob/master/DEVELOPER.md[Developer guidelines])
+* Try installing Jenkins and its agents as Windows services (link:https://jenkins.io/doc/book/installing/#windows[guidelines for the master], link:https://github.com/jenkinsci/windows-slave-installer-module#installation[guideline for agents])
+* Report any issues you discovered in the process
+
+== Newbie-friendly issues
+
+* WinSW: https://github.com/kohsuke/winsw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[GitHub Query]
+


### PR DESCRIPTION
I moved the description to Asciidoc and added `Quick start`, `Special requirements` and `Newbie-friendly issues`. I believe it is enough to get the project idea published as a final idea. 

CC @arnab1896 @slide 