### PR TITLE
Remove rsandell as potential GSoC mentor

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
+++ b/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
@@ -9,7 +9,6 @@ sig: platform
 mentors:
 - "markewaite"
 - "fcojfernandez"
-- "rsandell"
 skills:
 - Java
 - Git


### PR DESCRIPTION
## Remove rsandell as potential GSoC mentor

Bobby's schedule has changed. He is unavailable for this year's Google Summer of Code.

@rsandell as reviewer to confirm yesterday's conversation.