### PR TITLE
Jenkins 2.220 changelog: Add a banner warning for Swarm Plugin users

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6057,6 +6057,9 @@
 
 - version: '2.220'
   date: 2020-02-09
+  banner: >
+    This release includes an incompatible change which impacts users of the Self-Organizing Swarm Modules plugin.
+    Users of this plugin should upgrade it and its CLI client to the version 3.18 or above.
   changes:
   - type: major bug
     category: regression
@@ -6083,11 +6086,15 @@
   - type: major rfe
     category: major rfe
     pull: 4460
-    issue: 60913
     authors:
     - jeffret-b
     message: |-
       Remove network discovery services (UDP and DNS).
+      Users of the Self-Organizing Swarm Modules plugin should update the plugin and its CLI client to 3.18.
+    references:
+      - issue: 60913
+      - url: https://github.com/jenkinsci/swarm-plugin/releases/tag/swarm-plugin-3.18
+        title: Self-Organizing Swarm Modules Plugin 3.18 changelog
   - type: major rfe
     category: major rfe
     pull: 4450


### PR DESCRIPTION
Just improves the visibility a bit. CC @basil @jeffret-b 

https://github.com/jenkinsci/jenkins/pull/4460 also includes appropriate upgrade guidelines for LTS

![image](https://user-images.githubusercontent.com/3000480/74647488-059a1500-517c-11ea-9157-548582d36b9b.png)
