### PR TITLE
Jenkins Code of Conduct update

### DIFF
--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -133,23 +133,23 @@ Those groups must provide their own moderators and/or reporting system.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the link:/project/board[Jenkins board].
 If you feel somebody has breached this code, please send an email with the
-relevant information (links, etc) to jenkinsci-board@googlegroups.com. This
-email list is only readable by the
-link:/project/board[Governance
-Board] members.
+relevant information (links, etc) to `jenkinsci-board@googlegroups.com`.
+This email list is only readable by the link:/project/board[Governance Board] members.
+The board may not have all of the necessary context and history,
+so it's better to be more verbose than less verbose about such matters.
 All complaints will be reviewed
 and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances.
-
-Please understand that the board may not have all of the necessary context and
-history, so it's better to be more verbose than less verbose about such
-matters.
 
 If you believe one of the members of the board has violated the code of conduct
 above, please email one of the other members of the Governance Board with the
 details (their emails are visible on the
 link:/project/board[Governance
 Board] page).
+
+If the desired resolution cannot be reached on the Jenkins community level,
+an issue can be escalated to the Continuous Delivery Foundation (CDF) by contacting the project team at `conduct@cd.foundation`.
+See the link:https://github.com/cdfoundation/toc/blob/master/CODE_OF_CONDUCT.md[CDF Code of Conduct] for more information about reporting and enforcement in this case.
 
 == Handling of violations
 
@@ -252,6 +252,7 @@ enforcement ladder].
 ** Code of Conduct is updated to link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant, version 2.0]
 ** Align _Handling of Violations_ with link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant 2.0] _Enforcement Guidelines_
 ** Refresh the _Community Spaces_ section
+** Reference Continuous Delivery Foundation (CDF) as a second level of escalation
 * **Jan 06, 2016** - First version of Code of Conduct is introduced.
   It is adapted from the link:https://www.contributor-covenant.org/version/1/3/0/[Contributor Covenant, version 1.3.0].
   The Code of Conduct was approved by the project governance meeting on

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -7,21 +7,16 @@ section: conduct
 :toc:
 
 
-This document defines the Code of Conduct and Reporting/Handling processes
-for the Jenkins community. For more details about our cultural values,
-goals, philosophies, structure and so on, please consult our
-link:/project/governance[Governance Document]. 
-
-
-== Our Pledge
-
-// TODO(oleg_nenashev): First paragraph is an adapted paragraph of the Contributor Covenant 1.3.0. Should we keep it or remove it?
-
 As community members, contributors and maintainers of this project,
 and in the interest of fostering an open and welcoming community,
-we pledge to respect all people who participate in the community through reporting issues,
+we commit to respect all people who participate in the community through reporting issues,
 posting feature requests, updating documentation, submitting pull requests or
 patches, and other activities.
+
+This document defines the Code of Conduct and reporting/handling processes for the Jenkins community. 
+For more details about our cultural values, goals, philosophies, structure and so on, please consult our link:/project/governance[Governance Document]. 
+
+== Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -157,8 +157,7 @@ Community leaders will follow these Community Impact Guidelines in determining
 the consequences for any action they deem in violation of this Code of Conduct.
 
 Depending on the severity of the violations the board may elect to take one of the following paths.
-The resolution of violations will be done in private.
-And the affected people will be notified but there will not be a public announcement.
+The resolution of violations will be done in private and the affected people will be notified but there will not be a public announcement of the resolution.
 
 === 1. Correction
 
@@ -193,7 +192,7 @@ like social media. Violating these terms may lead to a _Probation_ or _Ban_.
 If the severity of the violation is serious or reprimands are not effective,
 the board will ask the community member to "take a break" 
 and to step
-away from the community for a period of time/
+away from the community for a period of time.
 The intent of this is to send a clear signal to the community member that their
 conduct is unacceptable, de-escalate the situation for everyone who are
 affected, and ask the community member to reflect on their behaviors.

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -90,7 +90,7 @@ It includes but not limited to:
 * Issues
 * Wikis
 
