### PR TITLE
Link Windows install page to www instead of wiki

### DIFF
--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -44,14 +44,14 @@
 
 %ul
   %li
-    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Running+Jenkins+behind+Apache'}
-      Running Jenkins behind Apache
+    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-iis'}
+      Running Jenkins behind Internet Information Server (IIS)
   %li
-    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Running+Jenkins+behind+Nginx'}
-      Running Jenkins behind Nginx
-    and
-    %a{:href => 'https://wiki.jenkins.io/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy'}
-      Jenkins behind an NGinX reverse proxy
+    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-nginx}
+      Running Jenkins behind nginx
+  %li
+    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-apache}
+      Running Jenkins behind Apache
 
 :javascript
   $(document).ready(function() {


### PR DESCRIPTION
## Link Windows install page to www instead of wiki

The reverse proxy instructions have migrated to www.jenkins.io so we can link to them instead of linking to the wiki page.  Can also include a link to the IIS instructions (though it is not clear if the IIS instructions are still useful for the current version).