### PR TITLE
Add checksum for war download

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -85,9 +85,12 @@ title: Jenkins download and deployment
           LTS for:
 
         .list-group
-          %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins.io/war-stable/latest/jenkins.war'}
+          %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins.io/war-stable/' + site.jenkins.stable + '/jenkins.war'}
             %span.title
-            Generic Java package (.war)
+              Generic Java package (.war)
+              %div{:style => 'font-size: x-small;'}
+                SHA-256:
+                = open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.stable + '/jenkins-war-' + site.jenkins.stable + '.war.sha256').read()
           %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins'}
             %span.icon
             %span.title
@@ -141,9 +144,12 @@ title: Jenkins download and deployment
         for:
 
       .list-group
-        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
+        %a.list-group-item.list-group-item-action{:href=>'http://mirrors.jenkins-ci.org/war/' + site.jenkins.latest + '/jenkins.war'}
           %span.title
-          Generic Java package (.war)
+            Generic Java package (.war)
+            %div{:style => 'font-size: x-small;'}
+              SHA-256:
+              = open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.latest + '/jenkins-war-' + site.jenkins.latest + '.war.sha256').read()
         %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins/'}
           %span.icon
           %span.title


### PR DESCRIPTION
We currently have no easily accessible way for people to confirm their manual war downloads are correct.

`update-center.json` has a checksum served via HTTPS, so updates in Jenkins are unaffected, but the initial download doesn't: `http://mirrors.jenkins.io/war/` isn't served via HTTPS, and `https://pkg.jenkins.io/war/` isn't there yet.

So add a sha256 checksum to the downloads page, retrieved via HTTPS from Artifactory during site build. This isn't pretty, but functional. Someone with more UI knowledge than me can figure out how to make this pretty.

Also link to the latest releases advertised on update sites; this way the download link and checksum will always match, and I always thought it was weird to advertise a specific release when that might not be what would be downloaded.

Also actually make the title part of `%span.title` for the war downloads, which it wasn't before. 😕

> <img width="1691" alt="Screenshot 2020-07-16 at 14 13 47" src="https://user-images.githubusercontent.com/1831569/87669607-98ac9a80-c76e-11ea-8d1d-fca9c6125bd5.png">

(Outdated versions because my local build didn't update that metadata.)