### PR TITLE
Reference the Windows Support Policy updates blogpost in the 2.248 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -8237,7 +8237,10 @@
     category: major rfe
     pull: 4823
     references:
-      - pull: 4823
+      - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/
+        title: announcement
+      - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/#use-cases-affected-by-net-framework-2-0-support-removal
+        title: upgrade guidelines
       - issue: 60005
       - issue: 61862
       - url: https://www.jenkins.io/doc/administration/requirements/windows/
@@ -8252,16 +8255,17 @@
     category: major rfe
     pull: 4823
     references:
-      - pull: 4823
+      - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/#windows-service-management-changes-in-jenkins-2-248
+        title: changes summary
       - url: https://github.com/winsw/winsw/releases
-        title: Windows Service Wrapper changelog
+        title: full WinSW changelog
       - url: https://github.com/jenkinsci/windows-slave-installer-module/releases/tag/windows-slave-installer-2.0
         title: Windows Agent Installer 2.0 changelog
     authors:
     - NextTurn
     - oleg-nenashev
     message: |-
-      Update Windows Service Wrapper from 2.3.0 to 2.9.0.
+      Update Windows Service Wrapper (WinSW) from 2.3.0 to 2.9.0.
       Includes numerous improvements and bugfixes.
       Most notably, the service installer will now ask for permission elevation if the required.
   - type: rfe
@@ -8367,6 +8371,17 @@
     - jglick
     message: |-
       Remove the fallback Jenkins URL from the JNLP launch file so that WebSocket agents can be connected over Java Web Start.
+  - type: bug
+    category: bug
+    pull: 4823
+    authors:
+    - NextTurn
+    message: |-
+      Fix the default domain name in Windows service <code>serviceaccount</code> configurations.
+    references:
+      - issue: 12660
+      - url: https://github.com/winsw/winsw/releases/tag/v2.7.0
+        title: Windows Service Wrapper 2.7.0 changelog
   - type: rfe
     category: developer
     pull: 4683

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -8265,7 +8265,7 @@
     - NextTurn
     - oleg-nenashev
     message: |-
-      Update Windows Service Wrapper (WinSW) from 2.3.0 executable for  .NET Framework 2.0 to 2.9.0 for .NET Framework 4.0.
+      Update Windows Service Wrapper (WinSW) from 2.3.0 executable for .NET Framework 2.0 to 2.9.0 for .NET Framework 4.0.
       Includes numerous improvements and bugfixes.
       Most notably, the service installer will now ask for permission elevation if the required.
   - type: rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -8265,7 +8265,7 @@
     - NextTurn
     - oleg-nenashev
     message: |-
-      Update Windows Service Wrapper (WinSW) from 2.3.0 to 2.9.0.
+      Update Windows Service Wrapper (WinSW) from 2.3.0 executable for  .NET Framework 2.0 to 2.9.0 for .NET Framework 4.0.
       Includes numerous improvements and bugfixes.
       Most notably, the service installer will now ask for permission elevation if the required.
   - type: rfe


### PR DESCRIPTION
Adds links to https://www.jenkins.io/blog/2020/07/23/windows-support-updates/ to the changelog , and adds an explicit changelog link to the https://issues.jenkins-ci.org/browse/JENKINS-12660 fix

CC @NextTurn 
