### PR TITLE
JEP-14 - Add Roadmap reference to the Governance doc, remove work-in-progress disclaimer

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -249,6 +249,17 @@ link:https://issues.jenkins-ci.org/[Our primary bug tracker] is maintained by th
 
 We link:https://ci.jenkins-ci.org/[run Jenkins for our own development] and to automate various infrastructure tasks. Because of the sensitive nature of setting up jobs, only the infra admins have full write access.
 
+== Roadmap
+
+Jenkins project offers a public community-driven roadmap.
+It aggregates key initiatives in all areas: features, infrastructure, documentation, community, etc.
+We do NOT commit on delivery dates, and we do not guarantee that an initiative will be implemented at all.
+All initiatives depend on contributions,
+and we invite all interested parties to join us and to contribute towards the roadmap goals.
+
+* link:/project/roadmap[Public Jenkins Roadmap]
+* jep:14[Public Jenkins Roadmap Process]
+
 [[meeting]]
 == Decision making
 

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -16,18 +16,15 @@ tags:
     return tooltip.merge({:href => url, :target => "_blank"})
   end
 
-%p.roadmap-warning-banner
-  %b WARNING!
-  This is a draft roadmap for the Jenkins project, it should not be considered as a final version.
-  See the Jenkins Enhancement Proposal for more information:
-  %a{:href => "https://github.com/jenkinsci/jep/tree/master/jep/14"}
-    JEP-14
-
 %p
   Jenkins project offers a public community-driven roadmap.
   It aggregates key initiatives in all areas: features, infrastructure, documentation, community, etc.
+  See
+  %a{:href => "https://github.com/jenkinsci/jep/tree/master/jep/14"}
+    JEP-14
+  for more information about the public roadmap process.
   We do NOT commit on delivery dates, all initiatives depend on contributions.
-  Anyone is welcome to participate!
+  Anyone is welcome to participate and help us to deliver the initiatves below!
   %a{:href => "/participate/"}
     Contributing to Jenkins
 


### PR DESCRIPTION
Finalizes the roadmap publishing. On-hold until the today;s governance meeting.

![image](https://user-images.githubusercontent.com/3000480/87570434-f090c600-c6c8-11ea-86f3-0b4e3d19294a.png)


![image](https://user-images.githubusercontent.com/3000480/87570487-0900e080-c6c9-11ea-951f-f07cc8e71ebd.png)
