### PR TITLE
GSoC 2020 - Remove inactive mentors from the GitHub Checks API project

### DIFF
--- a/content/projects/gsoc/2020/projects/github-checks.adoc
+++ b/content/projects/gsoc/2020/projects/github-checks.adoc
@@ -10,8 +10,6 @@ student: XiongKezhi
 mentors:
 - "uhafner"
 - "timja"
-- "ayush_agarwal"
-- "Sagar2366"
 advisors:
 - "jeffpearce"
 tags:


### PR DESCRIPTION
This pull request removes @Sagar2366 and @aagarwal1012 from the list of GitHub Checks API project mentors. 

CC @timja @uhafner 
