### PR TITLE
Fix anchor jump in the Glossary

### DIFF
--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -14,8 +14,15 @@ XXX: Pages to mark as deprecated by this document:
       * https://wiki.jenkins.io/display/JENKINS/Terminology
 ////
 
-[[glossary]]
 = Glossary
+
+++++
+<script>
+$(function () {
+    anchors.add('dt');
+})
+</script>
+++++
 
 ////
 NOTE: The [glossary] delimiter in AsciiDoctor doesn't autogenerate anchors for
@@ -37,92 +44,92 @@ To ensure it is rendered appropriately.
 == General Terms
 
 [glossary]
-Agent::  [[agent]]
+Agent::
     An agent is typically a machine, or container, which connects to a Jenkins
     master and executes tasks when directed by the master.
-Artifact:: [[artifact]]
+Artifact::
     An immutable file generated during a <<build,Build>> or <<pipeline,Pipeline>>
     run which is *archived* onto the Jenkins <<master,Master>> for
     later retrieval by users.
-Build:: [[build]]
+Build::
     Result of a single execution of a <<project,Project>>
-Cloud:: [[cloud]]
+Cloud::
     A System Configuration which provides dynamic <<agent,Agent>>
     provisioning and allocation, such as that provided by the
     plugin:azure-vm-agents[Azure VM Agents]
     or
     plugin:ec2[Amazon EC2] plugins.
-Core:: [[core]]
+Core::
     The primary Jenkins application (`jenkins.war`) which provides
     the basic web UI, configuration, and foundation upon which <<plugin, Plugins>>
     can be built.
-Downstream:: [[downstream]]
+Downstream::
     A configured <<pipeline,Pipeline>> or <<project,Project>> which is triggered
     as part of the execution of a separate Pipeline or Project.
-Executor:: [[executor]]
+Executor::
     A slot for execution of work defined by a <<pipeline,Pipeline>> or
     <<project,Project>> on a <<node, Node>>. A Node may have zero or more
     Executors configured which corresponds to how many concurrent Projects or
     Pipelines are able to execute on that Node.
-Fingerprint:: [[fingerprint]]
+Fingerprint::
     A hash considered globally unique to track the usage of an
     <<artifact,Artifact>> or other entity across multiple
     <<pipeline,Pipelines>> or <<project,Projects>>.
-Folder:: [[folder]]
+Folder::
     An organizational container for <<pipeline,Pipelines>> and/or
     <<project,Projects>>, similar to folders on a file system.
-Item:: [[item]]
+Item::
     An entity in the web UI corresponding to either a:
     <<folder,Folder>>, <<pipeline,Pipeline>>, or <<project,Project>>.
 Jenkins URL:: [[jenkins-url]]
     The main url for the jenkins application, as visited by a user.
     e.g. https://ci.jenkins.io/
-Job:: [[job]]
+Job::
     A deprecated term, synonymous with <<project,Project>>.
-Label:: [[label]]
+Label::
     User-defined text for grouping <<agent,Agents>>, typically by similar
     functionality or capability. For example `linux` for Linux-based agents or
     `docker` for Docker-capable agents.
-Master:: [[master]]
+Master::
     The central, coordinating process which stores configuration, loads plugins,
     and renders the various user interfaces for Jenkins.
-Node:: [[node]]
+Node::
     A machine which is part of the Jenkins environment and capable
     of executing <<pipeline,Pipelines>> or <<project,Projects>>. Both the
     <<master,Master>> and <<agent,Agents>> are considered to be Nodes.
-Project:: [[project]]
+Project::
     A user-configured description of work which Jenkins should perform, such as
     building a piece of software, etc.
-Pipeline:: [[pipeline]]
+Pipeline::
     A user-defined model of a continuous delivery pipeline, for more read the
     <<pipeline#,Pipeline chapter>> in this handbook.
-Plugin:: [[plugin]]
+Plugin::
     An extension to Jenkins functionality provided separately
     from Jenkins <<core,Core>>.
-Publisher:: [[publisher]]
+Publisher::
     Part of a <<build,Build>> after the completion of all configured
     <<step,Steps>> which publishes reports, sends notifications, etc.
 Resource Root URL:: [[resource-root-url]]
     A secondary url used to serve potentially untrusted content (especially
     build artifacts). This url is distinct from the <<jenkins-url,Jenkins URL>>.
-Stage:: [[stage]]
+Stage::
     `stage` is part of Pipeline, and used for defining a conceptually distinct
     subset of the entire Pipeline, for example: "Build", "Test", and "Deploy",
     which is used by many plugins to visualize or present Jenkins Pipeline
     status/progress.
-Step:: [[step]]
+Step::
     A single task; fundamentally steps tell Jenkins _what_ to do inside of a
     <<pipeline,Pipeline>> or <<project,Project>>.
-Trigger:: [[trigger]]
+Trigger::
     A criteria for triggering a new <<pipeline,Pipeline>> run or
     <<build,Build>>.
 Update Center:: [[update-center]]
     Hosted inventory of plugins and plugin metadata to enable plugin
     installation from within Jenkins.
-Upstream:: [[upstream]]
+Upstream::
     A configured <<pipeline,Pipeline>> or <<project,Project>> which triggers a
     separate Pipeline or Project as part of its execution.
-Workspace:: [[workspace]]
+Workspace::
     A disposable directory on the file system of a <<node,Node>>
     where work can be done by a <<pipeline,Pipeline>> or <<project,Project>>.
     Workspaces are typically left in place after a <<build,Build>> or


### PR DESCRIPTION
For issue https://github.com/jenkins-infra/jenkins.io/issues/3389

- Added anchor for `dt` element script (See https://github.com/jenkins-infra/jenkins.io/issues/3389, requires the change in `jenkins.css`)
- Removed manual anchors. 
- Checked that all generated anchor name are the same as the previous one. Space in a glossary term is replaced by a `-` in the anchor name. So, "Anchor" -> `anchor` and "Jenkins URL" -> `jenkins-url`

Now when the reader hover over a glossary term, a little link icon will appear (see screenshot). The reader can use it to bookmark the link. All previous links in-page or from another page work as the anchors have not changed. 

<img width="885" alt="Screenshot 2020-05-31 at 10 55 15" src="https://user-images.githubusercontent.com/6340362/83348528-c90ab780-a32d-11ea-94ce-b392df9479a2.png">

When clicked on a link to a glossary term, the text is now correctly positioned below the top navbar. 

<img width="885" alt="Screenshot 2020-05-31 at 10 55 34" src="https://user-images.githubusercontent.com/6340362/83348570-4c2c0d80-a32e-11ea-9ca3-95110ef87c46.png">


