### PR TITLE
Fix typo in web.adoc related to "to be" form

### DIFF
--- a/content/doc/developer/architecture/web.adoc
+++ b/content/doc/developer/architecture/web.adoc
@@ -15,7 +15,7 @@ A few examples of how the URL `/foo/bar` could be processed:
   The object returned has a method called `doIndex(…)` that gets called and renders the response.
 * `getFoo()` is defined and returns an object that has a `getBar` or `doBar` method.
   The object returned from that has an associated `index.jelly` or `index.groovy` view.
-* `getFoo()` is are defined and the returned object has a view named `bar.jelly` or `bar.groovy` defined.
+* `getFoo()` is defined and the returned object has a view named `bar.jelly` or `bar.groovy` defined.
 * `doFoo()` is defined.
 
 A number of additional ways to handle requests exist, but these are the most common.


### PR DESCRIPTION
Cause: there cannot be "is" and "are" in one place.