### PR TITLE
Remove self as mentor for GSoC 2020

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -13,7 +13,6 @@ skills:
 - Package management tool theory
 mentors:
 - "kwhetstone"
-- "stopalopa"
 - "timja"
 links:
   gitter: "jenkinsci/plugin-installation-manager-cli-tool"


### PR DESCRIPTION
Removing myself as a potential mentor for GSoC 2020 because I don't have a lot of time to commit right now. 