### PR TITLE
Use 'agent' term where possible, stop using 'blacklist' and 'whitelist'

### DIFF
--- a/content/security/advisory/2013-01-04.adoc
+++ b/content/security/advisory/2013-01-04.adoc
@@ -8,13 +8,13 @@ kind: core
 This advisory announces a security vulnerability that was found in Jenkins core.
 
 == Description
-This vulnerability allows attacker with an HTTP access to the server to retrieve the master cryptographic key of Jenkins. This key is used to encrypt sensitive data in configuration files under `$JENKINS_HOME` and in the HTML forms, authenticate slaves connecting to the master, as well as the authenticate REST API access from users.
+This vulnerability allows attacker with an HTTP access to the server to retrieve the master cryptographic key of Jenkins. This key is used to encrypt sensitive data in configuration files under `$JENKINS_HOME` and in the HTML forms, authenticate agents connecting to the master, as well as the authenticate REST API access from users.
 
 An attacker can then use this master cryptographic key to mount remote code execution attack against the Jenkins master, or impersonate arbitrary users in making REST API calls.
 
 There are several factors that mitigate some of these problems that may apply to specific installations.
 
-* The particular attack vector is only applicable on Jenkins instances that have slaves attached to them, and allow anonymous read access.
+* The particular attack vector is only applicable on Jenkins instances that have agents attached to them, and allow anonymous read access.
 * Jenkins allows users to re-generate the API tokens. Those re-generated API tokens cannot be impersonated by the attacker.
 
 == Severity
@@ -26,10 +26,10 @@ This vulnerability is rated as *critical*, as it can be mounted by an anonymous 
 
 All the prior versions are affected by these vulnerabilities.
 
-These new versions generate a new set of different cryptographic keys to protect sensitive data, authenticate slaves, and so on. Because of this, administrators of Jenkins need to be aware of the following implications of the upgrade:
+These new versions generate a new set of different cryptographic keys to protect sensitive data, authenticate agents, and so on. Because of this, administrators of Jenkins need to be aware of the following implications of the upgrade:
 
 * API tokens of many users will likely change as a result, and therefore if you have scripts and external programs that rely on these tokens, some of them will fail. Please retrieve the updated API tokens from the UI.
-* Slaves that are started via Java Web Start will fail to reconnect if the *.jnlp file is locally stored. This is because the authentication tokens change. An administrator would have to login to the UI, retrieve the *.jnlp file and overwrite what's already on the slave. A slave that was launched via Java Web Start and then turned into a service through its menu falls into this category.
+* Agents that are started via Java Web Start will fail to reconnect if the *.jnlp file is locally stored. This is because the authentication tokens change. An administrator would have to login to the UI, retrieve the *.jnlp file and overwrite what's already on the agent. An agent that was launched via Java Web Start and then turned into a service through its menu falls into this category.
 * Once the new version is started, the administrator needs to run the link:re-keying[re-keying] process to update the on-disk configuration files to use the newer encryption key. Go to "Manage Jenkins" page and follow the instruction at the top of the page. Also make sure to read link:re-keying[the Wiki page] to understand more about this process.
 
 == Other resources

--- a/content/security/advisory/2014-10-30.adoc
+++ b/content/security/advisory/2014-10-30.adoc
@@ -8,18 +8,18 @@ kind: core
 This advisory announces a security vulnerability/hardening (CVE-2014-3665) in Jenkins core.
 
 == Description
-Historically, Jenkins master and slaves behaved as if they altogether form a single distributed process. This means a slave can ask a master to do just about anything within the confinement of the operating system, such as accessing files on the master or trigger other jobs on Jenkins.
+Historically, Jenkins master and agents behaved as if they altogether form a single distributed process. This means an agent can ask a master to do just about anything within the confinement of the operating system, such as accessing files on the master or trigger other jobs on Jenkins.
 
