### PR TITLE
GSoC 2020 - Add support of publishing YAML project ideas as drafts + better draft notice

### DIFF
--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -15,37 +15,40 @@ project: gsoc
       Skills to study/improve:
     = page.skills.join(", ")
 
-- if page.status == "published"
-  %h2.title
-    Details
-  - if page.showGoogleDoc
-    %p
-      This project idea is published as a Google doc.
-      You are welcome to comment on the proposal or to suggest changes in the draft embedded below
-      (
-      %a{:href => page.links.draft, :target => "_blank"}
-        Google Doc
-      )
-    %iframe{:src => "#{page.links.draft}?embedded=true", :width => "100%", :height => "600px"}
-  - else
-    = content
-- else
+- if page.status != "published"
+  %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+    %b
+      NOTE:
+    This idea is published as a draft under active discussion, but it is confirmed in principle.
+    It is FINE to apply to it.
+    The scope and the suggested implementation may change significantly before the final version is published.
+    Sections like quickstart guide and newbie-friendly issues may be also missing.
+    As a student, you are welcome to request additional information and to join the discussions using channels linked on this page. 
+
+- if page.showGoogleDoc
   - if page.links
     - if page.links.draft
-      %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
-        This project idea is under review.
+      %p
+        This project idea is published as a Google doc.
         You are welcome to comment on the proposal or to suggest changes in the draft embedded below
         (
         %a{:href => page.links.draft, :target => "_blank"}
           Google Doc
         )
-      %iframe{:src => "#{page.links.draft}?embedded=true", :width => "100%", :height => "600px"}
     - else
       %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
         ERROR: The project idea draft link is missing, please report an error to GSoC org admins
   - else
     %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
       ERROR: The project links are not defined in the document, please report an error to GSoC org admins
+- else
+  %h2.title
+    Details
+
+- if page.showGoogleDoc && page.links && page.links.draft
+  %iframe{:src => "#{page.links.draft}?embedded=true", :width => "100%", :height => "600px"}
+- else
+  = content
 
 %h2.title
   Potential Mentors


### PR DESCRIPTION
GSoC 2019 process was focused on Google Doc drafts, and YAML ones are not rendered correctly. This pull request fixes that and also adds a better notice for draft project ideas to clarify what they mean.

![image](https://user-images.githubusercontent.com/3000480/72619246-284acb00-393d-11ea-9184-540c2fadeb8f.png)

CC @MarkEWaite @sladyn98 whose ideas are affected