### PR TITLE
[JENKINS-61932] Add redirect URLs for new empty page

### DIFF
--- a/content/redirect/distributed-builds.adoc
+++ b/content/redirect/distributed-builds.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Distributed+builds
+---

--- a/content/redirects/distributed-builds.adoc
+++ b/content/redirects/distributed-builds.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Distributed+builds
+---


### PR DESCRIPTION
Due to a typo in the original Jenkins change, the URL linked there
currently is invalid. So add it temporarily, once everyone is on a
newer release we can delete it again.

----

[JENKINS-61932](https://issues.jenkins-ci.org/browse/JENKINS-61932) because https://github.com/jenkinsci/jenkins/pull/4633 got merged earlier than expected and I then lost track of it.