### PR TITLE
Add changelog and upgrade guide for 2.222.3, edit 2.222.2

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -3448,6 +3448,19 @@
 
 - version: 2.222.2
   date: 2020-04-22
+  banner: >
+    Jenkins 2.222.2 was not packaged or delivered.
+    All changes planned for 2.222.2 are included in 2.222.3.
+  changes:
+  - type: bug
+    category: internal
+    authors:
+    - kohsuke
+    message: |-
+      Jenkins 2.222.2 was not placed in the artifact repository or on the download site.
+
+- version: 2.222.3
+  date: 2020-04-24
   changes:
   - type: major bug
     category: major bug

--- a/content/_data/upgrades/2-222-2.adoc
+++ b/content/_data/upgrades/2-222-2.adoc
@@ -1,1 +1,2 @@
+Jenkins 2.222.2 release was not delivered to the downloads site or to the artifact repository.
 No notable changes requiring upgrade notes.

--- a/content/_data/upgrades/2-222-3.adoc
+++ b/content/_data/upgrades/2-222-3.adoc
@@ -1,0 +1,1 @@
+No notable changes requiring upgrade notes.


### PR DESCRIPTION
Correct the entries for Jenkins 2.222.2.  Jenkins 2.222.2 was not released to the artifact repository or the downloads site.

![image](https://user-images.githubusercontent.com/156685/80287146-0657a600-86ed-11ea-9dfb-f5e3a54e4fe7.png)

