### PR TITLE
Remove link to repository list wiki page

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -223,7 +223,7 @@ link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account o
 
 === Source code
 
-The link:https://github.com/jenkinsci/[GitHub JenkinsCI organization] is where we host most of our code (see link:https://wiki.jenkins.io/display/JENKINS/GitHub+Repositories[the list of repositories] for easier navigation.) Because we previously used Subversion as the primary source code repository, we also have link:https://svn.jenkins-ci.org/[the subversion repository] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
+The link:https://github.com/jenkinsci/[GitHub JenkinsCI organization] is where we host most of our code. Because we previously used Subversion as the primary source code repository, we also have link:https://svn.jenkins-ci.org/[the subversion repository] that contains all the original project history. Some plugins are still actively maintained inside the Subversion repository.
 
 To aid classifying our 1000+ Git repositories, some naming conventions have been adopted:
 


### PR DESCRIPTION
The wiki page has not been updated since 2016 and we are moving away from the wiki in general.