-This has increasingly become problematic, as larger enterprise deployments have developed more sophisticated trust separation model, where the administators of a master might take slaves owned by other teams. In such an environment, slaves are less trusted than the master. Yet the "single distributed process" assumption was not communicated well to the users, resulting in vulnerabilities in some deployments.
+This has increasingly become problematic, as larger enterprise deployments have developed more sophisticated trust separation model, where the administators of a master might take agents owned by other teams. In such an environment, agents are less trusted than the master. Yet the "single distributed process" assumption was not communicated well to the users, resulting in vulnerabilities in some deployments.
 
 SECURITY-144 (CVE-2014-3665) introduces a new subsystem to address this problem. This feature is off by default for compatibility reasons. See link:/redirect/security-144/[Wiki] for more details, who should turn this on, and implications.
 
 
 == Severity
-CVE-2014-3665 is rated *high*. It only affects installations that accept slaves from less trusted computers, but this will allow an owner of of such slave to mount a remote code execution attack on Jenkins.
+CVE-2014-3665 is rated *high*. It only affects installations that accept agents from less trusted computers, but this will allow an owner of of such an agent to mount a remote code execution attack on Jenkins.
 
 == Affected Versions
-The following versions are affected, but only if you connect slaves that are managed by less trusted users.
+The following versions are affected, but only if you connect agents that are managed by less trusted users.
 
 * All the main line releases < 1.587
 * All the LTS releases < 1.580.1

--- a/content/security/advisory/2015-11-11.adoc
+++ b/content/security/advisory/2015-11-11.adoc
@@ -27,10 +27,10 @@ The salt used to generate the CSRF protection tokens was a publicly accessible v
 When creating a job using the create-job CLI command, external entities are not discarded (nor processed). If these job configurations are processed by another user with an XML-aware tool (e.g. using get-job/update-job), information from that user's computer may be disclosed to Jenkins and the attacker.
 
 
-=== Secret key not verified when connecting a slave
+=== Secret key not verified when connecting an agent
 *SECURITY-184 / CVE-2015-5320*
 
-JNLP slave connections did not verify that the correct secret was supplied, which allowed malicious users to connect their own machines as slaves to Jenkins knowing only the name of the slave. This enables attackers to take over Jenkins (unless the slave-to-master security subsystem is enabled) or gain access to private data like keys and source code.
+JNLP agent connections did not verify that the correct secret was supplied, which allowed malicious users to connect their own machines as agents to Jenkins knowing only the name of the agent. This enables attackers to take over Jenkins (unless the agent-to-master security subsystem is enabled) or gain access to private data like keys and source code.
 
 
 === Queue API did show items not visible to the current user
@@ -42,7 +42,7 @@ The /queue/api URL could return information about items not accessible to the cu
 === Information disclosure via sidepanel
 *SECURITY-192 / CVE-2015-5321*
 
-The CLI command overview and help pages in Jenkins were accessible without Overall/Read permission, resulting in disclosure of the names of configured slaves (and contents of other sidepanel widgets, if present) to unauthorized users.
+The CLI command overview and help pages in Jenkins were accessible without Overall/Read permission, resulting in disclosure of the names of configured agents (and contents of other sidepanel widgets, if present) to unauthorized users.
 
 
 === Local file inclusion vulnerability
@@ -57,16 +57,16 @@ Access to the `/jnlpJars/` URL was not limited to the specific JAR files users n
 API tokens of other users were exposed to admins by default. On instances that don't implicitly grant RunScripts permission to admins, this allowed admins to run scripts with another user's credentials.
 
 
-=== JNLP slaves not subject to slave-to-master access control
+=== JNLP agents not subject to agent-to-master access control
 *SECURITY-206 / CVE-2015-5325*
 
-Slaves connecting via JNLP were not subject to the optional slave-to-master access control documented at https://jenkins-ci.org/security-144 (CVE-2014-3665).
+Agents connecting via JNLP were not subject to the optional agent-to-master access control documented at https://jenkins-ci.org/security-144 (CVE-2014-3665).
 
 
-=== Stored XSS vulnerability in slave offline status message
+=== Stored XSS vulnerability in agent offline status message
 *SECURITY-214 / CVE-2015-5326*
 
-Users with the permission to take slave nodes offline can enter arbitrary HTML that gets shown unescaped to users visiting the slave overview page.
+Users with the permission to take agent nodes offline can enter arbitrary HTML that gets shown unescaped to users visiting the agent overview page.
 
 
 === Remote code execution vulnerability due to unsafe deserialization in Jenkins remoting

