### PR TITLE
Docs SIG now meets on fourth Friday of each month

### DIFF
--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -85,7 +85,7 @@ notitle: true
               .date-time
                 .date
                   .day.small
-                    Every fourth Fri
+                    Monthly on fourth Fri
                   .dow
                     Fri
                 .time

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -119,7 +119,7 @@ Useful links:
 
 === Meetings
 
-We have regular meetings on Fridays every four weeks, at *1PM UTC*.
+We have regular meetings on the fourth Friday of each month at *1PM UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].


### PR DESCRIPTION
## Update Docs SIG meeting frequency to 4th Friday of each month

Meeting is on the fourth Friday of each month.

* [x] Update [events calendar](https://jenkins.io/event-calendar/) to also show every 4 weeks beginning March 14, 2020