### PR TITLE
GSoC 2020: Publish the accepted projects

### DIFF
--- a/content/_data/authors/Sagar2366.adoc
+++ b/content/_data/authors/Sagar2366.adoc
@@ -2,7 +2,7 @@
 name: "Sagar Utekar"
 github: "Sagar2366"
 twitter: "named_uttu"
-linkedin: sagar-utekar-b32750116/
+linkedin: sagar-utekar-b32750116
 irc: "Sagar2366"
 ---
 

--- a/content/_data/authors/Sagar2366.adoc
+++ b/content/_data/authors/Sagar2366.adoc
@@ -2,7 +2,7 @@
 name: "Sagar Utekar"
 github: "Sagar2366"
 twitter: "named_uttu"
-linkedin: https://www.linkedin.com/in/sagar-utekar-b32750116/
+linkedin: sagar-utekar-b32750116/
 irc: "Sagar2366"
 ---
 

--- a/content/_data/authors/afalko.adoc
+++ b/content/_data/authors/afalko.adoc
@@ -3,6 +3,7 @@ name: "Andrey Falko"
 linkedin: andrey-falko
 github: afalko
 twitter: Ma3oxuct
+linkedin: andrey-falko
 ---
 
 Andrey has been a long-time Jenkins admin at link:https://salesforce.com[Salesforce] 

--- a/content/_data/authors/ayush_agarwal.adoc
+++ b/content/_data/authors/ayush_agarwal.adoc
@@ -4,6 +4,7 @@ twitter: "aagarwal1012"
 github: "aagarwal1012"
 blog: "https://ayushagarwal.ml/"
 irc: aagarwal1012
+linkedin: aagarwal1012
 ---
 
 Ayush is a developer, speaker, blogger, and learner from Jaipur, India.

--- a/content/_data/authors/baymac.adoc
+++ b/content/_data/authors/baymac.adoc
@@ -2,6 +2,7 @@
 name: "Parichay Barpanda"
 twitter: baymac04
 github: baymac
+linkedin: parichay.barpanda
 ---
 
 GSoC 2019 student under Jenkins project. Maintainer of GitLab Branch Source Plugin. Software Developer at Udaan, India.

--- a/content/_data/authors/buddhikac96.adoc
+++ b/content/_data/authors/buddhikac96.adoc
@@ -1,0 +1,4 @@
+---
+name: "Buddhika Chathuranga"
+github: buddhikac96
+---

--- a/content/_data/authors/fcojfernandez.adoc
+++ b/content/_data/authors/fcojfernandez.adoc
@@ -1,6 +1,10 @@
 ---
 name: "Francisco Fernandez"
+linkedin: fcojfernandez
 github: fcojfernandez
 ---
 
-Francisco is one of the maintainers of the Jenkins git plugin.
+Widely experienced Software Engineer focused mainly on Java developments.
+Francisco worked mainly on projects for different sectors such as banking or utilities, where he specialized in backend and architecture design.
+Since 2016 he has been working at CloudBees collaborating on different Jenkins related projects, such as Jenkinsfile Runner and Custom War Packager.
+He is the current maintainer of Folders plugin and one of the co-maintainers of EC2, Git and Git Client plugins.

--- a/content/_data/authors/imoutsatsos.adoc
+++ b/content/_data/authors/imoutsatsos.adoc
@@ -1,4 +1,8 @@
 ---
 name: "Ioannis Moutsatsos"
 github: "imoutsatsos"
+twitter: ioannismou
 ---
+
+Life scientist and software engineer.
+Interested in open source, research informatics, imaging, metadata, and reproducible data flows.

--- a/content/_data/authors/kwhetstone.adoc
+++ b/content/_data/authors/kwhetstone.adoc
@@ -3,4 +3,9 @@ name: "Kristin Whetstone"
 github: "kwhetstone"
 twitter: "lighteningdrake"
 irc: kwhetstone
+linkedin: kwhetstone
 ---
+
+Kristin Whetstone is a software engineer at CloudBees working on several different services and tools.
+She spends a lot of time thinking about test automation and testing that automation.
+She has participated in a few different areas of Jenkins since 2015, and has previously mentored Jenkins GSoC projects.

