### PR TITLE
Migrate 'Offline Jenkins Installation' from wiki

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -626,13 +626,11 @@ Plugins are a different matter, due to dependency requirements.
 The recommended approach is to use link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool].
 
 If you want to transfer the individual plugins, you'll need to retrieve
-all dependencies as well. There are several dependency retrieval scripts
+all dependencies as well. There are several dependency retrieval scripts and tools
 on Github. For example:
 
-* https://gist.github.com/micw/e80d739c6099078ce0f3 bash script
-* https://gist.github.com/chuxau/6bc42f0f271704cd4e91 forked from above
-* https://gist.github.com/Lucasus/1a6b8df71425c790361c requires Node
-* https://github.com/samrocketman/jenkins-bootstrap-shared only Java is
+* link:https://github.com/jenkinsci/docker/blob/master/install-plugins.sh[install-plugins.sh] - Bash script for managing plugins from the official Docker image for Jenkins
+* link:https://github.com/samrocketman/jenkins-bootstrap-shared[samrocketman/jenkins-bootstrap-shared] - Java is
 required; packages Jenkins and plugins into an immutable package
 installer.  Supported formats include: RPM, DEB, Docker.  Can proxy
 Jenkins and plugins through Nexus or Artifactory since Gradle is used to

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -621,13 +621,9 @@ that does not have an internet connection.
 To install Jenkins itself, download the appropriate war file and
 transfer it to your machine.
 
-Plugins are a different matter, due to dependency requirements. Two
-obvious choices are: +
-1) Install Jenkins and add required plugins on a network-attached
-computer. Make an archive of the Jenkins directory structure and
-transfer it to the offline machine. +
-2) Transfer Jenkins and plugin files separately and install on offline
-computer.
+Plugins are a different matter, due to dependency requirements. 
+
+The recommended approach is to use link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool].
 
 If you want to transfer the individual plugins, you'll need to retrieve
 all dependencies as well. There are several dependency retrieval scripts


### PR DESCRIPTION
Page to migrate: [Offline+Jenkins+Installation](https://wiki.jenkins.io/display/JENKINS/Offline+Jenkins+Installation)
Destination on jenkins.io: [installing](https://www.jenkins.io/doc/book/installing/)

Migration notes
Create a new section in the "Installing Jenkins page" section called "Offline Jenkins Installation". Migrate the content from the wiki page into that section and confirm that it works as described.