--- a/content/security/advisory/2016-04-11.adoc
+++ b/content/security/advisory/2016-04-11.adoc
@@ -22,7 +22,7 @@ The Extra Columns plugin rendered user-supplied HTML in tool tips without filter
 === Groovy sandbox protection incomplete in Script Security Plugin
 *SECURITY-258 / CVE-2016-3102*
 
-The Script Security plugin provides a Groovy sandbox implementation to other plugins that only allows whitelisted commands to be executed. This sandbox did not cover direct field access (`foo.@bar`) or get/set array operations (`foo[bar]`).
+The Script Security plugin provides a Groovy sandbox implementation to other plugins that only allows approved signatures to be executed. This sandbox did not cover direct field access (`foo.@bar`) or get/set array operations (`foo[bar]`).
 
 
 == Severity

--- a/content/security/advisory/2017-02-01.adoc
+++ b/content/security/advisory/2017-02-01.adoc
@@ -45,10 +45,10 @@ Users with the permission to configure jobs were able to inject JavaScript into 
 Jenkins bundled an outdated version of jbcrypt that was affected by CVE-2015-0886.
 
 
-=== Pipeline metadata files not blacklisted in agent-to-master security subsystem
+=== Pipeline metadata files not excluded in agent-to-master security subsystem
 *SECURITY-358 / CVE-2017-2602*
 
-The Pipeline suite of plugins stored build metadata in the file `program.dat` and the directory `workflow/`. These were not blacklisted in the link:https://jenkins-ci.org/security-144[agent-to-master security subsystem] and could therefore be written to by malicious agents.
+The Pipeline suite of plugins stored build metadata in the file `program.dat` and the directory `workflow/`. These were not excluded in the link:https://jenkins-ci.org/security-144[agent-to-master security subsystem] and could therefore be written to by malicious agents.
 
 
 === User data leak in disconnected agents' config.xml API
@@ -92,7 +92,7 @@ To prevent this, console notes are now signed by Jenkins when created, and Jenki
 
 XStream-based APIs in Jenkins (e.g. `/createItem` URLs, or `POST config.xml` remote API) were vulnerable to a remote code execution vulnerability involving the deserialization of various types in `javax.imageio`.
 
-In case this extension of the blacklist results in regressions, the blacklist can be customized as described link:/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[in the Jenkins LTS upgrade guide for Jenkins 2.19.3].
+In case this extension of the blocklist results in regressions, the blocklist can be customized as described link:/doc/upgrade-guide/2.19/#upgrading-to-jenkins-lts-2-19-3[in the Jenkins LTS upgrade guide for Jenkins 2.19.3].
 
 
 === Information disclosure vulnerability in search suggestions

--- a/content/security/advisory/2017-03-20.adoc
+++ b/content/security/advisory/2017-03-20.adoc
@@ -12,14 +12,14 @@ This advisory announces vulnerabilities in these Jenkins plugins:
 * plugin:email-ext[Email Extension (Email-ext)]
 * plugin:mailer[Mailer]
 * link:https://wiki.jenkins.io/display/JENKINS/Pipeline+Classpath+Step+Plugin[Pipeline: Classpath Step]
-* plugin:ssh-slaves[SSH Slaves]
+* plugin:ssh-slaves[SSH Build Agents]
 
 == Description
 
-=== SSH Slaves Plugin did not verify host keys
+=== SSH Build Agents Plugin did not verify host keys
 *SECURITY-161 / CVE-2017-2648*
 
-The SSH Slaves Plugin did not perform host key verification, thereby enabling Man-in-the-Middle attacks.
+The SSH Build Agents Plugin did not perform host key verification, thereby enabling Man-in-the-Middle attacks.
 
 === Active Directory Plugin did not verify certificate of AD server
 *SECURITY-251 / CVE-2017-2649*
@@ -58,7 +58,7 @@ There were no permission checks performed in the Distributed Fork plugin that pr
 * Email Extension (email-ext) Plugin up to and including version 2.57.
 * Mailer Plugin up to and including version 1.19.
 * Pipeline: Classpath Step Plugin: All versions. No fix for this plugin is currently planned.
