### PR TITLE
Link to updated DZone pipeline reference card

### DIFF
--- a/content/solutions/pipeline.adoc
+++ b/content/solutions/pipeline.adoc
@@ -42,7 +42,7 @@ which is worth mentioning as well.
   has a fairly comprehensive
   link:https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md[tutorial]
   checked into its source tree too.
-* link:https://dzone.com/refcardz/declarative-pipeline-with-jenkins[DZone Refcard]
+* link:https://dzone.com/refcardz/continuous-delivery-with-jenkins-pipeline[DZone Refcard]
 
 == Demos
 


### PR DESCRIPTION
## Link to updated DZone Pipeline Reference Card

Updated in March 2020 to match current declarative pipeline.