### PR TITLE
GSoC2020 Timeline update (remove absolute time references)

### DIFF
--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -20,7 +20,8 @@ Mandatory reading:
 * link:https://google.github.io/gsocguides/mentor/[GSoC Mentor Guide]
 * link:https://developers.google.com/open-source/gsoc/help/responsibilities#mentor_responsibilities[Mentoring Responsibilities]
 * link:https://summerofcode.withgoogle.com/terms/mentor[Google Summer of Code Mentor Participant Agreement]
-* link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline]
+* link:https://summerofcode.withgoogle.com/how-it-works/#timeline[Official GSoC timeline]
+* link:https://developers.google.com/open-source/gsoc/timeline[Unofficial GSoC timeline] (appears to be updated with a few days of lag behind the official one)
 * link:/conduct[Code of Conduct]
 
 Additional links:
@@ -70,15 +71,15 @@ Although we do our best to accommodate everyone, it is impossible to change the 
 == Expectations from mentors per phase
 
 We have divided what mentors should expect in the different phases.
-Always refer to the link:https://summerofcode.withgoogle.com/how-it-works/#timeline[official GSoC Timeline] for the official timeline, phases and their duration.
-We post the official timeline on the Jenkins mentor mailing list (see above for link) as a convenience.
+Always refer to the link:https://summerofcode.withgoogle.com/how-it-works/#timeline[Official GSoC Timeline] for the official timeline, phases and their duration.
+As soon as you become a registered mentor, you will receive via email all timeline updates and reminders.
 
 Overall for mentors the time commitment is (for details of activities see below):
 
 * <<org_application_phase>>: 2 to 3 hours per week
 * <<org_approval_waiting_phase>>: 2 to 3 hours per week
-* <<student_application_phase>>: 2 to 5 hours per week for 5.5 weeks.
-* <<slot_request_phase>>: about 5 hours total over 4 weeks, but because this phase is time critical and short, we insist that you make an extra effort to attend meetings and participate actively in this process (see below for details).
+* <<student_application_phase>>: 2 to 5 hours per week until the student proposal submission deadline
+* <<ranking_and_slot_request_phase>>: about 5 hours total until the slot request submission deadline, but because this phase is time critical and short, we insist that you make an extra effort to attend meetings and participate actively in this process (see below for details).
 * <<community_bonding_phase>>: 5 to 8 hours per week, this phase is critical for the success of the project, make sure you get on the ball right away.
 * <<coding_periods>>: 5 to 8 hours per week until the end of the program. The number of hours tend to vary, more at the start, less at the end, not everyone is the same.
 * <<eval_periods>>: Same as coding.
@@ -110,31 +111,27 @@ Optionally, you can:
 The important aspect of this phase is to produce a list of good project ideas, as this is key to be accepted in the GSoC program.
 
 The deadline for producing this list is indicated on the
-link:https://developers.google.com/open-source/gsoc/timeline[timeline]).
+link:https://summerofcode.withgoogle.com/how-it-works/#timeline[Official GSoC timeline].
 
 Jenkins GSoC Org Admins are responsible for submitting the application form for the Jenkins organization.
 
 [[org_approval_waiting_phase]]
 === Organization approval waiting period
 
-*This phase lasts 2 weeks.*
-
-*Expectation:* 2 to 3 hours per week.
+*Expectation:* 2 to 3 hours per week until organizations are announced.
 
 During this period, we wait for Google to approve our application request.
 
 Mentors should keep interacting with students during this period.
 
 Google publishes the list of accepted organizations according to the
-link:https://developers.google.com/open-source/gsoc/timeline[timeline]).
+link:https://summerofcode.withgoogle.com/how-it-works/#timeline[Official GSoC timeline].
 If we are accepted, we move on to the next phase.
 
 [[student_application_phase]]
 === Student exploration and application phase
 
