### PR TITLE
Updating end of month regular status meeting

### DIFF
--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -85,7 +85,7 @@ Some examples of such posts/guides:
 
 Meetings are held every Friday at 9:00 AM PST. You can find more details by visiting the link:/event-calendar/[community calendar]
 Prior to each meeting a link to the meeting and meeting notes are provided in the link:https://gitter.im/jenkinsci/pipeline-authoring-sig[Jenkins Pipeline-Authoring Gitter]
-The last Friday of every month, the meeting is dedicated to link:https://www.jenkins.io/project/roadmap/[roadmap] discussions and statuses.
+The last Friday of every month, the meeting is dedicated to link:/project/roadmap/[roadmap] discussions and statuses.
 
 === Code of Conduct
 

--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -85,6 +85,7 @@ Some examples of such posts/guides:
 
 Meetings are held every Friday at 9:00 AM PST. You can find more details by visiting the link:/event-calendar/[community calendar]
 Prior to each meeting a link to the meeting and meeting notes are provided in the link:https://gitter.im/jenkinsci/pipeline-authoring-sig[Jenkins Pipeline-Authoring Gitter]
+The last Friday of every month, the meeting is dedicated to link:https://www.jenkins.io/project/roadmap/[roadmap] discussions and statuses.
 
 === Code of Conduct
 


### PR DESCRIPTION
As detailed in the [mailing list](https://groups.google.com/forum/#!topic/jenkins-pipeline-authoring-sig/3c4_ahmlYic), this update will move the last Friday of the months pipeline-authoring SIG meeting to roadmap discussions and statuses.
There has been no objection in the mailing list and the recording where this was discussed and approved by members of the sig is [here](https://www.youtube.com/watch?v=I6E5zAKjobo&list=PLN7ajX_VdyaOKKLBXek6iG8wTS24Ac7Y3&index=15&t=2s).
Once this PR is merged, I will update the Jenkins events calendar.
Thanks kindly 😺 