### PR TITLE
Restructure the Downloads page

### DIFF
--- a/.github/workflows/compress-images-in-PRs.yml
+++ b/.github/workflows/compress-images-in-PRs.yml
@@ -1,0 +1,21 @@
+name: Compress images
+on:
+  pull_request:
+    paths:
+      - '**.jpg'
+      - '**.png'
+      - '**.webp'
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Compress Images
+        uses: calibreapp/image-actions@master
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          jpegQuality: "100"
+          pngQuality: "100"
+          webpQuality: "100"

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -100,26 +100,27 @@ title: Jenkins download and deployment
             %span.icon
             %span.title
               Docker
-          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/opensuse-stable/'}
-            %span.icon
-            %span.title
-              openSUSE
-          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat-stable/'}
-            %span.icon
-            %span.title
-              Red Hat/Fedora/CentOS
           %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian-stable/'}
             %span.icon
             %span.title
               Ubuntu/Debian
+          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat-stable/'}
+            %span.icon
+            %span.title
+              CentOS/Fedora/Red Hat
           %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer-stable'}
             %span.icon
             %span.title
               Windows
+          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/opensuse-stable/'}
+            %span.icon
+            %span.title
+              openSUSE
           %a.list-group-item.list-group-item-action{third_party_href('https://www.freshports.org/devel/jenkins-lts')}
             %span.icon
             %span.title
               FreeBSD
+            %span.icon-gear-menu-o/
           %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
             %span.title
               Gentoo
@@ -155,22 +156,22 @@ title: Jenkins download and deployment
           %span.icon
           %span.title
             Docker
-        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/opensuse/'}
-          %span.icon
-          %span.title
-            openSUSE
-        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/redhat/'}
-          %span.icon
-          %span.title
-            Red Hat/Fedora/CentOS
         %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian/'}
           %span.icon
           %span.title
             Ubuntu/Debian
+        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/redhat/'}
+          %span.icon
+          %span.title
+            CentOS/Fedora/Red Hat
         %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer'}
           %span.icon
           %span.title
             Windows
+        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/opensuse/'}
+          %span.icon
+          %span.title
+            openSUSE
         %a.list-group-item.list-group-item-action{third_party_href('https://www.archlinux.org/packages/community/any/jenkins/')}
           %span.title
             Arch Linux

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -223,4 +223,4 @@ title: Jenkins download and deployment
   NOTE: Packages with the
   %span.icon-gear-menu-o
   gear icon are maintained by third parties.
-  Such pachages may be not as frequently updated as packages supported by the Jenkins project directly. 
+  Such packages may be not as frequently updated as packages supported by the Jenkins project directly. 

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -9,11 +9,6 @@ title: Jenkins download and deployment
     return third_party.merge({:href => url})
   end
 
-
-%p
-
-// = partial('downloadbanner.html.haml')
-
 %p
   The Jenkins project produces two release lines: Stable (LTS) and regular (Weekly).
   Depending on your organization's needs, one may be preferred over the other.

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -1,6 +1,6 @@
 ---
-layout: default
-title: Jenkins installation and setup
+layout: simplepage
+title: Jenkins download and deployment
 ---
 
 :ruby
@@ -10,216 +10,221 @@ title: Jenkins installation and setup
   end
 
 
-= partial('downloadbanner.html.haml')
+%p
 
-.container
-  .row.body
-    .col-md-1
-    .col-md-10
-      %h2
-        Getting started with Jenkins
+// = partial('downloadbanner.html.haml')
 
