### PR TITLE
Add redirect for use by jenkinsci/jenkins#4683

### DIFF
--- a/content/redirect/starting-processes.adoc
+++ b/content/redirect/starting-processes.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/ProcessTreeKiller
+---


### PR DESCRIPTION
Supports jenkinsci/jenkins#4683. Not needed without that, so best for merging to be held off given the review hell that PR is in right now.