### PR TITLE
Remove wiki page creation instructions

### DIFF
--- a/content/_data/solutions/c.yml
+++ b/content/_data/solutions/c.yml
@@ -6,7 +6,7 @@ plugins:
   - 'Warnings Next Generation plugin'
   - 'collects compiler warnings and issues from static analysis tools such as CppCheck'
 -
-  - 'https://wiki.jenkins.io/display/JENKINS/Valgrind+Plugin'
+  - 'https://plugins.jenkins.io/valgrind'
   - 'Valgrind plugin'
   - 'run and incorporate Valgrind (memcheck) reports into Jenkins'
 -

--- a/content/_data/solutions/pipeline.yml
+++ b/content/_data/solutions/pipeline.yml
@@ -19,6 +19,6 @@ plugins:
   - 'Pipeline Utility Steps plugin'
   - 'provides a number of addition, useful, steps to the Pipeline DSL'
 -
-  - "https://wiki.jenkins.io/display/JENKINS/Job+DSL+Plugin"
+  - "https://plugins.jenkins.io/job-dsl"
   - "Job DSL plugin"
   - "creates a DSL to orchestrate job creation"

--- a/content/_data/upgrades/2-7-1.adoc
+++ b/content/_data/upgrades/2-7-1.adoc
@@ -47,6 +47,6 @@ One possible side effect is a memory leak described in JENKINS-33358 and https:/
 
 ==== Changes in UI theme
 