-      .container
-        .row
-          %p
-            The Jenkins project produces two release lines, LTS and weekly.
-            Depending on your organization's needs, one may be preferred over
-            the other.
-          %p
-            Both release lines are distributed as
-            %code
-              \.war
-            files, native packages, installers, and Docker containers. Packages with the
-            %span.icon-gear-menu-o
-            gear icon are maintained by third parties.
-          %p
-            Before downloading, please take a moment to review hardware recommendations
-            %strong
-              %a{:href => '/doc/book/hardware-recommendations/#hardware-recommendations'}
-                Hardware Recommendations
-            section of the User Handbook.
-        .row
-          .col-md-6
-            %h4
-              Long-term Support (LTS)
-            %p
-              LTS (Long-Term Support) releases are chosen every 12 weeks from the
-              stream of regular releases as the stable release for that time period.
+%p
+  The Jenkins project produces two release lines: Stable (LTS) and regular (Weekly).
+  Depending on your organization's needs, one may be preferred over the other.
+  See the links below for more information and recommendations about the release lines.
 
-              %a{'href' => 'lts'}
-                Learn more…
+.container          
+  .row
+    .col-md-6
+      %h4
+        Stable (LTS)
+      %p
+        Long-Term Support (LTS) release baselines are chosen every 12 weeks from the stream of regular releases.
+        Every 4 weeks we release stable releases which include bug and security fix backports. 
 
-              %p.details
-                %a.item{:href=>'/changelog-stable'}
-                  Changelog
-                |
-                %a.item{:href=>'/doc/upgrade-guide'}
-                  Upgrade Guide
-                |
-                %a.item{:href=>'http://mirrors.jenkins.io/war-stable/'}
-                  Past Releases
+        %a{'href' => 'lts'}
+          Learn more…
 
-          .col-md-6
-            %h4
-              Weekly
-            %p
-              A new release is produced weekly to deliver bug fixes and
-              features to users and plugin developers.
-              %a{'href' => 'weekly'}
-                Learn more…
+        %p.details
+          %a.item{:href=>'/changelog-stable'}
+            Changelog
+          |
+          %a.item{:href=>'/doc/upgrade-guide'}
+            Upgrade Guide
+          |
+          %a.item{:href=>'http://mirrors.jenkins.io/war-stable/'}
+            Past Releases
+    .col-md-6
+      %h4
+        Regular releases (Weekly)
+      %p
+        This release line delivers bug fixes and new features rapidly to users and plugin developers who need them.
+        It is generally delivered on a weekly cadence.
+        %a{'href' => 'weekly'}
+          Learn more…
 
-            %p.details
-              %a.item{:href=>'/changelog'}
-                Changelog
-              |
-              %a.item{:href=>'http://mirrors.jenkins.io/war/'}
-                Past Releases
-        .row
-          .col-md-6
-            %strong
-              %i.icon-box-add
-              Deploy Jenkins
-              = site.jenkins.stable
+      %p.details
+        %a.item{:href=>'/changelog'}
+          Changelog
+        |
+        %a.item{:href=>'http://mirrors.jenkins.io/war/'}
+          Past Releases
 
-              .container
-                .row
-                  .m-3
-                    %a{:href => 'https://aka.ms/jenkins-on-azure'}
-                      - # Contact azdevopspub@microsoft.com if issues arise
-                      %img{:src => '/images/azure-deploy-button.png'}/
+%h2
+  Downloading Jenkins
 
-            .list-group
-            %strong
-              %i.icon-box-add
-              Download Jenkins
-              = site.jenkins.stable
-              for:
+%p
+  Both release lines are distributed as
+  %code
+    \.war
+  files, native packages, installers, and Docker containers.
+  Follow the following steps to install Jenkins:
 
