### PR TITLE
Add changelog 2.222

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6306,7 +6306,23 @@
     message: |-
       Revamp the layout and icons of the header bar and breadcrumbs.
       Instances with plugins that depend on details of the Jenkins layout (e.g. Simple Theme Plugin) may experience UI/layout problems.
-      A new experimental header color scheme can be enabled by setting the system property <code>jenkins.ui.refresh</code> to <code>true</code>.
+      A new experimental header color scheme can be enabled by setting the <code>jenkins.ui.refresh</code> system property to <code>true</code>.
+  - type: major rfe
+    category: major rfe
+    pull: 4463
+    authors:
+    - fqueiruga
+    - daniel-beck
+    message: |-
+      Introduce a new experimental UI that can be enabled by setting the <code>jenkins.ui.refresh</code> system property to <code>true</code>.
+      Currently it includes a new header color scheme, more changes to be added as a part of the UI/UX revamp.
+    references:
+      - pull: 4463
+      - issue: 60920
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
+        title: JEP-223
+      - url: https://jenkins.io/sigs/ux/
+        title: Jenkins UX SIG
   - type: major rfe
     category: major rfe
     pull: 4501
@@ -6332,8 +6348,11 @@
       - issue: 12548
       - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
         title: JEP-224
+      - url: https://plugins.jenkins.io/extended-read-permission/
+        title: Extended Read Permission plugin
     message: |-
-      Add an experimental system read permission, which gives (almost) full read access to the Jenkins instance, this is disabled by default, install the extended-read plugin to activate it.
+      Add a new experimental `Overall/SystemRead` permission, which gives (almost) full read access to the Jenkins instance.
+      The permission is disabled by default, install the Extended Read Permission plugin plugin to activate it.
   - type: rfe
     category: rfe
     pull: 4365

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6304,12 +6304,12 @@
     - fqueiruga
     - daniel-beck
     message: |-
-      Visual revamp of the layout and icons of the header bar and breadcrumbs. Instances with plugins that depend on details of the Jenkins layout (e.g. Simple Theme Plugin) may experience UI/layout problems.
-      A new header color scheme can be enabled by setting the system property <code>jenkins.ui.refresh</code> to <code>true</code>.
+      Revamp the layout and icons of the header bar and breadcrumbs.
+      Instances with plugins that depend on details of the Jenkins layout (e.g. Simple Theme Plugin) may experience UI/layout problems.
+      A new experimental header color scheme can be enabled by setting the system property <code>jenkins.ui.refresh</code> to <code>true</code>.
   - type: major rfe
     category: major rfe
     pull: 4501
-    issue: 60266
     authors:
     - daniel-beck
     - timja
@@ -6319,12 +6319,11 @@
       - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
         title: JEP-223
     message: |-
-      Add a new permission <code>Overall/Manage</code> which allows a user to configure parts of the global Jenkins configuration without having the <code>Overall/Administer</code> permission.
+      Add a new experimental <code>Overall/Manage</code> permission which allows a user to configure parts of the global Jenkins configuration without having the <code>Overall/Administer</code> permission.
       This is an experimental feature, disabled by default, that can be enabled by setting the <code>jenkins.security.ManagePermission</code> system property to <code>true</code>.
   - type: major rfe
     category: major rfe
     pull: 4506
-    issue: 12548
     authors:
     - daniel-beck
     - timja
@@ -6334,50 +6333,7 @@
       - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
         title: JEP-224
     message: |-
