### PR TITLE
Google Season of Docs: Initialize landing and link it from other pages

### DIFF
--- a/content/participate/document.adoc
+++ b/content/participate/document.adoc
@@ -13,7 +13,7 @@ sig: docs
 Jenkins has lots of documentation, and we appreciate any contributions to it:
 new docs, design and styling, copy-editing, reviews, etc.
 
-We coordinate and discuss documentaton efforts in the link:/sigs/docs[Documentation Special Interest Group].
+We coordinate and discuss documentation efforts in the link:/sigs/docs[Documentation Special Interest Group].
 You can reach out to us in the mailing list or on link:[https://gitter.im/jenkinsci/docs[Gitter, and you can also join our link:/sigs/docs/#meetings[regular meetings.
 See the contacts on the right sidebar.
 
@@ -62,9 +62,10 @@ Useful links:
 == Featured projects
 
 Currently we are working on migrating the documentation from Jenkins Wiki to GitHub and jenkins.io.
-See link:/blog/2019/10/21/plugin-docs-on-github/[this blogpost] for more information about the reasons why we do this migration.
+See link:/blog/2019/10/21/plugin-docs-on-github/[this blog post] for more information about the reasons why we do this migration.
 This migration involves modification of hundreds of pages and repositories, and we invite everyone to contribute.
 
 * link:/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github[Migrating plugin documentation from Wiki to GitHub]
 * link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#moving-documentation-from-jenkins-wiki[Moving documentation from Jenkins Wiki to jenkins.io]
-* jira:JENKINS-59467[Template issue for plugin docs migration]
+
+There are also other ongoing projects which you can find on the link:/sigs/docs/#ongoing-projects[Documentation SIG page] and in the link:/project/roadmap[project roadmap].

--- a/content/sigs/advocacy-and-outreach/outreach-programs/index.adoc
+++ b/content/sigs/advocacy-and-outreach/outreach-programs/index.adoc
@@ -90,17 +90,15 @@ The Jenkins community has expressed interest in participating in the following p
 
 === Google Season of Docs
 
-image:/images/gsod/gsod.png[Google Season of Doc, role=center, float=right]
+image:/images/gsod/gsod.png[Google Season of Docs, role=center, float=right]
 
-The https://developers.google.com/season-of-docs/[Google Season of Doc]
+The https://developers.google.com/season-of-docs/[Google Season of Docs]
 program brings together open source and technical writers communities for the benefit of both.
 The program raises awareness of open source, of docs, and of technical writing.
 
 The Jenkins organization would like to participate in this program, but we have not yet been accepted.
-
-Please see the
-link:/sigs/docs[documentation SIG] page
-for contact information, and let us know if you'd like to help us participate in this program.
+We plan to apply in 2020.
+Please see the link:/sigs/docs/gsod[documentation SIG] page for more information and contacts.
 
 // The GSoD logo is a bit tall, so add some empty lines
 {empty} +

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -1,0 +1,132 @@
+---
+layout: project
+title: "Google Season of Docs in Jenkins"
+section: projects
+sig: docs
+tags:
+- gsod
+- docs
+- docs-sig
+opengraph:
+  image: /images/gsod/gsod.png
+links:
+  meetings: "/projects/gsoc/#office-hours"
+---
+
+image:/images/gsod/gsod.png[Google Season of Docs, role=center, float=right]
+
+The https://developers.google.com/season-of-docs/[Google Season of Docs (GSoD)]
+program brings together open source and technical writers communities for the benefit of both.
+The program raises awareness of open source, of docs, and of technical writing.
+GSoD in Jenkins is organized by the link:/sigs/docs[Documentation special interest group].
+
+== GSoD 2020
+
+Jenkins project will be applying to Google Season of Docs 2020.
+We invite technical writers to join the community and contribute to the documentation being used by millions of Jenkins users worldwide.
+
+=== Project ideas
+
+We invite technical writers to contribute to a major documentation update effort being coordinated in the documentation SIG.
+It includes a number of link:/sigs/docs/#ongoing-projects[ongoing projects],
+and technical writers are welcome to make their proposals in any area of the Jenkins documentation.
+We encourage proposals based on a technical writer's expertise and interests.
+
+[frame="topbot",grid="all",options="header",cols="30%,15%,55%"]
+|=========================================================
+|Project idea | Keywords | Description and links
+
+| Plugin documentation migration and update 
+| Markdown, GitHub, Plugins, Rewrite, Copy-editing
+| Currently we are migrating our plugin documentation from link:https://wiki.jenkins.io/[Confluence] to GitHub,
+  see link:/blog/2019/10/21/plugin-docs-on-github/[this blog post] for announcement.
+  We have already moved hundreds of pages, but there are more than 1000 pages remaining.
+  Migration itself can be done with automated tools we provide, but the documentation usually needs a significant update due to new features.
+  We invite technical writers to select an area (e.g. "plugins for Docker"), and to migrate and update documentation for a number of plugins in such an area.
+  link:/sigs/docs/#plugin-documentation-on-github[More Info]
+
+| Jenkins on Kubernetes
+| AsciiDoc, Guide, Compilation
+| Jenkins on Kubernetes is a popular theme for Jenkins users.
+  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we .
+  We would like to create new documentation which would describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
+  link:/sigs/docs/#jenkins-on-kubernetes[More Info]
+
+| Jenkins user documentation reorganization and update
+| AsciiDoc, Guide, Rewrite
+| Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook], and are frequently received to improve the user documentation.
+Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
+We would also like to restructure content to make it more discoverable and easy to read.
+link:/sigs/docs/#user-guide[More info]
+
+|=========================================================
+
+=== Getting started
+
+If you are interested to participate in Google Season of Docs as a technical writer, please do the following:
+
+. Join our link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Mailing list] and link:https://gitter.im/jenkinsci/docs[Gitter Channel].
+. Explore the project ideas listed on this page, find areas which would be interesting to you.
+. Try link:/participate/document/[contributing to Jenkins documentation] to study our documentation tools and contribution process.
+  There are some link:/participate/document/#newcomers[newcomer-friendly documentation tasks] you could try.
+. Send an introductory email to our mailing list. Please include a short self-introduction and list projects which would be interesting to you.
+
+=== Team
+
+* Org admins:
+  link:/blog/authors/oleg_nenashev/[Oleg Nenashev],
+  link:/blog/authors/markyjackson-taulia/[Marky Jackson].
+* Potential mentors:
+  link:/blog/authors/markewaite/[Mark Waite],
+  link:/blog/authors/kwhetstone/[Kristin Whetstone],
+  link:/blog/authors/oleg_nenashev/[Oleg Nenashev],
+  link:/blog/authors/sladyn98/[Sladyn Nunes].
+* Documentation SIG link:/sigs/docs/#members[members] and component maintainers (depends on the project).
+
+=== Technology and tools
+
+For all new documentation projects we are using the link:https://www.writethedocs.org/guide/docs-as-code/[Documentation as Code approach]
+when documentation is developed using markup languages and stored in source control management (SCM) systems.
+Here are the common tools we use:
+
+* Markdown languages: link:https://asciidoctor.org/[AsciiDoc] and link:https://github.github.com/gfm/[GitHub Flavored Markdown]
+** For example, this page is written in Asciidoc.
+   You can find its sources link:https://github.com/jenkins-infra/jenkins.io/blob/master/content/sigs/docs/gsod/index.adoc[here].
+* SCM: link:https://git-scm.com/[Git]
+* Source Code Hosting: link:http://github.com/[github.com]
+* Text editing: any text editor with AsciiDoc/Markdown support (e.g. link:https://code.visualstudio.com/[Visual Studio Code], link:https://notepad-plus-plus.org/[Notepad++]) or a specialized IDE 
+
+Particular components may also require additional tools for documentation development.
+For example, the jenkins.io website requires Docker for being built and tested locally.
+In such cases we document usage of these tools in link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[our contributing guidelines] and help newcomer maintainers if needed.
+
+== Contacts
+
+We will be using the link:/sigs/docs[Documentation SIG] communication channels for GSoD project discussions during the application phases.
+
+* link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Mailing list]
+* link:https://gitter.im/jenkinsci/docs[Gitter Channel]
+* link:/sigs/docs/#meetings[Regular SIG meetings]
+
+Once the projects are announced, other project-specific channels might be created by teams during the community bonding.
+
+== Additional Information
+
+=== Technical writers
+
+* link:/participate/document/[Contributing to Jenkins documentation]
+* link:https://developers.google.com/season-of-docs/docs/tech-writer-guide[GSoD Technical Writer guide]
+* link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
+
+== Mentors
+
+* link:https://developers.google.com/season-of-docs/docs/mentor-guide[GSoD Mentor Guide]
+* link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
+* link:https://developers.google.com/season-of-docs/docs/project-selection[Selecting projects]
+* link:https://developers.google.com/season-of-docs/docs/tech-writer-collaboration[Working with a technical writer]
+
+[#archive]
+== Previous years
+
+* GSoD 2019 - not accepted (
+link:https://docs.google.com/document/d/1ighqWo7gIDCnLQ-b6FouQKz-fvmHsnTsMfqBh_mVNbI/edit?usp=sharing[application form and project ideas])

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -128,5 +128,6 @@ Once the projects are announced, other project-specific channels might be create
 [#archive]
 == Previous years
 
-* GSoD 2019 - not accepted (
-link:https://docs.google.com/document/d/1ighqWo7gIDCnLQ-b6FouQKz-fvmHsnTsMfqBh_mVNbI/edit?usp=sharing[application form and project ideas])
+* GSoD 2019 - not accepted 
+(link:https://docs.google.com/document/d/1ighqWo7gIDCnLQ-b6FouQKz-fvmHsnTsMfqBh_mVNbI/edit?usp=sharing[application form and project ideas],
+link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#heading=h.g4afeqolzwpj[retrospective])

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -48,7 +48,7 @@ We encourage proposals based on a technical writer's expertise and interests.
 | Jenkins on Kubernetes
 | AsciiDoc, Guide, Compilation
 | Jenkins on Kubernetes is a popular theme for Jenkins users.
-  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we .
+  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need a central location for documentation describing Jenkins on Kubernetes.
   We would like to create new documentation which would describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
   link:/sigs/docs/#jenkins-on-kubernetes[More Info]
 

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -42,7 +42,7 @@ We encourage proposals based on a technical writer's expertise and interests.
   see link:/blog/2019/10/21/plugin-docs-on-github/[this blog post] for announcement.
   We have already moved hundreds of pages, but there are more than 1000 pages remaining.
   Migration itself can be done with automated tools we provide, but the documentation usually needs a significant update due to new features.
-  We invite technical writers to select an area (e.g. "plugins for Docker"), and to migrate and update documentation for a number of plugins in such an area.
+  We invite technical writers to select an area (e.g. "plugins for Docker"), and work closely with plugin maintainers to migrate and update documentation in such an area.
   link:/sigs/docs/#plugin-documentation-on-github[More Info]
 
 | Jenkins on Kubernetes
@@ -56,7 +56,7 @@ We encourage proposals based on a technical writer's expertise and interests.
 | AsciiDoc, Guide, Rewrite
 | Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook], and are frequently received to improve the user documentation.
 Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
-We would also like to restructure content to make it more discoverable and easy to read.
+The main aim of this project would be to  restructure content to make it more discoverable and easy to read.
 link:/sigs/docs/#user-guide[More info]
 
 |=========================================================

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -55,7 +55,7 @@ on topics related to Cloud-Native documentation efforts and
 with the link:/sigs/platform[Platform SIG].
 on platform topics.
 
-=== Topics
+== Topics
 
 * Creating new documentation
 * Improving existing documentation
@@ -63,19 +63,19 @@ on platform topics.
 * Coordinating documentation initiatives
 * Reviewing Jenkins Enhancement Proposals (JEPs) related to documentation
 
-=== Contributing
+== Contributing
 
 See link:/participate/document[this page] for information about contributing to Jenkins documentation.
 It contains links for newcomer and seasoned contributors.
 If you have any questions or ideas, please feel free to reach out to us using the channels listed on the right panel.
 
 [[ongoing-projects]]
-=== Projects
+== Projects
 
 This sections lists some of the projects being done under umbrella of this SIG.
 See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
-==== Plugin site integration with GitHub
+=== Plugin site integration with GitHub
 
 link:https://plugins.jenkins.io/[Jenkins Plugin Site] currently uses Jenkins update center and link:https://wiki.jenkins.io/[Jenkins Wiki] as a main source of information to be displayed on the website.
 We have recently added support of plugin documentation from GitHub (link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[announcement]), 
@@ -91,7 +91,7 @@ Useful links:
 * link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20WEBSITE%20AND%20component%20%3D%20plugin-site%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Newbie-friendly issues for the plugin site]
 * link:https://issues.jenkins-ci.org/browse/JENKINS-59467[Template issue for plugin documentation migration to GitHub] (newbie-friendly)
 
-==== Plugin documentation on GitHub
+=== Plugin documentation on GitHub
 
 Currently the SIG is migrating plugin documentation from https://wiki.jenkins.io/ to GitHub.
 Documentation in the plugin GitHub repository provides a good user experience for Jenkins users seeking documentation. 
@@ -106,12 +106,13 @@ It is also a great opportunity to update and copy-edit the documentation.
 
 Useful links:
 
+* link:/blog/2019/10/21/plugin-docs-on-github/[Documentation migration guidelines blog post]
 * link:https://issues.jenkins-ci.org/browse/JENKINS-59467[Template issue for plugin documentation migration to GitHub]
 * link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[Announcement in the developer mailing list]
 * link:/doc/developer/publishing/documentation/#plugin-pages[Using GitHub as a source of plugin documentation]
 
 [[administrator-guide]]
-==== Administrator Guide
+=== Administrator Guide
 
 Jenkins administration topics are included in the current link:/doc/book[Jenkins Handbook].
 Navigation can be improved for administrators by separating the administration topics into a separate volume.
@@ -119,7 +120,7 @@ This project will create a separate Jenkins Administrator Guide with content spe
 This project is tracked in the jira:WEBSITE-738[] EPIC.
 
 [[jenkins-on-kubernetes]]
-==== Jenkins on Kubernetes
+=== Jenkins on Kubernetes
 
 Jenkins on Kubernetes is a popular theme of Jenkins Meetups and presentations at conferences.
 The Jenkins on Kubernetes project will describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
@@ -144,14 +145,14 @@ link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenk
 * link:https://kubernetes.io/blog/2018/04/30/zero-downtime-deployment-kubernetes-jenkins/[Kubernetes project]
 
 [[user-guide]]
-==== User Guide
+=== User Guide Rework
 
 Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
 link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve the user documentation.
 Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
 This project is tracked in the jira:WEBSITE-739[] EPIC.
 
-==== Documentation Reviews
+=== Documentation Reviews
 
 * Reviewing Jenkins documentation link:https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=18640[bug reports]
 * Identifying link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20%22Jenkins%20Website%22%20and%20status%20!%3D%20done%20and%20labels%20%3D%20newbie-friendly%20ORDER%20BY%20%20%20type%20asc%2C%20status%2C%20updatedDate[newbie-friendly documentation bug reports]
@@ -159,7 +160,15 @@ This project is tracked in the jira:WEBSITE-739[] EPIC.
 * Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
 * link:https://plugins.jenkins.io/[Plugins site] improvements
 
-=== Meetings
+=== Google Season of Docs
+
+The https://developers.google.com/season-of-docs/[Google Season of Docs (GSoD)]
+program brings together open source and technical writers communities for the benefit of both.
+The program raises awareness of open source, of docs, and of technical writing.
+
+See link:/sigs/docs/gsod[this page] for more info.
+
+== Meetings
 
 We have regular meetings on the fourth Friday of each month at *1PM UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
@@ -167,7 +176,7 @@ At these meetings we discuss projects, share presentations, and demonstrate new 
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
 
-==== Meeting Agendas
+=== Meeting Agendas
 
 Meeting agendas and meeting notes for the SIG are posted in link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c[this Google Document].
 Anyone is welcome to add a topic for an upcoming meeting by suggesting a change in the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c[agenda].


### PR DESCRIPTION
This pull request initializes the GSoD landing page, including 3 initial project ideas and quick-start/overview documentation for technical writers. I did not follow the GSoC multi-page structure and put everything on a single page for now.

GSoD landing:

![image](https://user-images.githubusercontent.com/3000480/80101132-47c34680-8571-11ea-9166-560be86451c1.png)


Docs SIG page:

![image](https://user-images.githubusercontent.com/3000480/80101040-21051000-8571-11ea-8719-cd94fb8ffbcf.png)

Docs SIG ToC:

![image](https://user-images.githubusercontent.com/3000480/80101077-2f532c00-8571-11ea-91c9-9cb25e721dd2.png)

CC @sladyn98 @markyjackson-taulia @kwhetstone @MarkEWaite 