### PR TITLE
Migrate rewards/gifts for reporters from wiki

### DIFF
--- a/content/security/gift.adoc
+++ b/content/security/gift.adoc
@@ -1,0 +1,65 @@
+---
+layout: security
+title: "Gifts for Reporters"
+section: security
+---
+
+We want to show our appreciation to users privately reporting security issues in Jenkins by sending them a small gift.
+Other projects have "bug bounty" programs with (sometimes significant) rewards for people reporting security issues, but the Jenkins project finances don't allow us to offer the same.
+
+The Jenkins store is hosted at http://www.cafepress.com/jenkinsci[Cafepress], and we're offering to send you a 40 USD gift card (or, while that's not possible, any selection of up to 40 USD in value).
+
+For you to be sent a gift, you will need to be an *eligible reporter*, and have reported an *eligible issue*.
+
+
+== Eligible Reporters
+
+Almost everyone is eligible to receive security gifts, with the following exceptions:
+
+* *No maintainers*:
+  We of course appreciate if you tell us about issues in a plugin you maintain, but we're not going to send you stuff.
+  This only includes maintainers _of the same component_, if you maintain one plugin but report issues in other plugins, you're still eligible!
+* *No regular contributors*:
+  Members of the Jenkins board, officers, team members, and others with an official or semi-official role (e.g. press contacts, SIG leaders) in the Jenkins project are not eligible.
+* *No previous recipients*:
+  If you've received a gift for reporting a security issue in the past, we're not going to send you another one. Sorry!
+
+Logistical issues may prevent us from delivering, in this case we'll need to work something out (e.g. handing over the gift at an event).
+
+[NOTE]
+*Country Eligibility:*
+As of February 2018, Cafepress only ships to the following countries:
+AUSTRALIA, AUSTRIA, BELGIUM, CANADA, DENMARK, FINLAND, FRANCE, GERMANY,
+GREECE, GUERNSEY, IRELAND, ISLE OF MAN, ISRAEL, ITALY, JAPAN, JERSEY,
+LUXEMBOURG, MONACO, NETHERLANDS, NEW ZEALAND, NORWAY, PORTUGAL, PUERTO RICO, 
+SINGAPORE, SPAIN, SWEDEN, SWITZERLAND, UNITED KINGDOM, UNITED STATES
+
+
+== Eligible Issues
+
+- *Private reports only:*
+  Issues need to be link:/security/reporting[reported privately] and cannot have been published elsewhere before an advisory was released.
+- *Hosted by the Jenkins project:*
+  The affected component must primarily be hosted in the `jenkinsci` GitHub organization and be distributed (directly or bundled with other components) by the Jenkins project.
+- *Vulnerabilities only:*
+  Sometimes we get reports of issues that turn into improvements, hardening, or are rejected.
+  Issues need to be accepted as vulnerabilities by the Jenkins project.
+- *Previously unknown:*
+  Only issues the Jenkins security team or maintainers of affected components were previously unaware of are eligible.
+- *Fixed and announced:*
+  Issues need to have been _fixed_ by a security update and _announced_ in a security advisory.
+
+We also reserve the right to refuse sending a gift for any reason – not something we're likely to do, but just a catch-all rule to prevent someone from gaming the rules.
+
+
+=== Process
+
+Once the security issue is resolved and a fix (and advisory) has been published, the reporter of the security issue is eligible for this reward.
+We'll generally contact the reporter then to tell them we'd like to send them a gift and, if no gift card is possible, ask about their selection and delivery address.
+If we forget, feel free to remind us by posting a comment to the security issue you reported.
+
+
+=== History
+
+This program has been established in April 2015 and applies to issues reported from that point on (http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-01-18.02.log.html#l-224[first discussion], http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-04-29-18.00.log.html#l-4[second discussion]).
+When this was established, we expected that we could send gift cards/codes for Cafepress, but learned afterwards that this is currently not possible.

--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -53,7 +53,7 @@ We provide issue reporting guidelines and an overview of our process on link:rep
 If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
 `jenkinsci-cert@googlegroups.com`
 
-To show our appreciation for your help, we'll send you https://wiki.jenkins.io/display/JENKINS/Rewards+for+reporting+security+issues[a small reward] for privately reported, valid vulnerability reports.
+To show our appreciation for your help, we'll send you link:/security/gift/[a small reward] for privately reported, valid vulnerability reports.
 
 
 == Learn More
@@ -73,6 +73,9 @@ The Jenkins security team contacted me about a security vulnerability. Now what?
 
 link:for-administrators[Information for Administrators]::
 This page explains everything Jenkins users and administrators need to know about the Jenkins security process.
+
+link:gift[Gifts for Reporters]::
+To show our appreciation for your help, we'll send you a small reward for privately reported, valid vulnerability reports.
 
 link:cna[Jenkins CVE Numbers Authority]::
 The Jenkins project is a CVE Numbers Authority (CNA) for Jenkins and Jenkins plugins published by the Jenkins project.

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -91,7 +91,7 @@ We will credit reporters who informed us in private about security vulnerabiliti
 
 == Gift Policy
 
-See https://wiki.jenkins.io/display/JENKINS/Rewards+for+reporting+security+issues[Gifts for Reporters].
+See link:/security/gift/[Gifts for Reporters].
 
 
 == Security Advisories


### PR DESCRIPTION
Migrate https://wiki.jenkins.io/display/JENKINS/Rewards+for+reporting+security+issues from the wiki.

Some minor rephrasings, including two nontrivial updates:

* Extended the list of examples of people not eligible after changes to the Jenkins project. Not really a change as it's just examples, but since we now have SIGs and more substantial teams, it felt right to do that now.
* The issue needs to have been announced in a security advisory, not merely fixed. I think back when this was introduced, we didn't grant maintainers access to issues, so there never were "uncoordinated" releases (i.e. a fix that is published long before the advisory would be out), and this was implied. Today, it's not.

I would appreciate more eyes on the changes from the wiki page to ensure I didn't accidentally change content substantially.

While I changed some minor stuff around, this is not where you propose changes to the process. I'm not happy with some parts either, but that's irrelevant for this PR.

<details>
<summary>Screenshot</summary>

<img width="842" alt="Screenshot 2020-04-03 at 13 54 46" src="https://user-images.githubusercontent.com/1831569/78358012-c3edee00-75b2-11ea-8ed8-8708f15104c2.png">

</details>