### PR TITLE
Moving Jenkins & Artifactory REST to discussion projects

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/artifactory-rest-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/artifactory-rest-plugin.adoc
@@ -4,7 +4,7 @@ title: "Artifactory REST Plugin"
 goal: "Create a new plugin to give Jenkins users the ability to make REST API calls to Artifactory natively"
 category: Plugin
 year: 2020
-status: draft
+status: discussion
 showGoogleDoc: true
 sig: gsoc
 skills:

--- a/content/projects/gsoc/2020/project-ideas/jenkins-rest-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-rest-plugin.adoc
@@ -4,7 +4,7 @@ title: "Jenkins REST Plugin"
 goal: "Create a new plugin to give Jenkins users the ability to make calls to other Jenkins instances via their REST API"
 category: Plugin
 year: 2020
-status: draft
+status: discussion
 showGoogleDoc: true
 skills:
 - Java


### PR DESCRIPTION
Signed-off-by: markyjackson-taulia <marky.r.jackson@gmail.com>

Moving Jenkins & Artifactory REST to discussion projects.

@martinda  We agreed that `Artifactory REST` and `Jenkins REST` should be moved to `discussion` correct? What about `Bitbucket REST`?