-*This phase lasts 5.5 weeks.*
-
-*Expectation:* about 2 to 5 hours per week (more if you submit your own project ideas which we encourage highly).
+*Expectation:* about 2 to 5 hours per week (more if you submit your own project ideas which we encourage highly) until the student application phase ends.
 
 Officially, this phase is divided in two:
 
@@ -151,7 +148,7 @@ This means that you need to:
 ** of course we appreciate if you help us find more mentors if you can
 * participate in the weekly public meeting
 * make sure the students follow the process and that their application meets the requirements in the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/edit[template]
-** make sure the students determines whether they are link:gsoc/students/#eligibility-steps[eligible]
+** make sure the students determine whether they are link:gsoc/students/#eligibility-steps[eligible]
 * if the student proposes a genuine project idea in your area of interest or expertise, make sure it is presented and discussed in the community
 
 You can still submit new project ideas during this phase.
@@ -159,19 +156,17 @@ You can still submit new project ideas during this phase.
 This is a very important phase, use it to get to know the students who apply to projects that are of interest to you.
 
 For this deadline, please see the
-link:https://developers.google.com/open-source/gsoc/timeline[timeline]).
+link:https://summerofcode.withgoogle.com/how-it-works/#timeline[Official GSoC timeline].
 
-[[slot_request_phase]]
-=== Slot request and selection phase
+[[ranking_and_slot_request_phase]]
+=== Proposal ranking and slot request phase
 
-*This phase lasts 4 weeks.*
-
-*Expectation:* about 5 hours total.
+*Expectation:* about 5 hours total, plus continuous interaction with potential students, until the community bonding starts.
 
 This phase is divided in two sub-phases:
 
-* <<slot_request_sub_phase>>: duration 3 weeks
-* <<final_selection_phase>>: duration 1 week
+* <<slot_request_sub_phase>>: usually 2 to 3 weeks (not very long)
+* <<final_selection_phase>>: usually 1 week (very short!)
 
 Mentor team are formed during this phase, student proposals are ranked for slot requests, and a final selection is made.
 
@@ -194,9 +189,7 @@ ensuring communications are in public as this is an open source program, and rep
 Subject matter experts and active community contributors also participate in GSoC but not in official mentor roles.
 
 [[slot_request_sub_phase]]
-==== Regarding the slot request sub-phase
-
-*This sub-phase lasts 3 weeks.*
+==== Initial proposal ranking and slot request sub-phase
 
 The goal of this phase is to determine and request the minimum and the maximum number of projects we can take on as an organization.
 This process is explained in the Mentor Guide in the
@@ -237,28 +230,28 @@ Then our min and max would be 5 and 7.
 Then we send our slot request min and max numbers to Google.
 
 [[final_selection_phase]]
-==== Final selection phase
+==== Final proposal selection sub-phase
 
-*This phase lasts one week.*
+This phase is very short and starts immediately when Google sends us our final number of slots.
 
-This phase start immediately when Google sends us our final number of slots. We may get only the minimum.
-Sometimes heart wrenching decisions need to be made at this time.
+We may get only the minimum of slots.
+Sometimes heart wrenching decisions need to be made.
+
+Org Admins and Mentors need to make an extra effort to devote time to this phase because it is very short and this does not leave us much time to make critical decisions, and it just as important as the other phases.
 
 During this phase, mentors and Jenkins Org Admins hold a private meeting to make the final project selection
 and the mentor teams are finalized and confirmed. Then we submit our final selection to the GSoC program.
 
 === Final selection awaiting period
 
-*This phase lasts a few days.*
+This only usually lasts a few days.
 
 We wait. We are NOT allowed to communicate any information regarding the selection to students.
 
 [[community_bonding_phase]]
 === Community Bonding
 
-*This phase lasts 4 weeks.*
-
-*Expectation:* about 5 to 8 hours per week.
+*Expectation:* about 5 to 8 hours per week, until coding starts.
 
 This is the most critical phase when it comes to working with your student.
 Year after year, if this phase goes well, the rest of the program usually goes well, but if this phase does not go well, the project usually fails.
