### PR TITLE
User documentation: rework the navigation bar and tutorials page

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -35,48 +35,10 @@ section: doc
     .col-lg-3
       .sidebar-nav.tour
         %p
-          = active_href('doc', 'Jenkins User Documentation Home')
+          = active_href('doc', '> User Documentation Home')
 
-        %h4
-          Guided Tour
-        %ul
-          %li
-            = active_href('doc/pipeline/tour/getting-started', 'Getting started')
-          %li
-            = active_href('doc/pipeline/tour/hello-world', 'Creating your first Pipeline')
-          %li
-            = active_href('doc/pipeline/tour/running-multiple-steps', 'Running multiple steps')
-          %li
-            = active_href('doc/pipeline/tour/agents', 'Defining execution environments')
-          %li
-            = active_href('doc/pipeline/tour/environment', 'Using environment variables')
-          %li
-            = active_href('doc/pipeline/tour/tests-and-artifacts', 'Recording test results and artifacts')
-          %li
-            = active_href('doc/pipeline/tour/post', 'Cleaning up and notifications')
-          %li
-            = active_href('doc/pipeline/tour/deployment', 'Deployment')
-
-        %h4
-          Tutorials
-        %ul
-          %li
-            = active_href('doc/tutorials', 'Overview')
-          %li
-            = active_href('doc/tutorials/build-a-java-app-with-maven', 'Build a Java app with Maven')
-          %li
-            = active_href('doc/tutorials/build-a-node-js-and-react-app-with-npm', 'Build a Node.js and React app with npm')
-          %li
-            = active_href('doc/tutorials/build-a-python-app-with-pyinstaller', 'Build a Python app with PyInstaller')
-          %li
-            = active_href('doc/tutorials/build-a-labview-app', 'Build a LabVIEW app')
-          %li
-            = active_href('doc/tutorials/create-a-pipeline-in-blue-ocean', 'Create a Pipeline in Blue Ocean')
-          %li
-            = active_href('doc/tutorials/build-a-multibranch-pipeline-project', 'End-to-End Multibranch Pipeline Project Creation')
-
-        %h4
-          Handbook
+        %h5
+          User Handbook
         %ul
           - site.handbook.chapters.each do |chapter|
             %li
@@ -87,7 +49,18 @@ section: doc
                     - chapter.sections.each do |s|
                       %li
                         = active_href(File.join('doc/book', chapter.key, s.key), s.title, :fuzzy => true)
-        %h4
+
+        %h5
+          Tutorials
+        %ul
+          %li
+            = active_href('doc/pipeline/tour/getting-started', 'Guided Tour')
+          %li
+            = active_href('doc/tutorials#pipeline', 'Jenkins Pipeline')
+          %li
+            = active_href('doc/tutorials#tools', 'Using Build Tools')
+
+        %h5
           Resources
         %ul
           %li
@@ -95,21 +68,7 @@ section: doc
           %li
             = active_href('doc/pipeline/steps', 'Pipeline Steps reference')
           %li
-            = active_href('doc/upgrade-guide', 'LTS Upgrade Guide', :fuzzy => true)
-
-        %h5
-          Tutorial Blog Posts
-        %ul
-          - tutorials[0...3].each do |t|
-            %li
-              %a{:href => t.url}
-                = t.title
-        .small
-          %a{:href => '/node/tags/tutorial'}
-            View all tutorial blog posts
-
-        %p
-
+            = active_href('doc/upgrade-guide', 'LTS Upgrade guides', :fuzzy => true)
 
     .col-lg-9
       - unless page.notitle

--- a/content/doc/tutorials/index.adoc
+++ b/content/doc/tutorials/index.adoc
@@ -13,7 +13,36 @@ Integration (CI) / Continuous Delivery (CD) concepts, or you might already be
 familiar with these concepts but don't yet know how to implement them in
 Jenkins, then these tutorials are a great place to start.
 
