### PR TITLE
[JEP-14] - Preview status, Initiative labels, Roadmap filtering

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -14,6 +14,32 @@ statuses:
 - id: future
   displayName: "Future"
   description: "We intend to work on that in the short term, but there is no ongoing development"
+labels:
+- name: feature
+  displayName: Features
+  description: New features and improvements for users and maintainers
+- name: documentation
+  displayName: Documentation
+  description: Documentation-focused initiatives
+  link: /sigs/docs
+- name: outreach-program
+  displayName: Outreach Programs
+  description: Initiatives which facilitate contributions to specific areas
+  link: /sigs/advocacy-and-outreach/outreach-programs/
+- name: infrastructure
+  displayName: Infrastructure and Services
+  description: Services for Jenkins users and developers provided by the Jenkins project infrastructure
+  link: /projects/infrastructure/
+- name: policies
+  displayName: Policies
+  description: Jenkins policies and governance
+- name: tools
+  displayName: Tools
+  description: Tools for Jenkins users and developers
+- name: events
+  displayName: Community Events
+  description: Jenkins community events, e.g. conferences, meetups, hackathons, etc.
+  link: /events
 categories:
   - name: Pipeline authoring and development tools
     description: Initiatives focused on improving Jenkins Pipeline and experience of Pipeline developers
@@ -23,41 +49,64 @@ categories:
       description: "JTE enables the creation of tool-agnostic pipeline templates that can be shared across teams. Version 2.0 will have improved integration with the underlying pipeline engine and incorporate many of the community's top feature requests." 
       status: near-term
       link: https://github.com/jenkinsci/templating-engine-plugin/blob/2.0/Version_2.adoc
+      labels:
+      - feature
     - name: Pipeline development in IDE
       description: IDE integration, editors, and other development tools - IDE plugins, visual editors, etc
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-35396
+      labels:
+      - feature
     - name: Pipeline syntax improvements
       description: How Jenkinsfiles and shared libraries are written
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-55287
+      labels:
+      - feature
     - name: Static code analysis and linting
       description: A method of debugging by automatically examining pipeline before it is run
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-52939
+      labels:
+      - feature
+      - tools
     - name: Pipeline functional testing tools
       description: Unit and functional testing of Jenkinsfiles and shared libraries
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-61935
+      labels:
+      - feature
+      - tools
     - name: Pipeline integration testing tools
       description: The Pipeline Unit Testing Framework allows which allows the ability to test pipelines and shared Libraries before running
       status: future
+      labels:
+      - feature
+      - tools
     - name: Pipeline Documentation
       description: Reference documentation, tutorials, and more
       status: future
+      labels:
+      - documentation
     - name: Pipeline as YAML
       description: Official support for defining Jenkins Pipelines in YAML, without additional Pipeline libraries
       status: preview
       link: https://jenkins.io/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
+      labels:
+      - feature
     - name: Promotion support for Pipeline jobs
       description: Provide out-of-the-box support for manual and automatic promotion of build artifacts in a separate Pipeline after the job completion
       status: future
       link: https://issues.jenkins-ci.org/browse/JENKINS-36089
+      labels:
+      - feature
     - name: Improve Pipeline step documentation generator
       status: future
       description: >
         Enhance the Jenkins Pipeline documentation generator to produce better documentation for thousands of Pipeline developers.
       link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/pipeline-step-documentation-generator/
+      labels:
+      - documentation
   - name: Tool and Service integrations
     description: >
       Initiatives focused on integrations with various external tools and services.
@@ -66,51 +115,126 @@ categories:
     - name: "Pipeline: GitHub App authentication"
       status: released
       link: https://www.jenkins.io/blog/2020/04/16/github-app-authentication/
+      labels:
+      - feature
     - name: "Git Plugin Performance Improvements"
       status: current
       description: >
         Improve Jenkins git plugin performance by fixing known issues in performance critical areas
       link: https://www.jenkins.io/projects/gsoc/2020/projects/git-plugin-performance/
+      labels:
+      - feature
     - name: "GitHub Checks API integrations"
       status: current
       description: >
         Create a new plugin API so that plugins can publish GitHub Checks statuses.
         Implement Checks API support in Warnings NG and Code Coverage API plugins.
       link: https://www.jenkins.io/projects/gsoc/2020/projects/github-checks/
