### PR TITLE
Use correct blog post location

### DIFF
--- a/content/_data/upgrades/2-235-3.adoc
+++ b/content/_data/upgrades/2-235-3.adoc
@@ -23,4 +23,4 @@ Update Red Hat compatible operating systems (Red Hat Enterprise Linux, CentOS, F
 # rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 ----
 
-See the link:/blog/2020/07/2020-07-27-repository-signing-keys-changing/[blog post] for more details.
+See the link:/blog/2020/07/27/repository-signing-keys-changing/[blog post] for more details.


### PR DESCRIPTION
## Use correct blog post URL

Broken blog post link in the upgrade guide for 2.253.3 until this is merged.