### PR TITLE
Use grid-all as selector for tables

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1770,11 +1770,17 @@ table.syntax > tbody > tr > th {
   border: 1px solid #d3d3d3;
   border-radius: .25rem;
 }
-/* add border to tables */
-.tableblock.halign-left.valign-top { 
-  border: 1px solid #dee2e6; padding: 10px; 
-}
 
 .grid-container .card .content {
   padding: 15px;
+}
+
+/* add border to tables */
+.grid-all, .grid-all th, .grid-all td { 
+  border: 1px solid #dee2e6; 
+  padding: .75rem; 
+}
+
+.grid-all thead th {
+    border-bottom-width: 2px;
 }

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1776,9 +1776,9 @@ table.syntax > tbody > tr > th {
 }
 
 /* add border to tables */
-.grid-all, .grid-all th, .grid-all td { 
-  border: 1px solid #dee2e6; 
-  padding: .75rem; 
+.grid-all, .grid-all th, .grid-all td {
+  border: 1px solid #dee2e6;
+  padding: .75rem;
 }
 
 .grid-all thead th {

--- a/content/projects/gsoc/2019/project-ideas.html.haml
+++ b/content/projects/gsoc/2019/project-ideas.html.haml
@@ -43,12 +43,13 @@ project: gsoc
     %a{:href => expand_link("/projects/gsoc/proposing-project-ideas/")}
       proposing project ideas
 
-%table.pi_table{:border => 1}
-  %tbody
+%table.pi_table.grid-all
+  %thead
     %tr.pi_table_header
       %th Project
       %th Category
       %th Skills to study/improve
+  %tbody
     - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2019\/project-ideas\/[^\/]+.adoc/ }
     - ideas.each do |item|
       - if item.status == "published"
@@ -76,13 +77,13 @@ project: gsoc
 %h3
   Draft project ideas
 
-.markdown
+%p.markdown
   Below you can see draft project ideas, which are currently under review.
   The scope of such ideas may change significantly during the discussions until the first coding period starts.
   You are welcome to comment on the draft and to join the project as a mentor.
   If you are a student, it is also fine to apply to the draft project ideas.
 
-%table.pi_table{:border => 1}
+%table.pi_table.grid-all
   %tbody
     %tr.pi_table_header
       %th Project

--- a/content/projects/gsoc/2020/project-ideas.html.haml
+++ b/content/projects/gsoc/2020/project-ideas.html.haml
@@ -45,18 +45,19 @@ project: gsoc
 %h3
   Accepted ideas
 
-.markdown
+%p
   Below you can see the list of project ideas that fully match the Jenkins' project idea standard.
   The scope of these ideas is well known and we don't normally expect deep changes.
   All ideas have quick start guidelines and newbie-frienfly issues referenced.
   We welcome contributors to join the mentor teams, and we invite students to submit project proposal applications in relation to these ideas.
 
-%table.pi_table{:border => 1}
-  %tbody
+%table.pi_table.grid-all
+  %thead
     %tr.pi_table_header
       %th Project
       %th Category
       %th Skills to study/improve
+  %tbody
     - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2020\/project-ideas\/[^\/]+.adoc/ }
     - ideas.each do |item|
       - if item.status == "published"
@@ -84,18 +85,19 @@ project: gsoc
 %h3
   Draft project ideas
 
-.markdown
+%p
   Below you can see draft project ideas, which are currently under review.
   The scope of such ideas may change during the discussions, but the idea is accepted in principle.
   You are welcome to comment on the draft and to join the project as a mentor.
   If you are a student, it is also fine to explore and to apply to the draft project ideas.
 
-%table.pi_table{:border => 1}
-  %tbody
+%table.pi_table.grid-all
+  %thead
     %tr.pi_table_header
       %th Project
       %th Category
       %th Skills to study/improve
+  %tbody
     - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2020\/project-ideas\/[^\/]+.adoc/ }
     - ideas.each do |item|
       - if item.status == "draft"
@@ -124,16 +126,17 @@ project: gsoc
   %h3
     Ongoing discussion
 
-  .markdown
+  %p.markdown
     These are proposals in the mailing lists which have not been published as project ideas yet.
     The feasibility is yet to be defined, and the idea may be dismissed depending on the feedback.
     Everyone is welcome to participate in the discussion and to join as a potential mentor.
 
-  %table.pi_table{:border => 1}
-    %tbody
+  %table.pi_table.grid-all
+    %thead
       %tr.pi_table_header
         %th Project
         %th Category
+    %tbody
       - ideas.each do |item|
         - if item.status == "discussion"
           %tr


### PR DESCRIPTION
In asciidoctor you can define different table types (grid-all, grid-column, grid-row), this change makes sure the border styling is tied to the `grid-all` selector and does not depend on classes that are supposed to only change alignment.

Also
* Slightly thicker border for header (inspired by [table-bordered from Bootstrap](https://getbootstrap.com/docs/4.4/content/tables/#bordered-table))
* Minor markup changes on GSoC idea pages to use the same table styles and ensure there is enough space above the table.

CC @urwa 