### PR TITLE
Document the Weekly Release Line

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -65,6 +65,8 @@ title: Jenkins installation and setup
             %p
               A new release is produced weekly to deliver bug fixes and
               features to users and plugin developers.
+              %a{'href' => 'weekly'}
+                Learn more…
 
             %p.details
               %a.item{:href=>'/changelog'}

--- a/content/download/weekly/index.adoc
+++ b/content/download/weekly/index.adoc
@@ -21,7 +21,7 @@ Conditions for new releases of the _Weekly Release Line_:
 ** Currently these releases happen on a weekly basis on Tuesdays.
 * **Security releases** for the Jenkins core (see the link:/security[Jenkins Security] page).
 ** We coordinate Jenkins Weekly and LTS releases so that the vulnerabilities are fixed at the same time in all release lines.
-   Jenkins security team sends notifications about incoming security releases to link:/security/#advisories[Jenkins Security Advisory Channels].
+   Jenkins security team sends notifications about upcoming security releases to link:/security/#advisories[Jenkins Security Advisory Channels].
 ** Usually these releases happen on Wednesdays.
 * **Out-of-order releases** in the case of major regressions and/or other reasons.
 

--- a/content/download/weekly/index.adoc
+++ b/content/download/weekly/index.adoc
@@ -24,6 +24,7 @@ Conditions for new releases of the _Weekly Release Line_:
    Jenkins security team sends notifications about upcoming security releases to link:/security/#advisories[Jenkins Security Advisory Channels].
 ** Usually these releases happen on Wednesdays.
    If we release security updates on Wednesday, there will be no regular release the day before.
+   link:/security/scheduling/[Learn more about how we schedule security advisories].
 * **Out-of-order releases** in the case of major regressions and/or other reasons.
 
 Weekly releases are managed by Jenkins core maintainers
