### PR TITLE
Remove 'LTS' prefix from LTS versions again

### DIFF
--- a/content/security/advisory/2020-03-25.adoc
+++ b/content/security/advisory/2020-03-25.adoc
@@ -4,8 +4,8 @@ title: Jenkins Security Advisory 2020-03-25
 kind: core and plugins
 core:
   lts:
-    previous: LTS 2.204.5
-    fixed: LTS 2.204.6 or LTS 2.222.1
+    previous: 2.204.5
+    fixed: 2.204.6 or 2.222.1
   weekly:
     previous: '2.227'
     fixed: '2.228'


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/pull/2811 all over, because I don't learn.