### PR TITLE
GSoC 2020: Extend and detail the expectations from mentors during the community bonding

### DIFF
--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -272,8 +272,8 @@ Mentors are expected to:
 * Organize your first meeting with the student, within the first week.
   Bring as many contributors as possible there, and make sure to celebrate and to discuss the next steps.
 * Set the pace, establish your regular meeting times together.
-* Firm up on the main communication channels (chats or mailing lists).
-  GSoC org admins can help you to create ones if needed
+* Agree on the main communication channels (chats or mailing lists).
+  GSoC org admins can help you to create communication channels if needed
 * Help the student to do first contributions to the project if it has not happened before.
   Newbie-friendly issues might be a good start.
   Get them merged and released as soon as possible
@@ -318,7 +318,7 @@ Mentors are expected to:
 * ensure their student presents their project (presentation and demo) at a public meeting in the style of an on-line meetup.
 ** We record these presentations and publish them on YouTube.
 * evaluate their student by comparing the student project plan with the actual code produced.
-** There is usually great flexibility as we allow mentors and students to agree on what the expectation are in terms of features and content.
+** There is usually great flexibility as we allow mentors and students to agree on what the expectations are in terms of features and content.
 * fill in the GSoC evaluation form and provide written feedback in that form to their student and to the Google GSoC organization.
 
 This period is a good time to review the Jira tickets and prepare the tickets for the next coding phase.

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -60,8 +60,8 @@ Mentors are expected to...
 *** You could create a Q&A in the project description details where questions are anonymized
 
 Mentoring does **NOT** require strong expertise in Jenkins plugin development.
-The main objective is to guide students and to get them involved into the Jenkins community.
-GSoC org admins will help to find advisers if a special expertise is needed.
+The main objective is to guide students and to get them involved in the Jenkins community.
+GSoC org admins will help to find advisers if any special expertise is needed.
 
 GSoC is an international program.
 Some events and deadlines in the timeline may coincide with holidays and celebrations around the world.
@@ -70,7 +70,7 @@ Although we do our best to accommodate everyone, it is impossible to change the 
 
 == Expectations from mentors per phase
 
-We have divided what mentors should expect in the different phases.
+We have divided what mentors should expect in different phases.
 Always refer to the link:https://summerofcode.withgoogle.com/how-it-works/#timeline[Official GSoC Timeline] for the official timeline, phases and their duration.
 As soon as you become a registered mentor, you will receive via email all timeline updates and reminders.
 
@@ -102,7 +102,7 @@ During this phase, the mentor responsibilities are:
 You can also:
 
 * Engage with prospective students in Gitter and the mailing lists
-* Encourage students to study code and send newbie friendly pull-requests
+* Encourage students to study code and send newbie-friendly pull-requests
 * Ensure the project ideas you are interested in are discussed in the community with subject matter experts and potential users
 
 Optionally, you can:
@@ -268,11 +268,16 @@ Year after year, if this phase goes well, the rest of the program usually goes w
 
 Mentors are expected to:
 
-* Do not delay, start this phase immediately
-* Organize your first official meeting with the student, within the first week.
+* Send a welcome message to their student within 24 hours after the projects are announced (link:https://developers.google.com/open-source/gsoc/timeline[GSoC timeline])
+* Organize your first meeting with the student, within the first week.
+  Bring as many contributors as possible there, and make sure to celebrate and to discuss the next steps.
 * Set the pace, establish your regular meeting times together.
-* Firm up on the main communication channels.
-* Make sure the student works on a detailed plan and one a design document
+* Firm up on the main communication channels (chats or mailing lists).
+  GSoC org admins can help you to create ones if needed
+* Help the student to do first contributions to the project if it has not happened before.
+  Newbie-friendly issues might be a good start.
+  Get them merged and released as soon as possible
+* Make sure the student has a detailed plan and a design document for the first coding phase before it starts
 * Get the student to create issues in Jira for the work items of the coming coding phase
 
 We have written a guide for this phase, link:../students/#community-bonding[read it] and follow it.
@@ -311,9 +316,9 @@ Coding seldom completely stops during this period.
 Mentors are expected to:
 * ensure that the student creates a presentation and prepares a demo
 * ensure their student presents their project (presentation and demo) at a public meeting in the style of an on-line meetup.
-** We record these presentation and publish them on youtube.
+** We record these presentations and publish them on YouTube.
 * evaluate their student by comparing the student project plan with the actual code produced.
-** There is usually great flexibility as we allow mentor and student to agree on what the expectation are in terms of features and content.
+** There is usually great flexibility as we allow mentors and students to agree on what the expectation are in terms of features and content.
 * fill in the GSoC evaluation form and provide written feedback in that form to their student and to the Google GSoC organization.
 
 This period is a good time to review the Jira tickets and prepare the tickets for the next coding phase.
@@ -330,13 +335,13 @@ If not, let the Org Admins know as soon as possible.
 Many students ask their mentors how they can continue to contribute after the program.
 
 You could setup one-on-one on-line meeting with the student on a monthly basis.
-You can invite the student to the SIG meetings or other community meetings.
+You can invite the student to SIG or other community meetings.
 Jenkins also has on-line meetups with various people presenting that the student might be interested in joining.
 
 Usually, you can invite the student to look at the bugs and features that have been captured
 in Jira during the coding phases for inspiration on what to do next.
 You can also invite students to apply next year as a student or even as a mentor.
-Students like to see their project continue, and becoming a mentor is a great way to make that happen.
+Students like to see their projects continue, and becoming a mentor is a great way to make that happen.
 
 Google organizes a mentor summit a few months after the program has ended.
 Each year, the Jenkins Org Admins select 2 mentors who get to go to that summit
@@ -360,7 +365,7 @@ Here are some posts by mentors from past years conferences:
 The GSoC program lasts several months.
 We know people go on vacation and need to take time off from their regular day job.
 We are flexible.
-This is one of the reason why we also assign at least two mentors per student.
+This is one of the reasons why we also assign at least two mentors per student.
 Make sure you timely communicate your availability to your student, your co-mentors, and the org admins.
 
 If you must withdraw from the program completely, let the Jenkins Org Admins know as soon as possible.


### PR DESCRIPTION
This changes clarifies and extends some items for the community bonding period. Also, I fixed some spelling entries while I was around.