### PR TITLE
Clarify issue assignment process for wiki migration

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -444,8 +444,9 @@ C++/Windows specific content.
 
 The Jenkins project is moving documentation pages from the link:https://wiki.jenkins.io[Jenkins Wiki] to link:https://jenkins.io[www.jenkins.io].
 The link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter] tool uses link:https://pandoc.org/[Pandoc] to assist with the transition.
-Migrating a page from wiki.jenkins.io to www.jenkins.io with these steps:
+Migrate a page from wiki.jenkins.io to www.jenkins.io with these steps:
 
+* Choose the page to convert from the link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen[GitHub issues] and leave an link:https://help.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues[issue comment] that you want to convert that page
 . Paste the URL of the Wiki page you want to export into the link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter]
 . Select the __Asciidoc_ format for pages without images or _Asciidoc Zip_ format for pages with images
 . Click the _Convert_ button and wait till the files are generated

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -448,7 +448,7 @@ Migrate a page from wiki.jenkins.io to www.jenkins.io with these steps:
 
 * Choose the page to convert from the link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen[GitHub issues] and leave an link:https://help.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues[issue comment] that you want to convert that page
 . Paste the URL of the Wiki page you want to export into the link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter]
-. Select the __Asciidoc_ format for pages without images or _Asciidoc Zip_ format for pages with images
+. Select the _Asciidoc_ format for pages without images or _Asciidoc Zip_ format for pages with images
 . Click the _Convert_ button and wait till the files are generated
 . Place the Asciidoc content and the images in the correct repository locations
 . Review nd correct the exported file formatting


### PR DESCRIPTION
First time contributors are sometimes hesitant to start on an issue without being confident it is reserved for them.  This describes our using a comment in the issue to reserve the issue.