### PR TITLE
Add reference and link to Azure VM Agents plugin

### DIFF
--- a/content/doc/book/architecting-for-scale.adoc
+++ b/content/doc/book/architecting-for-scale.adoc
@@ -263,6 +263,11 @@ resources together with their destruction when they are not needed anymore:
   let Jenkins use AWS EC2 instances as cloud build resources when it runs out
   of on-premise slaves. The EC2 slaves will be dynamically created inside an
   AWS network and de-provisioned when they are not needed.
+* The plugin:azure-vm-agents[Azure VM Agents Plugin]
+  dynamically spins up Jenkins slaves as Azure VMs per user provided 
+  configuration via templates, including support for virtual network integration 
+  and subnet placement. Idle agents can be configured for automatic shutdown 
+  to reduce costs.
 * The plugin:jclouds-jenkins[JCloud plugin]
   creates the possibility of executing the jobs on any cloud provider supported
   by JCloud libraries


### PR DESCRIPTION
In addition to AWS and JCloud, users can also spin up slaves on Azure with a plugin maintained by the Azure DevOps team.