### PR TITLE
Roadmap pipeline

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -12,9 +12,32 @@ statuses:
   displayName: "Future"
   description: "We intend to work on that in the short term, but there is no ongoing development"
 categories:
-  - name: Jenkins jobs and integrations
-    description: Initiatives focused on new features for Jenkins end users
+  - name: Pipeline Authoring
+    description: This special interest group aims to improve and curate the experience of authoring Jenkins Pipelines
+    link: /sigs/pipeline-authoring
     initiatives:
+    - name: Pipeline development in IDE
+      description: IDE integration, editors, and other development tools - IDE plugins, visual editors, etc
+      status: future
+      link: https://issues.jenkins-ci.org/browse/JENKINS-35396
+    - name: Syntax Improvements
+      description: How Jenkinsfiles and shared libraries are written
+      status: future
+      link: https://issues.jenkins-ci.org/browse/JENKINS-55287
+    - name: Static Code Analysis and Linting
+      description: A method of debugging by automatically examining pipeline before it is run
+      status: future
+      link: https://issues.jenkins-ci.org/browse/JENKINS-52939
+    - name: Pipeline Testing
+      description: Unit and functional testing of Jenkinsfiles and shared libraries
+      status: future
+      link: https://issues.jenkins-ci.org/browse/JENKINS-61935
+    - name: Integration Testing
+      description: The Pipeline Unit Testing Framework allows which allows the ability to test pipelines and shared Libraries before running
+      status: future
+    - name: Documentation
+      description: Reference documentation, tutorials, and more
+      status: future
     - name: "Pipeline: GitHub App authentication"
       status: current
       link: https://issues.jenkins-ci.org/browse/JENKINS-57351

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -12,38 +12,32 @@ statuses:
   displayName: "Future"
   description: "We intend to work on that in the short term, but there is no ongoing development"
 categories:
-  - name: Pipeline Authoring
-    description: This special interest group aims to improve and curate the experience of authoring Jenkins Pipelines
+  - name: Pipeline authoring and development tools
+    description: Initiatives focused on improving Jenkins Pipeline and experience of Pipeline developers
     link: /sigs/pipeline-authoring
     initiatives:
     - name: Pipeline development in IDE
       description: IDE integration, editors, and other development tools - IDE plugins, visual editors, etc
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-35396
-    - name: Syntax Improvements
+    - name: Pipeline syntax improvements
       description: How Jenkinsfiles and shared libraries are written
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-55287
-    - name: Static Code Analysis and Linting
+    - name: Static code analysis and linting
       description: A method of debugging by automatically examining pipeline before it is run
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-52939
-    - name: Pipeline Testing
+    - name: Pipeline functional testing tools
       description: Unit and functional testing of Jenkinsfiles and shared libraries
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-61935
-    - name: Integration Testing
+    - name: Pipeline integration testing tools
       description: The Pipeline Unit Testing Framework allows which allows the ability to test pipelines and shared Libraries before running
       status: future
-    - name: Documentation
+    - name: Pipeline Documentation
       description: Reference documentation, tutorials, and more
       status: future
-    - name: "Pipeline: GitHub App authentication"
-      status: current
-      link: https://issues.jenkins-ci.org/browse/JENKINS-57351
-    - name: "GitHub Checks API integrations"
-      status: near-term
-      link: https://jenkins.io/projects/gsoc/2020/project-ideas/github-checks/
     - name: Pipeline as YAML
       description: Official support for defining Jenkins Pipelines in YAML, without additional Pipeline libraries
       status: near-term
@@ -52,6 +46,18 @@ categories:
       description: Provide out-of-the-box support for manual and automatic promotion of build artifacts in a separate Pipeline after the job completion
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-36089
+  - name: Tool and Service integrations
+    description: >
+      Initiatives focused on integrations with various external tools and services.
+      It includes but not limited to SCMs, source code hosting services, build and testing tools.
+    initiatives:
+    - name: "Pipeline: GitHub App authentication"
+      status: current
+      link: https://issues.jenkins-ci.org/browse/JENKINS-57351
+    - name: "GitHub Checks API integrations"
+      status: near-term
+      link: https://jenkins.io/projects/gsoc/2020/project-ideas/github-checks/
+    - name: Pipeline as YAML
   - name: User experience and interface
     description: Initiatives focused on improving the Jenkins user interface and user experience
     link: /sigs/ux


### PR DESCRIPTION
Follow-up to #3091 from @markyjackson-taulia . That pull request was submitted from the master branch, so I cannot suggest a PR against it. 

Summary of changer:

* A new roadmap category is introduced specifically for Pipeline authoring
* Tool and Service integrations are moved to a separate category
* Text is slightly edited

Current layout:

![image](https://user-images.githubusercontent.com/3000480/79841157-4b12d280-83b7-11ea-94b0-5a30dfb6b9b3.png)