-      Adds a system read permission, which gives (almost) full read access to the Jenkins instance, this is disabled by default, install the extended-read plugin to activate it.
-  - type: major rfe
-    category: developer
-    pull: 4506
-    issue: 12548
-    authors:
-    - daniel-beck
-    - timja
-    references:
-      - pull: 4506
-      - issue: 12548
-      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
-        title: JEP-224
-    message: |-
-      Developer: New <code>checkAnyPermission</code>, <code>hasAnyPermission</code> methods that allow access if a user has one of the supplied permissions,
-  - type: major rfe
-    category: developer
-    pull: 4506
-    issue: 12548
-    authors:
-    - daniel-beck
-    - timja
-    references:
-      - pull: 4506
-      - issue: 12548
-      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
-        title: JEP-224
-    message: |-
-      Developer: <code>f:possibleReadOnlyField</code> jelly tag, wraps fields in an if readonly check and then outputs the result as text if the authenticated user only has read access.
-      N/A is added if the field is empty.
-  - type: major rfe
-    category: developer
-    pull: 4506
-    issue: 12548
-    authors:
-    - daniel-beck
-    - timja
-    references:
-      - pull: 4506
-      - issue: 12548
-      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
-        title: JEP-224
-    message: |-
-      Developer: <code>l:hasAdministerOrManage</code> jelly tag, hides the body of the tag if the user doesn't have <code>Jenkins.ADMINISTER</code> or <code>Jenkins.MANAGE</code>.
+      Add an experimental system read permission, which gives (almost) full read access to the Jenkins instance, this is disabled by default, install the extended-read plugin to activate it.
   - type: rfe
     category: rfe
     pull: 4365
@@ -6389,8 +6345,13 @@
       - issue: 60266
       - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
         title: JEP-223
+      - url: https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+        title: 2017-04-10 security advisory for Matrix Authorization plugin
+      - url: https://jenkins.io/security/advisory/2017-04-10/#role-based-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+        title: 2017-04-10 security advisory for Role-Based Authorization plugin
     message: |-
-      The permissions <code>Overall/RunScripts</code>, <code>Overall/UploadPlugins</code>, and <code>Overall/ConfigureUpdateCenter</code> are now deprecated.
+      Deprecate the <code>Overall/RunScripts</code>, <code>Overall/UploadPlugins</code>, and <code>Overall/ConfigureUpdateCenter</code> permissions.
+      Permissions were announced as dangerous and disabled by default in major authorization plugins in 2017.
       Custom authorization strategy implementations that grant <code>Overall/Administer</code> without implying one or more of these three permissions will no longer work as expected.
       Configurations that grant any of these permissions to users without <code>Overall/Administer</code> will no longer work as expected.
   - type: rfe
@@ -6416,6 +6377,13 @@
     - daniel-beck
     message: |-
       Add memory usage monitor to system information page.
+  - type: rfe
+    category: rfe
+    pull: 4497
+    authors:
+    - res0nance
+    message: |-
+      Improve performance when loading tied jobs.
   - type: bug
     category: bug
     pull: 4504
@@ -6423,7 +6391,7 @@
     authors:
     - daniel-beck
     message: |-
-      Fix too many open files error when using resource domain.
+      Fix issue with too many open files error when using resource domain.
   - type: rfe
     category: localization
     pull: 4505
@@ -6432,12 +6400,48 @@
     message: |-
       Add french translation for concurrent build help.
   - type: rfe
-    category: internal
-    pull: 4497
+    category: developer
+    pull: 4506
+    issue: 12548
     authors:
-    - res0nance
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
     message: |-
-      Improve performance when loading tied jobs.
+      Developer: Add new <code>checkAnyPermission</code>, <code>hasAnyPermission</code> methods that allow access if a user has one of the supplied permissions.
+  - type: rfe
+    category: developer
+    pull: 4506
+    issue: 12548
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
+    message: |-
+      Developer: Add a new <code>f:possibleReadOnlyField</code> jelly tag, wraps fields in an if readonly check and then outputs the result as text if the authenticated user only has read access.
+      N/A is added if the field is empty.
+  - type: rfe
+    category: developer
+    pull: 4506
+    issue: 12548
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
+    message: |-
+      Developer: Add a new <code>l:hasAdministerOrManage</code> jelly tag, hides the body of the tag if the user doesn't have <code>Jenkins.ADMINISTER</code> or <code>Jenkins.MANAGE</code>.
   - type: rfe
     category: developer
     pull: 4488

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6328,7 +6328,9 @@
     pull: 4501
     authors:
     - daniel-beck