@@ -283,7 +276,7 @@ students and mentors alike benefit from attending.
 [[coding_periods]]
 === Coding Periods
 
-*Expectation:* about 5 to 8 hours per week.
+*Expectation:* about 5 to 8 hours per week until the end of the program.
 
 See also: link:../students/#coding-periods[student coding periods].
 
@@ -297,7 +290,7 @@ What if the student is done early? Student and mentor must determine other work 
 [[eval_periods]]
 === Evaluation periods
 
-*Expectation:* same as during the coding periods
+*Expectation:* same as during the coding periods.
 
 See also: link:../students/#evaluations[student evaluations].
 

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -70,13 +70,15 @@ Although we do our best to accommodate everyone, it is impossible to change the 
 == Expectations from mentors per phase
 
 We have divided what mentors should expect in the different phases.
+Always refer to the link:https://summerofcode.withgoogle.com/how-it-works/#timeline[official GSoC Timeline] for the official timeline, phases and their duration.
+We post the official timeline on the Jenkins mentor mailing list (see above for link) as a convenience.
 
 Overall for mentors the time commitment is (for details of activities see below):
 
 * <<org_application_phase>>: 2 to 3 hours per week
 * <<org_approval_waiting_phase>>: 2 to 3 hours per week
 * <<student_application_phase>>: 2 to 5 hours per week for 5.5 weeks.
-* <<slot_request_phase>>: about 5 hours total over 3 weeks, but because this phase is time critical and short, we insist that you make an extra effort to attend meetings and participate actively in this process (see below for details).
+* <<slot_request_phase>>: about 5 hours total over 4 weeks, but because this phase is time critical and short, we insist that you make an extra effort to attend meetings and participate actively in this process (see below for details).
 * <<community_bonding_phase>>: 5 to 8 hours per week, this phase is critical for the success of the project, make sure you get on the ball right away.
 * <<coding_periods>>: 5 to 8 hours per week until the end of the program. The number of hours tend to vary, more at the start, less at the end, not everyone is the same.
 * <<eval_periods>>: Same as coding.
@@ -162,13 +164,13 @@ link:https://developers.google.com/open-source/gsoc/timeline[timeline]).
 [[slot_request_phase]]
 === Slot request and selection phase
 
-*This phase lasts 3 weeks.*
+*This phase lasts 4 weeks.*
 
 *Expectation:* about 5 hours total.
 
 This phase is divided in two sub-phases:
 
-* <<slot_request_sub_phase>>: duration 2 weeks
+* <<slot_request_sub_phase>>: duration 3 weeks
 * <<final_selection_phase>>: duration 1 week
 
 Mentor team are formed during this phase, student proposals are ranked for slot requests, and a final selection is made.
@@ -194,13 +196,13 @@ Subject matter experts and active community contributors also participate in GSo
 [[slot_request_sub_phase]]
 ==== Regarding the slot request sub-phase
 
-*This sub-phase lasts 2 weeks.*
+*This sub-phase lasts 3 weeks.*
 
 The goal of this phase is to determine and request the minimum and the maximum number of projects we can take on as an organization.
 This process is explained in the Mentor Guide in the
 link:https://google.github.io/gsocguides/mentor/selecting-students-and-mentors#slot-count[Slot Count] section.
 
-We have two weeks to send our slot request to Google.
+We have three weeks to send our slot request to Google.
 *It is an intense and critical period for Org Admins and mentors*,
 as this determines who participates in the rest of the program!
 
@@ -254,7 +256,7 @@ We wait. We are NOT allowed to communicate any information regarding the selecti
 [[community_bonding_phase]]
 === Community Bonding
 
-*This phase lasts 3 weeks.*
+*This phase lasts 4 weeks.*
 
 *Expectation:* about 5 to 8 hours per week.
 


### PR DESCRIPTION
Updating the mentor info page to match the updates made to the [official GSOC 2020 Timeline](https://summerofcode.withgoogle.com/how-it-works/#timeline).
