### PR TITLE
Move the LTS baseline selection to take place 2 weeks earlier in the cycle

### DIFF
--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -65,7 +65,6 @@ The following table demonstrates release dates within the 12 week cycle:
   </tr>
   <tr>
     <th>Baseline Selection</th>
-    <td>X chosen</td>
     <td></td>
     <td></td>
     <td></td>
@@ -78,16 +77,16 @@ The following table demonstrates release dates within the 12 week cycle:
     <td></td>
     <td></td>
     <td>Z chosen</td>
+    <td></td>
   </tr>
 </table>
 ++++
 
-The cycle starts with picking an LTS baseline at week 0.
-Then, there is a two week period for backporting followed by two weeks for testing the release candidate resulting in the release of X.1.
+There is a two week period for backporting followed by two weeks for testing the release candidate resulting in the release of X.1.
 Backporting and RC testing is repeated twice, producing X.2 and X.3.
-This concludes the cycle for a given baseline and the new one is started immediately.
+This concludes the cycle for a given baseline and the new one is started immediately based on the new baseline selected in week 10.
 
-The baseline release is typically between 2-5 weeks old when it is chosen, so X.1 LTS releases are published about 6-9 weeks after their baseline.
+The baseline release is typically between 0-3 weeks old when it is chosen, so X.1 LTS releases are published about 6-9 weeks after their baseline.
 
 See the link:https://jenkins.io/content/event-calendar[event calendar] for the specific LTS RC/release dates in the near future.
 


### PR DESCRIPTION
As agreed on 2.204.* LTS line retrospective[1], I am proposing to adjust LTS schedule so that next LTS baseline will be selected in week 10 when .3 RC is published. It used to be in week 12 when .3 is released. There ware 2 reasons for this:

- Lately, we slowly shifted towards choosing too new baselines effectively shortening the core soak time. Making the call 2 weeks sooner (no matter how new the core) will create the time buffer for more issues to be discovered and fixed before the LTS is published.

- Core developers/reviewers tend to be busy testing during RC testing periods and preparing weeklies that are likely to be chosen an LTS baseline (LTS week 10-12). Making the call 2 weeks sooner will prevent the two to overlap.

[1] https://docs.google.com/document/d/1NzR1XtkCfk6MDSD1jRq5H-iPSjqKvP-pfUO0b9lVZ9k/edit?disco=AAAAJRfN_wA