-Jenkins 2 introduced changes to the UI of the New Item page and various configuration pages that may impact custom CSS/JS (injected e.g. using the https://wiki.jenkins.io/display/JENKINS/Simple+Theme+Plugin[Simple Theme Plugin]) relying on the DOM or other features of the Jenkins UI.
+Jenkins 2 introduced changes to the UI of the New Item page and various configuration pages that may impact custom CSS/JS (injected e.g. using the https://plugins.jenkins.io/simple-theme-plugin[Simple Theme Plugin]) relying on the DOM or other features of the Jenkins UI.
 
 Please note that we do not guarantee any UI level backwards compatibility for custom themes.

--- a/content/_partials/changelog-old.html
+++ b/content/_partials/changelog-old.html
@@ -402,11 +402,11 @@
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26940">issue 26940</a>)
   <li class="rfe">
     Update the minimal required versions of the detached Maven Project plugin from <code>2.7.1</code> to <code>2.14</code>.
-    Changelog is available <a href="https://wiki.jenkins.io/display/JENKINS/Maven+Project+Plugin">here</a>.
+    Changelog is available <a href="https://plugins.jenkins.io/maven-plugin">here</a>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2606">pull 2606</a>)
   <li class="rfe">
     Update the minimal required versions of the detached JUnit plugin from <code>1.2-beta-4</code> to <code>1.6</code>.
-    Changelog is available <a href="https://wiki.jenkins.io/display/JENKINS/JUnit+Plugin">here</a>.
+    Changelog is available <a href="https://plugins.jenkins.io/junit">here</a>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2606">pull 2606</a>))
   <li class="major bug">
     Relax requirements of the JNLP connection receiver, which was rejections connections from agents not using
@@ -5869,7 +5869,7 @@
     Matrix project pages don't show latest test results.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10864">issue 10864</a>)
   <li class=rfe>
-  Bundling <a href="https://wiki.jenkins.io/display/JENKINS/Translation+Assistance+Plugin">the translation assistance plugin</a> in the hope of increasing the contribution.
+  Bundling <a href="https://plugins.jenkins.io/translation">the translation assistance plugin</a> in the hope of increasing the contribution.
   <li class=rfe>
   Introduce a fine-grained permission to control who is allowed to run the Groovy Console.
   <li class=rfe>

--- a/content/blog/2010/2010-02-08-incoming-more-translations.md
+++ b/content/blog/2010/2010-02-08-incoming-more-translations.md
@@ -36,6 +36,6 @@ The locales included in this update are:
 
 If you're fluent in any of the locales above, check out the latest release of Hudson to verify that the translations are correct, if there's translations that you feel are incorrect, you can report them in [JIRA](https://issues.hudson-ci.org).
 
-The Hudson [Internationalization](https://wiki.jenkins.io/display/JENKINS/Internationalization) project could always use some more help whether it be from patches or via the [Translation Assistance Plugin](https://wiki.jenkins.io/display/JENKINS/Translation+Assistance+Plugin).
+The [internationalization]https://jenkins.io/doc/developer/internationalization/) project could always use some more help whether it be from patches or via the [Translation Assistance Plugin](https://plugins.jenkins.io/translation).
 
 

--- a/content/blog/2010/2010-02-11-spotlight-on-ita-software.md
+++ b/content/blog/2010/2010-02-11-spotlight-on-ita-software.md
@@ -63,7 +63,7 @@ languages/build system(s)? What platforms is Hudson performing builds? What kind
 </td><td>
 Our Hudson environments (yes, we have more than one) have been optimized for building C++, Java (all <a id="aptureLink_dkCKWMZxl1" href="https://en.wikipedia.org/wiki/Apache%20Maven">maven</a> based), Lisp (a surprise to some to be sure <a href="https://itasoftware.com/careers/l_e_t_lisp.html?catid=8" target="_blank">more about that here</a>), and Python on Linux build slaves (Fedora and CentOS).
 
-Our jobs are (loosely) grouped into one of three categories: rpm (we are primarily RedHat based), tests, and tools. The rpm jobs are the actual code builds and individual component unit tests. The test jobs (thank you <a id="aptureLink_ZDsnAh3cPt" href="https://wiki.jenkins.io/display/JENKINS/Parameterized+Trigger+Plugin">parameterized trigger plugin</a>!) are part of a larger cross-component integration testing and promotion scheme. The (handful of) tools jobs support us in tasks such as cleaning up stale sandbox database connections.
+Our jobs are (loosely) grouped into one of three categories: rpm (we are primarily RedHat based), tests, and tools. The rpm jobs are the actual code builds and individual component unit tests. The test jobs (thank you <a id="aptureLink_ZDsnAh3cPt" href="https://plugins.jenkins.io/parameterized-trigger">parameterized trigger plugin</a>!) are part of a larger cross-component integration testing and promotion scheme. The (handful of) tools jobs support us in tasks such as cleaning up stale sandbox database connections.
 </td></tr>
 <tr><td><br/></td></tr>
 

--- a/content/blog/2010/2010-02-12-this-week-in-plugins.md
+++ b/content/blog/2010/2010-02-12-this-week-in-plugins.md
@@ -11,44 +11,43 @@
 Since this is the first "This Week in Plugins" (TWiP), I'm trying a fairly basic format out. I'm debating how much information I want to include in these, while I would like to include details on "what's changed" for each plugin over the course of the week, the means of fetching that information would be incredibly tedious (read: no fun) since there's not particularly any standard meta-data to be scraped from the [wiki](https://wiki.jenkins.io). Duplicates have been pruned from the list, meaning the latest release of a plugin is what's being shown; sorting is also by day of release then alphabetical.
 
 * **Feb 4th, 2010**
-  * [Codescanner Plug-in 0.9 released](https://wiki.jenkins.io/display/JENKINS/CodeScanner+Plugin)
+  * [Codescanner Plug-in 0.9 released](https://plugins.jenkins.io/codescanner)
 
 * **Feb 5th, 2010**
-  * [Centralized Job(Re)Action 1.1 released](https://wiki.jenkins.io/display/JENKINS/Hudson+Centralized+Job(Re)Action+plugin)
-  * [Performance Publisher plugin 7.95 released](https://wiki.jenkins.io/display/JENKINS/PerfPublisher+Plugin)
-  * [Selenium Auto Exec Server(AES) plugin 0.3 released](https://wiki.jenkins.io/display/JENKINS/Selenium+AES+Plugin)
+  * [Centralized Job(Re)Action 1.1 released](https://plugins.jenkins.io/logaction-plugin)
+  * [Performance Publisher plugin 7.95 released](https://plugins.jenkins.io/perfpublisher)
+  * [Selenium Auto Exec Server(AES) plugin 0.3 released](https://plugins.jenkins.io/selenium-aes)
 
 * **Feb 6th, 2010**
-  * [MSTest plugin 0.5 released](https://wiki.jenkins.io/display/JENKINS/MSTest+Plugin)
-  * [TextFinder plugin 1.8 released](https://wiki.jenkins.io/display/JENKINS/Text-finder+Plugin)
-  * [WindmillPlugin 1.5 released](https://wiki.jenkins.io/display/JENKINS/Windmill+Plugin)
+  * [MSTest plugin 0.5 released](https://plugins.jenkins.io/mstest)
+  * [TextFinder plugin 1.8 released](https://plugins.jenkins.io/text-finder)
 
 * **Feb 7th, 2010**
-  * [Configuration Slicing plugin 1.16 released](https://wiki.jenkins.io/display/JENKINS/Configuration+Slicing+Plugin)
+  * [Configuration Slicing plugin 1.16 released](https://plugins.jenkins.io/configurationslicing)
 
 * **Feb 8th, 2010**
-  * [ClearCase UCM Baseline Plug-in 1.2 released](https://wiki.jenkins.io/display/JENKINS/ClearCase+UCM+Baseline+Plugin)
-  * [Join plugin 1.8 released](https://wiki.jenkins.io/display/JENKINS/Join+Plugin)
+  * [ClearCase UCM Baseline Plug-in 1.2 released](https://plugins.jenkins.io/ClearCase-UCM-Baseline)
+  * [Join plugin 1.8 released](https://plugins.jenkins.io/Join)
 
 * **Feb 9th, 2010**
-  * [Downstream-Ext 1.5 released](https://wiki.jenkins.io/display/JENKINS/Downstream-Ext+Plugin)
-  * [Groovy Postbuild 1.1 released](https://wiki.jenkins.io/display/JENKINS/Groovy+Postbuild+Plugin)
+  * [Downstream-Ext 1.5 released](https://plugins.jenkins.io/downstream-ext)
+  * [Groovy Postbuild 1.1 released](https://plugins.jenkins.io/groovy-postbuild)
 
 * **Feb 10th, 2010**
-  * [Batch task plugin 1.13 released](https://wiki.jenkins.io/display/JENKINS/Batch+Task+Plugin)
-  * [disk-usage plugin 0.10 released](https://wiki.jenkins.io/display/JENKINS/Disk+Usage+Plugin)
-  * [JBoss Management Plugin 1.0 released](https://wiki.jenkins.io/display/JENKINS/JBoss+Plugin) 
-  * [Sidebar Link 1.3 released](https://wiki.jenkins.io/display/JENKINS/Sidebar-Link+Plugin)
-  * [slave-status 1.4 released](https://wiki.jenkins.io/display/JENKINS/slave-status) 
-  * [SLOCCount Plug-in 1.4 released](https://wiki.jenkins.io/display/JENKINS/SLOCCount+Plugin) 
-  * [StarTeam plugin 0.2 released](https://wiki.jenkins.io/display/JENKINS/StarTeam)
-  * [Template Project plugin 1.1 released](https://wiki.jenkins.io/display/JENKINS/Template+Project+Plugin)
-  * [TuxDroid Plugin 1.6 released](https://wiki.jenkins.io/display/JENKINS/TuxDroid+Plugin)
-  * [Zentimestamp plugin 1.2 released](https://wiki.jenkins.io/display/JENKINS/ZenTimestamp+Plugin)
+  * [Batch task plugin 1.13 released](https://plugins.jenkins.io/batch-task)
+  * [disk-usage plugin 0.10 released](https://plugins.jenkins.io/disk-usage)
+  * [JBoss Management Plugin 1.0 released](https://plugins.jenkins.io/jboss)
+  * [Sidebar Link 1.3 released](https://plugins.jenkins.io/sidebar-link)
+  * [slave-status 1.4 released](https://plugins.jenkins.io/slave-status)
+  * [SLOCCount Plug-in 1.4 released](https://plugins.jenkins.io/sloccount)
+  * [StarTeam plugin 0.2 released](https://plugins.jenkins.io/starteam)
+  * [Template Project plugin 1.1 released](https://plugins.jenkins.io/template-project)
+  * [TuxDroid Plugin 1.6 released](https://plugins.jenkins.io/tuxdroid)
+  * [Zentimestamp plugin 1.2 released](https://plugins.jenkins.io/zentimestamp)
 
 * **Feb 11th, 2010**
-  * [Backup plugin 1.4 released](https://wiki.jenkins.io/display/JENKINS/Backup+Plugin)
-  * [Promoted Builds (Simple) 1.2 released](https://wiki.jenkins.io/display/JENKINS/Promoted+Builds+Simple+Plugin)
-  * [Python Plugin 1.1 released](https://wiki.jenkins.io/display/JENKINS/Python+Plugin)
-  * [Subversion Plug-in 1.11 released](https://wiki.jenkins.io/display/JENKINS/Subversion+Plugin)
+  * [Backup plugin 1.4 released](https://plugins.jenkins.io/backup)
+  * [Promoted Builds (Simple) 1.2 released](https://plugins.jenkins.io/promoted-builds-simple)
+  * [Python Plugin 1.1 released](https://plugins.jenkins.io/python)
+  * [Subversion Plug-in 1.11 released](https://plugins.jenkins.io/subversion)
 <!--break-->

--- a/content/blog/2010/2010-02-17-getting-started-building-android-apps-with-hudson.md
+++ b/content/blog/2010/2010-02-17-getting-started-building-android-apps-with-hudson.md
@@ -76,20 +76,20 @@ There is are some issues with this approach however. As you might have noticed:
 * Replacements are done in the workspace, we are not really building __exactly__ what's in svn
 * Each new build should start out fresh for that reason, for example by using the svn revert option.
 
-Additionally I can not yet tag the release version with the updated files, because the [subversion tagging plugin](https://wiki.jenkins.io/display/JENKINS/Subversion+Tagging+Plugin) doesn't support this by design. This could be worked around by adding svn statements in the build.xml however.  For now I don't really mind as I make minor changes to the resource files, but I'll be looking at improving this situation.
+Additionally I can not yet tag the release version with the updated files, because the [subversion tagging plugin](https://plugins.jenkins.io/subversion-tagging) doesn't support this by design. This could be worked around by adding svn statements in the build.xml however.  For now I don't really mind as I make minor changes to the resource files, but I'll be looking at improving this situation.
 
 ## Things to add: unit testing, coverage...
-One thing that I'd really like to add is unit testing. This is a little bit more complicated though, since unit tests require a running emulator and a running emulator requires a gui. The Hudson [Xvnc](https://wiki.jenkins.io/display/JENKINS/Xvnc+Plugin) plugin could be very helpful here.
+One thing that I'd really like to add is unit testing. This is a little bit more complicated though, since unit tests require a running emulator and a running emulator requires a gui. The Hudson [Xvnc](https://plugins.jenkins.io/xvnc) plugin could be very helpful here.
 
-The Android build scripts for test projects already include [EMMA](https://emma.sourceforge.net/) output, it shouldn't be to hard to use the Hudson [plugin](https://wiki.jenkins.io/display/JENKINS/Emma+Plugin) for that.
+The Android build scripts for test projects already include [EMMA](http://emma.sourceforge.net/) output, it shouldn't be to hard to use the Hudson [plugin](https://plugins.jenkins.io/emma) for that.
 
-When Hudson is running on a local machine, the [Batch task](https://wiki.jenkins.io/display/JENKINS/Batch+Task+Plugin) plugin can automate installing the apk on a device to automate things further.
+When Hudson is running on a local machine, the [Batch task](https://plugins.jenkins.io/batch-task) plugin can automate installing the apk on a device to automate things further.
 
 ## Summary
 Building Android applications with Hudson is not that hard, since the builds are based on Ant. By hooking in to the standard Android build targets it's easy to update files like *AndroidManifest.xml* which in turn makes sure the release process is controlled and predictable.  
 Android unit tests depend on the emulator which is a little bit more challenging to set up, but Hudson already has some plugins available to make this easier.
 
 ----
-**Editor's Note:** Hugo Visser is the developer of [Rainy Days](https://code.neenbedankt.com/my-first-published-android-app-rainy-days) and [Engine Watch](https://code.neenbedankt.com/monitor-your-app-engine-application-from-your) for Android. You can
+**Editor's Note:** Hugo Visser is the developer of [Rainy Days](https://code.neenbedankt.com/my-first-published-android-app-rainy-days) and [Engine Watch](https://code.neenbedankt.com/monitor-your-app-engine-application-from-your-pocket-with-engine-watch-for-android/) for Android. You can
 follow him [on Twitter](https://twitter.com/botteaap) and [on his blog](https://code.neenbedankt.com).
 <!--break-->

--- a/content/blog/2010/2010-02-19-this-week-in-plugins.md
+++ b/content/blog/2010/2010-02-19-this-week-in-plugins.md
@@ -12,42 +12,39 @@ Last week's TWIP enumerated the release of **26** different plugin, this past we
 
 Making their Hudson debut are the following
 
-* [Slave Monitor for system load average](https://wiki.jenkins.io/display/JENKINS/System+Load+Average+Monitor+Plugin)
-* [Tool Environment plugin](https://wiki.jenkins.io/display/JENKINS/Tool+Environment+Plugin)
-* [Ivy plugin](https://wiki.jenkins.io/display/JENKINS/Ivy+Plugin)
+* [Slave Monitor for system load average](https://plugins.jenkins.io/systemloadaverage-monitor)
+* [Tool Environment plugin](https://plugins.jenkins.io/toolenv)
+* [Ivy plugin](https://plugins.jenkins.io/ivy)
 
 If you're interested in contributing to an existing plugin, or building your own, I highly recommend checking out the [plugin tutorial](https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial) and joining the [dev@ mailing list](https://hudson.dev.java.net/servlets/ProjectMailingListList). That said, here are this week's releases, starting with last Friday.
 
 
 
 * **Feb 12th, 2010**
-  * [File System SCM 1.6 released](https://wiki.jenkins.io/display/JENKINS/File+System+SCM)
-  * [JIRA plugin 1.19 released](https://wiki.jenkins.io/display/JENKINS/JIRA+Plugin)
-  * [Job Configuration History Plugin 1.2 released](https://wiki.jenkins.io/display/JENKINS/JobConfigHistory+Plugin)
-  * [MSTest plugin 0.6 released](https://wiki.jenkins.io/display/JENKINS/MSTest+Plugin)
-  * [Slave Monitor for system load average 1.1 released](https://wiki.jenkins.io/display/JENKINS/System+Load+Average+Monitor+Plugin)
-  * [Template Project plugin 1.2 released](https://wiki.jenkins.io/display/JENKINS/Template+Project+Plugin)
+  * [File System SCM 1.6 released](https://plugins.jenkins.io/filesystem_scm)
+  * [JIRA plugin 1.19 released](https://plugins.jenkins.io/jira)
+  * [Job Configuration History Plugin 1.2 released](https://plugins.jenkins.io/jobconfighistory)
+  * [MSTest plugin 0.6 released](https://plugins.jenkins.io/mstest)
+  * [Slave Monitor for system load average 1.1 released](https://plugins.jenkins.io/systemloadaverage-monitor)
+  * [Template Project plugin 1.2 released](https://plugins.jenkins.io/template-project)
 
 * **Feb 13th, 2010**
-  * [xUnit plugin 0.5.2 released](https://wiki.jenkins.io/display/JENKINS/xUnit+Plugin)
+  * [xUnit plugin 0.5.2 released](https://plugins.jenkins.io/xunit)
 
 * **Feb 14th, 2010**
-  * [Amazon EC2 plugin 1.6 released](https://wiki.jenkins.io/display/JENKINS/Amazon+EC2+Plugin)
-  * [Build Secret plugin 1.5 released](https://wiki.jenkins.io/display/JENKINS/Build+Secret+Plugin)
-  * [Dependency Analyzer Plugin 0.5 released](https://wiki.jenkins.io/display/JENKINS/Dependency+Analyzer+Plugin)
-  * [DocLinks plugin 0.3 released](https://wiki.jenkins.io/display/JENKINS/DocLinks+Plugin)
-  * [Grails plugin 1.1 released](https://wiki.jenkins.io/display/JENKINS/Grails+Plugin)
-  * [Tool Environment plugin 1.0 released](https://wiki.jenkins.io/display/JENKINS/Tool+Environment+Plugin)
+  * [Amazon EC2 plugin 1.6 released](https://plugins.jenkins.io/ec2)
+  * [Dependency Analyzer Plugin 0.5 released](https://plugins.jenkins.io/dependencyanalyzer)
+  * [DocLinks plugin 0.3 released](https://plugins.jenkins.io/doclinks)
+  * [Tool Environment plugin 1.0 released](https://plugins.jenkins.io/toolenv)
 
 * **Feb 15th, 2010**
-  * [Artifactory Plugin 1.0.6 released](https://wiki.jenkins.io/display/JENKINS/Artifactory+Plugin)
-  * [Dimensions SCM plugin 0.6.8 released](https://wiki.jenkins.io/display/JENKINS/Dimensions+Plugin)
-  * [Perforce Plugin 1.0.20 released](https://wiki.jenkins.io/display/JENKINS/Perforce+Plugin)
+  * [Artifactory Plugin 1.0.6 released](https://plugins.jenkins.io/artifactory)
+  * [Dimensions SCM plugin 0.6.8 released](https://plugins.jenkins.io/dimensions)
 
 * **Feb 16th, 2010**
-  * [HTML Publisher plugin 0.2.2 released](https://wiki.jenkins.io/display/JENKINS/HTML+Publisher+Plugin)
+  * [HTML Publisher plugin 0.2.2 released](https://plugins.jenkins.io/htmlpublisher)
 
 * **Feb 17th, 2010**
-  * [Ivy plugin 1.0 released](https://wiki.jenkins.io/display/JENKINS/Ivy+Plugin)
-  * [JBoss Management Plugin 1.0.2 released](https://wiki.jenkins.io/display/JENKINS/JBoss+Management+Plugin)
+  * [Ivy plugin 1.0 released](https://plugins.jenkins.io/ivy)
+  * [JBoss Management Plugin 1.0.2 released](https://plugins.jenkins.io/jboss)
 <!--break-->

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -8,49 +8,11 @@ references:
   title: Jenkins Wiki Exporter
 ---
 
-WARNING: This page describes hosting of plugin documentation on link:https://wiki.jenkins.io[the Jenkins wiki].
-For newly created plugins it is recommended to keep plugin documentation in GitHub repositories.
-See link:../documentation[this page] for the guidelines.
+WARNING: The Jenkins wiki was made 'read-only' in link:https://groups.google.com/d/msg/jenkinsci-dev/lNmas8aBRrI/eL3u7A6qBwAJ[October 2019].
+Plugin documentation should be maintained in the GitHub repository of the plugin.
+See the link:../documentation[plugin documentation guidelines] for details.
 
-Plugins should have user documentation outside the plugin itself so that potential users can learn about the plugin without installing it.
-A common way to do this is to create a plugin wiki page on link:https://wiki.jenkins.io[the Jenkins wiki].
-
-== Creating a wiki page
-
-Plugin wiki pages should be organized as child pages of the https://wiki.jenkins.io/display/JENKINS/Plugins[Plugins] page.
-Go to that page, be sure to be logged in, and click _Create_ in the page header.
-The page you'll create will automatically be added as a child of the Plugins page.
-
-== Content recommendations
-
-=== Plugin macro
-
-Use the `+{jenkins-plugin-info:pluginId=YOUR-ARTIFACT-ID}+` macro near the top of your plugin's wiki page.
-It will link to the plugin's page on the link:../plugin-site[plugin site], as well as any security warnings applicable to the plugin to warn users.footnoteref:[previously,Before the plugin site existed, the wiki macro included various statistics, but that was removed as redundant.]
-
-
-=== Documentation
-
-The wiki page should contain basic documentation that explains what the plugin does, and how to configure it in Jenkins.
-This documentation should be kept up to date as the plugin changes.
-Note that it is best to keep the documentation as a whole in mind when amending it:
-For example, don't just add new sections at the bottom when you add new features, but write the documentation so that someone new to the plugin has the best experience reading the documentation.
-
-
-=== Changelog
-
-Include a changelog that shows the changes in every version you release.
-Keep in mind that many Jenkins users are not necessarily Java developers, so focus on the effect of a change to users, rather than exactly what code you changed.
-People can always read the source code if they want to know exactly what was changed.
-
-=== Basic macros only
-
-If a plugin links to its wiki page from its metadata (defined using the `<url>` tag in the `pom.xml`), the plugin site will scrape the wiki and include the page contents directly.
-If a non-wiki URL is specified, for example to a GitHub repository, it will only show a link instead.
-
-Given the limitations inherent in including scraped content, many advanced macros will not show up properly on the plugin site:
-Basically every macro that uses AJAX to load data in the background will not work.
-Since Jenkins will link to the plugin's page on the plugin site from its plugin manager, this will result in a bad experience reading broken documentation for many users.
+Plugin documentation is available from the link:https://plugins.jenkins.io[Jenkins plugins site] so that potential users can learn about the plugin without installing it.
 
 == Migrating from Wiki to GitHub
 


### PR DESCRIPTION
Removes the wiki page creation instructions from the developer document, since plugin creators cannot create a wiki page any longer.

Also includes the beginning of replacement of many references from jenkins.io to wiki.jenkins.io.  The pattern matching is not that hard, but it does accept that we're changing existing blog posts so that they point to current pages.

I'm also OK if the consensus is to not make these types of changes but rather to keep the wiki around long term.