### PR TITLE
[migrate] Matrix-based security

### DIFF
--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -43,7 +43,7 @@ To install the Blue Ocean suite of plugins on an existing Jenkins instance, your
 Jenkins instance must be running Jenkins 2.7.x or later.
 
 Plugins can be installed on a Jenkins instance by any Jenkins user who has the
-*Administer* permission (set through *Matrix-based security*). Jenkins users
+*Administer* permission (set through link:/doc/book/system-administration/security/matrix-based-security[*Matrix-based security*]). Jenkins users
 with this permission can also configure the permissions of other users on their
 system. Read more about this in the
 link:../../managing/security/#authorization[Authorization] section of
@@ -144,7 +144,7 @@ The navigation bar's common section includes the following buttons:
 * *Administration* - takes you to the *link:../../managing[Manage Jenkins]* page
   of the Jenkins classic UI. +
   *Note:* This button is not available if your Jenkins user does not have the
-  *Administer* permission (set through *Matrix-based security*). Read more about
+  *Administer* permission (set through link:/doc/book/system-administration/security/matrix-based-security[*Matrix-based security*]). Read more about
   this in the link:../../managing/security/#authorization[Authorization] section
   of link:../../managing/security[Managing Security].
 * *Go to classic* icon - takes you back to the Jenkins classic UI. Read more

--- a/content/doc/book/managing/security.adoc
+++ b/content/doc/book/managing/security.adoc
@@ -167,7 +167,7 @@ Logged in users can do anything:: In this mode, every logged-in user gets full
 control of Jenkins. Depending on an advanced option, anonymous users get read
 access to Jenkins, or no access at all. This mode is useful to force users to
 log in before taking actions, so that there is an audit trail of users' actions.
-Matrix-based security:: This authorization scheme allows for granular control
+link:/doc/book/system-administration/security/matrix-based-security[*Matrix-based security*]:: This authorization scheme allows for granular control
 over which users and groups are able to perform which actions in the Jenkins
 environment (see the screenshot below).
 Project-based Matrix Authorization Strategy:: This authorization scheme is an

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -46,7 +46,7 @@ database, and perform access control based on the permission/user matrix.
 * https://wiki.jenkins.io/display/JENKINS/Standard+Security+Setup[Standard Security Setup] --- discusses the most common setup of letting Jenkins run its own user database and do finer-grained access control
 * https://wiki.jenkins.io/display/JENKINS/Apache+frontend+for+security[Apache frontend for security] --- run Jenkins behind Apache and perform access control in Apache instead of Jenkins
 * https://wiki.jenkins.io/display/JENKINS/Authenticating+scripted+clients[Authenticating scripted clients] --- if you need to programmatically access security-enabled Jenkins web UI, use BASIC auth
-* https://wiki.jenkins.io/display/JENKINS/Matrix-based+security[Matrix-based security|Matrix-based security] --- Granting and denying finer-grained permissions
+* link:matrix-based-security[Matrix-based security] --- Granting and denying finer-grained permissions
 
 In addition to access control of users, link:build-authorization[access control for builds] limits what builds can do, once started.
 

--- a/content/doc/book/system-administration/security/matrix-based-security.adoc
+++ b/content/doc/book/system-administration/security/matrix-based-security.adoc
@@ -1,0 +1,102 @@
+---
+title: Matrix-based security
+layout: documentation
+---
+
+Matrix-based security is one of the authorization strategies available for link:/doc/book/system-administration/security[securing Jenkins].  It allows you to grant specific permissions to users and groups.  The available permissions are listed below with their descriptions, and are also available by hovering over the permission heading in the Jenkins UI.
+
+*Note:* These are the most common permissions available.  Other plugins may add their own permissions.
+
+== Overall
+
+[IMPORTANT]
+====
+Several of these permissions are at least as powerful as Administer, but for historical reasons are implied by the Administer permission (i.e. everyone with Administer can also perform the actions associated with these other permissions):
+
+* *RunScripts* allows executing arbitrary code in the context of any (Jenkins internal) user, including the internal SYSTEM user.
+* *UploadPlugins* allows uploading plugins, which in turn can execute arbitrary code in the context of any (Jenkins internal) user.
+* *ConfigureUpdateCenter* can configure proxy settings and thereby control the update site metadata and plugin files downloaded by the Jenkins plugin manager, which in turn can be used to execute arbitrary code.
+====
+
+[cols="1,2",options="header",]
+|===
+|Permission |Description
+|Administer |Make system-wide configuration changes.  Perform highly
+sensitive operations that amounts to full local system access (within
+the scope granted by the underlying OS). +
+
+|Read |View almost all pages within Jenkins.
+
+|RunScripts |Run groovy scripts via the groovy console or groovy cli
+command.
+
+|UploadPlugins |Upload arbitrary plugins.
+
+|ConfigureUpdateCenter |Configure update sites and proxy settings.
+|===
+
+== Agent
+
+[cols="1,2",options="header",]
+|===
+|Permission |Description
+|Configure |Configure existing agents.
+|Delete |Delete existing agents.
+|Create |Create new agents.
+|Disconnect |Disconnect agents or mark agents as temporarily offline.
+|Connect |Connect agents or mark agents as online.
+|===
+
+== Job
+
+[cols="1,2",options="header",]
+|===
+|Permission |Description
+|Create |Create a new job.
+
+|Delete |Delete an existing job.
+
+|Configure |Update the configuration of an existing job.
+
+|Read |Grants read-only access to project configurations.
+
+|Discover |Redirect anonymous users to a login form rather than
+presenting an error message if they don't have permission to view jobs.
+
+|Build |Start a new build and cancel a running build.
+
+|Workspace |Retrieve the contents of a workspace that Jenkins has
+checked out for performing a build. +
+
+|Cancel |Cancel a running build.
+|===
+
+== Run
+
+[cols="1,2",options="header",]
+|===
+|Permission |Description
+|Delete |Delete specific builds from a build's history.
+
+|Update |Update the description and other properties of a build.  (For
+example, to leave notes about the cause of a build failure.)
+|===
+
+== View
+
+[cols="1,2",options="header",]
+|===
+|Permission |Description
+|Create |Create new views.
+|Delete |Delete existing views.
+|Configure |Update the configuration of existing views.
+|Read |See any existing views.
+|===
+
+== SCM
+
+[cols="1,2",options="header",]
+|===
+|Permission |Description
+|Tag |Create a new tag in the source code repository for a given build.
+|===

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -73,7 +73,7 @@ Jenkins instance to another.
 This section describes procedures for configuring credentials in Jenkins.
 
 Credentials can be added to Jenkins by any Jenkins user who has the *Credentials
-> Create* permission (set through *Matrix-based security*). These permissions
+> Create* permission (set through link:/doc/book/system-administration/security/matrix-based-security[*Matrix-based security*]). These permissions
 can be configured by a Jenkins user with the *Administer* permission. Read more
 about this in the
 link:../../managing/security/#authorization[Authorization] section of


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/jenkins.io/issues/3390

### Screenshots

![localhost_4242_doc_book_system-administration_security_matrix-based-security_ (1)](https://user-images.githubusercontent.com/2871786/83248674-5cf94980-a19d-11ea-9f73-97ad457c55cd.png)

And the links from some other docs are now pointing to this new document, see for instance the `Getting started for BlueOcean` -> `Matrix-based security` link.

![localhost_4242_doc_book_blueocean_getting-started_](https://user-images.githubusercontent.com/2871786/83248719-6b476580-a19d-11ea-92fc-796197705dad.png)
