### PR TITLE
Rephrase SECURITY-1632 for consistency

### DIFF
--- a/content/security/advisory/2020-07-02.adoc
+++ b/content/security/advisory/2020-07-02.adoc
@@ -178,12 +178,11 @@ issues:
   cvss:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
-  description: "PLUGIN_NAME 1.8 and earlier stores a GitHub access token in plain\
-    \ text in its global configuration file `io.jenkins.plugins.gcr.PluginConfiguration.xml`.\n\
-    This can be viewed by users with access to the Jenkins master file system. \n\
-    It is also transmitted in plain text as part of the configuration form where it\
-    \ can be viewed by those who can read the system configuration.\n\nAs of publication\
-    \ of this advisory, there is no fix."
+  description: |-
+    PLUGIN_NAME 1.8 and earlier stores a GitHub access token in plain text in its global configuration file `io.jenkins.plugins.gcr.PluginConfiguration.xml`.
+    This token can be viewed by users with access to the Jenkins master file system.
+
+    As of publication of this advisory, there is no fix.
   plugins:
   - name: github-coverage-reporter
     previous: '1.8'


### PR DESCRIPTION
This aligns the entry more closely with similar ones.

Additionally, remove the ambiguous "read access to the form", as it seems to refer to System Read.
