### PR TITLE
[INFRA-910] - Use http://mirrors.jenkins-ci.org as a source of weekly releases, hardcode 2/232

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -184,15 +184,15 @@ title: Jenkins installation and setup
                 %span
                   &nbsp;
                 %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/opensuse/'}
+              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/opensuse/'}
                 %span.icon
                 %span.title
                   openSUSE
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat/'}
+              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/redhat/'}
                 %span.icon
                 %span.title
                   Red Hat/Fedora/CentOS
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian/'}
+              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/debian/'}
                 %span.icon
                 %span.title
                   Ubuntu/Debian
@@ -206,7 +206,7 @@ title: Jenkins installation and setup
                 %span.icon
                 %span.title
                   Windows
-              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins.io/war/latest/jenkins.war'}
+              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
                 %span.title
                 Generic Java package (.war)
 

--- a/content/download/thank-you-downloading-windows-installer.html.haml
+++ b/content/download/thank-you-downloading-windows-installer.html.haml
@@ -3,4 +3,4 @@
 :title: Thank you for downloading Windows installer
 ---
 
-= partial('thank-you-downloading-windows-installer.html.haml', :release_url => 'http://mirrors.jenkins-ci.org/windows/latest')
+= partial('thank-you-downloading-windows-installer.html.haml', :release_url => 'http://mirrors.jenkins-ci.org/windows/2.232/jenkins.msi')


### PR DESCRIPTION
This is a temporary fix until we fully deploy the new downloads site and fix the issues there.  After the fix Downloads at least ships recent releases as expected.

Windows link is hardcoded, because the "latest" symbolic link link is broken in the update center generator after MSI unpacking by defaul.