### PR TITLE
Add report on forked repositories in jenkinsci GitHub org

### DIFF
--- a/content/doc/developer/publishing/source-code-hosting/forks.adoc
+++ b/content/doc/developer/publishing/source-code-hosting/forks.adoc
@@ -1,17 +1,13 @@
 ---
-title: Source Code Hosting
+title: GitHub Forked Repositories
 layout: developersection
 ---
 
-The Jenkins project only publishes free and open source plugins distributed under an OSI-approved license.
-
 The canonical source code repository is in the `jenkinsci` GitHub organization to ensure source code access and project continuity in case previous maintainers move on.
 Some plugins we distribute are currently maintained outside the `jenkinsci` GitHub organization for historical reasons, but this is discouraged.
-link:forks[This page] lists all forked repositories in the `jenkinsci` GitHub organization and their source repositories.
 
-Plugin maintainers typically have repository admin permissions for plugins they maintain, but some features (like transfer and deletion of repos) are disabled.
+This page lists all forked repositories in the `jenkinsci` GitHub organization and their source repositories.
 
-This table shows the permissions currently granted to contributors in the `jenkinsci` GitHub repositories, excluding organization owners with full permissions to every repository:
 
 ////
 Testing changes to the script below locally without major changes is difficult due to CORS set up on reports.jenkins.io to only allow access from jenkins.io.
@@ -24,44 +20,41 @@ Starting Chrome with the arguments --disable-web-security --user-data-dir=<some 
     <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.21/datatables.js"></script>
     <script type="text/javascript">
 $(document).ready(function() {
-    $('#permissions').DataTable( {
+    $('#forks').DataTable( {
         ajax: {
-            url: 'https://reports.jenkins.io/github-jenkinsci-permissions-report.json',
+            url: 'https://reports.jenkins.io/github-jenkinsci-fork-report.json',
             dataSrc: ''
         },
         columns: [
-            { 
-                title: "Repository",
+            {
+                title: "Fork",
                 render: function(data, type, row, metadata) {
                     return '<a href="https://github.com/jenkinsci/' + data + '" target="_blank">' + data + '</a>';
                 }
             },
-            { 
-                title: "User",
+            {
+                title: "Origin",
                 render: function(data, type, row, metadata) {
                     return '<a href="https://github.com/' + data + '" target="_blank">' + data + '</a>';
                 }
-            },
-            { title: "Access" }
+            }
         ]
     } );
 } );
     </script>
-    <table id="permissions" class="display" cellspacing="0" width="100%">
-      <thead>
+    <table id="forks" class="display" cellspacing="0" width="100%">
+        <thead>
         <tr>
-          <th>Repository</th>
-          <th>User</th>
-          <th>Access</th>
+            <th>Fork</th>
+            <th>Origin</th>
         </tr>
-      </thead>
-      <tfoot>
+        </thead>
+        <tfoot>
         <tr>
-          <th>Repository</th>
-          <th>User</th>
-          <th>Access</th>
-          </tr>
-      </tfoot>
+            <th>Fork</th>
+            <th>Origin</th>
+        </tr>
+    </tfoot>
     </table>
 
 ++++


### PR DESCRIPTION
I plan to propose a cleanup of fork relationships soon, this is delivering the data for it so we know the scope.

Downstream of https://github.com/jenkins-infra/infra-reports/pull/24

### Unfiltered

> <img width="893" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/89183943-5241a300-d598-11ea-84ac-181565438eb3.png">

### Filtered

> <img width="885" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/89183958-57065700-d598-11ea-8079-795a4a03fb54.png">
