### PR TITLE
Add generated Jenkins inline help pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ content/doc/pipeline/steps/*.adoc
 # generated extension points documentation
 content/doc/developer/extensions/*.adoc
 
+# Jenkins built-in HTML help extracted from there
+content/doc/help/jenkins-core/
 
 # unknown
 /.sass-cache/

--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -69,6 +69,8 @@ section: doc
             = active_href('doc/pipeline/steps', 'Pipeline Steps reference')
           %li
             = active_href('doc/upgrade-guide', 'LTS Upgrade guides', :fuzzy => true)
+          %li
+            = active_href('doc/help', 'Jenkins help pages', :fuzzy => true)
 
     .col-lg-9
       - unless page.notitle

--- a/content/_layouts/inlinehelp.html.haml
+++ b/content/_layouts/inlinehelp.html.haml
@@ -1,0 +1,23 @@
+---
+layout: documentation
+section: doc
+title: Jenkins Help
+uneditable: true
+---
+
+%a{:href => '/doc/help'}
+    Back to index
+
+%div.admonitionblock.note
+    %table
+        %tr
+            %td.icon
+                %div.title
+                    Note
+            %td.content
+                This page is generated from Jenkins inline help intended to be rendered within the Jenkins UI.
+                Some minor content glitches are expected.
+
+%hr/
+
+= page.content

--- a/content/doc/help/index.html.haml
+++ b/content/doc/help/index.html.haml
@@ -1,0 +1,33 @@
+---
+layout: documentation
+section: doc
+title: Jenkins Help
+---
+
+%div.admonitionblock.note
+  %table
+    %tr
+      %td.icon
+        %div.title
+          Note
+      %td.content
+        These are inline help pages extracted from Jenkins and made available here for easy linking.
+        Some minor content glitches are expected.
+
+%hr/
+
+
+
+:ruby
+  html_pages = []
+  site.pages.each do |page|
+    next if page.layout.nil?
+    next unless page.layout == 'inlinehelp'
+    html_pages << page
+  end
+
+%ul
+  - html_pages.sort { |x, y| File.basename(File.dirname(x.url)) <=> File.basename(File.dirname(y.url)) }.each do |page|
+    %li
+      %a{ :href => page.url }
+        = "#{File.basename(File.dirname(page.url))} » #{File.basename(page.url)}"

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -18,11 +18,13 @@ RESOURCES = [
     'https://updates.jenkins.io/latestCore.txt',
     'content/_tmp/latestCore.txt',
     nil,
+    nil,
     nil
   ],
   [
     'https://updates.jenkins.io/stable/latestCore.txt',
     'content/_tmp/latestLTSCore.txt',
+    nil,
     nil,
     nil
   ],
@@ -30,17 +32,20 @@ RESOURCES = [
     'https://github.com/jenkinsci/pipeline-examples/archive/master.zip',
     'content/_tmp/pipeline-examples-master.zip',
     nil,
-    'content/_tmp/examples'
+    'content/_tmp/examples',
+    nil
   ],
   [
     'https://ci.jenkins.io/job/Infra/job/pipeline-steps-doc-generator/job/master/lastSuccessfulBuild/artifact/allAscii.zip',
     'content/_tmp/allAscii.zip',
     nil,
-    'content/doc/pipeline/steps'
+    'content/doc/pipeline/steps',
+    nil
   ],
   [
     'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1',
     'content/_data/_generated/lts_baselines.yml',
+    nil,
     nil,
     nil
   ],
@@ -48,13 +53,22 @@ RESOURCES = [
     'https://updates.jenkins.io/update-center.actual.json',
     'content/_data/_generated/update_center.yml',
     nil,
+    nil,
     nil
   ],
   [
     'https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/lastSuccessfulBuild/artifact/*.adoc/*zip*/extension-indexer.zip',
     'content/_tmp/extension-indexer.zip',
     nil,
-    'content/doc/developer/extensions'
+    'content/doc/developer/extensions',
+    nil
+  ],
+  [
+    'https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-core/2.222.4/jenkins-core-2.222.4.jar', # TODO figure out how to identify the latest release and download that
+    'content/_tmp/jenkins-core.zip',
+    { "layout": "inlinehelp" },
+    'content/doc/help/jenkins-core',
+    /.+(?<!_[a-z]{2})(?<!_[a-z]{2}_[A-Z]{2})[.]html/
   ],
 ]
 
@@ -77,7 +91,7 @@ class Fetcher
     failures = []
     puts "Fetching external resources:"
 
-    resources.each do |origin, destination, frontmatter, zip_dest|
+    resources.each do |origin, destination, frontmatter, zip_dest, zip_pattern|
       response = fetch_resource(origin)
 
       unless response.success?
@@ -88,7 +102,7 @@ class Fetcher
       FileUtils.mkdir_p File.dirname(destination)
 
       File.open(destination, 'w+') do |f|
-        if frontmatter
+        if frontmatter and !zip_dest
           f.write(frontmatter.to_yaml)
           f.write("---\n")
         end
@@ -110,9 +124,24 @@ class Fetcher
         FileUtils.mkdir_p zip_dest
 
         Zip::File.open(destination) do |zip_file|
-          zip_file.each do |f|
-            fpath = File.join(zip_dest, f.name)
-            zip_file.extract(f, fpath)
+          zip_file.each do |z|
+            if !zip_pattern || z.name =~ zip_pattern
+              fpath = File.join(zip_dest, z.name)
+              dirpath = File.dirname(fpath)
+
+              FileUtils.mkdir_p(dirpath)
+
+              if frontmatter
+                content = z.get_input_stream.read
+                File.open(fpath, 'w+') do |f|
+                  f.write(frontmatter.to_yaml)
+                  f.write("---\n")
+                  f.write(content)
+                end
+              else
+                zip_file.extract(z, fpath)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Many of them are not particularly useful outside the context of Jenkins, but for those it works for it's a lot nicer than linking to files within the GitHub repository.

Thoughts?

<details>
<summary>Screenshots</summary>

![index](https://user-images.githubusercontent.com/1831569/83432462-348d7b80-a439-11ea-8623-907de55cbf02.png)
![help](https://user-images.githubusercontent.com/1831569/83432477-3d7e4d00-a439-11ea-89d4-3539c0173df4.png)
