### PR TITLE
Update the Governance document

### DIFF
--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -19,7 +19,11 @@ you may find interesting opportunities in our project.
 The Jenkins project is spread across multiple organizations on GitHub.
 You are welcome to contribute to **any** repository in **any** of those organizations, or to any other Jenkins-related repository on GitHub.
 
-* https://github.com/jenkinsci[jenkinsci] - Main organization. Jenkins core, plugins and libraries reside there
+* https://github.com/jenkinsci[jenkinsci] - Main organization.
+  It includes Jenkins core, plugins and libraries reside there.
+  To aid classifying our 1000+ Git repositories, some naming conventions have been adopted:
+** plugins are named "*-plugin"
+** libraries are named "lib-*"
 * https://github.com/jenkins-infra[jenkins-infra] - Jenkins infrastructure, including the website and other services
 * https://github.com/stapler/[stapler] - Stapler Web Framework which is currently maintained by the Jenkins community
 * https://github.com/jenkins-zh[jenkins-zh] - organization of the link:/sigs/chinese-localization/[Chinese Localization SIG]

--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -20,8 +20,8 @@ The Jenkins project is spread across multiple organizations on GitHub.
 You are welcome to contribute to **any** repository in **any** of those organizations, or to any other Jenkins-related repository on GitHub.
 
 * https://github.com/jenkinsci[jenkinsci] - Main organization.
