### PR TITLE
GSoC 2020 External Storage: Fix the Gitter link, add meetings section and merge sentences in the first paragraph

### DIFF
--- a/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
+++ b/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
@@ -12,9 +12,10 @@ mentors:
 - "afalko"
 - "mikecirioli"
 links:
-  gitter: https://gitter.im/jenkinsci/external-fingerprint-storage
+  gitter: jenkinsci/external-fingerprint-storage
   draft: https://docs.google.com/document/d/10f3IXTA6UMLUOFMTH_atQ3XlyWB3S7KGNCtTZmOUGdM/edit?usp=sharing
   idea: /projects/gsoc/2020/project-ideas/external-fingerprint-storage-for-jenkins
+  meetings: "/projects/gsoc/2020/projects/external-fingerprint-storage#meetings"
 tags:
 - gsoc2020
 - pluggable-storage
@@ -24,14 +25,11 @@ tags:
 === Abstract
 
 File fingerprinting is a way to track which version of a file is being used by a job/build, making dependency tracking easy.
-
 The fingerprint engine of Jenkins can track usages of artifacts, credentials, files, etc. within the system.
-
 It does this by maintaining a local XML-based database.
-
 This leads to dependence on the physical disk of the Jenkins master.
 
-Hence, the core idea of this project is to extend Jenkins core to support storing of fingerprints in an external storage, which would also allow tracking them across the entire CI/CD flow.
+The core idea of this project is to extend Jenkins core to support storing of fingerprints in an external storage, which would also allow tracking them across the entire CI/CD flow.
 
 image:/images/post-images/gsoc-external-fingerprint-storage-for-jenkins/overview.png[title="External Fingerprint Storage for Jenkins Overview" role="center" width=1000,height=800]
 
@@ -68,6 +66,10 @@ image:/images/post-images/gsoc-external-fingerprint-storage-for-jenkins/overview
 * 1.0 version MongoDB plugin released.
 * 1.0 version Fingerprint External Storage API plugin released.
 * Blog Post (Final)
+
+=== Meetings
+
+Project meeting schedule will be announced soon!
 
 === Other Links
 


### PR DESCRIPTION
Fixes the Gitter link and applies a few extra patches. CC @stellargo 

Current layout on the website:

![image](https://user-images.githubusercontent.com/3000480/81473094-a4269700-91fc-11ea-9b20-1232c0d82d38.png)
