### PR TITLE
Responsive roadmap style

### DIFF
--- a/content/css/roadmap.css
+++ b/content/css/roadmap.css
@@ -3,7 +3,40 @@
   padding: 10px;
   background-color: #FFFFCE;
 }
+@media (max-width: 767px) {
 
+  /* Force table to not be like tables anymore */
+  table.roadmap-table, .roadmap-table thead, .roadmap-table tbody,
+  .roadmap-table th, .roadmap-table td, .roadmap-table tr {
+    display: block;
+  }
+  body table.roadmap-table tbody tr td {
+    position: relative;
+    padding-left: 50%;
+  }
+  /* Hide table headers (but not display: none;, for accessibility) */
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+  td {
+    border-bottom: 1px #e6eaee solid;
+  }
+  td:before {
+    position: absolute;
+    /* Top/left values mimic padding */
+    top: 8px;
+    left: 8px;
+    width: 45%;
+    padding-right: 8px;
+    white-space: nowrap;
+  }
+  /*
+  Label the data
+  */
+  td:not(.cat-name):before { content: attr(data-header); }
+}
 table.roadmap-table {
   border: 1px solid #e6eaee;
   border-radius: 3px;
@@ -15,36 +48,25 @@ table.roadmap-table {
       font-weight: 600;
       font-size: 12px;
       line-height: 16px;
-      color: rgba(53, 64, 82, 0.5);
+      color: rgba(0, 0, 0, 0.54);
       text-transform: uppercase;
       text-align: center;
       border-bottom: 1px solid #e6eaee;
       padding-top: 13px;
-      padding-bottom: 11px;
-      display: none; }
+      padding-bottom: 11px; }
       table.roadmap-table thead tr th:first-child {
         padding-left: 16px;
-        text-align: left;
-        max-width: 200px;
-        display: table-cell; }
-      table.roadmap-table thead tr th:nth-child(2) {
-        display: table-cell;
-        color: transparent; }
+        text-align: left; }
       table.roadmap-table thead tr th:last-child {
         padding-right: 24px; }
       @media (min-width: 768px) {
-        table.roadmap-table thead tr th {
-          display: table-cell; }
           table.roadmap-table thead tr th:first-child {
-            padding-left: 24px; }
-          table.roadmap-table thead tr th:nth-child(2) {
-            color: rgba(53, 64, 82, 0.5); } }
+            padding-left: 24px; } }
   table.roadmap-table tbody tr.status-category {
     background-color: rgba(248, 249, 251, 0.75);
     font-weight: 600; }
     table.roadmap-table tbody tr.status-category td {
       height: 40px;
-      display: none;
       border-left: none; }
       table.roadmap-table tbody tr.status-category td span {
         align-items: center;
@@ -52,13 +74,8 @@ table.roadmap-table {
         height: 100%; }
       table.roadmap-table tbody tr.status-category td:first-child {
         padding-left: 16px;
-        text-align: left;
-        display: table-cell; }
-      table.roadmap-table tbody tr.status-category td:nth-child(2) {
-        display: table-cell; }
+        text-align: left; }
       @media (min-width: 768px) {
-        table.roadmap-table tbody tr.status-category td {
-          display: table-cell; }
           table.roadmap-table tbody tr.status-category td:first-child {
             padding-left: 24px; } }
   table.roadmap-table tbody tr td {
@@ -66,7 +83,7 @@ table.roadmap-table {
     color: #354052;
     line-height: 16px;
     text-align: center;
-    height: 48px;
+    min-height: 48px;
     padding: 0;
     padding-right: 16px; }
     table.roadmap-table tbody tr td.feat-name a {
@@ -83,13 +100,14 @@ table.roadmap-table {
       display: flex;
       height: 100%; }
     table.roadmap-table tbody tr td div a {
-      height: 32px;
+      min-height: 32px;
       align-items: center;
       justify-content: center;
       display: flex;
-      margin-top: 8px;
+      margin: 8px 4px;
       border-radius: 10px;
       font-weight: bold;
+      padding: 4px 8px;
       color: white; }
       table.roadmap-table tbody tr td .status a:hover {
         cursor: help; }
@@ -129,11 +147,6 @@ table.roadmap-table {
       background: -o-linear-gradient(90deg, #2dbda8 0%, #1aab40 100%);
       background: linear-gradient(90deg, #2dbda8 0%, #1aab40 100%); }
     table.roadmap-table tbody tr td:first-child {
-      padding-left: 16px;
-      text-align: left;
-      max-width: 200px;
-      padding-right: 8px;
-      padding-top: 8px;
       padding-bottom: 8px; }
     table.roadmap-table tbody tr td:last-child {
       padding-right: 16px; }
@@ -143,10 +156,9 @@ table.roadmap-table {
         vertical-align: top;
         border-left: 1px dashed rgba(230, 234, 238, 0.25); }
         table.roadmap-table tbody tr td:first-child {
-          padding-left: 24px;
-          max-width: 200px; }
+          padding-left: 16px;}
         table.roadmap-table tbody tr td:last-child {
-          padding-right: 24px; } }
+          padding-right: 16px; } }
 
 .tooltip-inner {
   background-color: #354052;

--- a/content/css/roadmap.css
+++ b/content/css/roadmap.css
@@ -3,6 +3,7 @@
   padding: 10px;
   background-color: #FFFFCE;
 }
+/* Responsive table style based on https://css-tricks.com/responsive-data-tables/ by Chris Coyier */
 @media (max-width: 767px) {
 
   /* Force table to not be like tables anymore */

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -44,12 +44,12 @@ tags:
             = category.name
       %tr
         - site.roadmap[:roadmap].statuses.each do | status |
-          %td{:class => "status #{status.id}"}
+          %td{:class => "status #{status.id}", "data-header" => status.displayName}
             - category.initiatives.each do | initiative |
               - if initiative.status == status.id
 
                 %div{:class => "status #{status.id}"}
-                  //TODO(oleg-nenashev): Better default link for work-in-progress items?
+                  - # TODO(oleg-nenashev): Better default link for work-in-progress items?
                   - itemLink = initiative.link.nil? ? "/project/roadmap" : initiative.link
                   - itemTooltip = initiative.description.nil? ? status.description : initiative.description
                   %a{tooltip_href(itemLink, itemTooltip)}


### PR DESCRIPTION
Blatant copy of https://css-tricks.com/responsive-data-tables/ + some padding tweaks. Also header color slightly changed to meet the 4.5 contrast requirement.

Apparently some media queries were already overriding the `table-cell` display, but it seemed easier to remove the conflicting implementation than to fix it.

Fixes #3051 
