### PR TITLE
JEP-14: Initialize the "Jenkins on cloud platforms" roadmap section

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -73,7 +73,7 @@ categories:
     initiatives:
     - name: 'JEP-219: Jenkins Kubernetes Operator'
       description: >
-        Further evolution a Kubernetes Native Operator which manages operations for Jenkins on Kubernetes.
+        Further evolution of a Kubernetes Native Operator which manages operations for Jenkins on Kubernetes.
         It has been built with Immutability and declarative Configuration as Code in mind.
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/219

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -65,6 +65,33 @@ categories:
 #  - name: Jenkins Security
 #    description: "Public security hardening and management initiatives. Vulnerability fixes are not listed"
 #    initiatives:
+  - name: Jenkins on cloud platforms
+    description: >
+      Initiatives focused on making Jenkins easy to deploy and run in cloud environments,
+      including Kubernetes and various cloud providers.
+    link: /sigs/cloud-native
+    initiatives:
+    - name: 'JEP-219: Jenkins Kubernetes Operator'
+      description: >
+        Further evolution a Kubernetes Native Operator which manages operations for Jenkins on Kubernetes.
+        It has been built with Immutability and declarative Configuration as Code in mind.
+      status: current
+      link: https://github.com/jenkinsci/jep/tree/master/jep/219
+    - name: 'Jenkinsfile Runner 1.0'
+      description: >
+        Finalization of Jenkinsfile Runner prototype which would allow running jobs and pipelines as Function-as-Service in cloud environments.
+      status: current
+      link: https://github.com/jenkinsci/jenkinsfile-runner
+    - name: 'Jenkins FaaS Capability'
+      description: >
+        Continued development of the Jenkinsfile Runner and its packaging/development tools to simplify usage of the tool as Function-as-Service.
+      status: near-term
+      link: https://github.com/jenkinsci/jenkinsfile-runner
+    - name: 'Tekton support'
+      description: >
+        Support triggering Tekton pipelines as a part of the Jenkins Pipeline ecosystem.
+      status: future
+      link: https://cloud.google.com/tekton
   - name: Packaging and platform support
     link: /sigs/platform
     initiatives:


### PR DESCRIPTION
This pull request initializes roadmap items for the "Jenkins on cloud platforms" section. Roadmap items are yet to be formally discussed in the community, but at least it provides some overview of the current stories 

Open questions:

* Add Pluggable storage to the `future` section? might be too wide
* Adjust the Jenkins Kubernetes Operator status/wording? Will need feedback from @tomaszsek

Current look&feel:

![image](https://user-images.githubusercontent.com/3000480/79741551-bdc17680-8301-11ea-814f-4f56f8ac86f3.png)

 