### PR TITLE
Remove arnab as mentor for Windows YAML project

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/winsw-yaml-config-support.adoc
+++ b/content/projects/gsoc/2020/project-ideas/winsw-yaml-config-support.adoc
@@ -15,7 +15,6 @@ skills:
 - Java (optional)
 mentors:
 - "oleg_nenashev"
-- "arnab1896"
 links:
   draft: https://docs.google.com/document/d/16Aa3E9D_IYD-LO89bcInZQPwAfTOWfD_UrDbDxy8FKA
 ---


### PR DESCRIPTION
Removing myself as mostly focus will be on overall progress of all projects while helping admins rather than mentoring a specific project