-    - timja
+    - mikecirioli
+    - EstherAF
+    - aHenryJard
     references:
       - pull: 4501
       - issue: 60266
@@ -6341,8 +6343,8 @@
     category: major rfe
     pull: 4506
     authors:
-    - daniel-beck
     - timja
+    - daniel-beck
     references:
       - pull: 4506
       - issue: 12548

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6352,7 +6352,7 @@
         title: Extended Read Permission plugin
     message: |-
       Add a new experimental <code>Overall/SystemRead</code> permission, which gives (almost) full read access to the Jenkins instance.
-      The permission is disabled by default, install the Extended Read Permission plugin plugin to activate it.
+      The permission is disabled by default, install the Extended Read Permission plugin to activate it.
   - type: rfe
     category: rfe
     pull: 4365

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6293,6 +6293,166 @@
   # pull: 4494 (PR title: Remove references to Azure maven cache)
   # pull: 4502 (PR title: [JENKINS-61102] Use XMLUnit to fix test)
 
+- version: '2.222'
+  date: 2020-02-23
+  changes:
+  - type: major rfe
+    category: major rfe
+    pull: 4463
+    issue: 60920
+    authors:
+    - fqueiruga
+    - daniel-beck
+    message: |-
+      Visual revamp of the layout and icons of the header bar and breadcrumbs. Instances with plugins that depend on details of the Jenkins layout (e.g. Simple Theme Plugin) may experience UI/layout problems.
+      A new header color scheme can be enabled by setting the system property <code>jenkins.ui.refresh</code> to <code>true</code>.
+  - type: major rfe
+    category: major rfe
+    pull: 4501
+    issue: 60266
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4501
+      - issue: 60266
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
+        title: JEP-223
+    message: |-
+      Add a new permission <code>Overall/Manage</code> which allows a user to configure parts of the global Jenkins configuration without having the <code>Overall/Administer</code> permission.
+      This is an experimental feature, disabled by default, that can be enabled by setting the <code>jenkins.security.ManagePermission</code> system property to <code>true</code>.
+  - type: major rfe
+    category: major rfe
+    pull: 4506
+    issue: 12548
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
+    message: |-
+      Adds a system read permission, which gives (almost) full read access to the Jenkins instance, this is disabled by default, install the extended-read plugin to activate it.
+  - type: major rfe
+    category: developer
+    pull: 4506
+    issue: 12548
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
+    message: |-
+      Developer: New <code>checkAnyPermission</code>, <code>hasAnyPermission</code> methods that allow access if a user has one of the supplied permissions,
+  - type: major rfe
+    category: developer
+    pull: 4506
+    issue: 12548
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
+    message: |-
+      Developer: <code>f:possibleReadOnlyField</code> jelly tag, wraps fields in an if readonly check and then outputs the result as text if the authenticated user only has read access.
+      N/A is added if the field is empty.
+  - type: major rfe
+    category: developer
+    pull: 4506
+    issue: 12548
+    authors:
+    - daniel-beck
+    - timja
+    references:
+      - pull: 4506
+      - issue: 12548
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc
+        title: JEP-224
+    message: |-
+      Developer: <code>l:hasAdministerOrManage</code> jelly tag, hides the body of the tag if the user doesn't have <code>Jenkins.ADMINISTER</code> or <code>Jenkins.MANAGE</code>.
+  - type: rfe
+    category: rfe
+    pull: 4365
+    issue: 60266
+    authors:
+    - mikecirioli
+    references:
+      - pull: 4501
+      - issue: 60266
+      - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
+        title: JEP-223
+    message: |-
+      The permissions <code>Overall/RunScripts</code>, <code>Overall/UploadPlugins</code>, and <code>Overall/ConfigureUpdateCenter</code> are now deprecated.
+      Custom authorization strategy implementations that grant <code>Overall/Administer</code> without implying one or more of these three permissions will no longer work as expected.
+      Configurations that grant any of these permissions to users without <code>Overall/Administer</code> will no longer work as expected.
+  - type: rfe
+    category: rfe
+    pull: 4509
+    authors:
+    - daniel-beck
+    message: |-
+      Remove the ability to have CSRF protection disabled.
+      Instances upgrading from older versions of Jenkins will have CSRF protection enabled and the default issuer set if they currently have it disabled.
+  - type: rfe
+    category: rfe
+    pull: 4487
+    issue: 60966
+    authors:
+    - Dohbedoh
+    message: |-
+      Order Admin Monitors in Global Configuration page.
+  - type: rfe
+    category: rfe
+    pull: 4499
+    authors:
+    - daniel-beck
+    message: |-
+      Add memory usage monitor to system information page.
+  - type: bug
+    category: bug
+    pull: 4504
+    issue: 61121
+    authors:
+    - daniel-beck
+    message: |-
+      Fix too many open files error when using resource domain.
+  - type: rfe
+    category: localization
+    pull: 4505
+    authors:
+    - jbleduigou
+    message: |-
+      Add french translation for concurrent build help.
+  - type: rfe
+    category: internal
+    pull: 4497
+    authors:
+    - res0nance
+    message: |-
+      Improve performance when loading tied jobs.
+  - type: rfe
+    category: developer
+    pull: 4488
+    issue: 61046
+    authors:
+    - jtnord
+    message: |-
+      Developer: Allow plugins to force an update of an <code>UpdateSite</code>.
+
+  # pull: 4496 (PR title: Follow up optimizations to getAllItems() and getItems())
+  # pull: 4508 (PR title: [JENKINS-36720] Spotbugs fix possible NPE)
+  # pull: 4510 (PR title: [JENKINS-36720] Fix instances of double checked locking)
+  # pull: 4511 (PR title: [JENKINS-36720] Spotbugs fixes)
+  # pull: 4514 (PR title: Update note after this was done wrong yet again)
+
 # DO NOT EDIT THIS FILE DIRECTLY ON GITHUB IF YOU HAVE COMMIT ACCESS
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS
 # MALFORMED FILE CONTENTS WILL BREAK THE SITE BUILD

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6351,7 +6351,7 @@
       - url: https://plugins.jenkins.io/extended-read-permission/
         title: Extended Read Permission plugin
     message: |-
