### PR TITLE
Docker installation guide to use the jenkins/jenkins

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -58,7 +58,7 @@ docker container run \
 image. By default, Docker will generate a unique name for the container.
 <2> ( _Optional_ ) Automatically removes the Docker container (the instance of
 the Docker image) when it is shut down. This contains the Docker image cache
-used by Docker when invoked from the `jenkinsci/blueocean` container described
+used by Docker when invoked from the `jenkins/jenkins` container described
 below.
 <3> ( _Optional_ ) Runs the Docker container in the background. This instance
 can be stopped later by running `docker container stop jenkins-docker` and
@@ -99,7 +99,7 @@ docker container run --name jenkins-docker --rm --detach \
   --volume jenkins-data:/var/jenkins_home \
   --publish 2376:2376 docker:dind
 ----
-. Download the `jenkinsci/blueocean` image and run it as a container in Docker
+. Download the `jenkins/jenkins` image and run it as a container in Docker
   using the following
   link:https://docs.docker.com/engine/reference/commandline/container_run/[`docker container run`]
   command:
@@ -107,7 +107,7 @@ docker container run --name jenkins-docker --rm --detach \
 [source,bash]
 ----
 docker container run \
-  --name jenkins-blueocean \# <1>
+  --name jenkins-jenkins \# <1>
   --rm \# <2>
   --detach \# <3>
   --network jenkins \# <4>
@@ -118,15 +118,15 @@ docker container run \
   --publish 50000:50000 \# <7>
   --volume jenkins-data:/var/jenkins_home \# <8>
   --volume jenkins-docker-certs:/certs/client:ro \# <9>
-  jenkinsci/blueocean# <10>
+  jenkins/jenkins# <10>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name for this instance of
-the `jenkinsci/blueocean` Docker image. This makes it simpler to reference
+the `jenkins/jenkins` Docker image. This makes it simpler to reference
 by subsequent `docker container` commands.
 <2> ( _Optional_ ) Automatically removes the Docker container (which is the
-instantiation of the `jenkinsci/blueocean` image below) when it is shut down.
+instantiation of the `jenkins/jenkins` image below) when it is shut down.
 This keeps things tidy if you need to quit Jenkins.
-<3> ( _Optional_ ) Runs the `jenkinsci/blueocean` container in the background
+<3> ( _Optional_ ) Runs the `jenkins/jenkins` container in the background
 (i.e. "detached" mode) and outputs the container ID. If you do not specify this
 option, then the running Docker log for this container is output in the terminal
 window.
@@ -135,15 +135,15 @@ step. This makes the Docker daemon from the previous step available to this
 Jenkins container through the hostname `docker`.
 <5> Specifies the environment variables used by `docker`, `docker-compose`, and
 other Docker tools to connect to the Docker daemon from the previous step.