+      labels:
+      - feature
     - name: Machine Learning Plugin for Data Science
       status: current
       description: >
         Integrate Machine Learning workflow with Jenkins build tasks, including Data preprocessing, Model Training, Evaluation and Prediction.
         This plugin will be capable of executing code fragments via IPython kernel as currently supported by Jupyter.
       link: https://www.jenkins.io/projects/gsoc/2020/projects/machine-learning/
+      labels:
+      - feature
     - name: OpenAPI for Jenkins core and plugins
       status: future
       description: >
         Expose Jenkins REST APIs as the OpenAPI Specification so that users could easily integrate with Jenkins and create clients for it.
       link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api/
+      labels:
+      - feature
     - name: "Docker: image changes polling and security scans"
       status: future
       description: >
         Create a new Jenkins plugin to automate polling of image changes and security scans.
       link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/docker-registries-polling-plugin/
+      labels:
+      - feature
   - name: User experience and interface
     description: Initiatives focused on improving the Jenkins user interface and user experience
     link: /sigs/ux
     initiatives:
+    - name: Static plugin site
+      description: Convert plugins.jenkins.io to a static site and put it behind CDN to improve performance and user experience
+      status: released
+      link: https://plugins.jenkins.io/
+      labels:
+      - infrastructure
+      - documentation
+    - name: "Jenkins UI/UX online hackfest"
+      status: released
+      description: >
+        A week-long event with the goal of driving improvements in user experience in multiple areas:
+        user interface, user documentation and user success stories.
+        Planned start date: May 25, 2020.
+      link: https://www.jenkins.io/events/online-hackfest/2020-uiux/
+      labels:
+      - outreach-program
+      - events
     - name: "UI/UX: Look and Feel updates"
       status: current
       description: "Modernize the Jenkins Web interface styling and appearance"
       link: https://jenkins.io/sigs/ux/#project-ui-look-and-feel
+      labels:
+      - feature
     - name: "Plugin manager UX revamp"
       description: Better visualization and search for plugins
       status: current
+      labels:
+      - feature
+    - name: Plugin docs migration to GitHub
+      description: Host plugin documentation on GitHub rather than the Jenkins Wiki
+      status: current
+      link: https://jenkins.io/sigs/docs/#ongoing-projects
+      labels:
+      - documentation
+    - name: Docs migration to jenkins.io
+      description: Migrate remaining documentation from the Jenkins Wiki to jenkins.io
+      status: current
+      link: https://issues.jenkins-ci.org/browse/INFRA-2328
+      labels:
+      - documentation
+    - name: Agent terminology cleanup
+      description: In Jenkins 2.0 we deprecated the old "slave" terminology, but there are still occurrences in documentation and some components. We want to clean them up.
+      status: current
+      link: https://issues.jenkins-ci.org/browse/JENKINS-42816
+      labels:
+      - documentation
+      - feature
     - name: "UI/UX: Accessibility"
       status: near-term
       description: Improve Jenkins navigation and layouts to make it more usable by as many user groups as possible.
       link: https://jenkins.io/sigs/ux/#project-ui-accessibility
+      labels:
+      - feature
     - name: "UI/UX: User interface rework"
       status: future
       link: https://jenkins.io/sigs/ux/#project-ui-overhaul
+      labels:
+      - feature
+    - name: User Guide improvements
+      description: Improve Jenkins User Guide with pipeline examples, additional tutorials, and better navigation
+      status: future
+      link: https://issues.jenkins-ci.org/browse/WEBSITE-739
+      labels:
+      - documentation
+    - name: Solution Pages
+      description: Improve the navigation and content of the solution pages
+      status: future
+      link: https://issues.jenkins-ci.org/browse/WEBSITE-742
+      labels:
+      - documentation
+    - name: Modernize mirror infrastructure
+      description: >
+        Improve and expand the mirror infrastructure to provide fast and reliable downloads to Jenkins users.
+      status: near-term
+      link: https://issues.jenkins-ci.org/browse/INFRA-2516
+      labels:
+      - infrastructure
   - name: Management and Administration
     description: "Initiatives which help to manage Jenkins as Code: JCasC Plugin, etc."
     initiatives:
@@ -119,41 +243,63 @@ categories:
         Ensure wide support for Jenkins Configuration-as-Code in the Jenkins core and plugins.
       status: current
       link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/809
+      labels:
+      - feature
     - name: 'JEP-222: Remoting over WebSockets'
       status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/222
+      labels:
+      - feature
     - name: 'JEP-223: Manage permissions'
       status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/223
