### PR TITLE
Documentation for changeset when condition with shouldMatchAll

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1180,6 +1180,11 @@ to specify how any patterns are evaluated for a match:
 `GLOB` (the default) for an ANT style path glob case insensitive, this can be turned off with the `caseSensitive` parameter, or
 `REGEXP` for regular expression matching.
 For example: `when { changeset pattern: ".*TEST\\.java", comparator: "REGEXP" }` or `when { changeset pattern: "**/*TEST.java", caseSensitive: true }`
++
+The optional parameter `shouldMatchAll` may be added after an attribute
+to specify whether all the elements in the changeset should match with the given pattern. The default
+behaviour is "false".
+For example: `when { changeset pattern: ".*TEST\\.java", comparator: "REGEXP", shouldMatchAll: true }`
 
 changeRequest:: Executes the stage if the current build is for a "change request"
 (a.k.a. Pull Request on GitHub and Bitbucket, Merge Request on GitLab, Change in Gerrit, etc.).


### PR DESCRIPTION
See [JENKINS-60390](https://issues.jenkins-ci.org/browse/JENKINS-60390).

Documentation for the `changeset` when condition with a `shouldMatchAll` flag. Similar to:
- https://github.com/jenkins-infra/jenkins.io/pull/2450
- https://github.com/jenkins-infra/jenkins.io/pull/2664

Downstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/367