### PR TITLE
Fix CloudBees link and alt text in sponsor images

### DIFF
--- a/content/blog/2020/04/2020-04-30-jenkins-is-the-way.adoc
+++ b/content/blog/2020/04/2020-04-30-jenkins-is-the-way.adoc
@@ -64,4 +64,4 @@ Thanks to the Jenkins Advocacy and Outreach SIG for their reviews and feedback.
 
 Thanks also to CloudBees for sponsoring the "*Jenkins is the Way*" program.
 
-image:/images/sponsors/cloudbees.png[CloudBees]
+image:/images/sponsors/cloudbees.png[CloudBees,link="https://cloudbees.com"]

--- a/content/blog/2020/05/2020-05-12-uiux-hackfest-announcement.adoc
+++ b/content/blog/2020/05/2020-05-12-uiux-hackfest-announcement.adoc
@@ -121,5 +121,5 @@ link:https://cd.foundation/[Continuous Delivery Foundation (CDF)].
 In addition to swag, CloudBees donates working time for event hosts and reviewers.
 CDF also sponsors our link:/events/online-meetup[online meetup platform] which we will be using for the event.
 
-image:/images/sponsors/cloudbees.png[link="https://plugins.jenkins.io/mailer"]
-image:/images/sponsors/cdf.png[link="https://cd.foundation/"].
+image:/images/sponsors/cloudbees.png[CloudBees, link="https://cloudbees.com/"]
+image:/images/sponsors/cdf.png[Continuous Delivery Foundation, link="https://cd.foundation/"].

--- a/content/events/online-hackfest/2020-uiux/index.adoc
+++ b/content/events/online-hackfest/2020-uiux/index.adoc
@@ -357,5 +357,5 @@ link:https://cd.foundation/[Continuous Delivery Foundation (CDF)].
 In addition to swag, CloudBees donates working time for event hosts and reviewers.
 CDF also sponsors our link:/events/online-meetup[online meetup platform] which we will be using for the event.
 
-image:/images/sponsors/cloudbees.png[link="https://plugins.jenkins.io/mailer"]
-image:/images/sponsors/cdf.png[link="https://cd.foundation/"].
+image:/images/sponsors/cloudbees.png[CloudBees, link="https://cloudbees.com/"]
+image:/images/sponsors/cdf.png[Continuous Delivery Foundation, link="https://cd.foundation/"].


### PR DESCRIPTION
## Fix CloudBees link and alt text in sponsor images

Previously some of the links were directed to the mailer plugin rather than to the CloudBees.com web site.

Previously some of the images did not have alt text.  The page is a
little more accessible if the image has alt text.