### PR TITLE
Updates to /doc/book/managing/cli/ esp. w.r.t. -webSocket

### DIFF
--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -32,16 +32,12 @@ and more.
 The command line interface can be accessed over SSH or with the Jenkins CLI
 client, a `.jar` file distributed with Jenkins.
 
-[WARNING]
+[NOTE]
 ====
-Use of the CLI client distributed with Jenkins 2.53 and older and Jenkins LTS 2.46.1 and older
-is **not recommended** for security reasons.
+This document assumes Jenkins 2.54 or newer.
+Older versions of the CLI client are considered insecure and should not be used.
 
-The client distributed with Jenkins 2.54 and newer and Jenkins LTS 2.46.2 and newer
-is considered secure in its default (`-http`) or `-ssh` modes,
-as is using the standard `ssh` command.
-
-Jenkins 2.165 and newer no longer supports the old (`-remoting`) mode in either the client or server.
+WebSocket support is available when using both server and client 2.217 or newer.
 ====
 
 [[ssh]]
@@ -69,10 +65,10 @@ Whichever user used for authentication with the Jenkins master must have the
 `Overall/Read` permission in order to _access_ the CLI. The user may require
 additional permissions depending on the commands executed.
 
-Authentication relies on
+Authentication in SSH mode relies on
 SSH-based public/private key authentication. In order to add an SSH public key
 for the appropriate user, navigate to
-`https://JENKINS_URL/user/USERNAME/configure` and paste an SSH public key
+`https://JENKINS_URL/me/configure` and paste an SSH public key
 into the appropriate text area.
 
 image::managing/cli-adding-ssh-public-keys.png["Adding public SSH keys for a user", role=center]
@@ -268,11 +264,8 @@ ensure it does not buffer request or response bodies.
 
 [WARNING]
 ====
-The HTTP(S) connection mode of the CLI does not work
-correctly behind an Apache HTTP reverse proxy server using mod_proxy. Workarounds include using
-a different reverse proxy such as Nginx or HAProxy, or using the SSH connection
-mode where possible. See
-link:https://issues.jenkins-ci.org/browse/JENKINS-47279[JENKINS-47279].
+This mode is known to not work reliably or at all when using certain reverse proxies.
+Prefer WebSocket mode.
 ====
 
 ==== WebSocket connection mode


### PR DESCRIPTION
Amending #1164 & #2807 to better reflect https://github.com/jenkinsci/jenkins/pull/4369 as in https://github.com/jenkinsci/jep/blob/master/jep/222/README.adoc#cli and the fact that `-remoting` is long gone. CC @dwnusbaum 