--- a/content/_data/authors/linuxsuren.adoc
+++ b/content/_data/authors/linuxsuren.adoc
@@ -1,6 +1,7 @@
 ---
 name: "赵晓杰(Rick)"
 twitter: LinuxSuRen
+linkedin: linuxsuren
 github: LinuxSuRen
 ---
 Rick is a big fan of Jenkins, also as a contributor leading the Jenkins China community.

--- a/content/_data/authors/loghijiaha.adoc
+++ b/content/_data/authors/loghijiaha.adoc
@@ -1,0 +1,4 @@
+---
+name: "Loghi Perinpanayagam"
+github: loghijiaha
+---

--- a/content/_data/authors/marckk.adoc
+++ b/content/_data/authors/marckk.adoc
@@ -2,4 +2,11 @@
 name: "Kara de la Marck"
 twitter: KaraMarck
 github: MarckK
+linkedin: karadelamarck
 ---
+
+Kara works with the Jenkins X open source community at CloudBees.
+Previously, Kara worked as a developer for a Fortune 500 company and as a freelancer.
+Kara is a proponent of open source and has contributed to Pandas, Babel, and Jaeger, amongst others.
+As an organiser and board director of codebar.io, Kara works to increase diversity in the tech industry.
+She is passionate about making technology accessible and building welcoming tech communities.

--- a/content/_data/authors/markyjackson-taulia.adoc
+++ b/content/_data/authors/markyjackson-taulia.adoc
@@ -3,6 +3,7 @@ name: "Marky Jackson"
 twitter: markyjackson5
 github: "markyjackson-taulia"
 irc: markyjackson
+linkedin: marky-jackson
 ---
 Marky Jackson is a software developer. He is also a member of various Jenkins SIGs, a Google Summer of
 Code org Admin and a mentor as well as part of the Jenkins Core PR reviewers team.

--- a/content/_data/authors/mikecirioli.adoc
+++ b/content/_data/authors/mikecirioli.adoc
@@ -1,4 +1,11 @@
 ---
 name: "Michael Cirioli"
 github: mikecirioli
+twitter: mikecirioli
+linkedin: mike-cirioli-07b2223
 ---
+
+Full stack software developer with 20+ years experience.
+8 years experience as technical lead delivering both internal solutions and customer solutions.
+Strong project management skills, including planning, resources, testing and deliverables.
+Motivated team player willing to take initiative and deliver results.

--- a/content/_data/authors/nextturn.adoc
+++ b/content/_data/authors/nextturn.adoc
@@ -2,3 +2,5 @@
 name: Next Turn
 github: NextTurn
 ---
+
+Community contributor

--- a/content/_data/authors/nikhildarocha.adoc
+++ b/content/_data/authors/nikhildarocha.adoc
@@ -1,7 +1,12 @@
 ---
 name: "Nikhil Da Rocha"
 github: nikhildarocha
-linkedin: Nikhil Da Rocha
+linkedin: nikhil-da-rocha-63709358
 ---
 
 Nikhil is a Software Developer for Barclays in Pune, India.
+He has a B.Tech. from National Institute of Technology Goa.
+He is currently pursuing a part time M.Tech. in Software Systems from Birla Institute of Technology Pilani.
+He enjoys all things technology.
+When he is not learning new things, he likes playing soccer and basketball.
+He loves the outdoors a lot.

--- a/content/_data/authors/nodece.adoc
+++ b/content/_data/authors/nodece.adoc
@@ -1,0 +1,4 @@
+---
+name: "Zixuan Liu"
+github: "nodece"
+---

--- a/content/_data/authors/oleg_nenashev.adoc
+++ b/content/_data/authors/oleg_nenashev.adoc
@@ -3,6 +3,7 @@ name: Oleg Nenashev
 twitter: oleg_nenashev
 github: "oleg-nenashev"
 blog: 'https://oleg-nenashev.github.io/'
+linkedin: onenashev
 irc: oleg_nenashev
 ---
 

--- a/content/_data/authors/rishabhbudhouliya.adoc
+++ b/content/_data/authors/rishabhbudhouliya.adoc
@@ -1,0 +1,4 @@
+---
+name: "Rishabh Budhouliya"
+github: rishabhBudhouliya
+---

