### PR TITLE
Replace the whitelist/blacklist terminology in the changelogs

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1127,7 +1127,7 @@
   lts_predecessor: "2.89.4"
   lts_baseline: "2.107"
   banner: >
-    This is the first LTS release that includes <a href="https://jenkins.io/blog/2018/03/15/jep-200-lts/">the JEP-200 Remoting and XStream serialization whitelist</a>.
+    This is the first LTS release that includes <a href="https://jenkins.io/blog/2018/03/15/jep-200-lts/">the JEP-200 Remoting and XStream serialization allowlist</a>.
     This core change requires <a href="https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200">corresponding changes in many plugins</a> for them to be compatible.
     We strongly recommend that you read the <a href="/doc/upgrade-guide/2.107">LTS upgrade guide</a>, make sure you have good backups before upgrading, and validate this release in a staging environment first.
   lts_changes:
@@ -1136,14 +1136,14 @@
     - type: major rfe
       pull: 3120 # and 3230
       message: >
-        Switch Remoting/XStream blacklist to a whitelist.
+        Switch Remoting/XStream denylist to a allowlist.
       references:
         - issue: 47736
         - url: /blog/2018/01/13/jep-200/
           title: upgrade guidelines for admins and plugin maintainers
         - url: https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200
           title: list of plugins known to be impacted
-        # Whitelisting PRs:
+        # Serialization allowlist PRs:
         # issue: 48946
         # issue: 49000
         # issue: 49025
@@ -1319,7 +1319,7 @@
       pull: 3313
       issue: 49543
       message: >
-        Make JEP-200 serialization whitelist more reliable on old versions of Tomcat 8.
+        Make JEP-200 serialization allowlist more reliable on old versions of Tomcat 8.
     - type: bug
       pull: 3292
       message: >
@@ -1384,7 +1384,7 @@
       pull: 3359
       issue: 50237
       message: >
-        JEP-200: Whitelist <code>org.apache.tools.ant.Location</code> to prevent deserialization exception when listing agent files in non-existent directory or invalid filter.
+        JEP-200: Allow <code>org.apache.tools.ant.Location</code> deserialization to prevent exception when listing agent files in non-existent directory or invalid filter.
     - type: bug
       pull: 3312
       issue: 49795
@@ -1443,7 +1443,7 @@
         - issue: 50939
         - issue: 50616
       message:
-        Whitelist <code>java.util.EnumMap</code> and <code>org.jruby.RubyNil</code> for use in XStream (XML serialization) and Remoting (agent communication).
+        Allow <code>java.util.EnumMap</code> and <code>org.jruby.RubyNil</code> for use in XStream (XML serialization) and Remoting (agent communication).
     - type: rfe
       pull: 3384
       # issue: 50808
@@ -1511,7 +1511,7 @@
           title: full changelog
       pull: 3333 # and 3359, and 3398
       message: >
-        Update Remoting from 3.17 to 3.20 in order to apply various performance and diagnosability improvements, such as logging warnings when anonymous classes are serialized over a Remoting channel, and allowing Jenkins core to always deserialize exceptions even if they're not whitelisted.
+        Update Remoting from 3.17 to 3.20 in order to apply various performance and diagnosability improvements, such as logging warnings when anonymous classes are serialized over a Remoting channel, and allowing Jenkins core to always deserialize exceptions even if they're not allowed.
         To benefit from the latter improvement, Remoting needs to be updated on the agent side as well.
     - type: major bug
       pull: 3357 # and followup fix in 3419
@@ -1791,7 +1791,7 @@
     pull: 3542
     issue: 52534
     message: >
-      Whitelist <code>java.time.Ser</code> for use in XStream (XML serialization) and Remoting (agent communication).
+      Allow <code>java.time.Ser</code> for use in XStream (XML serialization) and Remoting (agent communication).
   - type: bug
     pull: 3354
     issue: 46248

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -1136,7 +1136,7 @@
     - type: major rfe
       pull: 3120 # and 3230
       message: >
-        Switch Remoting/XStream denylist to a allowlist.
+        Switch Remoting/XStream denylist to an allowlist.
       references:
         - issue: 47736
         - url: /blog/2018/01/13/jep-200/

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -5592,7 +5592,7 @@
     pull: 4373
     issue: 60278
     message: |-
-      Prevent Oops when Allowed Commands input is empty in 'Agent to Master Access Control'.
+      Prevent Oops when Whitelisted Commands input is empty in 'Agent to Master Access Control'.
     authors:
       - fedepell
   - type: bug
