### PR TITLE
GSoC 2020 - Publish the Pipeline as YAML project idea

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment.adoc
+++ b/content/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment.adoc
@@ -1,17 +1,18 @@
 ---
 layout: gsocprojectidea
-title: "Pipeline: YAML Plugin"
-goal: "Jenkins Pipeline as YAML: experimental plugin"
+title: "Jenkins Pipeline as YAML: experimental plugin"
+goal: "Add out-of-the-box support of Jenkins Pipeline definitions in YAML"
 category: Plugins
 year: 2020
-status: draft
+status: published
 sig: platform
 mentors:
 - "oleg_nenashev"
 skills:
 - Java
 - Jenkins Pipeline
-- DSL
+- Domain Specific Languages
+- YAML
 - Jenkins X
 links:
   gitter: "jenkinsci/pipeline-authoring-plugin"


### PR DESCRIPTION
The project idea matches the criteria for publishing, so I doubt it makes sense to keep it in the draft state.