### PR TITLE
Use mirrors.jenkins-ci.org/ instead of get.jenkins.io in the banner

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -7243,7 +7243,7 @@
   banner: |-
     <strong>NOTE:</strong> This is the first Jenkins weekly release delivered by the <a href="https://issues.jenkins-ci.org/browse/INFRA-910">core release automation project</a>.
     Some Jenkins Weekly distributables may not be accessible from the <a href="https://jenkins.io/download/">Jenkins Downloads</a> page.
-    In such case please see the package links on <a href="https://get.jenkins.io/"/>get.jenkins.io</a> in the <b>Releases</b> section.
+    In such case please see the package links on <a href="http://mirrors.jenkins-ci.org/"/>our mirrors</a> in the <b>Releases</b> section.
   changes:
   - type: bug
     category: regression


### PR DESCRIPTION
Follow-up to the comment from @olblak 

> this service can be deleted at any moment it's still experimental, regarding packages they can be downloaded from mirror.jenkins-ci.org, archives.jenkins-ci.org
