### PR TITLE
Update team-leads.adoc

### DIFF
--- a/content/project/team-leads.adoc
+++ b/content/project/team-leads.adoc
@@ -58,5 +58,5 @@ _note:  This team lead position was approved in the link:http://meetings.jenkins
 Oversees the Jenkins project documentation.
 
 * Enables website/documentation contribution from the community
-* Editor for Jenkins blog
+* Edits the Jenkins blog
 * Leads or is involved with link:/sigs/docs/[Documentation Special Interest Group]


### PR DESCRIPTION
Proposing minor changes to responsibilities of the doc team lead.
Now those responsibilities are starting with verb, describing the actions.