### PR TITLE
Remove @oleg-nenashev from the GitHub Checks API project idea

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/github-checks.adoc
+++ b/content/projects/gsoc/2020/project-ideas/github-checks.adoc
@@ -10,7 +10,6 @@ mentors:
 - "uhafner"
 - "timja"
 - "jeffpearce"
-- "oleg_nenashev"
 - "jonbrohauge"
 - "ayush_agarwal"
 skills:


### PR DESCRIPTION
Unfortunately I cannot longer be a mentor in this project due to the reasons outside my control. I wish the team good luck with the applications and the project, and I will be happy to help the project to succeed as a GSoC org admin. Have a great GSoC!

I do not stand down as a potential mentor in other projects, this is an exceptional case. FYI and sorry @uhafner @timja @jeffpearce @jonbrohauge @aagarwal1012 