### PR TITLE
[WEBSITE-714] - Replace JAM and Event mailing lists by Advocacy&Outreach SIG

### DIFF
--- a/content/_partials/mailing-lists/jenkinsci-jam.adoc
+++ b/content/_partials/mailing-lists/jenkinsci-jam.adoc
@@ -1,1 +1,0 @@
-Mailing list for link:/projects/jam/[Jenkins Area Meetup] coordination.

--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -12,10 +12,8 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkinsci-dev")
 
-= partial(group, :name => "events", :mailman => "true",
-  :description => "Mailing list for events, meet-ups, and fostering local communities.")
-
-= partial(group, :name => "jenkinsci-jam")
+= partial(group, :name => "jenkins-advocacy-and-outreach-sig",
+  :description => "Mailing list for events, meet-ups, outreach programs, and fostering local communities.")
 
 = partial(group, :name => "infra", :mailman => "true",
   :description => "Mailing list for jenkins-ci.org operations and infrastructure.")


### PR DESCRIPTION
Implements the proposal from https://groups.google.com/forum/#!msg/jenkinsci-dev/cviU5XUX8vQ/-c9uSe-PCgAJ

CC @alyssat 