@@ -34,7 +35,7 @@ See link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc[
 ## No Backporting
 
 Unlike for the LTS line,
-there is NO backporting process for the _Weekly Release Line_.
+there is no backporting process for the _Weekly Release Line_.
 Bug fixes, including fixes for regressions will be integrated towards the next release.
 While that release may be expedited (see out-of-order releases above), there won't be patches for previous releases.
 

--- a/content/download/weekly/index.adoc
+++ b/content/download/weekly/index.adoc
@@ -17,12 +17,13 @@ To get notifications about new releases, it is possible to subscribe to link:htt
 
 Conditions for new releases of the _Weekly Release Line_:
 
-* **Common releases** with all features, improvements and bug fixes integrated since the last release.
+* **Regular releases** with all features, improvements and bug fixes integrated since the last release.
 ** Currently these releases happen on a weekly basis on Tuesdays.
 * **Security releases** for the Jenkins core (see the link:/security[Jenkins Security] page).
 ** We coordinate Jenkins Weekly and LTS releases so that the vulnerabilities are fixed at the same time in all release lines.
    Jenkins security team sends notifications about upcoming security releases to link:/security/#advisories[Jenkins Security Advisory Channels].
 ** Usually these releases happen on Wednesdays.
+   If we release security updates on Wednesday, there will be no regular release the day before.
 * **Out-of-order releases** in the case of major regressions and/or other reasons.
 
 Weekly releases are managed by Jenkins core maintainers
@@ -32,10 +33,10 @@ See link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc[
 
 ## No Backporting
 
-Unlike for the LTS baseline,
+Unlike for the LTS line,
 there is NO backporting process for the _Weekly Release Line_.
-If a new release is needed to fix a discovered regression,
-we just release a new Jenkins weekly version. 
+Bug fixes, including fixes for regressions will be integrated towards the next release.
+While that release may be expedited (see out-of-order releases above), there won't be patches for previous releases.
 
 ## Switching Between Release Lines
 

--- a/content/download/weekly/index.adoc
+++ b/content/download/weekly/index.adoc
@@ -17,7 +17,7 @@ To get notifications about new releases, it is possible to subscribe to link:htt
 
 Conditions for new releases of the _Weekly Release Line_:
 
-* **Regular releases** with all features, improvements and bug fixes integrated since the last release.
+* **Regular releases** with all features, improvements, and bug fixes integrated since the last release.
 ** Currently these releases happen on a weekly basis on Tuesdays.
 * **Security releases** for the Jenkins core (see the link:/security[Jenkins Security] page).
 ** We coordinate Jenkins Weekly and LTS releases so that the vulnerabilities are fixed at the same time in all release lines.

--- a/content/download/weekly/index.adoc
+++ b/content/download/weekly/index.adoc
@@ -1,0 +1,49 @@
+---
+layout: simplepage
+title: Weekly Release Line
+---
+:toc:
+
+The Jenkins _Weekly Release Line_ delivers bug fixes and new features rapidly to users and plugin developers who need them.
+These releases are generally delivered on a weekly cadence, hence the name.
+For more conservative users, there is also a 
+link:/download/lts/[Long-Term Support (LTS)] line.
+
+## Model
+
+The "weekly" release cadence is **aspirational**.
+Generally we target releasing Jenkins every week, but sometimes we do out-of-order releases.
+To get notifications about new releases, it is possible to subscribe to link:https://www.jenkins.io/changelog/rss.xml[releases RSS feed].
+
+Conditions for new releases of the _Weekly Release Line_:
+
+* **Common releases** with all features, improvements and, and bugfixes integrated since the last release.
+** Currently these releases happen on a weekly basis on Tuesdays.
+* **Security releases** for the Jenkins core (see the link:/security[Jenkins Security] page).
+** We coordinate Jenkins Weekly and LTS releases so that the vulnerabilities are fixed at the same time in all release lines.
+   Jenkins security team sends notifications about incoming security releases to link:/security/#advisories[Jenkins Security Advisory Channels].
+** Usually these releases happen on Wednesdays.
+* **Out-of-order releases** in the case of major regressions and/or other reasons.
+
+Weekly releases are managed by Jenkins core maintainers
+who review the suggested pull requests, integrate changes and deliver the releases.
+The team also manages link:/changelog[changelogs] and the LTS backporting process.
+See link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc[this page] for more information about Jenkins core maintenance.
+
+## No Backporting
+
+Unlike for the LTS baseline,
+there is NO backporting process for the _Weekly Release Line_.
+If a new release is needed to fix a discovered regression,
+we just release a new Jenkins weekly version. 
+
+## Switching Between Release Lines
+
+It is possible to switch between Jenkins Weekly and LTS release line when needed.
+See the documentation link:/download/lts/#switching-between-release-lines[here].
+
+## References
+
+* link:/changelog[Jenkins Weekly Release changelog]
+* link:/download/lts/[Long-Term Support (LTS) Release Line]
+* link:/security[Jenkins Security Process]

--- a/content/download/weekly/index.adoc
+++ b/content/download/weekly/index.adoc
@@ -17,7 +17,7 @@ To get notifications about new releases, it is possible to subscribe to link:htt
 
 Conditions for new releases of the _Weekly Release Line_:
 
-* **Common releases** with all features, improvements and, and bugfixes integrated since the last release.
+* **Common releases** with all features, improvements and bug fixes integrated since the last release.
 ** Currently these releases happen on a weekly basis on Tuesdays.
 * **Security releases** for the Jenkins core (see the link:/security[Jenkins Security] page).
 ** We coordinate Jenkins Weekly and LTS releases so that the vulnerabilities are fixed at the same time in all release lines.
@@ -39,7 +39,7 @@ we just release a new Jenkins weekly version.
 
 ## Switching Between Release Lines
 
-It is possible to switch between Jenkins Weekly and LTS release line when needed.
+It is possible to switch between Jenkins Weekly and LTS release lines when needed.
 See the documentation link:/download/lts/#switching-between-release-lines[here].
 
 ## References


### PR DESCRIPTION
The CDF Graduation criteria requires us to document the release cycle ([checklist](https://docs.google.com/document/d/1Ldmtny6OfEtQlCqdFWqq9Z25cxkZFX6yNiRqOOxo77c/edit?usp=sharing)). At the moment there is no official documentation for the weekly releases, and I suggest to add one.

Once merged, I will also add the release lines documentation to the Jenkins core documentation and to the maintainer guide.

## Preview

![image](https://user-images.githubusercontent.com/3000480/86924843-4c3eda80-c130-11ea-912f-cbbeae6bc952.png)
