### PR TITLE
Migrated 'Thanks for using Windows Installer' wiki page to jenkins.io

### DIFF
--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -28,7 +28,7 @@
   Jenkins is installed as a Windows service, and it is configured to start automatically upon boot. To start/stop them manually, use the service manager from the control panel, or the 
   %code
     sc 
-   command line tool.
+  command line tool.
   
 %h2
   Inheriting your existing Jenkins installation
@@ -37,7 +37,7 @@
   If you'd like your new installation to take over your existing Jenkins data, copy your old data directory into the new  
   %code
     JENKINS_HOME
-   directory.
+  directory.
 
 %h2
   See Also

--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -8,6 +8,30 @@
 
   %a#startDownloadLink{:href => page.release_url}
     Click this link
+    
+%h2
+  Changing boot configuration
+
+%p
+  By default, your Jenkins runs at 
+  %a{:href => 'http://localhost:8080/'}
+    https://localhost:8080/. 
+  This can be changed by editing 
+  %code
+    jenkins.xml
+  , which is located in your installation directory. This file is also the place to change other boot configuration parameters, such as JVM options, HTTPS setup, etc.
+    
+%h2 
+  Starting/stopping the service
+  
+%p
+  Jenkins is installed as a Windows service, and it is configured to start automatically upon boot. To start/stop them manually, use the service manager from the control panel, or the sc command line tool.
+  
+%h2
+  Inheriting your existing Hudson/Jenkins installation
+  
+%p
+  If you'd like your new installation to take over your existing Jenkins/Hudson data, copy your old data directory into the new JENKINS_HOME directory.
 
 %h2
   What's next?

--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -25,25 +25,33 @@
   Starting/stopping the service
   
 %p
-  Jenkins is installed as a Windows service, and it is configured to start automatically upon boot. To start/stop them manually, use the service manager from the control panel, or the sc command line tool.
+  Jenkins is installed as a Windows service, and it is configured to start automatically upon boot. To start/stop them manually, use the service manager from the control panel, or the 
+  %code
+    sc 
+   command line tool.
   
 %h2
   Inheriting your existing Jenkins installation
   
 %p
-  If you'd like your new installation to take over your existing Jenkins data, copy your old data directory into the new JENKINS_HOME directory.
+  If you'd like your new installation to take over your existing Jenkins data, copy your old data directory into the new  
+  %code
+    JENKINS_HOME
+   directory.
 
 %h2
-  What's next?
+  See Also
 
 %ul
   %li
-    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Thanks+for+using+Windows+Installer'}
-      Learn how the Windows installer sets up your Jenkins, and how you can tweak it.
+    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Running+Jenkins+behind+Apache'}
+      Running Jenkins behind Apache
   %li
-    %a{:href => 'https://twitter.com/jenkinsci'}
-      Follow us
-    on Twitter for updates
+    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Running+Jenkins+behind+Nginx'}
+      Runnin Jenkins behind Nginx
+    and
+    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy'}
+      Jenkins behind an NGinX reverse proxy
 
 :javascript
   $(document).ready(function() {

--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -48,7 +48,7 @@
       Running Jenkins behind Apache
   %li
     %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Running+Jenkins+behind+Nginx'}
-      Runnin Jenkins behind Nginx
+      Running Jenkins behind Nginx
     and
     %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy'}
       Jenkins behind an NGinX reverse proxy

--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -28,10 +28,10 @@
   Jenkins is installed as a Windows service, and it is configured to start automatically upon boot. To start/stop them manually, use the service manager from the control panel, or the sc command line tool.
   
 %h2
-  Inheriting your existing Hudson/Jenkins installation
+  Inheriting your existing Jenkins installation
   
 %p
-  If you'd like your new installation to take over your existing Jenkins/Hudson data, copy your old data directory into the new JENKINS_HOME directory.
+  If you'd like your new installation to take over your existing Jenkins data, copy your old data directory into the new JENKINS_HOME directory.
 
 %h2
   What's next?


### PR DESCRIPTION
Fixes: #3206 

I haven't migrated the 'See also' section at the bottom of the page. Let me know if it has to be done too.

EDIT - I just did. I removed the 'What next' section and added 'See also' in its place.