### PR TITLE
Documentation for environment when condition with comparator

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1201,7 +1201,14 @@ to specify how any patterns are evaluated for a match:
 Example: `when { changeRequest authorEmail: "[\\w_-.]+@example.com", comparator: 'REGEXP' }`
 
 environment:: Execute the stage when the specified environment variable is set
-to the given value, for example: `when { environment name: 'DEPLOY_TO', value: 'production' }`
+to the given value or pattern, for example: `when { environment name: 'DEPLOY_TO', value: 'production' }`
++
+The optional parameter `comparator` may be added after an attribute
+to specify how any patterns are evaluated for a match:
+`EQUALS` (the default) for a simple string comparison,
+`GLOB` for an ANT style path  glob case insensitive, this can be turned off with the `ignoreCase` parameter (same as for example `changeset`), or
+`REGEXP` for regular expression matching.
+For example: `when { environment name: 'DEPLOY_TO', value: "productio.*", comparator: "REGEXP"}` or `when { environment name: 'DEPLOY_TO', value: "PRODUCTION", ignoreCase: true }`
 
 equals:: Execute the stage when the expected value is equal to the actual value,
 for example: `when { equals expected: 2, actual: currentBuild.number }`


### PR DESCRIPTION
See [JENKINS-60390](https://issues.jenkins-ci.org/browse/JENKINS-60390).

Documentation for the `environment` when condition with a comparator. Similar to:
- https://github.com/jenkins-infra/jenkins.io/pull/2450
- https://github.com/jenkins-infra/jenkins.io/pull/2664

Downstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/368