### PR TITLE
Migrate 'Pipeline CPS method mismatches' wiki page to jenkins.io

### DIFF
--- a/content/doc/book/pipeline/_chapter.yml
+++ b/content/doc/book/pipeline/_chapter.yml
@@ -10,5 +10,5 @@ sections:
   - syntax
   - pipeline-best-practices
   - scaling-pipeline
-
+  - cps-method-mismatches
 

--- a/content/doc/book/pipeline/cps-method-mismatches.adoc
+++ b/content/doc/book/pipeline/cps-method-mismatches.adoc
@@ -16,22 +16,14 @@ endif::[]
 
 = Pipeline CPS Method Mismatches
 
-Jenkins Pipeline uses a library called Groovy CPS to run Pipeline
-scripts. While Pipeline uses the Groovy parser and compiler, unlike a
-regular Groovy environment it runs most of the program inside a special
-interpreter. This uses a continuation-passing style (CPS) transform to
-turn your code into a version that can save its current state to disk (a
-file called `+program.dat+`  inside your build directory) and continue
-running even after Jenkins has restarted. (You can get some more
-technical background on
-the plugin:workflow-cps[Pipeline: Groovy plugin page]
-and the https://github.com/cloudbees/groovy-cps/blob/master/README.md[library page].)
+Jenkins Pipeline uses a library called Groovy CPS to run Pipeline scripts.
+While Pipeline uses the Groovy parser and compiler, unlike a regular Groovy environment it runs most of the program inside a special interpreter.
+This uses a continuation-passing style (CPS) transform to turn your code into a version that can save its current state to disk (a file called `+program.dat+`  inside your build directory) and continue running even after Jenkins has restarted.
+(You can get some more technical background on the plugin:workflow-cps[Pipeline: Groovy plugin page] and the https://github.com/cloudbees/groovy-cps/blob/master/README.md[library page].)
 
-While the CPS transform is usually transparent to users, there are
-limitations to what Groovy language constructs can be supported, and in
-some circumstances it can lead to counterintuitive behavior. https://issues.jenkins-ci.org/browse/JENKINS-31314[JENKINS-31314] makes the runtime try to detect the most common mistake: calling
-CPS-transformed code from non-CPS-transformed code. The following kinds
-of things are CPS-transformed:
+While the CPS transform is usually transparent to users, there are limitations to what Groovy language constructs can be supported, and in some circumstances it can lead to counterintuitive behavior.
+https://issues.jenkins-ci.org/browse/JENKINS-31314[JENKINS-31314] makes the runtime try to detect the most common mistake: calling CPS-transformed code from non-CPS-transformed code.
+The following kinds of things are CPS-transformed:
 
 * Almost all of the Pipeline script you write (including in libraries)
 * Most Pipeline steps, including all those which take a block
@@ -43,10 +35,8 @@ The following kinds of things are _not_ CPS-transformed:
 ** Jenkins core and plugins
 ** the runtime for the Groovy language
 * Constructor bodies in your Pipeline script
-* Any method in your Pipeline script marked with the `+@NonCPS+` 
-annotation
-* A few Pipeline steps which take no block and act instantaneously, such
-as `+echo+` or `+properties+`
+* Any method in your Pipeline script marked with the `+@NonCPS+` annotation
+* A few Pipeline steps which take no block and act instantaneously, such as `+echo+` or `+properties+`
 
 CPS-transformed code may call non-CPS-transformed code or other CPS-transformed code, and non-CPS-transformed code may call other non-CPS-transformed code, but non-CPS-transformed code *may not* call CPS-transformed code.
 If you try to call CPS-transformed code from non-CPS-transformed code, the CPS interpreter is unable to operate correctly, resulting in incorrect and often confusing results.
@@ -55,20 +45,16 @@ If you try to call CPS-transformed code from non-CPS-transformed code, the CPS i
 
 === Use of Pipeline steps from `+@NonCPS+`
 
-Sometimes users will apply the `+@NonCPS+`  annotation to a method
-definition in order to bypass the CPS transform inside that method. This
-can be done to work around limitations in Groovy language coverage
-(since the body of the method will execute using the native Groovy
-semantics), or to get better performance (the interpreter imposes a
-substantial overhead). However such methods must not call
-CPS-transformed code such as Pipeline steps. For example, the following
-will not work:
+Sometimes users will apply the `+@NonCPS+`  annotation to a method definition in order to bypass the CPS transform inside that method.
+This can be done to work around limitations in Groovy language coverage (since the body of the method will execute using the native Groovy semantics), or to get better performance (the interpreter imposes a substantial overhead).
+However, such methods must not call CPS-transformed code such as Pipeline steps.
+For example, the following will not work:
 
 [source,groovy]
 ----
 @NonCPS
 def compileOnPlatforms() {
-  ['linux', 'windows'].each {arch ->
+  ['linux', 'windows'].each { arch ->
     node(arch) {
       sh 'make'
     }
@@ -77,26 +63,21 @@ def compileOnPlatforms() {
 compileOnPlatforms()
 ----
 
-Using the `+node+`  or `+sh+`  steps from this method is illegal, and
-the behavior will be anomalous. The warning in the logs from running
-this script looks like this:
+Using the `+node+`  or `+sh+`  steps from this method is illegal, and the behavior will be anomalous.
+The warning in the logs from running this script looks like this:
 
 ____
-expected to call WorkflowScript.compileOnPlatforms but wound up catching
-node
+expected to call WorkflowScript.compileOnPlatforms but wound up catching node
 ____
 
 To fix this case, simply remove the annotation — it was not needed.
-(Longtime Pipeline users might have thought it was, prior to the fix of 
-https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481].)
+(Longtime Pipeline users might have thought it was, prior to the fix of https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481].)
 
 === Calling non-CPS-transformed methods with CPS-transformed arguments
 
-Some Groovy and Java methods take complex types as parameters to support
-dynamic behavior. A common case is sorting methods that allow callers to
-specify a method to use for comparing objects (https://issues.jenkins-ci.org/browse/JENKINS-44924[JENKINS-44924]).
-Many similar methods in the Groovy standard library work correctly after the fix
-for https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481], but some methods remain unfixed.
+Some Groovy and Java methods take complex types as parameters to support dynamic behavior.
+A common case is sorting methods that allow callers to specify a method to use for comparing objects (https://issues.jenkins-ci.org/browse/JENKINS-44924[JENKINS-44924]).
+Many similar methods in the Groovy standard library work correctly after the fix for https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481], but some methods remain unfixed.
 For example, the following will not work:
 
 [source,groovy]
@@ -108,32 +89,22 @@ def sorted = sortByLength(['333', '1', '4444', '22'])
 echo(sorted.toString())
 ----
 
-The closure passed to `+Iterable.toSorted+` is CPS-transformed, but
-`+Iterable.toSorted+` itself is not CPS-transformed internally, so this
-will not work as intended. The current behavior is that the return value
-of the method will be the return value of the first call to the closure.
-In the example, this results in `+sorted+` being set to `+-1+`, and the
-warning in the logs looks like this:
+The closure passed to `+Iterable.toSorted+` is CPS-transformed, but `+Iterable.toSorted+` itself is not CPS-transformed internally, so this will not work as intended.
+The current behavior is that the return value of the call to `toSorted` will be the return value of the first call to the closure.
+In the example, this results in `+sorted+` being set to `+-1+`, and the warning in the logs looks like this:
 
 ____
-expected to call java.util.ArrayList.toSorted but wound up catching
-org.jenkinsci.plugins.workflow.cps.CpsClosure2.call
+expected to call java.util.ArrayList.toSorted but wound up catching org.jenkinsci.plugins.workflow.cps.CpsClosure2.call
 ____
 
-To fix this case, any argument passed to these methods must not be
-CPS-transformed. This can be accomplished by encapsulating the
-problematic method (`+Iterable.toSorted+` in the example) inside another
-method, and annotating the outer method with `+@NonCPS+`, or by creating
-an explicit class for the argument and annotating the relevant methods
-on that class with `+@NonCPS+`.
+To fix this case, any argument passed to these methods must not be CPS-transformed.
+This can be accomplished by encapsulating the problematic method (`+Iterable.toSorted+` in the example) inside another method, and annotating the outer method with `+@NonCPS+`, or by creating an explicit class definition for the closure and annotating all methods on that class with `+@NonCPS+`.
 
 === Constructors
 
-Occasionally, users may attempt to use CPS-transformed code such as
-Pipeline steps inside of a constructor in a Pipeline script.
-Unfortunately, the construction of objects via the `+new+` operator in
-Groovy is not something that can be CPS-transformed (https://issues.jenkins-ci.org/browse/JENKINS-26313[JENKINS-26313]), and so this will not work. Here is an example that calls a
-CPS-transformed method in a constructor:
+Occasionally, users may attempt to use CPS-transformed code such as Pipeline steps inside of a constructor in a Pipeline script.
+Unfortunately, the construction of objects via the `+new+` operator in Groovy is not something that can be CPS-transformed (https://issues.jenkins-ci.org/browse/JENKINS-26313[JENKINS-26313]), and so this will not work.
+Here is an example that calls a CPS-transformed method in a constructor:
 
 [source,groovy]
 ----
@@ -150,27 +121,22 @@ def x = new Test().x
 echo "${x}"
 ----
 
-The construction of `+Test+` will fail when the constructor calls
-`+Test.setX+` because `+setX+` is a CPS-transformed method. The warning
-in the logs from running this script looks like this:
+The construction of `+Test+` will fail when the constructor calls `+Test.setX+` because `+setX+` is a CPS-transformed method.
+The warning in the logs from running this script looks like this:
 
 ____
 expected to call Test.<init> but wound up catching Test.setX
 ____
 
-To fix this case, ensure that any methods defined in a Pipeline script
-that are called from inside of a constructor are annotated
-with `+@NonCPS+` and that constructors do not call any Pipeline steps.
+To fix this case, ensure that any methods defined in a Pipeline script that are called from inside of a constructor are annotated with `+@NonCPS+` and that constructors do not call any Pipeline steps.
+If you must call CPS-transformed code such a Pipeline steps from the constructor, you need move the logic related to the CPS-transformed methods out of the constructor, for example into a static factory method that calls the CPS-transformed code and then passes the results to the constructor.
 
 === Overrides of non-CPS-transformed methods
 
-Users may create a class in a Pipeline Script that extends a preexisting
-class defined outside of the Pipeline script, for example from the Java
-or Groovy standard libraries. When doing so, the subclass must ensure
-that any overriding methods are annotated with `+@NonCPS+` and do not
-use any CPS-transformed code internally. Otherwise, the overriding
-methods will fail if called from a non-CPS context. For example, the
-following will not work:
+Users may create a class in a Pipeline Script that extends a preexisting class defined outside of the Pipeline script, for example from the Java or Groovy standard libraries.
+When doing so, the subclass must ensure that any overriding methods are annotated with `+@NonCPS+` and do not use any CPS-transformed code internally.
+Otherwise, the overriding methods will fail if called from a non-CPS context.
+For example, the following will not work:
 
 [source,groovy]
 ----
@@ -185,28 +151,21 @@ builder.append(new Test())
 echo(builder.toString())
 ----
 
-Calling the CPS-transformed override of `+toString+` from
-non-CPS-transformed code such as `+StringBuilder.append+` is not
-permitted and will not work as expected in most cases. The warning in
-the logs from running this script looks like this:
+Calling the CPS-transformed override of `+toString+` from non-CPS-transformed code such as `+StringBuilder.append+` is not permitted and will not work as expected in most cases.
+The warning in the logs from running this script looks like this:
 
 ____
-expected to call java.lang.StringBuilder.append but wound up catching
-Test.toString
+expected to call java.lang.StringBuilder.append but wound up catching Test.toString
 ____
 
-To fix this case, add the `+@NonCPS+` annotation to the overriding
-method, and remove any uses of CPS-transformed code such as Pipeline
-steps from the method.
+To fix this case, add the `+@NonCPS+` annotation to the overriding method, and remove any uses of CPS-transformed code such as Pipeline steps from the method.
 
 [[PipelineCPSmethodmismatches-ClosuresinsideGString]]
 === Closures inside `+GString+` 
 
-In Groovy, it is possible to use a closure in a `+GString+` so that the
-closure is evaluated every time the `+GString+` is used as a `+String+`.
-However, in Pipeline scripts, this will not work as expected, because
-the closure inside of the GString will be CPS-transformed. Here is an
-example:
+In Groovy, it is possible to use a closure in a `+GString+` so that the closure is evaluated every time the `+GString+` is used as a `+String+`.
+However, in Pipeline scripts, this will not work as expected, because the closure inside of the GString will be CPS-transformed.
+Here is an example:
 
 [source,groovy]
 ----
@@ -216,19 +175,14 @@ x = 2
 echo(s)
 ----
 
-Using a closure inside of a `+GString+`  as in this example will not
-work. The warning from the logs when running this script looks like
-this:
+Using a closure inside of a `+GString+`  as in this example will not work.
+The warning from the logs when running this script looks like this:
 
 ____
-expected to call WorkflowScript.echo but wound up catching
-org.jenkinsci.plugins.workflow.cps.CpsClosure2.call
+expected to call WorkflowScript.echo but wound up catching org.jenkinsci.plugins.workflow.cps.CpsClosure2.call
 ____
 
-To fix this case, replace the original GString with a closure that
-returns a GString that uses a normal expression rather than a closure,
-and then call the closure where you would have used the original
-`+GString+` as follows:
+To fix this case, replace the original GString with a closure that returns a GString that uses a normal expression rather than a closure, and then call the closure where you would have used the original `+GString+` as follows:
 
 [source,groovy]
 ----
@@ -240,7 +194,5 @@ echo(s())
 
 == False Positives
 
-Unfortunately, some expressions may incorrectly trigger this warning
-even though they execute correctly. If you run into such a case, please
-https://issues.jenkins-ci.org/[file a new issue] (after first checking
-for duplicates) and set the component to `+workflow-cps+`.
+Unfortunately, some expressions may incorrectly trigger this warning even though they execute correctly.
+If you run into such a case, please https://issues.jenkins-ci.org/[file a new issue] (after first checking for duplicates) and set the component to `+workflow-cps+`.

--- a/content/doc/book/pipeline/cps-method-mismatches.adoc
+++ b/content/doc/book/pipeline/cps-method-mismatches.adoc
@@ -14,7 +14,7 @@ ifndef::env-github[:imagesdir: ../../resources]
 :toc:
 endif::[]
 
-= Introduction
+= Pipeline CPS Method Mismatches
 
 Jenkins Pipeline uses a library called Groovy CPS to run Pipeline
 scripts. While Pipeline uses the Groovy parser and compiler, unlike a
@@ -55,9 +55,9 @@ code to call CPS-transformed code. If you try, there will be a mismatch
 between the method that the CPS interpreter thought it was calling and
 the method that it actually got a return value from.
 
-= Common problems and solutions
+== Common problems and solutions
 
-== Use of Pipeline steps from `+@NonCPS+` 
+=== Use of Pipeline steps from `+@NonCPS+`
 
 Sometimes users will apply the `+@NonCPS+`  annotation to a method
 definition, which bypasses the CPS transform inside that method. This
@@ -68,7 +68,7 @@ substantial overhead). However such methods must not call
 CPS-transformed code such as Pipeline steps. For example, the following
 will not work:
 
-[source,syntaxhighlighter-pre]
+[source,groovy]
 ----
 @NonCPS
 def compileOnPlatforms() {
@@ -94,7 +94,7 @@ To fix this case, simply remove the annotation—it was not needed.
 (Longtime Pipeline users might have thought it was, prior to the fix of 
 https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481].)
 
-== Calling non-CPS-transformed methods with CPS-transformed arguments
+=== Calling non-CPS-transformed methods with CPS-transformed arguments
 
 Some Groovy and Java methods take complex types as parameters to support
 dynamic behavior. A common case is sorting methods that allow callers to
@@ -103,7 +103,7 @@ Many similar methods in the Groovy standard library work correctly after the fix
 for https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481], but some methods remain unfixed.
 For example, the following will not work:
 
-[source,syntaxhighlighter-pre]
+[source,groovy]
 ----
 def sortByLength(List<String> list) {
   list.toSorted { a, b -> Integer.valueOf(a.length()).compareTo(b.length()) }
@@ -131,7 +131,7 @@ method, and annotating the outer method with `+@NonCPS+`, or by creating
 an explicit class for the argument and annotating the relevant methods
 on that class with `+@NonCPS+`.
 
-== Constructors
+=== Constructors
 
 Occasionally, users may attempt to use CPS-transformed code such as
 Pipeline steps inside of a constructor in a Pipeline script.
@@ -139,7 +139,7 @@ Unfortunately, the construction of objects via the `+new+` operator in
 Groovy is not something that can be CPS-transformed (https://issues.jenkins-ci.org/browse/JENKINS-26313[JENKINS-26313]), and so this will not work. Here is an example that calls a
 CPS-transformed method in a constructor:
 
-[source,syntaxhighlighter-pre]
+[source,groovy]
 ----
 class Test {
   def x
@@ -166,7 +166,7 @@ To fix this case, ensure that any methods defined in a Pipeline script
 that are called from inside of a constructor are annotated
 with `+@NonCPS+` and that constructors do not call any Pipeline steps.
 
-== Overrides of non-CPS-transformed methods
+=== Overrides of non-CPS-transformed methods
 
 Users may create a class in a Pipeline Script that extends a preexisting
 class defined outside of the Pipeline script, for example from the Java
@@ -176,7 +176,7 @@ use any CPS-transformed code internally. Otherwise, the overriding
 methods will fail if called from a non-CPS context. For example, the
 following will not work:
 
-[source,syntaxhighlighter-pre]
+[source,groovy]
 ----
 class Test {
   @Override
@@ -204,7 +204,7 @@ method, and remove any uses of CPS-transformed code such as Pipeline
 steps from the method.
 
 [[PipelineCPSmethodmismatches-ClosuresinsideGString]]
-== Closures inside `+GString+` 
+=== Closures inside `+GString+` 
 
 In Groovy, it is possible to use a closure in a `+GString+` so that the
 closure is evaluated every time the `+GString+` is used as a `+String+`.
@@ -212,7 +212,7 @@ However, in Pipeline scripts, this will not work as expected, because
 the closure inside of the GString will be CPS-transformed. Here is an
 example:
 
-[source,syntaxhighlighter-pre]
+[source,groovy]
 ----
 def x = 1
 def s = "x = ${-> x}"
@@ -234,7 +234,7 @@ returns a GString that uses a normal expression rather than a closure,
 and then call the closure where you would have used the original
 `+GString+` as follows:
 
-[source,syntaxhighlighter-pre]
+[source,groovy]
 ----
 def x = 1
 def s = { -> x = "${x}" }
@@ -242,8 +242,7 @@ x = 2
 echo(s())
 ----
 
-[[PipelineCPSmethodmismatches-FalsePositives]]
-= False Positives
+== False Positives
 
 Unfortunately, some expressions may incorrectly trigger this warning
 even though they execute correctly. If you run into such a case, please

--- a/content/doc/book/pipeline/cps-method-mismatches.adoc
+++ b/content/doc/book/pipeline/cps-method-mismatches.adoc
@@ -1,0 +1,251 @@
+---
+layout: section
+title: Pipeline CPS Method Mismatches
+---
+ifdef::backend-html5[]
+:notitle:
+:description:
+:author:
+:email: jenkinsci-docs@googlegroups.com
+:sectanchors:
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
+:hide-uri-scheme:
+:toc:
+endif::[]
+
+= Introduction
+
+Jenkins Pipeline uses a library called Groovy CPS to run Pipeline
+scripts. While Pipeline uses the Groovy parser and compiler, unlike a
+regular Groovy environment it runs most of the program inside a special
+interpreter. This uses a continuation-passing style (CPS) transform to
+turn your code into a version that can save its current state to disk (a
+file called `+program.dat+`  inside your build directory) and continue
+running even after Jenkins has restarted. (You can get some more
+technical background on
+the https://github.com/jenkinsci/workflow-cps-plugin/blob/master/README.md[plugin page]
+and the https://github.com/cloudbees/groovy-cps/blob/master/README.md[library page].)
+
+While the CPS transform is usually transparent to users, there are
+limitations to what Groovy language constructs can be supported, and in
+some circumstances it can lead to counterintuitive behavior. https://issues.jenkins-ci.org/browse/JENKINS-31314[JENKINS-31314] makes the runtime try to detect the most common mistake: calling
+CPS-transformed code from non-CPS-transformed code. The following kinds
+of things are CPS-transformed:
+
+* Almost all of the Pipeline script you write (including in libraries).
+* Most Pipeline steps, including all those which take a block.
+
+The following kinds of things are _not_ CPS-transformed:
+
+* Compiled Java bytecode, including
+** the Java Platform
+** Jenkins core and plugins
+** the runtime for the Groovy language
+* Constructor bodies in your Pipeline script.
+* Any method in your Pipeline script marked with the `+@NonCPS+` 
+annotation.
+* A few Pipeline steps which take no block and act instantaneously, such
+as `+echo+` or `+properties+`.
+
+CPS-transformed code may call non-CPS-transformed code or other
+CPS-transformed code, and non-CPS-transformed code may call other
+non-CPS-transformed code, but it is impossible for non-CPS-transformed
+code to call CPS-transformed code. If you try, there will be a mismatch
+between the method that the CPS interpreter thought it was calling and
+the method that it actually got a return value from.
+
+= Common problems and solutions
+
+== Use of Pipeline steps from `+@NonCPS+` 
+
+Sometimes users will apply the `+@NonCPS+`  annotation to a method
+definition, which bypasses the CPS transform inside that method. This
+can be done to work around limitations in Groovy language coverage
+(since the body of the method will execute using the native Groovy
+semantics), or to get better performance (the interpreter imposes a
+substantial overhead). However such methods must not call
+CPS-transformed code such as Pipeline steps. For example, the following
+will not work:
+
+[source,syntaxhighlighter-pre]
+----
+@NonCPS
+def compileOnPlatforms() {
+  ['linux', 'windows'].each {arch ->
+    node(arch) {
+      sh 'make'
+    }
+  }
+}
+compileOnPlatforms()
+----
+
+Using the `+node+`  or `+sh+`  steps from this method is illegal, and
+the behavior will be anomalous. The warning in the logs from running
+this script looks like this:
+
+____
+expected to call WorkflowScript.compileOnPlatforms but wound up catching
+node
+____
+
+To fix this case, simply remove the annotation—it was not needed.
+(Longtime Pipeline users might have thought it was, prior to the fix of 
+https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481].)
+
+== Calling non-CPS-transformed methods with CPS-transformed arguments
+
+Some Groovy and Java methods take complex types as parameters to support
+dynamic behavior. A common case is sorting methods that allow callers to
+specify a method to use for comparing objects (https://issues.jenkins-ci.org/browse/JENKINS-44924[JENKINS-44924]).
+Many similar methods in the Groovy standard library work correctly after the fix
+for https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481], but some methods remain unfixed.
+For example, the following will not work:
+
+[source,syntaxhighlighter-pre]
+----
+def sortByLength(List<String> list) {
+  list.toSorted { a, b -> Integer.valueOf(a.length()).compareTo(b.length()) }
+}
+def sorted = sortByLength(['333', '1', '4444', '22'])
+echo(sorted.toString())
+----
+
+The closure passed to `+Iterable.toSorted+` is CPS-transformed, but
+`+Iterable.toSorted+` itself is not CPS-transformed internally, so this
+will not work as intended. The current behavior is that the return value
+of the method will be the return value of the first call to the closure.
+In the example, this results in `+sorted+` being set to `+-1+`, and the
+warning in the logs looks like this:
+
+____
+expected to call java.util.ArrayList.toSorted but wound up catching
+org.jenkinsci.plugins.workflow.cps.CpsClosure2.call
+____
+
+To fix this case, any argument passed to these methods must not be
+CPS-transformed. This can be accomplished by encapsulating the
+problematic method (`+Iterable.toSorted+` in the example) inside another
+method, and annotating the outer method with `+@NonCPS+`, or by creating
+an explicit class for the argument and annotating the relevant methods
+on that class with `+@NonCPS+`.
+
+== Constructors
+
+Occasionally, users may attempt to use CPS-transformed code such as
+Pipeline steps inside of a constructor in a Pipeline script.
+Unfortunately, the construction of objects via the `+new+` operator in
+Groovy is not something that can be CPS-transformed (https://issues.jenkins-ci.org/browse/JENKINS-26313[JENKINS-26313]), and so this will not work. Here is an example that calls a
+CPS-transformed method in a constructor:
+
+[source,syntaxhighlighter-pre]
+----
+class Test {
+  def x
+  public Test() {
+    setX()
+  }
+  private void setX() {
+    this.x = 1;
+  }
+}
+def x = new Test().x
+echo "${x}"
+----
+
+The construction of `+Test+` will fail when the constructor calls
+`+Test.setX+` because `+setX+` is a CPS-transformed method. The warning
+in the logs from running this script looks like this:
+
+____
+expected to call Test.<init> but wound up catching Test.setX
+____
+
+To fix this case, ensure that any methods defined in a Pipeline script
+that are called from inside of a constructor are annotated
+with `+@NonCPS+` and that constructors do not call any Pipeline steps.
+
+== Overrides of non-CPS-transformed methods
+
+Users may create a class in a Pipeline Script that extends a preexisting
+class defined outside of the Pipeline script, for example from the Java
+or Groovy standard libraries. When doing so, the subclass must ensure
+that any overriding methods are annotated with `+@NonCPS+` and do not
+use any CPS-transformed code internally. Otherwise, the overriding
+methods will fail if called from a non-CPS context. For example, the
+following will not work:
+
+[source,syntaxhighlighter-pre]
+----
+class Test {
+  @Override
+  public String toString() {
+    return "Test"
+  }
+}
+def builder = new StringBuilder()
+builder.append(new Test())
+echo(builder.toString())
+----
+
+Calling the CPS-transformed override of `+toString+` from
+non-CPS-transformed code such as `+StringBuilder.append+` is not
+permitted and will not work as expected in most cases. The warning in
+the logs from running this script looks like this:
+
+____
+expected to call java.lang.StringBuilder.append but wound up catching
+Test.toString
+____
+
+To fix this case, add the `+@NonCPS+` annotation to the overriding
+method, and remove any uses of CPS-transformed code such as Pipeline
+steps from the method.
+
+[[PipelineCPSmethodmismatches-ClosuresinsideGString]]
+== Closures inside `+GString+` 
+
+In Groovy, it is possible to use a closure in a `+GString+` so that the
+closure is evaluated every time the `+GString+` is used as a `+String+`.
+However, in Pipeline scripts, this will not work as expected, because
+the closure inside of the GString will be CPS-transformed. Here is an
+example:
+
+[source,syntaxhighlighter-pre]
+----
+def x = 1
+def s = "x = ${-> x}"
+x = 2
+echo(s)
+----
+
+Using a closure inside of a `+GString+`  as in this example will not
+work. The warning from the logs when running this script looks like
+this:
+
+____
+expected to call WorkflowScript.echo but wound up catching
+org.jenkinsci.plugins.workflow.cps.CpsClosure2.call
+____
+
+To fix this case, replace the original GString with a closure that
+returns a GString that uses a normal expression rather than a closure,
+and then call the closure where you would have used the original
+`+GString+` as follows:
+
+[source,syntaxhighlighter-pre]
+----
+def x = 1
+def s = { -> x = "${x}" }
+x = 2
+echo(s())
+----
+
+[[PipelineCPSmethodmismatches-FalsePositives]]
+= False Positives
+
+Unfortunately, some expressions may incorrectly trigger this warning
+even though they execute correctly. If you run into such a case, please
+https://issues.jenkins-ci.org/[file a new issue] (after first checking
+for duplicates) and set the component to `+workflow-cps+`.

--- a/content/doc/book/pipeline/cps-method-mismatches.adoc
+++ b/content/doc/book/pipeline/cps-method-mismatches.adoc
@@ -24,7 +24,7 @@ turn your code into a version that can save its current state to disk (a
 file called `+program.dat+`  inside your build directory) and continue
 running even after Jenkins has restarted. (You can get some more
 technical background on
-the https://github.com/jenkinsci/workflow-cps-plugin/blob/master/README.md[plugin page]
+the plugin:workflow-cps[Pipeline: Groovy plugin page]
 and the https://github.com/cloudbees/groovy-cps/blob/master/README.md[library page].)
 
 While the CPS transform is usually transparent to users, there are
@@ -33,8 +33,8 @@ some circumstances it can lead to counterintuitive behavior. https://issues.jen
 CPS-transformed code from non-CPS-transformed code. The following kinds
 of things are CPS-transformed:
 
-* Almost all of the Pipeline script you write (including in libraries).
-* Most Pipeline steps, including all those which take a block.
+* Almost all of the Pipeline script you write (including in libraries)
+* Most Pipeline steps, including all those which take a block
 
 The following kinds of things are _not_ CPS-transformed:
 
@@ -42,25 +42,21 @@ The following kinds of things are _not_ CPS-transformed:
 ** the Java Platform
 ** Jenkins core and plugins
 ** the runtime for the Groovy language
-* Constructor bodies in your Pipeline script.
+* Constructor bodies in your Pipeline script
 * Any method in your Pipeline script marked with the `+@NonCPS+` 
-annotation.
+annotation
 * A few Pipeline steps which take no block and act instantaneously, such
-as `+echo+` or `+properties+`.
+as `+echo+` or `+properties+`
 
-CPS-transformed code may call non-CPS-transformed code or other
-CPS-transformed code, and non-CPS-transformed code may call other
-non-CPS-transformed code, but it is impossible for non-CPS-transformed
-code to call CPS-transformed code. If you try, there will be a mismatch
-between the method that the CPS interpreter thought it was calling and
-the method that it actually got a return value from.
+CPS-transformed code may call non-CPS-transformed code or other CPS-transformed code, and non-CPS-transformed code may call other non-CPS-transformed code, but non-CPS-transformed code *may not* call CPS-transformed code.
+If you try to call CPS-transformed code from non-CPS-transformed code, the CPS interpreter is unable to operate correctly, resulting in incorrect and often confusing results.
 
 == Common problems and solutions
 
 === Use of Pipeline steps from `+@NonCPS+`
 
 Sometimes users will apply the `+@NonCPS+`  annotation to a method
-definition, which bypasses the CPS transform inside that method. This
+definition in order to bypass the CPS transform inside that method. This
 can be done to work around limitations in Groovy language coverage
 (since the body of the method will execute using the native Groovy
 semantics), or to get better performance (the interpreter imposes a
@@ -90,7 +86,7 @@ expected to call WorkflowScript.compileOnPlatforms but wound up catching
 node
 ____
 
-To fix this case, simply remove the annotation—it was not needed.
+To fix this case, simply remove the annotation — it was not needed.
 (Longtime Pipeline users might have thought it was, prior to the fix of 
 https://issues.jenkins-ci.org/browse/JENKINS-26481[JENKINS-26481].)
 

--- a/content/redirect/pipeline-cps-method-mismatches.adoc
+++ b/content/redirect/pipeline-cps-method-mismatches.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Pipeline+CPS+method+mismatches
+redirect_url: https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/
 ---


### PR DESCRIPTION
Mostly a straight migration of the wiki page, although I removed some of the content in the "False Positives" section that discussed issues that have been fixed since the wiki became read only.

I have not yet built the site locally to check the rendered appearance. I will do that tomorrow. I did a quick check on what "Pipeline CPS Method Mismatches" looked like in the sidebar and it seems ok and is just a bit longer than all of the other page names. We could use "CPS Method Mismatches" in the sidebar instead if desired.

See also https://github.com/jenkins-infra/jenkins-infra/pull/1494 which adds a rewrite rule to redirect the wiki page to the new page.

Fixes #3194 