-Technical criticism is always appreciated, but avoid destructive behavior such as unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
+Technical criticism is always appreciated. Keep it positive and constructive. Don't merely decry the current state of affairs. Offer and solicit suggestions as to how things may be improved.
 (courtesy of the link:https://golang.org/conduct#values[Go Lang Code of Conduct])
 
 ==== Websites
@@ -131,12 +131,12 @@ If you feel somebody has breached this code, please send an email with the
 relevant information (links, etc) to `jenkinsci-board@googlegroups.com`.
 This email list is only readable by the link:/project/board[Governance Board] members.
 The board may not have all of the necessary context and history,
-so it's better to be more verbose than less verbose about such matters.
+so it's better to describe the issue thoroughly.
 All complaints will be reviewed
 and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances.
 
-If you believe one of the members of the board has violated the code of conduct
+If you believe one of the board members has violated the code of conduct
 above, please email one of the other members of the Governance Board with the
 details (their emails are visible on the
 link:/project/board[Governance

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -223,8 +223,7 @@ individual, or aggression toward or disparagement of classes of individuals.
 the community.
 // Addition to Contributor Covenant 2.0 begins here
 The individual will be expelled from the Jenkins community.
-After 12 months of ban they may appeal to the
-board for the ban to be lifted.
+After 12 months they may appeal to the board for the ban to be lifted.
 
 The ban will include but is not limited to:
 
@@ -246,13 +245,13 @@ enforcement ladder].
 
 == Version history
 
-* **Jul TODO, 2020** - The Code of Conduct was updated.
+* **Jul TODO, 2020** - Major update of the Code of Conduct.
   It was approved the project governance meeting, see the meeting notes link:TODO[here].
   Notable changes:
 ** Code of Conduct is updated to link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant, version 2.0]
 ** Align _Handling of Violations_ with link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant 2.0] _Enforcement Guidelines_
 ** Refresh the _Community Spaces_ section
-** Reference Continuous Delivery Foundation (CDF) as a second level of escalation
+** Reference Continuous Delivery Foundation (CDF) as a second escalation level
 * **Jan 06, 2016** - First version of Code of Conduct is introduced.
   It is adapted from the link:https://www.contributor-covenant.org/version/1/3/0/[Contributor Covenant, version 1.3.0].
   The Code of Conduct was approved by the project governance meeting on

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -7,63 +7,85 @@ section: conduct
 :toc:
 
 
-This document only defines the Code of Conduct and Reporting/Handling processes
-for the Jenkins project/community. For more details about our cultural values,
+This document defines the Code of Conduct and Reporting/Handling processes
+for the Jenkins community. For more details about our cultural values,
 goals, philosophies, structure and so on, please consult our
 link:/project/governance[Governance Document]. 
 
 
-== Code of Conduct
+== Our Pledge
 
-As contributors and maintainers of this project (defined under <<Community Spaces>>
-and the
-link:/project/governance[Governance
-Document]), and in the interest of fostering an open and welcoming community,
-we pledge to respect all people who contribute through reporting issues,
+// TODO(oleg_nenashev): First paragraph is an adapted paragraph of the Contributor Covenant 1.3.0. Should we keep it or remove it?
+
+As community members, contributors and maintainers of this project,
+and in the interest of fostering an open and welcoming community,
+we pledge to respect all people who participate in the community through reporting issues,
 posting feature requests, updating documentation, submitting pull requests or
 patches, and other activities.
 
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
-Examples of unacceptable behavior by participants include:
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
+== Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses, without explicit permission
-* Other unethical or unprofessional conduct
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
-The Jenkins board has the right and responsibility to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful. Plugin and other maintainers also have the
-right and responsibility to remove, edit, or reject comments, commits, code,
-wiki edits, issues, and other contributions that are not aligned to this Code
-of Conduct.
+== Enforcement Responsibilities
 
-By adopting this Code of Conduct, the Jenkins board commits themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
+Jenkins Board members are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
+Community leaders (Jenkins Board members, service administrators, plugin and other maintainers)
+have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the
-link:/project/board[Jenkins
-board] at jenkinsci-board@googlegroups.com.  All complaints will be reviewed
-and investigated and will result in a response that is deemed necessary and
-appropriate to the circumstances. The board is obligated to maintain
-confidentiality with regard to the reporter of an incident.
+== Scope
 
-This Code of Conduct is adapted from the
-link:https://www.contributor-covenant.org/[Contributor Covenant], version 1.3.0,
-available from link:https://www.contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct applies within all <<Community Spaces>>, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
+== Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant,
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by link:https://github.com/mozilla/diversity[Mozilla's code of conduct
+enforcement ladder].
 
 === Community Spaces
 
