### PR TITLE
Clarify use of Google Docs for GSoC projec ideas

### DIFF
--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -186,6 +186,17 @@ And remove the line that says `showGoogleDoc: true`.
 
 The `.adoc` will be displayed, and the Google Doc will be linked at the bottom.
 
+=== Additional links
+
+The `.adoc` can have links to chat rooms, mailing lists, etc. Simply name the links
+and they will be displayed:
+
+```
+links:
+    mailing list: https://somelink to the mailing list
+    chat: https://some link to a chat room on gitter or slask or other
+```
+
 == Submitting the project details
 
 Whether you use a Google Doc, the `.adoc` file or both to document the details of the project idea,

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -48,6 +48,7 @@ For more on the `adoc` format see link:https://asciidoctor.org/[asciidoctor.org]
 The format for the `.adoc` file is as follows:
 
 ```
+---
 layout: gsocprojectidea
 title: "Specify the project idea title"
 goal: "One sentence summarizing the goal of your idea"
@@ -63,13 +64,14 @@ skills:
 links:
   emailThread: link to the email thread in https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public
 ---
+
 TODO: DRAFT (this is a placeholder, it will not be shown)
 ```
 
 The last step is to submit this new file as a pull-request.
 
 [[submit_pr]]
-==== When you submit a pull-request
+=== When you submit a pull-request
 
 . add `CC @jenkins-infra/gsoc` so we get a notification, or request a review from `jenkins-infra/gsoc`
 . add a link to the related mailing list thread
@@ -120,11 +122,11 @@ Write your project idea here. Sometimes an abstract is enough, but you should in
 * Students will read this when they look to participate in the program, so make sure you catch their attention!
 * Have a look at other project ideas for inspiration to improve the way you present your idea
 
-==== Quickstart
+== Quickstart
 
 You may have quick start instructions for students, e.g. how to get started on your proposal. Provide this information here.
 
-==== Links
+== Links
 
 You may have additional links to the ideas here, including related discussions on
 the Jenkins Dev or Jenkins User mailing list, blogposts, Jiras, etc.
@@ -138,13 +140,12 @@ link:https://plugins.jenkins.io/role-strategy[Role Strategy Plugin]
 link:../../students[Information page for students]
 
 
-==== Newbie-friendly issues
+== Newbie-friendly issues
 
 If you are a potential mentor, propose examples of tickets the applicants could
 study while preparing their project proposals.
 We do NOT require students to make contributions before applying,
 but such tasks may help to select students who are interested to work on the project.
-
 ```
 
 === Using a Google Doc for capturing the details of the idea
@@ -169,9 +170,7 @@ skills:
 links:
   draft: <link to Google Doc>
 ---
-
 See Google doc.
-
 ```
 
 === Using both the `.adoc` and the Google Doc

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -39,10 +39,14 @@ link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list]
 .. create a new `.adoc` file under the
 link:https://github.com/jenkins-infra/jenkins.io/tree/master/content/projects/gsoc/2020/project-ideas[project-ideas]
 folder with your project idea
-.. look at existing idea files for the format you should follow (many existing ideas contain a link to a google doc but this is optional)
+.. document the details
+... either enter the details in the `.adoc` file (scroll down for the template)
+... or create a new google doc based on link:https://docs.google.com/document/d/1l5SdcLnlCwWA6qH8FKT9XC714Dl1XJ9lyy1CKDdKKAU/edit[this template] and allow other to comment
+.. look at existing idea `.adoc` files for the format you should follow (many existing ideas contain a link to a google doc but this is optional)
 .. in the pull-request comment box
-... add `CC @jenkins-infra/gsoc` so we get a notification
+... add `CC @jenkins-infra/gsoc` so we get a notification, or request a review from `jenkins-infra/gsoc`
 ... add a link to the related mailing list thread
+... assign the gsoc Label to the PR if you can
 .. post the pull-request link to the
 link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] and to the
 link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list] as a follow up to your original thread.

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -34,57 +34,63 @@ link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list]
 .. the technical feasability and the required changes to existing code when applicable
 .. the scope of the project (it should be defined to fit approximately 3 months of full time coding for a student)
 .. how it fits with existing projects (does it complement, augment, replace, combine, fix, etc. an existing project?)
-. If your idea gets good feedback, create a pull-request:
+
+Once the discussion has started on the mailing list,
+you can submit your idea for publication on the page of GSoC ideas under the discussion section
+by sending a pull request with an `.adoc` file for your project idea.
+
 .. fork and clone the link:https://github.com/jenkins-infra/jenkins.io[jenkins.io] repository
