### PR TITLE
Add s390x, ppc64, and ARM to roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -43,13 +43,18 @@ categories:
       status: future
   - name: Packaging and platform support
     initiatives:
-    - name: OpenJ9 distributions
+    - name: 'IBN s390x'
       status: current
-    - name: Docker images for Arm64
+      link: 'https://issues.jenkins-ci.org/browse/JENKINS-61773'
+    - name: 'PowerPC 64'
       status: current
+      link: 'https://issues.jenkins-ci.org/browse/JENKINS-61774'
+    - name: 'ARM64'
+      status: near-term
+      link: 'https://issues.jenkins-ci.org/browse/JENKINS-61775'
     - name: Multi-platform Docker images
       status: near-term
-      link: ''
+      link: 'https://issues.jenkins-ci.org/browse/JENKINS-52785'
     - name: New Windows installer
       status: current
   - name: Documentation

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -46,7 +46,7 @@ categories:
     - name: 'IBN s390x'
       status: current
       link: 'https://issues.jenkins-ci.org/browse/JENKINS-61773'
-    - name: 'PowerPC 64'
+    - name: 'Improve PowerPC 64 support'
       status: current
       link: 'https://issues.jenkins-ci.org/browse/JENKINS-61774'
     - name: 'Improve ARM64 support'

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -55,6 +55,9 @@ categories:
       status: near-term
       description: Docker image support for ARM 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61775
+    - name: Multi-platform Docker images
+      status: near-term
+      link: https://issues.jenkins-ci.org/browse/JENKINS-52785
     - name: New Windows installer
       status: current
   - name: Documentation

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -49,7 +49,7 @@ categories:
     - name: 'PowerPC 64'
       status: current
       link: 'https://issues.jenkins-ci.org/browse/JENKINS-61774'
-    - name: 'ARM64'
+    - name: 'Improve ARM64 support'
       status: near-term
       link: 'https://issues.jenkins-ci.org/browse/JENKINS-61775'
     - name: Multi-platform Docker images

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -43,7 +43,7 @@ categories:
       status: future
   - name: Packaging and platform support
     initiatives:
-    - name: 'IBN s390x'
+    - name: 'Improve IBM s390x support'
       status: current
       link: 'https://issues.jenkins-ci.org/browse/JENKINS-61773'
     - name: 'Improve PowerPC 64 support'

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -43,18 +43,18 @@ categories:
       status: future
   - name: Packaging and platform support
     initiatives:
-    - name: 'Improve IBM s390x support'
+    - name: Docker images for IBM s390x
       status: current
-      link: 'https://issues.jenkins-ci.org/browse/JENKINS-61773'
-    - name: 'Improve PowerPC 64 support'
+      link: https://issues.jenkins-ci.org/browse/JENKINS-61773
+    - name: Docker images for PowerPC 64
       status: current
-      link: 'https://issues.jenkins-ci.org/browse/JENKINS-61774'
-    - name: 'Improve ARM64 support'
+      link: https://issues.jenkins-ci.org/browse/JENKINS-61774
+    - name: Docker images for ARM 64
       status: near-term
-      link: 'https://issues.jenkins-ci.org/browse/JENKINS-61775'
+      link: https://issues.jenkins-ci.org/browse/JENKINS-61775
     - name: Multi-platform Docker images
       status: near-term
-      link: 'https://issues.jenkins-ci.org/browse/JENKINS-52785'
+      link: https://issues.jenkins-ci.org/browse/JENKINS-52785
     - name: New Windows installer
       status: current
   - name: Documentation

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -45,12 +45,15 @@ categories:
     initiatives:
     - name: Docker images for IBM s390x
       status: current
+      description: Docker image support for IBM series 390 mainframes running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61773
     - name: Docker images for PowerPC 64
       status: current
+      description: Docker image support for IBM PowerPC 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61774
     - name: Docker images for ARM 64
       status: near-term
+      description: Docker image support for ARM 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61775
     - name: Multi-platform Docker images
       status: near-term

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -55,9 +55,6 @@ categories:
       status: near-term
       description: Docker image support for ARM 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61775
-    - name: Multi-platform Docker images
-      status: near-term
-      link: https://issues.jenkins-ci.org/browse/JENKINS-52785
     - name: New Windows installer
       status: current
   - name: Documentation


### PR DESCRIPTION
Add the IBM s390x, PowerPC 64 LE, and ARM 64 platform support items to the Jenkins roadmap.

I've created Jira epics for each of those three items and connected related bug reports into those epics.  We may want to consider finer grained phases in a discussion with Jim Crowley and others in the Platform SIG.  For example, I think that Jenkins agents on s390x would likely be more important than Jenkins masters, and would be more likely to be used.