### PR TITLE
Jenkins 2.226 jelly enum tag change fixes JENKINS-61385

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -6813,6 +6813,7 @@
   - type: bug
     category: bug
     pull: 4556
+    issue: 61385
     authors:
     - knapsu
     message: |-


### PR DESCRIPTION
Thanks to @daniel-beck  for catching that mistake.

![image](https://user-images.githubusercontent.com/156685/76787141-11c6c180-677e-11ea-9e8d-b3989c98d8c9.png)