+      labels:
+      - feature
     - name: 'JEP-224: SystemRead permissions'
       description: >
         Update Jenkins Web UI to support read-only access to system configuration and diagnostics information.
         It complements Jenkins Configuration-as-Code stories by preventing undesired manual modifications on running instances.
       status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/224
+      labels:
+      - feature
     - name: "Windows Services: YAML Configuration Support"
       status: current
       description: >
         Enhance Jenkins master and agent service management on Windows by
         offering new configuration file formats and improving settings validation.
       link: https://www.jenkins.io/projects/gsoc/2020/projects/winsw-yaml-configs/
+      labels:
+      - feature
     - name: Built-in plugin management as-code
       description: >
         Evolution of plugin management capabilities in the Jenkins core and Docker images.
         It includes adoption of the new Plugin Management Tool in distributions, and support of advanced plugin definition formats like YAML.
       status: near-term
       link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool/
+      labels:
+      - feature
     - name: "JCasC: Pluggable configuration sources"
       description: >
         Support external configuration sources in the Jenkins Configuration-as-Code plugin.
         Examples of potential configuration sources: Git, S3 Buckets, Kubernetes CRD.
       status: future
       link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/1365
+      labels:
+      - feature
+    - name: Administrator Guide overhaul
+      description: Create a Jenkins Administrator Guide from the administration content in the Jenkins Handbook
+      status: future
+      link: https://issues.jenkins-ci.org/browse/WEBSITE-738
+      labels:
+      - documentation
     - name: "Better Remoting Monitoring"
       status: future
       description: >
         Support monitoring of Jenkins networking (master to agent communications, etc.) with open source monitoring tools such as Prometheus, Grafana, etc.
       link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/remoting-monitoring/
+      labels:
+      - feature
 #  - name: Jenkins Security
 #    description: "Public security hardening and management initiatives. Vulnerability fixes are not listed"
 #    initiatives:
@@ -169,26 +315,50 @@ categories:
         It has been built with Immutability and declarative Configuration as Code in mind.
       status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/219
+      labels:
+      - feature
     - name: 'Jenkinsfile Runner 1.0'
       description: >
         Finalization of Jenkinsfile Runner prototype which would allow running jobs and pipelines as Function-as-Service in cloud environments.
       status: preview
       link: https://github.com/jenkinsci/jenkinsfile-runner
+      labels:
+      - feature
     - name: 'External Fingerprint Storage'
       description: >
         Extend Jenkins to support storing artifact usage history in external databases.
       status: current
       link: https://www.jenkins.io/projects/gsoc/2020/projects/external-fingerprint-storage
+      labels:
+      - feature
+    - name: "Jenkins on Kubernetes online meetups"
+      status: current
+      description: >
+        Promote best practices and success stories for Jenkins on Kubernetes by organizing a series of online meetups.
+      link: https://www.meetup.com/Jenkins-online-meetup/
+      labels:
+      - outreach-program
+      - events
     - name: 'Jenkins FaaS Capability'
       description: >
         Continued development of the Jenkinsfile Runner and its packaging/development tools to simplify usage of the tool as Function-as-Service.
       status: near-term
       link: https://github.com/jenkinsci/jenkinsfile-runner
+      labels:
+      - feature
+    - name: Document Jenkins on Kubernetes
+      description: Describe the concepts, techniques, and choices available for Jenkins on Kubernetes
+      status: near-term
+      link: https://jenkins.io/sigs/docs/#jenkins-on-kubernetes
+      labels:
+      - documentation
     - name: 'Tekton support'
       description: >
         Support triggering Tekton pipelines as a part of the Jenkins Pipeline ecosystem.
       status: future
       link: https://cloud.google.com/tekton
+      labels:
+      - feature
   - name: Packaging and platform support
     link: /sigs/platform
     initiatives:
@@ -196,207 +366,253 @@ categories:
       description: Official Windows Docker images for Jenkins masters and agents.
       status: released
       link: https://www.jenkins.io/blog/2020/05/11/docker-windows-agents/
+      labels:
+      - feature
     - name: Docker images for IBM s390x
       status: current
       description: Docker image support for IBM series 390 mainframes running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61773
+      labels:
+      - feature
     - name: Docker images for PowerPC 64
       status: current
       description: Docker image support for IBM PowerPC 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61774
+      labels:
+      - feature
     - name: OpenJ9 Docker images
       status: current
       description: We would like to provide official images based on OpenJ9 JVM
       link: https://issues.jenkins-ci.org/browse/JENKINS-62150
