### PR TITLE
Migrate hudson.util.Secret

### DIFF
--- a/content/redirect/hudson.util.Secret.adoc
+++ b/content/redirect/hudson.util.Secret.adoc
@@ -1,4 +1,27 @@
----
-layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Secret+management
----
+[[Secretmanagement-Overview]]
+== Overview
+
+Jenkins provide class https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/Secret.java[hudson.util.Secret]
+to manage sensitive data in jenkins plugin. This class do offer to encrypt the sensitive value based on a confidential key generated first time jenkins is started on a fresh new `JENKINS_HOME`.
+
+This mechanism is used to store sensitive data in xml files, render web UI password elements, and more.
+
+[[Secretmanagement-UsebywebUI]]
+== Use by web UI
+
+Stapler is configured by Jenkins to support `Secret` for web UI data binding. You can declare `Secret` arguments for your
+DataBoundConstructor/DataBoundSetter, as well as getters. 
+
+If you use to accept a plain text password as DataBoundConstructor argument you can convert it to a `Secre` using
+https://javadoc.jenkins-ci.org/hudson/util/Secret.html#fromString-java.lang.String-[Secret.fromString].
+
+`<f:password>` jelly tag will render a `Secret` as an encrypted `String`, to avoid the actual value to leak in HTML DOM. If not modified by end-user, the encrypted value will be converted back to `Secret` when bound by stapler.
+
+[[Secretmanagement-Retrievingsensitivedata]]
+== Retrieving sensitive data
+
+Once you need to access the actual secret value as plain text, to configure some API or external tool, use
+https://javadoc.jenkins-ci.org/hudson/util/Secret.html#toString-hudson.util.Secret-[Secret.toString]
+to get a `Secret` instance decrypted into plain text value. For your convenience this method supports null argument.
+
+For legacy reasons, `Object.toString` is implemented as https://javadoc.jenkins-ci.org/hudson/util/Secret.html#toString--[Secret.toString] by dumping the decrypted value. This method is deprecated since `1.356`, but due to the inherited nature of `Object.toString` and general usage of `toString` to dump a representation of a class, you might not get notified by compiler that your code do rely on it. Typically, `toString` is implicitly invoked when you apply string concatenation using the operator.


### PR DESCRIPTION
Migrate from wiki to add more content afterwards.

I will add information about warnings showing up in console while debugging your code due to IDE calling `toString` on a Secret object.