### PR TITLE
fix spelling of OpenWrt project, not OpenWRT

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/jenkins-x-openwrt-ppa.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-x-openwrt-ppa.adoc
@@ -1,7 +1,7 @@
 ---
 layout: gsocprojectidea
-title: "Personal Package Archive platform for OpenWRT"
-goal: "Create a platform to build and host packages for OpenWRT (PPA, or Personal Package Archive) using Jenkins X"
+title: "Personal Package Archive platform for OpenWrt"
+goal: "Create a platform to build and host packages for OpenWrt (PPA, or Personal Package Archive) using Jenkins X"
 category: Jenkins X
 year: 2020
 status: draft


### PR DESCRIPTION
fix spelling of OpenWrt project, not OpenWRT

Under the request of some OpenWrt developer