-* SSH Slaves Plugin up to and including version 1.14.
+* SSH Build Agents Plugin up to and including version 1.14.
 
 == Fix
 // TODO Confirm these version numbers with uploaders
@@ -67,7 +67,7 @@ There were no permission checks performed in the Distributed Fork plugin that pr
 * DistFork Plugin should be updated to version 1.6.0.
 * Email Extension (email-ext) Plugin should be updated to version 2.57.1.
 * Mailer Plugin should be updated to version 1.20.
-* SSH Slaves Plugin should be updated to version 1.15.
+* SSH Build Agents Plugin should be updated to version 1.15.
 * Pipeline: Classpath Step Plugin should be disabled or uninstalled, and its uses replaced by the link:/doc/book/pipeline/shared-libraries/[Pipeline libraries feature]. No fix for this plugin is currently planned.
 
 These versions include fixes to the vulnerabilities described above. All prior versions are affected by these vulnerabilities unless otherwise noted.

--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -79,9 +79,9 @@ ARBITRARY CODE EXECUTION
 
 All of these allow users with relatively low privileges (like Overall/Read or Job/Configure) to run arbitrary code in Jenkins.
 
-These issues are typically resolved by either requiring approval by an administrator with Overall/Run Scripts permission before executing the script, or by running the script in a sandbox that only allows execution of whitelisted methods.
+These issues are typically resolved by either requiring approval by an administrator with Overall/Run Scripts permission before executing the script, or by running the script in a sandbox that only allows execution of approved methods.
 
-If you are upgrading any of these plugins to a version containing a fix, and use the affected scripting features, an administrator will typically have to approve entire scripts or whitelist specific methods for these features to resume working (see plugin:script-security[Script Security Plugin documentation]).
+If you are upgrading any of these plugins to a version containing a fix, and use the affected scripting features, an administrator will typically have to approve entire scripts or approve specific method signatures for these features to resume working (see plugin:script-security[Script Security Plugin documentation]).
 Meanwhile, certain features may not work as before the upgrade.
 
 
@@ -225,7 +225,7 @@ This has been addressed in Environment Injector Plugin version 2.0 by integratin
 After upgrading the plugin, any previously defined Groovy script will be checked for approval, and submitted for approval if it isn't, and then attempted to run in the sandbox.
 
 When configuring a job, users can choose to run Environment Injector scripts in the sandbox.
-If so, the methods called in the script are subject to Script Security Groovy sandbox whitelisting.
+If so, the methods called in the script are subject to the Script Security Groovy sandbox.
 If not, and the user configuring the job is not an administrator, the script will be submitted for approval.
 
 Likewise, custom classpath entries are now also subject to approval.
@@ -255,7 +255,7 @@ They can be reconfigured to run outside the sandbox, requiring approval by Jenki
 
 The pre-defined variable `jenkins` has been removed.
 Scripts requiring it will need to access `jenkins.model.Jenkins.getInstance()`.
-This should never be whitelisted for scripts running inside the sandbox.
+This should never be approved for scripts running inside the sandbox.
 
 To find out whether you're likely to be impacted by these changes, use link:https://github.com/jenkinsci-cert/security-advisory-2017-04-10/[these scripts].
 
@@ -525,7 +525,7 @@ For most Jenkins instances, there is no difference between the two, but hosted J
 
 This has been addressed in Warnings Plugin version 4.61 by integrating with plugin:script-security[Script Security Plugin].
 
-Custom warning parsers are now subject to the Script Security sandbox, and methods used there need to be added to the whitelist before they can be used.
+Custom warning parsers are now subject to the Script Security sandbox, and methods used there need to be added to the list of approved signatures before they can be used.
 
 To find out whether you're likely to be impacted by these changes, use link:https://github.com/jenkinsci-cert/security-advisory-2017-04-10/[these scripts].
 

--- a/content/security/advisory/2017-04-26.adoc
+++ b/content/security/advisory/2017-04-26.adoc
@@ -42,9 +42,9 @@ The above, as well as several other more minor issues, have all been fixed and t
 === CLI: Unauthenticated remote code execution
 *SECURITY-429 / CVE-2017-1000353*
 
