### PR TITLE
Platform SIG - Add project descriptions and roadmap items

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -68,6 +68,10 @@ categories:
   - name: Packaging and platform support
     link: /sigs/platform
     initiatives:
+    - name: Docker images for Windows
+      description: Official Windows Docker images for Jenkins masters and agents.
+      status: current
+      link: https://jenkins.io/sigs/platform/#windows-support
     - name: Docker images for IBM s390x
       status: current
       description: Docker image support for IBM series 390 mainframes running Java 8 and Java 11
@@ -76,6 +80,10 @@ categories:
       status: current
       description: Docker image support for IBM PowerPC 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61774
+    - name: OpenJ9 Docker images
+      status: current
+      description: We would like to provide official images based on OpenJ9 JVM
+      link: TODO
     - name: Docker images for ARM 64
       status: near-term
       description: Docker image support for ARM 64 running Java 8 and Java 11
@@ -91,6 +99,30 @@ categories:
       description: Currently Jenkins has no documented Windows Support policy. We want to add one and to deprecate/remove support for old platforms
       status: near-term
       link: https://issues.jenkins-ci.org/browse/JENKINS-61865
+    - name: Migration to AdoptOpenJDK in distributions
+      description: >
+        Currently Jenkins uses OpenJDK in the most of official Docker packages.
+        We would like to migrate to AdoptOpenJDK which offers wider range of supported platforms.
+      status: near-term
+      link: https://issues.jenkins-ci.org/browse/JENKINS-61865
+    - name: Custom Jenkins distribution build service
+      description: >
+        We would like to create a new service which would allow users to configure and build their own Jenkins distributions,
+        with custom plugin sets and configurations included.
+      status: near-term
+      link: https://jenkins.io/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service/
+    - name: Java 14+ support
+      description: >
+        We would like to support future mainstream JVM versions (Java 14+).
+        Right now Jenkins runs well on Java 11, but we may need to do some changes towards the next LTS baseline.
+      status: future
+      link: https://jenkins.io/sigs/platform/#java-support
+    - name: Cloud native Java support
+      description: >
+        We are interested to run Jenkins in cloud native environments.
+        To do so, we would like to introduce support for perspective virtual machines like GraalVM or Quarkus.
+      status: future
+      link: https://jenkins.io/sigs/platform/#java-support
   - name: Documentation
     link: /sigs/docs
     initiatives:

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -56,7 +56,7 @@ Platform SIG may be cooperating with other groups.
 For example, we will be cooperating with the link:/sigs/cloud-native[Cloud-Native Jenkins group]
 on topics related to Cloud-Native platforms like Kubernetes or Docker.
 
-=== Topics
+== Topics
 
 * Defining platform support policies (e.g. “defining Windows support policy”)
 * Coordinating effort on new platform support (e.g. jep:211[Java 11 Support in Jenkins])
@@ -65,20 +65,62 @@ on topics related to Cloud-Native platforms like Kubernetes or Docker.
 ARM architecture support, adapting RedHat packaging to best practices, etc.)
 * Reviewing JEPs submitted in the area
 
-=== Ongoing projects
+== Projects
 
-* Multi-architecture Docker images
-** Enabling official images to run on Arm, IBM s390x, and other platforms
-* Rework of Windows installers
-** New version of installers for 64bit platforms
-** Removal of Java bundling
-** Creating an official link:https://chocolatey.org/packages/jenkins[Jenkins Chocolatey package]
+This section lists the key initiatives being handled by the Platform SIG.
+See the link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y/edit?usp=sharing[SIG meeting notes] for more information about the ongoing projects.
+See the link:/project/roadmap[Jenkins Project roadmap] for a 
+
+=== Docker images
+
+Jenkins project ships official master and agent images,
+and we would like to offer Wide support of platforms and architectures there.
+Scope of interest:
+
+* Enabling official images to run on Arm, IBM s390x, and other platforms
+* Official master and agent images for Windows
+* Support Multi-architecture Docker images
 * Enabling continuous delivery for Jenkins packaging
 ** Experimental DockerHub organization and deployments from ci.jenkins.io (jep:217[])
 
-See the link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y/edit?usp=sharing[SIG meeting notes] for more information about the ongoing projects.
+=== Plugin management
 
-=== Meetings
+We are interested to improve plugin management experience in Jenkins.
+To do that, we work on new tools for Jenkins users and maintainers.
+Scope of interest:
+
+* link:/doc/book/managing/plugins/[Plugin management in Jenkins Web UI]
+* link:https://github.com/jenkinsci/docker#preinstalling-plugins[Plugin management in Jenkins Docker images]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager CLI Tool]
+* link:https://github.com/jenkinsci/custom-war-packager[Custom Jenkins WAR/Docker packager]
+* link:/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service/[Custom Jenkins distribution build service]
+* link:https://github.com/jenkinsci/bom[Bill of Materials for Jenkins plugins]
+
+=== Java support
+
+In our SIG we are interested to offer a wide range of supported JVMs.
+See the current list of supported versions link:/doc/administration/requirements/java/[here].
+Scope of interest:
+
+* Maintaining Java 11 support in Jenkins and driving its adoption
+* Migration to link:https://adoptopenjdk.net/[AdoptOpenJDK] in Docker images
+* Docker images based on the OpenJ9 JVM
+* Support for future mainstream JVM versions (Java 14+)
+* Support for perspective virtual machines like link:https://www.graalvm.org/[GraalVM] or link:https://quarkus.io/[Quarkus], including native executable packaging
+
+=== Windows support
+
+Many Jenkins users run master or agents on Windows.
+We are interested to support modern Windows platforms and to offer official distributions for the platform.
+Scope of interest:
+
+* Native Windows installers (MSI), including the ongoing link:/blog/2019/02/01/windows-installers/[rework of Windows installers]
+* Official Docker images for Windows masters and agents
+* Installation of masters and agents as Windows services
+* Official link:https://chocolatey.org/packages/jenkins[Jenkins Chocolatey package]
+* jira:JENKINS-61865[New Windows support policy]
+
+== Meetings
 
 We have regular meetings on Thursdays every two weeks, at *12:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
@@ -86,7 +128,7 @@ At these meetings we discuss projects, share presentations, and demonstrate new 
 Meetings are conducted and recorded via Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].
 Participant links are posted in the link:https://gitter.im/jenkinsci/platform-sig[SIG Gitter Chat] 10 minutes before the meeting starts.
 
-==== Meeting Agendas
+=== Meeting Agendas
 
 Meeting agendas and meeting notes for the SIG are posted in link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y[this Google Document].
 Anyone is welcome to add a topic for an upcoming meeting by suggesting a change in the link:https://docs.google.com/document/d/1bDfUdtjpwoX0HO2PRnfqns_TROBOK8tmP6SgVhubr2Y[agenda].


### PR DESCRIPTION
This PR updates the SIG page to list the ongoing/perspective projects, and it also adds roadmap items we discussed at previous SIG meetings. Roadmap is now a bit packed, but we will soon move two items to released (Windows Installer and Docker images).

SIG page is also updated to show items in ToC:

Roadmap:

![image](https://user-images.githubusercontent.com/3000480/79749905-4fd07b80-8310-11ea-9127-dd1277a8a215.png)

SIG page:

![image](https://user-images.githubusercontent.com/3000480/79750001-78f10c00-8310-11ea-99d7-c21834814a9a.png)

ToC:

![image](https://user-images.githubusercontent.com/3000480/79750070-94f4ad80-8310-11ea-9af1-5b3328fa0702.png)