-.. create a new `.adoc` file under the
-link:https://github.com/jenkins-infra/jenkins.io/tree/master/content/projects/gsoc/2020/project-ideas[project-ideas]
-folder with your project idea
-.. document the details
-... either enter the details in the `.adoc` file (scroll down for the template)
-... or create a new google doc based on link:https://docs.google.com/document/d/1l5SdcLnlCwWA6qH8FKT9XC714Dl1XJ9lyy1CKDdKKAU/edit[this template] and allow other to comment
-.. look at existing idea `.adoc` files for the format you should follow (many existing ideas contain a link to a google doc but this is optional)
-.. in the pull-request comment box
-... add `CC @jenkins-infra/gsoc` so we get a notification, or request a review from `jenkins-infra/gsoc`
-... add a link to the related mailing list thread
-... assign the gsoc Label to the PR if you can
+.. create a new `.adoc` file under the appropriate yearly folder in
+link:https://github.com/jenkins-infra/jenkins.io/tree/master/content/projects/gsoc[content/projects/gsoc].
+
+For more on the `adoc` format see link:https://asciidoctor.org/[asciidoctor.org].
+
+The format for the `.adoc` file is as follows:
+
+```
+layout: gsocprojectidea
+title: "Specify the project idea title"
+goal: "One sentence summarizing the goal of your idea"
+category: Plugins
+year: 2020
+status: discussion
+mentors:
+- "userid1"   # This userid must exist under /content/_data/authors/userid.adoc on jenkins.io
+- "userid2"   # You can have multiple mentors (and remove these comments when submitting)
+skills:
+- skills_go_here
+- add_more_if_needed
+links:
+  emailThread: link to the email thread in https://groups.google.com/forum/#!forum/jenkinsci-gsoc-all-public
+---
+TODO: DRAFT (this is a placeholder, it will not be shown)
+```
+
+The last step is to submit this new file as a pull-request.
+
+[[submit_pr]]
+==== When you submit a pull-request
+
+. add `CC @jenkins-infra/gsoc` so we get a notification, or request a review from `jenkins-infra/gsoc`
+. add a link to the related mailing list thread
+. assign the gsoc Label to the PR if you can
 .. post the pull-request link to the
 link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] and to the
 link:mailto:jenkinsci-gsoc-all-public@googlegroups.com[GSoC mailing list] as a follow up to your original thread.
 
-The goal when you submit a project idea is to attract attention and feedback from the community.
+If your idea gets good feedback, and you want to proceed with it,
+you will need to provide details about the project idea.
+This can be done using the `.adoc` file itself, a Google Doc, or both.
+What's the difference?
+A Google Doc lowers the barrier of entry for comments and feedback, and multiple authors can collaborate on the idea simultaneously.
+It is possible to discuss the project using the comments, but in the end the comment history is hidden once the comments are resolved.
+A pull-request is more rigid and once it is merged, the discussion about the project must take place either in subsequent pull-requests,
+or in a chat room or a mailing list. Both are offered and simultaneously possible, use the method that works best for you.
 
-== Requirements
 
-* GSoC is about code (though it may and likely should include some documentation)
-* Projects should be about Jenkins (plugins, core, infrastructure, integrations, test frameworks, etc.)
-* Projects should be potentially doable by a student in 3-4 months
+=== Using `.adoc` for capturing the details of the idea
 