-An unauthenticated remote code execution vulnerability allowed attackers to transfer a serialized Java `SignedObject` object to the remoting-based Jenkins CLI, that would be deserialized using a new `ObjectInputStream`, bypassing the existing blacklist-based protection mechanism.
+An unauthenticated remote code execution vulnerability allowed attackers to transfer a serialized Java `SignedObject` object to the remoting-based Jenkins CLI, that would be deserialized using a new `ObjectInputStream`, bypassing the existing blocklist-based protection mechanism.
 
-`SignedObject` has been added to the remoting blacklist.
+`SignedObject` has been added to the remoting blocklist.
 
 In Jenkins 2.54, the remoting-based CLI protocol was deprecated and a new, HTTP based protocol introduced as the new default, in addition to the existing SSH-based CLI.
 This feature has been backported to Jenkins 2.46.2.

--- a/content/security/advisory/2017-07-10.adoc
+++ b/content/security/advisory/2017-07-10.adoc
@@ -147,7 +147,7 @@ An enumeration of credentials IDs in this plugin now requires the permission to 
 If no job context exists, Overall/Administer permission is required.
 
 
-== Unsafe methods in the default allowed signature list in Script Security Plugin
+== Unsafe methods in the default list of approved signatures in Script Security Plugin
 *SECURITY-538 / CVE-2017-1000095*
 
 The default list of approved signatures included the entries:
@@ -162,7 +162,7 @@ Additionally, the following entries allowed accessing private data that would no
     groovy.json.JsonOutput.toJson(Closure)
     groovy.json.JsonOutput.toJson(Object)
 
-These have now been removed from the list of allowed signatures and added to the list of dangerous signatures.
+These have now been removed from the list of approved signatures and added to the list of dangerous signatures.
 
 Scripts, such as Pipeline jobs, that integrate with Script Security and use these methods will now fail.
 Use of these methods will appear on the In-Process Script Approval page, and it warns administrators that they are unsafe to approve.

--- a/content/security/advisory/2017-07-10.adoc
+++ b/content/security/advisory/2017-07-10.adoc
@@ -77,7 +77,7 @@ The Sidebar Link plugin allows users able to configure jobs, views, and agents t
 
 There was no input validation, which meant users were able to use `javascript:` schemes for these links, a persisted XSS vulnerability.
 
-Now, only a set of whitelisted schemes are allowed by default: `http`, `https`, `ftp`, `ftps`, `mailto`, `news`, `irc, gopher`, `nntp`, `feed`, `telnet`, `mms`, `rtsp`, `svn`, `tel`, `fax`, `xmpp`, as well as relative links.
+Now, only a set of approved schemes are allowed by default: `http`, `https`, `ftp`, `ftps`, `mailto`, `news`, `irc, gopher`, `nntp`, `feed`, `telnet`, `mms`, `rtsp`, `svn`, `tel`, `fax`, `xmpp`, as well as relative links.
 Sidebar entries configured with prohibited schemes instead redirect to an error page in Jenkins explaining that it's prohibited.
 
 To add or remove from this list of schemes, provide the Java system property `hudson.plugins.sidebar_link.LinkProtection.whitelistedSchemes` with the complete comma-separated list of schemes to allow.
@@ -147,10 +147,10 @@ An enumeration of credentials IDs in this plugin now requires the permission to 
 If no job context exists, Overall/Administer permission is required.
 
 
-== Unsafe methods in the default whitelist in Script Security Plugin
+== Unsafe methods in the default allowed signature list in Script Security Plugin
 *SECURITY-538 / CVE-2017-1000095*
 
-The default whitelist included the entries:
+The default list of approved signatures included the entries:
 
     DefaultGroovyMethods.putAt(Object, String, Object)
     DefaultGroovyMethods.getAt(Object, String)
@@ -162,7 +162,7 @@ Additionally, the following entries allowed accessing private data that would no
     groovy.json.JsonOutput.toJson(Closure)
     groovy.json.JsonOutput.toJson(Object)
 
-These have now been removed from the whitelist and added to the blacklist.
+These have now been removed from the list of allowed signatures and added to the list of dangerous signatures.
 
 Scripts, such as Pipeline jobs, that integrate with Script Security and use these methods will now fail.
 Use of these methods will appear on the In-Process Script Approval page, and it warns administrators that they are unsafe to approve.
