### PR TITLE
Fix typo

### DIFF
--- a/content/_layouts/developerbook.html.haml
+++ b/content/_layouts/developerbook.html.haml
@@ -57,7 +57,7 @@ layout: default
           = active_href('doc/developer/javadoc', 'Javadoc', :fuzzy => true)
 
         %h5
-          = active_href('doc/developer/development-environment/taglibs', 'Tablibs', :fuzzy => true)
+          = active_href('doc/developer/development-environment/taglibs', 'Taglibs', :fuzzy => true)
 
         %h5
           Tools


### PR DESCRIPTION
Originally caused by f34027696dffffccf34c0c7b01ecb5d1afc129cb in response to https://github.com/jenkins-infra/jenkins.io/pull/2407#discussion_r320270267 it seems.