### PR TITLE
Document more system properties

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -453,11 +453,6 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Since:** Up to 1.354 +
     **Description:** Control a slave based on a schedule
 
-`hudson.scm.CVSSCM.skipChangeLog`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Useful with ancient versions of CVS that don't support the -d option in the log command
-
 `hudson.scm.SCM.useAutoBrowserHolder`::
 
 `hudson.script.noCache`::

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -56,29 +56,32 @@ dd {
 ++++
 
 `debug.YUI`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Whether to use the minified (`false`) or debug (`true`) JS files for the YUI library.
 
 `executable-war`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** This is the path to `jenkins.war` and set by the `executable-war` wrapper when invoked using `java -jar jenkins.war`.
+    This allows Jenkins to find its own `.war` file and e.g. replace it to apply an update.
+    If undefined, Jenkins will not e.g. offer to update itself.
 
 `hudson.bundled.plugins`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Specify a location for additional bundled plugins during plugin development (`hpi:run`).
+    There is no reason this would be set by an administrator.
 
 `hudson.ClassicPluginStrategy.noBytecodeTransformer`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
 
 `hudson.ClassicPluginStrategy.useAntClassLoader`::
     **Default:** `false` +
     **Since:** 1.316 +
-    **Description:** +
+    **Description:** TODO: This may not actually be used anymore.
 
 `hudson.cli.CLI.pingInterval`::
     **Default:** 3000 +
@@ -127,8 +130,9 @@ dd {
 
 `hudson.Functions.hidingPasswordFields`::
     **Default**: `true` +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** 2.205 +
+    **Description:** Jenkins 2.205 and newer attempts to prevent browsers from offering to auto-fill password form fields by using a custom password control.
+    Setting this to `false` reverts to the legacy behavior of using mostly standard password form fields.
 
 `hudson.lifecycle`::
     **Default:** n/a +
@@ -138,47 +142,60 @@ dd {
 `hudson.logging.LogRecorderManager.skipPermissionCheck`::
     **Default:** `false` +
     **Since:** 2.121.3 and 2.138 +
-    **Description:** Disable security hardening for LogRecorderManager Stapler access. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+    **Description:** Disable security hardening for LogRecorderManager Stapler access.
+    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
 `hudson.Main.development`::
-    **Default**: TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default**: see description +
+    **Since:** n/a +
+    **Description:** Set to `true` by the development tooling to identify when Jenkins is running via `jetty:run` or `hpi:run`.
+    Can be used to distinguish between development and production use; most prominently used to bypass the setup wizard when running with an empty Jenkins home directory during development.
 
 `hudson.Main.timeout`::
     **Default**: 15000 +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** n/a +
+    **Description:** When using `jenkins-core.jar` from the CLI, this is the connection timeout connecting to Jenkins to report a build result.
 
 `hudson.matrix.MatrixConfiguration.useShortWorkspaceName`::
     **Default:** `false` +
     **Since:** n/a +
-    **Description:** Use shorter but cryptic names in matrix build workspace directories. Avoids problems with 256 character limit on paths in Cygwin, path depths problems on Windows, and shell metacharacter problems with label expressions on most platforms. See https://issues.jenkins-ci.org/browse/JENKINS-25783[JENKINS-25783].
+    **Description:** Use shorter but cryptic names in matrix build workspace directories.
+    Avoids problems with 256 character limit on paths in Cygwin, path depths problems on Windows, and shell metacharacter problems with label expressions on most platforms.
+    See https://issues.jenkins-ci.org/browse/JENKINS-25783[JENKINS-25783].
 
 `hudson.model.AbstractItem.skipPermissionCheck`::
     **Default:** `false` +
     **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for AbstractItem. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory]. 
+    **Description:** Disable security hardening related to Stapler routing for AbstractItem.
+    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
 `hudson.model.Api.INSECURE`::
     **Default**: `false` +
-    **Since:** TODO +
-    **Description:** TODO Jenkins (core): jenkins.security.SecureRequester$Default
+    **Since:** 1.502 +
+    **Description:** Set to `true` to permit accessing the Jenkins remote API in an unsafe manner.
+    See SECURITY-47.
+    Deprecated, use e.g. https://plugins.jenkins.io/secure-requester-whitelist/[Secure Requester Whitelist] instead.
 
 `hudson.model.AsyncAperiodicWork.logRotateMinutes`::
     **Default:** 1440 +
     **Since:** 1.651 +
-    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncAperiodicWork extension. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncAperiodicWork extension.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 
 `hudson.model.AsyncAperiodicWork.logRotateSize`::
     **Default:** -1 +
     **Since:** 1.651 +
-    **Description:** When starting a new run of any AsyncAperiodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** When starting a new run of any AsyncAperiodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 
 `hudson.model.AsyncPeriodicWork.logRotateMinutes`::
     **Default:** 1440 +
     **Since:** 1.651 +
-    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 +
 Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
 +
@@ -192,7 +209,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.model.AsyncPeriodicWork.logRotateSize`::
     **Default:** -1 +
     **Since:** 1.651 +
-    **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 +
 Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
 +
@@ -205,28 +224,29 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
     **Default**: `false` +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
 
 `hudson.model.DirectoryBrowserSupport.CSP`::
     **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
     **Since:** 1.625.3, 1.641 +
-    **Description:** Determines the Content Security Policy header sent for static files served by Jenkins. See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
+    **Description:** Determines the Content Security Policy header sent for static files served by Jenkins.
+    See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
 
 `hudson.model.DownloadService$Downloadable.defaultInterval`::
     **Default**: 86400000 (1 day)
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** n/a +
+    **Description:** Interval between periodic downloads of _Downloadables_, typically tool installer metadata.
 
 `hudson.model.DownloadService.never`::
     **Default:** `false` +
     **Since:** n/a +
-    **Description:** Suppress the periodic download of data files for plugins
+    **Description:** Suppress the periodic download of data files for plugins via browser-based download. Since Jenkins 2.200, this has no effect.
 
 `hudson.model.DownloadService.noSignatureCheck`::
     **Default:** `false` +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** n/a +
+    **Description:** Skip the update site signature check. Setting this to `true` can be unsafe.
 
 `hudson.model.Hudson.flyweightSupport`::
     **Default:** `false` before 1.337; `true` from 1.337; unused since 1.598 +
@@ -234,29 +254,29 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Matrix parent job and other flyweight tasks (e.g. Build Flow plugin) won't consume an executor when `true`. Unused since 1.598, flyweight support is now always enabled.
 
 `hudson.model.Hudson.initLogLevel`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.initLogLevel`.
 
 `hudson.model.Hudson.killAfterLoad`::
-    **Default:** `false` +
+    **Default:** n/a +
     **Since:** n/a +
-    **Description:** Exit Jenkins right after loading
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.killAfterLoad`.
 
 `hudson.model.Hudson.logStartupPerformance`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.logStartupPerformance`.
 
 `hudson.model.Hudson.parallelLoad`::
-    **Default:** `true` +
+    **Default:** n/a +
     **Since:** n/a +
-    **Description:** Loads job configurations in parallel on startup
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.parallelLoad`.
 
 `hudson.model.Hudson.workspaceDirName`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.workspaceDirName`.
 
 `hudson.model.LoadStatistics.clock`::
     **Default:** 10000 +
@@ -274,9 +294,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Font used for load statistics (see http://docs.oracle.com/javase/7/docs/api/java/awt/Font.html#decode%28java.lang.String%29[Java documentation] on how the value is decoded)
 
 `hudson.model.Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** n/a +
+    **Description:** Whether to allow building flyweight tasks even if the necessary permission (Computer/Build) is missing.
+    See https://issues.jenkins-ci.org/browse/JENKINS-46652[JENKINS-46652].
 
 `hudson.model.ParametersAction.keepUndefinedParameters`::
     **Default:** undefined +
@@ -329,9 +350,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** When true, don't automatically check for new versions
 
 `hudson.model.UpdateCenter.pluginDownloadReadTimeoutSeconds`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** 60 +
+    **Since:** n/a +
+    **Description:** Read timeout in seconds for downloading plugins.
 
 `hudson.model.UpdateCenter.skipPermissionCheck`::
     **Default:** `false` +
@@ -339,9 +360,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Disable security hardening related to Stapler routing for UpdateCenter. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
 `hudson.model.UpdateCenter.updateCenterUrl`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `https://updates.jenkins.io/` +
+    **Since:** n/a +
+    **Description:** Deprecated: Override the default update site URL.
+    May have no effect since Jenkins 1.333.
 
 `hudson.model.UsageStatistics.disabled`::
     **Default:** `false` +
@@ -384,9 +406,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Unused workspaces are retained for this many days before qualifying for deletion.
 
 `hudson.node_monitors.AbstractNodeMonitorDescriptor.periodMinutes`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** 60 +
+    **Since:** n/a +
+    **Description:** How frequently to update node monitors by default, in minutes.
 
 `hudson.os.solaris.ZFSInstaller.disabled`::
     **Default:** `false` +
@@ -394,9 +416,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** True to disable ZFS monitor on Solaris
 
 `hudson.os.solaris.ZFSInstaller.migrate`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Set by Jenkins itself when restarting Jenkins for a migration to a ZFS volume and contains the migration target dataset name.
+    There is no reason this would be set by administrators manually.
 
 `hudson.PluginManager.checkUpdateAttempts`::
     **Default:** 1 +
@@ -409,14 +432,14 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Time (milliseconds) elapsed between retries to check the updates sites.
 
 `hudson.PluginManager.className`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Can be used to specify a different `PluginManager` implementation when customizing the `.war` packaging of Jenkins.
 
 `hudson.PluginManager.noFastLookup`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Disable fast lookup using `ClassLoaderReflectionToolkit` which reflectively accesses internal methods of `ClassLoader`.
 
 `hudson.PluginManager.skipPermissionCheck`::
     **Default:** `false` +
@@ -444,9 +467,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Connection timeout applied to connections e.g. to the update site.
 
 `hudson.remoting.ClassFilter`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Allow or disallow the deserialization of specified types. Comma-separated class names, entries are whitelisted unless prefixed with `!`.
+    See https://github.com/jenkinsci/jep/tree/master/jep/200#backwards-compatibility[JEP-200] and https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736].
 
 `hudson.scheduledRetention`::
     **Default:** `false` +
@@ -454,11 +478,15 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Control a slave based on a schedule
 
 `hudson.scm.SCM.useAutoBrowserHolder`::
+    **Default:** `false` since Jenkins 2.9, `true` before +
+    **Since:** n/a +
+    **Description:** When set to `true`, Jenkins will guess the repository browser used to render links in the changelog.
 
 `hudson.script.noCache`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** see description +
+    **Since:** n/a +
+    **Description:** When set to true, Jenkins will not reference resource files through the `/static/.../` URL space, preventing their caching.
+    This is set to `true` during development by default, and `false` otherwise.
 
 `hudson.search.Search.skipPermissionCheck`::
     **Default:** `false` +
@@ -476,19 +504,19 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** The Artifacts permission allows to control access to artifacts; When this property is unset or set to false, access to artifacts is not controlled
 
 `hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.228 and 2.204.6 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
 `hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.186 and 2.176.2 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
 
 `hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.222 +
+    **Description:** Restore the ability to disable CSRF protection after the UI for doing so was removed from Jenkins 2.222.
 
 `hudson.security.csrf.requestfield`::
     **Default:** `.crumb` (Jenkins 1.x), `Jenkins-Crumb` (Jenkins 2.0) +
@@ -507,7 +535,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.security.LDAPSecurityRealm.groupSearch`::
@@ -517,7 +545,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.security.WipeOutPermission`::
@@ -542,42 +570,42 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.slaves.ConnectionActivityMonitor.enabled`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.ConnectionActivityMonitor.frequency`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.ConnectionActivityMonitor.timeToPing`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.initialDelay`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.MARGIN`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.MARGIN0`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.recurrencePeriod`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.WorkspaceList`::
@@ -637,17 +665,17 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.util.CharacterEncodingFilter.disableFilter`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.util.CharacterEncodingFilter.forceEncoding`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.Util.deletionRetryWait`::
@@ -685,14 +713,16 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Number of log entries in loggers available on the UI at `+/log/+`
 
 `hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.236 +
+    **Description:** Jenkins automatically round-trips `f:password` based form fields as encrypted `Secret` even if the field is not of type `Secret`.
+    Set this to `false` to disable this behavior, doing so is discouraged.
 
 `hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.236 +
+    **Description:** If the user is missing _Item/Configure_ permission, Jenkins 2.236 and newer will blank out the password value automatically even if the form field is not backed by a `Secret`.
+    Set this to `false` to disable this behavior, doing so is discouraged.
 
 `hudson.util.Secret.provider`::
     **Default:** n/a +
@@ -701,7 +731,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.util.StreamTaskListener.AUTO_FLUSH`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.Util.symlinkEscapeHatch`::
@@ -716,12 +746,12 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.WebAppMain.forceSessionTrackingByCookie`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.widgets.HistoryWidget.threshold`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.CLI.disabled`::
@@ -798,12 +828,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.model.Jenkins.initLogLevel`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.Jenkins.killAfterLoad`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.Jenkins.logStartupPerformance`::
@@ -813,7 +843,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.model.Jenkins.parallelLoad`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.Jenkins.slaveAgentPort`::
@@ -827,9 +857,9 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** If true, enforces the specified `+jenkins.model.Jenkins.slaveAgentPort+` on startup and will not allow changing it through the UI
 
 `jenkins.model.Jenkins.workspaceDirName`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `workspace` +
+    **Since:** n/a +
+    **Description:** Obsolete: Was used as the default workspace directory name in the legacy workspace directory layout (workspace directories within job directories).
 
 `jenkins.model.Jenkins.workspacesDir`::
     **Default:** $\{JENKINS_HOME}/workspace/$\{ITEM_FULL_NAME} +
@@ -843,7 +873,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.model.lazy.BuildReference.MODE`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.StandardArtifactManager.disableTrafficCompression`::
@@ -863,12 +893,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.FrameOptionsPageDecorator.enabled`::
@@ -878,32 +908,32 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.security.ignoreBasicAuth`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.ManagePermission`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.ResourceDomainRootAction.validForMinutes`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.s2m.DefaultFilePathFilter.allow`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.seed.UserSeedProperty.disableUserSeed`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.StaplerDispatchValidator.disabled`::
@@ -913,42 +943,42 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.TypedFilter.skipTypeCheck`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.228 and 2.204.6 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
 `jenkins.security.SystemReadPermission`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
@@ -963,12 +993,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.slaves.StandardOutputSwapper.disabled`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.telemetry.Telemetry.endpoint`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.ui.refresh`::
@@ -978,12 +1008,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `JENKINS_HOME`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
@@ -995,6 +1025,27 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Default:** 20 seconds +
     **Since:** workflow-durable-task-step-plugin 2.29  +
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
+
+`stapler.jelly.noCache`::
+    **Default:** false +
+    **Since:** n/a +
+    **Description:** TODO
+
+`stapler.resourcePath`::
+    **Default:** TODO +
+    **Since:** n/a +
+    **Description:** TODO
+
+`stapler.trace`::
+    **Default:** false +
+    **Since:** n/a +
+    **Description:** Trace request handling and report the result using `Stapler-Trace-...` response headers.
+    Additionally renders a diagnostic HTTP 404 error page when the request could not be processed.
+
+`stapler.trace.per-request`::
+    **Default:** false +
+    **Since:** n/a +
+    **Description:** Trace request handling (see above) for requests with the `X-Stapler-Trace` request header set.
 
 == Properties in plugins
 

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -825,14 +825,16 @@ For link:/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibr
 +
 ```sh
 mkdir -p [TARGET_DIR]/[JOB_NAME]/branches/
-mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
+mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds \
+    [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
 ```
 +
 For link:/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/
-mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]
+mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds \
+    [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]
 ```
 
 `jenkins.model.Jenkins.crumbIssuerProxyCompatibility`::

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -123,7 +123,7 @@ dd {
 `hudson.Functions.autoRefreshSeconds`::
     **Default:** 10 +
     **Since:** 1.365 +
-    **Description:** Number of seconds between reloads when Auto Refresh is enabled
+    **Description:** Number of seconds between reloads when Auto Refresh is enabled, obsolete since the feature was removed in Jenkins 2.223.
 
 `hudson.Functions.hidingPasswordFields`::
     **Default**: `true` +
@@ -179,11 +179,29 @@ dd {
     **Default:** 1440 +
     **Since:** 1.651 +
     **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
++
+Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
++
+* `hudson.model.WorkspaceCleanupThread`
+* `hudson.model.FingerprintCleanupThread`
+* `hudson.slaves.ConnectionActivityMonitor`
+* `jenkins.DailyCheck`
+* `jenkins.model.BackgroundGlobalBuildDiscarder`
+* `jenkins.telemetry.Telemetry$TelemetryReporter`
 
 `hudson.model.AsyncPeriodicWork.logRotateSize`::
     **Default:** -1 +
     **Since:** 1.651 +
     **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
++
+Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
++
+* `hudson.model.WorkspaceCleanupThread`
+* `hudson.model.FingerprintCleanupThread`
+* `hudson.slaves.ConnectionActivityMonitor`
+* `jenkins.DailyCheck`
+* `jenkins.model.BackgroundGlobalBuildDiscarder`
+* `jenkins.telemetry.Telemetry$TelemetryReporter`
 
 `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
     **Default**: `false` +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -18,7 +18,7 @@ $(function () {
 ++++
 
 Jenkins has several "hidden" features that can be enabled with system properties.
-This page describes how to configure them on your instance.
+This page documents many of them and explain how to configure them on your instance.
 
 == Usage
 
@@ -46,6 +46,9 @@ If you find some of those useful, please file a ticket to promote it to the offi
 
 
 == Properties in Jenkins Core
+
+[NOTE]
+Due to the very large number of system properties used, often just added as a "safety valve" or "escape hatch" in case a change causes problems, this is list is not expected to be complete.
 
 ++++
 <style>
@@ -77,12 +80,13 @@ dd {
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
-
+////
+TODO: This may not actually be used anymore. We probably should document deprecated/obsolete system properties in a separate section.
 `hudson.ClassicPluginStrategy.useAntClassLoader`::
     **Default:** `false` +
     **Since:** 1.316 +
-    **Description:** TODO: This may not actually be used anymore.
-
+    **Description:** +
+////
 `hudson.cli.CLI.pingInterval`::
     **Default:** 3000 +
     **Since:** 2.199 +
@@ -534,9 +538,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Regex for legal user names in Jenkins user database. See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
 
 `hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 18 +
+    **Since:** 2.161 +
+    **Description:** Limits the number of rounds for pre-computed BCrypt hashes of user passwords for the Jenkins user database to prevent excessive computation.
 
 `hudson.security.LDAPSecurityRealm.groupSearch`::
     **Default:** TBD +
@@ -544,9 +548,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** LDAP filter to look for groups by their names
 
 `hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.160 and 2.150.2 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
 
 `hudson.security.WipeOutPermission`::
     **Default:** `false` +
@@ -569,19 +573,21 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Timeout for each https://wiki.jenkins.io/display/JENKINS/Ping+Thread[ping between the master and slaves], in seconds
 
 `hudson.slaves.ConnectionActivityMonitor.enabled`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// This looks like a dead feature? Introduced 2011 and disabled by default?
+    **Default:** `false` +
+    **Since:** 1.326 +
+    **Description:** Whether to enable this feature that checks whether agents are alive and cuts them off if not.
 
 `hudson.slaves.ConnectionActivityMonitor.frequency`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// Actually dual use: Both for timeout (4 minutes) and time to ping (3 minutes). Possibly copy & paste issue and bug in core?
+    **Default:** 10000 (10 seconds) +
+    **Since:** 1.326 +
+    **Description:** How frequently to check for channel activity, in milliseconds.
 
 `hudson.slaves.ConnectionActivityMonitor.timeToPing`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 180000 (3 minutes) +
+    **Since:** 1.326 +
+    **Description:** How long to wait after startup to start checking agent connections, in milliseconds.
 
 `hudson.slaves.NodeProvisioner.initialDelay`::
     **Default:** TODO +
@@ -664,19 +670,20 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Pass blame information to downstream jobs
 
 `hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
-
+// The code is really confusing; there are two flags, one is always false, and will be forcibly set to false here, except using a new constructor that was deprecated in the same PR it was introduced in.
+    **Default:** `alse` +
+    **Since:** 2.102 +
+    **Description:** Disables the forced flushing when calling `#close()`.
+    Not expected to be used.
 `hudson.util.CharacterEncodingFilter.disableFilter`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Set to `true` to disable the filter that sets request encoding to UTF-8 if it's undefined and its content type is `text/xml` or `application/xml` (API submissions).
 
 `hudson.util.CharacterEncodingFilter.forceEncoding`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Set to `true` to force the request encoding to UTF-8 even if a different character set is declared.
 
 `hudson.Util.deletionRetryWait`::
     **Default:** 100 +
@@ -727,12 +734,15 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.util.Secret.provider`::
     **Default:** n/a +
     **Since:** 1.360 +
-    **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround a https://issues.jenkins-ci.org/browse/JENKINS-6459[known issue].
+    **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround https://issues.jenkins-ci.org/browse/JENKINS-6459[JENKINS-6459].
 
 `hudson.util.StreamTaskListener.AUTO_FLUSH`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// https://github.com/jenkinsci/jenkins/pull/3961
+    **Default:** `false` +
+    **Since:** 2.173 +
+    **Description:** Jenkins no longer automatically flushes streams for code running remotely on agents for better performance.
+    This may lead to loss of messages for plugins which print to a build log from the agent machine but do not flush their output.
+    Use this flag to restore the previous behavior for freestyle builds.
 
 `hudson.Util.symlinkEscapeHatch`::
     **Default:** `false` +
@@ -754,6 +764,12 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Since:** n/a +
     **Description:** TODO
 
+`HUDSON_HOME`::
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Backward compatible fallback name for `JENKINS_HOME`.
+    See documentation there.
+
 `jenkins.CLI.disabled`::
     **Default:** `false` +
     **Since:** 2.32 and 2.19.3 +
@@ -771,7 +787,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `jenkins.model.Jenkins.buildsDir`::
     **Default:** `$\{ITEM_ROOTDIR}/builds` +
-    **Since:** 2.119 + 
+    **Since:** 2.119 +
     **Description:** The configuration of a given job is located under `+$JENKINS_HOME/jobs/[JOB_NAME]/config.xml+` and its builds are under `+$JENKINS_HOME/jobs/[JOB_NAME]/builds+` by default.
     This option allows you to store builds elsewhere, which can be useful with finer-grained backup policies, or to store the build data on a faster disk such as an SSD.
     The following placeholders are supported for this value:
@@ -997,9 +1013,10 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** TODO
 
 `jenkins.telemetry.Telemetry.endpoint`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// https://github.com/jenkinsci/jenkins/pull/3604
+    **Default:** `+https://uplink.jenkins.io/events+` +
+    **Since:** 2.143 +
+    **Description:** Change the endpoint that JEP-214/Uplink telemetry sends data to. Expected to be used for testing only.
 
 `jenkins.ui.refresh`::
     **Default:** `false` +
@@ -1007,14 +1024,15 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see https://www.jenkins.io/sigs/ux/[Jenkins UX SIG].
 
 `jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
-    **Default:** TODO +
+    **Default:** 0 +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Debug/development option to slow down the cancelling of progressive rendering when the client fails to send a heartbeat.
 
 `JENKINS_HOME`::
-    **Default:** TODO +
+    **Default:** `~/.jenkins` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** While typically set as an environment variable, Jenkins also looks up the path to its home directory as a system property.
+    `JENKINS_HOME` set via JNDI context has higher priority than this, but this takes precedence over the environment variable.
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
     **Default:** undefined +
@@ -1027,7 +1045,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
 
 `stapler.jelly.noCache`::
-    **Default:** false +
+    **Default:** TODO +
     **Since:** n/a +
     **Description:** TODO
 

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -293,7 +293,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.workspaceDirName`.
 
 `hudson.model.LoadStatistics.clock`::
-    **Default:** 10000 +
+    **Default:** 10000 (10 seconds) +
     **Since:** n/a +
     **Description:** Load statistics clock cycle in milliseconds
 
@@ -601,9 +601,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** How long to wait after startup to start checking agent connections, in milliseconds.
 
 `hudson.slaves.NodeProvisioner.initialDelay`::
-    **Default:** TODO +
+    **Default:** 10 times `hudson.model.LoadStatistics.clock`, typically 100 seconds +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** How long to wait after startup before starting to provision nodes from clouds.
+    This will allow static agents to start and handle the load first.
 
 `hudson.slaves.NodeProvisioner.MARGIN`::
     **Default:** TODO +
@@ -621,9 +622,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.recurrencePeriod`::
-    **Default:** TODO +
+    **Default:** Equal to `hudson.model.LoadStatistics.clock`, typically 10 seconds +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** How frequently to possibly provision nodes.
 
 `hudson.slaves.WorkspaceList`::
     **Default:** `@` +
@@ -858,24 +859,26 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** When using the `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle`, exit using this exit code when Jenkins is restarted
 
 `jenkins.model.Jenkins.initLogLevel`::
-    **Default:** TODO +
+    **Default:** `FINE` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Log level for verbose messages from the init reactor listener.
 
 `jenkins.model.Jenkins.killAfterLoad`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Exit Jenkins right after loading.
+    Intended as a development/testing aid only.
 
 `jenkins.model.Jenkins.logStartupPerformance`::
     **Default:** `false` +
     **Since:** n/a +
-    **Description:** Log startup timing info
+    **Description:** Log startup timing info.
+    Note that some messages are not logged on levels visible by default (i.e. INFO and up).
 
 `jenkins.model.Jenkins.parallelLoad`::
-    **Default:** TODO +
+    **Default:** `true` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Loads job configurations in parallel on startup.
 
 `jenkins.model.Jenkins.slaveAgentPort`::
     **Default:** -1 (disabled) +
@@ -903,9 +906,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** Disable URL validation intended to prevent an XSS vulnerability. See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
 
 `jenkins.model.lazy.BuildReference.MODE`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `soft` +
+    **Since:** 1.548 +
+    **Description:** Configure the kind of reference Jenkins uses to hold builds in memory.
+    Choose from among `soft`, `weak`, `strong`, and `not` (do not hold builds in memory at all).
+    Intended mostly as a debugging aid.
+    See https://issues.jenkins-ci.org/browse/JENKINS-19400[JENKINS-19400].
 
 `jenkins.model.StandardArtifactManager.disableTrafficCompression`::
     **Default:** `false` +
@@ -1084,14 +1090,28 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
 
 `stapler.jelly.noCache`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Controls both caching of various cachable resources (Jelly scripts etc.) as well as the `Expires` HTTP response header for some static resources.
+    Useful during development to see the effect of changes after reload.
+
+`stapler.legacyGetterDispatcherMode`::
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Do not filter get methods at the Stapler framework level.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
+
+`stapler.legacyWebMethodDispatcherMode`::
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Do not filter web methods ("do" actions) at the Stapler framework level.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
 
 `stapler.resourcePath`::
-    **Default:** TODO +
+    **Default:** undefined +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Additional debug resource paths.
+    Set by the core development tooling so developers can see the effect of changes immediately after reloading the page.
 
 `stapler.trace`::
     **Default:** false +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -55,6 +55,26 @@ dd {
 </style>
 ++++
 
+`debug.YUI`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`executable-war`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.bundled.plugins`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.ClassicPluginStrategy.noBytecodeTransformer`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.ClassicPluginStrategy.useAntClassLoader`::
     **Default:** `false` +
     **Since:** 1.316 +
@@ -105,6 +125,11 @@ dd {
     **Since:** 1.365 +
     **Description:** Number of seconds between reloads when Auto Refresh is enabled
 
+`hudson.Functions.hidingPasswordFields`::
+    **Default**: `true` +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.lifecycle`::
     **Default:** n/a +
     **Since:** n/a +
@@ -115,6 +140,16 @@ dd {
     **Since:** 2.121.3 and 2.138 +
     **Description:** Disable security hardening for LogRecorderManager Stapler access. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
+`hudson.Main.development`::
+    **Default**: TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.Main.timeout`::
+    **Default**: 15000 +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.matrix.MatrixConfiguration.useShortWorkspaceName`::
     **Default:** `false` +
     **Since:** n/a +
@@ -124,6 +159,11 @@ dd {
     **Default:** `false` +
     **Since:** 2.121.3 / 2.138 +
     **Description:** Disable security hardening related to Stapler routing for AbstractItem. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory]. 
+
+`hudson.model.Api.INSECURE`::
+    **Default**: `false` +
+    **Since:** TODO +
+    **Description:** TODO Jenkins (core): jenkins.security.SecureRequester$Default
 
 `hudson.model.AsyncAperiodicWork.logRotateMinutes`::
     **Default:** 1440 +
@@ -145,30 +185,60 @@ dd {
     **Since:** 1.651 +
     **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
 
+`hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
+    **Default**: `false` +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.DirectoryBrowserSupport.CSP`::
     **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
     **Since:** 1.625.3, 1.641 +
     **Description:** Determines the Content Security Policy header sent for static files served by Jenkins. See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
+
+`hudson.model.DownloadService$Downloadable.defaultInterval`::
+    **Default**: 86400000 (1 day)
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.DownloadService.never`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Suppress the periodic download of data files for plugins
 
+`hudson.model.DownloadService.noSignatureCheck`::
+    **Default:** `false` +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.Hudson.flyweightSupport`::
     **Default:** `false` before 1.337; `true` from 1.337; unused since 1.598 +
     **Since:** 1.318 +
     **Description:** Matrix parent job and other flyweight tasks (e.g. Build Flow plugin) won't consume an executor when `true`. Unused since 1.598, flyweight support is now always enabled.
+
+`hudson.model.Hudson.initLogLevel`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.Hudson.killAfterLoad`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Exit Jenkins right after loading
 
+`hudson.model.Hudson.logStartupPerformance`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.Hudson.parallelLoad`::
     **Default:** `true` +
     **Since:** n/a +
     **Description:** Loads job configurations in parallel on startup
+
+`hudson.model.Hudson.workspaceDirName`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.LoadStatistics.clock`::
     **Default:** 10000 +
@@ -184,6 +254,11 @@ dd {
     **Default:** SansSerif-10 +
     **Since:** 1.562 +
     **Description:** Font used for load statistics (see http://docs.oracle.com/javase/7/docs/api/java/awt/Font.html#decode%28java.lang.String%29[Java documentation] on how the value is decoded)
+
+`hudson.model.Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.ParametersAction.keepUndefinedParameters`::
     **Default:** undefined +
@@ -235,10 +310,20 @@ dd {
     **Since:** n/a +
     **Description:** When true, don't automatically check for new versions
 
+`hudson.model.UpdateCenter.pluginDownloadReadTimeoutSeconds`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.UpdateCenter.skipPermissionCheck`::
     **Default:** `false` +
     **Since:** 2.121.3 / 2.138 +
     **Description:** Disable security hardening related to Stapler routing for UpdateCenter. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+`hudson.model.UpdateCenter.updateCenterUrl`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.UsageStatistics.disabled`::
     **Default:** `false` +
@@ -280,12 +365,22 @@ dd {
     **Since:** 1.608 +
     **Description:** Unused workspaces are retained for this many days before qualifying for deletion.
 
+`hudson.node_monitors.AbstractNodeMonitorDescriptor.periodMinutes`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.os.solaris.ZFSInstaller.disabled`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** True to disable ZFS monitor on Solaris
 
-`hudson.PluginManager.CHECK_UPDATE_ATTEMPTS`::
+`hudson.os.solaris.ZFSInstaller.migrate`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.PluginManager.checkUpdateAttempts`::
     **Default:** 1 +
     **Since:** 2.152 +
     **Description:** Number of attempts to check the updates sites.
@@ -294,6 +389,16 @@ dd {
     **Default:** 1000 +
     **Since:** 2.152 +
     **Description:** Time (milliseconds) elapsed between retries to check the updates sites.
+
+`hudson.PluginManager.className`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.PluginManager.noFastLookup`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.PluginManager.skipPermissionCheck`::
     **Default:** `false` +
@@ -320,6 +425,11 @@ dd {
     **Since:** 2.0 +
     **Description:** Connection timeout applied to connections e.g. to the update site.
 
+`hudson.remoting.ClassFilter`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.scheduledRetention`::
     **Default:** `false` +
     **Since:** Up to 1.354 +
@@ -329,6 +439,13 @@ dd {
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Useful with ancient versions of CVS that don't support the -d option in the log command
+
+`hudson.scm.SCM.useAutoBrowserHolder`::
+
+`hudson.script.noCache`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.search.Search.skipPermissionCheck`::
     **Default:** `false` +
@@ -345,6 +462,21 @@ dd {
     **Since:** 1.374 +
     **Description:** The Artifacts permission allows to control access to artifacts; When this property is unset or set to false, access to artifacts is not controlled
 
+`hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.security.csrf.requestfield`::
     **Default:** `.crumb` (Jenkins 1.x), `Jenkins-Crumb` (Jenkins 2.0) +
     **Since:** 1.310 +
@@ -360,10 +492,20 @@ dd {
     **Since:** 2.121 and 2.107.3 +
     **Description:** Regex for legal user names in Jenkins user database. See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
 
+`hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.security.LDAPSecurityRealm.groupSearch`::
     **Default:** TBD +
     **Since:** n/a +
     **Description:** LDAP filter to look for groups by their names
+
+`hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.security.WipeOutPermission`::
     **Default:** `false` +
@@ -384,6 +526,46 @@ dd {
     **Default:** 240 +
     **Since:** 2.37 +
     **Description:** Timeout for each https://wiki.jenkins.io/display/JENKINS/Ping+Thread[ping between the master and slaves], in seconds
+
+`hudson.slaves.ConnectionActivityMonitor.enabled`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.ConnectionActivityMonitor.frequency`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.ConnectionActivityMonitor.timeToPing`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.initialDelay`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.MARGIN`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.MARGIN0`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.recurrencePeriod`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.slaves.WorkspaceList`::
     **Default:** `@` +
@@ -440,6 +622,21 @@ dd {
     **Since:** 1.327 +
     **Description:** Pass blame information to downstream jobs
 
+`hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.util.CharacterEncodingFilter.disableFilter`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.util.CharacterEncodingFilter.forceEncoding`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.Util.deletionRetryWait`::
     **Default:** 100 +
     **Since:** 2.2 +
@@ -474,10 +671,25 @@ dd {
     **Since:** 1.563 +
     **Description:** Number of log entries in loggers available on the UI at `+/log/+`
 
+`hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.util.Secret.provider`::
     **Default:** n/a +
     **Since:** 1.360 +
     **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround a https://issues.jenkins-ci.org/browse/JENKINS-6459[known issue].
+
+`hudson.util.StreamTaskListener.AUTO_FLUSH`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.Util.symlinkEscapeHatch`::
     **Default:** `false` +
@@ -488,6 +700,16 @@ dd {
     **Default:** `false` +
     **Since:** 2.93 +
     **Description:** True to use native (JNA/JNR) implementation to set file permissions instead of NIO
+
+`hudson.WebAppMain.forceSessionTrackingByCookie`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.widgets.HistoryWidget.threshold`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.CLI.disabled`::
     **Default:** `false` +
@@ -561,10 +783,25 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 2.102 +
     **Description:** When using the `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle`, exit using this exit code when Jenkins is restarted
 
+`jenkins.model.Jenkins.initLogLevel`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.model.Jenkins.killAfterLoad`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.model.Jenkins.logStartupPerformance`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Log startup timing info
+
+`jenkins.model.Jenkins.parallelLoad`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.model.Jenkins.slaveAgentPort`::
     **Default:** -1 (disabled) +
@@ -576,6 +813,11 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 2.19.4 and 2.24 +
     **Description:** If true, enforces the specified `+jenkins.model.Jenkins.slaveAgentPort+` on startup and will not allow changing it through the UI
 
+`jenkins.model.Jenkins.workspaceDirName`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.model.Jenkins.workspacesDir`::
     **Default:** $\{JENKINS_HOME}/workspace/$\{ITEM_FULL_NAME} +
     **Since:** 2.119 +
@@ -585,6 +827,11 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Default:** `false` +
     **Since:** 2.197 / LTS 2.176.4 +
     **Description:** Disable URL validation intended to prevent an XSS vulnerability. See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
+
+`jenkins.model.lazy.BuildReference.MODE`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.model.StandardArtifactManager.disableTrafficCompression`::
     **Default:** `false` +
@@ -601,15 +848,95 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 1.638 +
     **Description:** True to show API tokens for users to administrators on the user configuration page. This was set to `false` as part of https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11#JenkinsSecurityAdvisory2015-11-11-APItokensofotherusersavailabletoadmins[SECURITY-200]
 
+`jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.security.FrameOptionsPageDecorator.enabled`::
     **Default:** `true` +
     **Since:** 1.581 +
     **Description:** Whether to send `+X-Frame-Options: sameorigin+` header, set to `false` to disable and make Jenkins embeddable
 
+`jenkins.security.ignoreBasicAuth`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.ManagePermission`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.ResourceDomainRootAction.validForMinutes`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.s2m.DefaultFilePathFilter.allow`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.seed.UserSeedProperty.disableUserSeed`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.security.stapler.StaplerDispatchValidator.disabled`::
     **Default:** `false` +
     **Since:** 2.186 / 2.176.2 +
     **Description:** `+true+`  to disable link:/security/advisory/2019-07-17/#SECURITY-534[the SECURITY-534 fix].
+
+`jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.stapler.TypedFilter.skipTypeCheck`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.SystemReadPermission`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
     **Default:** undefined +
@@ -621,10 +948,30 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 1.560 +
     **Description:** `true` to disable Nio for JNLP slaves
 
+`jenkins.slaves.StandardOutputSwapper.disabled`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.telemetry.Telemetry.endpoint`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.ui.refresh`::
     **Default:** `false` +
     **Since:** 2.222 +
     **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see https://www.jenkins.io/sigs/ux/[Jenkins UX SIG].
+
+`jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`JENKINS_HOME`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
     **Default:** undefined +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -607,19 +607,22 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     This will allow static agents to start and handle the load first.
 
 `hudson.slaves.NodeProvisioner.MARGIN`::
-    **Default:** TODO +
+// TODO
+    **Default:** +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** +
 
 `hudson.slaves.NodeProvisioner.MARGIN0`::
-    **Default:** TODO +
+// TODO
+    **Default:** +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** +
 
 `hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
-    **Default:** TODO +
+// TODO
+    **Default:** +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** +
 
 `hudson.slaves.NodeProvisioner.recurrencePeriod`::
     **Default:** Equal to `hudson.model.LoadStatistics.clock`, typically 10 seconds +
@@ -1034,6 +1037,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Default:** `false` +
     **Since:** 2.28 +
     **Description:** +
+// TODO
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
     **Default:** undefined +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -58,6 +58,16 @@ dd {
 </style>
 ++++
 
+////
+STYLE GUIDE
+
+Sort order:
+These properties are ordered alphabetically, case-insensitively.
+End of string sorts before alphanumeric sorts before period (.), sorts before underscore (_).
+Example: foo -> foobar -> foo.bar -> foo_bar
+
+////
+
 `debug.YUI`::
     **Default:** `false` +
     **Since:** n/a +
@@ -229,7 +239,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
     **Default**: `false` +
     **Since:** 2.154 and 2.138.4 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
+    **Description:** Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
 
 `hudson.model.DirectoryBrowserSupport.CSP`::
     **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
@@ -510,12 +520,12 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
     **Default:** `false` +
     **Since:** 2.228 and 2.204.6 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    **Description:** Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
 `hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
     **Default:** `false` +
     **Since:** 2.186 and 2.176.2 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
+    **Description:** Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
 
 `hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
     **Default:** `false` +
@@ -543,6 +553,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Limits the number of rounds for pre-computed BCrypt hashes of user passwords for the Jenkins user database to prevent excessive computation.
 
 `hudson.security.LDAPSecurityRealm.groupSearch`::
+// TODO move out, it's LDAP plugin
     **Default:** TBD +
     **Since:** n/a +
     **Description:** LDAP filter to look for groups by their names
@@ -550,7 +561,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
     **Default:** `false` +
     **Since:** 2.160 and 2.150.2 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
+    **Description:** Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
 
 `hudson.security.WipeOutPermission`::
     **Default:** `false` +
@@ -630,6 +641,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** When true, jobs associated through fingerprints are added to the dependency graph, even when there is no configured upstream/downstream relationship between them.
 
 `hudson.tasks.MailSender.maxLogLines`::
+// TODO is this mailer plugin now?
     **Default:** 250 +
     **Since:** n/a +
     **Description:** Number of lines of console output to include in emails
@@ -671,7 +683,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
 // The code is really confusing; there are two flags, one is always false, and will be forcibly set to false here, except using a new constructor that was deprecated in the same PR it was introduced in.
-    **Default:** `alse` +
+    **Default:** `false` +
     **Since:** 2.102 +
     **Description:** Disables the forced flushing when calling `#close()`.
     Not expected to be used.
@@ -755,14 +767,15 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** True to use native (JNA/JNR) implementation to set file permissions instead of NIO
 
 `hudson.WebAppMain.forceSessionTrackingByCookie`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.234 +
+    **Description:** Set to `false` to not force session tracking to be done via cookie.
+    Escape hatch for https://issues.jenkins-ci.org/browse/JENKINS-61738[JENKINS-61738].
 
 `hudson.widgets.HistoryWidget.threshold`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 30 +
+    **Since:** 1.433 +
+    **Description:** How many builds to show in the build history side panel widget.
 
 `HUDSON_HOME`::
     **Default:** n/a +
@@ -801,21 +814,21 @@ For instance, if you would like to store builds outside of Jenkins home, you can
 +
 To manually migrate existing build records when starting to use this option (`TARGET_DIR` is the value supplied to `jenkins.model.Jenkins.buildsDir`):
 +
-For link:https://www.jenkins.io/doc/book/pipeline/[Pipeline] and Freestyle job types, run this for each `JOB_NAME`:
+For link:/doc/book/pipeline/[Pipeline] and Freestyle job types, run this for each `JOB_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]
 mv $JENKINS_HOME/jobs/[JOB_NAME]/builds [TARGET_DIR]/[JOB_NAME]
 ```
 +
-For link:https://www.jenkins.io/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibranch Pipeline] jobs, run for each `BRANCH_NAME`:
+For link:/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibranch Pipeline] jobs, run for each `BRANCH_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]/[JOB_NAME]/branches/
 mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
 ```
 +
-For link:https://www.jenkins.io/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
+For link:/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/
@@ -908,94 +921,111 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** True to show API tokens for users to administrators on the user configuration page. This was set to `false` as part of https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11#JenkinsSecurityAdvisory2015-11-11-APItokensofotherusersavailabletoadmins[SECURITY-200]
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.102 +
+    **Description:** Do not perform any JEP-200 class filtering when deserializing data.
+    Setting this to `true` is unsafe.
+    See https://jenkins.io/redirect/class-filter/[documentation].
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.102 +
+    **Description:** Do not perform whitelist-based JEP-200 class filtering when deserializing data.
+    With this flag set, only explicitly blacklisted types will be rejected.
+    Setting this to `true` is unsafe.
+    See https://jenkins.io/redirect/class-filter/[documentation].
 
 `jenkins.security.FrameOptionsPageDecorator.enabled`::
     **Default:** `true` +
     **Since:** 1.581 +
-    **Description:** Whether to send `+X-Frame-Options: sameorigin+` header, set to `false` to disable and make Jenkins embeddable
+    **Description:** Whether to send `X-Frame-Options: sameorigin` header, set to `false` to disable and make Jenkins embeddable
 
 `jenkins.security.ignoreBasicAuth`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 1.421 +
+    **Description:** When set to `true`, disable `Basic` authentication with username and password (rather than API token).
 
 `jenkins.security.ManagePermission`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.222 +
+    **Description:** Enable the optional Overall/Manage permission that allows limited access to administrative features suitable for a hosted Jenkins environment.
+    See https://github.com/jenkinsci/jep/tree/master/jep/223[JEP-223].
 
 `jenkins.security.ResourceDomainRootAction.validForMinutes`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 30 +
+    **Since:** 2.200 +
+    **Description:** How long a resource URL served from the resource root URL will be valid for before users are required to reauthenticate to access it.
+    See inline documentation in Jenkins for details.
+
 
 `jenkins.security.s2m.DefaultFilePathFilter.allow`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 1.587 and 1.580.1 +
+    **Description:** Allow all file paths on the Jenkins master to be accessed from agents.
+    This disables a big part of link:/security/advisory/2014-10-30/[SECURITY-144] protections.
 
 `jenkins.security.seed.UserSeedProperty.disableUserSeed`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.160 and 2.105.2 +
+    **Description:** Disables _user seed_.
+    Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
 
 `jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.160 and 2.105.2 +
+    **Description:** Hide the UI for _user seed_ introduced for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
 
 `jenkins.security.stapler.StaplerDispatchValidator.disabled`::
     **Default:** `false` +
-    **Since:** 2.186 / 2.176.2 +
-    **Description:** `+true+`  to disable link:/security/advisory/2019-07-17/#SECURITY-534[the SECURITY-534 fix].
+    **Since:** 2.186 and 2.176.2 +
+    **Description:** Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534].
 
 `jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `stapler-views-whitelist.txt` in `JENKINS_HOME` +
+    **Since:** 2.186 and 2.176.2 +
+    **Description:** Override the location of the user configurable whitelist for stapler view dispatches.
+    This augments the built-in whitelist for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534] that allows dispatches to views that would otherwise be prohibited.
 
 `jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `stapler-whitelist.txt` in `JENKINS_HOME` +
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Override the location of the user configurable whitelist for stapler request routing.
+    This augments the built-in whitelist for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595] that allows routing requests through methods that would otherwise be prohibited.
 
 `jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Prohibits access to `public static` fields when routing requests in Stapler.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
 
 `jenkins.security.stapler.TypedFilter.skipTypeCheck`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Skip (return) type check when determining whether a method or field should be routable with Stapler (i.e. allow any return type).
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
 
 `jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
     **Default:** `false` +
     **Since:** 2.228 and 2.204.6 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    **Description:** Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    Allows requests to URLs with semicolon characters (`;`) in the request path.
 
 `jenkins.security.SystemReadPermission`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.222 +
+    **Description:** Enable the optional Overall/SystemRead permission that allows read-only access to administrative features suitable for a managed Jenkins Configuration as Code environment.
+    See https://github.com/jenkinsci/jep/tree/master/jep/224[JEP-224].
 
 `jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 120 (2 minutes) +
+    **Since:** 2.15 +
+    **Description:** How long a cache for `UserDetails` should be valid for before it is looked up again from the security realm.
+    See https://issues.jenkins-ci.org/browse/JENKINS-35493[JENKINS-35493].
 
 `jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.28 +
+    **Description:** +
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
     **Default:** undefined +
@@ -1008,9 +1038,14 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** `true` to disable Nio for JNLP slaves
 
 `jenkins.slaves.StandardOutputSwapper.disabled`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// TODO Unsure how this works. References:
+// - https://github.com/jenkinsci/jenkins/blob/3fd66ff22051a3309b8dc5130d8da0759ee27f48/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
+// - https://github.com/jenkinsci/remoting/commit/fad8c38724068dfbd155e64508e5d4c154240b87
+    **Default:** `false` +
+    **Since:** 1.429 +
+    **Description:** Some Unix-like agents (e.g. SSH Build Agents) can communicate via stdin/stdout, which is very convenient.
+    Unfortunately, some JVM output (e.g. related to GC) also goes to standard out.
+    This will swap output streams around to prevent stream corruption through unexpected writes to standard out.
 
 `jenkins.telemetry.Telemetry.endpoint`::
 // https://github.com/jenkinsci/jenkins/pull/3604
@@ -1021,7 +1056,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 `jenkins.ui.refresh`::
     **Default:** `false` +
     **Since:** 2.222 +
-    **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see https://www.jenkins.io/sigs/ux/[Jenkins UX SIG].
+    **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see link:/sigs/ux/[Jenkins UX SIG].
 
 `jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
     **Default:** 0 +
@@ -1035,11 +1070,13 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     `JENKINS_HOME` set via JNDI context has higher priority than this, but this takes precedence over the environment variable.
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
+// This is a core module, so this documentation should remain here.
     **Default:** undefined +
     **Since:** 2.22 +
     **Description:** Allows to configure the SSHD client idle timeout (value in milliseconds). Default value is 10min (600000ms).
 
 `org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT`::
+// TODO move to plugin documentation
     **Default:** 20 seconds +
     **Since:** workflow-durable-task-step-plugin 2.29  +
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).


### PR DESCRIPTION
Builds on top of #3393. https://github.com/jenkins-infra/jenkins.io/pull/3396/files/028aae99e95f36ee88966da81afdee78643874bd..57e4bc98e8dd702f8bc9463b3e9a95a2f5ec5676 is the first iteration of content specific to this PR. Individual commits make (some) sense.

I used https://github.com/jenkinsci/jenkins/pull/4680 and clicked around a bit to get Jenkins to tell me which system properties it looked up, plus added a few more I knew about anyway.

Before: 109 system properties
After: 184 system properties
That's 75 more 🎉 