### PR TITLE
Remove Azure and Rackspace from the sponsors list on the front page

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -9,18 +9,12 @@ homepage: true
   # Images should all be between 300 and 350 pixels wide, and no more than 180px tall
 
   sponsors = [
-    ['microsoft.png',
-     'Microsoft Azure',
-     'https://www.azure.com'],
     ['cloudbees.png',
     'CloudBees, Inc.',
     'https://cloudbees.com'],
     ['osuosl.png',
     'Oregon State University Open Source Lab',
     'https://osuosl.org'],
-    ['rackspace.png',
-    'Rackspace, Inc.',
-    'https://rackspace.com'],
     ['redhat.png',
     'RedHat, Inc.',
     'https://redhat.com'],


### PR DESCRIPTION
Just because they do not sponsor us....

CC @jenkins-infra/board 