### PR TITLE
Jenkins Roadmap: Add GSoC 2020 projects and project ideas

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -46,6 +46,11 @@ categories:
       description: Provide out-of-the-box support for manual and automatic promotion of build artifacts in a separate Pipeline after the job completion
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-36089
+    - name: Improve Pipeline step documentation generator
+      status: future
+      description: >
+        Enhance the Jenkins Pipeline documentation generator to produce better documentation for thousands of Pipeline developers.
+      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/pipeline-step-documentation-generator/
   - name: Tool and Service integrations
     description: >
       Initiatives focused on integrations with various external tools and services.
@@ -54,10 +59,33 @@ categories:
     - name: "Pipeline: GitHub App authentication"
       status: current
       link: https://issues.jenkins-ci.org/browse/JENKINS-57351
+    - name: "Git Plugin Performance Improvements"
+      status: current
+      description: >
+        Improve Jenkins git plugin performance by fixing known issues in performance critical areas
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/git-plugin-performance/
     - name: "GitHub Checks API integrations"
-      status: near-term
-      link: https://jenkins.io/projects/gsoc/2020/project-ideas/github-checks/
-    - name: Pipeline as YAML
+      status: current
+      description: >
+        Create a new plugin API so that plugins can publish GitHub Checks statuses.
+        Implement Checks API support in Warnings NG and Code Coverage API plugins.
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/github-checks/
+    - name: Machine Learning Plugin for Data Science
+      status: current
+      description: >
+        Integrating Machine Learning workflow with Jenkins build tasks, including Data preprocessing, Model Training, Evaluation and Prediction.
+        This plugin will be capable of executing code fragments via IPython kernel as currently supported by Jupyter.
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/machine-learning/
+    - name: OpenAPI for Jenkins core and plugins
+      status: future
+      description: >
+        Expose Jenkins REST APIs as the OpenAPI Specification so that users could easily integrate with Jenkins and create clients for it.
+      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api/
+    - name: "Docker: image changes polling and security scans"
+      status: future
+      description: >
+        Create a new Jenkins plugin to automate polling of image changes and security scans.
+      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/docker-registries-polling-plugin/
   - name: User experience and interface
     description: Initiatives focused on improving the Jenkins user interface and user experience
     link: /sigs/ux
@@ -92,18 +120,29 @@ categories:
         It complements Jenkins Configuration-as-Code stories by preventing undesired manual modifications on running instances.
       status: current
       link: https://github.com/jenkinsci/jep/tree/master/jep/224
+    - name: "Windows Services: YAML Configuration Support"
+      status: current
+      description: >
+        Enhance Jenkins master and agent service management on Windows by
+        offering new configuration file formats and improving settings validation.
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/winsw-yaml-configs/
     - name: Built-in plugin management as-code
       description: >
         Evolution of plugin management capabilities in the Jenkins core and Docker images.
-        It includes adoption of the new Plugin Management tool in distributions, and support of advanced plugin definition formats like YAML.
+        It includes adoption of the new Plugin Management Tool in distributions, and support of advanced plugin definition formats like YAML.
       status: near-term
-      link: https://jenkins.io/sigs/platform/#plugin-management
+      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool/
     - name: "JCasC: Pluggable configuration sources"
       description: >
         Support external configuration sources in the Jenkins Configuration-as-Code plugin.
         Examples of potential configuration sources: Git, S3 Buckets, Kubernetes CRD.
       status: future
       link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/1365
+    - name: "Better Remoting Monitoring"
+      status: future
+      description: >
+        Support monitoring of Jenkins networking (master to agent communications, etc.) with open source monitoring tools such as Prometheus, Grafana, etc.
+      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/remoting-monitoring/
 #  - name: Jenkins Security
 #    description: "Public security hardening and management initiatives. Vulnerability fixes are not listed"
 #    initiatives:
@@ -124,6 +163,11 @@ categories:
         Finalization of Jenkinsfile Runner prototype which would allow running jobs and pipelines as Function-as-Service in cloud environments.
       status: current
       link: https://github.com/jenkinsci/jenkinsfile-runner
+    - name: 'External Fingerprint Storage'
+      description: >
+        Extend Jenkins to support storing artifact usage history in external databases.
+      status: current
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/external-fingerprint-storage
     - name: 'Jenkins FaaS Capability'
       description: >
         Continued development of the Jenkinsfile Runner and its packaging/development tools to simplify usage of the tool as Function-as-Service.
@@ -179,7 +223,7 @@ categories:
         We would like to create a new service which would allow users to configure and build their own Jenkins distributions,
         with custom plugin sets and configurations included.
       status: near-term
-      link: https://jenkins.io/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service/
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
     - name: Java 14+ support
       description: >
         We would like to support future mainstream JVM versions (Java 14+).

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -73,7 +73,7 @@ categories:
     - name: Machine Learning Plugin for Data Science
       status: current
       description: >
-        Integrating Machine Learning workflow with Jenkins build tasks, including Data preprocessing, Model Training, Evaluation and Prediction.
+        Integrate Machine Learning workflow with Jenkins build tasks, including Data preprocessing, Model Training, Evaluation and Prediction.
         This plugin will be capable of executing code fragments via IPython kernel as currently supported by Jupyter.
       link: https://www.jenkins.io/projects/gsoc/2020/projects/machine-learning/
     - name: OpenAPI for Jenkins core and plugins


### PR DESCRIPTION
This change...

* Adds all accepted project ideas to the roadmap, makes them `current`. https://www.jenkins.io/projects/gsoc/#projects
* Adds well defined project ideas to the `future` category. I added only ideas which have strong consensus and enough specifics in their descriptions. https://www.jenkins.io/projects/gsoc/2020/project-ideas/
