### PR TITLE
Jenkins 3D model was not migrated from Wiki

### DIFF
--- a/content/artwork/index.html.haml
+++ b/content/artwork/index.html.haml
@@ -70,6 +70,30 @@ title: Jenkins Artwork
 .container
   .row
     .col-md-12
+      %h2
+        3D model
+
+      %p
+        3D version of Mr.Jenkins is 
+        %a{:href => 'https://www.shapeways.com/model/2183445/mr-jenkins.html?materialId=26'}
+          available here
+        for order. If you want to print your own, 
+        %a{:href => '/images/logos/3d-model/jenkins3d.zip'}
+          the data is here.
+
+      %p
+        As per the license of the original artwork, the 3D data model is under the same 
+        %a{:href => 'http://creativecommons.org/licenses/by-sa/3.0/'}
+          Creative Commons Attribution-ShareAlike 3.0 Unported License. 
+        The 3D logo design is by 
+        %a{:href => 'https://www.fast-d.com/search/engineers/2798'}
+          akiki.
+
+%hr/
+
+.container
+  .row
+    .col-md-12
       %h3
         Adding a Logo
       %p

--- a/content/artwork/index.html.haml
+++ b/content/artwork/index.html.haml
@@ -78,7 +78,7 @@ title: Jenkins Artwork
         %a{:href => 'https://www.shapeways.com/model/2183445/mr-jenkins.html?materialId=26'}
           available here
         for order. If you want to print your own, 
-        %a{:href => '/images/logos/3d-model/jenkins3d.zip'}
+        %a{:href => 'https://drive.google.com/file/d/1tdPch-TKVF6T7w3Et9aVYRnE-fRtm3cR/view?usp=sharing'}
           the data is here.
 
       %p


### PR DESCRIPTION
When migrating the Wiki, we forgot about this 3D model. It was still there but due to the redirection, it wasn't easy to access. Thanks to @kohsuke, we got the link to the archive file.

This is to make sure the model is now listed on the artwork page.

Screenshot: 
![Screenshot from 2020-03-10 10-24-14](https://user-images.githubusercontent.com/985955/76298163-56071d00-62b9-11ea-99a2-b1c65be25593.png)
