### PR TITLE
Contributing: Introduce a Triage team and Maintainer Guide, define ownership areas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,10 @@ content/conduct.adoc @jenkins-infra/board
 content/donate.adoc @jenkins-infra/board
 content/press.adoc @jenkins-infra/board
 
-# content/security - Security Team
+# Security and advisories
+content/security @jenkins-infra/security
+
+# Teams without GitHub aliases
 # content/events - Event organizers, Advocacy and Outreach SIG
 # contents/sigs - Special interest group leaders, unless another process is defined
 # contents/project - Project teams

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
-# All website content
+## See the maintainer guide in CONTRIBUTING.adoc for more details
+# All website content (default "area")
 content/ @jenkins-infra/copy-editors
 
 # Governance documents
@@ -6,6 +7,11 @@ content/project/ @jenkins-infra/board
 content/conduct.adoc @jenkins-infra/board
 content/donate.adoc @jenkins-infra/board
 content/press.adoc @jenkins-infra/board
+
+# content/security - Security Team
+# content/events - Event organizers, Advocacy and Outreach SIG
+# contents/sigs - Special interest group leaders, unless another process is defined
+# contents/project - Project teams
 
 # GSoC
 content/projects/gsoc/ @jenkins-infra/gsoc

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -638,7 +638,7 @@ Areas not in this file are considered as _common areas_ and maintained by teams 
 
 There are 2 teams which maintain the majority of the website content except special areas:
 
-* link:https://github.com/orgs/jenkins-infra/teams/jenkins-io-triage[Triage] team which performs triage and reviews the submitted issues and pull requests
+* link:https://github.com/orgs/jenkins-infra/teams/jenkins-io-triage[Triage] team which performs triage and reviews the submitted issues and pull requests.
 * link:https://github.com/orgs/jenkins-infra/teams/copy-editors[Copy Editors] team which, in addition to reviews and triage, has permissions to copy-edit and merge submitted changes.
 
 Both teams operate under the umbrella of link:https://www.jenkins.io/sigs/docs/[Jenkins Documentation Special Interest Group] led by the link:https://www.jenkins.io/project/team-leads/#documentation[Documentation Officer].
@@ -675,9 +675,9 @@ Some tips for contributors:
 === Merging changes in common areas
 
 Common area process applies when there is no special ownership or process defined.
-Pull requests to common areas can be merged by any _Copy Editor_ once...
+Pull requests to common areas can be merged by any _Copy Editor_ once all of the following apply:
 
-* Conversations in the pull request are over OR it is explicit that a reviewer does not block the change (often indicated by line comments attached to an approving PR review, or by using the term "nit", from "nit-picking")
+* Conversations in the pull request are completed OR it is explicit that a reviewer does not block the change (often indicated by line comments attached to an approving PR review, or by using the term "nit", from "nit-picking")
 * There are enough approvals
 ** For trivial changes (typo fixes, minor improvements) - 1 approval from a _Copy Editor_
 ** For major changes - at least 2 approvals from reviewers.
@@ -687,7 +687,7 @@ Pull requests to common areas can be merged by any _Copy Editor_ once...
 
 Special areas are managed by their owners.
 _Copy Editors_ should not merge substantial changes in these areas unless they get explicit sign-off from owners identified in the link:/.github/CODEOWNERS[CODEOWNERS].
-Minor changes like typo fixes might be integrated _Copy Editors_.
+Minor changes like typo fixes might be integrated by _Copy Editors_.
 
 [[user-site]]
 == Deploying jenkins.io on GitHub pages

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -678,7 +678,7 @@ Common area process applies when there is no special ownership or process define
 Pull requests to common areas can be merged by any _Copy Editor_ once...
 
 * Conversations in the pull request are over OR it is explicit that a reviewer does not block the change (often indicated by line comments attached to an approving PR review, or by using the term "nit", from "nit-picking")
-* There are enough approvals 2 approvals...
+* There are enough approvals
 ** For trivial changes (typo fixes, minor improvements) - 1 approval from a _Copy Editor_
 ** For major changes - at least 2 approvals from reviewers.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -630,7 +630,6 @@ Notable special areas:
 * Security pages and advisories under `jenkins.io/security/` - Managed by the link:https://www.jenkins.io/security/team/[Jenkins Security Team]
 * Event pages under `jenkins.io/events/` - Managed by event organizers, link:https://www.jenkins.io/sigs/advocacy-and-outreach/[Advocacy and Outreach SIG] and the link:https://www.jenkins.io/project/team-leads/#events[Jenkins Events Officer]
 * SIG and sub-project pages - Managed by teams
