### PR TITLE
Link to Google Doc from Pipeline Authoring 'Connect'

### DIFF
--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -37,7 +37,7 @@ organizations:
 links:
   gitter: jenkinsci/pipeline-authoring-sig
   googlegroup: jenkins-pipeline-authoring-sig
-  meetings: "/sigs/pipeline-authoring/#meetings"
+  meetings: "https://docs.google.com/document/d/1EhWoBplGl4M8bHz0uuP-iOynPGuONjcz4enQm8sDyUE/edit#"
 
 overview: >
   This special interest group aims to improve and curate the


### PR DESCRIPTION
## Link to Google Doc from Pipeline Authoring 'Connect' section

The Pipeline Authoring SIG provides meeting notes in a Google Doc, using the same pattern as several other Jenkins Special Interest Groups. The "Connect" section of each SIG page provides links to resources that are outside the jenkins.io site.  Other SIG's place a link to their meeting notes in the "Connect" section and rely on the generated table of contents to link to the description of meeting times and other information related to the meeting.  Let's do the same for the Pipeline Authoring SIG.

![screencapture-localhost-4242-sigs-pipeline-authoring-2020-05-10-07_54_09-edit](https://user-images.githubusercontent.com/156685/81501225-6ecd8800-9294-11ea-84cf-1481aa1dcfb9.png)

CC: @bitwiseman , @steven-terrana , @markyjackson-taulia 