### PR TITLE
Roadmap: Add more ongoing and planned Advocacy and Outreach stories

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -292,7 +292,7 @@ categories:
         Introduce a new system which would enable Jenkins plugin maintainers to add Continuous Delivery (CD) to their projects.
       status: future
       link: https://github.com/jenkinsci/jep/blob/master/jep/221
-  - name: Community marketing and outreach
+  - name: Community marketing and outreach programs
     description: Initiatives related to promoting Jenkins and facilitating contributions to the project
     link: /sigs/advocacy-and-outreach/
     initiatives:
@@ -306,11 +306,38 @@ categories:
       description: In Jenkins 2.0 we deprecated the old "slave" terminology, but there are still occurrences in documentation and some components. We want to clean them up.
       status: current
       link: https://issues.jenkins-ci.org/browse/JENKINS-42816
+    - name: Jenkins Is The Way program
+      status: released
+      description: >
+        Jenkins Is The Way is a collection of experiences from all around the world showcasing how users are building, deploying, and automating great stuff with Jenkins. 
+      link: https://www.jenkins.io/blog/2020/04/30/jenkins-is-the-way/
+    - name: New online meetup platform
+      status: released
+      description: >
+        Make it possible to regularly host Jenkins online meetups and webinars.
+      link: https://www.jenkins.io/events/online-meetup/
+    - name: "Jenkins UI/UX online hackfest"
+      status: current
+      description: >
+        A week-long event with the goal of driving improvements in user experience in multiple areas:
+        user interface, user documentation and user success stories.
+        Planned start date: May 25, 2020.
+      link: https://groups.google.com/forum/#!topic/jenkinsci-dev/d21hUK0m3nQ 
+    - name: "Jenkins on Kubernetes online meetups"
+      status: current
+      description: >
+        Promote best practices and success stories for Jenkins on Kubernetes by organizing a series of online meetups.
+      link: https://www.meetup.com/Jenkins-online-meetup/
     - name: Google Season of Docs 2020
       status: near-term
       link: https://jenkins.io/sigs/advocacy-and-outreach/outreach-programs/#google-season-of-docs
-    - name: Community Bridge
+    - name: Jenkins on LinkedIn
       status: near-term
+      description: >
+        Extend and automate Jenkins presence in LinkedIn so that we could outreach to its users and facilitate adoption and contributions.
+      link: https://www.linkedin.com/company/1846812/admin/
+    - name: Community Bridge Mentorship
+      status: future
       link: https://jenkins.io/sigs/advocacy-and-outreach/outreach-programs/#community-bridge
     - name: Hacktoberfest 2020
       status: future


### PR DESCRIPTION
This change adds some ongoing outreach programs to the Jenkins roadmap

![image](https://user-images.githubusercontent.com/3000480/81066240-189bc600-8edd-11ea-93c2-dc221476741f.png)

