### PR TITLE
Update author info: Fix erroneous twitter handle

### DIFF
--- a/content/_data/authors/jonbrohauge.adoc
+++ b/content/_data/authors/jonbrohauge.adoc
@@ -1,6 +1,6 @@
 ---
 name: "Jon Brohauge"
-twitter: jonbrohauge
+twitter: brohauge
 github: jonbrohauge
 ---
 


### PR DESCRIPTION
Apparantly made a "under the head" typo last year.