### PR TITLE
Fix typos in authors descriptions

### DIFF
--- a/content/_data/authors/jochenafuerbacher.adoc
+++ b/content/_data/authors/jochenafuerbacher.adoc
@@ -4,4 +4,4 @@ github: "Jochen-A-Fuerbacher"
 ---
 
 Jochen is a software developer for development infrastructure at 1&1 Telecommunication.
-He has been working with Jenkins for many years and develop some Jenkins plugins.
+He has been working with Jenkins for many years and develops some Jenkins plugins.

--- a/content/_data/authors/robinrschulz.adoc
+++ b/content/_data/authors/robinrschulz.adoc
@@ -4,4 +4,4 @@ github: "RobinRSchulz"
 ---
 
 Robin is a software developer for development infrastructure at 1&1 Telecommunication.
-He has been working with Jenkins for many years and develop some Jenkins plugins.
+He has been working with Jenkins for many years and develops some Jenkins plugins.

--- a/content/_data/authors/stefanbrausch.adoc
+++ b/content/_data/authors/stefanbrausch.adoc
@@ -4,4 +4,4 @@ github: "stefanbrausch"
 ---
 
 Stefan is a software developer for development infrastructure at 1&1 Telecommunication.
-He has been working with Jenkins for many years and develop some Jenkins plugins.
+He has been working with Jenkins for many years and develops some Jenkins plugins.


### PR DESCRIPTION
This PR corrects some typos in the blog authors descriptions of @stefanbrausch, @RobinRSchulz and me.