### PR TITLE
CODEOWNERS - Explicitly mark the Governance Board as an owner for Governance-related pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,12 @@
 # All website content
 content/ @jenkins-infra/copy-editors
 
+# Governance documents
+content/project/ @jenkins-infra/board
+content/conduct.adoc @jenkins-infra/board
+content/donate.adoc @jenkins-infra/board
+content/press.adoc @jenkins-infra/board
+
 # GSoC
 content/projects/gsoc/ @jenkins-infra/gsoc
 *gsoc* @jenkins-infra/gsoc


### PR DESCRIPTION
I suggest to explicitly mark Governance documents in the CODEOWNERS file. It is partially a folllow-up to #2939 which was merged without enough reviews. Right now such pull requests are automatically labeled, but it has low visibility. jenkins.io copy editors might miss it and handle a change as common documentation update, so highlightning the special case would be a good step IMHO. I think a clear distinction will be useful there to

CC @jenkins-infra/board 