### PR TITLE
Advoacy&Outreach SIG: Extend the project descriptions

### DIFF
--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -39,7 +39,7 @@ overview: >
 ---
 
 
-=== Topics
+== Topics
 
 * Attracting and onboarding new individual and company contributors
 * Documentation for newbie contributors
@@ -49,11 +49,37 @@ overview: >
 * Community Evangelism (Jenkins Ambassadors, etc.)
 * Infrastructure: Community metrics & Co, Hosting/Plugin adoption tooling
 
-=== Ongoing projects
+== Projects
 
-For a list of our on-going projects, see the link:outreach-programs[Outreach programs] page.
+=== Outreach programs
 
-=== Meetings
+The special interest groups coordinates various outreach programs which help the project to facilitate contributions and to onboard more contributors.
+For a list of our on-going and planned programs, see the link:outreach-programs[Outreach programs] page.
+
+=== Online Meetup
+
+Our SIG manages the link:/events/online-meetup[Jenkins Online Meetup platform] and helps to organize events on this platform.
+It includes user-focused and contributor-focused events.
+See the linked page for more information.
+
+=== Local Events
+
+Our SIG is interested to help with organizing and promoting local events which focus on Jenkins or have a substantial representation of Jenkins in their agenda.
+These meetups are not limited to link:/projects/jam[Jenkins Area Meetups] or link:/projects/jam[CI/CD Meetups],
+we are interested to help any other meetup group or entities organizing local meetups and conferences related to Jenkins.
+
+The SIG does not manage meetup operations (creating new meetups, delivering swag, etc.),
+but we are ready to help to find proper channels if needed.
+link:/projects/jam[This page] summarized the current state of meetup operations.
+
+=== Social media
+
+Our SIG coordinates Jenkins promotion in social media and other channels,
+including but not limited to link:https://twitter.com/jenkinsci[Twitter], link:https://www.youtube.com/user/jenkinsci/[YouTube] and link:https://www.linkedin.com/company/jenkins-project/[LinkedIn].
+If you would like to share any content about Jenkins on these platforms,
+please contact us and we will try to help.
+
+== Meetings
 
 * Schedule: one meeting every 2 weeks, usually on Thursdays. See the link:/event-calendar/[Event Calendar] for the schedule
 * Meeting link: https://zoom.us/j/324404020

--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -70,7 +70,7 @@ we are interested to help any other meetup group or entities organizing local me
 
 The SIG does not manage meetup operations (creating new meetups, delivering swag, etc.),
 but we are ready to help to find proper channels if needed.
-link:/projects/jam[This page] summarized the current state of meetup operations.
+link:/projects/jam[This page] summarizes the current state of meetup operations.
 
 === Social media
 
@@ -85,4 +85,3 @@ please contact us and we will try to help.
 * Meeting link: https://zoom.us/j/324404020
 * Agenda: https://docs.google.com/document/d/1K5dTSqe56chFhDSGNfg_MCy-LmseUs_S3ys_tg60sTs/edit#
 * link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaOfJSIQj85tYWds7JGkWdWb[Recordings of the previous Meetings]
-


### PR DESCRIPTION
This change adds some topics which are being actively worked on by the SIG. The list is not extensive, but I believe it would be a good start.

* Change indenting so that ToC is generated properly
* Add project descriptions for Outreach programs, online and offline events, social media outreach

Preview: 

![image](https://user-images.githubusercontent.com/3000480/80084038-a0d1b100-8556-11ea-9775-2ba06998cc01.png)


Depends on #3105 
