### PR TITLE
Removing items from roadmap for pipeline-auth sig

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -54,35 +54,8 @@ categories:
     - name: Pipeline development in IDE
       description: IDE integration, editors, and other development tools - IDE plugins, visual editors, etc
       status: future
-      link: https://issues.jenkins-ci.org/browse/JENKINS-35396
       labels:
       - feature
-    - name: Pipeline syntax improvements
-      description: How Jenkinsfiles and shared libraries are written
-      status: future
-      link: https://issues.jenkins-ci.org/browse/JENKINS-55287
-      labels:
-      - feature
-    - name: Static code analysis and linting
-      description: A method of debugging by automatically examining pipeline before it is run
-      status: future
-      link: https://issues.jenkins-ci.org/browse/JENKINS-52939
-      labels:
-      - feature
-      - tools
-    - name: Pipeline functional testing tools
-      description: Unit and functional testing of Jenkinsfiles and shared libraries
-      status: future
-      link: https://issues.jenkins-ci.org/browse/JENKINS-61935
-      labels:
-      - feature
-      - tools
-    - name: Pipeline integration testing tools
-      description: The Pipeline Unit Testing Framework allows which allows the ability to test pipelines and shared Libraries before running
-      status: future
-      labels:
-      - feature
-      - tools
     - name: Pipeline Documentation
       description: Reference documentation, tutorials, and more
       status: future


### PR DESCRIPTION
This PR removing pipeline-authoring sig items from the roadmap that are not clearly defined not detailed in JIRA.
Signed-off-by: markyjackson-taulia <marky.r.jackson@gmail.com>