### PR TITLE
Jenkins Roadmap: Add Promotion support for Pipeline, change Pipeline as YAML status to near-term

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -22,8 +22,13 @@ categories:
       status: near-term
       link: https://jenkins.io/projects/gsoc/2020/project-ideas/github-checks/
     - name: Pipeline as YAML
-      status: future
+      description: Official support for defining Jenkins Pipelines in YAML, without additional Pipeline libraries
+      status: near-term
       link: https://jenkins.io/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
+    - name: Promotion support for Pipeline jobs
+      description: Provide out-of-the-box support for manual and automatic promotion of build artifacts in a separate Pipeline after the job completion
+      status: future
+      link: https://issues.jenkins-ci.org/browse/JENKINS-36089
   - name: User experience and interface
     description: Initiatives focused on improving the Jenkins user interface and user experience
     link: /sigs/ux


### PR DESCRIPTION
As a maintainer of the Promoted Builds Plugin, I would like to add Promotion support story to the Jenkins long-term roadmap. [JENKINS-36089](https://issues.jenkins-ci.org/browse/JENKINS-36089) is the second most-voted Pipeline RFE, so I believe it is reasonable. CC @markyjackson-taulia @jonbrohauge @bicschneider who were interested in this story.

I also changed status of Pipeline as YAML to near-term, because @aytuncbeken is working on that at the moment. Maybe we could even change it to `current`

