### PR TITLE
Fix rendering of the subprojects nav menu

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -100,7 +100,7 @@
           %a.dropdown-item.feature{:href => expand_link('projects/')}
             Overview
           - site.pages.map do |page|
-            - if page.url && page.url.match(/\/projects\/([^\/]+)\/$/)
+            - if page.url && page.url.match(/\/projects\/([^\/]+)\/$/) && page.layout == "project"
               %a.dropdown-item.feature{:href => expand_link(page.url)}
                 = page.title
 


### PR DESCRIPTION
GSoC 2020 projects are grouped under https://www.jenkins.io/projects/gsoc/2020/projects/ . Yes, with two 'projects' in the path... It as confused regexps, so I also added a layout type check.

Before:

![image](https://user-images.githubusercontent.com/3000480/81019421-ea7b9f00-8e66-11ea-9b91-164f74ef7d72.png)

After:

![image](https://user-images.githubusercontent.com/3000480/81019457-fb2c1500-8e66-11ea-8ea8-61d4f2736781.png)
