### PR TITLE
Docs SIG now meets every 4 weeks

### DIFF
--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -85,7 +85,7 @@ notitle: true
               .date-time
                 .date
                   .day.small
-                    Every other Fri
+                    Every fourth Fri
                   .dow
                     Fri
                 .time

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -98,7 +98,7 @@ At the same time, plugin maintainers now can follow the documentation-as-code ap
 It also gives an opportunity to review the documentation changes and to add documentation contributor recognition, 
 especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation]. 
 
-We have more than 200 plugins which already use GitHub as a documentation source,
+We have more than 300 plugins which already use GitHub as a documentation source,
 but there are still hundreds of plugins to migrate.
 We invite contributors to participate in the project and to help us with migrating the docs.
 It is also a great opportunity to update and copy-edit the documentation.

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -119,7 +119,7 @@ Useful links:
 
 === Meetings
 
-We have regular meetings on Fridays every two weeks, at *1PM UTC*.
+We have regular meetings on Fridays every four weeks, at *1PM UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].


### PR DESCRIPTION
## Update Docs SIG meeting frequency to every 4 weeks

Meeting every two weeks is not making the documentation work faster or slower.  We'll meet every 4 weeks and continue the same pace.  Special thanks to Gavin Mogan, Tim Jacomb, Zbynek Konecny, and Oleg Nenashev.

* [ ] Update [events calendar](https://jenkins.io/event-calendar/) to also show every 4 weeks beginning March 14, 2020