### PR TITLE
Roadmap: Add descriptions and links for JCasC-related entries

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -47,21 +47,34 @@ categories:
     description: "Initiatives which help to manage Jenkins as Code: JCasC Plugin, etc."
     initiatives:
     - name: "JCasC: Plugin compatibility"
+      description: >
+        Ensure wide support for Jenkins Configuration-as-Code in the Jenkins core and plugins.
       status: current
       link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/809
-    - name: 'JEP-222: Remoting over Websockets'
+    - name: 'JEP-222: Remoting over WebSockets'
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/222
     - name: 'JEP-223: Manage permissions'
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/223
     - name: 'JEP-224: SystemRead permissions'
+      description: >
+        Update Jenkins Web UI to support read-only access to system configuration and diagnostics information.
+        It complements Jenkins Configuration-as-Code stories by preventing undesired manual modifications on running instances.
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/224
     - name: Built-in plugin management as-code
+      description: >
+        Evolution of plugin management capabilities in the Jenkins core and Docker images.
+        It includes adoption of the new Plugin Management tool in distributions, and support of advanced plugin definition formats like YAML.
       status: near-term
+      link: https://jenkins.io/sigs/platform/#plugin-management
     - name: "JCasC: Pluggable configuration sources"
+      description: >
+        Support external configuration sources in the Jenkins Configuration-as-Code plugin.
+        Examples of potential configuration sources: Git, S3 Buckets, Kubernetes CRD.
       status: future
+      link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/1365
 #  - name: Jenkins Security
 #    description: "Public security hardening and management initiatives. Vulnerability fixes are not listed"
 #    initiatives:

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -137,7 +137,7 @@ link:https://www.qwiklabs.com/focuses/1104?parent=catalog[Google Cloud self-pace
 * System providers (like
 link:https://code.vmware.com/samples/5160/Jenkins-CICD-Integration-with-PKS-provisioned-Kubernetes-Clusters[VMWare] and
 link:https://rancher.com/blog/2018/2018-11-27-scaling-jenkins/[Rancher])
-* Infrastructure as a Servier providers (like
+* Infrastructure as a Server providers (like
 link:https://platform9.com/blog/kubernetes-for-ci-cd-at-scale/[Platform9])
 * SCM providers (like
 link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenkins-and-kubernetes-on-aws[Bitbucket])

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -137,7 +137,7 @@ link:https://www.qwiklabs.com/focuses/1104?parent=catalog[Google Cloud self-pace
 * System providers (like
 link:https://code.vmware.com/samples/5160/Jenkins-CICD-Integration-with-PKS-provisioned-Kubernetes-Clusters[VMWare] and
 link:https://rancher.com/blog/2018/2018-11-27-scaling-jenkins/[Rancher])
-* Infrastructure as a Server providers (like
+* Infrastructure as a Service providers (like
 link:https://platform9.com/blog/kubernetes-for-ci-cd-at-scale/[Platform9])
 * SCM providers (like
 link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenkins-and-kubernetes-on-aws[Bitbucket])


### PR DESCRIPTION
Cleanup of the mock JCasc roadmap items which had no description/links. Addresses comments from @MarkEWaite about the Plugin management tool, and also fixes typo in #3090 while I was around

CC @timja @jetersen 