### PR TITLE
Add JSON metadata for shields.io badges

### DIFF
--- a/content/changelog-stable/badge.json.haml
+++ b/content/changelog-stable/badge.json.haml
@@ -1,0 +1,13 @@
+- release = site.changelogs[:lts].reverse.select { |release| Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest) }[0]
+
+// Compatible with shields.io JSON endpoint: https://shields.io/endpoint
+:plain
+  {
+    "schemaVersion": 1,
+    "label": "Jenkins LTS",
+    "message": "#{release.version}",
+    "color": "blue"
+    "version":"#{release.version}",
+    "date":"#{release.date}",
+    "changelogUrl":"https://www.jenkins.io/changelog-slable/##{release.version}"
+  }

--- a/content/changelog-stable/badge.json.haml
+++ b/content/changelog-stable/badge.json.haml
@@ -6,7 +6,7 @@
     "schemaVersion": 1,
     "label": "Jenkins LTS",
     "message": "#{release.version}",
-    "color": "blue"
+    "color": "blue",
     "version": "#{release.version}",
     "date": "#{release.date}",
     "changelogUrl": "https://www.jenkins.io/changelog-slable/##{release.version}"

--- a/content/changelog-stable/badge.json.haml
+++ b/content/changelog-stable/badge.json.haml
@@ -7,7 +7,7 @@
     "label": "Jenkins LTS",
     "message": "#{release.version}",
     "color": "blue"
-    "version":"#{release.version}",
-    "date":"#{release.date}",
-    "changelogUrl":"https://www.jenkins.io/changelog-slable/##{release.version}"
+    "version": "#{release.version}",
+    "date": "#{release.date}",
+    "changelogUrl": "https://www.jenkins.io/changelog-slable/##{release.version}"
   }

--- a/content/changelog/badge.json.haml
+++ b/content/changelog/badge.json.haml
@@ -6,7 +6,7 @@
     "schemaVersion": 1,
     "label": "Jenkins Weekly",
     "message": "#{release.version}",
-    "color": "blue"
+    "color": "blue",
     "version": "#{release.version}",
     "date": "#{release.date}",
     "changelogUrl": "https://www.jenkins.io/changelog/##{release.version}"

--- a/content/changelog/badge.json.haml
+++ b/content/changelog/badge.json.haml
@@ -7,7 +7,7 @@
     "label": "Jenkins Weekly",
     "message": "#{release.version}",
     "color": "blue"
-    "version":"#{release.version}",
-    "date":"#{release.date}",
-    "changelogUrl":"https://www.jenkins.io/changelog/##{release.version}"
+    "version": "#{release.version}",
+    "date": "#{release.date}",
+    "changelogUrl": "https://www.jenkins.io/changelog/##{release.version}"
   }

--- a/content/changelog/badge.json.haml
+++ b/content/changelog/badge.json.haml
@@ -1,0 +1,13 @@
+- release = site.changelogs[:weekly].reverse.select { |release| Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest) }[0]
+
+// Compatible with shields.io JSON endpoint: https://shields.io/endpoint
+:plain
+  {
+    "schemaVersion": 1,
+    "label": "Jenkins Weekly",
+    "message": "#{release.version}",
+    "color": "blue"
+    "version":"#{release.version}",
+    "date":"#{release.date}",
+    "changelogUrl":"https://www.jenkins.io/changelog/##{release.version}"
+  }


### PR DESCRIPTION
This change exposes version metadata which can be also consumed by https://shields.io/endpoint . It is a more production-grade implementation for Jenkins core badges which were reverted in https://github.com/jenkinsci/jenkins/pull/4703 due to the high download traffic. CC @daniel-beck 

Sample JSON:

```json
<!-- / Compatible with shields.io JSON endpoint: https://shields.io/endpoint -->
{
  "schemaVersion": 1,
  "label": "Jenkins Weekly",
  "message": "2.243",
  "color": "blue",
  "version": "2.243",
  "date": "2020-06-30",
  "changelogUrl": "https://www.jenkins.io/changelog/#2.243"
}

```