### PR TITLE
Withdrawing my name from GSoC projects

### DIFF
--- a/content/_ext/authorship.rb
+++ b/content/_ext/authorship.rb
@@ -36,4 +36,15 @@ module Authorship
 
     return "<a href=\"#{link}\">#{full_name}</a>"
   end
+
+  def display_user_no_fail(author)
+    if site.authors.has_key? author.to_sym
+      full_name = site.authors[author].name
+      link = author_link(author)
+      return "<a href=\"#{link}\">#{full_name}</a>"
+    else
+      return author
+    end
+
+  end
 end

--- a/content/projects/gsoc/2020/project-ideas.html.haml
+++ b/content/projects/gsoc/2020/project-ideas.html.haml
@@ -72,7 +72,7 @@ project: gsoc
             %b
               Potential Mentor(s):
             - item.mentors.each do |mentor|
-              = display_user(mentor)
+              = display_user_no_fail(mentor)
           %td.pi_table_category
             - if item.category
               = item.category
@@ -110,7 +110,7 @@ project: gsoc
             %b
               Potential Mentor(s):
             - item.mentors.each do |mentor|
-              = display_user(mentor)
+              = display_user_no_fail(mentor)
           %td.pi_table_category
             - if item.category
               = item.category

--- a/content/projects/gsoc/2020/project-ideas/artifactory-rest-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/artifactory-rest-plugin.adoc
@@ -13,7 +13,7 @@ skills:
 - Artifactory
 - Jenkins Pipeline
 mentors:
-- "martinda"
+- "TBD"
 links:
   draft: https://docs.google.com/document/d/1nZcgQuSLvNM-xhYLD60Q1MxPtCIpl5iUd3VOsSXUIis
 ---

--- a/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -11,7 +11,6 @@ skills:
 - REST API
 - OpenAPI / Swagger
 mentors:
-- "martinda"
 - "kwhetstone"
 - "oleg_nenashev"
 links:

--- a/content/projects/gsoc/2020/project-ideas/bitbucket-rest-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/bitbucket-rest-plugin.adoc
@@ -13,7 +13,6 @@ skills:
 - Bitbucket
 - Jenkins Pipeline
 mentors:
-- "martinda"
 - "shenyu_zheng"
 links:
   gitter: "jenkinsci/gsoc-sig"

--- a/content/projects/gsoc/2020/project-ideas/eda-coverage-adapters.adoc
+++ b/content/projects/gsoc/2020/project-ideas/eda-coverage-adapters.adoc
@@ -14,7 +14,6 @@ skills:
 - ASIC
 - Coverage
 mentors:
-- "martinda"
 - "oleg_nenashev"
 - "shenyu_zheng"
 links:

--- a/content/projects/gsoc/2020/project-ideas/eda-plugins.adoc
+++ b/content/projects/gsoc/2020/project-ideas/eda-plugins.adoc
@@ -10,7 +10,6 @@ skills:
 - Java
 - EDA Tools
 mentors:
-- "martinda"
 - "oleg_nenashev"
 links:
   gitter: "jenkinsci/hw-and-eda-sig"

--- a/content/projects/gsoc/2020/project-ideas/jenkins-rest-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-rest-plugin.adoc
@@ -11,7 +11,7 @@ skills:
 - REST API
 - Jenkins Pipeline
 mentors:
-- "martinda"
+- "TBD"
 links:
   draft: https://docs.google.com/document/d/1Xz3I02T-QxlJW-1nt_CofF2I6se3hztF9ZsHqxu55nU
 ---

--- a/content/projects/gsoc/2020/project-ideas/pipeline-step-documentation-generator.adoc
+++ b/content/projects/gsoc/2020/project-ideas/pipeline-step-documentation-generator.adoc
@@ -15,7 +15,6 @@ skills:
 - Asciidoc
 - JavaScript
 mentors:
-- "martinda"
 - "kwhetstone"
 links:
   draft: https://docs.google.com/document/d/19hf1FSs7Y4z7YjfqjareqaWURpZ3Elkvh4XgLKdX6Ho


### PR DESCRIPTION
As announced, I am not able to mentor in 2020. I am removing my name from the project ideas, and replacing with "TBD" on projects where I am the sole mentor. I also suggest a new mentor display method in authorship.rb: `display_user_no_fail`.

If you prefer, I can remove those project ideas from the list.

CC @jenkins-infra/gsoc