+      labels:
+      - feature
     - name: Docker images for ARM 64
       status: near-term
       description: Docker image support for ARM 64 running Java 8 and Java 11
       link: https://issues.jenkins-ci.org/browse/JENKINS-61775
+      labels:
+      - feature
     - name: Multi-platform Docker images
       status: near-term
       link: https://issues.jenkins-ci.org/browse/JENKINS-52785
+      labels:
+      - feature
     - name: New Windows installer
-      description: Rework of the Windows installer user experience
+      description: Rework of the Windows installer user experience. Java unbundling, account and port setup.
       status: preview
       link: https://jenkins.io/blog/2019/02/01/windows-installers/
-    - name: New Windows support policy
+      labels:
+      - feature
+    - name: Windows support policy
       description: Currently Jenkins has no documented Windows Support policy. We want to add one and to deprecate/remove support for old platforms
       status: released
       link: https://www.jenkins.io/doc/administration/requirements/windows/
+      labels:
+      - documentation
+      - policies
     - name: Migration to AdoptOpenJDK in distributions
       description: >
         Currently Jenkins uses OpenJDK in the most of official Docker packages.
         We would like to migrate to AdoptOpenJDK which offers wider range of supported platforms.
       status: current
       link: https://issues.jenkins-ci.org/browse/JENKINS-61865
+      labels:
+      - feature
     - name: Custom Jenkins distribution build service
       description: >
         We would like to create a new service which would allow users to configure and build their own Jenkins distributions,
         with custom plugin sets and configurations included.
       status: near-term
       link: https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
+      labels:
+      - feature
+      - infrastructure
     - name: Java 14+ support
       description: >
         We would like to support future mainstream JVM versions (Java 14+).
         Right now Jenkins runs well on Java 11, but we may need to do some changes towards the next LTS baseline.
       status: future
       link: https://jenkins.io/sigs/platform/#java-support
+      labels:
+      - feature
     - name: Cloud native Java support
       description: >
         We are interested to run Jenkins in cloud native environments.
         To do so, we would like to introduce support for perspective virtual machines like GraalVM or Quarkus.
       status: future
       link: https://jenkins.io/sigs/platform/#java-support
-  - name: Documentation
-    link: /sigs/docs
+      labels:
+      - feature
+  - name: Jenkins developer tools and services
+    description: >
+      Solutions and tools for Jenkins developers and contributors.
+      User-focused developer tools, e.g. for Pipeline development, are listed in other sections. 
     initiatives:
-    - name: Static plugin site
-      description: Convert plugins.jenkins.io to a static site
-      status: released
-      link: https://plugins.jenkins.io/
-    - name: Plugin docs migration to GitHub
-      description: Host plugin documentation on GitHub rather than the Jenkins Wiki
-      status: current
-      link: https://jenkins.io/sigs/docs/#ongoing-projects
-    - name: Docs migration to jenkins.io
-      description: Migrate remaining documentation from the Jenkins Wiki to jenkins.io
-      status: current
-      link: https://issues.jenkins-ci.org/browse/INFRA-2328
-    - name: Jenkins on Kubernetes
-      description: Describe the concepts, techniques, and choices available for Jenkins on Kubernetes
-      status: future
-      link: https://jenkins.io/sigs/docs/#jenkins-on-kubernetes
-    - name: Administrator Guide
-      description: Create a Jenkins Administrator Guide from the administration content in the Jenkins Handbook
-      status: future
-      link: https://issues.jenkins-ci.org/browse/WEBSITE-738
-    - name: User Guide improvements
-      description: Improve Jenkins User Guide with pipeline examples, additional tutorials, and better navigation
-      status: future
-      link: https://issues.jenkins-ci.org/browse/WEBSITE-739
-    - name: Solution Pages
-      description: Improve the navigation and content of the solution pages
-      status: future
-      link: https://issues.jenkins-ci.org/browse/WEBSITE-742
-  - name: Infrastructure
-    link: /projects/infrastructure/
-    initiatives:
-    - name: ACS to AKS migration
-      status: released
-      link: https://issues.jenkins-ci.org/browse/INFRA-1797
     - name: Core release automation
       status: preview
       link: https://issues.jenkins-ci.org/browse/INFRA-910
