### PR TITLE
Fix issue #3580 - broken links in Git plugin blog post

### DIFF
--- a/content/blog/2020/07/2020-07-29-git-performance-improvement-phase2.adoc
+++ b/content/blog/2020/07/2020-07-29-git-performance-improvement-phase2.adoc
@@ -99,5 +99,5 @@ In phase three, we wish to:
 Feel free to reach out to us for any questions or feedback on the project's link:https://gitter.im/jenkinsci/git-plugin[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins
 Developer Mailing list].
 
-* link:/projects/gsoc/2020/projects/git-plugin-performance.adoc[Project Page]
-* link:/blog/2020/07/2020-07-09-git-performance-improvement-phase1.adoc[Phase 1 Blog Post]
+* link:/projects/gsoc/2020/projects/git-plugin-performance/[Project Page]
+* link:/blog/2020/07/09/git-performance-improvement-phase1/[Phase 1 Blog Post]


### PR DESCRIPTION
## Fix issue #3580 - broken links in Git plugin blog post

The links to blog posts use a slightly different format than on disc path.  The links to other pages do not need the `.adoc` extension.