### PR TITLE
GSoC 2020 - Fix JX chat links and add a profile for @nehagup 

### DIFF
--- a/content/_data/authors/nehagup.adoc
+++ b/content/_data/authors/nehagup.adoc
@@ -1,0 +1,4 @@
+---
+name: "Neha Gupta"
+github: "nehagup"
+---

--- a/content/projects/gsoc/2020/project-ideas/jenkins-x-apps-consolidation.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-x-apps-consolidation.adoc
@@ -1,7 +1,7 @@
 ---
 layout: gsocprojectidea
-title: "Consolidate the use of Apps / Addons within Jenkins X"
-goal: "Consolidate Apps and Addons inside Jenkins "
+title: "Jenkins X: Consolidate the use of Apps / Addons"
+goal: "Consolidate Apps and Addons inside Jenkins X"
 category: Jenkins X
 year: 2020
 status: draft
@@ -11,8 +11,8 @@ skills:
 mentors:
 - "jstrachan"
 - "nehagup"
-- "TBD"
 links:
+  chat: https://jenkins-x.io/community/#slack
   mailing list: jenkinsci-gsoc-all-public
   draft: https://github.com/jenkins-x/enhancements/blob/master/proposals/1/README.md
 ---

--- a/content/projects/gsoc/2020/project-ideas/jenkins-x-boot-apps.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-x-boot-apps.adoc
@@ -12,6 +12,7 @@ mentors:
 - "markyjackson-taulia"
 - "jstrachan"
 links:
+  chat: https://jenkins-x.io/community/#slack
   mailing list: jenkinsci-gsoc-all-public
   draft: https://github.com/jenkins-x/enhancements/blob/master/proposals/2/README.md
 ---


### PR DESCRIPTION
CC @MarckK @jstrachan @markyjackson-taulia . It redirects the conversations to Jenkins X channels. I also fixed visualization for @nehagup on the project ideas list while I was around. In mid-2019 the GSoC metadata was merged into `authors` on jenkins.io, and hence now we need to create author profiles to have a better visualization of users