### PR TITLE
Fixed distribution link that is not clickable

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -20,7 +20,7 @@ For many users, they download Jenkins first, then select some plugins and config
 It might take a lot of time, like hours. But if we can get a perfect Jenkins distribution which contains all we need, 
 it can save that time for us.
 
-The service could be in the form of a website offered as https://customize.jenkins.io.
+The service could be in the form of a website offered as \https://customize.jenkins.io.
 Plus, it should support self-hosting by Jenkins users who want to run it internally. 
 People can select the following configuration items:
 


### PR DESCRIPTION
The link in question is on a gsoc(Google Summer of Code) project idea details page. That link was stated there as an example but to avoid confusion and in order to make it non-clickable I have backslashed it.
Closes https://github.com/jenkins-infra/jenkins.io/issues/3114
![Screenshot from 2020-04-26 14-02-41](https://user-images.githubusercontent.com/28837406/80302773-bac6fa00-87c9-11ea-9941-c8bade2c09b0.png)