-== Introductory tutorials
+[[getting-started]]
+== Getting started with Jenkins
+
+* link:/doc/pipeline/tour/getting-started[Guided Tour to Jenkins]
+
+[[pipeline]]
+== Pipeline
+
+The following tutorials show how to use key features of Jenkins to facilitate implementing CI/CD
+processes to build your applications:
+
+* link:/doc/pipeline/tour/getting-started/[Getting started with Jenkins Pipeline]
+* Publishing HTML Reports in Pipeline (link:/blog/2017/02/10/declarative-html-publisher/[Declarative Pipeline], link:/blog/2016/07/01/html-publisher-plugin/[Scripted Pipeline])
+* Sending Notifications in Pipeline: link:/blog/2017/02/15/declarative-notifications/[Declarative Pipeline], link:/blog/2016/07/18/pipeline-notifications/[Scripted Pipeline])
+* link:build-a-multibranch-pipeline-project[End-to-End Multibranch Pipeline Project Creation]
+* link:https://www.jenkins.io/blog/2017/02/15/declarative-notifications/#moving-notifications-to-shared-library[Creating a shared library]
+* link:/blog/2016/06/16/parallel-test-executor-plugin/[Faster Pipelines with the Parallel Test Executor Plugin]
+* link:https://www.jenkins.io/blog/2017/01/19/converting-conditional-to-pipeline/[Converting Conditional Build Steps to Jenkins Pipeline]
+* link:/blog/2017/05/18/pipeline-dev-tools/[Pipeline Development Tools]
+
+[[blueocean]]
+== Blue Ocean
+
+* link:/blog/2017/04/05/welcome-to-blue-ocean/[Getting Started with Blue Ocean]
+* Getting Started with Blue Ocean's Visual Pipeline Editor (link:create-a-pipeline-in-blue-ocean[guide], link:/blog/2017/04/06/welcome-to-blue-ocean-editor/[video guide])
+* link:/blog/2017/04/11/welcome-to-blue-ocean-pipeline-activity/[Getting Started with Blue Ocean's Activity View ]
+* link:/blog/2017/04/12/welcome-to-blue-ocean-dashboard/[Getting Started with the Blue Ocean Dashboard]
+
+[[tools]]
+== Using build tools
 
 The following tutorials show how to use Jenkins to cover the basics of CI/CD
 concepts based on specific technology stacks.
@@ -22,24 +51,16 @@ Choose the tutorial that's relevant to your technology stack or one that you're
 most familiar with:
 
 * link:build-a-java-app-with-maven[Build a Java app with Maven]
-* link:build-a-node-js-and-react-app-with-npm[Build a Node.js and React app with
-  npm]
+* link:/blog/2017/02/07/declarative-maven-project/[Declarative Pipeline for Maven Projects]
+* link:build-a-node-js-and-react-app-with-npm[Build a Node.js and React app with npm]
 * link:build-a-python-app-with-pyinstaller[Build a Python app with PyInstaller]
 * link:build-a-labview-app[Build a LabVIEW app]
+* link:/blog/2016/08/10/rails-cd-with-pipeline/[Continuous Security for Rails apps with Pipeline and Brakeman]
+* link:/blog/2016/08/29/sauce-pipeline/[Browser-testing with Sauce OnDemand and Pipeline]
 
-The following tutorials show how to use key features of Jenkins (such as
-link:/doc/book/blueocean/[Blue Ocean]) to facilitate implementing CI/CD
-processes to build your applications:
+== More tutorials
 
-* link:create-a-pipeline-in-blue-ocean[Create a Pipeline in Blue Ocean]
-
-== Advanced tutorials
-
-The following tutorials demonstrate more advanced features of Jenkins and how
-to manage your Pipeline projects with greater sophistication and flexibility.
-
-* link:build-a-multibranch-pipeline-project[End-to-End Multibranch Pipeline Project Creation]
-
+You may find more tutorials in link:/node/tags/tutorial[Tutorial blogposts].
 
 '''
 ++++


### PR DESCRIPTION
Currently the navigation bar takes about two pages full pages, and it is barely usable. Tutorial listing takes a lot of space, but at the same time it does not include recent tutorials. This pull request:

* Reworks the user docs nav bar as suggested in #3127
* Updates the documentation page to reference the tutorial blogs and other tutorials on a page instead of the navbar

## After

![image](https://user-images.githubusercontent.com/3000480/81474070-5f522e80-9203-11ea-96c9-b15045e1cfa8.png)

## Before (first page)

![image](https://user-images.githubusercontent.com/3000480/81474074-66793c80-9203-11ea-854d-ead3509fb2bf.png)


Fixes #3127