### PR TITLE
Include issue id in changelog references section

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6065,6 +6065,7 @@
     authors:
     - jeffret-b
     references:
+      - issue: 60926
       - url: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.2
         title: Remoting 4.2 changelog
       - url: https://github.com/jenkinsci/slave-installer-module/blob/master/CHANGELOG.md#17


### PR DESCRIPTION
The JENKINS-60926 issue reference was missed for the remoting regression fix on the agent installer for Windows.

![image](https://user-images.githubusercontent.com/156685/74147992-9e9bbf80-4bc1-11ea-89ad-1a7fa33b2424.png)
