### PR TITLE
Redirect deleted case study to 404

### DIFF
--- a/content/blog/2020/02/2020-02-10-t-mobile-case-study.adoc
+++ b/content/blog/2020/02/2020-02-10-t-mobile-case-study.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /node/tags/pipeline/
+---

--- a/content/blog/2020/02/2020-02-10-t-mobile-case-study.adoc
+++ b/content/blog/2020/02/2020-02-10-t-mobile-case-study.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: /node/tags/pipeline/
+redirect_url: /404/index.html
 ---


### PR DESCRIPTION
## Redirect removed case study to 404

The case study has been removed.  Links to it from within the site have been removed as well.  This redirect should only be visible to those who find the page through a search engine.