### PR TITLE
Small doc change

### DIFF
--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -302,9 +302,9 @@ The variables provided by default in Pipeline are:
 
 env::
 
-Environment variables accessible from Scripted Pipeline, for example:
+Exposes environment variables, for example:
 `env.PATH` or `env.BUILD_ID`. Consult the built-in global variable reference at
-`$\{YOUR_JENKINS_URL}/pipeline-syntax/globals`
+`$\{YOUR_JENKINS_URL}/pipeline-syntax/globals#env`
 for a complete, and up to date, list of environment variables
 available in Pipeline.
 


### PR DESCRIPTION
Removed text that would make one think that `env` is only available to Scripted syntax