### PR TITLE
Use quoted strings for YAML keys

### DIFF
--- a/content/solutions/index.html.haml
+++ b/content/solutions/index.html.haml
@@ -30,9 +30,9 @@ noanchors: true
 .grid-container.small
   - site.solutions.sort.each do |key, solution|
   - link = expand_link("solutions/#{key}")
-  - cssClass = solution[:dark] ? "dark" : "light"
-    %a.card{:style => "background-color:#{solution[:color]}", :href => link, :class => cssClass}
+  - cssClass = solution["dark"] ? "dark" : "light"
+    %a.card{:style => "background-color:#{solution["color"]}", :href => link, :class => cssClass}
       .content.text-center
         %h3
-          = solution[:usecase]
+          = solution["usecase"]
         %img{:src => "/images/solution-images/#{key}.svg"}


### PR DESCRIPTION
Output of YAML.load actually uses strings rather than symbols as keys. Converting hash into AStruct makes them available using either string or symbol or method:
https://github.com/awestruct/awestruct/blob/master/lib/awestruct/astruct_mixin.rb#L19
https://github.com/awestruct/awestruct/blob/master/lib/awestruct/astruct_mixin.rb#L39

As identified in #3120 the hash->AStruct conversion sometimes doesn't happen. Using symbols instead of methods has only hidden the problem. Hopefully, this is the actual fix.