### PR TITLE
Add Docs office hours

### DIFF
--- a/content/_data/events/2020-05-15-jom-anchore.adoc
+++ b/content/_data/events/2020-05-15-jom-anchore.adoc
@@ -1,8 +1,0 @@
----
-title: "Securing pipelines with Anchore"
-location: Online Meetup
-date: "2020-05-15T15:00:00"
-link: "https://www.meetup.com/Jenkins-online-meetup/events/270499803/"
----
-
-Marky Jackson will show how to secure your Jenkins CI/CD Container Pipeline with Anchore, and how to add the open-source Anchore Engine API service into your pipeline to validate that the flow of images you are shipping comply with your specific requirements, from a security point of view.

--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -81,7 +81,7 @@ notitle: true
                   .dow
                     Thu
                 .time
-                  12:00 UTC
+                  12h UTC
               %h5.title
                 Platform SIG Meeting
     .col-md-6.text-center

--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -40,6 +40,21 @@ notitle: true
     .col-md-6.text-center
       %ul.ji-item-list
         %li.post.event.floating
+          %a.body{:href => 'https://jenkins.io/sigs/docs#meetings', :target => '_blank'}
+            .header.time
+              .date-time
+                .date
+                  .day
+                    Monday
+                  .dow
+                    Mon
+                .time
+                  22h UTC
+              %h5.title
+                Docs Office Hours
+    .col-md-6.text-center
+      %ul.ji-item-list
+        %li.post.event.floating
           %a.body{:href => 'https://jenkins.io/projects/infrastructure/#meetings', :target => '_blank'}
             .header.time
               .date-time

--- a/content/events/index.html.haml
+++ b/content/events/index.html.haml
@@ -91,8 +91,8 @@ notitle: true
             .header.time
               .date-time
                 .date
-                  .day.small
-                    Wednesdays
+                  .day
+                    Wednesday
                   .dow
                     Wed
                 .time

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -138,6 +138,12 @@ Once the projects are announced, other project-specific channels might be create
 * link:https://developers.google.com/season-of-docs/docs/tech-writer-collaboration[Working with a technical writer]
 * link:/sigs/docs/gsod/2020/application[Our GSoD 2020 application]
 
+=== Office Hours
+
+Documentation office hours are held each Monday at *22:00 UTC*.
+Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
+Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+
 [#archive]
 == Previous years
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -187,7 +187,11 @@ See link:/sigs/docs/gsod[this page] for more info.
 
 == Meetings
 
-We have regular meetings on the fourth Friday of each month at *1PM UTC*.
+Documentation office hours are held each Monday at *22:00 UTC*.
+Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
+Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+
+The Documentation SIG meets on the fourth Friday of each month at *13:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].


### PR DESCRIPTION
## Add Docs Office Hours


Google Season of Docs technical writers and user experience Hackfest contributors may benefit from an hour dedicated to answering questions and helping new contributors.

Also makes minor fixes to two other recurring events and removes the Securing Pipelines event that has been cancelled.

![screencapture-localhost-4242-events-2020-05-14-08_43_26-edit (1)](https://user-images.githubusercontent.com/156685/81949508-2d084e80-95c0-11ea-9565-d50fcdf09a78.png)
