### PR TITLE
Improve the "Report a problem" button so that it uses the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-bug.md
+++ b/.github/ISSUE_TEMPLATE/4-bug.md
@@ -4,12 +4,17 @@ labels: bug
 about: Create a bug report to the website
 ---
 
-<!-- Describe the expected and actual behavior here. -->
+Problem with this page:
+TODO: provide a link
 
-## Steps to reproduce
+TODO: Describe the expected and actual behavior here
 
-<!-- Please clarify how to reproduce the issue. If it requires a special environment, please document it (e.g. browser, mobile phone) -->
+## Screenshots
+
+ TODO: Add screenshots if possible
 
 ## Possible Solution
 
 <!-- If you have suggestions on a fix for the bug, please describe it here. -->
+
+N/A

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -99,7 +99,7 @@
                 :title => "Edit #{page.relative_source_path} on GitHub",
                 } Improve this page
                 |
-                %a{:href => "https://github.com/jenkins-infra/jenkins.io/issues/new?title=#{page.title}&body=Problem with: [#{page.title}](https://www.jenkins.io#{page.url}), [source file](https://github.com/jenkins-infra/jenkins.io/blob/master/content#{page.relative_source_path})",
+                %a{:href => "https://github.com/jenkins-infra/jenkins.io/issues/new?labels=bug&template=4-bug.md&title=#{page.title} page - TODO: Put a summary here&body=Problem with the [#{page.title}](https://www.jenkins.io#{page.url}) page, [source file](https://github.com/jenkins-infra/jenkins.io/blob/master/content#{page.relative_source_path})%0A%0ATODO: Describe the expected and actual behavior here %0A%0A%23%23 Screenshots %0A%0A TODO: Add screenshots if possible %0A%0A%23%23 Possible Solution %0A%0A%3C!-- If you have suggestions on a fix for the bug, please describe it here. --%3E %0A%0AN/A",
                 :title => "Report a problem with #{page.relative_source_path}",
                 } Report a problem
 


### PR DESCRIPTION
GitHub does not really allow to append a description to a template, so I just put the entire template into URL...

![image](https://user-images.githubusercontent.com/3000480/82037682-c4de6900-96a2-11ea-8200-e6f79a288624.png)
