### PR TITLE
GSoC 2020 - Update the list of mentors and advisors + redirect for the projects link

### DIFF
--- a/content/_layouts/gsocproject.html.haml
+++ b/content/_layouts/gsocproject.html.haml
@@ -20,10 +20,23 @@ project: gsoc
   %li
     Student:
     = display_user(page.student)
-  - page.mentors.each do |mentor|
-    %li
-      Mentor:
+  %li
+    Mentor(s):
+    - i = 0
+    - page.mentors.each do |mentor|
       = display_user_optional(mentor)
+      - i = i+1
+      -if i != page.mentors.length
+        = ", "
+  -if page.advisors
+    %li
+      Advisor(s):
+      - i = 0
+      - page.advisors.each do |mentor|
+        = display_user_optional(mentor)
+        - i = i+1
+        -if i != page.advisors.length
+          = ", "
 
 %h2.title
   Details

--- a/content/projects/gsoc/2020/projects.adoc
+++ b/content/projects/gsoc/2020/projects.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /projects/gsoc#projects
+---

--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -8,8 +8,9 @@ status: "Active"
 student: sladyn98
 mentors:
 - "linuxsuren"
-- "jeffpearce"
 - "kwhetstone"
+advisors:
+- "oleg_nenashev"
 links:
   gitter: "jenkinsci/jenkins-custom-distribution-service"
   draft: https://docs.google.com/document/d/1C7VQJ92Yhr0KRDcNVHYxn4ri7OL9IGZmgxY6UFON6-g/edit?usp=sharing

--- a/content/projects/gsoc/2020/projects/github-checks.adoc
+++ b/content/projects/gsoc/2020/projects/github-checks.adoc
@@ -10,10 +10,10 @@ student: XiongKezhi
 mentors:
 - "uhafner"
 - "timja"
-- "jeffpearce"
-- "jonbrohauge"
 - "ayush_agarwal"
 - "Sagar2366"
+advisors:
+- "jeffpearce"
 tags:
 - gsoc2020
 - github


### PR DESCRIPTION
This change modifies the mentor lists in GitHub Checks API and Custom Jenkins Distribution Build Service after the recent announcements. It also adds official support for the "advisor" role which we did not have on the website before.

I also added redirect for the https://www.jenkins.io/projects/gsoc/2020/projects/ link which currently leads to 404 if used directly

Sample layout:

![image](https://user-images.githubusercontent.com/3000480/82307109-329ad580-99c0-11ea-8d7b-b5b939efca7f.png)
