### PR TITLE
Jumbotron - Remove the board elections and CDF announcement jumbotrons

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -36,20 +36,6 @@ homepage: true
 -# Carousel Slides
 - slides = []
 
--# 2019 Board elections
-- slides << {:href => expand_link('blog/2019/12/16/board-election-results'),
-  :title => '2019 Jenkins Board and Officer elections',
-  :intro => "In November 2019 we held the first Jenkins board elections elections ever. On behalf of the Jenkins community, we congratulate all elected board members and officers!",
-  :image => {:src => expand_link('/images/post-images/elections-2019/election-2019-opengraph.png'), :height => "300px"},
-  :call_to_action => {:text => 'See results', :href => expand_link('blog/2019/12/16/board-election-results')}}
-
--# CDF Blog
-- slides << {:href => expand_link('blog/2019/03/12/cdf-launch/'),
-  :title => 'A New Home for Jenkins',
-  :intro => "Jenkins is joining the newly created Continuous Delivery Foundation (CDF).",
-  :image => {:src => expand_link('images/cdf/logo/cdf-logo-white.png'), :height => "250px"},
-  :call_to_action => {:text => 'Read the Announcement', :href => expand_link('blog/2019/03/12/cdf-launch/')}}
-
 -# CDF Blog
 - slides << {:href => 'https://cd.foundation',
   :title => 'Meet the Continuous Delivery Foundation',


### PR DESCRIPTION
Cleans up old announcements

* CDF Announcement will be one year tomorrow. There is another jumbotron entry for CDF in general
* Board Elections jumbotron is 3 months old, and the image is not good. Would be better to kill it