### PR TITLE
GSoC 2020: Remove Table of Contents tag from the project ideas guide

### DIFF
--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -6,8 +6,6 @@ tags:
 project: gsoc
 ---
 
-:toc:
-
 New project ideas for GSoC can be proposed by mentors, students, or anyone in the Jenkins
 community with an idea they'd like to see implemented.
 


### PR DESCRIPTION
Otherwise the ToC gets duplicated, because Jenkins uses a different approach to ToC generation.

![image](https://user-images.githubusercontent.com/3000480/75173442-27246f00-572f-11ea-90ce-9b3b99d8e3a7.png)