-      Add a new experimental `Overall/SystemRead` permission, which gives (almost) full read access to the Jenkins instance.
+      Add a new experimental <code>Overall/SystemRead</code> permission, which gives (almost) full read access to the Jenkins instance.
       The permission is disabled by default, install the Extended Read Permission plugin plugin to activate it.
   - type: rfe
     category: rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6385,7 +6385,7 @@
     authors:
     - mikecirioli
     references:
-      - pull: 4501
+      - pull: 4365
       - issue: 60266
       - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
         title: JEP-223


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/156685/75128704-9728eb80-5682-11ea-9382-b189e8142c02.png)

I need help on the phrasing of the changelog entry for [PR-4365](https://github.com/jenkinsci/jenkins/pull/4365).  The proposed changelog entry says:

> The permissions Overall/RunScripts, Overall/UploadPlugins, and Overall/ConfigureUpdateCenter permissions are now deprecated. Custom authorization strategy implementations that grant Overall/Administer without implying one or more of these three permissions and as configurations that grant any of these permissions to users without Overall/Administer will will no longer work as expected.

I don't understand the last sentence in that proposed changelog entry.  I rephrased it as:

> The permissions <code>Overall/RunScripts</code>, <code>Overall/UploadPlugins</code>, and <code>Overall/ConfigureUpdateCenter</code> are now deprecated.  Custom authorization strategy implementations that grant <code>Overall/Administer</code> without implying one or more of these three permissions will no longer work as expected. Configurations that grant any of these permissions to users without <code>Overall/Administer</code> will no longer work as expected.

I'm not confident that my rephrasing is accurate.  @mikecirioli can you help me with it?