-  It includes Jenkins core, plugins and libraries reside there.
-  To aid classifying our 1000+ Git repositories, some naming conventions have been adopted:
+  Jenkins core, plugins and libraries reside there.
+  To aid in classifying our 1000+ Git repositories, some naming conventions have been adopted:
 ** plugins are named "*-plugin"
 ** libraries are named "lib-*"
 * https://github.com/jenkins-infra[jenkins-infra] - Jenkins infrastructure, including the website and other services

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -310,13 +310,16 @@ Every three months or so we pick a prior release as the new long-term support (L
 
 === Modules
 
-Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in `WEB-INF/lib` and therefore it behaves as if it's a part of the core from the users' point of view. Modules can be thought of as something in between a library and a plugin. It has its own POM, a set of source code, and built separately, like a library, but it gets the same compile-time processing as plugins do.
+Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in `WEB-INF/lib` and therefore it behaves as if it's a part of the core from the users' point of view.
+Modules can be thought of as something in between a library and a plugin.
+It has its own POM, a set of source code, and is built separately, like a library, but it gets the same compile-time processing as plugins do.
 
 This assists splitting a big hair ball (that is the core) into more manageable smaller pieces, and allow OEMs to add/remove functionalities separately.
 
 == Plugins
 
-Plugins are developed autonomously by the people working on the plugin. Each gets its own repository, its own Jenkins-on-Jenkins job, its own issue tracker component, and maintain their own release schedules.
+Plugins are developed autonomously by the people working on the plugin.
+Each gets its own repository, its own Jenkins-on-Jenkins job, its own issue tracker component, and maintains its own release schedule.
 
 Some plugins are actively maintained by a small number of people and they may have their own local culture, such as different coding convention, additional commit policies. We do this so that people can feel ownership and attachment to their effort, and so that they won’t feel like they have to follow externally decided rules.
 
@@ -327,7 +330,7 @@ Maintainer information should be listed in the info box of the plugin's wiki pag
 === Plugin Site
 
 Each published plugin has its own page on https://plugins.jenkins.io/, such as link:https://plugins.jenkins.io/git[this].
-This pages provide documentation and information about the plugin: installation stats, changelogs, known issues, etc.
+These pages provide documentation and information about the plugin: installation statistics, changelogs, known issues, etc.
 Documentation can be either retrieved from the plugin's GitHub repository or from a now-deprecated wiki.jenkins.io.
 See the link:/doc/developer/publishing/documentation/[Plugin Documentation Page] in the DEveloper guide for more information about how it works.
 
@@ -387,7 +390,7 @@ Many less active plugins do not really have any obvious owner, and they are coll
 
 If you are interested in just making small changes, the same process applies as plugins.
 Just submit a pull request!
-However, because core changes affect larger number of people, we’d be grateful if you’d try to go extra distance on the notes described in <<pull-request,using pull requests>>.
+However, because core changes affect a larger number of people, we’d be grateful if you’d try to go the extra distance on the notes described in <<pull-request,using pull requests>>.
 
 If you’d like to be involved more seriously in the Jenkins core, consider joining the Jenkins core maintainers team.
 See the onboarding guidelines link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc#team[here].

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -6,6 +6,8 @@ section: project
 
 :sectanchors:
 
+:toc:
+
 == Who we are
 
 The Jenkins project as a community revolves around Jenkins as a piece of software. We are a group of open-source developers and users who develop, use, promote Jenkins, software around Jenkins, and other related activities for our mutual benefit.
@@ -205,49 +207,50 @@ Users use Jenkins and its plugins. They contribute to the project by providing f
 
 == Communication
 
-The communication among people in the community is crucial to the oneness of the project. People in the Jenkins project communicates with each other in several different places.
+The communication among people in the community is crucial to the oneness of the project.
+People in the Jenkins project communicate with each other in several different places.
+There is an link:/sigs/advocacy-and-outreach/[Advocacy and Outreach] special interest group which focuses on public communications.
+Some of the communication channels are listed below.
 
-=== Mailing lists
-
+Mailing lists::
 We encourage mailing lists as the primary means of developer & user discussion, because of their asynchrony and ability to search the archive. The project website lists link:/mailing-lists[the active mailing lists and their purposes].
 
-=== IRC
+Chats::
+Jenkins project uses link:/chat[IRC and Gitter channels] for real time interactive communications. This is also the place where active members bond with each other.
 
-Jenkins project uses link:/chat[an IRC channel] for real time interactive communications. This is also the place where active members bond with each other.
+Twitter::
+link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account of the Jenkins project, run by the team of contributors (jep:10[]).
+There are also a link:https://twitter.com/jenkins_release[@jenkins_release] account for automatic plugin release announcements,
+and other accounts being run by sub-communities like meetup groups.
 
-=== Twitter
-
-link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account of the Jenkins project, run by the infrastructure admins.
+Special interest group channels::
+There are multiple link:/sigs/[Special Interest Groups] in the community.
+These groups focus on particular topics and organize dedicated communication channels including chats, mailing lists and regular meetings.
 
 == Infrastructure
 
-=== Source code
+This section summarizes the key infrastructure services we run in the project.
+See the link:/projects/infrastructure[Jenkins Infrastructure] page for the full list of services and more details.
 
-The link:https://github.com/jenkinsci/[GitHub JenkinsCI organization] is where we host most of our code (see link:https://wiki.jenkins.io/display/JENKINS/GitHub+Repositories[the list of repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have link:https://svn.jenkins-ci.org/[the subversion repository] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
+Website::
+Jenkins website (jenkins.io) is self-hosted by the Jenkins project.
+It follows the Infrastructure-as-code approach, and everyone can contribute to the website and content by just submitting a pull request.
+Its source codes can be found link:https://github.com/jenkins-infra/jenkins.io/[here].
 
-To aid classifying our 1000+ Git repositories, some naming conventions have been adopted:
+Source code::
+We host most of our code on GitHub. link:https://github.com/jenkinsci/[jenkinsci] and link:https://github.com/jenkins-infra/[jenkins-infra] are the organizations where we host most of our code.
+More information about the GitHub organization and repository structures can be found link:/participate/code/#where-to-contribute[here].
 
-* plugins are named "*-plugin"
-* libraries are named "lib-*"
-* backend infrastructure programs are named "backend-*"
+User Accounts::
+The infrastructure admins run an LDAP server and link:https://accounts.jenkins.io/[a small frontend program] to let users create accounts on jenkins.io.
+This account is used to access services ran by the Jenkins project: Issue tracker, Maven repository, CI instances, etc.
 
-To encourage migration of plugins from Subversion to Git, a daemon is used to mirror plugins individually to GitHub. See link:https://wiki.jenkins.io/display/JENKINS/Moving+from+Subversion+%28svn%29+to+Github[this page] for more about how to migrate your plugin to GitHub.
-
-=== User Accounts
-
-The infrastructure admins run an LDAP server and link:https://accounts.jenkins.io/[a small frontend program] to let users create accounts on jenkins-ci.org. This account is used for all the software that we run ourselves.
-
-=== Wiki
-
-This wiki that you are reading is our primary collaboration mechanism for documentation. This uses the LDAP server described above for access.
-
-=== Bug tracker
-
+Issue tracker::
 link:https://issues.jenkins-ci.org/[Our primary bug tracker] is maintained by the infra admins. This uses the LDAP server described above for access.
 
-=== Jenkins on Jenkins
-
-We link:https://ci.jenkins-ci.org/[run Jenkins for our own development] and to automate various infrastructure tasks. Because of the sensitive nature of setting up jobs, only the infra admins have full write access.
+Jenkins on Jenkins::
+We run a link:https://ci.jenkins.io/[Jenkins instance] for Jenkins core and plugin continuous integration.
+There are also other Jenkins instances which automate releases and infrastructure management.
 
 == Roadmap
 
@@ -263,48 +266,57 @@ and we invite all interested parties to join us and to contribute towards the ro
 [[meeting]]
 == Decision making
 
-The Jenkins project uses biweekly project meetings as the primary forum of decision making for matters that need consensus.
-The meeting is link:/chat/#meeting[conducted on IRC] and open to anyone.
+The Jenkins project uses link:/project/governance-meeting[biweekly project meetings] as the primary forum of decision making for matters that need consensus.
+The meeting is conducted using a video call or link:/chat/#meeting[IRC].
+These meetings are open to anyone, and everyone is welcome to provide their feedback and vote on decisions at the meeting.
 Agenda items can be added by anyone by simply adding your topic to link:/project/governance-meeting[the Governance Meeting Agenda].
-Be sure to include your user name (so we know who proposed a topic).
 
 The meeting minutes are public:
 
-* link:http://meetings.jenkins-ci.org/jenkins/[2011 to September 2015]
+* link:link:/project/governance-meeting[Governance Meeting Agenda] for meetings held in as video calls
 * link:http://meetings.jenkins-ci.org/jenkins-meeting/[September 2015 to today]
+* link:http://meetings.jenkins-ci.org/jenkins/[2011 to September 2015]
 
 The board serves as the ultimate decision-making body in case the project meeting fails to reach a consensus on a particular topic.
 
-== How we develop code
+//TODO(oleg_nenashev): This section is dated and not really relevant to the project governance
+// IMO we should move it elsewhere and leave only Governance-related parts like ownership, teams, consensus building, etc.
 
-=== Core
+== Jenkins Core
 
-The core refers to a set of code and libraries that result in the `jenkins.war` binary. link:https://github.com/jenkinsci/jenkins[The official core repository] is hosted on GitHub.
+The _Jenkins core_ refers to a set of code, modules and libraries that result in the `jenkins.war` binary.
+link:https://github.com/jenkinsci/jenkins[The official core repository] is hosted on GitHub.
 
-Long time committers push changes directly into this repository, although other core committers can still revert their changes and discuss them when they feel that is necessary. New committers can also do the same when they feel good about their changes, or if the changes are trivial.
-
-Committers old and new who feel their changes need review use link:https://github.com/jenkinsci/jenkins/pulls[GitHub pull requests] as a way to solicit feedback. People without commit access also use pull requests to get their changes into the core. Core committers are expected to be attentive to pending pull requests, and try to act on them quickly.
+The Jenkins core is maintained by a team of long time committers who review and integrate changes submitted through link:https://github.com/jenkinsci/jenkins/pulls[GitHub pull requests].
+They also coordinate the Jenkins releases.
+See the link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc[Jenkins Core maintainer guidelines] for more information about roles, their responsibilities and maintenance processes.
 
 Core committers generally use their own judgement to decide what to work on.
+Core committers are expected to be attentive to pending pull requests, and try to act on them quickly.
 
-=== Releases
+=== Release lines
 
-Every weekend a new release is built from the master branch and released, in various forms, including `jenkins.war` and native packages. This allows us to get new features and bug fixes into the hands of users relatively quickly.
+The Jenkins project provides two release lines for the Jenkins core.
+For both lines we provide multiple distributions including `jenkins.war`, Docker images, installers and native packages.
+They can be downloaded by users link:/download[here].
 
-=== LTS Releases
+Regular releases::
+Every week a new release is built from the master branch and released.
+This allows us to get new features and bug fixes into the hands of users relatively quickly.
+See the link:/download/weekly/[Regular (Weekly) Release Line] for more details.
 
+LTS Releases::
 Every three months or so we pick a prior release as the new long-term support (LTS) release and then create the ‘stable’ branch, from that release point. This branch gets important bug fixes backported from the master branch, and further patch releases are built roughly every two weeks until the next LTS baseline is chosen. See link:/download/lts/[LTS Release Line] for more details.
 
-=== Core Coding Convention
+=== Modules
 
-We roughly follow link:https://www.oracle.com/technetwork/java/codeconvtoc-136057.html[Sun coding convention] in the source code, and we use 4 space indentation and don’t use tabs. It's generally more practical and appreciated if you submit changes that don't change the code format too much as it eases the coding review job. Try submitting formatting changes and functional changes in separate commits.
+Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in `WEB-INF/lib` and therefore it behaves as if it's a part of the core from the users' point of view. Modules can be thought of as something in between a library and a plugin. It has its own POM, a set of source code, and built separately, like a library, but it gets the same compile-time processing as plugins do.
 
-With that said, we do not believe in rigorously enforcing coding convention, and we don’t want to turn down contributions because their code format doesn’t match what we use. So consider this informational.
+This assists splitting a big hair ball (that is the core) into more manageable smaller pieces, and allow OEMs to add/remove functionalities separately.
 
+== Plugins
 
-=== Plugins
-
-Plugins are developed autonomously by the people working on the plugin. Each gets its own repository, its own Jenkins-on-Jenkins job, its own bug tracker component, and maintain their own release schedules.
+Plugins are developed autonomously by the people working on the plugin. Each gets its own repository, its own Jenkins-on-Jenkins job, its own issue tracker component, and maintain their own release schedules.
 
 Some plugins are actively maintained by a small number of people and they may have their own local culture, such as different coding convention, additional commit policies. We do this so that people can feel ownership and attachment to their effort, and so that they won’t feel like they have to follow externally decided rules.
 
@@ -312,17 +324,22 @@ Since much of such local culture is implicit, it's often difficult to tell from 
 
 Maintainer information should be listed in the info box of the plugin's wiki page. If you have trouble figuring out who to contact, the good fallback option is the developers' mailing list.
 
-=== Plugin Wiki Page
+=== Plugin Site
 
-Each plugin has its own Wiki page in https://wiki.jenkins.io/, such as link:https://wiki.jenkins.io/display/JENKINS/Git+Plugin[this]. Plugin wiki pages should the macro that produces the stock header table, describing what the plugin does, along with the release history / changelog. Take a look at some plugin wiki pages as a guideline of what you should do.
+Each published plugin has its own page on https://plugins.jenkins.io/, such as link:https://plugins.jenkins.io/git[this].
+This pages provide documentation and information about the plugin: installation stats, changelogs, known issues, etc.
+Documentation can be either retrieved from the plugin's GitHub repository or from a now-deprecated wiki.jenkins.io.
+See the link:/doc/developer/publishing/documentation/[Plugin Documentation Page] in the DEveloper guide for more information about how it works.
 
-These wiki pages are referenced from the update center built in to Jenkins, and they are the primary means through which users discover information about plugins.
+== How we develop code
 
-=== Modules
+=== Coding Convention
 
-Modules are libraries that are built separately from the core (much like plugins are), but are bundled into the WAR file as a JAR file in `WEB-INF/lib` and therefore it behaves as if it's a part of the core from the users' point of view. Modules can be thought of as something in between a library and a plugin. It has its own POM, a set of source code, and built separately, like a library, but it gets the same compile-time processing as plugins do.
+In the Jenkins core we roughly follow link:https://www.oracle.com/technetwork/java/codeconvtoc-136057.html[Sun coding convention] in the source code, and we use 4 space indentation and don’t use tabs. It's generally more practical and appreciated if you submit changes that don't change the code format too much as it eases the coding review job. Try submitting formatting changes and functional changes in separate commits.
 
-This assists splitting a big hair ball (that is the core) into more manageable smaller pieces, and allow OEMs to add/remove functionalities separately.
+With that said, we do not believe in rigorously enforcing coding convention, and we don’t want to turn down contributions because their code format doesn’t match what we use. So consider this informational.
+
+Jenkins plugins and other components may define their own code conventions.
 
 === Commit guidelines
 
@@ -333,10 +350,9 @@ See <<pull-request,the pull request checklist>> for guidelines on submitting cod
 When you have a license to do so, and when that license is compatible with the MIT license, you can copy the code from elsewhere into Jenkins.
 
 The most typical case of this is that the original code is licensed under a certain subset of the open-source licenses, such as ASL, BSD, and MIT license. Copyleft licenses, even though they are open-sourced, cannot be copied, such as EPL and GPL.
+In particular, this means we can copy Oracle Hudson's source code under the MIT license, but not Eclipse Hudson's source code under EPL.
 
 The code to be copied must be clearly marked with the license it is under, and when copying, you need to maintain the copyright/license attribution in the header. Please also indicate the origin of the copy as a part of the commit message.
-
-In particular, this means we can copy Oracle Hudson's source code under the MIT license, but not Eclipse Hudson's source code under EPL.
 
 === Locally patching dependencies
 
@@ -362,15 +378,19 @@ If you’d like to be involved more seriously, in addition to the pull request, 
 
 It is often the case that the original developer moves onto other things once the plugin becomes good enough for them (or if the original author changes the job and no longer has incentive to work on the technology.) So we encourage new developers or developers of different plugin to pitch in on other plugins’ pending pull requests or work on issues filed against them.
 
-To that end, we also encourage people to pick up dormant plugins and consider them theirs. To do this, drop us a note at the dev list, and try to contact the previous maintainer to find out if they are still interested in driving the plugin. Trying insistently to contact the latest apparently inactive maintainer(s) before taking over is is an important practice to us. The practice is generally to add them in CC on your maintainership requests to the dev ML.
+To that end, we also encourage people to pick up dormant plugins and consider them theirs.
+See the link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopt a Plugin] guidelines for more information.
 
 Many less active plugins do not really have any obvious owner, and they are collaboratively maintained by people making small changes and releasing them whenever the need arises. If in doubt, ask on the dev list.
 
 === Making changes to core
 