--- a/content/_data/authors/sharepointoscar.adoc
+++ b/content/_data/authors/sharepointoscar.adoc
@@ -2,4 +2,7 @@
 name: "Oscar Medina"
 twitter: sharepointoscar
 github: sharepointoscar
+linkedin: oscarmedina
 ---
+
+Oscar is a developer advocate at CloudBees, focusing on Jenkins X.

--- a/content/_data/authors/timja.adoc
+++ b/content/_data/authors/timja.adoc
@@ -2,6 +2,7 @@
 name: "Tim Jacomb"
 github: "timja"
 twitter: Tjaynz
+linkedin: tim-jacomb-98043174
 ---
 Jenkins core maintainer, along with slack, azure-keyvault and configuration-as-code plugins.
 Tim started using Jenkins in 2013 and became an active contributor in 2018.

--- a/content/_layouts/gsocproject.html.haml
+++ b/content/_layouts/gsocproject.html.haml
@@ -43,7 +43,10 @@ project: gsoc
   Links
 %ul
   = partial("connect-links.html.haml", :links => page.links, :sig => page.sig, :project => page.project)
+  -if page.links.idea
+    %li
+      %a{:href => "#{page.links.idea}", :target => "_blank"}
+        Original GSoC project idea
   %li
     %a{:href => "/projects/gsoc", :target => "_blank"}
       Jenkins GSoC page
-

--- a/content/projects/gsoc/2020/project-ideas/github-checks.adoc
+++ b/content/projects/gsoc/2020/project-ideas/github-checks.adoc
@@ -12,11 +12,6 @@ mentors:
 - "jeffpearce"
 - "jonbrohauge"
 - "ayush_agarwal"
-skills:
-- Java
-- REST API
-- GitHub
-
 links:
   gitter: "jenkinsci/gsoc-sig"
   draft: https://docs.google.com/document/d/1fl3sF0mArtv2THOjPSZvNufGme4P24BtT0BirHMeMRY

--- a/content/projects/gsoc/2020/project-ideas/github-checks.adoc
+++ b/content/projects/gsoc/2020/project-ideas/github-checks.adoc
@@ -12,6 +12,10 @@ mentors:
 - "jeffpearce"
 - "jonbrohauge"
 - "ayush_agarwal"
+skills:
+- Java
+- REST API
+- GitHub
 links:
   gitter: "jenkinsci/gsoc-sig"
   draft: https://docs.google.com/document/d/1fl3sF0mArtv2THOjPSZvNufGme4P24BtT0BirHMeMRY

--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -1,0 +1,24 @@
+---
+layout: gsocproject
+title: "Custom Jenkins distribution build service"
+goal: "Provide an out of the box solution for packaging Jenkins distributions as WAR files or Docker images"
+category: Tools
+showGoogleDoc: true
+year: 2020
+status: "Active"
+student: sladyn98
+mentors:
+- "linuxsuren"
+- "jeffpearce"
+- "kwhetstone"
+links:
+  gitter: "jenkinsci/platform-sig"
+  draft: https://docs.google.com/document/d/1C7VQJ92Yhr0KRDcNVHYxn4ri7OL9IGZmgxY6UFON6-g/edit?usp=sharing
+  idea: /projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service
+tags:
+- gsoc2020
+- packaging
+- tools
+---
+
+// TODO: add details here, remove `showGoogleDoc: true`

--- a/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
+++ b/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
@@ -1,0 +1,24 @@
+---
+layout: gsocproject
+title: "External Fingerprint Storage for Jenkins"
+goal: "Extend Jenkins to support storing artifact usage history in external databases"
+category: Core
+year: 2020
+showGoogleDoc: true
+sig: cloud-native
+status: "Active"
+student: stellargo
+mentors:
+- "oleg_nenashev"
+- "afalko"
+- "mikecirioli"
+links:
+  draft: https://docs.google.com/document/d/10f3IXTA6UMLUOFMTH_atQ3XlyWB3S7KGNCtTZmOUGdM/edit?usp=sharing
+  idea: /projects/gsoc/2020/project-ideas/external-fingerprint-storage-for-jenkins
+tags:
+- gsoc2020
+- pluggable-storage
+- fingerprints
+---
+
+// TODO: add details here, remove `showGoogleDoc: true`

