### PR TITLE
JEP-14 - Link the Windows Installer initiative

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -51,7 +51,9 @@ categories:
       status: near-term
       link: ''
     - name: New Windows installer
+      description: Rework of the Windows installer user experience
       status: current
+      link: https://jenkins.io/blog/2019/02/01/windows-installers/
   - name: Documentation
     initiatives:
     - name: Static plugin site


### PR DESCRIPTION
New Windows Installer initiative was missing a link. I was unable to find an Jira ticket for it, so I referenced the blogpost for now.

@MarkEWaite @slide would it make sense to create a EPIC for it? If it exists, I would like to create items like switching the Installer to a .NET Core native WinSW executable as we discussed before.
