### PR TITLE
Fix Red Hat company name in sponsors hover text

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -19,7 +19,7 @@ homepage: true
     'Continuous Delivery Foundation',
     'https://cd.foundation/'],
     ['redhat.png',
-    'RedHat, Inc.',
+    'Red Hat, Inc.',
     'https://redhat.com'],
     ['aws.png',
     'AWS',


### PR DESCRIPTION
Company is Red Hat, Inc., not RedHat, Inc.