### PR TITLE
Pipeline Authoring Roadmap - Use links from initiative metadata, extend descriptions

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -58,12 +58,15 @@ categories:
       labels:
       - feature
     - name: Pipeline development in IDE
-      description: IDE integration, editors, and other development tools - IDE plugins, visual editors, etc
+      description: >
+        The goal is to extend support for Pipeline development in IDEs, visual editors, and other development tools.
+        The scope may include creation of new IDE plugins and extending Jenkins Pipeline to support common features like live code deployment and debugging.
       status: future
       labels:
       - feature
     - name: Pipeline Documentation
-      description: Reference documentation, tutorials, and more
+      description: >
+        Expand Pipeline reference documentation, tutorials, and more.
       status: future
       labels:
       - documentation
@@ -204,7 +207,7 @@ categories:
     - name: "Configuration UI: Tables to Divs migration"
       status: current
       description: >
-        Improve visualuzation of configuration pages by changing layouts from tables to divs.
+        Improve visualization of configuration pages by changing layouts from tables to divs.
         It will improve layout on narrow screens and particularly on mobile devices.
       link: https://issues.jenkins-ci.org/browse/JENKINS-62437
       labels:

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -13,7 +13,7 @@ tags:
 :ruby
   def tooltip_href(url, title)
     tooltip = {'data-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => title}
-    return tooltip.merge({:href => url, :target => "_blank"})
+    return url != null ? tooltip.merge({:href => url, :target => "_blank"}) : tooltip
   end
 
 %p.roadmap-warning-banner
@@ -59,8 +59,7 @@ tags:
                   - initiative.labels.each do | label |
                     - labelClasses = "#{labelClasses} initiative-label-#{label}"
                 %div{:class => "status initiative #{status.id} #{labelClasses}"}
-                  - # TODO(oleg-nenashev): Better default link for work-in-progress items?
-                  - itemLink = initiative.link.nil? ? "/project/roadmap" : initiative.link
+                  - itemLink = initiative.link.nil? ? category.link : initiative.link
                   - itemTooltip = initiative.description.nil? ? status.description : initiative.description
                   %a{tooltip_href(itemLink, itemTooltip)}
                     = initiative.name


### PR DESCRIPTION
This patch slightly improves UX of the roadmap by redirecting users to the Pipeline Authoring SIG page referenced in the category metadata. I have also slightly expanded the text based on the SIG discussion notes.

CC @bitwiseman  @steven-terrana 