-You can find more information about requirements and practices in the
-link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide].
-
-== Examples
-
-Need some hints? Here are examples of project ideas:
-
-* A new plugin for integration with various development tools or services
-* link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopting an existing plugin],
-extending it by adding new features like link:/doc/book/pipeline/[Jenkins Pipeline]
-* Working on major feature requests from the link:https://issues.jenkins-ci.org/secure/Dashboard.jspa[Jenkins bugtracker]
-* Creating new demo and reference setups,
-powered by various "-as-Code" engines (e.g. Jenkins Pipeline, JobDSL, Docker, link:/projects/gsoc/gsoc2018-project-ideas/#jenkins-configuration-as-code[Configuration-as-Code plugin], etc.)
-
-== Notes for students
-
-Although we encourage students to propose their own project ideas, we cannot guarantee
-that will find potential mentors for every proposal, especially for narrow areas.
-During the selection phase we won't be able to accept proposals without mentors, so
-we highly recommend getting initial feedback in the mailing lists before spending too much
-time on such proposals.
-
-== Template
-
-Below is an `adoc` template for submitting a project idea to jenkins.io.
-For more on `adoc` see link:https://asciidoctor.org/[asciidoctor.org].
+To use the `.adoc` file for the details, please modify your `.adoc` file according to this template:
 
 
 ```
@@ -94,7 +100,7 @@ title: "Specify the project idea title"
 goal: "One sentence summarizing the goal of your idea"
 category: Plugins
 year: 2020
-status: published
+status: draft
 mentors:
 - "userid1"   # This userid must exist under /content/_data/authors/userid.adoc on jenkins.io
 - "userid2"   # You can have multiple mentors (and remove these comments when submitting)
@@ -102,7 +108,7 @@ skills:
 - skills_go_here
 - add_more_if_needed
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci/gsoc-sig" # This can be the gitter link of your project's chat room
 ---
 
 Write your project idea here. Sometimes an abstract is enough, but you should include:
@@ -141,9 +147,93 @@ but such tasks may help to select students who are interested to work on the pro
 
 ```
 
+=== Using a Google Doc for capturing the details of the idea
+
+To use a Google Doc for the details, please modify your `.adoc` file according to this template:
+
+```
+---
+layout: gsocprojectidea
+title: "Specify the project idea title"
+goal: "One sentence summarizing the goal of your idea"
+category: Plugins
+year: 2020
+status: draft
+showGoogleDoc: true  # This line causes the google doc to be embedded on jenkins.io
+mentors:
+- "userid1"   # This userid must exist under /content/_data/authors/userid.adoc on jenkins.io
+- "userid2"   # You can have multiple mentors (and remove these comments when submitting)
+skills:
+- skills_go_here
+- add_more_if_needed
+links:
+  draft: <link to Google Doc>
+---
+
+See Google doc.
+
+```
+
+=== Using both the `.adoc` and the Google Doc
+
+To use both, add a `draft` entry to the `links` like this:
+```
+links:
+    draft: <link to google doc>
+    ...
+```
+
+And remove the line that says `showGoogleDoc: true`.
+
+The `.adoc` will be displayed, and the Google Doc will be linked at the bottom.
+
+== Submitting the project details
+
+Whether you use a Google Doc, the `.adoc` file or both to document the details of the project idea,
+you need to submit a pull-request, following the link:#submit_pr[process described] earlier in this document.
+Make sure you post and follow up to all the places where your idea is discussed
+so that participants get the link to the Google Doc.
+
+== Publishing the idea
+
+Project ideas are published once they have been reviewed by the Org Admin team to ensure they contain
+enough information, all the expected sections, and that the meta information is correct (sig, links, mentors, etc.).
+
+Publishing is done via a pull-request that changes the status to `published`.
+
+== Requirements
+
+* GSoC is about code (though it may and likely should include some documentation)
+* Projects should be about Jenkins (plugins, core, infrastructure, integration, test frameworks, etc.)
+* Projects should be potentially doable by a student in 3-4 months
+* If your project takes multiple years, try to split it in 3-4 month long chunks so it fits with the GSoC timeline
+
+You can find more information about requirements and practices in the
+link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide].
+
+== Examples
+
+Need some hints? Here are examples of project ideas:
+
+* A new plugin for integration with various development tools or services
+* link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopting an existing plugin],
+extending it by adding new features like link:/doc/book/pipeline/[Jenkins Pipeline]
+* Working on major feature requests from the link:https://issues.jenkins-ci.org/secure/Dashboard.jspa[Jenkins bugtracker]
+* Creating new demo and reference setups,
+powered by various "-as-Code" engines (e.g. Jenkins Pipeline, JobDSL, Docker, link:/projects/gsoc/gsoc2018-project-ideas/#jenkins-configuration-as-code[Configuration-as-Code plugin], etc.)
+
+== Notes for students
+
+Although we encourage students to propose their own project ideas, we cannot guarantee
+that will find potential mentors for every proposal, especially for narrow areas.
+During the selection phase we won't be able to accept proposals without mentors, so
+we highly recommend getting initial feedback in the mailing lists before spending too much
+time on such proposals.
+
+
 == More examples of how to write project ideas
 
 Refer to the following files on Github for additional example to format your project idea submission:
 
-* link:https://github.com/jenkins-infra/jenkins.io/blob/master/content/projects/gsoc/2019/project-ideas/artifactory-rest-plugin.adoc[Project idea with link to a google doc]
-* link:https://github.com/jenkins-infra/jenkins.io/blob/master/content/projects/gsoc/2019/project-ideas/role-strategy-ux.adoc[Project idea with no link to google doc]
+* link:https://github.com/jenkins-infra/jenkins.io/blob/master/content/projects/gsoc/2019/project-ideas/artifactory-rest-plugin.adoc[Project idea with link to a Google Doc]
+* link:https://github.com/jenkins-infra/jenkins.io/blob/master/content/projects/gsoc/2019/project-ideas/role-strategy-ux.adoc[Project idea with no link to Google Doc]


### PR DESCRIPTION
I decided to clarify that Google Docs are allowed when submitting project ideas, and provided additional information on how to format the `.adoc` project idea files.

This PR is not urgent.