### PR TITLE
Make the distribution-customize-service proposal publishable

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -2,7 +2,7 @@
 layout: gsocprojectidea
 title: "Custom Jenkins distribution build service"
 goal: "Provide an out of the box solution for packaging Jenkins distributions as WAR files or Docker images"
-category: Tools
+category: published
 year: 2020
 status: draft
 skills:

--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -45,20 +45,15 @@ We can start the backend project with SpringBoot, it might save a lot of time.
 
 == Quickstart
 
-The link:https://github.com/jenkinsci/custom-war-packager[Custom WAR Packager for Jenkins] is a good starting point.
-
-* Clone the repository and build the project, Try using the `all-latest-core` folder inside the demo folder and generate your own war.
-*  Change the input by modifying the plugins used in the sample yml files.
-*  Run the war.
-
-Points to note about the WAR Packager:
-
-* How is the war generated.
-* Different methods of inputs eg: JCasC
+The link:https://github.com/jenkinsci/ci.jenkins.io-runner[ci.jenkins.io-runner] is a good starting poinClone the repository and follow the quickstart guide provided in the readme.
 
 The link:https://spring.io/projects/spring-boot[Spring Boot Documentation] is a good reference to have a look at, which can give you a fair idea about the services that could be incorporarted via a REST API Interface into the project.
 
+The link:https://reactjs.org/docs/getting-started.html[React Getting Started] guide is a good way to get started with getting familiar with the front end framework required for the project. You could begin by learning how the front end and backend communicate with each other and how would that work out in terms of this custom service.
 
+== Newbie-friendly Issues
+
+You could start out with link:https://issues.jenkins-ci.org/browse/JENKINS-54377?jql=project%20%3D%20JENKINS%20AND%20status%20%3D%20Open%20AND%20component%20%3D%20custom-war-packager%20AND%20labels%20%3D%20newbie-friendly%20AND%20assignee%20in%20(EMPTY)[Newbie-Friendly-Issues].
 
 ## References
 

--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -43,6 +43,23 @@ A readable API documentation is
 necessary. Like many projects, the Swagger UI is a good example.
 We can start the backend project with SpringBoot, it might save a lot of time.
 
+== Quickstart
+
+The link:https://github.com/jenkinsci/custom-war-packager[Custom WAR Packager for Jenkins] is a good starting point.
+
+* Clone the repository and build the project, Try using the `all-latest-core` folder inside the demo folder and generate your own war.
+*  Change the input by modifying the plugins used in the sample yml files.
+*  Run the war.
+
+Points to note about the WAR Packager:
+
+* How is the war generated.
+* Different methods of inputs eg: JCasC
+
+The link:https://spring.io/projects/spring-boot[Spring Boot Documentation] is a good reference to have a look at, which can give you a fair idea about the services that could be incorporarted via a REST API Interface into the project.
+
+
+
 ## References
 
 Below you can find a list of existing plugins and libraries which can be used for inspiration:

--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -45,11 +45,11 @@ We can start the backend project with SpringBoot, it might save a lot of time.
 
 == Quickstart
 
-The link:https://github.com/jenkinsci/ci.jenkins.io-runner[ci.jenkins.io-runner] is a good starting poinClone the repository and follow the quickstart guide provided in the readme.
+The link:https://github.com/jenkinsci/ci.jenkins.io-runner[ci.jenkins.io-runner] is a good starting point. Clone the repository and follow the quickstart guide provided in the readme.
 
 The link:https://spring.io/projects/spring-boot[Spring Boot Documentation] is a good reference to have a look at, which can give you a fair idea about the services that could be incorporarted via a REST API Interface into the project.
 
-The link:https://reactjs.org/docs/getting-started.html[React Getting Started] guide is a good way to get started with getting familiar with the front end framework required for the project. You could begin by learning how the front end and backend communicate with each other and how would that work out in terms of this custom service.
+The link:https://reactjs.org/docs/getting-started.html[React Getting Started] guide is a good way to get familiar with the front end framework required for the project. You could begin by learning how the front end and backend communicate with each other and how would that work out in terms of this custom service.
 
 == Newbie-friendly Issues
 

--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -2,9 +2,9 @@
 layout: gsocprojectidea
 title: "Custom Jenkins distribution build service"
 goal: "Provide an out of the box solution for packaging Jenkins distributions as WAR files or Docker images"
-category: published
+category: Tools
 year: 2020
-status: draft
+status: published
 skills:
 - Java
 - Web Development


### PR DESCRIPTION
- [:heavy_check_mark:  ] Added a quick start guide

**TO-DO**
- [ ] Newbie-Friendly Issues
I am not sure whether it would be a good idea to include all newbie friendly issues with the `component` war package manager plugin or just to have the applicant solve the general newbie friendly issues.