### PR TITLE
fix: mailing lists links are broken in the online-hackfest/2020-uiux

### DIFF
--- a/content/events/online-hackfest/2020-uiux/index.adoc
+++ b/content/events/online-hackfest/2020-uiux/index.adoc
@@ -71,10 +71,10 @@ Here are the following communication channels at your disposal:
 
 * Chat: link:https://gitter.im/jenkinsci/hackfest[UI/UX Hackfest channel] in Gitter
 * Mailing lists:
-  link:https://groups.google.com/forum/#!forum/jenkinsci-ux[User Experience],
-  link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Documentation],
-  link:https://groups.google.com/forum/#!forum/jenkins-advocacy-and-outreach-sig[Advocacy & Outreach] - for event tracks.
-  There is also a link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Developer mailing list] for common matters.
+  link:https://groups.google.com/d/forum/jenkinsci-ux[User Experience],
+  link:https://groups.google.com/d/forum/jenkinsci-docs[Documentation],
+  link:https://groups.google.com/d/forum/jenkins-advocacy-and-outreach-sig[Advocacy & Outreach] - for event tracks.
+  There is also a link:https://groups.google.com/d/forum/jenkinsci-dev[Developer mailing list] for common matters.
 * Office Hours: We will be organizing sessions in two timezones during the event (in Zoom or Google Meet). See the link:https://calendar.google.com/calendar/embed?src=0hc89b1nlp2ld35mtupb3o7cfs%40group.calendar.google.com&ctz=UTC&mode=week[Jenkins UI/UX Hackfest Calendar] for meeting links.
 
 == Tracks and Project ideas


### PR DESCRIPTION
For some reason `/#!` gets converted to `/<mark>!` and therefore the links are broken

### Before

![image](https://user-images.githubusercontent.com/2871786/82954207-2dcbb800-9fa4-11ea-9415-ca0ac008c233.png)

### After

![image](https://user-images.githubusercontent.com/2871786/82954177-1e4c6f00-9fa4-11ea-82f7-b260f7487482.png)
