### PR TITLE
Add Custom Distribution Service github project link

### DIFF
--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -74,6 +74,10 @@ image:/images/post-images/gsoc-custom-jenkins-service-distribution/cds-sequence-
 Office hours are scheduled every Tuesday at 13:00 UTC, and every Thursday at 12:00 UTC
  The link:https://docs.google.com/document/d/1vMiU1kmtmKh1QC_9fwe7nc1LvAGk7gj4tf4GjB5i5vU/edit?usp=sharing[meeting notes] available for anyone to read.
 
+=== Getting the Code
+
+The Custom Distribution Service was created from scratch during GSoC and can be found link:https://github.com/jenkinsci/custom-distribution-service[here on Github].
+
 === Other links
 
 https://docs.google.com/document/d/1C7VQJ92Yhr0KRDcNVHYxn4ri7OL9IGZmgxY6UFON6-g/edit?usp=sharing[GSoC Proposal] +


### PR DESCRIPTION
This section adds the github project link to the Custom Distribution Service.
Closes: https://github.com/jenkinsci/custom-distribution-service/issues/1