### PR TITLE
Add report a problem link

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -99,9 +99,9 @@
                 :title => "Edit #{page.relative_source_path} on GitHub",
                 } Improve this page
                 |
-                %a{:href => "https://github.com/jenkins-infra/jenkins.io/commits/master/content/#{page.relative_source_path}",
-                :title => "View #{page.relative_source_path} history on GitHub",
-                } Page history
+                %a{:href => "https://github.com/timja/jenkins.io/issues/new?title=#{page.title}&body=Problem with: [#{page.title}](https://jenkins.io#{page.url}), [source file](https://github.com/jenkins-infra/jenkins.io/blob/master/content#{page.relative_source_path})",
+                :title => "Report a problem with #{page.relative_source_path}",
+                } Report a problem
 
             .license-box
               #creativecommons

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -99,7 +99,7 @@
                 :title => "Edit #{page.relative_source_path} on GitHub",
                 } Improve this page
                 |
-                %a{:href => "https://github.com/timja/jenkins.io/issues/new?title=#{page.title}&body=Problem with: [#{page.title}](https://jenkins.io#{page.url}), [source file](https://github.com/jenkins-infra/jenkins.io/blob/master/content#{page.relative_source_path})",
+                %a{:href => "https://github.com/jenkins-infra/jenkins.io/issues/new?title=#{page.title}&body=Problem with: [#{page.title}](https://jenkins.io#{page.url}), [source file](https://github.com/jenkins-infra/jenkins.io/blob/master/content#{page.relative_source_path})",
                 :title => "Report a problem with #{page.relative_source_path}",
                 } Report a problem
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21194782/75096043-31116b00-5593-11ea-8e68-13e718f51d63.png)

![image](https://user-images.githubusercontent.com/21194782/75096073-a3824b00-5593-11ea-8dc8-b51010bcd39b.png)


Do we still need the page history link? Do people actually use it?
Can add it back, but was worried about links getting too cluttered

Fixes #2894