### PR TITLE
Event Calendar: Switch the default mode to weeks, make the calendar wider

### DIFF
--- a/content/event-calendar.html.haml
+++ b/content/event-calendar.html.haml
@@ -63,12 +63,12 @@ notitle: true
   :plain
     var deviceTimeZone = jstz.determine().name();
     var calendarSrc = 'https://calendar.google.com/calendar/b/1/embed'
-      + '?showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF'
+      + '?showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;mode=WEEK'
       + '&amp;src=4ss12f0mqr3tbp1t2fe369slf4%40group.calendar.google.com&amp;color=%2329527A'
       + '&amp;ctz='
 
     var calendarSrcPrefix = '<iframe src="' + calendarSrc;
-    var calendarSrcSuffix = '" style=" border-width:0 " width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+    var calendarSrcSuffix = '" style=" border-width:0 " width="1024" height="600" frameborder="0" scrolling="no"></iframe>';
 
     function set_calendar(timezone) {
       timezone = timezone || deviceTimeZone;


### PR DESCRIPTION
Just a minor layout improvements for the event calendar. I am still not a big fan of the layout, but after the switch to weekly layout it is at least comprehensible on the screen. Maybe we could use an agenda view instead

## After, current option

![image](https://user-images.githubusercontent.com/3000480/81741403-cf301580-949e-11ea-9fcb-1751ac6de39a.png)

## Alternative suggestion

![image](https://user-images.githubusercontent.com/3000480/81741795-609f8780-949f-11ea-8c40-606e2cc1bf89.png)


## Before

![image](https://user-images.githubusercontent.com/3000480/81741510-f8e93c80-949e-11ea-94ce-3026a98c8170.png)
