### PR TITLE
Avoid missing method error

### DIFF
--- a/content/solutions/index.html.haml
+++ b/content/solutions/index.html.haml
@@ -30,8 +30,9 @@ noanchors: true
 .grid-container.small
   - site.solutions.sort.each do |key, solution|
   - link = expand_link("solutions/#{key}")
-    %a.card{:style=>"background-color:#{solution[:color]}", :href => link, :class=> solution[:dark] ? "dark" : "light"}
+  - cssClass = solution[:dark] ? "dark" : "light"
+    %a.card{:style => "background-color:#{solution[:color]}", :href => link, :class => cssClass}
       .content.text-center
         %h3
-          = solution.usecase
+          = solution[:usecase]
         %img{:src => "/images/solution-images/#{key}.svg"}


### PR DESCRIPTION
Accessing hash properties as methods seems unreliable (see comments in #3118), this should fix it.

CC @oleg-nenashev @MarkEWaite 