@@ -8215,7 +8215,7 @@
   date: 2020-07-21
   banner: >
     This release build was not properly signed on the release infrastructure.
-    Jenkins.war is depublished from the Update Center and not recommended for use.
+    Distribution of jenkins.war has been suspended and it is not recommended for use.
     Installers and native packages were not published.
   changes: []
 
@@ -8223,7 +8223,7 @@
   date: 2020-07-21
   banner: >
     This release build was not properly signed on the release infrastructure.
-    Jenkins.war is depublished from the Update Center and not recommended for use.
+    Distribution of jenkins.war has been suspended and it is not recommended for use.
     Installers and native packages were not published.
   changes: []
 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -49,7 +49,7 @@
     - type: rfe
       message: >
         Upgrade Apache Commons Collections to version 3.2.2.
-        <strong>Note:</strong> Jenkins has been using a blacklist to prevent exploiting the serialization vulnerability in 3.2.1 since before 3.2.2 was released.
+        <strong>Note:</strong> Jenkins has been using a denylist to prevent exploiting the serialization vulnerability in 3.2.1 since before 3.2.2 was released.
       issue: 31598
       pull: 2761
     - type: rfe
@@ -1815,7 +1815,7 @@
 - version: "2.102"
   date: 2018-01-14
   banner: >
-    JEP-200: &quot;Switch Remoting/XStream blacklist to a whitelist&quot; has been integrated to this release.
+    JEP-200: &quot;Switch Remoting/XStream denylist to a allowlist &quot; has been integrated to this release.
     This change implies a HIGH RISK of regressions in plugins.
     See <a href="/blog/2018/01/13/jep-200/">this blogpost</a> for list of plugins known to be affected,
     with instructions how to resolve possible problems.
@@ -1823,7 +1823,7 @@
     - type: major rfe
       pull: 3120 # and 3230
       message: >
-        Switch Remoting/XStream blacklist to a whitelist.
+        Switch Remoting/XStream denylist to a allowlist.
       references:
         - issue: 47736
         - url: /blog/2018/01/13/jep-200/
@@ -1874,14 +1874,14 @@
 - version: "2.103"
   date: 2018-01-21
   banner: >
-    JEP-200: &quot;Switch Remoting/XStream blacklist to a whitelist&quot; has been integrated into 2.102.
+    JEP-200: &quot;Switch Remoting/XStream denylist to a allowlist&quot; has been integrated into 2.102.
     This change implies a HIGH RISK of regressions in plugins.
     See <a href="/blog/2018/01/13/jep-200/">this blogpost</a> for list of plugins known to be affected,
     with instructions how to resolve possible problems.
   changes:
     - type: rfe
       message: >
-        Whitelist additional safe types for use in XStream (XML serialization) and Remoting (agent communication).
+        Permit additional safe types for use in XStream (XML serialization) and Remoting (agent communication).
       references:
         - issue: 48946
         - issue: 49000
@@ -1939,7 +1939,7 @@
   changes:
     - type: rfe
       message: >
-        Whitelist additional safe Java platform types for use in XStream (XML serialization) and Remoting (agent communication).
+        Permit additional safe Java platform types for use in XStream (XML serialization) and Remoting (agent communication).
       references:
         - pull: 3251
         - pull: 3252
@@ -2180,7 +2180,7 @@
       pull: 3313
       issue: 49543
       message: >
-        Make JEP-200 serialization whitelist more reliable on old versions of Tomcat 8.
+        Make JEP-200 serialization allowlist more reliable on old versions of Tomcat 8.
     - type: bug
       pull: 3312
       issue: 49795
@@ -2357,7 +2357,7 @@
     - type: major rfe
       pull: 3359
       message: >
-        Update Remoting from 3.18 to 3.19 so that Jenkins core can always deserialize exceptions even if they're not whitelisted.
+        Update Remoting from 3.18 to 3.19 so that Jenkins core can always deserialize exceptions even if they're not permitted.
         To benefit from this improvement, Remoting needs to be updated on the agent side as well.
       references:
         - issue: 50237
@@ -2368,7 +2368,7 @@
       pull: 3359
       issue: 50237
       message: >
-        JEP-200: Whitelist <code>org.apache.tools.ant.Location</code> to prevent deserialization exception when listing agent files in non-existent directory or invalid filter.
+        JEP-200: Allow <code>org.apache.tools.ant.Location</code> deserialization to prevent exception when listing agent files in non-existent directory or invalid filter.
     - type: bug
       issue: 46386
       pull: 3362
