### PR TITLE
Revert "Update events officer role"

### DIFF
--- a/content/project/team-leads.adoc
+++ b/content/project/team-leads.adoc
@@ -28,15 +28,19 @@ Oversees the Jenkins project infrastructure.
 
 _note: This team lead position was approved in the link:http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-02-17-19.00.html[2015-02-17 governance meeting]_
 
-Has an active role in driving and managing Jenkins community events. Such events include Jenkins User Conference, Jenkins Area Meetups, other Jenkins community events (FOSDEM, SCALE), and speaking opportunities.
+Has an active role in driving and managing Jenkins community events. Such events include Jenkins User Conference, Jenkins Area Meetups, other Jenkins community events (FOSDEM, SCALE), and speaking opportunities. 
 
 The Events Team Lead is tasked with the following responsibilities:
 
-* Process incoming events related requests from users, dev, events mailing lists
+* Process in coming events related requests from users, dev, events mailing lists
 * Point of contact for Jenkins community events (mentioned above)
 * Drive communication efforts surrounding Jenkins community events
-* Drive content/agenda for DevOps World and other conferences
+* Drive content/agenda for JUC
 * Plan and coordinate logistics as needed for Jenkins community events
+* Oversee and ensure the success of the overall Jenkins Area Meetups:
+* Maintainer of Jenkins Area Meetup account on meetup.com
+* Work with organizers to ensure their success - assist as needed with speaker, sponsors identification
+* Guide new organizers process to start up their local JAM
 
 ## Release
 


### PR DESCRIPTION
Reverts jenkins-infra/jenkins.io#2939

As a Governance Board member, I request a formal process for changing officer role description. IMO it should be discussed in the community