### PR TITLE
Fix the list in automatic spec generator idea

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -55,15 +55,16 @@ Plugins and the core would thus have their own version number, and an additional
 
 === Links
 There are many examples of such documentation on the web:
+
 * link:https://docs.atlassian.com/bitbucket-server/rest/5.15.0/bitbucket-rest.html?utm_source=%2Fstatic%2Frest%2Fbitbucket-server%2Flatest%2Fbitbucket-rest.html&utm_medium=301[Bitbucket REST API] (link to Bitbucket documentation)
 * link:https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API[Artifactory REST API ](link to Artifactory documentation)
-* OpenAPI3 description of the Jenkins REST API: https://github.com/cliffano/swaggy-jenkins (note: the swaggy-jenkins author now recommends OpenAPI (explanation).
-* This stackoverflow question talks briefly about generating a REST API spec in WADL format: https://stackoverflow.com/questions/12405911/how-can-i-generate-wadl-for-rest-services
-* This blog post talks about swagger and WADL: https://swagger.io/blog/api-development/getting-started-with-swagger-i-what-is-swagger/
+* OpenAPI3 description of the Jenkins REST API: link:https://github.com/cliffano/swaggy-jenkins[swaggy jenkins] (note: the swaggy-jenkins author now recommends OpenAPI (explanation).
+* This link:https://stackoverflow.com/questions/12405911/how-can-i-generate-wadl-for-rest-services[stackoverflow] question talks briefly about generating a REST API spec in WADL format
+* A link:https://swagger.io/blog/api-development/getting-started-with-swagger-i-what-is-swagger/[blog post] that talks about swagger and WADL
 * Making Stapler more declarative link:https://groups.google.com/d/msg/jenkinsci-dev/UrVVT8wbHIE/_1O35oU4AgAJ[discussion] leading to a comment on swagger.
-* Seeking help on clarifying this proposal: https://groups.google.com/forum/#!topic/jenkinsci-dev/mYeM5qA6tGM
-* Plugin skeleton generator: https://github.com/jenkinsci/maven-hpi-plugin
-* Jira ticket on generating spec for Jenkins REST API from 2016 https://issues.jenkins-ci.org/browse/JENKINS-35808
+* A link:https://groups.google.com/forum/#!topic/jenkinsci-dev/mYeM5qA6tGM[google group discussion] on seeking help on clarifying this proposal
+* link:https://github.com/jenkinsci/maven-hpi-plugin[Plugin skeleton generator]
+* link:https://issues.jenkins-ci.org/browse/JENKINS-35808[Jira ticket JENKINS-35808] on generating spec for Jenkins REST API from 2016
 
 
 === Newbie-friendly issues


### PR DESCRIPTION
A minor fix for the bullet list in the GSoC automatic spec generator idea.

CC @kwhetstone @jenkins-infra/gsoc 