### PR TITLE
Properly format as Asciidoc

### DIFF
--- a/content/_data/upgrades/2-204-1.adoc
+++ b/content/_data/upgrades/2-204-1.adoc
@@ -15,10 +15,10 @@ java.lang.IllegalStateException: An attempt to save the global configuration
 
 If you encounter this, you can tell the plugin to delay configuration for an amount of time to give Jenkins time to load the global configuration before the configuration is applied by the plugin.
 
-To enable this set the <code>io.jenkins.plugins.casc.ConfigurationAsCode.initialDelay<code> system property to a number of milliseconds to delay the initialisation.
+To enable this set the `io.jenkins.plugins.casc.ConfigurationAsCode.initialDelay` system property to a number of milliseconds to delay the initialisation.
 The required value will be dependant on aspects of your system (cpu/disk) and configuration, and how it can be found is mostly a trial and error.
 A suggestion would be to start with 5000 (5 Seconds) and then increment by 2000 (2 seconds) until you no longer exhibit the issue and finally add 1000 (1 second) for some extra safety.
-For example, to delay the configuration by 9 seconds you would use something like the following command <code>java -Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=9000 -jar jenkins.war</code>.
+For example, to delay the configuration by 9 seconds you would use something like the following command `java -Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=9000 -jar jenkins.war`.
 Exactly how and where you specify this option depends on the installation method used to install Jenkins.
 
 ==== Remove browser-based metadata download settings


### PR DESCRIPTION
https://www.jenkins.io/doc/upgrade-guide/2.204/#global-configuration-save-and-configuration-as-code-plugin is broken otherwise.

Sorry for the origin branch, my local copy is a mess right now I cannot just stash away…