### PR TITLE
Make system properties page YAML-based

### DIFF
--- a/content/_layouts/systemproperties.html.haml
+++ b/content/_layouts/systemproperties.html.haml
@@ -1,0 +1,45 @@
+---
+layout: section
+---
+
+= page.content
+
+:ruby
+  require 'asciidoctor'
+
+- if page.properties
+  %dl
+    - page.properties.sort { |x, y| x.name.downcase <=> y.name.downcase }.each do |property|
+      %dt
+        %code
+          = property.name
+      %dd
+        - if property.since
+          %div.since
+            %strong
+              Since:
+            = property.since
+        - else
+          %div.since
+            %strong
+              Since:
+            %em
+              n/a
+        - if property.def
+          %div.def
+            %strong
+              Default:
+            = Asciidoctor.convert property.def.to_s, safe: :safe
+        - else
+          %div.def
+            %strong
+              Default:
+            %em
+              n/a
+        %strong
+          Description:
+        - if property.description
+          = Asciidoctor.convert property.description, safe: :safe
+        - else
+          %em
+            n/a

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -453,11 +453,6 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Since:** Up to 1.354 +
     **Description:** Control a slave based on a schedule
 
-`hudson.scm.CVSSCM.skipChangeLog`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Useful with ancient versions of CVS that don't support the -d option in the log command
-
 `hudson.scm.SCM.useAutoBrowserHolder`::
 
 `hudson.script.noCache`::

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -56,29 +56,32 @@ dd {
 ++++
 
 `debug.YUI`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Whether to use the minified (`false`) or debug (`true`) JS files for the YUI library.
 
 `executable-war`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** This is the path to `jenkins.war` and set by the `executable-war` wrapper when invoked using `java -jar jenkins.war`.
+    This allows Jenkins to find its own `.war` file and e.g. replace it to apply an update.
+    If undefined, Jenkins will not e.g. offer to update itself.
 
 `hudson.bundled.plugins`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Specify a location for additional bundled plugins during plugin development (`hpi:run`).
+    There is no reason this would be set by an administrator.
 
 `hudson.ClassicPluginStrategy.noBytecodeTransformer`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
 
 `hudson.ClassicPluginStrategy.useAntClassLoader`::
     **Default:** `false` +
     **Since:** 1.316 +
-    **Description:** +
+    **Description:** TODO: This may not actually be used anymore.
 
 `hudson.cli.CLI.pingInterval`::
     **Default:** 3000 +
@@ -127,8 +130,9 @@ dd {
 
 `hudson.Functions.hidingPasswordFields`::
     **Default**: `true` +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** 2.205 +
+    **Description:** Jenkins 2.205 and newer attempts to prevent browsers from offering to auto-fill password form fields by using a custom password control.
+    Setting this to `false` reverts to the legacy behavior of using mostly standard password form fields.
 
 `hudson.lifecycle`::
     **Default:** n/a +
@@ -138,47 +142,60 @@ dd {
 `hudson.logging.LogRecorderManager.skipPermissionCheck`::
     **Default:** `false` +
     **Since:** 2.121.3 and 2.138 +
-    **Description:** Disable security hardening for LogRecorderManager Stapler access. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+    **Description:** Disable security hardening for LogRecorderManager Stapler access.
+    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
 `hudson.Main.development`::
-    **Default**: TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default**: see description +
+    **Since:** n/a +
+    **Description:** Set to `true` by the development tooling to identify when Jenkins is running via `jetty:run` or `hpi:run`.
+    Can be used to distinguish between development and production use; most prominently used to bypass the setup wizard when running with an empty Jenkins home directory during development.
 
 `hudson.Main.timeout`::
     **Default**: 15000 +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** n/a +
+    **Description:** When using `jenkins-core.jar` from the CLI, this is the connection timeout connecting to Jenkins to report a build result.
 
 `hudson.matrix.MatrixConfiguration.useShortWorkspaceName`::
     **Default:** `false` +
     **Since:** n/a +
-    **Description:** Use shorter but cryptic names in matrix build workspace directories. Avoids problems with 256 character limit on paths in Cygwin, path depths problems on Windows, and shell metacharacter problems with label expressions on most platforms. See https://issues.jenkins-ci.org/browse/JENKINS-25783[JENKINS-25783].
+    **Description:** Use shorter but cryptic names in matrix build workspace directories.
+    Avoids problems with 256 character limit on paths in Cygwin, path depths problems on Windows, and shell metacharacter problems with label expressions on most platforms.
+    See https://issues.jenkins-ci.org/browse/JENKINS-25783[JENKINS-25783].
 
 `hudson.model.AbstractItem.skipPermissionCheck`::
     **Default:** `false` +
     **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for AbstractItem. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory]. 
+    **Description:** Disable security hardening related to Stapler routing for AbstractItem.
+    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
 `hudson.model.Api.INSECURE`::
     **Default**: `false` +
-    **Since:** TODO +
-    **Description:** TODO Jenkins (core): jenkins.security.SecureRequester$Default
+    **Since:** 1.502 +
+    **Description:** Set to `true` to permit accessing the Jenkins remote API in an unsafe manner.
+    See SECURITY-47.
+    Deprecated, use e.g. https://plugins.jenkins.io/secure-requester-whitelist/[Secure Requester Whitelist] instead.
 
 `hudson.model.AsyncAperiodicWork.logRotateMinutes`::
     **Default:** 1440 +
     **Since:** 1.651 +
-    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncAperiodicWork extension. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncAperiodicWork extension.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 
 `hudson.model.AsyncAperiodicWork.logRotateSize`::
     **Default:** -1 +
     **Since:** 1.651 +
-    **Description:** When starting a new run of any AsyncAperiodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** When starting a new run of any AsyncAperiodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 
 `hudson.model.AsyncPeriodicWork.logRotateMinutes`::
     **Default:** 1440 +
     **Since:** 1.651 +
-    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 +
 Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
 +
@@ -192,7 +209,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.model.AsyncPeriodicWork.logRotateSize`::
     **Default:** -1 +
     **Since:** 1.651 +
-    **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
+    **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
 +
 Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
 +
@@ -205,28 +224,29 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
     **Default**: `false` +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
 
 `hudson.model.DirectoryBrowserSupport.CSP`::
     **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
     **Since:** 1.625.3, 1.641 +
-    **Description:** Determines the Content Security Policy header sent for static files served by Jenkins. See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
+    **Description:** Determines the Content Security Policy header sent for static files served by Jenkins.
+    See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
 
 `hudson.model.DownloadService$Downloadable.defaultInterval`::
     **Default**: 86400000 (1 day)
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** n/a +
+    **Description:** Interval between periodic downloads of _Downloadables_, typically tool installer metadata.
 
 `hudson.model.DownloadService.never`::
     **Default:** `false` +
     **Since:** n/a +
-    **Description:** Suppress the periodic download of data files for plugins
+    **Description:** Suppress the periodic download of data files for plugins via browser-based download. Since Jenkins 2.200, this has no effect.
 
 `hudson.model.DownloadService.noSignatureCheck`::
     **Default:** `false` +
-    **Since:** TODO +
-    **Description:** TODO
+    **Since:** n/a +
+    **Description:** Skip the update site signature check. Setting this to `true` can be unsafe.
 
 `hudson.model.Hudson.flyweightSupport`::
     **Default:** `false` before 1.337; `true` from 1.337; unused since 1.598 +
@@ -234,29 +254,29 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Matrix parent job and other flyweight tasks (e.g. Build Flow plugin) won't consume an executor when `true`. Unused since 1.598, flyweight support is now always enabled.
 
 `hudson.model.Hudson.initLogLevel`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.initLogLevel`.
 
 `hudson.model.Hudson.killAfterLoad`::
-    **Default:** `false` +
+    **Default:** n/a +
     **Since:** n/a +
-    **Description:** Exit Jenkins right after loading
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.killAfterLoad`.
 
 `hudson.model.Hudson.logStartupPerformance`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.logStartupPerformance`.
 
 `hudson.model.Hudson.parallelLoad`::
-    **Default:** `true` +
+    **Default:** n/a +
     **Since:** n/a +
-    **Description:** Loads job configurations in parallel on startup
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.parallelLoad`.
 
 `hudson.model.Hudson.workspaceDirName`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.workspaceDirName`.
 
 `hudson.model.LoadStatistics.clock`::
     **Default:** 10000 +
@@ -274,9 +294,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Font used for load statistics (see http://docs.oracle.com/javase/7/docs/api/java/awt/Font.html#decode%28java.lang.String%29[Java documentation] on how the value is decoded)
 
 `hudson.model.Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** n/a +
+    **Description:** Whether to allow building flyweight tasks even if the necessary permission (Computer/Build) is missing.
+    See https://issues.jenkins-ci.org/browse/JENKINS-46652[JENKINS-46652].
 
 `hudson.model.ParametersAction.keepUndefinedParameters`::
     **Default:** undefined +
@@ -329,9 +350,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** When true, don't automatically check for new versions
 
 `hudson.model.UpdateCenter.pluginDownloadReadTimeoutSeconds`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** 60 +
+    **Since:** n/a +
+    **Description:** Read timeout in seconds for downloading plugins.
 
 `hudson.model.UpdateCenter.skipPermissionCheck`::
     **Default:** `false` +
@@ -339,9 +360,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Disable security hardening related to Stapler routing for UpdateCenter. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
 `hudson.model.UpdateCenter.updateCenterUrl`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `https://updates.jenkins.io/` +
+    **Since:** n/a +
+    **Description:** Deprecated: Override the default update site URL.
+    May have no effect since Jenkins 1.333.
 
 `hudson.model.UsageStatistics.disabled`::
     **Default:** `false` +
@@ -384,9 +406,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Unused workspaces are retained for this many days before qualifying for deletion.
 
 `hudson.node_monitors.AbstractNodeMonitorDescriptor.periodMinutes`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** 60 +
+    **Since:** n/a +
+    **Description:** How frequently to update node monitors by default, in minutes.
 
 `hudson.os.solaris.ZFSInstaller.disabled`::
     **Default:** `false` +
@@ -394,9 +416,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** True to disable ZFS monitor on Solaris
 
 `hudson.os.solaris.ZFSInstaller.migrate`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Set by Jenkins itself when restarting Jenkins for a migration to a ZFS volume and contains the migration target dataset name.
+    There is no reason this would be set by administrators manually.
 
 `hudson.PluginManager.checkUpdateAttempts`::
     **Default:** 1 +
@@ -409,14 +432,14 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Time (milliseconds) elapsed between retries to check the updates sites.
 
 `hudson.PluginManager.className`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Can be used to specify a different `PluginManager` implementation when customizing the `.war` packaging of Jenkins.
 
 `hudson.PluginManager.noFastLookup`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Disable fast lookup using `ClassLoaderReflectionToolkit` which reflectively accesses internal methods of `ClassLoader`.
 
 `hudson.PluginManager.skipPermissionCheck`::
     **Default:** `false` +
@@ -444,9 +467,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Connection timeout applied to connections e.g. to the update site.
 
 `hudson.remoting.ClassFilter`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** undefined +
+    **Since:** n/a +
+    **Description:** Allow or disallow the deserialization of specified types. Comma-separated class names, entries are whitelisted unless prefixed with `!`.
+    See https://github.com/jenkinsci/jep/tree/master/jep/200#backwards-compatibility[JEP-200] and https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736].
 
 `hudson.scheduledRetention`::
     **Default:** `false` +
@@ -454,11 +478,15 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Control a slave based on a schedule
 
 `hudson.scm.SCM.useAutoBrowserHolder`::
+    **Default:** `false` since Jenkins 2.9, `true` before +
+    **Since:** n/a +
+    **Description:** When set to `true`, Jenkins will guess the repository browser used to render links in the changelog.
 
 `hudson.script.noCache`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** see description +
+    **Since:** n/a +
+    **Description:** When set to true, Jenkins will not reference resource files through the `/static/.../` URL space, preventing their caching.
+    This is set to `true` during development by default, and `false` otherwise.
 
 `hudson.search.Search.skipPermissionCheck`::
     **Default:** `false` +
@@ -476,19 +504,19 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** The Artifacts permission allows to control access to artifacts; When this property is unset or set to false, access to artifacts is not controlled
 
 `hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.228 and 2.204.6 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
 `hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.186 and 2.176.2 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
 
 `hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.222 +
+    **Description:** Restore the ability to disable CSRF protection after the UI for doing so was removed from Jenkins 2.222.
 
 `hudson.security.csrf.requestfield`::
     **Default:** `.crumb` (Jenkins 1.x), `Jenkins-Crumb` (Jenkins 2.0) +
@@ -507,7 +535,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.security.LDAPSecurityRealm.groupSearch`::
@@ -517,7 +545,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.security.WipeOutPermission`::
@@ -542,42 +570,42 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.slaves.ConnectionActivityMonitor.enabled`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.ConnectionActivityMonitor.frequency`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.ConnectionActivityMonitor.timeToPing`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.initialDelay`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.MARGIN`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.MARGIN0`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.recurrencePeriod`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.slaves.WorkspaceList`::
@@ -637,17 +665,17 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.util.CharacterEncodingFilter.disableFilter`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.util.CharacterEncodingFilter.forceEncoding`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.Util.deletionRetryWait`::
@@ -685,14 +713,16 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Number of log entries in loggers available on the UI at `+/log/+`
 
 `hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.236 +
+    **Description:** Jenkins automatically round-trips `f:password` based form fields as encrypted `Secret` even if the field is not of type `Secret`.
+    Set this to `false` to disable this behavior, doing so is discouraged.
 
 `hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.236 +
+    **Description:** If the user is missing _Item/Configure_ permission, Jenkins 2.236 and newer will blank out the password value automatically even if the form field is not backed by a `Secret`.
+    Set this to `false` to disable this behavior, doing so is discouraged.
 
 `hudson.util.Secret.provider`::
     **Default:** n/a +
@@ -701,7 +731,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.util.StreamTaskListener.AUTO_FLUSH`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.Util.symlinkEscapeHatch`::
@@ -716,12 +746,12 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.WebAppMain.forceSessionTrackingByCookie`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `hudson.widgets.HistoryWidget.threshold`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.CLI.disabled`::
@@ -798,12 +828,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.model.Jenkins.initLogLevel`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.Jenkins.killAfterLoad`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.Jenkins.logStartupPerformance`::
@@ -813,7 +843,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.model.Jenkins.parallelLoad`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.Jenkins.slaveAgentPort`::
@@ -827,9 +857,9 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** If true, enforces the specified `+jenkins.model.Jenkins.slaveAgentPort+` on startup and will not allow changing it through the UI
 
 `jenkins.model.Jenkins.workspaceDirName`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `workspace` +
+    **Since:** n/a +
+    **Description:** Obsolete: Was used as the default workspace directory name in the legacy workspace directory layout (workspace directories within job directories).
 
 `jenkins.model.Jenkins.workspacesDir`::
     **Default:** $\{JENKINS_HOME}/workspace/$\{ITEM_FULL_NAME} +
@@ -843,7 +873,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.model.lazy.BuildReference.MODE`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.model.StandardArtifactManager.disableTrafficCompression`::
@@ -863,12 +893,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.FrameOptionsPageDecorator.enabled`::
@@ -878,32 +908,32 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.security.ignoreBasicAuth`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.ManagePermission`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.ResourceDomainRootAction.validForMinutes`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.s2m.DefaultFilePathFilter.allow`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.seed.UserSeedProperty.disableUserSeed`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.StaplerDispatchValidator.disabled`::
@@ -913,42 +943,42 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.stapler.TypedFilter.skipTypeCheck`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
-    **Default:** TODO +
-    **Since:** TODO +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.228 and 2.204.6 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
 `jenkins.security.SystemReadPermission`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
@@ -963,12 +993,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.slaves.StandardOutputSwapper.disabled`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.telemetry.Telemetry.endpoint`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `jenkins.ui.refresh`::
@@ -978,12 +1008,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 
 `jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `JENKINS_HOME`::
     **Default:** TODO +
-    **Since:** TODO +
+    **Since:** n/a +
     **Description:** TODO
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
@@ -995,6 +1025,27 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Default:** 20 seconds +
     **Since:** workflow-durable-task-step-plugin 2.29  +
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
+
+`stapler.jelly.noCache`::
+    **Default:** false +
+    **Since:** n/a +
+    **Description:** TODO
+
+`stapler.resourcePath`::
+    **Default:** TODO +
+    **Since:** n/a +
+    **Description:** TODO
+
+`stapler.trace`::
+    **Default:** false +
+    **Since:** n/a +
+    **Description:** Trace request handling and report the result using `Stapler-Trace-...` response headers.
+    Additionally renders a diagnostic HTTP 404 error page when the request could not be processed.
+
+`stapler.trace.per-request`::
+    **Default:** false +
+    **Since:** n/a +
+    **Description:** Trace request handling (see above) for requests with the `X-Stapler-Trace` request header set.
 
 == Properties in plugins
 

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -825,14 +825,16 @@ For link:/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibr
 +
 ```sh
 mkdir -p [TARGET_DIR]/[JOB_NAME]/branches/
-mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
+mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds \
+    [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
 ```
 +
 For link:/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/
-mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]
+mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds \
+    [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]
 ```
 
 `jenkins.model.Jenkins.crumbIssuerProxyCompatibility`::

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -123,7 +123,7 @@ dd {
 `hudson.Functions.autoRefreshSeconds`::
     **Default:** 10 +
     **Since:** 1.365 +
-    **Description:** Number of seconds between reloads when Auto Refresh is enabled
+    **Description:** Number of seconds between reloads when Auto Refresh is enabled, obsolete since the feature was removed in Jenkins 2.223.
 
 `hudson.Functions.hidingPasswordFields`::
     **Default**: `true` +
@@ -179,11 +179,29 @@ dd {
     **Default:** 1440 +
     **Since:** 1.651 +
     **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
++
+Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
++
+* `hudson.model.WorkspaceCleanupThread`
+* `hudson.model.FingerprintCleanupThread`
+* `hudson.slaves.ConnectionActivityMonitor`
+* `jenkins.DailyCheck`
+* `jenkins.model.BackgroundGlobalBuildDiscarder`
+* `jenkins.telemetry.Telemetry$TelemetryReporter`
 
 `hudson.model.AsyncPeriodicWork.logRotateSize`::
     **Default:** -1 +
     **Since:** 1.651 +
     **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
++
+Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
++
+* `hudson.model.WorkspaceCleanupThread`
+* `hudson.model.FingerprintCleanupThread`
+* `hudson.slaves.ConnectionActivityMonitor`
+* `jenkins.DailyCheck`
+* `jenkins.model.BackgroundGlobalBuildDiscarder`
+* `jenkins.telemetry.Telemetry$TelemetryReporter`
 
 `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
     **Default**: `false` +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -18,7 +18,7 @@ $(function () {
 ++++
 
 Jenkins has several "hidden" features that can be enabled with system properties.
-This page describes how to configure them on your instance.
+This page documents many of them and explain how to configure them on your instance.
 
 == Usage
 
@@ -46,6 +46,9 @@ If you find some of those useful, please file a ticket to promote it to the offi
 
 
 == Properties in Jenkins Core
+
+[NOTE]
+Due to the very large number of system properties used, often just added as a "safety valve" or "escape hatch" in case a change causes problems, this is list is not expected to be complete.
 
 ++++
 <style>
@@ -77,12 +80,13 @@ dd {
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
-
+////
+TODO: This may not actually be used anymore. We probably should document deprecated/obsolete system properties in a separate section.
 `hudson.ClassicPluginStrategy.useAntClassLoader`::
     **Default:** `false` +
     **Since:** 1.316 +
-    **Description:** TODO: This may not actually be used anymore.
-
+    **Description:** +
+////
 `hudson.cli.CLI.pingInterval`::
     **Default:** 3000 +
     **Since:** 2.199 +
@@ -534,9 +538,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Regex for legal user names in Jenkins user database. See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
 
 `hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 18 +
+    **Since:** 2.161 +
+    **Description:** Limits the number of rounds for pre-computed BCrypt hashes of user passwords for the Jenkins user database to prevent excessive computation.
 
 `hudson.security.LDAPSecurityRealm.groupSearch`::
     **Default:** TBD +
@@ -544,9 +548,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** LDAP filter to look for groups by their names
 
 `hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.160 and 2.150.2 +
+    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
 
 `hudson.security.WipeOutPermission`::
     **Default:** `false` +
@@ -569,19 +573,21 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Timeout for each https://wiki.jenkins.io/display/JENKINS/Ping+Thread[ping between the master and slaves], in seconds
 
 `hudson.slaves.ConnectionActivityMonitor.enabled`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// This looks like a dead feature? Introduced 2011 and disabled by default?
+    **Default:** `false` +
+    **Since:** 1.326 +
+    **Description:** Whether to enable this feature that checks whether agents are alive and cuts them off if not.
 
 `hudson.slaves.ConnectionActivityMonitor.frequency`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// Actually dual use: Both for timeout (4 minutes) and time to ping (3 minutes). Possibly copy & paste issue and bug in core?
+    **Default:** 10000 (10 seconds) +
+    **Since:** 1.326 +
+    **Description:** How frequently to check for channel activity, in milliseconds.
 
 `hudson.slaves.ConnectionActivityMonitor.timeToPing`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 180000 (3 minutes) +
+    **Since:** 1.326 +
+    **Description:** How long to wait after startup to start checking agent connections, in milliseconds.
 
 `hudson.slaves.NodeProvisioner.initialDelay`::
     **Default:** TODO +
@@ -664,19 +670,20 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Pass blame information to downstream jobs
 
 `hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
-
+// The code is really confusing; there are two flags, one is always false, and will be forcibly set to false here, except using a new constructor that was deprecated in the same PR it was introduced in.
+    **Default:** `alse` +
+    **Since:** 2.102 +
+    **Description:** Disables the forced flushing when calling `#close()`.
+    Not expected to be used.
 `hudson.util.CharacterEncodingFilter.disableFilter`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Set to `true` to disable the filter that sets request encoding to UTF-8 if it's undefined and its content type is `text/xml` or `application/xml` (API submissions).
 
 `hudson.util.CharacterEncodingFilter.forceEncoding`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Set to `true` to force the request encoding to UTF-8 even if a different character set is declared.
 
 `hudson.Util.deletionRetryWait`::
     **Default:** 100 +
@@ -727,12 +734,15 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.util.Secret.provider`::
     **Default:** n/a +
     **Since:** 1.360 +
-    **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround a https://issues.jenkins-ci.org/browse/JENKINS-6459[known issue].
+    **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround https://issues.jenkins-ci.org/browse/JENKINS-6459[JENKINS-6459].
 
 `hudson.util.StreamTaskListener.AUTO_FLUSH`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// https://github.com/jenkinsci/jenkins/pull/3961
+    **Default:** `false` +
+    **Since:** 2.173 +
+    **Description:** Jenkins no longer automatically flushes streams for code running remotely on agents for better performance.
+    This may lead to loss of messages for plugins which print to a build log from the agent machine but do not flush their output.
+    Use this flag to restore the previous behavior for freestyle builds.
 
 `hudson.Util.symlinkEscapeHatch`::
     **Default:** `false` +
@@ -754,6 +764,12 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Since:** n/a +
     **Description:** TODO
 
+`HUDSON_HOME`::
+    **Default:** n/a +
+    **Since:** n/a +
+    **Description:** Backward compatible fallback name for `JENKINS_HOME`.
+    See documentation there.
+
 `jenkins.CLI.disabled`::
     **Default:** `false` +
     **Since:** 2.32 and 2.19.3 +
@@ -771,7 +787,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `jenkins.model.Jenkins.buildsDir`::
     **Default:** `$\{ITEM_ROOTDIR}/builds` +
-    **Since:** 2.119 + 
+    **Since:** 2.119 +
     **Description:** The configuration of a given job is located under `+$JENKINS_HOME/jobs/[JOB_NAME]/config.xml+` and its builds are under `+$JENKINS_HOME/jobs/[JOB_NAME]/builds+` by default.
     This option allows you to store builds elsewhere, which can be useful with finer-grained backup policies, or to store the build data on a faster disk such as an SSD.
     The following placeholders are supported for this value:
@@ -997,9 +1013,10 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** TODO
 
 `jenkins.telemetry.Telemetry.endpoint`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// https://github.com/jenkinsci/jenkins/pull/3604
+    **Default:** `+https://uplink.jenkins.io/events+` +
+    **Since:** 2.143 +
+    **Description:** Change the endpoint that JEP-214/Uplink telemetry sends data to. Expected to be used for testing only.
 
 `jenkins.ui.refresh`::
     **Default:** `false` +
@@ -1007,14 +1024,15 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see https://www.jenkins.io/sigs/ux/[Jenkins UX SIG].
 
 `jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
-    **Default:** TODO +
+    **Default:** 0 +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Debug/development option to slow down the cancelling of progressive rendering when the client fails to send a heartbeat.
 
 `JENKINS_HOME`::
-    **Default:** TODO +
+    **Default:** `~/.jenkins` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** While typically set as an environment variable, Jenkins also looks up the path to its home directory as a system property.
+    `JENKINS_HOME` set via JNDI context has higher priority than this, but this takes precedence over the environment variable.
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
     **Default:** undefined +
@@ -1027,7 +1045,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
 
 `stapler.jelly.noCache`::
-    **Default:** false +
+    **Default:** TODO +
     **Since:** n/a +
     **Description:** TODO
 

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -293,7 +293,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.workspaceDirName`.
 
 `hudson.model.LoadStatistics.clock`::
-    **Default:** 10000 +
+    **Default:** 10000 (10 seconds) +
     **Since:** n/a +
     **Description:** Load statistics clock cycle in milliseconds
 
@@ -601,9 +601,10 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** How long to wait after startup to start checking agent connections, in milliseconds.
 
 `hudson.slaves.NodeProvisioner.initialDelay`::
-    **Default:** TODO +
+    **Default:** 10 times `hudson.model.LoadStatistics.clock`, typically 100 seconds +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** How long to wait after startup before starting to provision nodes from clouds.
+    This will allow static agents to start and handle the load first.
 
 `hudson.slaves.NodeProvisioner.MARGIN`::
     **Default:** TODO +
@@ -621,9 +622,9 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** TODO
 
 `hudson.slaves.NodeProvisioner.recurrencePeriod`::
-    **Default:** TODO +
+    **Default:** Equal to `hudson.model.LoadStatistics.clock`, typically 10 seconds +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** How frequently to possibly provision nodes.
 
 `hudson.slaves.WorkspaceList`::
     **Default:** `@` +
@@ -858,24 +859,26 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** When using the `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle`, exit using this exit code when Jenkins is restarted
 
 `jenkins.model.Jenkins.initLogLevel`::
-    **Default:** TODO +
+    **Default:** `FINE` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Log level for verbose messages from the init reactor listener.
 
 `jenkins.model.Jenkins.killAfterLoad`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Exit Jenkins right after loading.
+    Intended as a development/testing aid only.
 
 `jenkins.model.Jenkins.logStartupPerformance`::
     **Default:** `false` +
     **Since:** n/a +
-    **Description:** Log startup timing info
+    **Description:** Log startup timing info.
+    Note that some messages are not logged on levels visible by default (i.e. INFO and up).
 
 `jenkins.model.Jenkins.parallelLoad`::
-    **Default:** TODO +
+    **Default:** `true` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Loads job configurations in parallel on startup.
 
 `jenkins.model.Jenkins.slaveAgentPort`::
     **Default:** -1 (disabled) +
@@ -903,9 +906,12 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** Disable URL validation intended to prevent an XSS vulnerability. See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
 
 `jenkins.model.lazy.BuildReference.MODE`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `soft` +
+    **Since:** 1.548 +
+    **Description:** Configure the kind of reference Jenkins uses to hold builds in memory.
+    Choose from among `soft`, `weak`, `strong`, and `not` (do not hold builds in memory at all).
+    Intended mostly as a debugging aid.
+    See https://issues.jenkins-ci.org/browse/JENKINS-19400[JENKINS-19400].
 
 `jenkins.model.StandardArtifactManager.disableTrafficCompression`::
     **Default:** `false` +
@@ -1084,14 +1090,28 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
 
 `stapler.jelly.noCache`::
-    **Default:** TODO +
+    **Default:** `false` +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Controls both caching of various cachable resources (Jelly scripts etc.) as well as the `Expires` HTTP response header for some static resources.
+    Useful during development to see the effect of changes after reload.
+
+`stapler.legacyGetterDispatcherMode`::
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Do not filter get methods at the Stapler framework level.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
+
+`stapler.legacyWebMethodDispatcherMode`::
+    **Default:** `false` +
+    **Since:** n/a +
+    **Description:** Do not filter web methods ("do" actions) at the Stapler framework level.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
 
 `stapler.resourcePath`::
-    **Default:** TODO +
+    **Default:** undefined +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** Additional debug resource paths.
+    Set by the core development tooling so developers can see the effect of changes immediately after reloading the page.
 
 `stapler.trace`::
     **Default:** false +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -55,6 +55,26 @@ dd {
 </style>
 ++++
 
+`debug.YUI`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`executable-war`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.bundled.plugins`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.ClassicPluginStrategy.noBytecodeTransformer`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.ClassicPluginStrategy.useAntClassLoader`::
     **Default:** `false` +
     **Since:** 1.316 +
@@ -105,6 +125,11 @@ dd {
     **Since:** 1.365 +
     **Description:** Number of seconds between reloads when Auto Refresh is enabled
 
+`hudson.Functions.hidingPasswordFields`::
+    **Default**: `true` +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.lifecycle`::
     **Default:** n/a +
     **Since:** n/a +
@@ -115,6 +140,16 @@ dd {
     **Since:** 2.121.3 and 2.138 +
     **Description:** Disable security hardening for LogRecorderManager Stapler access. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
 
+`hudson.Main.development`::
+    **Default**: TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.Main.timeout`::
+    **Default**: 15000 +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.matrix.MatrixConfiguration.useShortWorkspaceName`::
     **Default:** `false` +
     **Since:** n/a +
@@ -124,6 +159,11 @@ dd {
     **Default:** `false` +
     **Since:** 2.121.3 / 2.138 +
     **Description:** Disable security hardening related to Stapler routing for AbstractItem. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory]. 
+
+`hudson.model.Api.INSECURE`::
+    **Default**: `false` +
+    **Since:** TODO +
+    **Description:** TODO Jenkins (core): jenkins.security.SecureRequester$Default
 
 `hudson.model.AsyncAperiodicWork.logRotateMinutes`::
     **Default:** 1440 +
@@ -145,30 +185,60 @@ dd {
     **Since:** 1.651 +
     **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated. For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension. _It is not anticipated that you will ever need to change these defaults_
 
+`hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
+    **Default**: `false` +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.DirectoryBrowserSupport.CSP`::
     **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
     **Since:** 1.625.3, 1.641 +
     **Description:** Determines the Content Security Policy header sent for static files served by Jenkins. See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
+
+`hudson.model.DownloadService$Downloadable.defaultInterval`::
+    **Default**: 86400000 (1 day)
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.DownloadService.never`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Suppress the periodic download of data files for plugins
 
+`hudson.model.DownloadService.noSignatureCheck`::
+    **Default:** `false` +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.Hudson.flyweightSupport`::
     **Default:** `false` before 1.337; `true` from 1.337; unused since 1.598 +
     **Since:** 1.318 +
     **Description:** Matrix parent job and other flyweight tasks (e.g. Build Flow plugin) won't consume an executor when `true`. Unused since 1.598, flyweight support is now always enabled.
+
+`hudson.model.Hudson.initLogLevel`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.Hudson.killAfterLoad`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Exit Jenkins right after loading
 
+`hudson.model.Hudson.logStartupPerformance`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.Hudson.parallelLoad`::
     **Default:** `true` +
     **Since:** n/a +
     **Description:** Loads job configurations in parallel on startup
+
+`hudson.model.Hudson.workspaceDirName`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.LoadStatistics.clock`::
     **Default:** 10000 +
@@ -184,6 +254,11 @@ dd {
     **Default:** SansSerif-10 +
     **Since:** 1.562 +
     **Description:** Font used for load statistics (see http://docs.oracle.com/javase/7/docs/api/java/awt/Font.html#decode%28java.lang.String%29[Java documentation] on how the value is decoded)
+
+`hudson.model.Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.ParametersAction.keepUndefinedParameters`::
     **Default:** undefined +
@@ -235,10 +310,20 @@ dd {
     **Since:** n/a +
     **Description:** When true, don't automatically check for new versions
 
+`hudson.model.UpdateCenter.pluginDownloadReadTimeoutSeconds`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.model.UpdateCenter.skipPermissionCheck`::
     **Default:** `false` +
     **Since:** 2.121.3 / 2.138 +
     **Description:** Disable security hardening related to Stapler routing for UpdateCenter. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+`hudson.model.UpdateCenter.updateCenterUrl`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.model.UsageStatistics.disabled`::
     **Default:** `false` +
@@ -280,12 +365,22 @@ dd {
     **Since:** 1.608 +
     **Description:** Unused workspaces are retained for this many days before qualifying for deletion.
 
+`hudson.node_monitors.AbstractNodeMonitorDescriptor.periodMinutes`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.os.solaris.ZFSInstaller.disabled`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** True to disable ZFS monitor on Solaris
 
-`hudson.PluginManager.CHECK_UPDATE_ATTEMPTS`::
+`hudson.os.solaris.ZFSInstaller.migrate`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.PluginManager.checkUpdateAttempts`::
     **Default:** 1 +
     **Since:** 2.152 +
     **Description:** Number of attempts to check the updates sites.
@@ -294,6 +389,16 @@ dd {
     **Default:** 1000 +
     **Since:** 2.152 +
     **Description:** Time (milliseconds) elapsed between retries to check the updates sites.
+
+`hudson.PluginManager.className`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.PluginManager.noFastLookup`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.PluginManager.skipPermissionCheck`::
     **Default:** `false` +
@@ -320,6 +425,11 @@ dd {
     **Since:** 2.0 +
     **Description:** Connection timeout applied to connections e.g. to the update site.
 
+`hudson.remoting.ClassFilter`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.scheduledRetention`::
     **Default:** `false` +
     **Since:** Up to 1.354 +
@@ -329,6 +439,13 @@ dd {
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Useful with ancient versions of CVS that don't support the -d option in the log command
+
+`hudson.scm.SCM.useAutoBrowserHolder`::
+
+`hudson.script.noCache`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.search.Search.skipPermissionCheck`::
     **Default:** `false` +
@@ -345,6 +462,21 @@ dd {
     **Since:** 1.374 +
     **Description:** The Artifacts permission allows to control access to artifacts; When this property is unset or set to false, access to artifacts is not controlled
 
+`hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.security.csrf.requestfield`::
     **Default:** `.crumb` (Jenkins 1.x), `Jenkins-Crumb` (Jenkins 2.0) +
     **Since:** 1.310 +
@@ -360,10 +492,20 @@ dd {
     **Since:** 2.121 and 2.107.3 +
     **Description:** Regex for legal user names in Jenkins user database. See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
 
+`hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.security.LDAPSecurityRealm.groupSearch`::
     **Default:** TBD +
     **Since:** n/a +
     **Description:** LDAP filter to look for groups by their names
+
+`hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.security.WipeOutPermission`::
     **Default:** `false` +
@@ -384,6 +526,46 @@ dd {
     **Default:** 240 +
     **Since:** 2.37 +
     **Description:** Timeout for each https://wiki.jenkins.io/display/JENKINS/Ping+Thread[ping between the master and slaves], in seconds
+
+`hudson.slaves.ConnectionActivityMonitor.enabled`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.ConnectionActivityMonitor.frequency`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.ConnectionActivityMonitor.timeToPing`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.initialDelay`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.MARGIN`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.MARGIN0`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.slaves.NodeProvisioner.recurrencePeriod`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.slaves.WorkspaceList`::
     **Default:** `@` +
@@ -440,6 +622,21 @@ dd {
     **Since:** 1.327 +
     **Description:** Pass blame information to downstream jobs
 
+`hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.util.CharacterEncodingFilter.disableFilter`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.util.CharacterEncodingFilter.forceEncoding`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.Util.deletionRetryWait`::
     **Default:** 100 +
     **Since:** 2.2 +
@@ -474,10 +671,25 @@ dd {
     **Since:** 1.563 +
     **Description:** Number of log entries in loggers available on the UI at `+/log/+`
 
+`hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `hudson.util.Secret.provider`::
     **Default:** n/a +
     **Since:** 1.360 +
     **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround a https://issues.jenkins-ci.org/browse/JENKINS-6459[known issue].
+
+`hudson.util.StreamTaskListener.AUTO_FLUSH`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `hudson.Util.symlinkEscapeHatch`::
     **Default:** `false` +
@@ -488,6 +700,16 @@ dd {
     **Default:** `false` +
     **Since:** 2.93 +
     **Description:** True to use native (JNA/JNR) implementation to set file permissions instead of NIO
+
+`hudson.WebAppMain.forceSessionTrackingByCookie`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`hudson.widgets.HistoryWidget.threshold`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.CLI.disabled`::
     **Default:** `false` +
@@ -561,10 +783,25 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 2.102 +
     **Description:** When using the `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle`, exit using this exit code when Jenkins is restarted
 
+`jenkins.model.Jenkins.initLogLevel`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.model.Jenkins.killAfterLoad`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.model.Jenkins.logStartupPerformance`::
     **Default:** `false` +
     **Since:** n/a +
     **Description:** Log startup timing info
+
+`jenkins.model.Jenkins.parallelLoad`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.model.Jenkins.slaveAgentPort`::
     **Default:** -1 (disabled) +
@@ -576,6 +813,11 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 2.19.4 and 2.24 +
     **Description:** If true, enforces the specified `+jenkins.model.Jenkins.slaveAgentPort+` on startup and will not allow changing it through the UI
 
+`jenkins.model.Jenkins.workspaceDirName`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.model.Jenkins.workspacesDir`::
     **Default:** $\{JENKINS_HOME}/workspace/$\{ITEM_FULL_NAME} +
     **Since:** 2.119 +
@@ -585,6 +827,11 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Default:** `false` +
     **Since:** 2.197 / LTS 2.176.4 +
     **Description:** Disable URL validation intended to prevent an XSS vulnerability. See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
+
+`jenkins.model.lazy.BuildReference.MODE`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.model.StandardArtifactManager.disableTrafficCompression`::
     **Default:** `false` +
@@ -601,15 +848,95 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 1.638 +
     **Description:** True to show API tokens for users to administrators on the user configuration page. This was set to `false` as part of https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11#JenkinsSecurityAdvisory2015-11-11-APItokensofotherusersavailabletoadmins[SECURITY-200]
 
+`jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.security.FrameOptionsPageDecorator.enabled`::
     **Default:** `true` +
     **Since:** 1.581 +
     **Description:** Whether to send `+X-Frame-Options: sameorigin+` header, set to `false` to disable and make Jenkins embeddable
 
+`jenkins.security.ignoreBasicAuth`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.ManagePermission`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.ResourceDomainRootAction.validForMinutes`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.s2m.DefaultFilePathFilter.allow`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.seed.UserSeedProperty.disableUserSeed`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.security.stapler.StaplerDispatchValidator.disabled`::
     **Default:** `false` +
     **Since:** 2.186 / 2.176.2 +
     **Description:** `+true+`  to disable link:/security/advisory/2019-07-17/#SECURITY-534[the SECURITY-534 fix].
+
+`jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.stapler.TypedFilter.skipTypeCheck`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.SystemReadPermission`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
     **Default:** undefined +
@@ -621,10 +948,30 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Since:** 1.560 +
     **Description:** `true` to disable Nio for JNLP slaves
 
+`jenkins.slaves.StandardOutputSwapper.disabled`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`jenkins.telemetry.Telemetry.endpoint`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
 `jenkins.ui.refresh`::
     **Default:** `false` +
     **Since:** 2.222 +
     **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see https://www.jenkins.io/sigs/ux/[Jenkins UX SIG].
+
+`jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
+
+`JENKINS_HOME`::
+    **Default:** TODO +
+    **Since:** TODO +
+    **Description:** TODO
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
     **Default:** undefined +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -607,19 +607,22 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     This will allow static agents to start and handle the load first.
 
 `hudson.slaves.NodeProvisioner.MARGIN`::
-    **Default:** TODO +
+// TODO
+    **Default:** +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** +
 
 `hudson.slaves.NodeProvisioner.MARGIN0`::
-    **Default:** TODO +
+// TODO
+    **Default:** +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** +
 
 `hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
-    **Default:** TODO +
+// TODO
+    **Default:** +
     **Since:** n/a +
-    **Description:** TODO
+    **Description:** +
 
 `hudson.slaves.NodeProvisioner.recurrencePeriod`::
     **Default:** Equal to `hudson.model.LoadStatistics.clock`, typically 10 seconds +
@@ -1034,6 +1037,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Default:** `false` +
     **Since:** 2.28 +
     **Description:** +
+// TODO
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
     **Default:** undefined +

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1,30 +1,1271 @@
 ---
-layout: section
+layout: systemproperties
 references:
 - url: https://wiki.jenkins.io/display/JENKINS/Administering+Jenkins
   title: Administering Jenkins
 - url: http://jenkins.io/doc/book/installing/#configuring-http
   title: Configuring HTTP in Jenkins
+- url: https://github.com/jenkinsci/remoting/blob/master/docs/configuration.md
+  title: Remoting configuration
+properties:
+# Possible keys:
+# name: foo.bar.baz
+# def: Supports Asciidoc
+# since: 1.234
+# description: Supports Asciidoc
+
+- name: debug.YUI
+  def: '`false`'
+  # since: n/a
+  description: |
+    Whether to use the minified (`false`) or debug (`true`) JS files for the YUI library.
+
+- name: executable-war
+  # def: n/a
+  # since: n/a
+  description: |
+    This is the path to `jenkins.war` and set by the `executable-war` wrapper when invoked using `java -jar jenkins.war`.
+    This allows Jenkins to find its own `.war` file and e.g. replace it to apply an update.
+    If undefined, Jenkins will not e.g. offer to update itself.
+
+- name: hudson.bundled.plugins
+  def: undefined
+  # since: n/a
+  description: |
+    Specify a location for additional bundled plugins during plugin development (`hpi:run`).
+    There is no reason this would be set by an administrator.
+
+- name: hudson.ClassicPluginStrategy.noBytecodeTransformer
+  def: '`false`'
+  # since: n/a
+  description: |
+    Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
+#//
+#TODO: This may not actually be used anymore. We probably should document deprecated/obsolete system properties in a separate section.
+#- name: hudson.ClassicPluginStrategy.useAntClassLoader
+#  def: '`false`'
+#  since: 1.316
+#  #description: ''
+#//
+- name: hudson.cli.CLI.pingInterval
+  def: 3000
+  since: 2.199
+  description: |
+    Client-side HTTP CLI ping interval in milliseconds. Set on the CLI client (`+java -jar jenkins-cli.jar+`), not Jenkins server process.
+
+- name: hudson.ConsoleNote.INSECURE
+  def: '`false`'
+  since: 2.44 / 2.32.2
+  description: |
+    Whether to load unsigned console notes (see SECURITY-382 on link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-console-notes[Jenkins Security Advisory 2017-02-01])
+
+- name: hudson.consoleTailKB
+  def: 150
+  since: Actually works since 2.98/2.89.3
+  description: |
+    How many KB of console log to show in default console view
+
+- name: hudson.diagnosis.HudsonHomeDiskUsageChecker.freeSpaceThreshold
+  def: 1073741824 (1 GB, up to 2.39), 10737418240 (10 GB, from 2.40)
+  since: 1.339
+  description: |
+    If there's less than this amount of free disk space, in bytes, on the disk with the Jenkins home directory, and the disk is 90% or more full, a warning will be shown to administrators
+
+- name: hudson.diyChunking
+  def: '`false`'
+  # since: n/a
+  description: |
+    Set to `true` if the servlet container doesn't support chunked encoding
+
+- name: hudson.DNSMultiCast.disabled
+  def: '`false`'
+  since: 1.359
+  description: |
+    Set to `true` to disable DNS multicast
+
+- name: hudson.FilePath.VALIDATE_ANT_FILE_MASK_BOUND
+  def: 10000
+  since: 1.592
+  description: |
+    Max. number of operations to validate a file mask (e.g. pattern to archive artifacts).
+
+- name: hudson.footerURL
+  def: https://jenkins.io
+  since: 1.416
+  description: |
+    Allows tweaking the URL displayed at the bottom of Jenkins' UI
+
+- name: hudson.Functions.autoRefreshSeconds
+  def: 10
+  since: 1.365
+  description: |
+    Number of seconds between reloads when Auto Refresh is enabled, obsolete since the feature was removed in Jenkins 2.223.
+
+- name: hudson.Functions.hidingPasswordFields
+  def: '`true`'
+  since: 2.205
+  description: |
+    Jenkins 2.205 and newer attempts to prevent browsers from offering to auto-fill password form fields by using a custom password control.
+    Setting this to `false` reverts to the legacy behavior of using mostly standard password form fields.
+
+- name: hudson.lifecycle
+  # def: n/a
+  # since: n/a
+  description: |
+    Specify full class name for Lifecycle implementation to override default
+
+- name: hudson.logging.LogRecorderManager.skipPermissionCheck
+  def: '`false`'
+  since: 2.121.3 and 2.138
+  description: |
+    Disable security hardening for LogRecorderManager Stapler access.
+    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+- name: hudson.Main.development
+  def: see description
+  # since: n/a
+  description: |
+    Set to `true` by the development tooling to identify when Jenkins is running via `jetty:run` or `hpi:run`.
+    Can be used to distinguish between development and production use; most prominently used to bypass the setup wizard when running with an empty Jenkins home directory during development.
+
+- name: hudson.Main.timeout
+  def: 15000
+  # since: n/a
+  description: |
+    When using `jenkins-core.jar` from the CLI, this is the connection timeout connecting to Jenkins to report a build result.
+
+- name: hudson.matrix.MatrixConfiguration.useShortWorkspaceName
+  def: '`false`'
+  # since: n/a
+  description: |
+    Use shorter but cryptic names in matrix build workspace directories.
+    Avoids problems with 256 character limit on paths in Cygwin, path depths problems on Windows, and shell metacharacter problems with label expressions on most platforms.
+    See https://issues.jenkins-ci.org/browse/JENKINS-25783[JENKINS-25783].
+
+- name: hudson.model.AbstractItem.skipPermissionCheck
+  def: '`false`'
+  since: 2.121.3 / 2.138
+  description: |
+    Disable security hardening related to Stapler routing for AbstractItem.
+    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+- name: hudson.model.Api.INSECURE
+  def: '`false`'
+  since: 1.502
+  description: |
+    Set to `true` to permit accessing the Jenkins remote API in an unsafe manner.
+    See SECURITY-47.
+    Deprecated, use e.g. https://plugins.jenkins.io/secure-requester-whitelist/[Secure Requester Whitelist] instead.
+
+- name: hudson.model.AsyncAperiodicWork.logRotateMinutes
+  def: 1440
+  since: 1.651
+  description: |
+    The number of minutes after which to try and rotate the log file used by any AsyncAperiodicWork extension.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
+
+- name: hudson.model.AsyncAperiodicWork.logRotateSize
+  def: -1
+  since: 1.651
+  description: |
+    When starting a new run of any AsyncAperiodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
+
+- name: hudson.model.AsyncPeriodicWork.logRotateMinutes
+  def: 1440
+  since: 1.651
+  description: |
+    The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
+
+    Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
+
+    * `hudson.model.WorkspaceCleanupThread`
+    * `hudson.model.FingerprintCleanupThread`
+    * `hudson.slaves.ConnectionActivityMonitor`
+    * `jenkins.DailyCheck`
+    * `jenkins.model.BackgroundGlobalBuildDiscarder`
+    * `jenkins.telemetry.Telemetry$TelemetryReporter`
+
+- name: hudson.model.AsyncPeriodicWork.logRotateSize
+  def: -1
+  since: 1.651
+  description: |
+    When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
+    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
+    _It is not anticipated that you will ever need to change these defaults_
+
+    Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
+
+    * `hudson.model.WorkspaceCleanupThread`
+    * `hudson.model.FingerprintCleanupThread`
+    * `hudson.slaves.ConnectionActivityMonitor`
+    * `jenkins.DailyCheck`
+    * `jenkins.model.BackgroundGlobalBuildDiscarder`
+    * `jenkins.telemetry.Telemetry$TelemetryReporter`
+
+- name: hudson.model.DirectoryBrowserSupport.allowSymlinkEscape
+  def: '`false`'
+  since: 2.154 and 2.138.4
+  description: |
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
+
+- name: hudson.model.DirectoryBrowserSupport.CSP
+  def: |
+    `sandbox; default-src 'none'; image-src 'self'; style-src 'self';`
+  since: 1.625.3, 1.641
+  description: |
+    Determines the Content Security Policy header sent for static files served by Jenkins.
+    See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
+
+- name: hudson.model.DownloadService$Downloadable.defaultInterval
+  def: 86400000 (1 day)
+  # since: n/a
+  description: |
+    Interval between periodic downloads of _Downloadables_, typically tool installer metadata.
+
+- name: hudson.model.DownloadService.never
+  def: '`false`'
+  # since: n/a
+  description: |
+    Suppress the periodic download of data files for plugins via browser-based download. Since Jenkins 2.200, this has no effect.
+
+- name: hudson.model.DownloadService.noSignatureCheck
+  def: '`false`'
+  # since: n/a
+  description: |
+    Skip the update site signature check. Setting this to `true` can be unsafe.
+
+- name: hudson.model.Hudson.flyweightSupport
+  def: '`false` before 1.337; `true` from 1.337; unused since 1.598'
+  since: 1.318
+  description: |
+    Matrix parent job and other flyweight tasks (e.g. Build Flow plugin) won't consume an executor when `true`. Unused since 1.598, flyweight support is now always enabled.
+
+- name: hudson.model.Hudson.initLogLevel
+  # def: n/a
+  # since: n/a
+  description: |
+    Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.initLogLevel`.
+
+- name: hudson.model.Hudson.killAfterLoad
+  # def: n/a
+  # since: n/a
+  description: |
+    Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.killAfterLoad`.
+
+- name: hudson.model.Hudson.logStartupPerformance
+  # def: n/a
+  # since: n/a
+  description: |
+    Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.logStartupPerformance`.
+
+- name: hudson.model.Hudson.parallelLoad
+  # def: n/a
+  # since: n/a
+  description: |
+    Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.parallelLoad`.
+
+- name: hudson.model.Hudson.workspaceDirName
+  # def: n/a
+  # since: n/a
+  description: |
+    Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.workspaceDirName`.
+
+- name: hudson.model.LoadStatistics.clock
+  def: 10000 (10 seconds)
+  # since: n/a
+  description: |
+    Load statistics clock cycle in milliseconds
+
+- name: hudson.model.LoadStatistics.decay
+  def: 0.9
+  # since: n/a
+  description: |
+    Decay ratio for every clock cycle in node utilization charts
+
+- name: hudson.model.MultiStageTimeSeries.chartFont
+  def: SansSerif-10
+  since: 1.562
+  description: |
+    Font used for load statistics (see http://docs.oracle.com/javase/7/docs/api/java/awt/Font.html#decode%28java.lang.String%29[Java documentation] on how the value is decoded)
+
+- name: hudson.model.Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS
+  def: '`true`'
+  # since: n/a
+  description: |
+    Whether to allow building flyweight tasks even if the necessary permission (Computer/Build) is missing.
+    See https://issues.jenkins-ci.org/browse/JENKINS-46652[JENKINS-46652].
+
+- name: hudson.model.ParametersAction.keepUndefinedParameters
+  def: undefined
+  since: 1.651.2 / 2.3
+  description: |
+    If true, not discard parameters for builds that are not defined on the job. *Enabling this can be unsafe* Since Jenkins 2.40, if set to false, will not log a warning message that parameters were defined but ignored.
+
+- name: hudson.model.ParametersAction.safeParameters
+  def: undefined
+  since: 1.651.2 / 2.3
+  description: |
+    Comma-separated list of additional build parameter names that should not be discarded even when not defined on the job.
+
+- name: hudson.model.Queue.cacheRefreshPeriod
+  def: 1000
+  since: 1.577 up to 1.647
+  description: |
+    Defines the refresh period for the internal queue cache (in milliseconds). The greater period workarounds web UI delays on large installations, which may be caused by locking of the build queue by build executors. Downside - builds appear in the queue with a noticeable delay.
+
+- name: hudson.model.Queue.Saver.DELAY_SECONDS
+  def: 60
+  since: 2.109
+  description: |
+    Maximal delay of a save operation when content of Jenkins queue changes. This works as a balancing factor between queue consistency guarantee in case of Jenkins crash (short delay) and decreasing IO activity based on Jenkins load (long delay).
+
+- name: hudson.model.Run.ArtifactList.listCutoff
+  def: 16
+  since: 1.330
+  description: |
+    More artifacts than this will use tree view or simple link rather than listing out artifacts
+
+- name: hudson.model.Run.ArtifactList.treeCutoff
+  def: 40
+  since: 1.330
+  description: |
+    More artifacts than this will show a simple link to directory browser rather than showing artifacts in tree view
+
+- name: hudson.model.Slave.workspaceRoot
+  def: workspace
+  since: 1.341?
+  description: |
+    name of the folder within the slave root directory to contain workspaces
+
+- name: hudson.model.UpdateCenter.className
+  # def: n/a
+  since: 2.4
+  description: |
+    Allow overriding the implementation class for update center. Useful for custom war distributions with a different update center implementation. Cannot be used for plugins.
+
+- name: hudson.model.UpdateCenter.defaultUpdateSiteId
+  def: default
+  since: 2.4
+  description: |
+    Configure a different ID for the default update site. Useful for custom war distributions or externally provided UC data files
+
+- name: hudson.model.UpdateCenter.never
+  def: '`false`'
+  # since: n/a
+  description: |
+    When true, don't automatically check for new versions
+
+- name: hudson.model.UpdateCenter.pluginDownloadReadTimeoutSeconds
+  def: 60
+  # since: n/a
+  description: |
+    Read timeout in seconds for downloading plugins.
+
+- name: hudson.model.UpdateCenter.skipPermissionCheck
+  def: '`false`'
+  since: 2.121.3 / 2.138
+  description: |
+    Disable security hardening related to Stapler routing for UpdateCenter. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+- name: hudson.model.UpdateCenter.updateCenterUrl
+  def: '`https://updates.jenkins.io/`'
+  # since: n/a
+  description: |
+    Deprecated: Override the default update site URL.
+    May have no effect since Jenkins 1.333.
+
+- name: hudson.model.UsageStatistics.disabled
+  def: '`false`'
+  since: 1.312 or so?
+  description: |
+    Set to `true` to opt out of usage statistics collection, independent of UI option.
+
+- name: hudson.model.User.allowNonExistentUserToLogin
+  def: '`false`'
+  since: 1.602
+  description: |
+    When `true`, does not check auth realm for existence of user if there's a record in Jenkins. Unsafe, but may be used on some instances for service accounts
+
+- name: hudson.model.User.allowUserCreationViaUrl
+  def: '`false`'
+  since: 2.44 / 2.32.2
+  description: |
+    Whether admins accessing `+/user/example+` creates a user record (see SECURITY-406 on https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[Jenkins Security Advisory 2017-02-01])
+
+- name: hudson.model.User.SECURITY_243_FULL_DEFENSE
+  def: '`true`'
+  since: 1.651.2 / 2.3
+  description: |
+    When false, skips part of the fix that tries to determine whether a given user ID exists, and if so, doesn't consider users with the same full name during resolution.
+
+- name: hudson.model.User.skipPermissionCheck
+  def: '`false`'
+  since: 2.121.3 / 2.138
+  description: |
+    Disable security hardening related to Stapler routing for User. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+- name: hudson.model.WorkspaceCleanupThread.disabled
+  def: '`false`'
+  # since: n/a
+  description: |
+    Don't clean up old workspaces on slave nodes
+
+- name: hudson.model.WorkspaceCleanupThread.recurrencePeriodHours
+  def: 24
+  since: 1.608
+  description: |
+    How often workspace cleanup should run, in hours.
+
+- name: hudson.model.WorkspaceCleanupThread.retainForDays
+  def: 30
+  since: 1.608
+  description: |
+    Unused workspaces are retained for this many days before qualifying for deletion.
+
+- name: hudson.node_monitors.AbstractNodeMonitorDescriptor.periodMinutes
+  def: 60
+  # since: n/a
+  description: |
+    How frequently to update node monitors by default, in minutes.
+
+- name: hudson.os.solaris.ZFSInstaller.disabled
+  def: '`false`'
+  # since: n/a
+  description: |
+    True to disable ZFS monitor on Solaris
+
+- name: hudson.os.solaris.ZFSInstaller.migrate
+  def: undefined
+  # since: n/a
+  description: |
+    Set by Jenkins itself when restarting Jenkins for a migration to a ZFS volume and contains the migration target dataset name.
+    There is no reason this would be set by administrators manually.
+
+- name: hudson.PluginManager.checkUpdateAttempts
+  def: 1
+  since: 2.152
+  description: |
+    Number of attempts to check the updates sites.
+
+- name: hudson.PluginManager.checkUpdateSleepTimeMillis
+  def: 1000
+  since: 2.152
+  description: |
+    Time (milliseconds) elapsed between retries to check the updates sites.
+
+- name: hudson.PluginManager.className
+  def: undefined
+  # since: n/a
+  description: |
+    Can be used to specify a different `PluginManager` implementation when customizing the `.war` packaging of Jenkins.
+
+- name: hudson.PluginManager.noFastLookup
+  def: '`false`'
+  # since: n/a
+  description: |
+    Disable fast lookup using `ClassLoaderReflectionToolkit` which reflectively accesses internal methods of `ClassLoader`.
+
+- name: hudson.PluginManager.skipPermissionCheck
+  def: '`false`'
+  since: 2.121.3 / 2.138
+  description: |
+    Disable security hardening related to Stapler routing for PluginManager. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+- name: hudson.PluginManager.workDir
+  def: undefined
+  since: 1.649
+  description: |
+    Location of the base directory for all exploded .hpi/.jpi plugins. By default the plugins will be extracted under _$JENKINS_HOME/plugins/._
+
+- name: hudson.PluginStrategy
+  # def: n/a
+  # since: n/a
+  description: |
+    Allow plugins to be loaded into a different environment, such as an existing DI container like Plexus; specify full class name here to override default ClassicPluginStrategy
+
+- name: hudson.PluginWrapper.dependenciesVersionCheck.enabled
+  def: '`true`'
+  since: 2.0
+  description: |
+    Set to `+false+` to skip the version check for plugin dependencies.
+
+- name: hudson.ProxyConfiguration.DEFAULT_CONNECT_TIMEOUT_MILLIS
+  def: 20000
+  since: 2.0
+  description: |
+    Connection timeout applied to connections e.g. to the update site.
+
+- name: hudson.remoting.ClassFilter
+  def: undefined
+  # since: n/a
+  description: |
+    Allow or disallow the deserialization of specified types. Comma-separated class names, entries are whitelisted unless prefixed with `!`.
+    See https://github.com/jenkinsci/jep/tree/master/jep/200#backwards-compatibility[JEP-200] and https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736].
+
+- name: hudson.scheduledRetention
+  def: '`false`'
+  since: Up to 1.354
+  description: |
+    Control a slave based on a schedule
+
+- name: hudson.scm.SCM.useAutoBrowserHolder
+  def: '`false` since Jenkins 2.9, `true` before'
+  # since: n/a
+  description: |
+    When set to `true`, Jenkins will guess the repository browser used to render links in the changelog.
+
+- name: hudson.script.noCache
+  def: see description
+  # since: n/a
+  description: |
+    When set to true, Jenkins will not reference resource files through the `/static/.../` URL space, preventing their caching.
+    This is set to `true` during development by default, and `false` otherwise.
+
+- name: hudson.search.Search.skipPermissionCheck
+  def: '`false`'
+  since: 2.121.3 / 2.138
+  description: |
+    Disable security hardening related to Stapler routing for Search. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
+
+- name: hudson.security.AccessDeniedException2.REPORT_GROUP_HEADERS
+  def: '`false`'
+  since: 2.46 / 2.32.3
+  description: |
+    If set to true, restore pre-2.46 behavior of sending HTTP headers on "access denied" pages listing group memberships.
+
+- name: hudson.security.ArtifactsPermission
+  def: '`false`'
+  since: 1.374
+  description: |
+    The Artifacts permission allows to control access to artifacts; When this property is unset or set to false, access to artifacts is not controlled
+
+- name: hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO
+  def: '`false`'
+  since: 2.228 and 2.204.6
+  description: |
+    Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+
+- name: hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID
+  def: '`false`'
+  since: 2.186 and 2.176.2
+  description: |
+    Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
+
+- name: hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION
+  def: '`false`'
+  since: 2.222
+  description: |
+    Restore the ability to disable CSRF protection after the UI for doing so was removed from Jenkins 2.222.
+
+- name: hudson.security.csrf.requestfield
+  def: '`.crumb` (Jenkins 1.x), `Jenkins-Crumb` (Jenkins 2.0)'
+  since: 1.310
+  description: |
+    Parameter name that contains a crumb value on POST requests
+
+- name: hudson.security.ExtendedReadPermission
+  def: '`false`'
+  since: 1.324
+  description: |
+    The ExtendedReadPermission allows read-only access to "Configure" pages; can also enable with extended-read-permission plugin
+
+- name: hudson.security.HudsonPrivateSecurityRealm.ID_REGEX
+  def: '`+[a-zA-Z0-9_-]++`'
+  since: 2.121 and 2.107.3
+  description: |
+    Regex for legal user names in Jenkins user database. See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
+
+- name: hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound
+  def: 18
+  since: 2.161
+  description: |
+    Limits the number of rounds for pre-computed BCrypt hashes of user passwords for the Jenkins user database to prevent excessive computation.
+
+- name: hudson.security.LDAPSecurityRealm.groupSearch
+# TODO move out, it's LDAP plugin
+  # def: TODO recover default that was apparently lost after wiki
+  # since: n/a
+  description: |
+    LDAP filter to look for groups by their names
+
+- name: hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck
+  def: '`false`'
+  since: 2.160 and 2.150.2
+  description: |
+    Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
+
+- name: hudson.security.WipeOutPermission
+  def: '`false`'
+  since: 1.416
+  description: |
+    The WipeOut permission allows to control access to the "Wipe Out Workspace" action, which is normally available as soon as the Build permission is granted
+
+- name: hudson.slaves.ChannelPinger.pingInterval
+  def: 5
+  since: 1.405
+  description: |
+    *(Deprecated since 2.37)* Frequency (in minutes) of https://wiki.jenkins.io/display/JENKINS/Ping+Thread[pings between the master and slaves]
+
+- name: hudson.slaves.ChannelPinger.pingIntervalSeconds
+  def: 300
+  since: 2.37
+  description: |
+    Frequency of https://wiki.jenkins.io/display/JENKINS/Ping+Thread[pings between the master and slaves], in seconds
+
+- name: hudson.slaves.ChannelPinger.pingTimeoutSeconds
+  def: 240
+  since: 2.37
+  description: |
+    Timeout for each https://wiki.jenkins.io/display/JENKINS/Ping+Thread[ping between the master and slaves], in seconds
+
+- name: hudson.slaves.ConnectionActivityMonitor.enabled
+# This looks like a dead feature? Introduced 2011 and disabled by default?
+  def: '`false`'
+  since: 1.326
+  description: |
+    Whether to enable this feature that checks whether agents are alive and cuts them off if not.
+
+- name: hudson.slaves.ConnectionActivityMonitor.frequency
+# Actually dual use: Both for timeout (4 minutes) and time to ping (3 minutes). Possibly copy & paste issue and bug in core?
+  def: 10000 (10 seconds)
+  since: 1.326
+  description: |
+    How frequently to check for channel activity, in milliseconds.
+
+- name: hudson.slaves.ConnectionActivityMonitor.timeToPing
+  def: 180000 (3 minutes)
+  since: 1.326
+  description: |
+    How long to wait after startup to start checking agent connections, in milliseconds.
+
+- name: hudson.slaves.NodeProvisioner.initialDelay
+  def: '10 times `hudson.model.LoadStatistics.clock`, typically 100 seconds'
+  # since: n/a
+  description: |
+    How long to wait after startup before starting to provision nodes from clouds.
+    This will allow static agents to start and handle the load first.
+
+- name: hudson.slaves.NodeProvisioner.MARGIN
+# TODO
+  # since: n/a
+  #description: ''
+
+- name: hudson.slaves.NodeProvisioner.MARGIN0
+# TODO
+  # since: n/a
+  #description: ''
+
+- name: hudson.slaves.NodeProvisioner.MARGIN_DECAY
+# TODO
+  # since: n/a
+  #description: ''
+
+- name: hudson.slaves.NodeProvisioner.recurrencePeriod
+  def: 'Equal to `hudson.model.LoadStatistics.clock`, typically 10 seconds'
+  # since: n/a
+  description: |
+    How frequently to possibly provision nodes.
+
+- name: hudson.slaves.WorkspaceList
+  def: '`@`'
+  since: 1.424
+  description: |
+    When concurrent builds is enabled, a unique workspace directory name is required for each concurrent build. To create this name, this token is placed between project name and a unique ID, e.g. "my-project@123".
+
+- name: hudson.tasks.ArtifactArchiver.warnOnEmpty
+  def: '`false`'
+  # since: n/a
+  description: |
+    When true, builds don't fail when there is nothing to archive
+
+- name: hudson.tasks.Fingerprinter.enableFingerprintsInDependencyGraph
+  def: '`false`'
+  since: 1.430
+  description: |
+    When true, jobs associated through fingerprints are added to the dependency graph, even when there is no configured upstream/downstream relationship between them.
+
+- name: hudson.tasks.MailSender.maxLogLines
+# TODO is this mailer plugin now?
+  def: 250
+  # since: n/a
+  description: |
+    Number of lines of console output to include in emails
+
+- name: hudson.TcpSlaveAgentListener.hostName
+  # def: n/a
+  # since: n/a
+  description: |
+    Host name that Jenkins advertises to its clients. Especially useful when running Jenkins behind a reverse proxy.
+
+- name: hudson.TcpSlaveAgentListener.port
+  # def: n/a
+  # since: n/a
+  description: |
+    Port that Jenkins advertises to its clients. Especially useful when running Jenkins behind a reverse proxy.
+
+- name: hudson.TreeView
+  def: '`false`'
+  # since: n/a
+  description: |
+    Experimental nested views feature
+
+- name: hudson.triggers.SafeTimerTask.logsTargetDir
+  def: '`$JENKINS_HOME/logs`'
+  since: 2.114
+  description: |
+    Allows to move the logs usually found under `+$JENKINS_HOME/logs+` to another location. Beware that no migration is handled if you change it on an existing instance.
+
+- name: hudson.triggers.SCMTrigger.starvationThreshold
+  def: 1 hour
+  # since: n/a
+  description: |
+    Milliseconds waiting for polling executor before trigger reports it is clogged
+
+- name: hudson.udp
+  def: 33848
+  # since: n/a
+  description: |
+    Port for UDP multicast broadcast (set to -1 to disable)
+
+- name: hudson.upstreamCulprits
+  def: '`false`'
+  since: 1.327
+  description: |
+    Pass blame information to downstream jobs
+
+- name: hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH
+# The code is really confusing; there are two flags, one is always false, and will be forcibly set to false here, except using a new constructor that was deprecated in the same PR it was introduced in.
+  def: '`false`'
+  since: 2.102
+  description: |
+    Disables the forced flushing when calling `#close()`.
+    Not expected to be used.
+
+- name: hudson.util.CharacterEncodingFilter.disableFilter
+  def: '`false`'
+  # since: n/a
+  description: |
+    Set to `true` to disable the filter that sets request encoding to UTF-8 if it's undefined and its content type is `text/xml` or `application/xml` (API submissions).
+
+- name: hudson.util.CharacterEncodingFilter.forceEncoding
+  def: '`false`'
+  # since: n/a
+  description: |
+    Set to `true` to force the request encoding to UTF-8 even if a different character set is declared.
+
+- name: hudson.Util.deletionRetryWait
+  def: 100
+  since: 2.2
+  description: |
+    The time (in milliseconds) to wait between attempts to delete files when retrying. This has no effect unless _hudson.Util.maxFileDeletionRetries_ is greater than 1. If zero, there will be no delay between attempts. If negative, the delay will be a (linearly) increasing multiple of this value between attempts.
+
+- name: hudson.Util.maxFileDeletionRetries
+  def: 3
+  since: 2.2
+  description: |
+    The number of times to attempt to delete files/directory trees before giving up and throwing an exception. Specifying a value less than 1 is invalid and will be treated as if a value of 1 (i.e. one attempt, no retries) was specified. See https://issues.jenkins-ci.org/browse/JENKINS-10113[JENKINS-10113] and https://issues.jenkins-ci.org/browse/JENKINS-15331[JENKINS-15331].
+
+- name: hudson.Util.noSymLink
+  def: '`false`'
+  # since: n/a
+  description: |
+    True to disable creation of symbolic links in job/builds directories
+
+- name: hudson.Util.performGCOnFailedDelete
+  def: '`false`'
+  since: 2.2
+  description: |
+    If this flag is set to `true` then we will request a garbage collection after a deletion failure before we next retry the delete.
+    It is ignored unless _hudson.Util.maxFileDeletionRetries_ is greater than 1.
+    Setting this flag to `true` _may_ resolve some problems on Windows, and also for directory trees residing on an NFS share, but it can have a negative impact on performance and may have no effect at all (GC behavior is JVM-specific).
+    **Warning**: This should only ever be used if you find that your builds are failing because Jenkins is unable to delete files, that this failure is because Jenkins itself has those files locked "open", and even then it should only be used on slaves with relatively few executors (because the garbage collection can impact the performance of all job executors on that slave).
+    _Setting this flag is a act of last resort - it is not recommended, and should not be used on your main Jenkins server unless you can tolerate the performance impact_.
+
+- name: hudson.util.ProcessTree.disable
+  def: '`false`'
+  # since: n/a
+  description: |
+    True to disable cleanup of child processes
+
+- name: hudson.util.RingBufferLogHandler.defaultSize
+  def: 256
+  since: 1.563
+  description: |
+    Number of log entries in loggers available on the UI at `+/log/+`
+
+- name: hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL
+  def: '`true`'
+  since: 2.236
+  description: |
+    Jenkins automatically round-trips `f:password` based form fields as encrypted `Secret` even if the field is not of type `Secret`.
+    Set this to `false` to disable this behavior, doing so is discouraged.
+
+- name: hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE
+  def: '`true`'
+  since: 2.236
+  description: |
+    If the user is missing _Item/Configure_ permission, Jenkins 2.236 and newer will blank out the password value automatically even if the form field is not backed by a `Secret`.
+    Set this to `false` to disable this behavior, doing so is discouraged.
+
+- name: hudson.util.Secret.provider
+  # def: n/a
+  since: 1.360
+  description: |
+    Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround https://issues.jenkins-ci.org/browse/JENKINS-6459[JENKINS-6459].
+
+- name: hudson.util.StreamTaskListener.AUTO_FLUSH
+# https://github.com/jenkinsci/jenkins/pull/3961
+  def: '`false`'
+  since: 2.173
+  description: |
+    Jenkins no longer automatically flushes streams for code running remotely on agents for better performance.
+    This may lead to loss of messages for plugins which print to a build log from the agent machine but do not flush their output.
+    Use this flag to restore the previous behavior for freestyle builds.
+
+- name: hudson.Util.symlinkEscapeHatch
+  def: '`false`'
+  # since: n/a
+  description: |
+    True to use exec of "ln" binary to create symbolic links instead of native code
+
+- name: hudson.Util.useNativeChmodAndMode
+  def: '`false`'
+  since: 2.93
+  description: |
+    True to use native (JNA/JNR) implementation to set file permissions instead of NIO
+
+- name: hudson.WebAppMain.forceSessionTrackingByCookie
+  def: '`true`'
+  since: 2.234
+  description: |
+    Set to `false` to not force session tracking to be done via cookie.
+    Escape hatch for https://issues.jenkins-ci.org/browse/JENKINS-61738[JENKINS-61738].
+
+- name: hudson.widgets.HistoryWidget.threshold
+  def: 30
+  since: 1.433
+  description: |
+    How many builds to show in the build history side panel widget.
+
+- name: HUDSON_HOME
+  # def: n/a
+  # since: n/a
+  description: |
+    Backward compatible fallback name for `JENKINS_HOME`.
+    See documentation there.
+
+- name: jenkins.CLI.disabled
+  def: '`false`'
+  since: 2.32 and 2.19.3
+  description: |
+    `+true+` to disable Jenkins CLI via JNLP and HTTP (SSHD can still be enabled)
+
+- name: jenkins.InitReactorRunner.concurrency
+  def: 2x of CPU
+  # since: n/a
+  description: |
+    During start of Jenkins, loading of jobs in parallel have a fixed number of threads by default (twice the CPU). To make Jenkins load time 8x faster, increase it to 8x. For example, 24 CPU Jenkins Master host use this: -Dhudson.InitReactorRunner.concurrency=192
+
+- name: jenkins.install.runSetupWizard
+  def: undefined
+  since: 2.0
+  description: |
+    Set to `+false+` to skip install wizard. Note that this leaves Jenkins unsecured by default. Development-mode only: Set to `+true+` to not skip showing the setup wizard during Jenkins development. This property is only effective the first time you run Jenkins in given JENKINS_HOME.
+
+- name: jenkins.model.Jenkins.buildsDir
+  def: '`$\{ITEM_ROOTDIR}/builds`'
+  since: 2.119
+  description: |
+    The configuration of a given job is located under `+$JENKINS_HOME/jobs/[JOB_NAME]/config.xml+` and its builds are under `+$JENKINS_HOME/jobs/[JOB_NAME]/builds+` by default.
+    This option allows you to store builds elsewhere, which can be useful with finer-grained backup policies, or to store the build data on a faster disk such as an SSD.
+    The following placeholders are supported for this value:
+
+    * *$\{JENKINS_HOME}*  – Resolves to the Jenkins home directory.
+    * *$\{ITEM_ROOTDIR}* – The directory containing the job metadata within Jenkins home.
+    * *$\{ITEM_FULL_NAME}* – The full name of the item, with file system unsafe characters replaced by others.
+    * *$\{ITEM_FULLNAME}* – See above, but does not replace unsafe characters. This is a legacy option and should not be used.
+
+    For instance, if you would like to store builds outside of Jenkins home, you can use a value like the following: `+/some_other_root/builds/${ITEM_FULL_NAME}+` This used to be a UI setting, but was removed in 2.119 as it did not support migration of existing build records and could lead to build-related errors until restart.
+
+    To manually migrate existing build records when starting to use this option (`TARGET_DIR` is the value supplied to `jenkins.model.Jenkins.buildsDir`):
+
+    For link:/doc/book/pipeline/[Pipeline] and Freestyle job types, run this for each `JOB_NAME`:
+
+    ```sh
+    mkdir -p [TARGET_DIR]
+    mv $JENKINS_HOME/jobs/[JOB_NAME]/builds [TARGET_DIR]/[JOB_NAME]
+    ```
+
+    For link:/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibranch Pipeline] jobs, run for each `BRANCH_NAME`:
+
+    ```sh
+    mkdir -p [TARGET_DIR]/[JOB_NAME]/branches/
+    mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds \
+        [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
+    ```
+
+    For link:/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
+
+    ```sh
+    mkdir -p [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/
+    mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds \
+        [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]
+    ```
+
+- name: jenkins.model.Jenkins.crumbIssuerProxyCompatibility
+  def: '`false`'
+  since: 2.119
+  description: |
+    `+true+` to enable crumb proxy compatibility when running the Setup Wizard for the first time.
+
+- name: jenkins.model.Jenkins.disableExceptionOnNullInstance
+  def: '`false`'
+  since: 2.4 *only*
+  description: |
+    `+true+` to disable throwing an `+IllegalStateException+` when `+Jenkins.getInstance()+` returns `+null+`
+
+- name: jenkins.model.Jenkins.enableExceptionOnNullInstance
+  def: '`false`'
+  since: 2.5
+  description: |
+    `+true+` to enable throwing an `+IllegalStateException+` when `+Jenkins.getInstance()+` returns `+null+`
+
+- name: jenkins.model.Jenkins.exitCodeOnRestart
+  def: 5
+  since: 2.102
+  description: |
+    When using the `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle`, exit using this exit code when Jenkins is restarted
+
+- name: jenkins.model.Jenkins.initLogLevel
+  def: '`FINE`'
+  # since: n/a
+  description: |
+    Log level for verbose messages from the init reactor listener.
+
+- name: jenkins.model.Jenkins.killAfterLoad
+  def: '`false`'
+  # since: n/a
+  description: |
+    Exit Jenkins right after loading.
+    Intended as a development/testing aid only.
+
+- name: jenkins.model.Jenkins.logStartupPerformance
+  def: '`false`'
+  # since: n/a
+  description: |
+    Log startup timing info.
+    Note that some messages are not logged on levels visible by default (i.e. INFO and up).
+
+- name: jenkins.model.Jenkins.parallelLoad
+  def: '`true`'
+  # since: n/a
+  description: |
+    Loads job configurations in parallel on startup.
+
+- name: jenkins.model.Jenkins.slaveAgentPort
+  def: -1 (disabled)
+  since: 1.643
+  description: |
+    Specifies the default TCP slave agent port unless/until configured differently on the UI. `-1` to disable, `0` for random port, other values for fixed port. Used to be 0 by default before Jenkins 2.0
+
+- name: jenkins.model.Jenkins.slaveAgentPortEnforce
+  def: '`false`'
+  since: 2.19.4 and 2.24
+  description: |
+    If true, enforces the specified `+jenkins.model.Jenkins.slaveAgentPort+` on startup and will not allow changing it through the UI
+
+- name: jenkins.model.Jenkins.workspaceDirName
+  def: '`workspace`'
+  # since: n/a
+  description: |
+    Obsolete: Was used as the default workspace directory name in the legacy workspace directory layout (workspace directories within job directories).
+
+- name: jenkins.model.Jenkins.workspacesDir
+  def: '$\{JENKINS_HOME}/workspace/$\{ITEM_FULL_NAME}'
+  since: 2.119
+  description: |
+    Allows to change the directory layout for the job workspaces on the master node. See `+jenkins.model.Jenkins.buildsDir+` for supported placeholders.
+
+- name: jenkins.model.JenkinsLocationConfiguration.disableUrlValidation
+  def: '`false`'
+  since: 2.197 / LTS 2.176.4
+  description: |
+    Disable URL validation intended to prevent an XSS vulnerability. See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
+
+- name: jenkins.model.lazy.BuildReference.MODE
+  def: '`soft`'
+  since: 1.548
+  description: |
+    Configure the kind of reference Jenkins uses to hold builds in memory.
+    Choose from among `soft`, `weak`, `strong`, and `not` (do not hold builds in memory at all).
+    Intended mostly as a debugging aid.
+    See https://issues.jenkins-ci.org/browse/JENKINS-19400[JENKINS-19400].
+
+- name: jenkins.model.StandardArtifactManager.disableTrafficCompression
+  def: '`false`'
+  since: 2.196
+  description: |
+    `+true+` to disable GZIP compression of artifacts when they're transferred from slave nodes to master.  Uses less CPU at the cost of increased network traffic.
+
+- name: jenkins.security.ApiTokenProperty.adminCanGenerateNewTokens 
+  def: '`false`'
+  since: 2.129
+  description: |
+    `+true+` to allow users with `+ADMINISTER+` permission to create API tokens using the new system for any user. Note that the user will not be able to use that token since it's only displayed to the creator, once.
+
+- name: jenkins.security.ApiTokenProperty.showTokenToAdmins
+  def: '`false`'
+  since: 1.638
+  description: |
+    True to show API tokens for users to administrators on the user configuration page. This was set to `false` as part of https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11#JenkinsSecurityAdvisory2015-11-11-APItokensofotherusersavailabletoadmins[SECURITY-200]
+
+- name: jenkins.security.ClassFilterImpl.SUPPRESS_ALL
+  def: '`false`'
+  since: 2.102
+  description: |
+    Do not perform any JEP-200 class filtering when deserializing data.
+    Setting this to `true` is unsafe.
+    See https://jenkins.io/redirect/class-filter/[documentation].
+
+- name: jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST
+  def: '`false`'
+  since: 2.102
+  description: |
+    Do not perform whitelist-based JEP-200 class filtering when deserializing data.
+    With this flag set, only explicitly blacklisted types will be rejected.
+    Setting this to `true` is unsafe.
+    See https://jenkins.io/redirect/class-filter/[documentation].
+
+- name: jenkins.security.FrameOptionsPageDecorator.enabled
+  def: '`true`'
+  since: 1.581
+  description: |
+    Whether to send `X-Frame-Options: sameorigin` header, set to `false` to disable and make Jenkins embeddable
+
+- name: jenkins.security.ignoreBasicAuth
+  def: '`false`'
+  since: 1.421
+  description: |
+    When set to `true`, disable `Basic` authentication with username and password (rather than API token).
+
+- name: jenkins.security.ManagePermission
+  def: '`false`'
+  since: 2.222
+  description: |
+    Enable the optional Overall/Manage permission that allows limited access to administrative features suitable for a hosted Jenkins environment.
+    See https://github.com/jenkinsci/jep/tree/master/jep/223[JEP-223].
+
+- name: jenkins.security.ResourceDomainRootAction.validForMinutes
+  def: 30
+  since: 2.200
+  description: |
+    How long a resource URL served from the resource root URL will be valid for before users are required to reauthenticate to access it.
+    See inline documentation in Jenkins for details.
+
+
+- name: jenkins.security.s2m.DefaultFilePathFilter.allow
+  def: '`false`'
+  since: 1.587 and 1.580.1
+  description: |
+    Allow all file paths on the Jenkins master to be accessed from agents.
+    This disables a big part of link:/security/advisory/2014-10-30/[SECURITY-144] protections.
+
+- name: jenkins.security.seed.UserSeedProperty.disableUserSeed
+  def: '`false`'
+  since: 2.160 and 2.105.2
+  description: |
+    Disables _user seed_.
+    Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
+
+- name: jenkins.security.seed.UserSeedProperty.hideUserSeedSection
+  def: '`false`'
+  since: 2.160 and 2.105.2
+  description: |
+    Hide the UI for _user seed_ introduced for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
+
+- name: jenkins.security.stapler.StaplerDispatchValidator.disabled
+  def: '`false`'
+  since: 2.186 and 2.176.2
+  description: |
+    Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534].
+
+- name: jenkins.security.stapler.StaplerDispatchValidator.whitelist
+  def: '`stapler-views-whitelist.txt` in `JENKINS_HOME`'
+  since: 2.186 and 2.176.2
+  description: |
+    Override the location of the user configurable whitelist for stapler view dispatches.
+    This augments the built-in whitelist for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534] that allows dispatches to views that would otherwise be prohibited.
+
+- name: jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist
+  def: '`stapler-whitelist.txt` in `JENKINS_HOME`'
+  since: 2.154 and 2.138.4
+  description: |
+    Override the location of the user configurable whitelist for stapler request routing.
+    This augments the built-in whitelist for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595] that allows routing requests through methods that would otherwise be prohibited.
+
+- name: jenkins.security.stapler.TypedFilter.prohibitStaticAccess
+  def: '`true`'
+  since: 2.154 and 2.138.4
+  description: |
+    Prohibits access to `public static` fields when routing requests in Stapler.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
+
+- name: jenkins.security.stapler.TypedFilter.skipTypeCheck
+  def: '`false`'
+  since: 2.154 and 2.138.4
+  description: |
+    Skip (return) type check when determining whether a method or field should be routable with Stapler (i.e. allow any return type).
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
+
+- name: jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath
+  def: '`false`'
+  since: 2.228 and 2.204.6
+  description: |
+    Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    Allows requests to URLs with semicolon characters (`;`) in the request path.
+
+- name: jenkins.security.SystemReadPermission
+  def: '`false`'
+  since: 2.222
+  description: |
+    Enable the optional Overall/SystemRead permission that allows read-only access to administrative features suitable for a managed Jenkins Configuration as Code environment.
+    See https://github.com/jenkinsci/jep/tree/master/jep/224[JEP-224].
+
+- name: jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC
+  def: 120 (2 minutes)
+  since: 2.15
+  description: |
+    How long a cache for `UserDetails` should be valid for before it is looked up again from the security realm.
+    See https://issues.jenkins-ci.org/browse/JENKINS-35493[JENKINS-35493].
+
+- name: jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification
+  def: '`false`'
+  since: 2.28
+  #description: ''
+# TODO
+
+- name: jenkins.slaves.JnlpSlaveAgentProtocol3.enabled
+  def: undefined
+  since: 1.653
+  description: |
+    `+false+` to disable the JNLP3 agent protocol, `+true+` to enable it. Otherwise it's randomly enabled/disabled to A/B test it.
+
+- name: jenkins.slaves.NioChannelSelector.disabled
+  def: '`false`'
+  since: 1.560
+  description: |
+    `true` to disable Nio for JNLP slaves
+
+- name: jenkins.slaves.StandardOutputSwapper.disabled
+# TODO Unsure how this works. References:
+# - https://github.com/jenkinsci/jenkins/blob/3fd66ff22051a3309b8dc5130d8da0759ee27f48/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
+# - https://github.com/jenkinsci/remoting/commit/fad8c38724068dfbd155e64508e5d4c154240b87
+  def: '`false`'
+  since: 1.429
+  description: |
+    Some Unix-like agents (e.g. SSH Build Agents) can communicate via stdin/stdout, which is very convenient.
+    Unfortunately, some JVM output (e.g. related to GC) also goes to standard out.
+    This will swap output streams around to prevent stream corruption through unexpected writes to standard out.
+
+- name: jenkins.telemetry.Telemetry.endpoint
+# https://github.com/jenkinsci/jenkins/pull/3604
+  def: '`+https://uplink.jenkins.io/events+`'
+  since: 2.143
+  description: |
+    Change the endpoint that JEP-214/Uplink telemetry sends data to. Expected to be used for testing only.
+
+- name: jenkins.ui.refresh
+  def: '`false`'
+  since: 2.222
+  description: |
+    `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see link:/sigs/ux/[Jenkins UX SIG].
+
+- name: jenkins.util.ProgressiveRendering.DEBUG_SLEEP
+  def: 0
+  # since: n/a
+  description: |
+    Debug/development option to slow down the cancelling of progressive rendering when the client fails to send a heartbeat.
+
+- name: JENKINS_HOME
+  def: '`~/.jenkins`'
+  # since: n/a
+  description: |
+    While typically set as an environment variable, Jenkins also looks up the path to its home directory as a system property.
+    `JENKINS_HOME` set via JNDI context has higher priority than this, but this takes precedence over the environment variable.
+
+- name: org.jenkinsci.main.modules.sshd.SSHD.idle-timeout
+# This is a core module, so this documentation should remain here.
+  def: undefined
+  since: 2.22
+  description: |
+    Allows to configure the SSHD client idle timeout (value in milliseconds). Default value is 10min (600000ms).
+
+- name: org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT
+# TODO move to plugin documentation
+  def: 20 seconds
+  since: workflow-durable-task-step-plugin 2.29
+  description: |
+    How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
+
+- name: stapler.jelly.noCache
+  def: '`false`'
+  # since: n/a
+  description: |
+    Controls both caching of various cachable resources (Jelly scripts etc.) as well as the `Expires` HTTP response header for some static resources.
+    Useful during development to see the effect of changes after reload.
+
+- name: stapler.legacyGetterDispatcherMode
+  def: '`false`'
+  # since: n/a
+  description: |
+    Do not filter get methods at the Stapler framework level.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
+
+- name: stapler.legacyWebMethodDispatcherMode
+  def: '`false`'
+  # since: n/a
+  description: |
+    Do not filter web methods ("do" actions) at the Stapler framework level.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
+
+- name: stapler.resourcePath
+  def: undefined
+  # since: n/a
+  description: |
+    Additional debug resource paths.
+    Set by the core development tooling so developers can see the effect of changes immediately after reloading the page.
+
+- name: stapler.trace
+  def: '`false`'
+  # since: n/a
+  description: |
+    Trace request handling and report the result using `Stapler-Trace-...` response headers.
+    Additionally renders a diagnostic HTTP 404 error page when the request could not be processed.
+
+- name: stapler.trace.per-request
+  def: '`false`'
+  # since: n/a
+  description: |
+    Trace request handling (see above) for requests with the `X-Stapler-Trace` request header set.
+
 ---
 
 = Jenkins Features Controlled with System Properties
 
-++++
-<script>
-$(function () {
-    anchors.add('dt');
-})
-</script>
-++++
-
 Jenkins has several "hidden" features that can be enabled with system properties.
 This page documents many of them and explain how to configure them on your instance.
+
+Some system properties related to the Remoting library used for communication between master and agents are documented in https://github.com/jenkinsci/remoting/blob/master/docs/configuration.md[that component's repository].
 
 == Usage
 
 System properties are defined by passing `+-Dproperty=value+` to the `+java+` command line to start Jenkins.
-Make sure to pass all of these arguments *before* the `+-jar+` argument,
-otherwise they will be ignored.
+Make sure to pass all of these arguments *before* the `+-jar+` argument, otherwise they will be ignored.
 Example:
 
 ```sh
@@ -38,11 +1279,11 @@ The following lists the properties and the version of Jenkins they were introduc
 * *Since* - The version of Jenkins the property was introduced in
 * *Description* - Other notes
 
-=== Compatibility notice
+=== Compatibility
 
-We do **NOT** guarantee compatibility for system properties.
+We do **NOT** guarantee that system properties will remain unchanged and functional indefinitely.
 These switches are often experimental in nature, and subject to change without notice.
-If you find some of those useful, please file a ticket to promote it to the official feature.
+If you find these useful, please file a ticket to promote it to an official feature.
 
 
 == Properties in Jenkins Core
@@ -55,1086 +1296,17 @@ Due to the very large number of system properties used, often just added as a "s
 dd {
   margin-left: 30px;
 }
+/* Work around wrapper block elements added for Asciidoctor conversions that would break the layout */
+.def div {
+    display: inline-block;
+}
+.def div p {
+    margin: 0;
+}
 </style>
+<script>
+document.addEventListener('DOMContentLoaded', function(event) {
+    anchors.add('dt');
+});
+</script>
 ++++
-
-////
-STYLE GUIDE
-
-Sort order:
-These properties are ordered alphabetically, case-insensitively.
-End of string sorts before alphanumeric sorts before period (.), sorts before underscore (_).
-Example: foo -> foobar -> foo.bar -> foo_bar
-
-////
-
-`debug.YUI`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Whether to use the minified (`false`) or debug (`true`) JS files for the YUI library.
-
-`executable-war`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** This is the path to `jenkins.war` and set by the `executable-war` wrapper when invoked using `java -jar jenkins.war`.
-    This allows Jenkins to find its own `.war` file and e.g. replace it to apply an update.
-    If undefined, Jenkins will not e.g. offer to update itself.
-
-`hudson.bundled.plugins`::
-    **Default:** undefined +
-    **Since:** n/a +
-    **Description:** Specify a location for additional bundled plugins during plugin development (`hpi:run`).
-    There is no reason this would be set by an administrator.
-
-`hudson.ClassicPluginStrategy.noBytecodeTransformer`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
-////
-TODO: This may not actually be used anymore. We probably should document deprecated/obsolete system properties in a separate section.
-`hudson.ClassicPluginStrategy.useAntClassLoader`::
-    **Default:** `false` +
-    **Since:** 1.316 +
-    **Description:** +
-////
-`hudson.cli.CLI.pingInterval`::
-    **Default:** 3000 +
-    **Since:** 2.199 +
-    **Description:** Client-side HTTP CLI ping interval in milliseconds. Set on the CLI client (`+java -jar jenkins-cli.jar+`), not Jenkins server process.
-
-`hudson.ConsoleNote.INSECURE`::
-    **Default:** `false` +
-    **Since:** 2.44 / 2.32.2 +
-    **Description:** Whether to load unsigned console notes (see SECURITY-382 on link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-console-notes[Jenkins Security Advisory 2017-02-01])
-
-`hudson.consoleTailKB`::
-    **Default:** 150 +
-    **Since:** Actually works since 2.98/2.89.3 +
-    **Description:** How many KB of console log to show in default console view
-
-`hudson.diagnosis.HudsonHomeDiskUsageChecker.freeSpaceThreshold`::
-    **Default**: 1073741824 (1 GB, up to 2.39), 10737418240 (10 GB, from 2.40) +
-    **Since:** 1.339 +
-    **Description:** If there's less than this amount of free disk space, in bytes, on the disk with the Jenkins home directory, and the disk is 90% or more full, a warning will be shown to administrators
-
-`hudson.diyChunking`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Set to `true` if the servlet container doesn't support chunked encoding
-
-`hudson.DNSMultiCast.disabled`::
-    **Default:** `false` +
-    **Since:** 1.359 +
-    **Description:** Set to `true` to disable DNS multicast
-
-`hudson.FilePath.VALIDATE_ANT_FILE_MASK_BOUND`::
-    **Default:** 10000 +
-    **Since:** 1.592 +
-    **Description:** Max. number of operations to validate a file mask (e.g. pattern to archive artifacts).
-
-`hudson.footerURL`::
-    **Default:** https://jenkins.io +
-    **Since:** 1.416 +
-    **Description:** Allows tweaking the URL displayed at the bottom of Jenkins' UI
-
-`hudson.Functions.autoRefreshSeconds`::
-    **Default:** 10 +
-    **Since:** 1.365 +
-    **Description:** Number of seconds between reloads when Auto Refresh is enabled, obsolete since the feature was removed in Jenkins 2.223.
-
-`hudson.Functions.hidingPasswordFields`::
-    **Default**: `true` +
-    **Since:** 2.205 +
-    **Description:** Jenkins 2.205 and newer attempts to prevent browsers from offering to auto-fill password form fields by using a custom password control.
-    Setting this to `false` reverts to the legacy behavior of using mostly standard password form fields.
-
-`hudson.lifecycle`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Specify full class name for Lifecycle implementation to override default
-
-`hudson.logging.LogRecorderManager.skipPermissionCheck`::
-    **Default:** `false` +
-    **Since:** 2.121.3 and 2.138 +
-    **Description:** Disable security hardening for LogRecorderManager Stapler access.
-    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
-
-`hudson.Main.development`::
-    **Default**: see description +
-    **Since:** n/a +
-    **Description:** Set to `true` by the development tooling to identify when Jenkins is running via `jetty:run` or `hpi:run`.
-    Can be used to distinguish between development and production use; most prominently used to bypass the setup wizard when running with an empty Jenkins home directory during development.
-
-`hudson.Main.timeout`::
-    **Default**: 15000 +
-    **Since:** n/a +
-    **Description:** When using `jenkins-core.jar` from the CLI, this is the connection timeout connecting to Jenkins to report a build result.
-
-`hudson.matrix.MatrixConfiguration.useShortWorkspaceName`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Use shorter but cryptic names in matrix build workspace directories.
-    Avoids problems with 256 character limit on paths in Cygwin, path depths problems on Windows, and shell metacharacter problems with label expressions on most platforms.
-    See https://issues.jenkins-ci.org/browse/JENKINS-25783[JENKINS-25783].
-
-`hudson.model.AbstractItem.skipPermissionCheck`::
-    **Default:** `false` +
-    **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for AbstractItem.
-    Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
-
-`hudson.model.Api.INSECURE`::
-    **Default**: `false` +
-    **Since:** 1.502 +
-    **Description:** Set to `true` to permit accessing the Jenkins remote API in an unsafe manner.
-    See SECURITY-47.
-    Deprecated, use e.g. https://plugins.jenkins.io/secure-requester-whitelist/[Secure Requester Whitelist] instead.
-
-`hudson.model.AsyncAperiodicWork.logRotateMinutes`::
-    **Default:** 1440 +
-    **Since:** 1.651 +
-    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncAperiodicWork extension.
-    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
-    _It is not anticipated that you will ever need to change these defaults_
-
-`hudson.model.AsyncAperiodicWork.logRotateSize`::
-    **Default:** -1 +
-    **Since:** 1.651 +
-    **Description:** When starting a new run of any AsyncAperiodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
-    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
-    _It is not anticipated that you will ever need to change these defaults_
-
-`hudson.model.AsyncPeriodicWork.logRotateMinutes`::
-    **Default:** 1440 +
-    **Since:** 1.651 +
-    **Description:** The number of minutes after which to try and rotate the log file used by any AsyncPeriodicWork extension.
-    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateMinutes system property to only affect a specific extension.
-    _It is not anticipated that you will ever need to change these defaults_
-+
-Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
-+
-* `hudson.model.WorkspaceCleanupThread`
-* `hudson.model.FingerprintCleanupThread`
-* `hudson.slaves.ConnectionActivityMonitor`
-* `jenkins.DailyCheck`
-* `jenkins.model.BackgroundGlobalBuildDiscarder`
-* `jenkins.telemetry.Telemetry$TelemetryReporter`
-
-`hudson.model.AsyncPeriodicWork.logRotateSize`::
-    **Default:** -1 +
-    **Since:** 1.651 +
-    **Description:** When starting a new run of any AsyncPeriodicWork extension, if this value is non-negative and the existing log file is larger than the specified number of bytes then the log file will be rotated.
-    For fine-grained control of a specific extension you can use the _FullyQualifiedClassName_.logRotateSize system property to only affect a specific extension.
-    _It is not anticipated that you will ever need to change these defaults_
-+
-Some implementations that can be individually configured (see _FullyQualifiedClassName_ above):
-+
-* `hudson.model.WorkspaceCleanupThread`
-* `hudson.model.FingerprintCleanupThread`
-* `hudson.slaves.ConnectionActivityMonitor`
-* `jenkins.DailyCheck`
-* `jenkins.model.BackgroundGlobalBuildDiscarder`
-* `jenkins.telemetry.Telemetry$TelemetryReporter`
-
-`hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
-    **Default**: `false` +
-    **Since:** 2.154 and 2.138.4 +
-    **Description:** Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
-
-`hudson.model.DirectoryBrowserSupport.CSP`::
-    **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
-    **Since:** 1.625.3, 1.641 +
-    **Description:** Determines the Content Security Policy header sent for static files served by Jenkins.
-    See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy[Configuring Content Security Policy] for more details.
-
-`hudson.model.DownloadService$Downloadable.defaultInterval`::
-    **Default**: 86400000 (1 day)
-    **Since:** n/a +
-    **Description:** Interval between periodic downloads of _Downloadables_, typically tool installer metadata.
-
-`hudson.model.DownloadService.never`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Suppress the periodic download of data files for plugins via browser-based download. Since Jenkins 2.200, this has no effect.
-
-`hudson.model.DownloadService.noSignatureCheck`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Skip the update site signature check. Setting this to `true` can be unsafe.
-
-`hudson.model.Hudson.flyweightSupport`::
-    **Default:** `false` before 1.337; `true` from 1.337; unused since 1.598 +
-    **Since:** 1.318 +
-    **Description:** Matrix parent job and other flyweight tasks (e.g. Build Flow plugin) won't consume an executor when `true`. Unused since 1.598, flyweight support is now always enabled.
-
-`hudson.model.Hudson.initLogLevel`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.initLogLevel`.
-
-`hudson.model.Hudson.killAfterLoad`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.killAfterLoad`.
-
-`hudson.model.Hudson.logStartupPerformance`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.logStartupPerformance`.
-
-`hudson.model.Hudson.parallelLoad`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.parallelLoad`.
-
-`hudson.model.Hudson.workspaceDirName`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Deprecated: Backward-compatible fallback for `jenkins.model.Jenkins.workspaceDirName`.
-
-`hudson.model.LoadStatistics.clock`::
-    **Default:** 10000 (10 seconds) +
-    **Since:** n/a +
-    **Description:** Load statistics clock cycle in milliseconds
-
-`hudson.model.LoadStatistics.decay`::
-    **Default:** 0.9 +
-    **Since:** n/a +
-    **Description:** Decay ratio for every clock cycle in node utilization charts
-
-`hudson.model.MultiStageTimeSeries.chartFont`::
-    **Default:** SansSerif-10 +
-    **Since:** 1.562 +
-    **Description:** Font used for load statistics (see http://docs.oracle.com/javase/7/docs/api/java/awt/Font.html#decode%28java.lang.String%29[Java documentation] on how the value is decoded)
-
-`hudson.model.Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS`::
-    **Default:** `true` +
-    **Since:** n/a +
-    **Description:** Whether to allow building flyweight tasks even if the necessary permission (Computer/Build) is missing.
-    See https://issues.jenkins-ci.org/browse/JENKINS-46652[JENKINS-46652].
-
-`hudson.model.ParametersAction.keepUndefinedParameters`::
-    **Default:** undefined +
-    **Since:** 1.651.2 / 2.3 +
-    **Description:** If true, not discard parameters for builds that are not defined on the job. *Enabling this can be unsafe* Since Jenkins 2.40, if set to false, will not log a warning message that parameters were defined but ignored.
-
-`hudson.model.ParametersAction.safeParameters`::
-    **Default:** undefined +
-    **Since:** 1.651.2 / 2.3 +
-    **Description:** Comma-separated list of additional build parameter names that should not be discarded even when not defined on the job.
-
-`hudson.model.Queue.cacheRefreshPeriod`::
-    **Default:** 1000 +
-    **Since:** 1.577 up to 1.647 +
-    **Description:** Defines the refresh period for the internal queue cache (in milliseconds). The greater period workarounds web UI delays on large installations, which may be caused by locking of the build queue by build executors. Downside - builds appear in the queue with a noticeable delay.
-
-`hudson.model.Queue.Saver.DELAY_SECONDS`::
-    **Default:** 60 +
-    **Since:** 2.109 +
-    **Description:** Maximal delay of a save operation when content of Jenkins queue changes. This works as a balancing factor between queue consistency guarantee in case of Jenkins crash (short delay) and decreasing IO activity based on Jenkins load (long delay).
-
-`hudson.model.Run.ArtifactList.listCutoff`::
-    **Default:** 16 +
-    **Since:** 1.330 +
-    **Description:** More artifacts than this will use tree view or simple link rather than listing out artifacts
-
-`hudson.model.Run.ArtifactList.treeCutoff`::
-    **Default:** 40 +
-    **Since:** 1.330 +
-    **Description:** More artifacts than this will show a simple link to directory browser rather than showing artifacts in tree view
-
-`hudson.model.Slave.workspaceRoot`::
-    **Default:** workspace +
-    **Since:** 1.341? +
-    **Description:** name of the folder within the slave root directory to contain workspaces
-
-`hudson.model.UpdateCenter.className`::
-    **Default:** n/a +
-    **Since:** 2.4 +
-    **Description:** Allow overriding the implementation class for update center. Useful for custom war distributions with a different update center implementation. Cannot be used for plugins.
-
-`hudson.model.UpdateCenter.defaultUpdateSiteId`::
-    **Default:** default +
-    **Since:** 2.4 +
-    **Description:** Configure a different ID for the default update site. Useful for custom war distributions or externally provided UC data files
-
-`hudson.model.UpdateCenter.never`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** When true, don't automatically check for new versions
-
-`hudson.model.UpdateCenter.pluginDownloadReadTimeoutSeconds`::
-    **Default:** 60 +
-    **Since:** n/a +
-    **Description:** Read timeout in seconds for downloading plugins.
-
-`hudson.model.UpdateCenter.skipPermissionCheck`::
-    **Default:** `false` +
-    **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for UpdateCenter. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
-
-`hudson.model.UpdateCenter.updateCenterUrl`::
-    **Default:** `https://updates.jenkins.io/` +
-    **Since:** n/a +
-    **Description:** Deprecated: Override the default update site URL.
-    May have no effect since Jenkins 1.333.
-
-`hudson.model.UsageStatistics.disabled`::
-    **Default:** `false` +
-    **Since:** 1.312 or so? +
-    **Description:** Set to `true` to opt out of usage statistics collection, independent of UI option.
-
-`hudson.model.User.allowNonExistentUserToLogin`::
-    **Default:** `false` +
-    **Since:** 1.602 +
-    **Description:** When `true`, does not check auth realm for existence of user if there's a record in Jenkins. Unsafe, but may be used on some instances for service accounts
-
-`hudson.model.User.allowUserCreationViaUrl`::
-    **Default:** `false` +
-    **Since:** 2.44 / 2.32.2 +
-    **Description:** Whether admins accessing `+/user/example+` creates a user record (see SECURITY-406 on https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[Jenkins Security Advisory 2017-02-01])
-
-`hudson.model.User.SECURITY_243_FULL_DEFENSE`::
-    **Default:** `true` +
-    **Since:** 1.651.2 / 2.3 +
-    **Description:** When false, skips part of the fix that tries to determine whether a given user ID exists, and if so, doesn't consider users with the same full name during resolution.
-
-`hudson.model.User.skipPermissionCheck`::
-    **Default:** `false` +
-    **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for User. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
-
-`hudson.model.WorkspaceCleanupThread.disabled`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Don't clean up old workspaces on slave nodes
-
-`hudson.model.WorkspaceCleanupThread.recurrencePeriodHours`::
-    **Default:** 24 +
-    **Since:** 1.608 +
-    **Description:** How often workspace cleanup should run, in hours.
-
-`hudson.model.WorkspaceCleanupThread.retainForDays`::
-    **Default:** 30 +
-    **Since:** 1.608 +
-    **Description:** Unused workspaces are retained for this many days before qualifying for deletion.
-
-`hudson.node_monitors.AbstractNodeMonitorDescriptor.periodMinutes`::
-    **Default:** 60 +
-    **Since:** n/a +
-    **Description:** How frequently to update node monitors by default, in minutes.
-
-`hudson.os.solaris.ZFSInstaller.disabled`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** True to disable ZFS monitor on Solaris
-
-`hudson.os.solaris.ZFSInstaller.migrate`::
-    **Default:** undefined +
-    **Since:** n/a +
-    **Description:** Set by Jenkins itself when restarting Jenkins for a migration to a ZFS volume and contains the migration target dataset name.
-    There is no reason this would be set by administrators manually.
-
-`hudson.PluginManager.checkUpdateAttempts`::
-    **Default:** 1 +
-    **Since:** 2.152 +
-    **Description:** Number of attempts to check the updates sites.
-
-`hudson.PluginManager.checkUpdateSleepTimeMillis`::
-    **Default:** 1000 +
-    **Since:** 2.152 +
-    **Description:** Time (milliseconds) elapsed between retries to check the updates sites.
-
-`hudson.PluginManager.className`::
-    **Default:** undefined +
-    **Since:** n/a +
-    **Description:** Can be used to specify a different `PluginManager` implementation when customizing the `.war` packaging of Jenkins.
-
-`hudson.PluginManager.noFastLookup`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Disable fast lookup using `ClassLoaderReflectionToolkit` which reflectively accesses internal methods of `ClassLoader`.
-
-`hudson.PluginManager.skipPermissionCheck`::
-    **Default:** `false` +
-    **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for PluginManager. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
-
-`hudson.PluginManager.workDir`::
-    **Default:** undefined +
-    **Since:** 1.649 +
-    **Description:** Location of the base directory for all exploded .hpi/.jpi plugins. By default the plugins will be extracted under _$JENKINS_HOME/plugins/._
-
-`hudson.PluginStrategy`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Allow plugins to be loaded into a different environment, such as an existing DI container like Plexus; specify full class name here to override default ClassicPluginStrategy
-
-`hudson.PluginWrapper.dependenciesVersionCheck.enabled`::
-    **Default:** `true` +
-    **Since:** 2.0 +
-    **Description:** Set to `+false+` to skip the version check for plugin dependencies.
-
-`hudson.ProxyConfiguration.DEFAULT_CONNECT_TIMEOUT_MILLIS`::
-    **Default:** 20000 +
-    **Since:** 2.0 +
-    **Description:** Connection timeout applied to connections e.g. to the update site.
-
-`hudson.remoting.ClassFilter`::
-    **Default:** undefined +
-    **Since:** n/a +
-    **Description:** Allow or disallow the deserialization of specified types. Comma-separated class names, entries are whitelisted unless prefixed with `!`.
-    See https://github.com/jenkinsci/jep/tree/master/jep/200#backwards-compatibility[JEP-200] and https://issues.jenkins-ci.org/browse/JENKINS-47736[JENKINS-47736].
-
-`hudson.scheduledRetention`::
-    **Default:** `false` +
-    **Since:** Up to 1.354 +
-    **Description:** Control a slave based on a schedule
-
-`hudson.scm.SCM.useAutoBrowserHolder`::
-    **Default:** `false` since Jenkins 2.9, `true` before +
-    **Since:** n/a +
-    **Description:** When set to `true`, Jenkins will guess the repository browser used to render links in the changelog.
-
-`hudson.script.noCache`::
-    **Default:** see description +
-    **Since:** n/a +
-    **Description:** When set to true, Jenkins will not reference resource files through the `/static/.../` URL space, preventing their caching.
-    This is set to `true` during development by default, and `false` otherwise.
-
-`hudson.search.Search.skipPermissionCheck`::
-    **Default:** `false` +
-    **Since:** 2.121.3 / 2.138 +
-    **Description:** Disable security hardening related to Stapler routing for Search. Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
-
-`hudson.security.AccessDeniedException2.REPORT_GROUP_HEADERS`::
-    **Default:** `false` +
-    **Since:** 2.46 / 2.32.3 +
-    **Description:** If set to true, restore pre-2.46 behavior of sending HTTP headers on "access denied" pages listing group memberships.
-
-`hudson.security.ArtifactsPermission`::
-    **Default:** `false` +
-    **Since:** 1.374 +
-    **Description:** The Artifacts permission allows to control access to artifacts; When this property is unset or set to false, access to artifacts is not controlled
-
-`hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
-    **Default:** `false` +
-    **Since:** 2.228 and 2.204.6 +
-    **Description:** Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
-
-`hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
-    **Default:** `false` +
-    **Since:** 2.186 and 2.176.2 +
-    **Description:** Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
-
-`hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
-    **Default:** `false` +
-    **Since:** 2.222 +
-    **Description:** Restore the ability to disable CSRF protection after the UI for doing so was removed from Jenkins 2.222.
-
-`hudson.security.csrf.requestfield`::
-    **Default:** `.crumb` (Jenkins 1.x), `Jenkins-Crumb` (Jenkins 2.0) +
-    **Since:** 1.310 +
-    **Description:** Parameter name that contains a crumb value on POST requests
-
-`hudson.security.ExtendedReadPermission`::
-    **Default:** `false` +
-    **Since:** 1.324 +
-    **Description:** The ExtendedReadPermission allows read-only access to "Configure" pages; can also enable with extended-read-permission plugin
-
-`hudson.security.HudsonPrivateSecurityRealm.ID_REGEX`::
-    **Default:** `+[a-zA-Z0-9_-]++` +
-    **Since:** 2.121 and 2.107.3 +
-    **Description:** Regex for legal user names in Jenkins user database. See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
-
-`hudson.security.HudsonPrivateSecurityRealm.maximumBCryptLogRound`::
-    **Default:** 18 +
-    **Since:** 2.161 +
-    **Description:** Limits the number of rounds for pre-computed BCrypt hashes of user passwords for the Jenkins user database to prevent excessive computation.
-
-`hudson.security.LDAPSecurityRealm.groupSearch`::
-// TODO move out, it's LDAP plugin
-    **Default:** TBD +
-    **Since:** n/a +
-    **Description:** LDAP filter to look for groups by their names
-
-`hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
-    **Default:** `false` +
-    **Since:** 2.160 and 2.150.2 +
-    **Description:** Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
-
-`hudson.security.WipeOutPermission`::
-    **Default:** `false` +
-    **Since:** 1.416 +
-    **Description:** The WipeOut permission allows to control access to the "Wipe Out Workspace" action, which is normally available as soon as the Build permission is granted
-
-`hudson.slaves.ChannelPinger.pingInterval`::
-    **Default:** 5 +
-    **Since:** 1.405 +
-    **Description:** *(Deprecated since 2.37)* Frequency (in minutes) of https://wiki.jenkins.io/display/JENKINS/Ping+Thread[pings between the master and slaves]
-
-`hudson.slaves.ChannelPinger.pingIntervalSeconds`::
-    **Default:** 300 +
-    **Since:** 2.37 +
-    **Description:** Frequency of https://wiki.jenkins.io/display/JENKINS/Ping+Thread[pings between the master and slaves], in seconds
-
-`hudson.slaves.ChannelPinger.pingTimeoutSeconds`::
-    **Default:** 240 +
-    **Since:** 2.37 +
-    **Description:** Timeout for each https://wiki.jenkins.io/display/JENKINS/Ping+Thread[ping between the master and slaves], in seconds
-
-`hudson.slaves.ConnectionActivityMonitor.enabled`::
-// This looks like a dead feature? Introduced 2011 and disabled by default?
-    **Default:** `false` +
-    **Since:** 1.326 +
-    **Description:** Whether to enable this feature that checks whether agents are alive and cuts them off if not.
-
-`hudson.slaves.ConnectionActivityMonitor.frequency`::
-// Actually dual use: Both for timeout (4 minutes) and time to ping (3 minutes). Possibly copy & paste issue and bug in core?
-    **Default:** 10000 (10 seconds) +
-    **Since:** 1.326 +
-    **Description:** How frequently to check for channel activity, in milliseconds.
-
-`hudson.slaves.ConnectionActivityMonitor.timeToPing`::
-    **Default:** 180000 (3 minutes) +
-    **Since:** 1.326 +
-    **Description:** How long to wait after startup to start checking agent connections, in milliseconds.
-
-`hudson.slaves.NodeProvisioner.initialDelay`::
-    **Default:** 10 times `hudson.model.LoadStatistics.clock`, typically 100 seconds +
-    **Since:** n/a +
-    **Description:** How long to wait after startup before starting to provision nodes from clouds.
-    This will allow static agents to start and handle the load first.
-
-`hudson.slaves.NodeProvisioner.MARGIN`::
-// TODO
-    **Default:** +
-    **Since:** n/a +
-    **Description:** +
-
-`hudson.slaves.NodeProvisioner.MARGIN0`::
-// TODO
-    **Default:** +
-    **Since:** n/a +
-    **Description:** +
-
-`hudson.slaves.NodeProvisioner.MARGIN_DECAY`::
-// TODO
-    **Default:** +
-    **Since:** n/a +
-    **Description:** +
-
-`hudson.slaves.NodeProvisioner.recurrencePeriod`::
-    **Default:** Equal to `hudson.model.LoadStatistics.clock`, typically 10 seconds +
-    **Since:** n/a +
-    **Description:** How frequently to possibly provision nodes.
-
-`hudson.slaves.WorkspaceList`::
-    **Default:** `@` +
-    **Since:** 1.424 +
-    **Description:** When concurrent builds is enabled, a unique workspace directory name is required for each concurrent build. To create this name, this token is placed between project name and a unique ID, e.g. "my-project@123".
-
-`hudson.tasks.ArtifactArchiver.warnOnEmpty`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** When true, builds don't fail when there is nothing to archive
-
-`hudson.tasks.Fingerprinter.enableFingerprintsInDependencyGraph`::
-    **Default:** `false` +
-    **Since:** 1.430 +
-    **Description:** When true, jobs associated through fingerprints are added to the dependency graph, even when there is no configured upstream/downstream relationship between them.
-
-`hudson.tasks.MailSender.maxLogLines`::
-// TODO is this mailer plugin now?
-    **Default:** 250 +
-    **Since:** n/a +
-    **Description:** Number of lines of console output to include in emails
-
-`hudson.TcpSlaveAgentListener.hostName`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Host name that Jenkins advertises to its clients. Especially useful when running Jenkins behind a reverse proxy.
-
-`hudson.TcpSlaveAgentListener.port`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Port that Jenkins advertises to its clients. Especially useful when running Jenkins behind a reverse proxy.
-
-`hudson.TreeView`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Experimental nested views feature
-
-`hudson.triggers.SafeTimerTask.logsTargetDir`::
-    **Default:** `$JENKINS_HOME/logs` +
-    **Since:** 2.114 +
-    **Description:** Allows to move the logs usually found under `+$JENKINS_HOME/logs+` to another location. Beware that no migration is handled if you change it on an existing instance.
-
-`hudson.triggers.SCMTrigger.starvationThreshold`::
-    **Default:** 1 hour +
-    **Since:** n/a +
-    **Description:** Milliseconds waiting for polling executor before trigger reports it is clogged
-
-`hudson.udp`::
-    **Default:** 33848 +
-    **Since:** n/a +
-    **Description:** Port for UDP multicast broadcast (set to -1 to disable)
-
-`hudson.upstreamCulprits`::
-    **Default:** `false` +
-    **Since:** 1.327 +
-    **Description:** Pass blame information to downstream jobs
-
-`hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
-// The code is really confusing; there are two flags, one is always false, and will be forcibly set to false here, except using a new constructor that was deprecated in the same PR it was introduced in.
-    **Default:** `false` +
-    **Since:** 2.102 +
-    **Description:** Disables the forced flushing when calling `#close()`.
-    Not expected to be used.
-`hudson.util.CharacterEncodingFilter.disableFilter`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Set to `true` to disable the filter that sets request encoding to UTF-8 if it's undefined and its content type is `text/xml` or `application/xml` (API submissions).
-
-`hudson.util.CharacterEncodingFilter.forceEncoding`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Set to `true` to force the request encoding to UTF-8 even if a different character set is declared.
-
-`hudson.Util.deletionRetryWait`::
-    **Default:** 100 +
-    **Since:** 2.2 +
-    **Description:** The time (in milliseconds) to wait between attempts to delete files when retrying. This has no effect unless _hudson.Util.maxFileDeletionRetries_ is greater than 1. If zero, there will be no delay between attempts. If negative, the delay will be a (linearly) increasing multiple of this value between attempts.
-
-`hudson.Util.maxFileDeletionRetries`::
-    **Default:** 3 +
-    **Since:** 2.2 +
-    **Description:** The number of times to attempt to delete files/directory trees before giving up and throwing an exception. Specifying a value less than 1 is invalid and will be treated as if a value of 1 (i.e. one attempt, no retries) was specified. See https://issues.jenkins-ci.org/browse/JENKINS-10113[JENKINS-10113] and https://issues.jenkins-ci.org/browse/JENKINS-15331[JENKINS-15331].
-
-`hudson.Util.noSymLink`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** True to disable creation of symbolic links in job/builds directories
-
-`hudson.Util.performGCOnFailedDelete`::
-    **Default:** `false` +
-    **Since:** 2.2 +
-    **Description:** If this flag is set to `true` then we will request a garbage collection after a deletion failure before we next retry the delete.
-    It is ignored unless _hudson.Util.maxFileDeletionRetries_ is greater than 1. +
-    Setting this flag to `true` _may_ resolve some problems on Windows, and also for directory trees residing on an NFS share, but it can have a negative impact on performance and may have no effect at all (GC behavior is JVM-specific).
-    **Warning**: This should only ever be used if you find that your builds are failing because Jenkins is unable to delete files, that this failure is because Jenkins itself has those files locked "open", and even then it should only be used on slaves with relatively few executors (because the garbage collection can impact the performance of all job executors on that slave).
-    _Setting this flag is a act of last resort - it is not recommended, and should not be used on your main Jenkins server unless you can tolerate the performance impact_.
-
-`hudson.util.ProcessTree.disable`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** True to disable cleanup of child processes
-
-`hudson.util.RingBufferLogHandler.defaultSize`::
-    **Default:** 256 +
-    **Since:** 1.563 +
-    **Description:** Number of log entries in loggers available on the UI at `+/log/+`
-
-`hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL`::
-    **Default:** `true` +
-    **Since:** 2.236 +
-    **Description:** Jenkins automatically round-trips `f:password` based form fields as encrypted `Secret` even if the field is not of type `Secret`.
-    Set this to `false` to disable this behavior, doing so is discouraged.
-
-`hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE`::
-    **Default:** `true` +
-    **Since:** 2.236 +
-    **Description:** If the user is missing _Item/Configure_ permission, Jenkins 2.236 and newer will blank out the password value automatically even if the form field is not backed by a `Secret`.
-    Set this to `false` to disable this behavior, doing so is discouraged.
-
-`hudson.util.Secret.provider`::
-    **Default:** n/a +
-    **Since:** 1.360 +
-    **Description:** Force a particular crypto provider; with Glassfish Enterprise set value to `+SunJCE+` to workaround https://issues.jenkins-ci.org/browse/JENKINS-6459[JENKINS-6459].
-
-`hudson.util.StreamTaskListener.AUTO_FLUSH`::
-// https://github.com/jenkinsci/jenkins/pull/3961
-    **Default:** `false` +
-    **Since:** 2.173 +
-    **Description:** Jenkins no longer automatically flushes streams for code running remotely on agents for better performance.
-    This may lead to loss of messages for plugins which print to a build log from the agent machine but do not flush their output.
-    Use this flag to restore the previous behavior for freestyle builds.
-
-`hudson.Util.symlinkEscapeHatch`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** True to use exec of "ln" binary to create symbolic links instead of native code
-
-`hudson.Util.useNativeChmodAndMode`::
-    **Default:** `false` +
-    **Since:** 2.93 +
-    **Description:** True to use native (JNA/JNR) implementation to set file permissions instead of NIO
-
-`hudson.WebAppMain.forceSessionTrackingByCookie`::
-    **Default:** `true` +
-    **Since:** 2.234 +
-    **Description:** Set to `false` to not force session tracking to be done via cookie.
-    Escape hatch for https://issues.jenkins-ci.org/browse/JENKINS-61738[JENKINS-61738].
-
-`hudson.widgets.HistoryWidget.threshold`::
-    **Default:** 30 +
-    **Since:** 1.433 +
-    **Description:** How many builds to show in the build history side panel widget.
-
-`HUDSON_HOME`::
-    **Default:** n/a +
-    **Since:** n/a +
-    **Description:** Backward compatible fallback name for `JENKINS_HOME`.
-    See documentation there.
-
-`jenkins.CLI.disabled`::
-    **Default:** `false` +
-    **Since:** 2.32 and 2.19.3 +
-    **Description:** `+true+` to disable Jenkins CLI via JNLP and HTTP (SSHD can still be enabled)
-
-`jenkins.InitReactorRunner.concurrency`::
-    **Default:** 2x of CPU +
-    **Since:** n/a +
-    **Description:** During start of Jenkins, loading of jobs in parallel have a fixed number of threads by default (twice the CPU). To make Jenkins load time 8x faster, increase it to 8x. For example, 24 CPU Jenkins Master host use this: -Dhudson.InitReactorRunner.concurrency=192
-
-`jenkins.install.runSetupWizard`::
-    **Default:** undefined +
-    **Since:** 2.0 +
-    **Description:** Set to `+false+` to skip install wizard. Note that this leaves Jenkins unsecured by default. Development-mode only: Set to `+true+` to not skip showing the setup wizard during Jenkins development. This property is only effective the first time you run Jenkins in given JENKINS_HOME.
-
-`jenkins.model.Jenkins.buildsDir`::
-    **Default:** `$\{ITEM_ROOTDIR}/builds` +
-    **Since:** 2.119 +
-    **Description:** The configuration of a given job is located under `+$JENKINS_HOME/jobs/[JOB_NAME]/config.xml+` and its builds are under `+$JENKINS_HOME/jobs/[JOB_NAME]/builds+` by default.
-    This option allows you to store builds elsewhere, which can be useful with finer-grained backup policies, or to store the build data on a faster disk such as an SSD.
-    The following placeholders are supported for this value:
-+
-    * *$\{JENKINS_HOME}*  – Resolves to the Jenkins home directory.
-    * *$\{ITEM_ROOTDIR}* – The directory containing the job metadata within Jenkins home.
-    * *$\{ITEM_FULL_NAME}* – The full name of the item, with file system unsafe characters replaced by others.
-    * *$\{ITEM_FULLNAME}* – See above, but does not replace unsafe characters. This is a legacy option and should not be used.
-+
-For instance, if you would like to store builds outside of Jenkins home, you can use a value like the following: `+/some_other_root/builds/${ITEM_FULL_NAME}+` This used to be a UI setting, but was removed in 2.119 as it did not support migration of existing build records and could lead to build-related errors until restart.
-+
-To manually migrate existing build records when starting to use this option (`TARGET_DIR` is the value supplied to `jenkins.model.Jenkins.buildsDir`):
-+
-For link:/doc/book/pipeline/[Pipeline] and Freestyle job types, run this for each `JOB_NAME`:
-+
-```sh
-mkdir -p [TARGET_DIR]
-mv $JENKINS_HOME/jobs/[JOB_NAME]/builds [TARGET_DIR]/[JOB_NAME]
-```
-+
-For link:/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibranch Pipeline] jobs, run for each `BRANCH_NAME`:
-+
-```sh
-mkdir -p [TARGET_DIR]/[JOB_NAME]/branches/
-mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds \
-    [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
-```
-+
-For link:/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
-+
-```sh
-mkdir -p [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/
-mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds \
-    [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]
-```
-
-`jenkins.model.Jenkins.crumbIssuerProxyCompatibility`::
-    **Default:** `false` +
-    **Since:** 2.119 +
-    **Description:** `+true+` to enable crumb proxy compatibility when running the Setup Wizard for the first time.
-
-`jenkins.model.Jenkins.disableExceptionOnNullInstance`::
-    **Default:** `false` +
-    **Since:** 2.4 *only* +
-    **Description:** `+true+` to disable throwing an `+IllegalStateException+` when `+Jenkins.getInstance()+` returns `+null+`
-
-`jenkins.model.Jenkins.enableExceptionOnNullInstance`::
-    **Default:** `false` +
-    **Since:** 2.5 +
-    **Description:** `+true+` to enable throwing an `+IllegalStateException+` when `+Jenkins.getInstance()+` returns `+null+`
-
-`jenkins.model.Jenkins.exitCodeOnRestart`::
-    **Default:** 5 +
-    **Since:** 2.102 +
-    **Description:** When using the `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle`, exit using this exit code when Jenkins is restarted
-
-`jenkins.model.Jenkins.initLogLevel`::
-    **Default:** `FINE` +
-    **Since:** n/a +
-    **Description:** Log level for verbose messages from the init reactor listener.
-
-`jenkins.model.Jenkins.killAfterLoad`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Exit Jenkins right after loading.
-    Intended as a development/testing aid only.
-
-`jenkins.model.Jenkins.logStartupPerformance`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Log startup timing info.
-    Note that some messages are not logged on levels visible by default (i.e. INFO and up).
-
-`jenkins.model.Jenkins.parallelLoad`::
-    **Default:** `true` +
-    **Since:** n/a +
-    **Description:** Loads job configurations in parallel on startup.
-
-`jenkins.model.Jenkins.slaveAgentPort`::
-    **Default:** -1 (disabled) +
-    **Since:** 1.643 +
-    **Description:** Specifies the default TCP slave agent port unless/until configured differently on the UI. `-1` to disable, `0` for random port, other values for fixed port. Used to be 0 by default before Jenkins 2.0
-
-`jenkins.model.Jenkins.slaveAgentPortEnforce`::
-    **Default:** `false` +
-    **Since:** 2.19.4 and 2.24 +
-    **Description:** If true, enforces the specified `+jenkins.model.Jenkins.slaveAgentPort+` on startup and will not allow changing it through the UI
-
-`jenkins.model.Jenkins.workspaceDirName`::
-    **Default:** `workspace` +
-    **Since:** n/a +
-    **Description:** Obsolete: Was used as the default workspace directory name in the legacy workspace directory layout (workspace directories within job directories).
-
-`jenkins.model.Jenkins.workspacesDir`::
-    **Default:** $\{JENKINS_HOME}/workspace/$\{ITEM_FULL_NAME} +
-    **Since:** 2.119 +
-    **Description:** Allows to change the directory layout for the job workspaces on the master node. See `+jenkins.model.Jenkins.buildsDir+` for supported placeholders.
-
-`jenkins.model.JenkinsLocationConfiguration.disableUrlValidation`::
-    **Default:** `false` +
-    **Since:** 2.197 / LTS 2.176.4 +
-    **Description:** Disable URL validation intended to prevent an XSS vulnerability. See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
-
-`jenkins.model.lazy.BuildReference.MODE`::
-    **Default:** `soft` +
-    **Since:** 1.548 +
-    **Description:** Configure the kind of reference Jenkins uses to hold builds in memory.
-    Choose from among `soft`, `weak`, `strong`, and `not` (do not hold builds in memory at all).
-    Intended mostly as a debugging aid.
-    See https://issues.jenkins-ci.org/browse/JENKINS-19400[JENKINS-19400].
-
-`jenkins.model.StandardArtifactManager.disableTrafficCompression`::
-    **Default:** `false` +
-    **Since:** 2.196 +
-    **Description:** `+true+` to disable GZIP compression of artifacts when they're transferred from slave nodes to master.  Uses less CPU at the cost of increased network traffic.
-
-`jenkins.security.ApiTokenProperty.adminCanGenerateNewTokens `::
-    **Default:** `false` +
-    **Since:** 2.129 +
-    **Description:** `+true+` to allow users with `+ADMINISTER+` permission to create API tokens using the new system for any user. Note that the user will not be able to use that token since it's only displayed to the creator, once.
-
-`jenkins.security.ApiTokenProperty.showTokenToAdmins`::
-    **Default:** `false` +
-    **Since:** 1.638 +
-    **Description:** True to show API tokens for users to administrators on the user configuration page. This was set to `false` as part of https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11#JenkinsSecurityAdvisory2015-11-11-APItokensofotherusersavailabletoadmins[SECURITY-200]
-
-`jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
-    **Default:** `false` +
-    **Since:** 2.102 +
-    **Description:** Do not perform any JEP-200 class filtering when deserializing data.
-    Setting this to `true` is unsafe.
-    See https://jenkins.io/redirect/class-filter/[documentation].
-
-`jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
-    **Default:** `false` +
-    **Since:** 2.102 +
-    **Description:** Do not perform whitelist-based JEP-200 class filtering when deserializing data.
-    With this flag set, only explicitly blacklisted types will be rejected.
-    Setting this to `true` is unsafe.
-    See https://jenkins.io/redirect/class-filter/[documentation].
-
-`jenkins.security.FrameOptionsPageDecorator.enabled`::
-    **Default:** `true` +
-    **Since:** 1.581 +
-    **Description:** Whether to send `X-Frame-Options: sameorigin` header, set to `false` to disable and make Jenkins embeddable
-
-`jenkins.security.ignoreBasicAuth`::
-    **Default:** `false` +
-    **Since:** 1.421 +
-    **Description:** When set to `true`, disable `Basic` authentication with username and password (rather than API token).
-
-`jenkins.security.ManagePermission`::
-    **Default:** `false` +
-    **Since:** 2.222 +
-    **Description:** Enable the optional Overall/Manage permission that allows limited access to administrative features suitable for a hosted Jenkins environment.
-    See https://github.com/jenkinsci/jep/tree/master/jep/223[JEP-223].
-
-`jenkins.security.ResourceDomainRootAction.validForMinutes`::
-    **Default:** 30 +
-    **Since:** 2.200 +
-    **Description:** How long a resource URL served from the resource root URL will be valid for before users are required to reauthenticate to access it.
-    See inline documentation in Jenkins for details.
-
-
-`jenkins.security.s2m.DefaultFilePathFilter.allow`::
-    **Default:** `false` +
-    **Since:** 1.587 and 1.580.1 +
-    **Description:** Allow all file paths on the Jenkins master to be accessed from agents.
-    This disables a big part of link:/security/advisory/2014-10-30/[SECURITY-144] protections.
-
-`jenkins.security.seed.UserSeedProperty.disableUserSeed`::
-    **Default:** `false` +
-    **Since:** 2.160 and 2.105.2 +
-    **Description:** Disables _user seed_.
-    Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
-
-`jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
-    **Default:** `false` +
-    **Since:** 2.160 and 2.105.2 +
-    **Description:** Hide the UI for _user seed_ introduced for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
-
-`jenkins.security.stapler.StaplerDispatchValidator.disabled`::
-    **Default:** `false` +
-    **Since:** 2.186 and 2.176.2 +
-    **Description:** Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534].
-
-`jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
-    **Default:** `stapler-views-whitelist.txt` in `JENKINS_HOME` +
-    **Since:** 2.186 and 2.176.2 +
-    **Description:** Override the location of the user configurable whitelist for stapler view dispatches.
-    This augments the built-in whitelist for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534] that allows dispatches to views that would otherwise be prohibited.
-
-`jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
-    **Default:** `stapler-whitelist.txt` in `JENKINS_HOME` +
-    **Since:** 2.154 and 2.138.4 +
-    **Description:** Override the location of the user configurable whitelist for stapler request routing.
-    This augments the built-in whitelist for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595] that allows routing requests through methods that would otherwise be prohibited.
-
-`jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
-    **Default:** `true` +
-    **Since:** 2.154 and 2.138.4 +
-    **Description:** Prohibits access to `public static` fields when routing requests in Stapler.
-    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
-
-`jenkins.security.stapler.TypedFilter.skipTypeCheck`::
-    **Default:** `false` +
-    **Since:** 2.154 and 2.138.4 +
-    **Description:** Skip (return) type check when determining whether a method or field should be routable with Stapler (i.e. allow any return type).
-    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
-
-`jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
-    **Default:** `false` +
-    **Since:** 2.228 and 2.204.6 +
-    **Description:** Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
-    Allows requests to URLs with semicolon characters (`;`) in the request path.
-
-`jenkins.security.SystemReadPermission`::
-    **Default:** `false` +
-    **Since:** 2.222 +
-    **Description:** Enable the optional Overall/SystemRead permission that allows read-only access to administrative features suitable for a managed Jenkins Configuration as Code environment.
-    See https://github.com/jenkinsci/jep/tree/master/jep/224[JEP-224].
-
-`jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
-    **Default:** 120 (2 minutes) +
-    **Since:** 2.15 +
-    **Description:** How long a cache for `UserDetails` should be valid for before it is looked up again from the security realm.
-    See https://issues.jenkins-ci.org/browse/JENKINS-35493[JENKINS-35493].
-
-`jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
-    **Default:** `false` +
-    **Since:** 2.28 +
-    **Description:** +
-// TODO
-
-`jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
-    **Default:** undefined +
-    **Since:** 1.653 +
-    **Description:** `+false+` to disable the JNLP3 agent protocol, `+true+` to enable it. Otherwise it's randomly enabled/disabled to A/B test it.
-
-`jenkins.slaves.NioChannelSelector.disabled`::
-    **Default:** `false` +
-    **Since:** 1.560 +
-    **Description:** `true` to disable Nio for JNLP slaves
-
-`jenkins.slaves.StandardOutputSwapper.disabled`::
-// TODO Unsure how this works. References:
-// - https://github.com/jenkinsci/jenkins/blob/3fd66ff22051a3309b8dc5130d8da0759ee27f48/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
-// - https://github.com/jenkinsci/remoting/commit/fad8c38724068dfbd155e64508e5d4c154240b87
-    **Default:** `false` +
-    **Since:** 1.429 +
-    **Description:** Some Unix-like agents (e.g. SSH Build Agents) can communicate via stdin/stdout, which is very convenient.
-    Unfortunately, some JVM output (e.g. related to GC) also goes to standard out.
-    This will swap output streams around to prevent stream corruption through unexpected writes to standard out.
-
-`jenkins.telemetry.Telemetry.endpoint`::
-// https://github.com/jenkinsci/jenkins/pull/3604
-    **Default:** `+https://uplink.jenkins.io/events+` +
-    **Since:** 2.143 +
-    **Description:** Change the endpoint that JEP-214/Uplink telemetry sends data to. Expected to be used for testing only.
-
-`jenkins.ui.refresh`::
-    **Default:** `false` +
-    **Since:** 2.222 +
-    **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see link:/sigs/ux/[Jenkins UX SIG].
-
-`jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
-    **Default:** 0 +
-    **Since:** n/a +
-    **Description:** Debug/development option to slow down the cancelling of progressive rendering when the client fails to send a heartbeat.
-
-`JENKINS_HOME`::
-    **Default:** `~/.jenkins` +
-    **Since:** n/a +
-    **Description:** While typically set as an environment variable, Jenkins also looks up the path to its home directory as a system property.
-    `JENKINS_HOME` set via JNDI context has higher priority than this, but this takes precedence over the environment variable.
-
-`org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
-// This is a core module, so this documentation should remain here.
-    **Default:** undefined +
-    **Since:** 2.22 +
-    **Description:** Allows to configure the SSHD client idle timeout (value in milliseconds). Default value is 10min (600000ms).
-
-`org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT`::
-// TODO move to plugin documentation
-    **Default:** 20 seconds +
-    **Since:** workflow-durable-task-step-plugin 2.29  +
-    **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).
-
-`stapler.jelly.noCache`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Controls both caching of various cachable resources (Jelly scripts etc.) as well as the `Expires` HTTP response header for some static resources.
-    Useful during development to see the effect of changes after reload.
-
-`stapler.legacyGetterDispatcherMode`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Do not filter get methods at the Stapler framework level.
-    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
-
-`stapler.legacyWebMethodDispatcherMode`::
-    **Default:** `false` +
-    **Since:** n/a +
-    **Description:** Do not filter web methods ("do" actions) at the Stapler framework level.
-    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
-
-`stapler.resourcePath`::
-    **Default:** undefined +
-    **Since:** n/a +
-    **Description:** Additional debug resource paths.
-    Set by the core development tooling so developers can see the effect of changes immediately after reloading the page.
-
-`stapler.trace`::
-    **Default:** false +
-    **Since:** n/a +
-    **Description:** Trace request handling and report the result using `Stapler-Trace-...` response headers.
-    Additionally renders a diagnostic HTTP 404 error page when the request could not be processed.
-
-`stapler.trace.per-request`::
-    **Default:** false +
-    **Since:** n/a +
-    **Description:** Trace request handling (see above) for requests with the `X-Stapler-Trace` request header set.
-
-== Properties in plugins
-
-Plugins may define their own system properties. See the plugin documentation for more info.
-
-== Properties in other components
-
-Particular Jenkins component have their own release cycle and documentation. In particular cases such components also include System Properties.
-
-* Remoting - Jenkins Communication Layer: 
-  https://github.com/jenkinsci/remoting/blob/master/docs/configuration.md[Remoting Configuration]

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -58,6 +58,16 @@ dd {
 </style>
 ++++
 
+////
+STYLE GUIDE
+
+Sort order:
+These properties are ordered alphabetically, case-insensitively.
+End of string sorts before alphanumeric sorts before period (.), sorts before underscore (_).
+Example: foo -> foobar -> foo.bar -> foo_bar
+
+////
+
 `debug.YUI`::
     **Default:** `false` +
     **Since:** n/a +
@@ -229,7 +239,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.model.DirectoryBrowserSupport.allowSymlinkEscape`::
     **Default**: `false` +
     **Since:** 2.154 and 2.138.4 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
+    **Description:** Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904].
 
 `hudson.model.DirectoryBrowserSupport.CSP`::
     **Default:** `sandbox; default-src 'none'; image-src 'self'; style-src 'self';` +
@@ -510,12 +520,12 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO`::
     **Default:** `false` +
     **Since:** 2.228 and 2.204.6 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    **Description:** Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
 `hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID`::
     **Default:** `false` +
     **Since:** 2.186 and 2.176.2 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
+    **Description:** Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
 
 `hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`::
     **Default:** `false` +
@@ -543,6 +553,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** Limits the number of rounds for pre-computed BCrypt hashes of user passwords for the Jenkins user database to prevent excessive computation.
 
 `hudson.security.LDAPSecurityRealm.groupSearch`::
+// TODO move out, it's LDAP plugin
     **Default:** TBD +
     **Since:** n/a +
     **Description:** LDAP filter to look for groups by their names
@@ -550,7 +561,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 `hudson.security.TokenBasedRememberMeServices2.skipTooFarExpirationDateCheck`::
     **Default:** `false` +
     **Since:** 2.160 and 2.150.2 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
+    **Description:** Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
 
 `hudson.security.WipeOutPermission`::
     **Default:** `false` +
@@ -630,6 +641,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** When true, jobs associated through fingerprints are added to the dependency graph, even when there is no configured upstream/downstream relationship between them.
 
 `hudson.tasks.MailSender.maxLogLines`::
+// TODO is this mailer plugin now?
     **Default:** 250 +
     **Since:** n/a +
     **Description:** Number of lines of console output to include in emails
@@ -671,7 +683,7 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
 
 `hudson.util.AtomicFileWriter.DISABLE_FORCED_FLUSH`::
 // The code is really confusing; there are two flags, one is always false, and will be forcibly set to false here, except using a new constructor that was deprecated in the same PR it was introduced in.
-    **Default:** `alse` +
+    **Default:** `false` +
     **Since:** 2.102 +
     **Description:** Disables the forced flushing when calling `#close()`.
     Not expected to be used.
@@ -755,14 +767,15 @@ Some implementations that can be individually configured (see _FullyQualifiedCla
     **Description:** True to use native (JNA/JNR) implementation to set file permissions instead of NIO
 
 `hudson.WebAppMain.forceSessionTrackingByCookie`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.234 +
+    **Description:** Set to `false` to not force session tracking to be done via cookie.
+    Escape hatch for https://issues.jenkins-ci.org/browse/JENKINS-61738[JENKINS-61738].
 
 `hudson.widgets.HistoryWidget.threshold`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 30 +
+    **Since:** 1.433 +
+    **Description:** How many builds to show in the build history side panel widget.
 
 `HUDSON_HOME`::
     **Default:** n/a +
@@ -801,21 +814,21 @@ For instance, if you would like to store builds outside of Jenkins home, you can
 +
 To manually migrate existing build records when starting to use this option (`TARGET_DIR` is the value supplied to `jenkins.model.Jenkins.buildsDir`):
 +
-For link:https://www.jenkins.io/doc/book/pipeline/[Pipeline] and Freestyle job types, run this for each `JOB_NAME`:
+For link:/doc/book/pipeline/[Pipeline] and Freestyle job types, run this for each `JOB_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]
 mv $JENKINS_HOME/jobs/[JOB_NAME]/builds [TARGET_DIR]/[JOB_NAME]
 ```
 +
-For link:https://www.jenkins.io/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibranch Pipeline] jobs, run for each `BRANCH_NAME`:
+For link:/doc/book/pipeline/multibranch/#creating-a-multibranch-pipeline[Multibranch Pipeline] jobs, run for each `BRANCH_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]/[JOB_NAME]/branches/
 mv $JENKINS_HOME/jobs/[JOB_NAME]/branches/[BRANCH_NAME]/builds [TARGET_DIR]/[JOB_NAME]/branches/[BRANCH_NAME]
 ```
 +
-For link:https://www.jenkins.io/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
+For link:/doc/book/pipeline/multibranch/#organization-folders[Organization Folders], run this for each `REPO_NAME` and `BRANCH_NAME`:
 +
 ```sh
 mkdir -p [TARGET_DIR]/[ORG_NAME]/jobs/[REPO_NAME]/branches/
@@ -908,94 +921,111 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** True to show API tokens for users to administrators on the user configuration page. This was set to `false` as part of https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11#JenkinsSecurityAdvisory2015-11-11-APItokensofotherusersavailabletoadmins[SECURITY-200]
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_ALL`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.102 +
+    **Description:** Do not perform any JEP-200 class filtering when deserializing data.
+    Setting this to `true` is unsafe.
+    See https://jenkins.io/redirect/class-filter/[documentation].
 
 `jenkins.security.ClassFilterImpl.SUPPRESS_WHITELIST`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.102 +
+    **Description:** Do not perform whitelist-based JEP-200 class filtering when deserializing data.
+    With this flag set, only explicitly blacklisted types will be rejected.
+    Setting this to `true` is unsafe.
+    See https://jenkins.io/redirect/class-filter/[documentation].
 
 `jenkins.security.FrameOptionsPageDecorator.enabled`::
     **Default:** `true` +
     **Since:** 1.581 +
-    **Description:** Whether to send `+X-Frame-Options: sameorigin+` header, set to `false` to disable and make Jenkins embeddable
+    **Description:** Whether to send `X-Frame-Options: sameorigin` header, set to `false` to disable and make Jenkins embeddable
 
 `jenkins.security.ignoreBasicAuth`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 1.421 +
+    **Description:** When set to `true`, disable `Basic` authentication with username and password (rather than API token).
 
 `jenkins.security.ManagePermission`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.222 +
+    **Description:** Enable the optional Overall/Manage permission that allows limited access to administrative features suitable for a hosted Jenkins environment.
+    See https://github.com/jenkinsci/jep/tree/master/jep/223[JEP-223].
 
 `jenkins.security.ResourceDomainRootAction.validForMinutes`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 30 +
+    **Since:** 2.200 +
+    **Description:** How long a resource URL served from the resource root URL will be valid for before users are required to reauthenticate to access it.
+    See inline documentation in Jenkins for details.
+
 
 `jenkins.security.s2m.DefaultFilePathFilter.allow`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 1.587 and 1.580.1 +
+    **Description:** Allow all file paths on the Jenkins master to be accessed from agents.
+    This disables a big part of link:/security/advisory/2014-10-30/[SECURITY-144] protections.
 
 `jenkins.security.seed.UserSeedProperty.disableUserSeed`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.160 and 2.105.2 +
+    **Description:** Disables _user seed_.
+    Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
 
 `jenkins.security.seed.UserSeedProperty.hideUserSeedSection`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.160 and 2.105.2 +
+    **Description:** Hide the UI for _user seed_ introduced for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
 
 `jenkins.security.stapler.StaplerDispatchValidator.disabled`::
     **Default:** `false` +
-    **Since:** 2.186 / 2.176.2 +
-    **Description:** `+true+`  to disable link:/security/advisory/2019-07-17/#SECURITY-534[the SECURITY-534 fix].
+    **Since:** 2.186 and 2.176.2 +
+    **Description:** Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534].
 
 `jenkins.security.stapler.StaplerDispatchValidator.whitelist`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `stapler-views-whitelist.txt` in `JENKINS_HOME` +
+    **Since:** 2.186 and 2.176.2 +
+    **Description:** Override the location of the user configurable whitelist for stapler view dispatches.
+    This augments the built-in whitelist for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534] that allows dispatches to views that would otherwise be prohibited.
 
 `jenkins.security.stapler.StaticRoutingDecisionProvider.whitelist`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `stapler-whitelist.txt` in `JENKINS_HOME` +
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Override the location of the user configurable whitelist for stapler request routing.
+    This augments the built-in whitelist for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595] that allows routing requests through methods that would otherwise be prohibited.
 
 `jenkins.security.stapler.TypedFilter.prohibitStaticAccess`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `true` +
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Prohibits access to `public static` fields when routing requests in Stapler.
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
 
 `jenkins.security.stapler.TypedFilter.skipTypeCheck`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.154 and 2.138.4 +
+    **Description:** Skip (return) type check when determining whether a method or field should be routable with Stapler (i.e. allow any return type).
+    Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
 
 `jenkins.security.SuspiciousRequestFilter.allowSemicolonsInPath`::
     **Default:** `false` +
     **Since:** 2.228 and 2.204.6 +
-    **Description:** Escape hatch for https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    **Description:** Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
+    Allows requests to URLs with semicolon characters (`;`) in the request path.
 
 `jenkins.security.SystemReadPermission`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.222 +
+    **Description:** Enable the optional Overall/SystemRead permission that allows read-only access to administrative features suitable for a managed Jenkins Configuration as Code environment.
+    See https://github.com/jenkinsci/jep/tree/master/jep/224[JEP-224].
 
 `jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** 120 (2 minutes) +
+    **Since:** 2.15 +
+    **Description:** How long a cache for `UserDetails` should be valid for before it is looked up again from the security realm.
+    See https://issues.jenkins-ci.org/browse/JENKINS-35493[JENKINS-35493].
 
 `jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+    **Default:** `false` +
+    **Since:** 2.28 +
+    **Description:** +
 
 `jenkins.slaves.JnlpSlaveAgentProtocol3.enabled`::
     **Default:** undefined +
@@ -1008,9 +1038,14 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     **Description:** `true` to disable Nio for JNLP slaves
 
 `jenkins.slaves.StandardOutputSwapper.disabled`::
-    **Default:** TODO +
-    **Since:** n/a +
-    **Description:** TODO
+// TODO Unsure how this works. References:
+// - https://github.com/jenkinsci/jenkins/blob/3fd66ff22051a3309b8dc5130d8da0759ee27f48/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
+// - https://github.com/jenkinsci/remoting/commit/fad8c38724068dfbd155e64508e5d4c154240b87
+    **Default:** `false` +
+    **Since:** 1.429 +
+    **Description:** Some Unix-like agents (e.g. SSH Build Agents) can communicate via stdin/stdout, which is very convenient.
+    Unfortunately, some JVM output (e.g. related to GC) also goes to standard out.
+    This will swap output streams around to prevent stream corruption through unexpected writes to standard out.
 
 `jenkins.telemetry.Telemetry.endpoint`::
 // https://github.com/jenkinsci/jenkins/pull/3604
@@ -1021,7 +1056,7 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
 `jenkins.ui.refresh`::
     **Default:** `false` +
     **Since:** 2.222 +
-    **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see https://www.jenkins.io/sigs/ux/[Jenkins UX SIG].
+    **Description:** `+true+` to enable the new experimental UX on Jenkins. See https://issues.jenkins-ci.org/browse/JENKINS-60920[JENKINS-60920]. Also see link:/sigs/ux/[Jenkins UX SIG].
 
 `jenkins.util.ProgressiveRendering.DEBUG_SLEEP`::
     **Default:** 0 +
@@ -1035,11 +1070,13 @@ mv $JENKINS_HOME/jobs/[ORG_NAME]/jobs/[REPO_NAME]/branches/[BRANCH_NAME]/builds 
     `JENKINS_HOME` set via JNDI context has higher priority than this, but this takes precedence over the environment variable.
 
 `org.jenkinsci.main.modules.sshd.SSHD.idle-timeout`::
+// This is a core module, so this documentation should remain here.
     **Default:** undefined +
     **Since:** 2.22 +
     **Description:** Allows to configure the SSHD client idle timeout (value in milliseconds). Default value is 10min (600000ms).
 
 `org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT`::
+// TODO move to plugin documentation
     **Default:** 20 seconds +
     **Since:** workflow-durable-task-step-plugin 2.29  +
     **Description:** How long to wait for remote calls (see https://issues.jenkins-ci.org/browse/JENKINS-46507[JENKINS-46507]).


### PR DESCRIPTION
Based on https://github.com/jenkins-infra/jenkins.io/pull/3396, only the latest commit (as of opening the PR) is new here.

Migrate the System Properties page to a YAML based generated format. Much easier to restructure output when we don't need to re-do all the content every time.

Unfortunately, we need a workaround due to the following constraints:

* Handbook code expects all pages to be adoc, not haml.
* We cannot inline code in adoc as we can in haml (AFAIK).

This is resolved by creating a new layout for this one page. An alternative could be to extract the actual list out of the handbook, but it seems worse structurally even if the internals would be cleaner. I have no interest in revising handbook code to handle haml pages.

We're also reordering the page content a bit, as `page.content` needs to be one block, and all the generated content needs to be before or after. We could work around that by adding more data to the page and rendering it at the appropriate location in the layout, but probably good enough as is (IMO).

This version of the page ended up failing to properly jump to anchors on load for me (see https://github.com/jenkins-infra/jenkins.io/pull/3393#issuecomment-636510512), so I changed how we insert anchors, this now works for me in both Firefox and Chrome. CC @zbynek 