### PR TITLE
Offline Jenkins Install at correct heading level

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -663,7 +663,7 @@ ZFS integration with Jenkins should be considered.
 
 include::doc/book/installing/_setup-wizard.adoc[]
 
-=== Offline Jenkins Installation
+== Offline Jenkins Installation
 
 This section describes how to install Jenkins on a machine
 that does not have an internet connection.


### PR DESCRIPTION
Previously it was at the same level as "Creating the first administrator user" and "Customizing Jenkins with plugins".

This change places it at the same level as "Jenkins Parameters and "Configuring HTTP".