### PR TITLE
Fix Debian install instructions, add Red Hat & CentOS

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -283,7 +283,7 @@ Port `8080` is the most common.
 
 [source,bash]
 ----
-YOUPORT=8080
+YOURPORT=8080
 PERM="--permanent"
 SERV="$PERM --service=jenkins"
 

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -276,14 +276,14 @@ You can start the Jenkins service with the command:
 
 [source,bash]
 ----
-sudo systemctl start jenkins.service
+sudo systemctl start jenkins
 ----
 
 You can check the status of the Jenkins service using the command:
 
 [source,bash]
 ----
-sudo systemctl status jenkins.service
+sudo systemctl status jenkins
 ----
 
 If everything has been set up correctly, you should see an output like this:
@@ -356,14 +356,14 @@ You can start the Jenkins service with the command:
 
 [source,bash]
 ----
-sudo systemctl start jenkins.service
+sudo systemctl start jenkins
 ----
 
 You can check the status of the Jenkins service using the command:
 
 [source,bash]
 ----
-sudo systemctl status jenkins.service
+sudo systemctl status jenkins
 ----
 
 If everything has been set up correctly, you should see an output like this:

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -176,6 +176,11 @@ any operating system or platform that supports Java.
 
 === Linux
 
+Jenkins installers are available for several Linux distributions.
+
+* <<Debian/Ubuntu>>
+* <<Fedora>>
+* <<Red Hat / CentOS>>
 
 ==== Debian/Ubuntu
 
@@ -264,6 +269,91 @@ You can check the status of the Jenkins service using this systemctl command:
 [source,bash]
 ----
 systemctl status jenkins
+----
+
+If everything has been set up correctly, you should see an output like this:
+
+[source,bash]
+----
+Loaded: loaded (/etc/rc.d/init.d/jenkins; generated)
+Active: active (running) since Tue 2018-11-13 16:19:01 +03; 4min 57s ago
+----
+
+[NOTE]
+====
+If you have a firewall installed, you must add Jenkins as an exception.
+You must change `YOURPORT` in the script below to the port you want to use.
+Port `8080` is the most common.
+
+[source,bash]
+----
+YOURPORT=8080
+PERM="--permanent"
+SERV="$PERM --service=jenkins"
+
+firewall-cmd $PERM --new-service=jenkins
+firewall-cmd $SERV --set-short="Jenkins ports"
+firewall-cmd $SERV --set-description="Jenkins port exceptions"
+firewall-cmd $SERV --add-port=$YOURPORT/tcp
+firewall-cmd $PERM --add-service=jenkins
+firewall-cmd --zone=public --add-service=http --permanent
+firewall-cmd --reload
+----
+
+====
+
+==== Red Hat / CentOS
+
+You can install Jenkins through `yum` on Red Hat Enterprise Linux, CentOS, and other Red Hat based distributions.
+You need to choose either the Jenkins Long Term Support release or the Jenkins weekly release.
+
+===== Long Term Support release
+
+A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
+It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
+
+[source,bash]
+----
+sudo wget -O /etc/yum.repos.d/jenkins.repo \
+    https://pkg.jenkins.io/redhat-stable/jenkins.repo
+sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+----
+
+===== Weekly release
+
+A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
+It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum repository.
+
+[source,bash]
+----
+sudo wget -O /etc/yum.repos.d/jenkins.repo \
+    https://pkg.jenkins.io/redhat/jenkins.repo
+sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
+----
+
+===== Install Jenkins
+
+Then, you can install Jenkins.
+The following command also ensures you have java installed.
+
+[source,bash]
+----
+sudo yum upgrade
+sudo yum install jenkins java-1.8.0-openjdk-devel
+----
+
+Next, start the Jenkins service.
+
+[source,bash]
+----
+sudo systemctl start jenkins.service
+----
+
+You can check the status of the Jenkins service using this systemctl command:
+
+[source,bash]
+----
+sudo systemctl status jenkins.service
 ----
 
 If everything has been set up correctly, you should see an output like this:

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -179,14 +179,31 @@ any operating system or platform that supports Java.
 
 ==== Debian/Ubuntu
 
-On Debian-based distributions, such as Ubuntu, you can install Jenkins through `apt`.
+On Debian and Debian-based distributions like Ubuntu you can install Jenkins through `apt`.
 