-    - name: Migrate Jenkins agents to AWS
-      status: preview
-      link: https://issues.jenkins-ci.org/browse/INFRA-2525
-    - name: ci.jenkins.io as code
-      status: near-term
-      description: Define and maintain ci.jenkins.io configuration as code rather than through the user interface
-    - name: Modernize mirror infrastructure
-      status: near-term
-      link: https://issues.jenkins-ci.org/browse/INFRA-2516
-  - name: Jenkins plugin and core developer tools
-    description: >
-      Developer tools for Jenkins plugin and core developers.
-      User-focused developer tools, e.g. for Pipeline development, are listed in other sections.
-    link: /projects/infrastructure/
-    initiatives:
+      labels:
+      - infrastructure
     - name: Jenkins core BOM
       description: > 
         This Bill of Materials lists libraries and versions supplied by the Jenkins core.
         It can be used by plugin developers to prevent risk of binary conflicts between plugins.
       status: released
       link: https://jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-core-bom
+      labels:
+      - tools
     - name: Plugin POM 4.0
       description: >
         New Plugin POM release which enables best practices like Jenkins Core bill of materials by design.
       status: released
       link: https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.0
+      labels:
+      - tools
     - name: Jenkins plugin BOM
       description: >
         This Bill of materials can be used by plugin developers to more easily manage dependencies on other common plugins.
         It includes a cross-verified set of plugins compatible with a particular Jenkins core baseline.
       status: preview
       link: https://github.com/jenkinsci/bom
+      labels:
+      - tools
     - name: Static analysis for security issues
       description: >
         Extending static analysis to discover potential security issues with help of the Find Security Bugs tools.
       status: preview
       link: https://groups.google.com/forum/#!msg/jenkinsci-dev/exd3fc9NUAg/xn--6vNSBgAJ
+      labels:
+      - tools
     - name: "Changelog automation"
       description: >
         Jenkins project now offers changelog automation powered by Release Drafter GitHub Apps or GitHub Actions.
         We would like to update the flow and to support changelog generation within Jenkins pipelines.
       status: preview
       link: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+      labels:
+      - tools
+      - documentation
     - name: "Automated Dependency management"
       description: >
         We want to widely adopt Dependabot in the project to simplify dependency management along with BOMs.
         In order to do so, additional Jenkins-specific guidelines and documentation are needed.
       status: current
       link: https://groups.google.com/forum/#!searchin/jenkinsci-dev/dependabot%7Csort:date/jenkinsci-dev/XMllKuWLO_8/5hagrjApEgAJ
+      labels:
+      - tools
     - name: "JEP-217: Infrastructure for Experimental Docker images"
       description: >
         Provide a storage for experimental Jenkins Docker images so that maintainers can build and deploy untrusted images
         from ci.jenkins.io and other services.
       status: near-term
       link: https://github.com/jenkinsci/jep/blob/master/jep/217
+      labels:
+      - infrastructure
     - name: "JEP-221: Continuous Delivery of Jenkins Plugins"
       description: >
         Introduce a new system which would enable Jenkins plugin maintainers to add Continuous Delivery (CD) to their projects.
       status: future
       link: https://github.com/jenkinsci/jep/blob/master/jep/221
-  - name: Community marketing and outreach programs
-    description: Initiatives related to promoting Jenkins and facilitating contributions to the project
-    link: /sigs/advocacy-and-outreach/
+      labels:
+      - tools
+      - infrastructure
+  - name: Contributing to Jenkins
+    description: >
+      Initiatives focused on onboarding and enabling Jenkins contributors.
+      It includes helping newcomers to join the project,
+      and helping experienced contributors to step up and take maintainer and other roles in the project.
+    link: /participate
     initiatives:
+    - name: Plugin adoption process revamp
+      status: released
+      link: https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/
+      labels:
+      - documentation
+      - policies  
     - name: Contributor guidelines refresh 
       status: preview
       link: https://issues.jenkins-ci.org/browse/WEBSITE-662
+      labels:
+      - community
+      - documentation
     - name: Google Summer of Code 2020
       status: current
       link: https://jenkins.io/projects/gsoc/2020
-    - name: Agent terminology cleanup
-      description: In Jenkins 2.0 we deprecated the old "slave" terminology, but there are still occurrences in documentation and some components. We want to clean them up.
+      labels:
+      - outreach-program
+      - events
+      - feature
+    - name: Google Season of Docs 2020
       status: current
