### PR TITLE
Mention EMIT_LOCATION in docs on views

### DIFF
--- a/content/doc/developer/views/index.adoc
+++ b/content/doc/developer/views/index.adoc
@@ -25,3 +25,8 @@ references:
 ////
 TODO INFRA-897    Jelly taglib reference core define, stapler, and taglibs defined in Jenkins core
 ////
+
+## Debugging Tips and Tricks
+
+Set the static field `org.kohsuke.stapler.jelly.ReallyStaticTagLibrary.EMIT_LOCATION` to `true` (e.g. via Script Console) to have Jelly emit `line` and `file` attributes on rendered HTML/XML tags.
+This can help understand how a view is composed.


### PR DESCRIPTION
Really not happy how this is the start of recreating wiki pages with bits of information lacking an overall concept, OTOH this information is so obscure that having it documented at all seems worthwhile. AFAICT, this has never been documented anywhere, and I've never come across it before today.