### PR TITLE
GSoC 2020 - Adjust headers in the student guide so that the Project Proposal requirements are visible in ToC

### DIFF
--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -46,12 +46,15 @@ We cannot make any exception. Please:
 
 You can find more details about application steps below.
 
-==== Expectations
+[#expectations]
+=== Expectations
 
 When you apply to the GSoC program, you are committing to 30..40 hours of coding per week for the duration of the program.
 
 . We expect students to get involved into project discussions at the beginning of the student application period in order to have the opportunity to discuss the project with potential mentors and to jointly review the proposal drafts.
 . We expect students to attend at least one office hours during the application period.
+
+=== Rules of Engaement
 
 ==== Communications are in English
 
@@ -111,7 +114,7 @@ in public and are visible to the entire community. There is always a
 public debate on ideas and proposals.
 
 [#student-proposals]
-==== Student Proposals
+=== Student Proposals
 
 We expect proposals from students to contain all the sections discussed in the
 link:https://google.github.io/gsocguides/student/[Google Summer of Code Student Guide],


### PR DESCRIPTION
Current state:

![image](https://user-images.githubusercontent.com/3000480/75968339-81f75c80-5ecd-11ea-8cbd-676557ffa967.png)