-      link: https://issues.jenkins-ci.org/browse/JENKINS-42816
+      link: https://www.jenkins.io/sigs/docs/gsod/
+      labels:
+      - outreach-program
+      - documentation
+      - events
+    - name: Community Bridge Mentorship
+      status: future
+      link: https://jenkins.io/sigs/advocacy-and-outreach/outreach-programs/#community-bridge
+      labels:
+      - outreach-program
+      - community
+      - events
+    - name: Hacktoberfest 2020
+      status: future
+      link: https://jenkins.io/events/hacktoberfest/
+      labels:
+      - outreach-program
+      - feature
+      - documentation
+      - community
+      - events
+  - name: Community advocacy and marketing
+    description: Initiatives related to promoting Jenkins and facilitating contributions to the project
+    link: /sigs/advocacy-and-outreach/
+    initiatives:
     - name: Jenkins Is The Way program
       status: released
       description: >
         Jenkins Is The Way is a collection of experiences from all around the world showcasing how users are building, deploying, and automating great stuff with Jenkins. 
       link: https://www.jenkins.io/blog/2020/04/30/jenkins-is-the-way/
+      labels:
+      - outreach-program
     - name: New online meetup platform
       status: released
       description: >
         Make it possible to regularly host Jenkins online meetups and webinars.
       link: https://www.jenkins.io/events/online-meetup/
-    - name: "Jenkins UI/UX online hackfest"
-      status: released
-      description: >
-        A week-long event with the goal of driving improvements in user experience in multiple areas:
-        user interface, user documentation and user success stories.
-        Planned start date: May 25, 2020.
-      link: https://www.jenkins.io/events/online-hackfest/2020-uiux/
-    - name: "Jenkins on Kubernetes online meetups"
-      status: current
-      description: >
-        Promote best practices and success stories for Jenkins on Kubernetes by organizing a series of online meetups.
-      link: https://www.meetup.com/Jenkins-online-meetup/
-    - name: Google Season of Docs 2020
-      status: current
-      link: https://www.jenkins.io/sigs/docs/gsod/
+      labels:
+      - outreach-program
+      - infrastructure
     - name: Jenkins on LinkedIn
       status: near-term
       description: >
         Extend and automate Jenkins presence in LinkedIn so that we could outreach to its users and facilitate adoption and contributions.
       link: https://www.linkedin.com/company/1846812/admin/
-    - name: Community Bridge Mentorship
-      status: future
-      link: https://jenkins.io/sigs/advocacy-and-outreach/outreach-programs/#community-bridge
-    - name: Hacktoberfest 2020
-      status: future
-      link: https://jenkins.io/events/hacktoberfest/
+      labels:
+      - outreach-program
+  - name: Jenkins Project Internals
+    description: >
+      Initiatives which focus on project internals which have no immediate impact on users.
+      It includes the project infrastructure maintenance and similar topics which are critical to the project health.
+    initiatives:
+    - name: ACS to AKS migration
+      status: released
+      link: https://issues.jenkins-ci.org/browse/INFRA-1797
+      labels:
+      - infrastructure
+    - name: "Migrate ci.jenkins.io agents to AWS"
+      description: >
+        Migration of agent workload from Azure to AWS in order to optimize the infrastructure costs for the project.
+      status: preview
+      link: https://issues.jenkins-ci.org/browse/INFRA-2525
+      labels:
+      - infrastructure
+    - name: ci.jenkins.io as code
+      status: near-term
+      description: Define and maintain ci.jenkins.io configuration as code rather than through the user interface
+      labels:
+      - infrastructure
   - name: Governance
     description: Initiatives targeting project governance, policies, funding, etc. 
     link: /project
@@ -404,18 +620,23 @@ categories:
     - name: Public roadmap
       status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/14
+      labels:
+      - documentation
+      - policies
     - name: Funding through Community Bridge
       status: current
       link: https://issues.jenkins-ci.org/browse/INFRA-2396
-    - name: Plugin adoption process revamp
-      status: released
-      link: https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/
+      labels:
+      - policies
     - name: Core Infrastructure Initiative compliance
       status: near-term
       description: >
         Pass the Core Infrastructure Initiative (CII) compliance certification so that we are aligned with Linux Foundation quality and security standards.
         It unlocks targeted security projects funding and access to additional developer tools and services.
       link: https://groups.google.com/forum/#!msg/jenkinsci-dev/n1qH1K5_td0/pA_nUN_6BgAJ
+      labels:
+      - documentation
+      - policies
     - name: 2020 Governance Board and Officer elections
       status: future
       description: >
@@ -426,3 +647,5 @@ categories:
       status: future
       description: >
         Introduce an official entity which would drive Jenkins architecture and the technical roadmap.
