### PR TITLE
Update 2018-04-09-whats-in-declarative.adoc

### DIFF
--- a/content/blog/2018/04/2018-04-09-whats-in-declarative.adoc
+++ b/content/blog/2018/04/2018-04-09-whats-in-declarative.adoc
@@ -126,7 +126,7 @@ conditions, or in `environment` variables.
 ----
 // Declarative //
 pipeline {
-    agent any
+    agent none
     stages {
         stage('Example') {
             input {
@@ -137,6 +137,7 @@ pipeline {
                     string(name: 'PERSON', defaultValue: 'Mr Jenkins', description: 'Who should I say hello to?')
                 }
             }
+            agent any
             steps {
                 echo "Hello, ${PERSON}, nice to meet you."
             }


### PR DESCRIPTION
Adjust the `input` example so that it corresponds to the advice given about not blocking the executor unnecessarily.