-            .list-group
-              %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins'}
-                %span.icon
-                %span.title
-                  Docker
-              %a.list-group-item.list-group-item-action{:href => 'https://www.freshports.org/devel/jenkins-lts'}
-                %span.icon
-                %span.title
-                  FreeBSD
-              %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
-                %span.title
-                  Gentoo
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{third_party_href('/download/lts/macos')}
-                %span.icon
-                %span.title
-                  macOS
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{third_party_href('http://openports.se/devel/jenkins/stable')}
-                %span.title
-                  OpenBSD
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/opensuse-stable/'}
-                %span.icon
-                %span.title
-                  openSUSE
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat-stable/'}
-                %span.icon
-                %span.title
-                  Red Hat/Fedora/CentOS
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian-stable/'}
-                %span.icon
-                %span.title
-                  Ubuntu/Debian
-              %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer-stable'}
-                %span.icon
-                %span.title
-                  Windows
-              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins.io/war-stable/latest/jenkins.war'}
-                %span.title
-                Generic Java package (.war)
+%ol
+  %li
+    Before downloading, please take a moment to review the
+    %strong
+      %a{:href => '/doc/book/installing/#prerequisites'}
+        Hardware and Software requirements
+    section of the User Handbook.
+  %li
+    Select one of the packages below and follow the download instructions.
+  %li
+    Once a Jenkins package has been downloaded, proceed to the
+    %strong
+      %a{:href => '/doc/book/getting-started/installing/'}
+        Installing Jenkins
+    section of the User Handbook.
 
-          .col-md-6
-            %strong
-              %i.icon-box-add
-              Download Jenkins
-              = site.jenkins.latest
-              for:
+.container          
+  .row
+    .col-md-6
+      .list-group
+        %strong
+          %i.icon-box-add
+          Download Jenkins
+          = site.jenkins.stable
+          LTS for:
 
