### PR TITLE
Fix broken windows install page

### DIFF
--- a/content/_partials/thank-you-downloading-windows-installer.html.haml
+++ b/content/_partials/thank-you-downloading-windows-installer.html.haml
@@ -47,10 +47,10 @@
     %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-iis'}
       Running Jenkins behind Internet Information Server (IIS)
   %li
-    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-nginx}
+    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-nginx'}
       Running Jenkins behind nginx
   %li
-    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-apache}
+    %a{:href => '/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-apache'}
       Running Jenkins behind Apache
 
 :javascript


### PR DESCRIPTION
## Fix broken windows install page

Missed two single quote characters that broke https://www.jenkins.io/download/thank-you-downloading-windows-installer/

Reminder that I should have attached an image of the page to confirm that I'd shown that the page renders correctly.

![screencapture-localhost-4242-download-thank-you-downloading-windows-installer-2020-08-09-21_56_05-edit](https://user-images.githubusercontent.com/156685/89751158-2c326c00-da8c-11ea-86ac-39a7bf28e817.png)
