### PR TITLE
Updated node docker image version

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -76,7 +76,7 @@ container and execute the defined steps within it:
 [Pipeline] sh
 [guided-tour] Running shell script
 + node --version
-v7.4.0
+v14.5.0
 [Pipeline] }
 [Pipeline] // stage
 [Pipeline] }

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -45,7 +45,7 @@ can be used with ease by making only minor edits to a `Jenkinsfile`.
 // Declarative //
 pipeline {
     agent {
-        docker { image 'node:7-alpine' }
+        docker { image 'node:14-alpine' }
     }
     stages {
         stage('Test') {
@@ -58,7 +58,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('node:7-alpine').inside {
+    docker.image('node:14-alpine').inside {
         stage('Test') {
             sh 'node --version'
         }
@@ -156,7 +156,7 @@ pipeline {
         }
         stage('Front-end') {
             agent {
-                docker { image 'node:7-alpine' }
+                docker { image 'node:14-alpine' }
             }
             steps {
                 sh 'node --version'
@@ -175,7 +175,7 @@ node {
     }
 
     stage('Front-end') {
-        docker.image('node:7-alpine').inside {
+        docker.image('node:14-alpine').inside {
             sh 'node --version'
         }
     }
@@ -197,7 +197,7 @@ Re-using an example from above, with a more custom `Dockerfile`:
 .Dockerfile
 [source]
 ----
-FROM node:7-alpine
+FROM node:14-alpine
 
 RUN apk add -U subversion
 ----

--- a/content/doc/pipeline/tour/agents.adoc
+++ b/content/doc/pipeline/tour/agents.adoc
@@ -49,7 +49,7 @@ link:/doc/book/pipeline/syntax#agent[syntax reference].
 // Declarative //
 pipeline {
     agent {
-        docker { image 'node:7-alpine' }
+        docker { image 'node:14-alpine' }
     }
     stages {
         stage('Test') {
@@ -62,7 +62,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('node:7-alpine').inside {
+    docker.image('node:14-alpine').inside {
         stage('Test') {
             sh 'node --version'
         }
@@ -80,7 +80,7 @@ container and execute the defined steps within it:
 [Pipeline] sh
 [guided-tour] Running shell script
 + node --version
-v7.4.0
+v14.5.0
 [Pipeline] }
 [Pipeline] // stage
 [Pipeline] }


### PR DESCRIPTION
**node:7-alpine** tag is not supported any more, see the [Docker Hub](https://hub.docker.com/_/node) for more details.

As of 7 July 2020 the [first example](https://www.jenkins.io/doc/book/pipeline/docker/#execution-environment) of Pipeline execution fails:

```
[Pipeline] sh
+ docker inspect -f . node:7-alpine
Error: No such image or container: node:7-alpine
[Pipeline] sh
+ docker pull node:7-alpine
Pulling repository node
Get https://index.docker.io/v1/repositories/library/node/images: dial tcp 3.220.75.233:443: connection timed out
```