### PR TITLE
JEP-14 - Add support for archiving roadmap items, expand status descriptions

### DIFF
--- a/content/_data/roadmap/archive.yml
+++ b/content/_data/roadmap/archive.yml
@@ -1,0 +1,10 @@
+# This file contains archive of items which were completed or removed from the roadmap
+# They should either have "released" or "deferred" state
+categories:
+  - name: Jenkins Project Internals
+    initiatives:
+    - name: ACS to AKS migration
+      status: released
+      link: https://issues.jenkins-ci.org/browse/INFRA-1797
+      labels:
+      - infrastructure

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -1,19 +1,33 @@
 statuses:
 - id: released
   displayName: "Released"
-  description: "The initiative is completed"
+  description: >
+    The initiative is completed and available to users.
+    There might be follow-up improvements to the initiative, and any contributions are welcome.
 - id: preview
   displayName: "Preview"
-  description: "This initiative is available to Jenkins users and contributors as preview. We would appreciate testing and any feedback!"
+  description: > 
+    This initiative is available to Jenkins users and contributors for preview.
+    We would appreciate testing and any feedback!
 - id: current
   displayName: "Current"
-  description: "Things being worked on presently with a specific scope, typically a JEP, though no specific delivery dates"
+  description: >
+    Things being worked on presently with a specific scope, typically a JEP, though no specific delivery databases.
+    Please see the link if you want to contribute to the initiative.
 - id: near-term
   displayName: "Near Term"
   description: "We intend to work on that in the short term, but there is no ongoing development"
 - id: future
   displayName: "Future"
-  description: "We intend to work on that in the short term, but there is no ongoing development"
+  description: >
+    There is a consensus within the community that we would like this initiative to happen.
+    We intend to work on that in the future, but there is no ongoing development.
+- id: withdrawn
+  hide: true
+  displayName: "Withdrawn"
+  description: >
+    This initiative is no longer relevant due to the ecosystem change or competing initiatives.
+    The status is used to indicate archived items which were not delivered.
 labels:
 - name: feature
   displayName: Features
@@ -628,11 +642,6 @@ categories:
       Initiatives which focus on project internals which have no immediate impact on users.
       It includes the project infrastructure maintenance and similar topics which are critical to the project health.
     initiatives:
-    - name: ACS to AKS migration
-      status: released
-      link: https://issues.jenkins-ci.org/browse/INFRA-1797
-      labels:
-      - infrastructure
     - name: "Migrate ci.jenkins.io agents to AWS"
       description: >
         Migration of agent workload from Azure to AWS in order to optimize the infrastructure costs for the project.

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -37,10 +37,16 @@ tags:
     %input{:type=>"checkbox", :class => "initiative-selector", :id =>"initiative-label-#{label.name}", :onclick=>"filterRoadmap()"}
       = label.displayName
 
+- statuses = []
+- site.roadmap[:roadmap].statuses.each do | status |
+  - if status.hide
+  - else
+    - statuses << status
+
 %table.roadmap-table
   %thead
     %tr
-      - site.roadmap[:roadmap].statuses.each do | status |
+      - statuses.each do | status |
         %th
           = status.displayName
   %tbody
@@ -50,7 +56,7 @@ tags:
           %span
             = category.name
       %tr.category-initiatives
-        - site.roadmap[:roadmap].statuses.each do | status |
+        - statuses.each do | status |
           %td{:class => "status #{status.id}", "data-header" => status.displayName}
             - category.initiatives.each do | initiative |
               - if initiative.status == status.id
@@ -75,4 +81,7 @@ tags:
       HOWTO: Suggest a new roadmap item
   %li
     %a{:href => "https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/roadmap/roadmap.yml"}
-      Open data
+      Open data (roadmap.yml)
+  %li
+    %a{:href => "https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/roadmap/archive.yml"}
+      Archive (completed and withdrawn roadmap items)


### PR DESCRIPTION
This change adds a "withdrawn" state to the roadmap initiatives and adds new `archive.yml` which will act as an archive for completed and wuthdrawn roadmap items