@@ -74,6 +96,7 @@ available from link:https://www.contributor-covenant.org/version/1/3/0/[contribu
 *** link:https://github.com/jenkinsci[jenkinsci]
 *** link:https://github.com/jenkinsci-cert[jenkinsci-cert]
 *** link:https://github.com/jenkins-infra[jenkins-infra]
+*** link:https://github.com/stapler[stapler]
 ** Commits
 ** Pull requests
 ** Issues
@@ -122,11 +145,16 @@ page, e.g.
 
 == Reporting
 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the link:/project/board[Jenkins board].
 If you feel somebody has breached this code, please send an email with the
 relevant information (links, etc) to jenkinsci-board@googlegroups.com. This
 email list is only readable by the
 link:/project/board[Governance
 Board] members.
+All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances.
 
 Please understand that the board may not have all of the necessary context and
 history, so it's better to be more verbose than less verbose about such
@@ -177,10 +205,13 @@ The ban will include but is not limited to:
 *  Blocking their GitHub username from the jenkinsci github organization
 *  Banning their email address from jenkins mailing lists
 
+== Version history
 
-
-NOTE: This page has been imported from the
-link:https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of
-Conduct] wiki page, which, as of `v15`, was approved by the project governance
-meeting on
-link:http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[2016-01-06]
+* **Jul TODO, 2020** - The Code of Conduct was updated.
+  It was approved the project governance meeting, see the meeting notes link:TODO[here].
+  Notable changes:
+** Code of Conduct is updated to link:[Contributor Covenant, version 2.0]
+* **Jan 06, 2016** - First version of Code of Conduct is introduced.
+  It is adapted from the link:https://www.contributor-covenant.org/version/1/3/0/[Contributor Covenant, version 1.3.0].
+  The Code of Conduct was approved by the project governance meeting on
+  link:http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[2016-01-06]

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -78,70 +78,55 @@ Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
-== Attribution
-
-This Code of Conduct is adapted from the Contributor Covenant,
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
-
-Community Impact Guidelines were inspired by link:https://github.com/mozilla/diversity[Mozilla's code of conduct
-enforcement ladder].
-
 === Community Spaces
 
 ==== Source Control
 
-* GitHub
-** Organizations
-*** link:https://github.com/jenkinsci[jenkinsci]
-*** link:https://github.com/jenkinsci-cert[jenkinsci-cert]
-*** link:https://github.com/jenkins-infra[jenkins-infra]
-*** link:https://github.com/stapler[stapler]
-** Commits
-** Pull requests
-** Issues
-** Wikis
-* Subversion
+All resources and conversations within the Jenkins GitHub organizations are subject to the code of conduct.
+It includes but not limited to:
+
+* Organizations
+** link:https://github.com/jenkinsci[jenkinsci]
+** link:https://github.com/jenkinsci-cert[jenkinsci-cert]
+** link:https://github.com/jenkins-infra[jenkins-infra]
+** link:https://github.com/stapler[stapler]
+* Commits
+* Pull requests
+* Issues
+* Wikis
 
 Technical criticism is always appreciated, but avoid destructive behavior such as unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
