### PR TITLE
[JEP-15] - Refactor the "Why donate?" text

### DIFF
--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -5,7 +5,8 @@ title: "Donate to Jenkins"
 
 The Jenkins project operates thanks to individual and company contributors
 investing their time and resources to maintain and evolve the project.
-The best way to help the project is to link:/participate[participate and contribute].
+The best way to help the project is to link:/participate[participate and contribute],
+volunteer time is the most precious resource for an open-source project. 
 We will appreciate any contributions to the Jenkins: code, documentation, etc.
 If you have no opportunity to contribute your time, we also appreciate donations of money and equipment.
 

--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -4,27 +4,22 @@ title: "Donate to Jenkins"
 ---
 
 The Jenkins project operates thanks to individual and company contributors
-investing their resources to maintain and evolve the project.
+investing their time and resources to maintain and evolve the project.
 The best way to help the project is to link:/participate[participate and contribute].
 We will appreciate any contributions to the Jenkins: code, documentation, etc.
-If you have no opportunity to contribute, we also appreciate donations of money and equipment.
+If you have no opportunity to contribute your time, we also appreciate donations of money and equipment.
 
 You can donate here:
 image:/images/governance/funding/communitybridge.png[Donate via Community Bridge, link="https://funding.communitybridge.org/projects/jenkins", role=center, height=48]
 
 == Why donate?
 
-Historically we have not spent much money on day-to-day operations.
-The Jenkins project has no personnel on payroll, all contributions come from individual and company contributors.
-Sponsorships cover most of our "big" expenses: most of the infrastructure costs, contributor summits, meetup accounts, swag, etc.
-At the same time, your donations help to keep the project going and to facilitate its evolution.
+Your donations help to keep the project going and to accelerate its evolution:
 
-How do we use the donated money?
-
-* Facilitating initiatives within the link:/roadmap/[public Jenkins Roadmap]:
+* Facilitating key initiatives within the link:/roadmap/[Jenkins Roadmap]:
   new features, documentation, user experience improvement, etc.
-** Organizing community events
-** Running self-funded link:/sigs/advocacy-and-outreach/outreach-programs/[outreach and mentorship programs]
+** Organizing community events and outreach programs
+** Running self-funded link:/sigs/advocacy-and-outreach/outreach-programs/[mentorship programs] like Outreachy and Community Bridge
 ** Swag for active Jenkins contributors
 * Operating and infrastructure expenses not covered by existing sponsorships
 ** Certificates and domains for our websites, network transit costs, hardware for self-hosted services
@@ -33,26 +28,27 @@ How do we use the donated money?
 * Gifts for link:/security/#reporting-vulnerabilities[reporting security vulnerabilities] (link:https://www.jenkins.io/security/gift/[more info])
 * Funding the jep:12[Jenkins Travel Grant Program] to help community members to attend Jenkins related events.
 
-Your contribution is *NOT* used for paying personnel, for placing ads, or for other forms of commercial promotion.
+Your contribution will *NOT* be used for paying personnel, for placing ads, or for other forms of commercial promotion.
+The Jenkins project has no personnel on payroll, all contributions come from individual and company contributors.
+Sponsorships cover most of our "big" expenses: most of the infrastructure costs, contributor summits, meetup accounts, swag, etc.
+It allows spending the most of donations on targeted projects focused on evolving the project and the community.
+Many initiatives we run require "just" hundreds or thousands of US dollars,
+even small contributions can make a real difference for the project and its users.
 
-== Ways to donate money
-
-There are multiple ways to donate money to the Jenkins project.
-
-=== Donations through Community Bridge
+== Donations through Community Bridge
 
 image:/images/governance/funding/communitybridge.png[Donate via Community Bridge, link="https://funding.communitybridge.org/projects/jenkins", role=center, height=48]
 
 The Jenkins project https://funding.communitybridge.org/projects/jenkins[has an account] on the Community Bridge funding platform.
 It provides support for donations by individuals and by organizations, including anonymous donations.
-Minimum donation is 5USD for individuals and 500 USD for organizations.
+Minimum donation is 5 USD for individuals and 500 USD for organizations.
 
 * You can make a one-time donation or configure monthly donations using your credit card.
 * Organizations can also make a donation via invoice
 
 See jep:15[Jenkins funding on Community Bridge] for more details about the donation process and targets.
 
-=== Donations through Continuous Delivery Foundation 
+== Donations through Continuous Delivery Foundation 
 
 Large donations can be also made through link:https://cd.foundation/[Continuous Delivery Foundation].
 Please contact the link://jenkinsci-board@googlegroups.com[Jenkins Governance Board] if you want to make such a donation.


### PR DESCRIPTION
This PR refactors the "Why donate?" text to avoid a long abstract (moved to the bottom). I also removed the "How to donate?" header which does not seem to be very useful in the current state.
