### PR TITLE
Update the infrastructure provisioning section

### DIFF
--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -44,9 +44,10 @@ link:https://docs.google.com/document/d/1uNneXKcIYrpBtfkkfWvtSWYgZ-6rgf4YvCqxJqB
 
 == Infrastructure
 === Provisioning
-The Jenkins project has a link:/blog/2016/05/18/announcing-azure-partnership/[partnership] with Microsoft to run the infrastructure on Azure. This infrastructure is provisioned from the repository https://github.org/jenkins-infra/azure[jenkins-infra/azure] using Terraform.
+The Jenkins project runs the most of its infrastructure on Azure, sponsored by link:https://cd.foundation/[Continuous Delivery Foundation].
+This infrastructure is provisioned from the repository https://github.org/jenkins-infra/azure[jenkins-infra/azure] using Terraform and using AKS link:https://github.com/jenkins-infra/charts/[charts].
 
-While we try to stick to Azure, we still have machines sponsored by different organizations such as OSUOSL, Rackspace or CloudBees. 
+While we try to stick to Azure, we still have machines sponsored by different organizations such as OSUOSL, AWS, Rackspace or CloudBees. 
 
 === Configuration Management
 


### PR DESCRIPTION
Removes the link to Azure sponsorship, minor cleanup for the rest