### PR TITLE
Highlight Documentation SIG channels as contact points for the website contributions

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,7 +1,10 @@
 :toc:
+:toc-placement: preamble
 :toclevels: 3
 
 = Contributing to jenkins.io
+
+image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
 
 toc::[]
 
@@ -26,6 +29,16 @@ You can also find some newbie-friendly issues in our task trackers:
 
 * link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good First Issues on GitHub]
 * link:https://issues.jenkins-ci.org/issues/?filter=18650&jql=project%20%3D%20WEBSITE%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Jenkins Jira query]
+
+[[contacts]]
+=== Communication channels
+
+Jenkins website is largely maintained by the link:https://jenkins.io/sigs/docs/[Jenkins documentation] special interest group.
+This group has various communication channels which can be used to discuss contributing to the website:
+
+* link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Mailing list]
+* link:https://gitter.im/jenkinsci/docs[Gitter chat]
+* link:https://jenkins.io/sigs/docs/#meetings[Regular meetings]
 
 [[forking]]
 === Creating a fork

--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,14 @@
 = jenkins.io
 
+image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
+
 This repository is what powers the link:https://jenkins.io/[Jenkins
 website]. This uses link:https://github.com/awestruct/awestruct[Awestruct]
 with link:https://asciidoctor.org[Asciidoctor] under the hood to provide a very
 useful and compelling web presence for the link:https://jenkins.io/[Jenkins
 automation server].
 
+== Contributing
 
 If you're interested in contributing to the site, please see our
 link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[Contributing


### PR DESCRIPTION
Was following-up on https://twitter.com/wololock/status/1251837164599554048 and discovered that it might be difficult to discover the communication channels for the website