### PR TITLE
Add table of contents example to plugin docs guide

### DIFF
--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -54,6 +54,7 @@ Documentation examples:
 * https://plugins.jenkins.io/gradle
 * https://plugins.jenkins.io/mailer
 
+[[valid-url-formats]]
 Valid URL formats for GitHub based documentation are
 
 https&#58;//github.com/jenkinsci/YOUR-PLUGIN::
@@ -73,7 +74,7 @@ It also include Wiki=>GitHub migration guidelines.
 
 === Referencing the documentation page from the project file
 
-You should link to your plugin's documentation, whether on the wiki or elsewhere, in your plugin's pom.xml, like this:
+You should link to your plugin's documentation, whether on the wiki or elsewhere, in your plugin's pom.xml, (using one of the link:#valid-url-formats[valid URL formats]) like this:
 
 ```xml
 <project>

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -28,7 +28,7 @@ repository and hence all common practices can be applied:
 * Pull requests and reviews
 * Creating documentation in parallel with features
 * Editing docs from GitHub Web UI, with preview support
-* Versioning, documentation for previous plugin versions can be easily accessed 
+* Versioning, documentation for previous plugin versions can be easily accessed
 
 === Using GitHub as a source of documentation
 
@@ -58,7 +58,7 @@ Valid URL formats for GitHub based documentation are
 
 https&#58;//github.com/jenkinsci/YOUR-PLUGIN::
 Loads README located in the root of `YOUR-PLUGIN` repository from the master branch
-https&#58;//github.com/jenkinsci/YOUR-PLUGIN/tree/REF:: 
+https&#58;//github.com/jenkinsci/YOUR-PLUGIN/tree/REF::
 Load README located in the root of `YOUR-PLUGIN` repository from the tag or branch `REF`
 https&#58;//github.com/jenkinsci/YOUR-PLUGIN/blob/REF/path/to/readme.md::
 Loads a Markdown or AsciiDoc file specified by path from `YOUR-PLUGIN` repository's tag or branch `REF`.
@@ -83,7 +83,7 @@ You should link to your plugin's documentation, whether on the wiki or elsewhere
 </project>
 ```
 
-If you're building your plugin with https://github.com/jenkinsci/gradle-jpi-plugin[Gradle], 
+If you're building your plugin with https://github.com/jenkinsci/gradle-jpi-plugin[Gradle],
 you can set the URL in your `+build.gradle+` like so:
 
 ```groovy
@@ -118,19 +118,18 @@ In your POM, make sure to include developer information, such as:
 </project>
 ```
 
-
-The `id` is your jenkins.io account. 
+The `id` is your jenkins.io account.
 The `name` is a human readable display name.
 This ensures that the update center and related tools are able to properly display the maintainer for your plugin.
-It's advisable to include an email address so that people can contact you (this will be shown in the plugin infobox on the wiki), but it's optional. 
+It's advisable to include an email address so that people can contact you (this will be shown in the plugin infobox on the wiki), but it's optional.
 
 == Changelogs
 
-Once you have made your first release, you should add release notes to your plugin. 
+Once you have made your first release, you should add release notes to your plugin.
 You have many options how to do it:
 
 * use GitHub Releases (possibly with the help of
-https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[Release Drafter]), 
+https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[Release Drafter]),
 add a link to releases page to your documentation page
 (recommended)
 * create a CHANGELOG file (Markdown, Asciidoc) in the repository root and link it from the documentation page

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -151,3 +151,28 @@ Some notes:
   It is defined for all repositories using the link:https://github.com/jenkinsci/.github[jenkinsci/.github] repository,
   plugin maintainers do not need to set it up.
 * Pull request templates: see link:https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository[Creating a pull request template for your repository].
+
+== Table of Contents
+
+Plugins that create their documentation in link:http://asciidoc.org/[AsciiDoc] may automatically generate a link:https://asciidoctor.org/docs/user-manual/#user-toc[table of contents] for the documentation.
+The generated table of contents includes level 2 and level 3 headings by default.
+The table of contents is requested by assigning the value `macro` to the `toc` variable and by inserting a reference to the `toc` variable at the location where the table of contents should be inserted in the page.
+
+```adoc
+= Your Plugin Name
+:toc: macro
+
+[[Introduction]]
+== Introduction
+
+Some introductory text that is placed before the table of contents.
+
+toc:[]
+
+[[other-heading]]
+== Other Heading
+
+Text that describes more about the plugin and is placed after the table of contents.
+```
+
+See the link:https://github.com/jenkinsci/git-plugin/blob/master/README.adoc#introduction[Git plugin] as a table of contents example.

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -104,7 +104,7 @@ It is currently sourced from the Maven metadata.
 
 WARNING: There is a plan to use link:https://github.com/jenkins-infra/repository-permissions-updater[repository-permissions-updater],
 See jira:WEBSITE-658[] in the issue tracker.
-Once it is implemented, the guidelines below will changed.
+Once it is implemented, the guidelines below will change.
 
 In your POM, make sure to include developer information, such as:
 

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -50,9 +50,11 @@ relative links
 
 Documentation examples:
 
-* https://plugins.jenkins.io/configuration-as-code
-* https://plugins.jenkins.io/gradle
-* https://plugins.jenkins.io/mailer
+* https://plugins.jenkins.io/configuration-as-code using maven and README.md
+* https://plugins.jenkins.io/gradle using gradle and README.adoc
+* https://plugins.jenkins.io/mailer using maven and README.adoc
+// Include this example after scm-api release 2.6.5 or later
+// * https://plugins.jenkins.io/scm-api using maven and a non-default adoc file
 
 [[valid-url-formats]]
 Valid URL formats for GitHub based documentation are


### PR DESCRIPTION
## [WEBSITE-689](https://issues.jenkins-ci.org/browse/WEBSITE-689) Include TOC instructions in plugin docs guide

A table of contents helps with navigation of large documentation pages.  This pull request guides the author to create a table of contents that is automatically maintained.