### PR TITLE
JEP-14: Add a link to documentation about adding roadmap items

### DIFF
--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -69,7 +69,10 @@ tags:
 %ul
   %li
     %a{:href => "https://github.com/jenkinsci/jep/tree/master/jep/14"}
-      JEP-14 - Roadmap process documentation
+      Roadmap process documentation (JEP-14)
+  %li
+    %a{:href => "https://github.com/jenkinsci/jep/tree/master/jep/14#submitting-roadmap-suggestions"}
+      HOWTO: Suggest a new roadmap item
   %li
     %a{:href => "https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/roadmap/roadmap.yml"}
       Open data


### PR DESCRIPTION
Just a minor enhancement targeting potential roadmap contributors