+      labels:
+      - policies

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -2,6 +2,9 @@ statuses:
 - id: released
   displayName: "Released"
   description: "The initiative is completed"
+- id: preview
+  displayName: "Preview"
+  description: "This initiative is available to Jenkins users and contributors as preview. We would appreciate testing and any feedback!"
 - id: current
   displayName: "Current"
   description: "Things being worked on presently with a specific scope, typically a JEP, though no specific delivery dates"
@@ -44,7 +47,7 @@ categories:
       status: future
     - name: Pipeline as YAML
       description: Official support for defining Jenkins Pipelines in YAML, without additional Pipeline libraries
-      status: current
+      status: preview
       link: https://jenkins.io/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
     - name: Promotion support for Pipeline jobs
       description: Provide out-of-the-box support for manual and automatic promotion of build artifacts in a separate Pipeline after the job completion
@@ -117,16 +120,16 @@ categories:
       status: current
       link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/809
     - name: 'JEP-222: Remoting over WebSockets'
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/222
     - name: 'JEP-223: Manage permissions'
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/223
     - name: 'JEP-224: SystemRead permissions'
       description: >
         Update Jenkins Web UI to support read-only access to system configuration and diagnostics information.
         It complements Jenkins Configuration-as-Code stories by preventing undesired manual modifications on running instances.
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/224
     - name: "Windows Services: YAML Configuration Support"
       status: current
@@ -164,12 +167,12 @@ categories:
       description: >
         Further evolution of a Kubernetes Native Operator which manages operations for Jenkins on Kubernetes.
         It has been built with Immutability and declarative Configuration as Code in mind.
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/219
     - name: 'Jenkinsfile Runner 1.0'
       description: >
         Finalization of Jenkinsfile Runner prototype which would allow running jobs and pipelines as Function-as-Service in cloud environments.
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jenkinsfile-runner
     - name: 'External Fingerprint Storage'
       description: >
@@ -214,7 +217,7 @@ categories:
       link: https://issues.jenkins-ci.org/browse/JENKINS-52785
     - name: New Windows installer
       description: Rework of the Windows installer user experience
-      status: current
+      status: preview
       link: https://jenkins.io/blog/2019/02/01/windows-installers/
     - name: New Windows support policy
       description: Currently Jenkins has no documented Windows Support policy. We want to add one and to deprecate/remove support for old platforms
@@ -282,10 +285,10 @@ categories:
       status: released
       link: https://issues.jenkins-ci.org/browse/INFRA-1797
     - name: Core release automation
-      status: current
+      status: preview
       link: https://issues.jenkins-ci.org/browse/INFRA-910
     - name: Migrate Jenkins agents to AWS
-      status: current
+      status: preview
       link: https://issues.jenkins-ci.org/browse/INFRA-2525
     - name: ci.jenkins.io as code
       status: near-term
@@ -314,18 +317,18 @@ categories:
       description: >
         This Bill of materials can be used by plugin developers to more easily manage dependencies on other common plugins.
         It includes a cross-verified set of plugins compatible with a particular Jenkins core baseline.
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/bom
     - name: Static analysis for security issues
       description: >
         Extending static analysis to discover potential security issues with help of the Find Security Bugs tools.
-      status: current
+      status: preview
       link: https://groups.google.com/forum/#!msg/jenkinsci-dev/exd3fc9NUAg/xn--6vNSBgAJ
     - name: "Changelog automation"
       description: >
         Jenkins project now offers changelog automation powered by Release Drafter GitHub Apps or GitHub Actions.
         We would like to update the flow and to support changelog generation within Jenkins pipelines.
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
     - name: "Automated Dependency management"
       description: >
@@ -349,7 +352,7 @@ categories:
     link: /sigs/advocacy-and-outreach/
     initiatives:
     - name: Contributor guidelines refresh 
-      status: current
+      status: preview
       link: https://issues.jenkins-ci.org/browse/WEBSITE-662
     - name: Google Summer of Code 2020
       status: current
@@ -399,7 +402,7 @@ categories:
     link: /project
     initiatives:
     - name: Public roadmap
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jep/tree/master/jep/14
     - name: Funding through Community Bridge
       status: current