@@ -171,7 +171,7 @@ Use of these methods will appear on the In-Process Script Approval page, and it 
 == Arbitrary code execution due to incomplete sandbox protection in Pipeline: Groovy Plugin
 *SECURITY-551 / CVE-2017-1000096*
 
-Pipelines are subject to _script security_: Either the entire Pipeline needs to be approved, or it runs in a sandbox, with only whitelisted methods etc. allowed to be called.
+Pipelines are subject to _script security_: Either the entire Pipeline needs to be approved, or it runs in a sandbox, with only approved methods etc. allowed to be called.
 
 Constructors, instance variable initializers, and instance initializers in Pipeline scripts were not subject to sandbox protection, and could therefore execute arbitrary code.
 

--- a/content/security/advisory/2017-08-07.adoc
+++ b/content/security/advisory/2017-08-07.adoc
@@ -101,7 +101,7 @@ interface I {
 (Jenkins as I).getInstance()
 ----
 
-Casts like this are now prohibited unless all interface methods are already whitelisted on the actual receiver.
+Casts like this are now prohibited unless all interface methods are already approved on the actual receiver.
 
 ==== Method references
 *SECURITY-567*

--- a/content/security/advisory/2018-02-05.adoc
+++ b/content/security/advisory/2018-02-05.adoc
@@ -99,7 +99,7 @@ This issue did apply to freestyle and other classic job types, but does not appl
 *SECURITY-699 / CVE-2018-1000058*
 
 Pipelines are subject to _script security_:
-Either the entire Pipeline needs to be approved, or it runs in a sandbox, with only whitelisted methods etc. allowed to be called.
+Either the entire Pipeline needs to be approved, or it runs in a sandbox, with only approved methods etc. allowed to be called.
 
 Methods related to Java deserialization like `readResolve` implemented in Pipeline scripts were not subject to sandbox protection, and could therefore execute arbitrary code.
 This could be exploited e.g. by regular Jenkins users with the permission to configure Pipelines in Jenkins, or by trusted committers to repositories containing Jenkinsfiles.

--- a/content/security/advisory/2019-05-31.adoc
+++ b/content/security/advisory/2019-05-31.adoc
@@ -61,18 +61,18 @@ issues:
 
 - id: SECURITY-921
   reporter: Jesse Glick, CloudBees, Inc.
-  title: Unsafe Script Security whitelist entry in PLUGIN_NAME
+  title: Unsafe entry in Script Security list of approved signatures in PLUGIN_NAME
   cve: CVE-2019-10328
   cvss:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
-    PLUGIN_NAME provides a custom Script Security whitelist.
+    PLUGIN_NAME provides a custom list of pre-approved signatures for Script Security.
     Those entries apply to all scripts with sandbox protection, such as Pipeline.
 
     One entry provided here was unsafe, as it allowed invoking arbitrary methods, bypassing sandbox protection.
 
-    The unsafe whitelist entry has been removed.
+    The unsafe pre-approved entry has been removed.
   plugins:
   - name: workflow-remote-loader
     previous: 1.4

--- a/content/security/advisory/2019-07-31.adoc
+++ b/content/security/advisory/2019-07-31.adoc
@@ -16,7 +16,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
     Sandbox protection in PLUGIN_NAME could be circumvented by casting crafted objects to other types.
-    This allowed attackers able to specify sandboxed scripts to invoke constructors that weren't whitelisted.
+    This allowed attackers able to specify sandboxed scripts to invoke constructors that weren't approved.
 
     Additionally, this could be used to read arbitrary files on the Jenkins master.
 

--- a/content/security/advisory/2019-08-07.adoc
+++ b/content/security/advisory/2019-08-07.adoc
@@ -243,9 +243,9 @@ issues:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
-    PLUGIN_NAME defines a custom whitelist for scripts protected by the Script Security sandbox.
+    PLUGIN_NAME defines a custom list of pre-approved signatures for scripts protected by the Script Security sandbox.
 
-    This custom whitelist allows the use of methods that can be used to bypass Script Security sandbox protection.
+    This custom list of pre-approved signatures allows the use of methods that can be used to bypass Script Security sandbox protection.
     This results in arbitrary code execution on any Jenkins instance with this plugin installed.
 
     As of publication of this advisory, there is no fix.

--- a/content/security/advisory/2019-09-25.adoc
+++ b/content/security/advisory/2019-09-25.adoc
@@ -369,9 +369,9 @@ issues:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
-    Kubernetes Pipeline - Kubernetes Steps Plugin defines a custom whitelist for all scripts protected by the Script Security sandbox.
+    Kubernetes Pipeline - Kubernetes Steps Plugin defines a custom list of pre-approved signatures for all scripts protected by the Script Security sandbox.
 
-    This custom whitelist allows the use of methods that can be used to bypass Script Security sandbox protection.
+    This custom list of pre-approved signatures allows the use of methods that can be used to bypass Script Security sandbox protection.
     This results in arbitrary code execution on any Jenkins instance with this plugin installed.
 
     As of publication of this advisory, there is no fix.
@@ -390,9 +390,9 @@ issues:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
-    Kubernetes Pipeline - Arquillian Steps Plugin defines a custom whitelist for all scripts protected by the Script Security sandbox.
+    Kubernetes Pipeline - Arquillian Steps Plugin defines a custom list of pre-approved signatures for all scripts protected by the Script Security sandbox.
 
-    This custom whitelist allows the use of methods that can be used to bypass Script Security sandbox protection.
+    This custom list of pre-approved signatures allows the use of methods that can be used to bypass Script Security sandbox protection.
     This results in arbitrary code execution on any Jenkins instance with this plugin installed.
 
     As of publication of this advisory, there is no fix.

--- a/content/security/advisory/2019-10-16.adoc
+++ b/content/security/advisory/2019-10-16.adoc
@@ -177,9 +177,9 @@ issues:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
-    PLUGIN_NAME defines a custom whitelist for all scripts protected by the Script Security sandbox.
+    PLUGIN_NAME defines a custom list of pre-approved signatures for all scripts protected by the Script Security sandbox.
 
-    This custom whitelist allows the use of methods that can be used to bypass Script Security sandbox protection.
+    This custom list of pre-approved signatures allows the use of methods that can be used to bypass Script Security sandbox protection.
     This results in arbitrary code execution on any Jenkins instance with this plugin installed.
 
     As of publication of this advisory there is no fix.

--- a/content/security/advisory/2020-03-09.adoc
+++ b/content/security/advisory/2020-03-09.adoc
@@ -19,7 +19,7 @@ issues:
     This allows attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
 
     PLUGIN_NAME 1.71 has additional restrictions and sanity checks to ensure that super constructors cannot be constructed without being intercepted by the sandbox.
-    In addition, it also intercepts method calls on objects that implement `GroovyInterceptable` as calls to `GroovyObject#invokeMethod(String, Object)`, which is a blacklisted method.
+    In addition, it also intercepts method calls on objects that implement `GroovyInterceptable` as calls to `GroovyObject#invokeMethod(String, Object)`, which is a prohibited method.
   plugins:
   - name: script-security
     previous: '1.70'

--- a/content/security/advisory/2020-03-09.adoc
+++ b/content/security/advisory/2020-03-09.adoc
@@ -19,7 +19,7 @@ issues:
     This allows attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
 
     PLUGIN_NAME 1.71 has additional restrictions and sanity checks to ensure that super constructors cannot be constructed without being intercepted by the sandbox.
-    In addition, it also intercepts method calls on objects that implement `GroovyInterceptable` as calls to `GroovyObject#invokeMethod(String, Object)`, which is a prohibited method.
+    In addition, it also intercepts method calls on objects that implement `GroovyInterceptable` as calls to `GroovyObject#invokeMethod(String, Object)`, which is on the list of dangerous signatures and should not be approved for use in the sandbox.
   plugins:
   - name: script-security
     previous: '1.70'


### PR DESCRIPTION
Also quite a few occurrences of `blacklist` and `whitelist` which are pretty clunky now. CC @dwnusbaum to review those, perhaps there's better terms than I chose.

I only applied the changes to `/security/`. Some occurrences are left but those cannot be updated in documentation only:

* System properties
* Plugin artifact IDs and display names (if unchanged)
* class names
* URLs