### PR TITLE
Fix 2.237 changelog entries

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -7589,23 +7589,15 @@
     - oleg-nenashev
     message: |-
       Ensure that <code>UserLanguages</code> telemetry initializer always runs after extensions are augmented.
-  - type: bug
-    category: bug
-    pull: 4684
-    issue: 61956
-    authors:
-    - calvinpark
-    message: |-
-      Ensure that job/folder creation routines properly check the requested name for invalid characters.
   - type: rfe
-    category: developer
+    category: rfe
     pull: 4725
     authors:
     - jvz
     message: |-
-      Developer: Update Apache Ant from 1.10.7 to 1.10.8.
+      Update Apache Ant from 1.10.7 to 1.10.8.
   - type: rfe
-    category: developer
+    category: internal
     pull: 4656
     authors:
     - jvz
@@ -7618,7 +7610,15 @@
       - url: https://github.com/javaee/jstl-api/compare/javax.servlet.jsp.jstl-1.2.1..javax.servlet.jsp.jstl-1.2.3
         title: Diff of 1.2.1 to 1.2.3
     message: |-
-      Developer: Update the JSTL API library from 1.2.1 to 1.2.7.
+      Internal: Update the JSTL API library from 1.2.1 to 1.2.7.
+  - type: bug
+    category: developer
+    pull: 4684
+    issue: 61956
+    authors:
+    - calvinpark
+    message: |-
+      Developer: Ensure that job/folder creation routines properly check the requested name for invalid characters.
   - type: rfe
     category: developer
     pull: 4715


### PR DESCRIPTION
## Fix 2.237 changelog entries

Correctly classify 3 entries that were misclassified earlier.

Based on comments from @daniel-beck in https://github.com/jenkins-infra/jenkins.io/pull/3286#pullrequestreview-417682331