### PR TITLE
Add FreeBSD install instructions

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -415,7 +415,7 @@ Jenkins can be installed on FreeBSD using the standard FreeBSD package manager, 
 
 [IMPORTANT]
 ====
-Disclaimer: The FreeBSD project maintains the Jenkins packaging for FreeBSD.
+Disclaimer: The link:https://www.freebsd.org/[FreeBSD project] maintains the Jenkins packaging for FreeBSD.
 The Jenkins package for FreeBSD is NOT officially supported by the Jenkins project,
 but it is actively used by the link:https://www.freebsd.org/[FreeBSD project] at https://ci.freebsd.org/ .
 ====
@@ -487,6 +487,7 @@ Once Jenkins is enabled, it can be started with:
 ----
 
 Other configuration values that can be set in `/etc/rc.conf` or in `/etc/rc.conf.d/jenkins` are described in `/usr/local/etc/rc.d/jenkins`.
+Refer to the link:https://wiki.freebsd.org/Jenkins[Jenkins page] on the link:https://wiki.freebsd.org/[FreeBSD wiki] for more information specific to Jenkins on FreeBSD.
 
 
 ==== OpenIndiana Hipster

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -409,6 +409,86 @@ To install from the website, using the installer:
 === Other operating systems
 
 
+==== FreeBSD
+
+Jenkins can be installed on FreeBSD using the standard FreeBSD package manager, `pkg`.
+
+[IMPORTANT]
+====
+Disclaimer: The FreeBSD project maintains the Jenkins packaging for FreeBSD.
+The Jenkins package for FreeBSD is NOT officially supported by the Jenkins project,
+but it is actively used by the link:https://www.freebsd.org/[FreeBSD project] at https://ci.freebsd.org/ .
+====
+
+===== Long Term Support release
+
+A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
+It can be installed from the FreeBSD `pkg` package manager.
+
+[source,bash]
+----
+# pkg install jenkins-lts
+----
+
+===== Weekly release
+
+A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
+It can be installed from the FreeBSD `pkg` package manager.
+
+[source,bash]
+----
+# pkg install jenkins
+----
+
+The long term support package `jenkins-lts` and the weekly package installation `jenkins` will:
+
+* Configure Jenkins as a daemon which may optionally be launched on start. See `/etc/rc.conf` for more details
+* Create a '`jenkins`' user to run the service
+* Direct console log output to the file `/var/log/jenkins.log`. Check this file when troubleshooting Jenkins
+* Set Jenkins to listen on port 8180 from the path `/jenkins`.  Open \http://localhost:8180/jenkins to login to Jenkins
+
+===== Start Jenkins
+
+You can start the Jenkins service with the command:
+
+[source,bash]
+----
+# service jenkins onestart
+----
+
+You can check the status of the Jenkins service using the command:
+
+[source,bash]
+----
+# service jenkins status
+----
+
+You can stop the Jenkins service with the command:
+
+[source,bash]
+----
+# service jenkins stop
+----
+
+===== Enable Jenkins
+
+Add the following to `/etc/rc.conf` to start Jenkins automatically on system boot:
+
+[source,bash]
+----
+jenkins_enable="YES"
+----
+
+Once Jenkins is enabled, it can be started with:
+
+[source,bash]
+----
+# service jenkins start
+----
+
+Other configuration values that can be set in `/etc/rc.conf` or in `/etc/rc.conf.d/jenkins` are described in `/usr/local/etc/rc.d/jenkins`.
+
+
 ==== OpenIndiana Hipster
 
 On a system running link:https://www.openindiana.org/[OpenIndiana Hipster]


### PR DESCRIPTION
## Add FreeBSD install instructions

A disclaimer is included to note that the FreeBSD packaging of Jenkins is maintained by the FreeBSD project.  That is similar to the OpenIndiana packaging that is also documented in the installation guide.