@@ -2550,7 +2550,7 @@
         - issue: 50939
         - issue: 50616
       message:
-        Whitelist <code>java.util.EnumMap</code> and <code>org.jruby.RubyNil</code> for use in XStream (XML serialization) and Remoting (agent communication).
+        Allow <code>java.util.EnumMap</code> and <code>org.jruby.RubyNil</code> for use in XStream (XML serialization) and Remoting (agent communication).
     - type: rfe
       pull: 3082
       message: >
@@ -3024,7 +3024,7 @@
       pull: 3542
       issue: 52534
       message: >
-        Whitelist <code>java.time.Ser</code> for use in XStream (XML serialization) and Remoting (agent communication).
+        Allow <code>java.time.Ser</code> for use in XStream (XML serialization) and Remoting (agent communication).
     - type: bug
       issue: 52325
       pull: 3537
@@ -5212,7 +5212,7 @@
   - type: rfe
     pull: 4300
     message: |-
-      Add <code>java.util.concurrent.ConcurrentLinkedDeque</code> to the JEP-200 deserialization whitelist.
+      Add <code>java.util.concurrent.ConcurrentLinkedDeque</code> to the JEP-200 deserialization allowlist.
   - type: rfe
     pull: 4259
     message: |-
@@ -5592,7 +5592,7 @@
     pull: 4373
     issue: 60278
     message: |-
-      Prevent Oops when Whitelisted Commands input is empty in 'Agent to Master Access Control'.
+      Prevent Oops when Allowed Commands input is empty in 'Agent to Master Access Control'.
     authors:
       - fedepell
   - type: bug
@@ -8215,7 +8215,7 @@
   date: 2020-07-21
   banner: >
     This release build was not properly signed on the release infrastructure.
-    Jenkins.war is blacklisted and not recommended for use.
+    Jenkins.war is depublished from the Update Center and not recommended for use.
     Installers and native packages were not published.
   changes: []
 
@@ -8223,7 +8223,7 @@
   date: 2020-07-21
   banner: >
     This release build was not properly signed on the release infrastructure.
-    Jenkins.war is blacklisted and not recommended for use.
+    Jenkins.war is depublished from the Update Center and not recommended for use.
     Installers and native packages were not published.
   changes: []
 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -1815,7 +1815,7 @@
 - version: "2.102"
   date: 2018-01-14
   banner: >
-    JEP-200: &quot;Switch Remoting/XStream denylist to a allowlist &quot; has been integrated to this release.
+    JEP-200: &quot;Switch Remoting/XStream denylist to an allowlist &quot; has been integrated to this release.
     This change implies a HIGH RISK of regressions in plugins.
     See <a href="/blog/2018/01/13/jep-200/">this blogpost</a> for list of plugins known to be affected,
     with instructions how to resolve possible problems.
@@ -1823,7 +1823,7 @@
     - type: major rfe
       pull: 3120 # and 3230
       message: >
-        Switch Remoting/XStream denylist to a allowlist.
+        Switch Remoting/XStream denylist to an allowlist.
       references:
         - issue: 47736
         - url: /blog/2018/01/13/jep-200/
@@ -1874,7 +1874,7 @@
 - version: "2.103"
   date: 2018-01-21
   banner: >
-    JEP-200: &quot;Switch Remoting/XStream denylist to a allowlist&quot; has been integrated into 2.102.
+    JEP-200: &quot;Switch Remoting/XStream denylist to an allowlist&quot; has been integrated into 2.102.
     This change implies a HIGH RISK of regressions in plugins.
     See <a href="/blog/2018/01/13/jep-200/">this blogpost</a> for list of plugins known to be affected,
     with instructions how to resolve possible problems.


### PR DESCRIPTION
This pull request acts on agreements reached in the https://groups.google.com/forum/#!topic/jenkinsci-dev/CLR55wMZwZ8 thread. We agreed to discourage use of `whitelist/blacklist` and to recommend using `Allowlist/Denylist` or `Allowlist/Blocklist` instead. I believe we should act on this recommendation in the Jenkins core, and hence the changelog update.

AFAICT none of the changes are confusing in the context of the changelog, even if the underlying changes in the Jenkins core and blogposts  have not been made yet

CC @jglick since the changelog entry updates are mostly about JEP-200
