### PR TITLE
Adjust GSoC jumbotron for May 4 announcement

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -53,11 +53,11 @@ homepage: true
   :image => {:src => expand_link('images/cdf/logo/cdf-logo-white.png'), :height => "250px"},
   :call_to_action => {:text => 'Learn about CDF', :href => 'https://cd.foundation'}}
 
-// TODO(oleg-nenashev): Remove on Mar 31 
+// TODO(oleg-nenashev): Replace on May 4 with announcement link
 -# GSoC 2020
 - slides << {:href => expand_link('projects/gsoc/'),
-  :title => 'GSoC 2020: Call for student proposals',
-  :intro => "Jenkins project will be a mentoring organization in Google Summer of Code 2020. We are looking for students and mentors, join us! Applications close on Mar 30.",
+  :title => 'GSoC 2020: Student Projects',
+  :intro => "Jenkins project will be a mentoring organization in Google Summer of Code 2020. Student projects will be announced May 4. Stay tuned!",
   :image => {:src => expand_link('images/gsoc/jenkins-gsoc-transparent.png'), :height => "300px"},
   :call_to_action => {:text => 'More info', :href => expand_link('projects/gsoc/')}}
 


### PR DESCRIPTION
## Prepare readers for May 4 announcement

Google Summer of Code will announce accepted student projects May 4, 2020.