### PR TITLE
Changelog badges: Ensure the shields.io schema is followed

### DIFF
--- a/content/changelog-stable/badge.json.haml
+++ b/content/changelog-stable/badge.json.haml
@@ -1,13 +1,10 @@
 - release = site.changelogs[:lts].reverse.select { |release| Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest) }[0]
 
-// Compatible with shields.io JSON endpoint: https://shields.io/endpoint
 :plain
   {
     "schemaVersion": 1,
     "label": "Jenkins LTS",
     "message": "#{release.version}",
     "color": "blue",
-    "version": "#{release.version}",
-    "date": "#{release.date}",
-    "changelogUrl": "https://www.jenkins.io/changelog-slable/##{release.version}"
+    "cacheSeconds": 300
   }

--- a/content/changelog/badge.json.haml
+++ b/content/changelog/badge.json.haml
@@ -1,13 +1,10 @@
 - release = site.changelogs[:weekly].reverse.select { |release| Gem::Version.new(release.version) <= Gem::Version.new(site.jenkins.latest) }[0]
 
-// Compatible with shields.io JSON endpoint: https://shields.io/endpoint
 :plain
   {
     "schemaVersion": 1,
     "label": "Jenkins Weekly",
     "message": "#{release.version}",
     "color": "blue",
-    "version": "#{release.version}",
-    "date": "#{release.date}",
-    "changelogUrl": "https://www.jenkins.io/changelog/##{release.version}"
+    "cacheSeconds": 300
   }


### PR DESCRIPTION
Apparently shields.io parser does not always handle additional fields, so removing everything except the spec requirements from https://shields.io/endpoint