-<6> Maps (i.e. "publishes") port 8080 of the `jenkinsci/blueocean` container to
+<6> Maps (i.e. "publishes") port 8080 of the `jenkins/jenkins` container to
 port 8080 on the host machine. The first number represents the port on the host
 while the last represents the container's port. Therefore, if you specified `-p
 49000:8080` for this option, you would be accessing Jenkins on your host machine
 through port 49000.
-<7> ( _Optional_ ) Maps port 50000 of the `jenkinsci/blueocean` container to
+<7> ( _Optional_ ) Maps port 50000 of the `jenkins/jenkins` container to
 port 50000 on the host machine. This is only necessary if you have set up one or
 more JNLP-based Jenkins agents on other machines, which in turn interact with
-the `jenkinsci/blueocean` container (acting as the "master" Jenkins server, or
+the `jenkins/jenkins` container (acting as the "master" Jenkins server, or
 simply "Jenkins master"). JNLP-based Jenkins agents communicate with the Jenkins
 master through TCP port 50000 by default. You can change this port number on
 your Jenkins master through the <<managing/security#,Configure Global Security>>
@@ -170,7 +170,7 @@ from the `docker:dind` container above needs to be updated to match this.
 `jenkins-docker-certs` volume. This makes the client TLS certificates needed
 to connect to the Docker daemon available in the path specified by the
 `DOCKER_CERT_PATH` environment variable.
-<10> The `jenkinsci/blueocean` Docker image itself. If this image has not already
+<10> The `jenkins/jenkins` Docker image itself. If this image has not already
 been downloaded, then this `docker container run` command will automatically download the
 image for you. Furthermore, if any updates to this image were published since
 you last ran this command, then running this command again will automatically
@@ -179,19 +179,19 @@ download these published image updates for you. +
 using the
 link:https://docs.docker.com/engine/reference/commandline/image_pull/[`docker image pull`]
 command: +
-`docker image pull jenkinsci/blueocean`
+`docker image pull jenkins/jenkins`
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
 +
 [source,bash]
 ----
-docker container run --name jenkins-blueocean --rm --detach \
+docker container run --name jenkins-jenkins --rm --detach \
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 \
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
-  --publish 8080:8080 --publish 50000:50000 jenkinsci/blueocean
+  --publish 8080:8080 --publish 50000:50000 jenkins/jenkins
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
@@ -238,39 +238,39 @@ docker container run --name jenkins-docker --rm --detach ^
   --volume jenkins-data:/var/jenkins_home ^
   docker:dind
 ----
-. Download the `jenkinsci/blueocean` image and run it as a container in Docker
+. Download the `jenkins/jenkins` image and run it as a container in Docker
   using the following
   link:https://docs.docker.com/engine/reference/commandline/container_run/[`docker container run`]
   command:
 +
 [source]
 ----
-docker container run --name jenkins-blueocean --rm --detach ^
+docker container run --name jenkins-jenkins --rm --detach ^
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
   --volume jenkins-data:/var/jenkins_home ^
   --volume jenkins-docker-certs:/certs/client:ro ^
-  --publish 8080:8080 --publish 50000:50000 jenkinsci/blueocean
+  --publish 8080:8080 --publish 50000:50000 jenkins/jenkins
 ----
 For an explanation of each of these options, refer to the <<on-macos-and-linux,
 macOS and Linux>> instructions above.
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
-[[accessing-the-jenkins-blue-ocean-docker-container]]
-==== Accessing the Jenkins/Blue Ocean Docker container
+[[accessing-the-jenkins-jenkins-docker-container]]
+==== Accessing the Jenkins/Jenkins Docker container
 
 If you have some experience with Docker and you wish or need to access the
-`jenkinsci/blueocean` container through a terminal/command prompt using the
+`jenkins/jenkins` container through a terminal/command prompt using the
 link:https://docs.docker.com/engine/reference/commandline/container_exec/[`docker container exec`]
-command, you can add an option like `--name jenkins-blueocean` (with the
+command, you can add an option like `--name jenkins-jenkins` (with the
 link:https://docs.docker.com/engine/reference/commandline/container_run/[`docker container run`]
-above), which would give the `jenkinsci/blueocean` container the name
-"jenkins-blueocean".
+above), which would give the `jenkins/jenkins` container the name
+"jenkins-jenkins".
 
 This means you could access the container (through a separate terminal/command
 prompt window) with a `docker container exec` command like:
 
-`docker container exec -it jenkins-blueocean bash`
+`docker container exec -it jenkins-jenkins bash`
 
 
 ==== Accessing the Jenkins console log through Docker logs
@@ -287,19 +287,18 @@ which you ran this Docker command.
 
 Otherwise, you can access the Jenkins console log through the
 link:https://docs.docker.com/engine/reference/commandline/container_logs/[Docker logs] of
-the `jenkinsci/blueocean` container using the following command:
+the `jenkins/jenkins` container using the following command:
 
 `docker container logs <docker-container-name>`
 
 Your `<docker-container-name>` can be obtained using the
 link:https://docs.docker.com/engine/reference/commandline/container_ls/[`docker container ls`]
 command. If you specified the +
-`--name jenkins-blueocean` option in the `docker container run ...` command above (see
+`--name jenkins-jenkins` option in the `docker container run ...` command above (see
 also
-<<accessing-the-jenkins-blue-ocean-docker-container,Accessing the Jenkins/Blue
-Ocean Docker container>>), you can simply use the `docker container logs` command:
+<<accessing-the-jenkins-jenkins-docker-container,Accessing the Jenkins/Jenkins Docker container>>), you can simply use the `docker container logs` command:
 
-`docker container logs jenkins-blueocean`
+`docker container logs jenkins-jenkins`
 
 
 ==== Accessing the Jenkins home directory
@@ -315,7 +314,7 @@ contents of this directory through your machine's usual terminal/command prompt.
 
 Otherwise, if you specified the `--volume jenkins-data:/var/jenkins_home` option in
 the `docker container run ...` command, you can access the contents of the Jenkins home
-directory through the `jenkinsci/blueocean` container's terminal/command prompt
+directory through the `jenkins/jenkins` container's terminal/command prompt
 using the
 link:https://docs.docker.com/engine/reference/commandline/container_exec/[`docker container exec`]
 command:
@@ -326,22 +325,21 @@ As mentioned <<accessing-the-jenkins-console-log-through-docker-logs,above>>,
 your `<docker-container-name>` can be obtained using the
 link:https://docs.docker.com/engine/reference/commandline/container_ls/[`docker container ls`]
 command. If you specified the +
-`--name jenkins-blueocean` option in the `docker container run ...`
+`--name jenkins-jenkins` option in the `docker container run ...`
 command above (see also
-<<accessing-the-jenkins-blue-ocean-docker-container,Accessing the Jenkins/Blue
-Ocean Docker container>>), you can simply use the `docker container exec` command:
+<<<accessing-the-jenkins-jenkins-docker-container,Accessing the Jenkins/Jenkins Docker container>>), you can simply use the `docker container exec` command:
 
-`docker container exec -it jenkins-blueocean bash`
+`docker container exec -it jenkins-jenkins bash`
 
 ////
 Might wish to add explaining the `docker run -t` option, which was covered in
 the old installation instructions but not above.
 
-Also mention that spinning up a container of the `jenkinsci/blueocean` Docker
+Also mention that spinning up a container of the `jenkins/jenkins` Docker
 image can be done so with all the same
 https://github.com/jenkinsci/docker#usage[configuration options] available to
 the other images published by the Jenkins project.
 
 Explain colon syntax on Docker image references like
-`jenkinsci/blueocean:latest'.
+`jenkins/jenkins:latest'.
 ////

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -112,10 +112,11 @@ information about how to configure Docker to start on boot.
 
 There are several Docker images of Jenkins available.
 
-The recommended Docker image to use is the
-link:https://hub.docker.com/r/jenkinsci/blueocean/[`jenkinsci/blueocean` image]
-(from the link:https://hub.docker.com/[Docker Hub repository]). This image
-contains the current link:/download[Long-Term Support (LTS) release of Jenkins]
+The recommended Docker image to use is the link:https://hub.docker.com/r/jenkins/jenkins/[`jenkins/jenkins`] (from the link:https://hub.docker.com/[Docker Hub repository]).
+
+==== Blue Ocean
+The Docker link:https://hub.docker.com/r/jenkinsci/blueocean/[`jenkinsci/blueocean` image]
+(from the link:https://hub.docker.com/[Docker Hub repository]) contains the current link:/download[Long-Term Support (LTS) release of Jenkins]
 (which is production-ready) bundled with all Blue Ocean plugins and features.
 This means that you do not need to install the Blue Ocean plugins separately.
 
@@ -125,13 +126,6 @@ A new `jenkinsci/blueocean` image is published each time a new release of Blue
 Ocean is published. You can see a list of previously published versions of the
 `jenkinsci/blueocean` image on the
 link:https://hub.docker.com/r/jenkinsci/blueocean/tags/[tags] page.
-
-There are also other Jenkins Docker images you can use (accessible through
-link:https://hub.docker.com/r/jenkins/jenkins/[`jenkins/jenkins`] on Docker
-Hub). However, these do not come with Blue Ocean, which would need to be
-installed via the link:../managing[*Manage Jenkins*] >
-link:../managing/plugins[*Manage Plugins*] page in Jenkins. Read more
-about this in link:../blueocean/getting-started[Getting started with Blue Ocean].
 ====
 
 include::doc/book/installing/_docker.adoc[]


### PR DESCRIPTION
Rewrite the Docker installation guide to use the jenkins/jenkins image instead of the Blue Ocean images 