--- a/content/css/roadmap.css
+++ b/content/css/roadmap.css
@@ -140,6 +140,13 @@ table.roadmap-table {
       background: -ms-linear-gradient(90deg, #9677df 0%, #7347d5 100%);
       background: -o-linear-gradient(90deg, #9677df 0%, #7347d5 100%);
       background: linear-gradient(90deg, #9677df 0%, #7347d5 100%); }
+    table.roadmap-table tbody tr td .preview a {
+        background: #7b817c;
+        background: -webkit-linear-gradient(90deg, #7b817c 0%, #6b816f 100%);
+        background: -moz-linear-gradient(90deg, #7b817c 0%, #6b816f 100%);
+        background: -ms-linear-gradient(90deg, #7b817c 0%, #6b816f 100%);
+        background: -o-linear-gradient(90deg, #7b817c 0%, #6b816f 100%);
+        background: linear-gradient(90deg, #7b817c 0%, #6b816f 100%); }
     table.roadmap-table tbody tr td .released a {
       background: #2dbda8;
       background: -webkit-linear-gradient(90deg, #2dbda8 0%, #1aab40 100%);

--- a/content/js/roadmap.js
+++ b/content/js/roadmap.js
@@ -1,0 +1,35 @@
+function filterRoadmap() {
+    // Declare variables
+    var input, filter, table, tr, td, i, txtValue;
+    selectors = document.getElementsByClassName("initiative-selector");
+    filters = []
+    filterInitiatives = false
+    for (i = 0; i < selectors.length; i++) {
+        selector = selectors[i]
+        if (selector.checked == true){
+            filters.push(selector.id)
+            filterInitiatives = true
+        }
+    }
+
+   // table = document.getElementsByClassName("roadmap-table");
+    initiatives = document.getElementsByClassName("initiative");
+  
+    // Loop through all table rows, and hide those who don't match the search query
+    for (i = 0; i < initiatives.length; i++) {
+      initiative = initiatives[i];
+      display = !filterInitiatives
+      for (j = 0; j < filters.length; j++) {
+        if (initiative.classList.contains(filters[j])) {
+            display = true
+            break
+        }
+      }
+      if (display) {
+          initiative.style.display = "";
+        } else {
+          initiative.style.display = "none";
+        }
+    }
+}
+  

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -46,7 +46,7 @@ tags:
   %tbody
     - site.roadmap[:roadmap].categories.each do | category |
       %tr.status-category
-        %td.cat-name{:colspan => 4}
+        %td.cat-name{:colspan => 5}
           %span
             = category.name
       %tr

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -8,6 +8,7 @@ tags:
 ---
 
 %link{:href => "/css/roadmap.css", :rel => "stylesheet", :type => "text/css"}/
+%script{:src => expand_link('js/roadmap.js'), :type => "text/javascript"}
 
 :ruby
   def tooltip_href(url, title)
@@ -30,6 +31,12 @@ tags:
   %a{:href => "/participate/"}
     Contributing to Jenkins
 
+%p
+  Filters:
+  - site.roadmap[:roadmap].labels.each do | label |
+    %input{:type=>"checkbox", :class => "initiative-selector", :id =>"initiative-label-#{label.name}", :onclick=>"filterRoadmap()"}
+      = label.displayName
+
 %table.roadmap-table
   %thead
     %tr
@@ -47,8 +54,11 @@ tags:
           %td{:class => "status #{status.id}", "data-header" => status.displayName}
             - category.initiatives.each do | initiative |
               - if initiative.status == status.id
-
-                %div{:class => "status #{status.id}"}
+                - labelClasses = ""
+                - if initiative.labels
+                  - initiative.labels.each do | label |
+                    - labelClasses = "#{labelClasses} initiative-label-#{label}"
+                %div{:class => "status initiative #{status.id} #{labelClasses}"}
                   - # TODO(oleg-nenashev): Better default link for work-in-progress items?
                   - itemLink = initiative.link.nil? ? "/project/roadmap" : initiative.link
                   - itemTooltip = initiative.description.nil? ? status.description : initiative.description


### PR DESCRIPTION
See the discussion in https://groups.google.com/forum/#!topic/jenkinsci-dev/Ez7nZxlxSWk

- [x] Add support for the Preview status in the roadmap
- [x] Regroup items: Documentation, Infrastructure and Outreach programs are largely merged into other categories where appropriate
- [x] Add initiative labels and support for filtering roadmap by labels

Preview status:

![image](https://user-images.githubusercontent.com/3000480/84308779-68665080-ab5f-11ea-9e19-5ffb744d986e.png)

Filtering:

![image](https://user-images.githubusercontent.com/3000480/84501276-84c8d100-acb6-11ea-8e19-2da2252f0eb7.png)

