### PR TITLE
Make pipeline steps collapsible

### DIFF
--- a/content/_layouts/pipelinesteps.html.haml
+++ b/content/_layouts/pipelinesteps.html.haml
@@ -24,3 +24,32 @@ notitle: true
 
 .container
 = partial ('_feedback-footer.html')
+
+:javascript
+  $(function() {
+    var collapsibleList = function(e){
+      for (var i=1; i < e.length; i++) {
+        var li = e[i];
+        if (li.tagName == "LI" && li.children[0]) {
+          var r=li.children[0].innerText;
+
+          var plus = $("<button class='btn btn-outline-secondary btn-xs'>+</button>");
+          var minus = $("<button class='btn btn-outline-secondary btn-xs'>-</button>");
+          $(li.children[0]).prepend(minus);
+
+          var expander = $("<li/>").append($("<code/>").text(r)).prepend(plus);
+          var toggle = (function() {
+            this.next().toggleClass("collapse");
+            this.toggleClass("collapse")
+          }).bind(plus.parent());
+          plus.on("click", toggle);
+          minus.on("click", toggle);
+          expander.insertBefore($(li));
+          $(li).addClass("collapse");
+        }
+      }
+    };
+    $("ul>b:contains('Nested')").each(function(e,f){
+      collapsibleList($(f).parent().children())
+    });
+  });

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1751,3 +1751,12 @@ table.syntax > tbody > tr > th {
 .logo-thumb {
   max-height: 256px;
 }
+
+.btn.btn-xs {
+  line-height: .5rem;
+  padding: .15rem;
+  margin: .2rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: .2rem;
+}


### PR DESCRIPTION
*Before:*
the first step in https://jenkins.io/doc/pipeline/steps/workflow-cps-global-lib/ is 300,000 pixels long

*After:*
the step description is <1,000px long, you can expand the individual options recursively
![image](https://user-images.githubusercontent.com/1105305/76577853-d8186100-64c6-11ea-9d1f-41e35e2b3c5d.png)

To get a list of plugins with HUGE docs, please check: https://bl.ocks.org/zbynek/raw/16108faa00a11d6570a48126fc382ebc/?a
(that graph illustrates https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/18 )

CC @kwhetstone @uhafner @MarkEWaite 