### PR TITLE
Add plugin tutorial with ide settings

### DIFF
--- a/content/_data/authors/XiongKezhi.adoc
+++ b/content/_data/authors/XiongKezhi.adoc
@@ -1,0 +1,4 @@
+---
+name: "Kezhi Xiong"
+twitter: AugustX_
+github: XiongKezhi

--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -62,6 +62,45 @@ This prints some diagnostic output, including the versions of Java and Maven, an
 This should indicate a _1.8_ version of Java, and list the path to the JDK.
 If either of these is not the case, see <<Troubleshooting>>.
 
+== Setting up a productive environment with your IDE
+====   NetBeans
+
+NetBeans users can use the IDE's Maven support to open the project directly.
+
+As you navigate through the code, you can tell NetBeans to attach source code JAR files by clicking the "Attach" button that appears in the top of the main content window. This allows you to read the Jenkins core source code as you develop plugins. (Or just select Download Sources on the Dependencies node.)
+
+You are advised to use the  https://github.com/stapler/netbeans-stapler-plugin[ NetBeans plugin for Jenkins/Stapler development]. This offers many Jenkins-specific features. Most visibly, create a new plugin using New Project » Maven » Jenkins Plugin, and use Run project to test it.
+
+==== IntelliJ IDEA
+IntelliJ 7.0 (or later) users can load pom.xml directly from IDE, and you should see all the source code of libraries and Jenkins core all the way to the bottom. Consider installing the IntelliJ IDEA plugin for Stapler to make the development easier.
+
+Alternatively,emtpy create a new Maven project using Create from archetype and Add an Archetype. Select the GroupId and ArtifactId as above and choose RELEASE as version. In the next screen select io.jenkins.plugins as groupID and choose an artifactId (Project name) and Version to your liking. This will automatically create a maven project based on the specified artifact (e.g. empty-plugin).
+
+NOTE: IntelliJ defaults to downloading sources and JavaDocs on demand. So, to see the source, you may need to click the Download artifacts button in the Maven Projects tab.
+
+==== Eclipse
+Use Eclipse Juno (4.2) or later for the best experience.
+
+NOTE: Eclipse versions between 4.5 and < 4.6.2 contain a bug that causes errors such as "Only a type can be imported. hudson.model.Job resolves to a package".
+If you encounter this error please upgrade to Eclipse Neon.2 (4.6.2) or higher (https://bugs.eclipse.org/bugs/show_bug.cgi?id=495598[Bug 495598]).
+
+As Jenkins plugins are Maven projects, Eclipse users have two ways to load a Jenkins plugin project. One is to use m2e, which tries to make Eclipse understand Maven "natively", and the other is to use theusing maven, but http://maven.apache.org/plugins/maven-eclipse-plugin/[Maven Eclipse plugin], which makes Maven generate Eclipse project definitions. At the moment, unless you have some prior experience with m2e, we currently recommend plugin developers to go with the Maven Eclipse plugin.
+
+Eclipse users can run the following Maven command to generate Eclipse project files (the custom outputDirectory parameter is used to work around the lack of JSR-269 annotation processor support in Eclipse:)
+
+[listing]
+$ mvn -DdownloadSources=true -DdownloadJavadocs=true -DoutputDirectory=target/eclipse-classes -Declipse.workspace=/path/to/workspace eclipse:eclipse eclipse:configure-workspace
+
+Where /path/to/workspace is the path to your Eclipse workspace.
+
+Once this command completes successfully, use "Import..." (under the File menu in Eclipse) and select "General" > "Existing Projects into Workspace".
+
+NOTE: Do not select "Existing Maven Projects", which takes you to the m2e route
+
+See https://wiki.jenkins.io/display/JENKINS/Jenkins+plugin+development+with+Eclipse[Jenkins plugin development with Eclipse] for gotchas and other known Eclipse/Maven related issues with Jenkins plugin development.
+
+See https://wiki.jenkins.io/display/JENKINS/Eclipse+alternative+build+setup[Eclipse alternative build setup] for an alternative way of setting up the Eclipse build environment, that is a bit more technically involved than using Maven but can give faster build times.
+
 Next step: link:../create[Create and build your first Jenkins plugin].
 
 == Troubleshooting

--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -63,7 +63,7 @@ This should indicate a _1.8_ version of Java, and list the path to the JDK.
 If either of these is not the case, see <<Troubleshooting>>.
 
 == Setting up a productive environment with your IDE
-====   NetBeans
+===   NetBeans
 
 NetBeans users can use the IDE's Maven support to open the project directly.
 
@@ -71,14 +71,14 @@ As you navigate through the code, you can tell NetBeans to attach source code JA
 
 You are advised to use the  https://github.com/stapler/netbeans-stapler-plugin[ NetBeans plugin for Jenkins/Stapler development]. This offers many Jenkins-specific features. Most visibly, create a new plugin using New Project » Maven » Jenkins Plugin, and use Run project to test it.
 
-==== IntelliJ IDEA
+=== IntelliJ IDEA
 IntelliJ 7.0 (or later) users can load pom.xml directly from IDE, and you should see all the source code of libraries and Jenkins core all the way to the bottom. Consider installing the IntelliJ IDEA plugin for Stapler to make the development easier.
 
 Alternatively,emtpy create a new Maven project using Create from archetype and Add an Archetype. Select the GroupId and ArtifactId as above and choose RELEASE as version. In the next screen select io.jenkins.plugins as groupID and choose an artifactId (Project name) and Version to your liking. This will automatically create a maven project based on the specified artifact (e.g. empty-plugin).
 
 NOTE: IntelliJ defaults to downloading sources and JavaDocs on demand. So, to see the source, you may need to click the Download artifacts button in the Maven Projects tab.
 
-==== Eclipse
+=== Eclipse
 Use Eclipse Juno (4.2) or later for the best experience.
 
 NOTE: Eclipse versions between 4.5 and < 4.6.2 contain a bug that causes errors such as "Only a type can be imported. hudson.model.Job resolves to a package".


### PR DESCRIPTION
Move https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial#Plugintutorial-SettingupaproductiveenvironmentwithyourIDE to https://jenkins.io/doc/developer/tutorial/prepare/ without any changes.