### PR TITLE
Chats: Remove #jenkins-community, update #jenkins-meeting links

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -59,18 +59,12 @@ Established contributors typically have _voice_ (+) in this channel.
 [[meeting]]
 === `#jenkins-meeting`
 
-We conduct bi-weekly project meetings in this channel.
+We conduct the project governance meetings in this channel (every two week).
 These meetings are open to everyone.
-link:/project/governance/#meeting[Learn more about the project governance meeting].
+link:/project/governance-meeting[Learn more about the project governance meeting].
+Meetings are logged, see the referenced page for the agenda and meeting note links.
 
-Meetings are logged, and the channel is unused the rest of the time.
-We use the *robobutler* to run these meetings.
-See the link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[about project meetings] for more details.
-
-=== `#jenkins-community`
-
-The channel to help organize events, documentation and more "meta conversations" around the Jenkins project.
-We don't discuss Jenkins -- the software -- here. You can find conversation logs on https://botbot.me/freenode/jenkins-community/[botbot.me].
+The channel is used ONLY for meetings, and it is moderated during the rest of the time.
 
 === `#jenkins-infra`
 

--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -12,10 +12,8 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkinsci-dev")
 
-= partial(group, :name => "events", :mailman => "true",
-  :description => "Mailing list for events, meet-ups, and fostering local communities.")
-
-= partial(group, :name => "jenkinsci-jam")
+= partial(group, :name => "jenkins-advocacy-and-outreach-sig",
+  :description => "Mailing list for events, meet-ups, outreach programs, and fostering local communities.")
 
 = partial(group, :name => "infra", :mailman => "true",
   :description => "Mailing list for jenkins-ci.org operations and infrastructure.")


### PR DESCRIPTION
We moved out of IRC in the case of the community channel. Jenkins Meeting included obsolete link

Depends on #2789 (because I messed up the branch)
