### PR TITLE
Adopters: Ensure that Adopters are always sorted

### DIFF
--- a/content/project/adopters/index.html.haml
+++ b/content/project/adopters/index.html.haml
@@ -8,7 +8,7 @@ description: "List of Jenkins adopters"
 This page provides a list of Jenkins adopters.
 
 .grid-container    
-  - site.adopters.keys.each do |p|
+  - site.adopters.keys.sort.each do |p|
     - if p != "README"
       = partial("company-card.html.haml", :companyId => p)
 


### PR DESCRIPTION
Looks like the production build does not guarantee the keys order by default