### PR TITLE
GSoD 2020: Publish the application draft on the website

### DIFF
--- a/content/projects/gsoc/2020/application.md
+++ b/content/projects/gsoc/2020/application.md
@@ -10,8 +10,7 @@
      Google's GSoC site uses Markdown as an engine, using Markdown here allows copy-pasting
  -->
 
-The data below represents the 2020 GSoC application draft.
-Please feel free to contribute to it by proposing pull requests against the page.
+The data below represents the 2020 GSoC application.
 
 ### Organization Profile
 

--- a/content/sigs/docs/gsod/2020/application.md
+++ b/content/sigs/docs/gsod/2020/application.md
@@ -1,0 +1,97 @@
+---
+:layout: simplepage
+:title: "Jenkins GSoD application draft, 2020"
+:tags:
+- gsod
+- gsod2020
+---
+
+<!-- This file uses Markdown intentionally.
+     The application is actually a plain text, but we use Markdown to follow the GSoC format which is likely to be adopted by GSoD later.
+ -->
+
+The data below represents the Google Season of Docs 2020 application draft.
+
+### Organization Profile
+
+* Name: Jenkins project
+* Website: https://jenkins.io/
+* Contact email for GSoD: jenkinsci-docs@googlegroups.com 
+* GSoD page link: http://jenkins.io/sigs/docs/gsod
+* Does your organization want to accept the mentor stipend? => Yes
+* Link to project ideas list: https://jenkins.io/sigs/docs/gsod#project-ideas 
+
+### Org admins
+
+* Primary: Oleg Nenashev
+* Secondary: Marky Jackson
+
+### Org description
+
+Jenkins, originally founded in 2006 as "Hudson", is one of the leading automation servers.
+The project’s motto is "Build great things at any scale".
+Using extensible, plugin-based architecture developers have created hundreds of plugins to adapt Jenkins to a multitude of build, test, and deployment automation workloads.
+Jenkins is open-source, MIT License is used for most of the components.
+
+The project has thousands of active contributors working on Jenkins core, plugins, website, project infrastructure, localization activities, and, of course, documentation.
+We invite technical writers to join the community and contribute to the documentation being used by millions of Jenkins users worldwide.
+
+### What previous experience has your organization had in the documentation or collaborating with technical writers?
+
+> If you or any of your mentors have worked with technical writers before, or have developed documentation, mention this in your answer.
+> Describe the documentation that you produced and the ways in which you worked with the technical writer.
+> For example, describe any review processes that you used, or how the technical writer's skills were useful to your project.
+> Explain how this previous experience may help you to work with a technical writer in Season of Docs.
+
+In the Jenkins project, we believe that documentation is as important as code.
+In 2019, we introduced an official Documentation Officer role and started a Documentation special interest group (https://jenkins.io/sigs/docs/) 
+which, among other things, coordinates the Google Season of Docs application in the project.
+We have several documentation initiatives listed on our project roadmap: https://jenkins.io/project/roadmap/.
+The Documentation SIG facilitates documentation improvement across the organization.
+In the last quarter, we had 219 unique documentation committers in the organization.
+
+We have extensive documentation on the jenkins.io website (https://jenkins.io/doc/) as well as the plugin site (http://plugins.jenkins.io/).
+This repository has a copy-editors team which assists submitters with reviews of their documentation.
+A large majority of Jenkins components and plugins also have documentation in GitHub and other resources, including user, administrator, developer, and contributor guidelines.
+The Jenkins project hosts a repository for technical specifications called the Jenkins Enhancement Proposals https://github.com/jenkinsci/jep.
+
+The Jenkins project follows the documentation-as-code approach for all new documentation,
+and we use industry-standard tools (Git/GitHub) and markup languages (AsciiDoc, GitHub Flavored Markdown) so that
+Jenkins contribution provides relevant and widely applicable experience to technical writers.
+
+The Jenkins project has a wealth of knowledge working with technical writers.
+A portion of the Jenkins documentation has been created by professional technical writers whose time was donated to the project by company contributors.
+We previously had several coordinated documentation initiatives, e.g. creation of new documentation for Jenkins Pipeline.
+We also facilitate documentation contributions and encourage newcomers to participate (https://jenkins.io/participate/#document), regardless of their experience with Jenkins and our tools.
+We also invest time in contributing guidelines for documentation contributors,
+e.g. here are our contributing guidelines for the website: https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc.
+
+Reviews: jenkins.io and GitHub documentation are managed and reviewed via pull requests.
+For example, there are contribution guidelines for jenkins.io: https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc.
+In the project, we also have a team of copy-editors who review the content: https://github.com/orgs/jenkins-infra/teams/copy-editors.
+Contributions to Jenkins component documentation (e.g. plugin docs) are usually reviewed by maintainers.
+
+We also have channels specifically dedicated to the documentation.
+These channels act as an additional contact point for technical writers in the community:
+
+* Mailing list: https://groups.google.com/forum/#!forum/jenkinsci-docs
+* Chat on Gitter: https://gitter.im/jenkinsci/docs
+* Regular Documentation SIG meetings: https://www.jenkins.io/sigs/docs/#meetings
+
+### What previous experience has your organization had mentoring individuals?
+
+> Comment: If you or any of your mentors have taken part in Google Summer of Code or a similar program that mentors individuals, mention this in your answer.
+> Describe your achievements in that program. Explain how this experience may influence the way you work in Season of Docs.
+
+Jenkins project has successfully participated in Google Summer of Code and Outreachy before, including both programs in 2019 (https://jenkins.io/projects/gsoc/).
+Last year we also ran our first mentorship on CommunityBridge: https://www.jenkins.io/projects/jcasc/dev-tools/.
+In 2019 we had 12 mentees in total.
+The Jenkins project has also been selected for Google Summer of Code 2020.
+The project also has many contributors whose roles at work include mentoring people (university professors and advisors, training leads, developer relations, senior engineers and tech writers).
+As an organization, we do not have particular experience in mentoring technical writers,
+but we do have experience in onboarding documentation contributors to the community.
+We also work on onboarding programs for documentation contributors, e.g. for website copy-editors: https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#maintainer-guide.
+
+### How many technical writers does your organization want to mentor this year?
+
+1

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -117,6 +117,7 @@ Once the projects are announced, other project-specific channels might be create
 * link:/participate/document/[Contributing to Jenkins documentation]
 * link:https://developers.google.com/season-of-docs/docs/tech-writer-guide[GSoD Technical Writer guide]
 * link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
+* link:/sigs/docs/gsod/2020/application[Our GSoD 2020 application]
 
 == Mentors
 
@@ -124,6 +125,7 @@ Once the projects are announced, other project-specific channels might be create
 * link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
 * link:https://developers.google.com/season-of-docs/docs/project-selection[Selecting projects]
 * link:https://developers.google.com/season-of-docs/docs/tech-writer-collaboration[Working with a technical writer]
+* link:/sigs/docs/gsod/2020/application[Our GSoD 2020 application]
 
 [#archive]
 == Previous years


### PR DESCRIPTION
Moves https://docs.google.com/document/d/1dioogEr7KUbzbIXeGRws84VZokFoJNGXRpGv1K6Qs3s/edit?usp=sharing to the website. The document  has passed through several cycles of review, so I consider it as a release-candidate version. Let's use this pull request and the page for future comments