### PR TITLE
docs(mentors.adoc): fix link to contact Org Admins

### DIFF
--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -18,7 +18,7 @@ Student resources can be found link:/projects/gsoc/students[here].
 * link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide]
 * link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline]
 * Mailing list for mentors: jenkins-gsoc-2020-mentors@googlegroups.com
-* link:http://localhost:4242/projects/gsoc/#orgadmin[Mailing list for contacting Org Admins]
+* link:/projects/gsoc/#orgadmin[Mailing list for contacting Org Admins]
 * link:/conduct[Code of Conduct]
 
 == What do mentors get?


### PR DESCRIPTION
http://localhost:4242/projects/gsoc/#orgadmin -> /projects/gsoc/#orgadmin