### PR TITLE
Use NonNull annotation instead of deprecated Nonnull

### DIFF
--- a/content/blog/2016/2016-05-25-update-plugin-for-pipeline.adoc
+++ b/content/blog/2016/2016-05-25-update-plugin-for-pipeline.adoc
@@ -132,7 +132,7 @@ public class GatlingArchiverStep extends AbstractStepImpl {
             return "gatlingArchive";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Archive Gatling reports";

--- a/content/blog/2018/08/2018-08-17-code-coverage-api-plugin-1.0-release.adoc
+++ b/content/blog/2018/08/2018-08-17-code-coverage-api-plugin-1.0-release.adoc
@@ -157,7 +157,7 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
             super(JacocoReportAdapter.class);
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.JacocoReportAdapter_displayName();

--- a/content/blog/2019/06/2019-06-21-performance-testing-jenkins.adoc
+++ b/content/blog/2019/06/2019-06-21-performance-testing-jenkins.adoc
@@ -110,13 +110,13 @@ containing the benchmark state.
 @JmhBenchmark
 public class SampleBenchmark {
     public static class MyState extends CascJmhBenchmarkState {
-        @Nonnull
+        @NonNull
         @Override
         protected String getResourcePath() {
             return "config.yml";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         protected Class<?> getEnclosingClass() {
             return SampleBenchmark.class;

--- a/content/doc/developer/extensibility/action-for-all-projects.adoc
+++ b/content/doc/developer/extensibility/action-for-all-projects.adoc
@@ -97,9 +97,9 @@ public class SampleActionFactory extends TransientActionFactory<Project> {
         return Project.class; // <1>
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public Collection<? extends Action> createFor(@Nonnull Project project) {
+    public Collection<? extends Action> createFor(@NonNull Project project) {
         return Collections.singleton(new SampleAction(project)); // <2>
     }
 }

--- a/content/doc/developer/plugin-development/pipeline-integration.adoc
+++ b/content/doc/developer/plugin-development/pipeline-integration.adoc
@@ -156,16 +156,16 @@ If you do not care about XStream hygiene, for example because the `Describable` 
 
 [source,java]
 ----
-@Nonnull
+@NonNull
 private String stuff = DescriptorImpl.defaultStuff;
 
-@Nonnull
+@NonNull
 public String getStuff() {
     return stuff;
 }
 
 @DataBoundSetter
-public void setStuff(@Nonnull String stuff) {
+public void setStuff(@NonNull String stuff) {
     this.stuff = stuff;
 }
 
@@ -189,13 +189,13 @@ and configuration form but _null_ out the default:
 @CheckForNull
 private String stuff;
 
-@Nonnull
+@NonNull
 public String getStuff() {
     return stuff == null ? DescriptorImpl.defaultStuff : stuff;
 }
 
 @DataBoundSetter
-public void setStuff(@Nonnull String stuff) {
+public void setStuff(@NonNull String stuff) {
     this.stuff = stuff.equals(DescriptorImpl.defaultStuff) ? null : stuff;
 }
 ----


### PR DESCRIPTION
Refer to [PR-4604](https://github.com/jenkinsci/jenkins/pull/4604) and [JENKINS-55973](https://issues.jenkins-ci.org/browse/JENKINS-55973) for the rationale.

Replaces the deprecated javax.annotations references with non-deprecated references to the spotbugs annotations package.

The deprecated javax.annotations were removed from Jenkins 2.231 and later.