### PR TITLE
GSoC 2020 - Publish the External Fingerprint storage project idea

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/external-fingerprint-storage-for-jenkins.adoc
+++ b/content/projects/gsoc/2020/project-ideas/external-fingerprint-storage-for-jenkins.adoc
@@ -4,7 +4,7 @@ title: "External Fingerprint Storage for Jenkins"
 goal: "Extend Jenkins to support storing artifact usage history in external databases"
 category: Core
 year: 2020
-status: draft
+status: published
 showGoogleDoc: true
 sig: cloud-native
 skills:


### PR DESCRIPTION
I have added the Quick Start guide to the project idea. Taking #2858 , we can now publish it even if it embeds a Google Doc