-            .list-group
-              %a.list-group-item.list-group-item-action{third_party_href('https://www.archlinux.org/packages/community/any/jenkins/')}
-                %span.title
-                  Arch Linux
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins/'}
-                %span.icon
-                %span.title
-                  Docker
-              %a.list-group-item.list-group-item-action{third_party_href('https://www.freshports.org/devel/jenkins')}
-                %span.title
-                  FreeBSD
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
-                %span.title
-                  Gentoo
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{third_party_href('/download/weekly/macos')}
-                %span.icon
-                %span.title
-                  macOS
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{third_party_href('http://openports.se/devel/jenkins/devel')}
-                %span.title
-                  OpenBSD
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/opensuse/'}
-                %span.icon
-                %span.title
-                  openSUSE
-              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/redhat/'}
-                %span.icon
-                %span.title
-                  Red Hat/Fedora/CentOS
-              %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian/'}
-                %span.icon
-                %span.title
-                  Ubuntu/Debian
-              %a.list-group-item.list-group-item-action{third_party_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins')}
-                %span.title
-                  OpenIndiana Hipster
-                %span
-                  &nbsp;
-                %span.icon-gear-menu-o/
-              %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer'}
-                %span.icon
-                %span.title
-                  Windows
-              %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
-                %span.title
-                Generic Java package (.war)
+        .list-group
+          %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins.io/war-stable/latest/jenkins.war'}
+            %span.title
+            Generic Java package (.war)
+          %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins'}
+            %span.icon
+            %span.title
+              Docker
+          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/opensuse-stable/'}
+            %span.icon
+            %span.title
+              openSUSE
+          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat-stable/'}
+            %span.icon
+            %span.title
+              Red Hat/Fedora/CentOS
+          %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian-stable/'}
+            %span.icon
+            %span.title
+              Ubuntu/Debian
+          %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer-stable'}
+            %span.icon
+            %span.title
+              Windows
+          %a.list-group-item.list-group-item-action{third_party_href('https://www.freshports.org/devel/jenkins-lts')}
+            %span.icon
+            %span.title
+              FreeBSD
+          %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
+            %span.title
+              Gentoo
+            %span
+              &nbsp;
+            %span.icon-gear-menu-o/
+          %a.list-group-item.list-group-item-action{third_party_href('/download/lts/macos')}
+            %span.icon
+            %span.title
+              macOS
+            %span
+              &nbsp;
+            %span.icon-gear-menu-o/
+          %a.list-group-item.list-group-item-action{third_party_href('http://openports.se/devel/jenkins/stable')}
+            %span.title
+              OpenBSD
+            %span
+              &nbsp;
+            %span.icon-gear-menu-o/
 
+    .col-md-6
+      %strong
+        %i.icon-box-add
+        Download Jenkins
+        = site.jenkins.latest
+        for:
 
-        %hr/
+      .list-group
+        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
+          %span.title
+          Generic Java package (.war)
+        %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins/'}
+          %span.icon
+          %span.title
+            Docker
+        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/opensuse/'}
+          %span.icon
+          %span.title
+            openSUSE
+        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/redhat/'}
+          %span.icon
+          %span.title
+            Red Hat/Fedora/CentOS
+        %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian/'}
+          %span.icon
+          %span.title
+            Ubuntu/Debian
+        %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer'}
+          %span.icon
+          %span.title
+            Windows
+        %a.list-group-item.list-group-item-action{third_party_href('https://www.archlinux.org/packages/community/any/jenkins/')}
+          %span.title
+            Arch Linux
+          %span
+            &nbsp;
+          %span.icon-gear-menu-o/
+        %a.list-group-item.list-group-item-action{third_party_href('https://www.freshports.org/devel/jenkins')}
+          %span.title
+            FreeBSD
+          %span
+            &nbsp;
+          %span.icon-gear-menu-o/
+        %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
+          %span.title
+            Gentoo
+          %span
+            &nbsp;
+          %span.icon-gear-menu-o/
+        %a.list-group-item.list-group-item-action{third_party_href('/download/weekly/macos')}
+          %span.icon
+          %span.title
+            macOS
+          %span
+            &nbsp;
+          %span.icon-gear-menu-o/
+        %a.list-group-item.list-group-item-action{third_party_href('http://openports.se/devel/jenkins/devel')}
+          %span.title
+            OpenBSD
+          %span
+            &nbsp;
+          %span.icon-gear-menu-o/
+        %a.list-group-item.list-group-item-action{third_party_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins')}
+          %span.title
+            OpenIndiana Hipster
+          %span
+            &nbsp;
+          %span.icon-gear-menu-o/
 
-        .row
-          .col-md-12
-            %p
-              Once a Jenkins package has been downloaded, proceed to the
-              %strong
-                %a{:href => '/doc/book/getting-started/installing/'}
-                  Installing Jenkins
-              section of the User Handbook.
+%h2
+  Deploying Jenkins in public cloud
+
+%p
+  There are public cloud vendors providing their own Jenkins distributions on marketplaces.
+  Such distributions may be used to quickly deploy Jenkins and, in many cases,
+  to get an instance preconfigured to be used within the public cloud
+  (e.g. bundled plugins, integrations with public cloud services, etc.).
+
+  %div
+    %a{third_party_href('https://aka.ms/jenkins-on-azure')}
+      - # Contact azdevopspub@microsoft.com if issues arise
+      %img{:src => '/images/azure-deploy-button.png'}/
+      %span.icon-gear-menu-o/
+%hr
+  NOTE: Packages with the
+  %span.icon-gear-menu-o
+  gear icon are maintained by third parties.
+  Such pachages may be not as frequently updated as packages supported by the Jenkins project directly. 


### PR DESCRIPTION
This pull request restructures the Downloads page. Changes summary:

* Remove the big Jenkins banner on the top (consumes 1/3 of the page in the top)
* Simplify layouts, fix #3516 which impacts the mobile screens
* Move deployments to public clouds into a separate section. It was briefly discussed with @rtyler and other @jenkins-infra/board members before
* Reorder downloads: Push 3rd-party distributions to the bottom of the list, move WAR and Docker to the top

### After

![image](https://user-images.githubusercontent.com/3000480/87051212-92af3a80-c1ff-11ea-853f-0bffb48682fb.png)

### Before

![image](https://user-images.githubusercontent.com/3000480/87025614-ed826b00-c1da-11ea-9bce-6028fbd041ea.png)

