### PR TITLE
Remove redundant redirects to wiki

### DIFF
--- a/content/redirect/api-token.adoc
+++ b/content/redirect/api-token.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Remote+access+API
+redirect_url: /doc/book/using/remote-access-api/
 localized_urls:
   ja: https://wiki.jenkins.io/display/JA/Remote+access+API
 ---

--- a/content/redirect/csrf-protection.adoc
+++ b/content/redirect/csrf-protection.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/CSRF+Protection
+redirect_url: "/doc/book/managing/security/#cross-site-request-forgery"
 ---

--- a/content/redirect/fingerprint.adoc
+++ b/content/redirect/fingerprint.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Fingerprint
+redirect_url: /doc/book/using/fingerprints/
 localized_urls:
   ja: https://wiki.jenkins.io/display/JA/Fingerprint
 ---

--- a/content/redirect/installation-wizard.adoc
+++ b/content/redirect/installation-wizard.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins#InstallingJenkins-InstallationWizard
+redirect_url: "/doc/book/installing/#setup-wizard"
 ---

--- a/content/redirect/offline-installation.adoc
+++ b/content/redirect/offline-installation.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Offline+Jenkins+Installation
+redirect_url: "/doc/book/installing/#offline-jenkins-installation"
 ---

--- a/content/redirect/remote-api.adoc
+++ b/content/redirect/remote-api.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Remote+access+API
+redirect_url: /doc/book/using/remote-access-api/
 localized_urls:
   ja: https://wiki.jenkins.io/display/JA/Remote+access+API
 ---

--- a/content/redirect/report-an-issue.adoc
+++ b/content/redirect/report-an-issue.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue
+redirect_url: /participate/report-issue/
 ---

--- a/content/redirect/securing-jenkins.adoc
+++ b/content/redirect/securing-jenkins.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Securing+Jenkins
+redirect_url: /doc/book/system-administration/security/
 ---

--- a/content/redirect/troubleshooting/broken-reverse-proxy.adoc
+++ b/content/redirect/troubleshooting/broken-reverse-proxy.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Jenkins+says+my+reverse+proxy+setup+is+broken
+redirect_url: "/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#jenkins-says-my-reverse-proxy-setup-is-broken"
 ---


### PR DESCRIPTION
## Remove redundant redirects to wiki

Redirect to wiki would then redirect to www.jenkins.io in many of these cases.  In other cases, the information in the wiki is much less accurate than the information on www.jenkins.io.