### PR TITLE
Add links for mentors

### DIFF
--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -15,11 +15,18 @@ Student resources can be found link:/projects/gsoc/students[here].
 
 == Links
 
+Mandatory reading:
+
 * link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide]
+* link:https://developers.google.com/open-source/gsoc/help/responsibilities#mentor_responsibilities[Mentoring Responsibilities]
+* link:https://summerofcode.withgoogle.com/terms/mentor[Google summer of Code Mentor Participant Agreement]
 * link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline]
+* link:/conduct[Code of Conduct]
+
+Additional links:
+
 * Mailing list for mentors: jenkins-gsoc-2020-mentors@googlegroups.com
 * link:/projects/gsoc/#orgadmin[Mailing list for contacting Org Admins]
-* link:/conduct[Code of Conduct]
 
 == What do mentors get?
 

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -19,7 +19,7 @@ Mandatory reading:
 
 * link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide]
 * link:https://developers.google.com/open-source/gsoc/help/responsibilities#mentor_responsibilities[Mentoring Responsibilities]
-* link:https://summerofcode.withgoogle.com/terms/mentor[Google summer of Code Mentor Participant Agreement]
+* link:https://summerofcode.withgoogle.com/terms/mentor[Google Summer of Code Mentor Participant Agreement]
 * link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline]
 * link:/conduct[Code of Conduct]
 


### PR DESCRIPTION
I added some very important links at the top of the mentor information page to the Google mentor responsibilities and mentor participant agreement.