### PR TITLE
Update JTE 2.0 link on roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -19,7 +19,7 @@ categories:
     - name: Jenkins Templating Engine 2.0 
       description: "JTE enables the creation of tool-agnostic pipeline templates that can be shared across teams. Version 2.0 will have improved integration with the underlying pipeline engine and incorporate many of the community's top feature requests." 
       status: near-term
-      link: https://github.com/jenkinsci/templating-engine-plugin
+      link: https://github.com/jenkinsci/templating-engine-plugin/blob/2.0/Version_2.adoc
     - name: Pipeline development in IDE
       description: IDE integration, editors, and other development tools - IDE plugins, visual editors, etc
       status: future


### PR DESCRIPTION
Per @oleg-nenashev's advice, updating the link corresponding to the roadmap item Jenkins Templating Engine 2.0 to reference a [document](https://github.com/jenkinsci/templating-engine-plugin/blob/2.0/Version_2.adoc) outlining the scope of the 2.0 release. 