--- a/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
+++ b/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
@@ -1,0 +1,26 @@
+---
+layout: gsocproject
+title: "Git Plugin Performance Improvements"
+goal: "Improve git plugin performance"
+category: Plugins
+year: 2020
+status: "Active"
+showGoogleDoc: true
+sig: platform
+tags:
+- gsoc2020
+- git
+- performance
+student: rishabhbudhouliya
+mentors:
+- "markewaite"
+- "fcojfernandez"
+- "baymac"
+- "justinharringa"
+links:
+  draft: https://docs.google.com/document/d/1vy9tkFbhl5KX7QcjH3QbzFzbKEONw6gaLZSmNXgB06Y/edit?usp=sharing
+  gitter: jenkinsci/git-plugin
+  idea: /projects/gsoc/2020/project-ideas/git-plugin-performance
+---
+
+// TODO: add details here, remove `showGoogleDoc: true`

--- a/content/projects/gsoc/2020/projects/github-checks.adoc
+++ b/content/projects/gsoc/2020/projects/github-checks.adoc
@@ -1,0 +1,27 @@
+---
+layout: gsocproject
+title: "GitHub Checks API for Jenkins Plugins"
+goal: "Create a new plugin API so that plugins can publish GitHub checks status messages"
+category: Plugins
+year: 2020
+status: "Active"
+sig: platform
+student: XiongKezhi
+showGoogleDoc: true
+mentors:
+- "uhafner"
+- "timja"
+- "jeffpearce"
+- "jonbrohauge"
+- "ayush_agarwal"
+- "Sagar2366"
+tags:
+- gsoc2020
+- github
+links:
+  gitter: "jenkinsci/gsoc-sig"
+  draft: https://docs.google.com/document/d/1gpG7jeQmb9zz46t0ewNNRUrYbl7iHGScp5vgkn7MCXs/edit?usp=sharing
+  idea: /projects/gsoc/2020/project-ideas/github-checks
+---
+
+// TODO: add details here, remove `showGoogleDoc: true`

--- a/content/projects/gsoc/2020/projects/jenkins-x-apps-consolidation.adoc
+++ b/content/projects/gsoc/2020/projects/jenkins-x-apps-consolidation.adoc
@@ -1,0 +1,26 @@
+---
+layout: gsocproject
+title: "Jenkins X: Consolidate the use of Apps / Addons"
+goal: "Consolidate Apps and Addons inside Jenkins X"
+category: Jenkins X
+year: 2020
+status: "Active"
+student: nodece
+showGoogleDoc: true
+mentors:
+- "marckk"
+- "jstrachan"
+- "nehagup"
+- "sharepointoscar"
+- "nikhildarocha"
+- "sahilrkalra"
+tags:
+- gsoc2020
+- jenkins-x
+links:
+  chat: https://jenkins-x.io/community/#slack
+  draft: https://docs.google.com/document/d/1Ph-Jo8KGYzTLMXLIDJQB6XbVcnILETfXEMXXczrxb4s/edit?usp=sharing
+  idea: /projects/gsoc/2020/project-ideas/jenkins-x-apps-consolidation
+---
+
+// TODO: add details here, remove `showGoogleDoc: true`

--- a/content/projects/gsoc/2020/projects/machine-learning.adoc
+++ b/content/projects/gsoc/2020/projects/machine-learning.adoc
@@ -1,0 +1,26 @@
+---
+layout: gsocproject
+title: "Machine Learning Plugins for Data Science"
+goal: "Create a new plugin for integrating Jenkins with one of Machine Learning tools (e.g. Jupyter Python, TensorBoard, or Sacred)"
+category: Plugins
+year: 2020
+status: "Active"
+showGoogleDoc: true
+sig: pipeline-authoring
+student: loghijiaha
+mentors:
+- "kinow"
+- "imoutsatsos"
+- "markyjackson-taulia"
+- "shivaylamba"
+tags:
+- gsoc2020
+- machine-learning
+- data-science
+links:
+  gitter: "jenkinsci/gsoc-machine-learning-project"
+  draft: https://docs.google.com/document/d/1YaQfzvYV2G-wby2jcOzITKveaowTXMN77fkMq5hBe6E/edit?usp=sharing
+  idea: /projects/gsoc/2020/project-ideas/machine-learning
+---
+
+// TODO: add details here, remove `showGoogleDoc: true`

