### PR TITLE
Docs SIG: Replace User Guide rework by a GitHub project, link the UI/UX hackfest from GSoD

### DIFF
--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -78,6 +78,8 @@ If you are interested to participate in Google Season of Docs as a technical wri
 . Explore the project ideas listed on this page, find areas which would be interesting to you.
 . Try link:/participate/document/[contributing to Jenkins documentation] to study our documentation tools and contribution process.
   There are some link:/participate/document/#newcomers[newcomer-friendly documentation tasks] you could try.
+. If you start exploring the project before May 29, consider joining our link:/events/online-hackfest/2020-uiux/[UI/UX hackfest] which includes the link:/events/online-hackfest/2020-uiux/#user-documentation[user documentation track].
+  It is a good opportunity to get know the community better.
 . Send an introductory email to our mailing list. Please include a short self-introduction and list projects which would be interesting to you.
 
 === Team
@@ -128,7 +130,7 @@ Once the projects are announced, other project-specific channels might be create
 * link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
 * link:/sigs/docs/gsod/2020/application[Our GSoD 2020 application]
 
-== Mentors
+=== Mentors
 
 * link:https://developers.google.com/season-of-docs/docs/mentor-guide[GSoD Mentor Guide]
 * link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -111,6 +111,17 @@ Useful links:
 * link:https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A[Announcement in the developer mailing list]
 * link:/doc/developer/publishing/documentation/#plugin-pages[Using GitHub as a source of plugin documentation]
 
+[[user-guide]]
+=== User Guide Rework
+
+Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
+link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve user documentation.
+Common improvement themes include adding migration of the documentation from Wiki, pipeline examples with each of the pipeline steps, additional tutorials for new users, better search and navigation.
+
+Links: 
+
+* link:https://github.com/jenkins-infra/jenkins.io/projects/1[GitHub Project]
+
 [[administrator-guide]]
 === Administrator Guide
 
@@ -124,7 +135,7 @@ This project is tracked in the jira:WEBSITE-738[] EPIC.
 
 Jenkins on Kubernetes is a popular theme of Jenkins Meetups and presentations at conferences.
 The Jenkins on Kubernetes project will describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
-The project can refer to existing information from
+The project can refer to existing information from:
 
 * Jenkins online meetups (like
 link:https://www.youtube.com/watch?v=h4hKSXjCqyI[Jenkins on Kubernetes: Getting Started])
@@ -143,14 +154,6 @@ link:https://platform9.com/blog/kubernetes-for-ci-cd-at-scale/[Platform9])
 * SCM providers (like
 link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenkins-and-kubernetes-on-aws[Bitbucket])
 * link:https://kubernetes.io/blog/2018/04/30/zero-downtime-deployment-kubernetes-jenkins/[Kubernetes project]
-
-[[user-guide]]
-=== User Guide Rework
-
-Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
-link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve the user documentation.
-Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
-This project is tracked in the jira:WEBSITE-739[] EPIC.
 
 [[solution-pages]]
 === Solution Pages


### PR DESCRIPTION
CC @jenkins-infra/docs 
