### PR TITLE
[INFRA-1105] - Rename agent Docker image names

### DIFF
--- a/content/_data/upgrades/2-121-1.adoc
+++ b/content/_data/upgrades/2-121-1.adoc
@@ -14,7 +14,7 @@ The following agent types should be updated:
 
 * Java Web Start agents with `agent.jar` / `slave.jar` JARs on the disk need to update those to version 3.19 or above.
 * plugin:swarm[Swarm Plugin] Client needs to be updated to version 3.11 or above.
-* Agent Docker Packages offered by the Jenkins project (https://hub.docker.com/r/jenkins/slave/[jenkins/slave] and https://hub.docker.com/r/jenkins/jnlp-slave/[jenkins/jnlp-slave]) need to be updated to version 3.19-1 or above.
+* Agent Docker Packages offered by the Jenkins project (https://hub.docker.com/r/jenkins/agent/[jenkins/agent] and https://hub.docker.com/r/jenkins/jnlp-agent/[jenkins/jnlp-agent]) need to be updated to version 3.19-1 or above.
 
 
 ==== Job/Build permission no longer implies Job/Cancel permission

--- a/content/_data/upgrades/2-121-1.adoc
+++ b/content/_data/upgrades/2-121-1.adoc
@@ -14,7 +14,7 @@ The following agent types should be updated:
 
 * Java Web Start agents with `agent.jar` / `slave.jar` JARs on the disk need to update those to version 3.19 or above.
 * plugin:swarm[Swarm Plugin] Client needs to be updated to version 3.11 or above.
-* Agent Docker Packages offered by the Jenkins project (https://hub.docker.com/r/jenkins/agent/[jenkins/agent] and https://hub.docker.com/r/jenkins/jnlp-agent/[jenkins/jnlp-agent]) need to be updated to version 3.19-1 or above.
+* Agent Docker Packages offered by the Jenkins project (https://hub.docker.com/r/jenkins/agent/[jenkins/agent] and https://hub.docker.com/r/jenkins/inbound-agent/[jenkins/inbound-agent]) need to be updated to version 3.19-1 or above.
 
 
 ==== Job/Build permission no longer implies Job/Cancel permission

--- a/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
+++ b/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
@@ -117,7 +117,7 @@ If you use containerized agents via Docker or Kubernetes plugins,
 we have also released official Docker images for Jenkins agents:
 
 * link:https://hub.docker.com/r/jenkins/agent/[jenkins/agent]
-* link:https://hub.docker.com/r/jenkins/jnlp-agent/[jenkins/jnlp-agent]
+* link:https://hub.docker.com/r/jenkins/inbound-agent/[jenkins/inbound-agent]
 * link:https://hub.docker.com/r/jenkins/ssh-build-agent/[jenkins/ssh-build-agent]
 
 All images use the `latest-jdk11` image tag for JDK11 bundles.

--- a/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
+++ b/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
@@ -116,9 +116,9 @@ e.g. you can use `plugins.txt` to install plugins, mount volumes and pass extra 
 If you use containerized agents via Docker or Kubernetes plugins,
 we have also released official Docker images for Jenkins agents:
 
-* link:https://hub.docker.com/r/jenkins/slave/[jenkins/slave]
-* link:https://hub.docker.com/r/jenkins/jnlp-slave/[jenkins/jnlp-slave]
-* link:https://hub.docker.com/r/jenkins/ssh-slave/[jenkins/ssh-slave]
+* link:https://hub.docker.com/r/jenkins/agent/[jenkins/agent]
+* link:https://hub.docker.com/r/jenkins/jnlp-agent/[jenkins/jnlp-agent]
+* link:https://hub.docker.com/r/jenkins/ssh-build-agent/[jenkins/ssh-build-agent]
 
 All images use the `latest-jdk11` image tag for JDK11 bundles.
 And sorry for the obsolete names!

--- a/content/projects/remoting/index.adoc
+++ b/content/projects/remoting/index.adoc
@@ -68,8 +68,8 @@ Modules:
 There are several packages which bundle the Remoting library and allow connecting Jenkins agents
 via one of remoting protocols.
 
-* link:https://hub.docker.com/r/jenkinsci/slave/[Docker Agent]: Base image, which bundles Remoting
-* link:https://hub.docker.com/r/jenkinsci/jnlp-slave/[Docker JNLP Agent]: Image, which can be used to connect JNLP
+* link:https://hub.docker.com/r/jenkins/agent/[Docker Agent]: Base image, which bundles Remoting
+* link:https://hub.docker.com/r/jenkins/jnlp-agent/[Docker JNLP Agent]: Image, which can be used to connect JNLP
 * Jenkins CLI executable (Requires Remoting CLI to be enabled on the master side)
 * Swarm Agent Connector executable in link:https://plugins.jenkins.io/swarm[Swarm Plugin]
 

--- a/content/projects/remoting/index.adoc
+++ b/content/projects/remoting/index.adoc
@@ -69,7 +69,7 @@ There are several packages which bundle the Remoting library and allow connectin
 via one of remoting protocols.
 
 * link:https://hub.docker.com/r/jenkins/agent/[Docker Agent]: Base image, which bundles Remoting
-* link:https://hub.docker.com/r/jenkins/jnlp-agent/[Docker JNLP Agent]: Image, which can be used to connect JNLP
+* link:https://hub.docker.com/r/jenkins/inbound-agent/[Docker Inbound Agent]: Image, which can be used to connect agents using TCP (JNLP protocols) or WebSockets
 * Jenkins CLI executable (Requires Remoting CLI to be enabled on the master side)
 * Swarm Agent Connector executable in link:https://plugins.jenkins.io/swarm[Swarm Plugin]
 


### PR DESCRIPTION
Stages documentation updates for https://issues.jenkins-ci.org/browse/INFRA-1105 . Should not be merged until the images are actually renamed