### PR TITLE
Document how to use the Experimental update center from JCasC and Docker images

### DIFF
--- a/content/doc/developer/publishing/releasing-experimental-updates.adoc
+++ b/content/doc/developer/publishing/releasing-experimental-updates.adoc
@@ -27,6 +27,7 @@ Submit, and then select _Check Now_.
 Experimental plugin updates will be marked as such on the _Available_ and _Updates_ tabs of the _Plugin Manager_.
 
 Once you install the beta plugins that you wanted, you can switch back to the default `\https://updates.jenkins.io/update-center.json` update center URL.
+The experimental update center only offers the latest version of each plugin, even if it is incompatible with your version of Jenkins.
 
 === In Jenkins Configuration-as-Code plugin
 
@@ -45,5 +46,5 @@ jenkins:
 
 === In official Docker images
 
-Official link:https://github.com/jenkinsci/docker[Jenkins master Docker image] includes plugin management scripts which allow to preinstall plugins from the Experimental update center.
+Official link:https://github.com/jenkinsci/docker[Jenkins master Docker image] includes plugin management scripts which allow preinstalling plugins from the Experimental update center.
 See the documentation and examples link:https://github.com/jenkinsci/docker#preinstalling-plugins[here].

--- a/content/doc/developer/publishing/releasing-experimental-updates.adoc
+++ b/content/doc/developer/publishing/releasing-experimental-updates.adoc
@@ -18,8 +18,32 @@ Other version strings like `proto`, `rc`, and `unstable` **will appear** in the 
 
 == Using the Experimental Update Center
 
+Experimental Update Center is not enabled by default in Jenkins, additional steps are needed to enable it in Jenkins.
+
+=== From the Web interface
+
 Users who are interested in downloading experimental plugin releases can go to _Plugin Manager_, then to the _Advanced_ tab, and configure the update center URL `\https://updates.jenkins.io/experimental/update-center.json`.
 Submit, and then select _Check Now_.
 Experimental plugin updates will be marked as such on the _Available_ and _Updates_ tabs of the _Plugin Manager_.
 
 Once you install the beta plugins that you wanted, you can switch back to the default `\https://updates.jenkins.io/update-center.json` update center URL.
+
+=== In Jenkins Configuration-as-Code plugin
+
+plugin:configuration-as-code[Jenkins Configuration-as-Code plugin] allows configuring update centers in configuration YAMLs.
+Once configured, it will be possible to install experimenta plugins and versions from the _Plugin Manager_ Web UI.
+
+```yml
+jenkins:
+  updateCenter:
+    sites:
+      - id: "default"
+        url: "https://updates.jenkins.io/update-center.json"
+      - id: "experimental"
+        url: "https://updates.jenkins.io/experimental/update-center.json"
+```
+
+=== In official Docker images
+
+Official link:https://github.com/jenkinsci/docker[Jenkins master Docker image] includes plugin management scripts which allow to preinstall plugins from the Experimental update center.
+See the documentation and examples link:https://github.com/jenkinsci/docker#preinstalling-plugins[here].


### PR DESCRIPTION
We just rolled out a GitHub App Authentication support in GitHub Branch Source Beta. This feature is released to the experimental update center. Unfrtunately our guidelines are slightly obsolete, and they do not include new ways to manage plugins in Jenkins. Tried to fix that.

Contributes to #2988 

CC @timja @bitwiseman 