-
 (courtesy of the link:https://golang.org/conduct#values[Go Lang Code of Conduct])
 
 ==== Websites
 
-Everything hosted under link:https://jenkins-ci.org/[jenkins-ci.org] and its sub-domains such as:
+Everything hosted under link:https://jenkins.io/[jenkins.io], link:https://jenkins-ci.org/[jenkins-ci.org] and their sub-domains such as:
 
+* link:https://jenkins.io[jenkins.io]
 * link:https://issues.jenkins-ci.org/[issues.jenkins-ci.org]
 * link:https://wiki.jenkins.io/[wiki.jenkins.io]
-* link:http://lists.jenkins-ci.org/mailman/listinfo[lists.jenkins-ci.org]
 
 ==== Mailing lists
 
-Those hosted on Google Groups (see
-link:/mailing-lists[here]) and those self-hosted
-on link:http://lists.jenkins-ci.org/mailman/listinfo[lists.jenkins-ci.org].
+All link:/mailing-lists[mailing lists] hosted on Google Groups and other platforms.
 
-==== IRC Channels
+==== Chats
 
-Documented in the
-link:/chat[IRC Channel] wiki
-page, e.g.
-
-* `#jenkins`
-* `#jenkins-meeting`
-* `#jenkins-infra`
-* `#jenkins-community`
+* All chats documented on the link:/chat[this page], e.g. IRC channels: `#jenkins`, `#jenkins-meeting`, `#jenkins-infra`, etc.
+* Gitter channels within the link:https://gitter.im/jenkinsci/home[https://gitter.im/jenkinsci/] space
+* Jenkins chats hosted by Linux Foundation and its subsidiaries including Continuous Delivery Foundation 
 
 ==== Events
 
-* link:/projects/jam/[Jenkins
-  Area Meetup]
+* link:/projects/jam/[Jenkins Area Meetups]
+* link:/events/online-meetup[Jenkins Online Meetup]
 * Events where Jenkins is officially being represented (e.g.
   link:https://fosdem.org[FOSDEM], link:https://socallinuxexpo.org/[SCaLE])
-* Other Jenkins groups (such as conferences, meetups, and other unofficial
-  forums) are encouraged to adopt this Code of Conduct. Those groups must
-  provide their own moderators and/or reporting system.
 
+=== Other Jenkins Communities
+
+Other Jenkins groups (such as conferences, meetups, and other unofficial forums) and local communities are encouraged to adopt this Code of Conduct.
+Those groups must provide their own moderators and/or reporting system.
 
 == Reporting
 
@@ -250,6 +235,15 @@ The ban will include but is not limited to:
 *  Banning them from social media and meetup groups
 *  Banning them from participating in Community-organized events
 
+== Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant,
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by link:https://github.com/mozilla/diversity[Mozilla's code of conduct
+enforcement ladder].
+
 == Version history
 
 * **Jul TODO, 2020** - The Code of Conduct was updated.
@@ -257,6 +251,7 @@ The ban will include but is not limited to:
   Notable changes:
 ** Code of Conduct is updated to link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant, version 2.0]
 ** Align _Handling of Violations_ with link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant 2.0] _Enforcement Guidelines_
+** Refresh the _Community Spaces_ section
 * **Jan 06, 2016** - First version of Code of Conduct is introduced.
   It is adapted from the link:https://www.contributor-covenant.org/version/1/3/0/[Contributor Covenant, version 1.3.0].
   The Code of Conduct was approved by the project governance meeting on

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -152,7 +152,9 @@ Community leaders will follow these Community Impact Guidelines in determining
 the consequences for any action they deem in violation of this Code of Conduct.
 
 Depending on the severity of the violations the board may elect to take one of the following paths.
-The resolution of violations will be done in private and the affected people will be notified but there will not be a public announcement of the resolution.
+Handling of violations will be done in private and the affected people will be notified.
+In the majority of cases there will not be a public announcement of the resolution,
+unless the Governance Board deems it necessary to announce the resolution in public.
 
 === 1. Correction
 

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -168,49 +168,95 @@ Board] page).
 
 == Handling of violations
 
-Depending on the severity of the violations the board may elect to take one of the following paths. The resolution of violations will be done in private, and the affected people will be notified but there will not be a public announcement. We aim to prevent mud-slinging and unnecessary further personal attacks/etc.
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct.
 
-=== Reprimand
+Depending on the severity of the violations the board may elect to take one of the following paths.
+The resolution of violations will be done in private.
+And the affected people will be notified but there will not be a public announcement.
 
-If the severity of the violation is mild enough, the board will notify the
-community member that his or her conduct is not acceptable and needs to change.
+=== 1. Correction
 
-=== Probation
+If the severity of the violation is mild enough, the board will notify the community member that their conduct is not acceptable and needs to change.
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+=== 2. Warning
+
+If the severity of the violation is serious enough,
+the board will issue an official warning to the community member.
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a _Probation_ or _Ban_.
+
+=== 3. Probation
+
+// oleg_nenashev: It merges statements of "3. Temporary ban" in Contributor Covenant 2.0
+// + original statements of the Probation period in Jenkins CoC 2016
 
 If the severity of the violation is serious or reprimands are not effective,
