### PR TITLE
Add a permanent jumbotron for /participate

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -43,12 +43,21 @@ homepage: true
   :image => {:src => expand_link('images/cdf/logo/cdf-logo-white.png'), :height => "250px"},
   :call_to_action => {:text => 'Learn about CDF', :href => 'https://cd.foundation'}}
 
+// TODO(oleg-nenashev): Remove on Mar 31 
 -# GSoC 2020
 - slides << {:href => expand_link('projects/gsoc/'),
   :title => 'GSoC 2020: Call for student proposals',
   :intro => "Jenkins project will be a mentoring organization in Google Summer of Code 2020. We are looking for students and mentors, join us! Applications close on Mar 30.",
   :image => {:src => expand_link('images/gsoc/jenkins-gsoc-transparent.png'), :height => "300px"},
   :call_to_action => {:text => 'More info', :href => expand_link('projects/gsoc/')}}
+
+// Permanent
+-# Participate
+- slides << {:href => expand_link('participate'),
+  :title => 'Participate and Contribute!',
+  :intro => "Jenkins is a community-driven project. We invite everyone to join us and move it forward. Any contribution matters: code, documentation, localization, blog posts, artwork, meetups, and anything else. If you have five minutes or a few hours, you can help!",
+  :image => {:src => expand_link('images/logos/needs-you/Jenkins_Needs_You-transparent.png'), :height => "320px"},
+  :call_to_action => {:text => 'More info', :href => expand_link('participate')}}
 
 -# Carousel
 = partial('projectcarousel.html.haml',


### PR DESCRIPTION
We have completely reworked https://jenkins.io/participate/ since Hacktoberfest 2019 started. Now the page is quite fancy, and I believe we could promote it to highlight contributing opportunities to the website visitors.

![image](https://user-images.githubusercontent.com/3000480/76605513-de332f80-6510-11ea-9b40-298878067298.png)
