### PR TITLE
GSoC 2020 - Publish the EDA coverage project idea

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/eda-coverage-adapters.adoc
+++ b/content/projects/gsoc/2020/project-ideas/eda-coverage-adapters.adoc
@@ -4,7 +4,7 @@ title: "EDA Coverage Adapters"
 goal: "Create Jenkins plugins for various Electronic Design Automation coverage reports"
 category: Plugins
 year: 2020
-status: draft
+status: published
 showGoogleDoc: true
 sig: hw-and-eda
 skills:


### PR DESCRIPTION
I have reviewed an expanded the Google doc for this year, it is up to date. Also, I expanded the quick start guide to set more explicit expectations about the project

See https://docs.google.com/document/d/1pW9cSPTSekhMirHWKGnchmsDGsGLeN8MBEpMyN9HDEo