### PR TITLE
Fix grave accent expansion in extend.adoc

### DIFF
--- a/content/doc/developer/tutorial/extend.adoc
+++ b/content/doc/developer/tutorial/extend.adoc
@@ -222,7 +222,7 @@ public class HelloWorldAction implements RunAction2 { // <1>
     }
 (...)
 ----
-<1> `RunAction2` is the interface to implement so that actions added to `jenkinsdoc:Run[]`s properly get references to the `Run`.
+<1> `RunAction2` is the interface to implement so that actions added to `jenkinsdoc:Run[]` properly get references to the `Run`.
 <2> The `Run` is stored in a transient action so this field won't be serialized to disk with the action.
 <3> Setting the field when first attaching this action to the `Run`.
 <4> Setting the field when loading this action from disk.


### PR DESCRIPTION
**Cause:** grave accent expansion works incorrectly due to leading 's' character

**Picture:**
![image](https://user-images.githubusercontent.com/16368046/72886719-5f452600-3d1b-11ea-851a-1ecc64fb7153.png)

**Proposed solution:** delete leading 's' character to fix grave accent expansion