### PR TITLE
Add websocket configuration for nginx reverse proxy

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
@@ -469,6 +469,12 @@ upstream jenkins {
   server 127.0.0.1:8080; # jenkins ip and port
 }
 
+# Required for Jenkins websocket agents
+map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+}
+
 server {
   listen          80;       # Listen on port 80 for IPv4 requests
 
@@ -506,6 +512,10 @@ server {
       proxy_pass         http://jenkins;
       proxy_redirect     default;
       proxy_http_version 1.1;
+
+      # Required for Jenkins websocket agents
+      proxy_set_header   Connection        $connection_upgrade;
+      proxy_set_header   Upgrade           $http_upgrade;
 
       proxy_set_header   Host              $host;
       proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
## Add websocket configuration for nginx reverse proxy

Special thanks to [Karl Palsson](https://github.com/karlp) for [his instructions](https://github.com/jenkins-infra/jenkins.io/issues/3599). I was able to use to confirm that my nginx reverse proxy would not allow a websocket agent to connect before these changes and was able to connect a websocket agent after the changes were applied.

See https://github.com/jenkins-infra/jenkins.io/issues/3599 for the details provided by Karl.