### PR TITLE
Remove incorrect entries from 2.221 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6208,21 +6208,6 @@
   changes:
   - type: major rfe
     category: major rfe
-    pull: 4501
-    issue: 60266
-    authors:
-    - daniel-beck
-    - timja
-    references:
-      - pull: 4501
-      - issue: 60266
-      - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
-        title: JEP-223
-    message: |-
-      Add a new permission <code>Overall/Manage</code> which allows a user to configure parts of the global Jenkins configuration without having the <code>Overall/Administer</code> permission.
-      This is an experimental feature, disabled by default, that can be enabled by setting the <code>jenkins.security.ManagePermission</code> system property to <code>true</code>.
-  - type: major rfe
-    category: major rfe
     pull: 4368
     authors:
     - daniel-beck
@@ -6247,28 +6232,6 @@
       Dynamically loading certain plugins could result in permission errors.
   - type: rfe
     category: rfe
-    pull: 4499
-    authors:
-    - daniel-beck
-    message: |-
-      Add memory usage monitor to system information page.
-  - type: rfe
-    category: rfe
-    pull: 4487
-    issue: 60966
-    authors:
-    - Dohbedoh
-    message: |-
-      Order Admin Monitors in Global Configuration page.
-  - type: rfe
-    category: rfe
-    pull: 4497
-    authors:
-    - res0nance
-    message: |-
-      Improve performance when loading tied jobs.
-  - type: rfe
-    category: rfe
     pull: 4490
     authors:
     - daniel-beck
@@ -6281,14 +6244,6 @@
     - daniel-beck
     message: |-
       Do not show disabled permissions in permission errors.
-  - type: rfe
-    category: developer
-    pull: 4488
-    issue: 61046
-    authors:
-    - jtnord
-    message: |-
-      Developer: Allow plugins to force an update of an <code>UpdateSite</code>.
   - type: rfe
     category: developer
     pull: 4493


### PR DESCRIPTION
The 2.221 release **did not** include the following items which were listed in the original 2.221 changelog:

* New permission Overall/Manage - JEP-223, [PR-4501](https://github.com/jenkinsci/jenkins/pull/4501)
* Memory usage monitor in system info page - [PR-4499](https://github.com/jenkinsci/jenkins/pull/4499)
* Allow plugins to force an update of UpdateCenter - [PR-4488](https://github.com/jenkinsci/jenkins/pull/4488)
* Admin monitors sorted in global config page - [PR-4487](https://github.com/jenkinsci/jenkins/pull/4487)
* Tied job loading performance improvement - [PR-4497](https://github.com/jenkinsci/jenkins/pull/4497)

Thanks to @mikecirioli for detecting the mistake in my original changelog submission!