-* etc.
 
 Areas not in this file are considered as _common areas_ and maintained by teams listed below.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -612,25 +612,82 @@ vector: '/images/logos/${imageId}/${imageId}.svg'
 credit: 'Your Name'
 credit_url: 'https://twitter.com/yourtwitteraccount'
 ```
+== Maintainer guide
+
+This section contains information for contributors who are interested to help with the Jenkins website maintenance.
+
+=== Website structure and ownership
+
+The Jenkins website hosts various content: user and developer documentation, blog, governance materials, pages for special interest groups and sub-projects, etc.
+This information is maintained by multiple teams.
+Ownership domains are also defined in the link:/.github/CODEOWNERS[CODEOWNERS] file.
+Note that this file might be out of date or missing some entries, so common sense there applies.
+
+Notable special areas:
+
+* link:https://jenkins.io/project[Governance documents] - Managed by the link:https://www.jenkins.io/project/board/#current-board-members[Governance Board]
+* Jenkins core changelogs - Managed by the link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc#roles[Jenkins core maintainers]
+* Security pages and advisories under `jenkins.io/security/` - Managed by the link:https://www.jenkins.io/security/team/[Jenkins Security Team]
+* Event pages under `jenkins.io/events/` - Managed by event organizers, link:https://www.jenkins.io/sigs/advocacy-and-outreach/[Advocacy and Outreach SIG] and the link:https://www.jenkins.io/project/team-leads/#events[Jenkins Events Officer]
+* SIG and sub-project pages - Managed by teams
+* etc.
+
+Areas not in this file are considered as _common areas_ and maintained by teams listed below.
+
+=== Teams and roles
+
+There are 2 teams which maintain the majority of the website content except special areas:
+
+* link:https://github.com/orgs/jenkins-infra/teams/jenkins-io-triage[Triage] team which performs triage and reviews the submitted issues and pull requests
+* link:https://github.com/orgs/jenkins-infra/teams/copy-editors[Copy Editors] team which, in addition to reviews and triage, has permissions to copy-edit and merge submitted changes.
+
+Both teams operate under the umbrella of link:https://www.jenkins.io/sigs/docs/[Jenkins Documentation Special Interest Group] led by the link:https://www.jenkins.io/project/team-leads/#documentation[Documentation Officer].
+
+=== Joining the teams
+
+If you are interested to join the Triage or Copy Editors team, 
+you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list] or in the link:https://www.jenkins.io/sigs/docs/[Documentation SIG channels].
+The request will be processed and discussed by the community, and then the link:https://www.jenkins.io/project/team-leads/#documentation[documentation officer] will make a decision.
+
+Eligibility requirements:
+
+* Membership in both teams requires a track of contributions to the Jenkins website and/or documentation.
+  _Triage_ team is effectively an onboarding team for contributors interested in becoming copy editors,
+  and this team has a low entry bar.
+* Applicants to the _Copy Editors_ team should have a signed link:https://github.com/jenkinsci/infra-cla[Contributor License Agreement].
 
 [[reviewing]]
-== Reviewing changes
+=== Reviewing changes
 
 There are many pull requests being submitted to jenkins.io every week.
 Reviews are driven by the community, and any contributions are always welcome.
-There is also a link:https://github.com/orgs/jenkins-infra/teams/copy-editors[Copy Editors] team which performs reviews and merges, 
-but such reviews may take some time depending on availability of contributors.
+Reviews may take some time depending on availability of contributors.
 
-Some tips:
+Some tips for contributors:
 
 * Pull requests are open to public, and any GitHub user can review changes and provide feedback.
   If you are interested to review changes, please just do so (and thanks in advance!). 
   No special permissions needed
 * If you need help with reviews for documentation changes,
-  you can in the link:https://gitter.im/jenkinsci/docs[Documentation SIG Gitter channel].
-* If you are interested to join the Copy Editors team, 
-  you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list].
-  Such membership requires a track of contributions to Jenkins, and also a signed link:https://github.com/jenkinsci/infra-cla[Contributor License Agreement]
+  you can ask in the link:https://gitter.im/jenkinsci/docs[Documentation SIG Gitter channel].
+
+[[merging-common]]
+=== Merging changes in common areas
+
+Common area process applies when there is no special ownership or process defined.
+Pull requests to common areas can be merged by any _Copy Editor_ once...
+
+* Conversations in the pull request are over OR it is explicit that a reviewer does not block the change (often indicated by line comments attached to an approving PR review, or by using the term "nit", from "nit-picking")
+* There are enough approvals 2 approvals...
+** For trivial changes (typo fixes, minor improvements) - 1 approval from a _Copy Editor_
+** For major changes - at least 2 approvals from reviewers.
+
+[[merging-special-areas]]
+=== Merging changes in special areas
+
+Special areas are managed by their owners.
+_Copy Editors_ should not merge substantial changes in these areas unless they get explicit sign-off from owners identified in the link:/.github/CODEOWNERS[CODEOWNERS].
+Minor changes like typo fixes might be integrated _Copy Editors_.
 
 [[user-site]]
 == Deploying jenkins.io on GitHub pages


### PR DESCRIPTION
This pull request...

* Introduces a new "maintainer guide" section in CONTRIBUTING
* Documents the Triage Team as discussed in https://groups.google.com/forum/#!topic/jenkinsci-docs/aunhIJbOvbc
* Document ownership for "special areas" so that prevent collisions between @jenkins-infra/copy-editors and owners of these areas. We had very few cases of that, but I think it makes sense to make it explicit since we onboard more contributors
* Extend the review and process documentation
* Add some commented-out ownership sections to `CODEOWNERS` in areas where we do not have GitHub Teams at the moment

FYI @MarkEWaite @timja @vsilverman @sladyn98 @daniel-beck @markyjackson-taulia 