### PR TITLE
Contributing: Move author metadata guide to a separate section

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -161,7 +161,6 @@ it is recommended that you refer to the
 link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[quick reference]
 to become more familiar with what is available.
 
-
 === Adding a blog post
 
 In order to add a new blog post, create a new file ending in **.adoc** (for
@@ -212,31 +211,8 @@ To see tags people have used before:
 egrep -h '^- [^ ]+$' content/blog/*/*/*.adoc | sort | uniq -c
 ----
 
-The `author` attribute will map your
-GitHub name to author information, if this is your first time adding a blog
-post, please also create an "author" file in `content/_data/authors/` with the
-file named `yourgithubname.adoc`. The format of this file should be:
-
-.yourgithubname.adoc
-[source, asciidoc]
-----
----
-name: "Your Display Name"
-twitter: meontwitter
-github: yourgithubname
----
-
-This is an *AsciiDoc* formatted bio, but it is completely optional!
----
-----
-
-Only the `name:` and `github:` sections are mandatory.
-
-You may also add an avatar image file for yourself in `content/images/avatars/`
-with the file named `yourgithubname.jpg`.
-You can use an image file with one of the following extensions:
-`.bmp`, `.gif`, `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg`.
-
+The `author` attribute will map your GitHub name to author information which will be displayed in the blogpost.
+If this is your first time adding a blog post, please create an author file as documented in the section below.
 Once your author file is defined, you can return to your blog post file
 (`1970-01-01-hello-world.adoc`), finish creating the "front matter" and then
 write your blog post!
@@ -262,6 +238,33 @@ TIP: If you're unfamiliar with the AsciiDoc syntax, please consult this
 link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[handy quick
 reference guide].
 
+=== Adding contributor/author info
+
+Contributor info might be needed for creating a blogpost,
+but it is also used in other locations to reference contributors (e.g. in GSoC projects or SIG pages).
+
+Please also create an "contributor" file in `content/_data/authors/` with the file named `yourgithubname.adoc`.
+The format of this file should be:
+
+.yourgithubname.adoc
+[source, asciidoc]
+----
+---
+name: "Your Display Name"
+twitter: meontwitter
+github: yourgithubname
+---
+
+This is an *AsciiDoc* formatted bio, but it is completely optional!
+---
+----
+
+Only the `name:` and `github:` sections are mandatory.
+
+You may also add an avatar image file for yourself in `content/images/avatars/`
+with the file named `yourgithubname.jpg`.
+You can use an image file with one of the following extensions:
+`.bmp`, `.gif`, `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg`.
 
 === Adding documentation
 


### PR DESCRIPTION
we use authors not only for blogposts, but also for some other use-cases. 
Having a hyperlink would not hurt.