### PR TITLE
Add upgrade guideline stub for Jenkins 2.204.2 LTS

### DIFF
--- a/content/_data/upgrades/2-204-2.adoc
+++ b/content/_data/upgrades/2-204-2.adoc
@@ -1,0 +1,1 @@
+No notable changes requiring upgrade notes.


### PR DESCRIPTION
AFAICT there is no changes requiring upgrade guidelines in https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%202.204.2-fixed