### PR TITLE
Fix description of SECURITY-698

### DIFF
--- a/content/security/advisory/2018-02-05.adoc
+++ b/content/security/advisory/2018-02-05.adoc
@@ -85,7 +85,7 @@ External entity resolution has been adjusted to avoid XXE and still satisfy the 
 Credentials Binding plugin allows specifying passwords and other secrets as environment variables, and will hide them from console output in builds.
 
 However, since Jenkins will try to resolve references to other environment variables in environment variables passed to a build, this can result in other values than the one specified being provided to a build.
-For example, the value `+++p4$$w0rd+++` would result in Jenkins passing on `+++p4$$w0rd+++`, as `+++$$+++` is the escape sequence for a single `$`.
+For example, the value `+++p4$$w0rd+++` would result in Jenkins passing on `+++p4$w0rd+++`, as `+++$$+++` is the escape sequence for a single `$`.
 
 Credentials Binding plugin does not prevent such a transformed value (e.g. `p4$w0rd`) from being shown on the build log, allowing users to reconstruct the actual password value from the transformed one.
 


### PR DESCRIPTION
Broke in https://github.com/jenkins-infra/jenkins.io/pull/1648 -- my best guess is that @bitwiseman wanted to be helpful and fix a typo, but it's not.