--- a/content/projects/gsoc/2020/projects/winsw-yaml-configs.adoc
+++ b/content/projects/gsoc/2020/projects/winsw-yaml-configs.adoc
@@ -1,0 +1,35 @@
+---
+layout: gsocproject
+title: "Jenkins Windows Services: YAML Configuration Support"
+goal: "Enhance Jenkins master and agent service management on Windows by offering new configuration file formats and improving settings validation"
+category: Core, Tools
+year: 2020
+status: "Active"
+sig: platform
+student: buddhikac96
+mentors:
+- "oleg_nenashev"
+- "mikecirioli"
+- "nextturn"
+tags:
+- gsoc2020
+- windows
+- windows-services
+links:
+  draft: https://drive.google.com/file/d/1G2cOaRb-Mle_Fl7YVAzlVITDgrN6eCbE/view?usp=sharing
+  gitter: winsw/winsw
+  idea: /projects/gsoc/2020/project-ideas/winsw-yaml-config-support
+---
+
+// TODO: add details here, cannot embed draft due to wrong format
+
+On Windows machines, Jenkins master and agents can be installed as Windows Services in order to get better robustness and manageability within the system.
+This is a functionality bundled into the Jenkins core directly.
+When installed as a service, Jenkins uses the Windows Service Wrapper executable (.NET, written in C#) which is being configured by XML config files.
+Currently, there are only a few configuration checks there (no XML Schema, limited validation, etc.),
+and it’s often that the service wrapper is misconfigured by Jenkins users.
+
+In this project we propose to update Windows Service Wrapper to support YAML files as configuration inputs and to introduce better configuration validation during the service installation and startup.
+Usage of YAML should simplify configuration management in Jenkins, especially when automated tools are used.
+
+See the link:https://drive.google.com/file/d/1G2cOaRb-Mle_Fl7YVAzlVITDgrN6eCbE/view?usp=sharingp[GSoC Project application draft] for more details.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -27,9 +27,18 @@ in completing their summer projects.
 
 == GSoC 2020
 
-Jenkins has been accepted in the GSoC program in 2020.
-We invite potential mentors and students to contact us and to propose their projects.
-We are also looking for mentors for the current project ideas and accept new project ideas.
+Jenkins participates in the GSoC program in 2020.
+Below you can find links to the ongoing projects and other materials.
+
+== Projects
+
+* link:/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service[Custom Jenkins distribution build service] by link:/blog/authors/sladyn98[Sladyn Nunes]
+* link:/projects/gsoc/2020/projects/external-fingerprint-storage[External Fingerprint Storage] by link:/blog/authors/stellargo[Sumit Sarin]
+* link:/projects/gsoc/2020/projects/git-plugin-performance[Git Plugin Performance Improvements] by link:/blog/authors/rishabhbudhouliya[Rishabh Budhouliya]
+* link:/projects/gsoc/2020/projects/github-checks[GitHub Checks API for Jenkins Plugins] by link:/blog/authors/XiongKezhi[Kezhi Xiong]
+* link:/projects/gsoc/2020/projects/jenkins-x-apps-consolidation[Jenkins X: Apps/Addons consolidation] by link:/blog/authors/nodece[Zixuan Liu]
+* link:/projects/gsoc/2020/projects/machine-learning[Machine Learning Plugins for Data Science] by link:/blog/authors/loghijiaha[Loghi Perinpanayagam]
+* link:/projects/gsoc/2020/projects/winsw-yaml-configs[Jenkins Windows Services: YAML Configuration Support] by link:/blog/authors/buddhikac96[Buddhika Chathuranga]
 
 == Students
 


### PR DESCRIPTION
This pull request initializes the GSoC 2020 pages. I will update the jumbotron later once the blogpost is ready, and once students update their projects.

Landing:

![image](https://user-images.githubusercontent.com/3000480/80999454-053d1c00-8e45-11ea-8f46-df7ac13e0297.png)

Project page with embedded Google Doc (for now):

![image](https://user-images.githubusercontent.com/3000480/80999435-fce4e100-8e44-11ea-89ab-5f72f26a86bc.png)
