### PR TITLE
Jenkins Board Election Process: restructure the page

### DIFF
--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -4,25 +4,7 @@ title: "Board election process"
 section: project
 ---
 
-This document outlines the link:/project/governance[Governance Document] election process as discussed in governance meetings:
-
-2015-11-11
-
-Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.log.html[raw]
-
-2015-09-30
-
-Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.log.html[raw]
-
-And agreed upon in the meeting on:
-
-2015-12-09
-
-Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.log.html[raw]
-
-2019-09-11
-
-Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.log.html[raw]
+This document outlines the link:/project/governance/#governance-board[Jenkins Governance Board] election process as discussed in governance meetings.
 
 The charter of the Jenkins board is to ensure the health of not only the software project, but of the communities of plugin developers and users. To do this effectively, members of the board must bring various perspectives to the table: what are the needs of users; of committers; of organizations, both large and small; of commercial interests. As the composition of the Jenkins board changes over time, we want to ensure that this balance of viewpoints is maintained. Current board members best understand this balance, and so are in the best position to select candidates for inclusion onto the board. A board comprised fully of write-in candidates runs the risk of being overweighed with one type of perspective over all others.
 
@@ -36,7 +18,9 @@ The opinion of members of the community at large is highly valued, and the board
 
 ## Process
 
-. Expand the board from 3 people to 5 people; link:/blog/authors/kohsuke[Kohsuke] holding a permanent board seat until such a time he decides to resign.
+. The Governance Board includes 5 members
+** link:/blog/authors/kohsuke[Kohsuke] holds a permanent board seat until such a time he decides to resign.
+** 4 members are elected. If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected.
 . Have election every year, electing 2 people in each year (that means the term is 2 years, without term limit: you can be candidate and be re-elected indefinitely)
 . There'll be a period of 3 weeks designated for the board to encourage the community to send in the nominations. The board will meet in private to come up with the list of candidates at the end
 . Any company should not dominate in the board (link:/project/board-election-process/#corporate-involvement[see below])
@@ -69,3 +53,43 @@ There are several motivations behind the above proposal:
 
 . Odd number of people prevents the tie problem
 . Given the low bar to the committership, we couldn't really come up with any criteria to decide who has the voting right. At the same time, we did want to restrict who can vote (as opposed to anyone unrelated to the project) for the stability.
+
+## Change History
+
+### 2019-09-11
+
+Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.log.html[raw]
+
+* 3 Board positions are elected instead of 2 in the base document (Dean Yu's seat + 2 new seats).
+  With this change, the 2020 election will have only one board member elected unless a board member steps down.
+* Continuous Delivery Foundation will supervise the election
+* We will run the voting using The Condorcet Internet voting system instead of Single Transferable Vote
+
+Related decisions:
+
+* Introduce a new link:/project/team-leads/#documentation[Documentation officer position] (content officer from the 2015 Proposal)
+* All link:/project/team-leads/[officer positions] will be voted on in 2019 and then in 2020
+
+#### 2015-12-09
+
+Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.log.html[raw]
+
+Decisions:
+
+* Formally approve the Governance board election process.
+  This page represents the process
+* Expand the board from 3 people to 5 people;
+  link:/blog/authors/kohsuke[Kohsuke] holding a permanent board seat until such a time he decides to resign.
+
+Related decisions:
+
+* link:/conduct[Jenkins Code of Conduct] is accepted and published.
+  Jenkins Governance Board will be responsible for processing escalations and enforcing the Code of Conduct if needed.
+
+### 2015-11-11
+
+Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.log.html[raw]
+
+### 2015-09-30
+
+Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.log.html[raw]

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -52,7 +52,7 @@ Like many things in the Jenkins community, the disclosure of corporate affiliati
 There are several motivations behind the above proposal:
 
 . Odd number of people prevents the tie problem
-. Given the low bar to the committership, we couldn't really come up with any criteria to decide who has the voting right. At the same time, we did want to restrict who can vote (as opposed to anyone unrelated to the project) for the stability.
+. Given the low bar for permission to commit, we couldn't identify precise criteria to define the right to vote in board elections.  At the same time, we wanted to preserve stability by limiting voting rights to only those with some involvement in the project.
 
 ## Change History
 


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/jenkins.io/pull/3164 I noticed that this page could be improved significantly. 

* The page text is updated to reference the current state of the process
* History of decisions and changes is moved to the bottom
* 2019 decisions summary is explicitly added to the list 

There is no other substantial changes though "4 members are elected. If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected" might benefit from additional feedback.

CC @jenkins-infra/board 
