### PR TITLE
Updating "Installing Docker" section

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -90,7 +90,7 @@ which is also running Docker.
 ==== Installing Docker
 
 To install Docker on your operating system, follow "prerequisits" section of the 
-link:https://www.jenkins.io/doc/pipeline/tour/getting-started/#prerequisites[Guided Tour page]
+link:/doc/pipeline/tour/getting-started/#prerequisites[Guided Tour page]
 
 As an alternative solution you can visit the
 link:https://store.docker.com/search?type=edition&offering=community[Docker

--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -65,9 +65,9 @@ operating systems.
 
 ////
 IMPORTANT: If you update content in this section, please ensure you check these
-changes against the procedures documented in the sibling
-'_run-jenkins-in-docker.adoc' file, which is used in the Tutorials of the
-Jenkins User Documentation.
+changes against the procedures documented in the
+'_prerequisites.adoc' file, which is used in the Guided Tour of the
+Jenkins Documentation.
 ////
 
 link:https://docs.docker.com/engine/docker-overview/[Docker] is a platform for
@@ -89,7 +89,10 @@ which is also running Docker.
 
 ==== Installing Docker
 
-To install Docker on your operating system, visit the
+To install Docker on your operating system, follow "prerequisits" section of the 
+link:https://www.jenkins.io/doc/pipeline/tour/getting-started/#prerequisites[Guided Tour page]
+
+As an alternative solution you can visit the
 link:https://store.docker.com/search?type=edition&offering=community[Docker
 store] website and click the *Docker Community Edition* box which is suitable
 for your operating system or cloud service. Follow the installation instructions


### PR DESCRIPTION
The purpose of this change is to make the content of
[Installing docker](https://www.jenkins.io/doc/book/installing/#installing-docker) section of the [Installing Jenkins](https://www.jenkins.io/doc/book/installing/) page compliant with the DRY principle.
Currently the content on the page contradicts with instructions at
https://www.jenkins.io/doc/pipeline/tour/getting-started/#prerequisites