-If you are interested in just making small changes without an intent to stay, the same process applies as plugins, described above. However, because core changes affect larger number of people, we’d be grateful if you’d try to go extra distance on the notes described in <<pull-request,using pull requests>>.
+If you are interested in just making small changes, the same process applies as plugins.
+Just submit a pull request!
+However, because core changes affect larger number of people, we’d be grateful if you’d try to go extra distance on the notes described in <<pull-request,using pull requests>>.
 
-If you’d like to be involved more seriously, consider getting commit access. See the section about becoming a plugin developer for how to get this. In addition, we need to ask you to <<cla,sign the contributor license agreement>> (CLA).
+If you’d like to be involved more seriously in the Jenkins core, consider joining the Jenkins core maintainers team.
+See the onboarding guidelines link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc#team[here].
 
 When making changes, use your common sense. For example, if you are thinking about making a big change, it is recommended that you discuss your changes with the developers upfront. Or if you see that the part you’d like to work on has been actively modified by others, give them a heads-up.
 
@@ -391,8 +411,11 @@ As discussed above, Jenkins project uses pull requests as one of the main workfl
 * Try to describe your changes so that other people understand what you did.
 * Make sure you didn’t modify portions that aren’t related to your changes (most often caused by IDE auto-fixing import statements and other code formats.)
 
-We do try to be attentive to inbound pull requests, but as you can see link:https://wiki.jenkins.io/display/JENKINS/Pending+Pull+Requests[here], unfortunately we can fail to resolve some of them in a timely fashion. If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list, and please consider becoming a committer and push the changes directly. See link:https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[Pull Request to Repositories] for more.
+We do try to be attentive to inbound pull requests, unfortunately we may fail to review some of them in a timely fashion.
+If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list or ping us in the GitHub pull request.
+See link:https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[Pull Request to Repositories] for more recommendations about pull request.
 
 == This document
 
-This document is owned by the community and substantial changes are approved via the project meeting. Send your questions to the dev list, or add an item to the link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[next meeting's agenda].
+This document is owned by the community and substantial changes are approved via the project meeting.
+Send your questions to the dev list, or add an item to the link:/project/governance-meeting/[next governance meeting's agenda].


### PR DESCRIPTION
This change is a bulk facelift of the Governance doc which is currently very dates. It does not make it perfect, but at least it starts the cleanup process

- [x] - Add ToC
- [x] - Update the social media section, remove unnecessary headers
- [x] - Update the infrastructure services listing
- [x] - Update the core structure and contributing sections. I would like to move them elsewhere, but just a facelift for now
