### PR TITLE
Suggest a concrete LTS version to be used as Jenkins baseline

### DIFF
--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -23,7 +23,7 @@ There are link:https://stats.jenkins.io/pluginversions/[statistics of core versi
 
 General tip: When upgrading, choose the link:/changelog-stable/[newest LTS version] that doesn't alienate the majority of users of your latest few releases (by requiring a newer Jenkins than they have).
 
-If you do not have special requirements, then a good idea is to support the latest three
+If you do not have special requirements then a good idea is to support the latest three
 LTS minor versions. This helps to ensure that teams that are slower at adapting new Jenkins versions 
 will not be forced to update their Jenkins too frequently. Additionally, other plugins that 
 depend on your plugin also need to upgrade their minimum Jenkins version to your Jenkins version, 
@@ -32,7 +32,7 @@ otherwise the injected tests will fail.
 Example: if we are currently at Jenkins 2.248 then the latest LTS version is 
 2.235.x. Then it would make sense to also support 2.222.x and 2.204.x. When setting the Jenkins version
 please also make sure to use the .1 patch version of the LTS version: 2.204.1, or 2.222.1. Using
-a newer patch version like 2.222.6 causes the build problems in depending plugins that depend on the
+a newer patch version like 2.222.6 causes  build problems in depending plugins that depend on the
 .1 patch version.
 
 == Changing the minimum required version

--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -5,24 +5,37 @@ title: Choosing a Jenkins version to build against
 
 Your plugin's POM controls which version of Jenkins it is building/testing against.
 
-## Choosing a version
+== Choosing a version
 
 You need to balance compatibility and features:
 
-* *Keeping the Jenkins version your plugin builds against low* will allow more users to install and use your plugin. 
+* *Keeping the Jenkins version your plugin builds against low* will allow more users to install and use your plugin.
 In particular, the LTS Release Line is based on slightly older releases to provide a more stable experience for conservative users.
-* *Building against recent Jenkins versions* allows you to use recently added core features and API from your plugin. 
-You will also use that newer version for `mvn hpi:run`, so it may be easier to test your plugin with newer Jenkins releases. 
+* *Building against recent Jenkins versions* allows you to use recently added core features and API from your plugin.
+You will also use that newer version for `mvn hpi:run`, so it may be easier to test your plugin with newer Jenkins releases.
 Additionally, since features are sometimes moved from core into plugins, depending on a more recent Jenkins version will make your plugin's dependencies on what used to be core features explicit, otherwise your plugin will not work.
 * *Use at least the minimum version supported by the update center*, the supported update center versions can be found at link:https://updates.jenkins.io[updates.jenkins.io], at the time of writing (2020-03) this is 2.164.x.
 
-There are link:https://stats.jenkins.io/pluginversions/[statistics of core versions by plugin] that can help you decide.
+There are link:https://stats.jenkins.io/pluginversions/[statistics of core versions by plugin] that can help you decide. These are updated monthly.
 
-These are updated monthly.
+
+== Suggested minimum version
 
 General tip: When upgrading, choose the link:/changelog-stable/[newest LTS version] that doesn't alienate the majority of users of your latest few releases (by requiring a newer Jenkins than they have).
 
-## Changing the minimum required version
+If you do not have special requirements, then a good idea is to support the latest three
+LTS minor versions. This helps to ensure that teams that are slower at adapting new Jenkins versions 
+will not be forced to update their Jenkins too frequently. Additionally, other plugins that 
+depend on your plugin also need to upgrade their minimum Jenkins version to your Jenkins version, 
+otherwise the injected tests will fail.
+
+Example: if we are currently at Jenkins 2.248 then the latest LTS version is 
+2.235.x. Then it would make sense to also support 2.222.x and 2.204.x. When setting the Jenkins version
+please also make sure to use the .1 patch version of the LTS version: 2.204.1, or 2.222.1. Using
+a newer patch version like 2.222.6 causes the build problems in depending plugins that depend on the
+.1 patch version.
+
+== Changing the minimum required version
 
 Set the `jenkins.version` property in `pom.xml` to the version you need to depend on.
 

--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -14,7 +14,7 @@ In particular, the LTS Release Line is based on slightly older releases to provi
 * *Building against recent Jenkins versions* allows you to use recently added core features and API from your plugin.
 You will also use that newer version for `mvn hpi:run`, so it may be easier to test your plugin with newer Jenkins releases.
 Additionally, since features are sometimes moved from core into plugins, depending on a more recent Jenkins version will make your plugin's dependencies on what used to be core features explicit, otherwise your plugin will not work.
-* *Use at least the minimum version supported by the update center*, the supported update center versions can be found at link:https://updates.jenkins.io[updates.jenkins.io], at the time of writing (2020-03) this is 2.164.x.
+* *Use at least the minimum version supported by the update center*, the supported update center versions can be found at link:https://updates.jenkins.io[updates.jenkins.io], at the time of writing (August 2020) this is 2.176.x.
 
 There are link:https://stats.jenkins.io/pluginversions/[statistics of core versions by plugin] that can help you decide. These are updated monthly.
 


### PR DESCRIPTION
Recently a lot of my builds failed (my baseline was 2.204.4) because some frequently used base plugins updated their minimum Jenkins version to a higher LTS minor version (like 2.222.1) or a higher patch version (2.204.6).  

So it might make sense to make the baseline selection more precise.  