### PR TITLE
Remove docker image after use in the build

### DIFF
--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -360,13 +360,13 @@ stage runs successfully (with output)",width=100%]
             steps {
                 dir(path: env.BUILD_ID) {
                     unstash(name: 'compiled-results')
-                    sh "docker run -v ${VOLUME} ${IMAGE} 'pyinstaller -F add2vals.py'"
+                    sh "docker run --rm -v ${VOLUME} ${IMAGE} 'pyinstaller -F add2vals.py'"
                 }
             }
             post {
                 success {
                     archiveArtifacts "${env.BUILD_ID}/sources/dist/add2vals"
-                    sh "docker run -v ${VOLUME} ${IMAGE} 'rm -rf build dist'"
+                    sh "docker run --rm -v ${VOLUME} ${IMAGE} 'rm -rf build dist'"
                 }
             }
         }
@@ -416,13 +416,13 @@ pipeline {
             steps {
                 dir(path: env.BUILD_ID) { // <3>
                     unstash(name: 'compiled-results') // <4>
-                    sh "docker run -v ${VOLUME} ${IMAGE} 'pyinstaller -F add2vals.py'" // <5>
+                    sh "docker run --rm -v ${VOLUME} ${IMAGE} 'pyinstaller -F add2vals.py'" // <5>
                 }
             }
             post {
                 success {
                     archiveArtifacts "${env.BUILD_ID}/sources/dist/add2vals" // <6>
-                    sh "docker run -v ${VOLUME} ${IMAGE} 'rm -rf build dist'"
+                    sh "docker run --rm -v ${VOLUME} ${IMAGE} 'rm -rf build dist'"
                 }
             }
         }


### PR DESCRIPTION
## Remove docker image after use in the build

The manual page for `docker run` says:

> By default a container’s file system persists even after the container exits. This makes debugging a lot easier (since you can inspect the final state) and you retain all your data by default. But if you are running short-term foreground processes, these container file systems can really pile up. If instead you’d like Docker to automatically clean up the container and remove the file system when the container exits, you can add the --rm flag

Thanks to @jglick for detecting that mistake!