### PR TITLE
Add online and local meetup references to the events page

### DIFF
--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -12,6 +12,28 @@ notitle: true
 
 .container
   .row
+    .col
+      %h1
+        Jenkins Events
+      %p
+        There are many online and local Jenkins-related events: including conferences, meetups, webinars, hackathons, etc.
+        
+      %ul
+        %li
+          %a{:href => expand_link("event-calendar")}
+            Event Calendar
+          These and other periodic events can be found on the Jenkins project.
+        %li
+          %a{:href => expand_link("events/online-meetup")}
+            Jenkins Online Meetup
+          Our project has a virtual meetup for users and developers.
+          We organize regular events and webinars there.
+        %li
+          %a{:href => expand_link("projects/jam")}
+            Local meetups
+          Jenkins contributors organize many local CI/CD and Jenkins meetups around the world.
+          There might be one in your city!
+  .row
     %h1
       Recurring Events
   .row
@@ -94,20 +116,12 @@ notitle: true
                 Docs SIG Meeting
 
   .row
-    .col
-      %h2
-        Event Calendar
-      %p
-        These and other periodic events can be found on the Jenkins project
-        %a{:href => '/content/event-calendar'}
-          event calendar.
-
-  .row
     %h1
       Upcoming Events
   .row
     - # Sort by the date defined for each of the events
     - now = Time.now.utc
+    - no_events = true
     - site.events.keys.each do |name|
       - data = site.events[name]
       - raise ArgumentError.new("No `date` specified: #{name}")  unless data.date
@@ -118,6 +132,7 @@ notitle: true
       - data = site.events[name]
       - event_time = data.event_time
       - next unless event_time > now
+      - no_events = false
       - raise ArgumentError.new("No `location` specified: #{name}") unless data.location
       .col-md-3.text-center
         %ul.ji-item-list
@@ -144,3 +159,10 @@ notitle: true
               .more
 
             .attrs
+    - if no_events
+      %p
+        There is no upcoming events registered in the Jenkins project.
+        If you see that your event is missing, please submit a change to our website.
+      %p
+        %a.body{:href => 'https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-an-event', :target => '_blank'}
+          How to add an event to the Jenkins website?

--- a/content/events/online-meetup/index.adoc
+++ b/content/events/online-meetup/index.adoc
@@ -10,11 +10,16 @@ opengraph:
   image: /images/logos/worldwide/worldwide.png
 ---
 
-Jenkins project has a link:https://www.meetup.com/Jenkins-online-meetup/[virtual meetup group] for Jenkins users and developers around the world.
+Our project has a link:https://www.meetup.com/Jenkins-online-meetup/[virtual meetup group] for users and developers around the world.
 The aim of this group is to conduct regular online webinars about Jenkins.
-We also record these meetups and publish them on link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaOfwJ-BMZo_JNTIMCMNxlbN[our YouTube Channel].
+We record these meetups and publish them on link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaOfwJ-BMZo_JNTIMCMNxlbN[our YouTube Channel].
+The majority of the online meetups are held in English, but we also host virtual events in other languages.
 
 image:/images/logos/worldwide/256.png[Jenkins Online Meetup logo, role=center, float=right]
+
+The meetup is managed under the umbrella of the link:/sigs/advocacy-and-outreach[Jenkins Advocacy and Outreach] special interest group.
+
+== Areas of interest
 
 Areas of interest for this meetup include but not limited to...
 
@@ -24,9 +29,6 @@ Areas of interest for this meetup include but not limited to...
 * Jenkins on classic and cloud platforms (e.g. Docker, Kubernetes or Windows)
 * Jenkins development and developer tools
 * Key public events related to the link:/project/governance[Jenkins governance]
-
-The meetup is managed under the umbrella of the link:/sigs/advocacy-and-outreach[Jenkins Advocacy and Outreach] special interest group.
-The vast majority of the online meetups are held in English, but we can host virtual events in other languages.
 
 == Speaking
 


### PR DESCRIPTION
Out events page is slightly dated, and it looks pretty bad when there is no upcoming events (like now). I suggest putting some text there sot that we could at least link users to other event listings.

![image](https://user-images.githubusercontent.com/3000480/80238299-7cf99280-865e-11ea-8698-b0462b6690b9.png)