-the board will ask the community member to "take a break." Meaning, to step
-away from the project for a period of time. This means no participating in:
-
-* The link:/chat/[IRC Channels]
-* Mailing lists
-* Pull requests
-* Events
-* etc
-
+the board will ask the community member to "take a break" 
+and to step
+away from the community for a period of time/
 The intent of this is to send a clear signal to the community member that their
 conduct is unacceptable, de-escalate the situation for everyone who are
 affected, and ask the community member to reflect on their behaviors.
 
-=== Expulsion
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
 
-If probation clearly doesn't address the issue, or the issue is of high
-severity to warrant an expulsion, the contributor will be expelled from the
-Jenkins community for a period of 12 months. After which they may appeal to the
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time
+(chats, mailing lists, pull requests, issues, events, etc.).
+No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a ban.
+
+=== 4. Ban
+
+//oleg_nenashev: There is a deviation from Contributor Covenant 2.0 which recommends a Permanent Ban.
+// Jenkins Code of Conduct in the 2016 edition offered a way to restore accounts after 12 months in the case of explusion,
+// and it is retained in this edition
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+// Addition to Contributor Covenant 2.0 begins here
+The individual will be expelled from the Jenkins community.
+After 12 months of ban they may appeal to the
 board for the ban to be lifted.
 
 The ban will include but is not limited to:
 
-*  Bans from Jenkins community IRC Channels
+*  Bans from Jenkins community link:/chat[chats]
 *  Deletion of their LDAP account
-*  Blocking their GitHub username from the jenkinsci github organization
-*  Banning their email address from jenkins mailing lists
+*  Blocking their GitHub username from the Jenkins GitHub organizations
+*  Banning their email address from Jenkins mailing lists
+*  Banning them from social media and meetup groups
+*  Banning them from participating in Community-organized events
 
 == Version history
 
 * **Jul TODO, 2020** - The Code of Conduct was updated.
   It was approved the project governance meeting, see the meeting notes link:TODO[here].
   Notable changes:
-** Code of Conduct is updated to link:[Contributor Covenant, version 2.0]
+** Code of Conduct is updated to link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant, version 2.0]
+** Align _Handling of Violations_ with link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant 2.0] _Enforcement Guidelines_
 * **Jan 06, 2016** - First version of Code of Conduct is introduced.
   It is adapted from the link:https://www.contributor-covenant.org/version/1/3/0/[Contributor Covenant, version 1.3.0].
   The Code of Conduct was approved by the project governance meeting on

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -13,8 +13,8 @@ we commit to respect all people who participate in the community through reporti
 posting feature requests, updating documentation, submitting pull requests or
 patches, and other activities.
 
-This document defines the Code of Conduct and reporting/handling processes for the Jenkins community. 
-For more details about our cultural values, goals, philosophies, structure and so on, please consult our link:/project/governance[Governance Document]. 
+This document defines the Code of Conduct along with reporting and handling guidelines for the Jenkins community. 
+For more details about our cultural values, goals, philosophies, and structure, please consult our link:/project/governance[Governance Document]. 
 
 == Our Pledge
 

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -241,8 +241,10 @@ enforcement ladder].
 
 == Version history
 
-* **Jul TODO, 2020** - Major update of the Code of Conduct.
-  It was approved the project governance meeting, see the meeting notes link:TODO[here].
+* **Jul 02, 2020** - Major update of the Code of Conduct.
+  It was approved the project governance meeting on Jul 01
+  (link:https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit#heading=h.6rx5y09hwmti[meeting notes],
+   link:https://groups.google.com/forum/#!topic/jenkinsci-dev/u0T56f9MSZY[developer mailing list discussion]).
   Notable changes:
 ** Code of Conduct is updated to link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant, version 2.0]
 ** Align _Handling of Violations_ with link:https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Contributor Covenant 2.0] _Enforcement Guidelines_


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/jenkinsci-dev/u0T56f9MSZY for the context. The change is on hold until the updates are officially approved by the Jenkins Governance Meeting.

Changes summary:

- [x] Update Code of Conduct text (pledge and standards) to [Contributor Covenant, version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/)
- [x] Align _Handling of Violations_ with Contributor Covenant 2.0 _Enforcement Guidelines_
- [x] Refresh the _Community Spaces_ section
- [x] Reference Continuous Delivery Foundation (CDF) as a second escalation level

CC @jenkins-infra/board @markyjackson-taulia @jeffret-b @tracymiranda who actively participated in the initial discussion.