-Recent versions are available in link:https://pkg.jenkins.io/debian/[an apt repository]. Older but stable LTS versions are in link:https://pkg.jenkins.io/debian-stable/[this apt repository].
+===== Long Term Support release
+
+A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
+It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-stable` apt repository].
+
+[source,bash]
+----
+wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
+sudo sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > \
+    /etc/apt/sources.list.d/jenkins.list'
+sudo apt-get update
+sudo apt-get install jenkins
+----
+
+===== Weekly release
+
+A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
+It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt repository].
 
 [source,bash]
 ----
 wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | sudo apt-key add -
-sudo sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > \
+sudo sh -c 'echo deb https://pkg.jenkins.io/debian binary/ > \
     /etc/apt/sources.list.d/jenkins.list'
 sudo apt-get update
 sudo apt-get install jenkins
@@ -194,7 +211,7 @@ sudo apt-get install jenkins
 
 [NOTE]
 ====
-If you face error "jenkins : Depends: daemon but it is not installable", execute following command after `sudo apt-get update` -
+If an error is reported, "`jenkins : Depends: daemon but it is not installable`", add the link:https://help.ubuntu.com/community/Repositories/Ubuntu["universe" apt repository] of community maintained free and open source software for Ubuntu by executing this command after `sudo apt-get update`:
 [source,bash]
 ----
 sudo add-apt-repository universe

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -242,33 +242,48 @@ Here, "8081" was chosen but you can put another port available.
 
 You can install Jenkins through `dnf`. You need to add the Jenkins repository from the Jenkins website to the package manager first.
 
+===== Long Term Support release
+
+A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
+It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
+
+[source,bash]
+----
+sudo wget -O /etc/yum.repos.d/jenkins.repo \
+    https://pkg.jenkins.io/redhat-stable/jenkins.repo
+sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+sudo dnf upgrade
+sudo dnf install jenkins java-devel
+----
+
+===== Weekly release
+
+A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
+It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum repository.
+
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     http://pkg.jenkins-ci.org/redhat/jenkins.repo
 sudo rpm --import https://jenkins-ci.org/redhat/jenkins-ci.org.key
+sudo dnf upgrade
+sudo dnf install jenkins java-devel
 ----
 
-Then, you can install Jenkins.  The following command also ensures you have java installed.
+===== Start Jenkins
 
-[source,bash]
-----
-sudo dnf upgrade && sudo dnf install jenkins java
-----
-
-Next, start the Jenkins service.
+You can start the Jenkins service with the command:
 
 [source,bash]
 ----
-sudo service jenkins start
-sudo chkconfig jenkins on
+sudo systemctl start jenkins.service
 ----
 
-You can check the status of the Jenkins service using this systemctl command:
+You can check the status of the Jenkins service using the command:
 
 [source,bash]
 ----
-systemctl status jenkins
+sudo systemctl status jenkins.service
 ----
 
 If everything has been set up correctly, you should see an output like this:
@@ -317,6 +332,8 @@ It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+sudo yum upgrade
+sudo yum install jenkins java-1.8.0-openjdk-devel
 ----
 
 ===== Weekly release
@@ -329,27 +346,20 @@ It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum r
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
-----
-
-===== Install Jenkins
-
-Then, you can install Jenkins.
-The following command also ensures you have java installed.
-
-[source,bash]
-----
 sudo yum upgrade
 sudo yum install jenkins java-1.8.0-openjdk-devel
 ----
 
-Next, start the Jenkins service.
+===== Start Jenkins
+
+You can start the Jenkins service with the command:
 
 [source,bash]
 ----
 sudo systemctl start jenkins.service
 ----
 
-You can check the status of the Jenkins service using this systemctl command:
+You can check the status of the Jenkins service using the command:
 
 [source,bash]
 ----

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -192,7 +192,7 @@ title: Jenkins installation and setup
                 %span.icon
                 %span.title
                   Red Hat/Fedora/CentOS
-              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/debian/'}
+              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian/'}
                 %span.icon
                 %span.title
                   Ubuntu/Debian


### PR DESCRIPTION
## Fix Debian install instructions, add Red Hat

Describe LTS and weekly separately for Debian so that users retrieve the correct package signing key for the distribution they are using.  [Install page feedback (row 859)](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) noted that we were providing inconsistent and incorrect instructions for the Debian package signing keys.

This uses https://pkg.jenkins.io for Debian package installation to match with the [existing weekly instructions](http://mirrors.jenkins-ci.org/debian/) and [existing LTS instructions](https://pkg.jenkins.io/debian-stable/).

### LTS Download Pages

* https://pkg.jenkins.io/debian-stable/
* http://pkg.jenkins-ci.org/debian-stable/ (note, this URL is HTTP, not HTTPS)

### Weekly Download Pages

* https://pkg.jenkins.io/debian/
* http://pkg.jenkins-ci.org/debian/ (note, this URL is HTTP, not HTTPS)
* http://mirrors.jenkins.io/debian/ (note, this URL is HTTP, not HTTPS)
* http://mirrors.jenkins-ci.org/debian/ (note, this URL is HTTP, not HTTPS)

Also adds Red Hat / CentOS installation instructions, expands the Fedora instructions to cover both LTS and weekly, and fixes a typographical error in the Fedora firewall configuration instructions.