### PR TITLE
Create Plugin Installation Manager Tool GSoC proposal

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -4,9 +4,9 @@ title: "Plugin Installation Manager Tool Improvements"
 goal: "Update the plugin installation manager to integrate with the docker image and Configuration as Code projects"
 category: Tools
 year: 2020
-status: published
+status: draft
 showGoogleDoc: true
-sig: gsoc
+sig: platform
 skills:
 - Java
 - JSON
@@ -20,5 +20,35 @@ links:
   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
+=== Background
+Last summer, there was a Jenkins Google Summer of Code project to create a tool to automatically install plugins from the command line based on a provided input.
+This is meant to help with creating reproducible environments and other places where you would want to install a certain set of plugins.
+The project was successful in creating a useable tool to install plugins with a 1.0 release.
+As the project progressed over the summer, the student received a lot of enhancement suggestions that were great, but out of the scope of the summer project.
+This summer, the project should incorporate enough enhancements to be used by the official Jenkins docker tooling and Configuration as Code.
 
-See Google Doc
+Following the project tracker, there are several tickets specific to better running with the docker image that would make it more universal.
+Most of these revolve around using alternative locations for downloading plugins, and sharing a cache with the maven repo.
+
+Along with improvements that are already known, it’s important for the student to work with the community to integrate the tool with the docker image and with Configuration as Code.
+There are some requirements the student will have to discover to fully integrate the plugin installation manager tool.
+
+=== Quick Start
+Visit the project page at https://github.com/jenkinsci/plugin-installation-manager-tool
+1. Clone the project
+2. Run the tests; there are several different lists of plugins
+3. You would also want to try experimenting with other lists of plugins; you can almost pick at random and see how it installs.  You can launch an instance of Jenkins using your created plugin folder to see how it loads
+
+=== Open Questions
+How do we use other update-center jsons without compromising download accuracy?
+How do we better catch edge cases for dependent plugins?
+
+=== Skills to Study and Improve
+Java
+* JSON/data structures/package management tools
+* Writing command line interfaces
+* How the Jenkins Docker image and Configuration as Code (CasC) work
+
+Newbie Friendly Issues
+For information about how to contribute to and what to work on, please use the gitter channel.
+Since the project is in active development, these issues could be closed by the time you are looking at them.

--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -1,0 +1,24 @@
+---
+layout: gsocprojectidea
+title: "Plugin Installation Manager Tool Improvements"
+goal: "Update the plugin installation manager to integrate with the docker image and Configuration as Code projects"
+category: Tools
+year: 2020
+status: published
+showGoogleDoc: true
+sig: gsoc
+skills:
+- Java
+- JSON
+- Command line tools
+- Package management tool theory
+mentors:
+- "kwhetstone"
+- "stopalopa"
+- "timja"
+links:
+  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+---
+
+See Google Doc

--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -44,11 +44,11 @@ How do we use other update-center jsons without compromising download accuracy?
 How do we better catch edge cases for dependent plugins?
 
 === Skills to Study and Improve
-Java
+* Java
 * JSON/data structures/package management tools
 * Writing command line interfaces
 * How the Jenkins Docker image and Configuration as Code (CasC) work
 
-Newbie Friendly Issues
+=== Newbie Friendly Issues
 For information about how to contribute to and what to work on, please use the gitter channel.
 Since the project is in active development, these issues could be closed by the time you are looking at them.

--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -5,7 +5,6 @@ goal: "Update the plugin installation manager to integrate with the docker image
 category: Tools
 year: 2020
 status: draft
-showGoogleDoc: true
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -4,7 +4,7 @@ title: "Plugin Installation Manager Tool Improvements"
 goal: "Update the plugin installation manager to integrate with the docker image and Configuration as Code projects"
 category: Tools
 year: 2020
-status: draft
+status: published
 sig: platform
 skills:
 - Java


### PR DESCRIPTION
@jenkins-infra/gsoc 

This is the proposal for further improvements to the plugin installation manager tool.  The Google doc draft was discussed on the plugin installation manager tool gitter channel and changes/suggestions have been merged in.  Pending review.