### PR TITLE
Separating the screenshots in the VSCode Case Study.

### DIFF
--- a/content/blog/2020/02/2020-02-25-vscode-caseStudy.adoc
+++ b/content/blog/2020/02/2020-02-25-vscode-caseStudy.adoc
@@ -60,7 +60,11 @@ i) The above yaml file is valid according to the schema and vscode should provid
 === Screenshots
 
 image:/images/projects/jcasc/VSCode/vscode.png[]
+
+
 image:/images/projects/jcasc/VSCode/userDocs1.png[]
+
+
 image:/images/projects/jcasc/VSCode/userDocs2.png[]
 
 


### PR DESCRIPTION
The screenshots in the Case Study are not separated clearly and it looks a bit cluttered. 
