### PR TITLE
Add redirect URLs for removed network discovery features

### DIFF
--- a/content/redirect/dns-multicast.adoc
+++ b/content/redirect/dns-multicast.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Auto-discovering+Jenkins+on+the+network
+---

--- a/content/redirect/udp-broadcast.adoc
+++ b/content/redirect/udp-broadcast.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Auto-discovering+Jenkins+on+the+network
+---


### PR DESCRIPTION
These URLs are used in https://github.com/jenkinsci/jenkins/pull/4460 and that will be in 2.220.

I added a warning to the wiki page at https://wiki.jenkins.io/display/JENKINS/Auto-discovering+Jenkins+on+the+network and so that URL is probably the best target for these redirects while there's no LTS upgrade guide with more specific information.
