### PR TITLE
End quoted string to fix weekly changelog rendering

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6584,7 +6584,8 @@
 - version: 2.224
   date: 2020-03-08
   banner: |-
-    <strong>WARNING:</strong> This release introduces a critical regression when saving jobs, see <a href="https://issues.jenkins-ci.org/browse/JENKINS-61398>JENKINS-61398</a>.
+    <strong>WARNING:</strong> This release introduces a critical regression when saving jobs.
+    See <a href="https://issues.jenkins-ci.org/browse/JENKINS-61398">JENKINS-61398</a>.
     Please avoid updating to this version.
   changes:
   - type: major bug


### PR DESCRIPTION
## Fix broken weekly changelog formatting

I broke the weekly changelog rendering with #2946  .  This fixes it.

### Before Fix

![broken](https://user-images.githubusercontent.com/156685/76255219-7381ab80-6213-11ea-9149-4b6937a444b2.png)

### After Fix

![fixed](https://user-images.githubusercontent.com/156685/76255229-78def600-6213-11ea-809b-793f5d1477aa.png)

### Moral of the Story

Always provide screenshots of the proposed changelog page.  Helps the submitter see their proposal accurately and helps reviewers see the proposal also.