### PR TITLE
Suggested fix for grammatical typo

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -21,7 +21,7 @@ for deploying applications. Starting with Pipeline versions 2.5 and higher,
 Pipeline has built-in support for interacting with Docker from within a
 `Jenkinsfile`.
 
-While this section will cover the basics of utilizing Docker from with a
+While this section will cover the basics of utilizing Docker from within a
 `Jenkinsfile`, it will not cover the fundamentals of Docker, which can be read
 about in the
 link:https://docs.docker.com/get-started/[Docker Getting Started Guide].


### PR DESCRIPTION
"While this section will cover the basics of utilizing Docker from with a `Jenkinsfile`"  >>>> "While this section will cover the basics of utilizing Docker from within a `Jenkinsfile`"