### PR TITLE
Add Admin Guide and User Guide as Docs Projects

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -109,6 +109,20 @@ Useful links:
 * link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[Announcement in the developer mailing list]
 * link:/doc/developer/publishing/documentation/#plugin-pages[Using GitHub as a source of plugin documentation]
 
+==== Administrator Guide
+
+Jenkins administration topics are included in the current link:/doc/book[Jenkins Handbook].
+Navigation can be improved for administrators by separating the administration topics into a separate volume.
+This project will create a separate Jenkins Administrator Guide with content specific for administrators.
+This project is tracked in the jira:WEBSITE-738[] EPIC.
+
+==== User Guide
+
+Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
+link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve the user documentation.
+Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
+This project is tracked in the jira:WEBSITE-739[] EPIC.
+
 ==== Documentation Reviews
 
 * Reviewing Jenkins documentation link:https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=18640[bug reports]


### PR DESCRIPTION
## Admin Guide and User Guide as Docs Projects

Provide basic description as an umbrella for large scale topics to be
included in the Docs SIG roadmap.