### PR TITLE
Avoid WEBSITE-630 non-deletion of removed files

### DIFF
--- a/content/blog/2020/02/2020-02-10-t-mobile-case-study.adoc
+++ b/content/blog/2020/02/2020-02-10-t-mobile-case-study.adoc
@@ -1,0 +1,12 @@
+---
+layout: post
+title: 'Jenkins Case Study'
+tags:
+- pipeline
+authors:
+- alyssat
+---
+
+== Case Study Removed
+
+This case study was removed at the request of the author.


### PR DESCRIPTION
## Avoid [WEBSITE-630](https://issues.jenkins-ci.org/browse/WEBSITE-630) non-deletion of removed files

Replace content of case study with a page noting that the case study has been removed.

The URL to the case study will still include the name of the company that provided the case study, but there will be no mention of the company name in the list of blog posts.  The prior author reference to an employee of the company has been removed as well so that the page will be less likely to be associated with the company.

Once we resolve WEBSITE-630, this page can be deleted.