### PR TITLE
JEP-14 - recategorize roadmap to focus on use-cases, not on components

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -12,8 +12,36 @@ statuses:
   displayName: "Future"
   description: "We intend to work on that in the short term, but there is no ongoing development"
 categories:
-  - name: Jenkins Core Features
+  - name: Jenkins jobs and integrations
+    description: Initiatives focused on new features for Jenkins end users
     initiatives:
+    - name: "Pipeline: GitHub App authentication"
+      status: current
+      link: https://issues.jenkins-ci.org/browse/JENKINS-57351
+    - name: "GitHub Checks API integrations"
+      status: near-term
+      link: https://jenkins.io/projects/gsoc/2020/project-ideas/github-checks/
+    - name: Pipeline as YAML
+      status: future
+      link: https://jenkins.io/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
+  - name: User experience and interface
+    description: Initiatives focused on improving the Jenkins user interface and user experience
+    initiatives:
+    - name: "Jenkins UI/UX: CSS revamp"
+      status: current
+      link: https://jenkins.io/sigs/ux/#ongoing-projects
+    - name: "Plugin manager UX revamp"
+      description: Better visualization and search for plugins
+      status: current
+    - name: "Jenkins UI/UX: UI rework"
+      status: future
+      link: https://jenkins.io/sigs/ux/#ongoing-projects
+  - name: Management and Administration
+    description: "Initiatives which help to manage Jenkins as Code: JCasC Plugin, etc."
+    initiatives:
+    - name: "JCasC: Plugin compatibility"
+      status: current
+      link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/809
     - name: 'JEP-222: Remoting over Websockets'
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/222
@@ -23,24 +51,13 @@ categories:
     - name: 'JEP-224: SystemRead permissions'
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/224
-    - name: "Jenkins UI/UX: CSS revamp"
-      status: current
-      link: https://jenkins.io/sigs/ux/#ongoing-projects
-    - name: "Jenkins UI/UX: UI rework"
-      status: future
-      link: https://jenkins.io/sigs/ux/#ongoing-projects
-    - name: Pipeline as YAML
-      status: future
-      link: https://jenkins.io/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
-  - name: Configuration as Code
-    initiatives:
-    - name: Plugin compatibility
-      status: current
-      link: TODO
     - name: Built-in plugin management as-code
       status: near-term
-    - name: Pluggable configuration sources
+    - name: "JCasC: Pluggable configuration sources"
       status: future
+#  - name: Jenkins Security
+#    description: "Public security hardening and management initiatives. Vulnerability fixes are not listed"
+#    initiatives:
   - name: Packaging and platform support
     initiatives:
     - name: OpenJ9 distributions
@@ -63,6 +80,7 @@ categories:
     - name: Jenkins docs migration to jenkins.io
       status: near-term
       link: https://issues.jenkins-ci.org/browse/INFRA-2328
+#TODO: Add section for developer tools
   - name: Infrastructure
     initiatives:
     - name: ACS to AKS migration
@@ -82,6 +100,9 @@ categories:
       link: https://issues.jenkins-ci.org/browse/INFRA-2516
   - name: Community marketing and outreach
     initiatives:
+    - name: Contributor guidelines refresh 
+      status: current
+      link: https://issues.jenkins-ci.org/browse/WEBSITE-662
     - name: Google Summer of Code 2020
       status: current
       link: https://jenkins.io/projects/gsoc/2020


### PR DESCRIPTION
JEP-14 presumes that the roadmap is mostly user-focused. So I went ahead and tried to restructure it accordingly. Also added some stories including GitHub Apps authentication, Checks API and Plugin manager UX updates. FY @uhafner @timja @daniel-beck 

## After

![image](https://user-images.githubusercontent.com/3000480/78245926-93418200-74e8-11ea-9dc4-85a55832988a.png)

## Before

![image](https://user-images.githubusercontent.com/3000480/78246000-b5d39b00-74e8-11ea-9ac5-e24f8fcb6292.png)
