### PR TITLE
GSoC 2020: Add a OpenAPI link to the Open API specification project idea

### DIFF
--- a/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -19,7 +19,8 @@ links:
 
 === Background
 Developers need to know what to expect in terms of responses for each REST API endpoint, so external tools like jenkins-rest can be developed with confidence, and possibly with the help of some REST specification automation.
-For example, this could be done using OpenAPI. The two main contents users of the REST API are looking for are:
+For example, this could be done using the link:https://www.openapis.org/[OpenAPI Specification] (formerly known as Swagger Specification).
+The two main contents users of the REST API are looking for are:
 
 * HTTP responses and codes
 * Body of message and its format (e.g. JSON, html, etc.)

--- a/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -20,7 +20,7 @@ links:
 === Background
 Developers need to know what to expect in terms of responses for each REST API endpoint, so external tools like jenkins-rest can be developed with confidence, and possibly with the help of some REST specification automation.
 For example, this could be done using the link:https://www.openapis.org/[OpenAPI Specification] (formerly known as Swagger Specification).
-The two main contents users of the REST API are looking for are:
+Users of the REST API most often want:
 
 * HTTP responses and codes
 * Body of message and its format (e.g. JSON, html, etc.)


### PR DESCRIPTION
I am about linking this project idea from the roadmap, so an explicit OpenAPI link would not hurt