### PR TITLE
Clarify only OSS plugins are hostable

### DIFF
--- a/content/doc/developer/publishing/requesting-hosting.adoc
+++ b/content/doc/developer/publishing/requesting-hosting.adoc
@@ -11,6 +11,8 @@ Once you've completed all steps described on this page you will have accomplishe
   You will have admin access to this repository.
 * You will be allowed to release the plugin to the Jenkins project Maven repository, which serves as a source for the Jenkins project operated update sites.
 
+CAUTION: The Jenkins Project will only host Open Source plugins.
+
 == Preparation
 
 Complete the following steps before requesting plugin hosting with the Jenkins project:


### PR DESCRIPTION
After a chat with Wadeck, I realized this is not called out in a crystal clear manner on the main page AFAICT.

https://www.jenkins.io/doc/developer/publishing/requesting-hosting/