### PR TITLE
Add a Gitter channel reference to the UX SIG metadata

### DIFF
--- a/content/sigs/ux/index.adoc
+++ b/content/sigs/ux/index.adoc
@@ -17,6 +17,7 @@ participants:
 - "oleg_nenashev"
 - "markewaite"
 links:
+  gitter: "jenkinsci/ux-sig"
   googlegroup: "jenkinsci-ux"
   meetings: "https://docs.google.com/document/d/1xA6UN7ORv3OFYBC3Kw6y4mtqDekAjwYVNhsrH4PBwBk/edit?usp=sharing"
 overview: >


### PR DESCRIPTION
CC @jphartley @fqueiruga