### PR TITLE
Document label condition configurability

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -134,6 +134,8 @@ need to contain its own `agent` section. For example: `agent none`
 
 label:: Execute the Pipeline, or stage, on an agent available in the Jenkins
 environment with the provided label. For example: `agent { label 'my-defined-label' }`
++
+Label conditions can also be used. For example: `agent { label 'my-label1 && my-labe2' }` or `agent { label 'my-label1 || my-labe2' }`
 
 node:: `agent { node { label 'labelName' } }` behaves the same as
 `agent { label 'labelName' }`, but `node` allows for additional options (such
@@ -278,7 +280,7 @@ Refer to the following example for reference: https://github.com/jenkinsci/kuber
 These are a few options that can be applied to two or more `agent` implementations.
 They are not required unless explicitly stated.
 
-label:: A string. The label on which to run the Pipeline or individual `stage`.
+label:: A string. The label or label condition on which to run the Pipeline or individual `stage`.
 +
 This option is valid for `node`, `docker`, and `dockerfile`, and is required for
 `node`.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -135,7 +135,7 @@ need to contain its own `agent` section. For example: `agent none`
 label:: Execute the Pipeline, or stage, on an agent available in the Jenkins
 environment with the provided label. For example: `agent { label 'my-defined-label' }`
 +
-Label conditions can also be used. For example: `agent { label 'my-label1 && my-labe2' }` or `agent { label 'my-label1 || my-labe2' }`
+Label conditions can also be used. For example: `agent { label 'my-label1 && my-label2' }` or `agent { label 'my-label1 || my-label2' }`
 
 node:: `agent { node { label 'labelName' } }` behaves the same as
 `agent { label 'labelName' }`, but `node` allows for additional options (such


### PR DESCRIPTION
It is my understanding, from other sources (and inferred from classic build configurations), that label conditions can be used which should definitely be documented in this official syntax reference documentation but is completely missing atm.