### PR TITLE
Revamp the Documentation menu in the toolbar

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -29,17 +29,35 @@
         = partial("dropdown.html.haml", :name => "Documentation")
 
         .dropdown-menu
-          %a.dropdown-item{:href => expand_link('doc')}
-            Use Jenkins
-          %a.dropdown-item{:href => expand_link('doc/developer')}
-            Extend Jenkins
-          %span.dropdown-item
+          %a.dropdown-item.feature{:href => expand_link('doc/book')}
             %strong
-              Use-cases
-          - site.solutions.keys.sort.each do |key|
-            - link = expand_link("solutions/#{key}")
-            %a.dropdown-item.feature{:href => link, :class => active_link?(key.to_s)}
-              = '&nbsp;-&nbsp;' + site.solutions[key].usecase
+              User Guide
+          %a.dropdown-item{:href => expand_link('doc/book/installing/')}
+            = '&nbsp;-&nbsp;Installing Jenkins'
+          %a.dropdown-item{:href => expand_link('doc/book/pipeline')}
+            = '&nbsp;-&nbsp;Jenkins Pipeline'
+          %a.dropdown-item{:href => expand_link('doc/book/managing/')}
+            = '&nbsp;-&nbsp;Managing Jenkins'
+          %a.dropdown-item{:href => expand_link('doc/book/system-administration')}
+            = '&nbsp;-&nbsp;System Administration'
+          %a.dropdown-item{:href => expand_link('doc/book/glossary/')}
+            = '&nbsp;-&nbsp;Terms and Definitions'
+          %a.dropdown-item{:href => expand_link('solutions')}
+            %strong
+              Solution Pages
+          %a.dropdown-item{:href => expand_link('doc/tutorials/')}
+            %strong
+              Tutorials
+          %a.dropdown-item{:href => expand_link('doc/pipeline/tour/getting-started/')}
+            = '&nbsp;-&nbsp;Guided Tour'
+          %a.dropdown-item{:href => expand_link('doc/tutorials/')}
+            = '&nbsp;-&nbsp;More Tutorials'
+          %a.dropdown-item.feature{:href => expand_link('doc/developer')}
+            %strong
+              Developer Guide
+          %a.dropdown-item{:href => expand_link('participate')}
+            %strong
+              Contributor Guide
 
       %li.nav-item{:class => active_link?('plugins')}
         %a.nav-link{:href => 'https://plugins.jenkins.io/'}


### PR DESCRIPTION
This change removes references to dated solution pages  and instead of that emphasizes sections of the User Guide which might be more relevant to users. I also added links to the contributor Guidelines, because why not?

I deliberately skipped the following Jenkins Handbook sections:

- https://www.jenkins.io/doc/book/using/ . This section is nearly empty 😢 
- https://www.jenkins.io/doc/book/blueocean/ . Maintenance state concerns
- "Tutorial Blog Posts" - should be refactored and just added to Tutorials as links

Before:

![image](https://user-images.githubusercontent.com/3000480/80232428-2f2c5c80-8655-11ea-864e-19fdcdd6da0e.png)


After:

![image](https://user-images.githubusercontent.com/3000480/80232396-1de35000-8655-11ea-9587-8e4938719753.png)
