### PR TITLE
Replace 'master' with 'controller' where appropriate

### DIFF
--- a/content/security/advisory/2012-09-17.adoc
+++ b/content/security/advisory/2012-09-17.adoc
@@ -7,7 +7,7 @@ kind: core and plugins
 
 This advisory announces security vulnerabilities that were found in Jenkins core and several plugins.
 
-* The first vulnerability in Jenkins core allows unprivileged users to insert data into Jenkins master, which can lead to remote code execution. For this vulnerability to be exploited, the attacker must have an HTTP access to a Jenkins master, and he must have a read access to Jenkins.
+* The first vulnerability in Jenkins core allows unprivileged users to insert data into the Jenkins controller, which can lead to remote code execution. For this vulnerability to be exploited, the attacker must have an HTTP access to a Jenkins controller, and he must have a read access to Jenkins.
 * The second vulnerability in Jenkins core is a cross-site scripting vulnerability. This allows an attacker to craft an URL that points to Jenkins, and if a legitimate user clicks this link, and the attacker will be able to hijack the user session.
 * The third vulnerability is a cross-site scripting vulnerability in plugin:violations[the Violations plugin]
 * The fourth vulnerability is a cross-site scripting vulnerability in plugin:ci-game[the Continuous Integration Game plugin]

--- a/content/security/advisory/2013-01-04.adoc
+++ b/content/security/advisory/2013-01-04.adoc
@@ -8,9 +8,9 @@ kind: core
 This advisory announces a security vulnerability that was found in Jenkins core.
 
 == Description
-This vulnerability allows attacker with an HTTP access to the server to retrieve the master cryptographic key of Jenkins. This key is used to encrypt sensitive data in configuration files under `$JENKINS_HOME` and in the HTML forms, authenticate agents connecting to the master, as well as the authenticate REST API access from users.
+This vulnerability allows attacker with an HTTP access to the server to retrieve the master cryptographic key of Jenkins. This key is used to encrypt sensitive data in configuration files under `$JENKINS_HOME` and in the HTML forms, authenticate agents connecting to the Jenkins controller, as well as the authenticate REST API access from users.
 
-An attacker can then use this master cryptographic key to mount remote code execution attack against the Jenkins master, or impersonate arbitrary users in making REST API calls.
+An attacker can then use this master cryptographic key to mount remote code execution attack against the Jenkins controller, or impersonate arbitrary users in making REST API calls.
 
 There are several factors that mitigate some of these problems that may apply to specific installations.
 

--- a/content/security/advisory/2013-01-04/re-keying.adoc
+++ b/content/security/advisory/2013-01-04/re-keying.adoc
@@ -46,7 +46,7 @@ If you are in the middle of the background re-keying operation and found that yo
 
 == After you re-key
 
-Once the re-keying process is completed, the aforementioned backup directory should be moved off from the Jenkins master to prevent future leakage of the sensitive data.
+Once the re-keying process is completed, the aforementioned backup directory should be moved off from the Jenkins controller file system to prevent future leakage of the sensitive data.
 
 To really verify that the re-keying process didn't cause any issues, you'll have to reboot Jenkins one more time, so that fresh reads will be attempted from disk.
 

--- a/content/security/advisory/2013-02-16.adoc
+++ b/content/security/advisory/2013-02-16.adoc
@@ -8,7 +8,7 @@ kind: core
 This advisory announces multiple security vulnerabilities that were found in Jenkins core.
 
 == Description
-One of the vulnerabilities allows link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery (CSRF) attacks] on Jenkins master, which causes an user to make unwanted actions on Jenkins.
+One of the vulnerabilities allows link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery (CSRF) attacks] on the Jenkins controller, which causes an user to make unwanted actions on Jenkins.
 
 Another vulnerability enables link:https://owasp.org/www-community/attacks/xss/[cross-site scripting (XSS) attacks], which has the similar consequence.
 

--- a/content/security/advisory/2013-05-02.adoc
+++ b/content/security/advisory/2013-05-02.adoc
@@ -10,7 +10,7 @@ This advisory announces multiple security vulnerabilities that were found in Jen
 
 == Description
 === SECURITY-63 / CVE-2013-2034
-This creates a link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery (CSRF)] vulnerability on Jenkins master, where an anonymous attacker can trick an administrator to execute arbitrary code on Jenkins master by having him open a specifically crafted attack URL.
+This creates a link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery (CSRF)] vulnerability on the Jenkins controller, where an anonymous attacker can trick an administrator to execute arbitrary code on the Jenkins controller by having him open a specifically crafted attack URL.
 
 There's also a related vulnerability where the permission check on this ability is done imprecisely, which may affect those who are running Jenkins instances with a jenkinsdoc:AuthorizationStrategy[custom authorization strategy] plugin.
 

--- a/content/security/advisory/2013-11-20.adoc
+++ b/content/security/advisory/2013-11-20.adoc
@@ -9,7 +9,7 @@ This advisory announces multiple security vulnerabilities that were found in sev
 
 == Description
 === SECURITY-58 / CVE-2013-6372
-plugin:subversion[Subversion plugin] was not storing credentials by using the security mechanism Jenkins core provides to plugins. As a result people with local system access on Jenkins master can compromise passwords and SSH private key passphrases Jenkins uses to access Subversion repositories. Jenkins project would like to thank Lennart Starr for finding this issue.
+plugin:subversion[Subversion plugin] was not storing credentials by using the security mechanism Jenkins core provides to plugins. As a result people with local system access on the Jenkins controller can compromise passwords and SSH private key passphrases Jenkins uses to access Subversion repositories. Jenkins project would like to thank Lennart Starr for finding this issue.
 
 === SECURITY-53 / CVE-2013-6373
 plugin:Exclusion[Exclusion-plugin] wasn't protecting itself from unauthorized access to list and release resource locks that on-going builds have held. Jenkins project would like to thank mwebber for finding this issue.
@@ -19,7 +19,7 @@ plugin:build-failure-analyzer[build failure analyzer] plugin had a link:https://
 
 
 == Severity
-SECURITY-58 is rated *low* as it requires an attacker to have local access to the Jenkins master. Subversion itself does not store passwords securely anyway.
+SECURITY-58 is rated *low* as it requires an attacker to have local access to the Jenkins controller. Subversion itself does not store passwords securely anyway.
 
 SECURITY-53 is rated *medium*, as it allows anyone with access to Jenkins to mount an attack. However, the impact of the attack is limited, as it can only cause builds to fail and leads to no privilege escalation nor data loss.
 

--- a/content/security/advisory/2014-02-14.adoc
+++ b/content/security/advisory/2014-02-14.adoc
@@ -9,7 +9,7 @@ This advisory announces multiple security vulnerabilities that were found in Jen
 
 == Description
 === SECURITY-105
-In some places, Jenkins XML API uses XStream to deserialize arbitrary content, which is affected by link:https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-7285[CVE-2013-7285] reported against XStream. This allows malicious users of Jenkins with a limited set of permissions to execute arbitrary code inside Jenkins master.
+In some places, Jenkins XML API uses XStream to deserialize arbitrary content, which is affected by link:https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-7285[CVE-2013-7285] reported against XStream. This allows malicious users of Jenkins with a limited set of permissions to execute arbitrary code inside the Jenkins controller.
 
 === SECURITY-76 & SECURITY-88 / CVE-2013-5573
 Restrictions of HTML tags for user-editable contents are too lax. This allows malicious users of Jenkins to trick other unsuspecting users into providing sensitive information.
@@ -18,7 +18,7 @@ Restrictions of HTML tags for user-editable contents are too lax. This allows ma
 Plugging a hole in the earlier fix to SECURITY-55. Under some circimstances, a malicious user of Jenkins can configure job X to trigger another job Y that the user has no access to.
 
 === SECURITY-108
-CLI job creation had a directory traversal vulnerability. This allows a malicious user of Jenkins with a limited set of permissions to overwrite files in the Jenkins master and escalate privileges.
+CLI job creation had a directory traversal vulnerability. This allows a malicious user of Jenkins with a limited set of permissions to overwrite files in the Jenkins controller and escalate privileges.
 
 === SECURITY-106
 The embedded Winstone servlet container is susceptive to session hijacking attack.

--- a/content/security/advisory/2014-10-01.adoc
+++ b/content/security/advisory/2014-10-01.adoc
@@ -30,14 +30,14 @@ If a parameterized job has a default value in a password field, that default val
 Reflected cross-site scripting vulnerability in Jenkins core. An attacker can navigate the user to a carefully crafted URL and have the user execute unintended actions.
 
 === SECURITY-150/CVE-2014-3666 (remote code execution from CLI)
-Unauthenticated user can execute arbitrary code on Jenkins master by sending carefully crafted packets over the CLI channel.
+Unauthenticated user can execute arbitrary code on the Jenkins controller by sending carefully crafted packets over the CLI channel.
 
 [#SECURITY-155]
 === SECURITY-155/CVE-2014-3667 (exposure of plugin code)
 Programs that constitute plugins can be downloaded by anyone with the Overall/READ permission, resulting in the exposure of otherwise sensitive information, such as hard-coded keys in plugins, if any.
 
 === SECURITY-159/CVE-2013-2186 (arbitrary file system write)
-Security vulnerability in commons fileupload allows unauthenticated attacker to upload arbitrary files to Jenkins master.
+Security vulnerability in commons fileupload allows unauthenticated attacker to upload arbitrary files to the Jenkins controller.
 
 === SECURITY-149/CVE-2014-1869 (XSS vulnerabilities in ZeroClipboard)
 reflective XSS vulnerability in one of the library dependencies of Jenkins.
@@ -57,7 +57,7 @@ SECURITY-127 and SECURITY-128 are rated *high*. The former can be used to furthe
 
 SECURITY-131 and SECURITY-138 is rated *critical*. This vulnerabilities results in exposure of sensitie information and is easily exploitable.
 
-SECURITY-143 is rated *high*. It is a passive attack, but it can result in a compromise of Jenkins master or loss of data.
+SECURITY-143 is rated *high*. It is a passive attack, but it can result in a compromise of the Jenkins controller or loss of data.
 
 SECURITY-150 is rated *critical*. This attack can be mounted by any unauthenticated anonymous user with HTTP reachability to Jenkins instance, and results in remote code execution on Jenkins.
 
@@ -65,7 +65,7 @@ SECURITY-155 is rated *medium*. This only affects users who have installed propr
 
 SECURITY-159 is rated *critical*. This attack can be mounted by any unauthenticated anonymous user with HTTP reachability to Jenkins instance.
 
-SECURITY-113 is rated *high*. It is a passive attack, but it can result in a compromise of Jenkins master or loss of data.
+SECURITY-113 is rated *high*. It is a passive attack, but it can result in a compromise of the Jenkins controller or loss of data.
 
 == Affected Versions
 * All the Jenkins releases <= 1.582

--- a/content/security/advisory/2014-10-15.adoc
+++ b/content/security/advisory/2014-10-15.adoc
@@ -8,10 +8,10 @@ kind: other
 This advisory discusses the impact of so-called link:https://poodle.io/[Poodle vulnerability] (CVE-2014-3566) in Jenkins core.
 
 == Description
-This vulnerability allows a man-in-the-middle attacker to decrypt SSLv3 communication. See link:https://www.imperialviolet.org/2014/10/14/poodle.html[this post] for the technical detail of the attack. This involves an attacker who sits in the middle of a Jenkins master and a victim, and a victim who opens a web page controller by an attacker. By repeatedly making the victim's browser to issue an HTTPS request to Jenkins master, the attacker can decrypt sensitive information such as session cookie one byte at a time.
+This vulnerability allows a man-in-the-middle attacker to decrypt SSLv3 communication. See link:https://www.imperialviolet.org/2014/10/14/poodle.html[this post] for the technical detail of the attack. This involves an attacker who sits in the middle of a Jenkins controller and a victim, and a victim who opens a web page controller by an attacker. By repeatedly making the victim's browser to issue an HTTPS request to the Jenkins controller, the attacker can decrypt sensitive information such as session cookie one byte at a time.
 
 == Severity
-CVE-2014-3566 is rated *high*. An man-in-the-middle attacker can relatively easily trick a victim into opening an unencrypted web page controlled by an attacker, and a successful exploit results in a compromise of Jenkins master and/or loss of data.
+CVE-2014-3566 is rated *high*. An man-in-the-middle attacker can relatively easily trick a victim into opening an unencrypted web page controlled by an attacker, and a successful exploit results in a compromise of the Jenkins controller and/or loss of data.
 
 == Affected Versions
 All versions of Jenkins released to date is vulnerable, but only if all the following conditions are met:

--- a/content/security/advisory/2014-10-30.adoc
+++ b/content/security/advisory/2014-10-30.adoc
@@ -8,9 +8,9 @@ kind: core
 This advisory announces a security vulnerability/hardening (CVE-2014-3665) in Jenkins core.
 
 == Description
-Historically, Jenkins master and agents behaved as if they altogether form a single distributed process. This means an agent can ask a master to do just about anything within the confinement of the operating system, such as accessing files on the master or trigger other jobs on Jenkins.
+Historically, Jenkins controller and agents behaved as if they altogether form a single distributed process. This means an agent can ask a controller to do just about anything within the confinement of the operating system, such as accessing files on the Jenkins controller or trigger other jobs on Jenkins.
 
-This has increasingly become problematic, as larger enterprise deployments have developed more sophisticated trust separation model, where the administators of a master might take agents owned by other teams. In such an environment, agents are less trusted than the master. Yet the "single distributed process" assumption was not communicated well to the users, resulting in vulnerabilities in some deployments.
+This has increasingly become problematic, as larger enterprise deployments have developed more sophisticated trust separation model, where the administators of a controller might take agents owned by other teams. In such an environment, agents are less trusted than the Jenkins controller. Yet the "single distributed process" assumption was not communicated well to the users, resulting in vulnerabilities in some deployments.
 
 SECURITY-144 (CVE-2014-3665) introduces a new subsystem to address this problem. This feature is off by default for compatibility reasons. See link:/redirect/security-144/[Wiki] for more details, who should turn this on, and implications.
 

--- a/content/security/advisory/2015-02-27.adoc
+++ b/content/security/advisory/2015-02-27.adoc
@@ -13,10 +13,10 @@ This advisory announces:
 
 == Description
 === SECURITY-125 (Combination filter Groovy script unsecured)
-This vulnerability allows users with the job configuration privilege to escalate his privileges, resulting in arbitrary code execution to the master.
+This vulnerability allows users with the job configuration privilege to escalate his privileges, resulting in arbitrary code execution to the Jenkins controller.
 
 === SECURITY-162 (directory traversal from artifacts via symlink)
-This vulnerability allows users with the job configuration privilege or users with commit access to the build script to access arbitrary files/directories on the master, resulting in the exposure of sensitive information, such as encryption keys.
+This vulnerability allows users with the job configuration privilege or users with commit access to the build script to access arbitrary files/directories on the Jenkins controller, resulting in the exposure of sensitive information, such as encryption keys.
 
 === SECURITY-163 (update center metadata retrieval DoS attack)
 This vulnerability allows authenticated users to disrupt the operation of Jenkins by feeding malicious update center data into Jenkins, affecting plugin installation and tool installation.
@@ -32,7 +32,7 @@ This vulnerability allows attackers to create malicious XML documents and feed t
 
 
 == Severity
-SECURITY-125 is rated *critical*. This attack can be only mounted by users with some trust, but it results in arbitrary code execution on the master.
+SECURITY-125 is rated *critical*. This attack can be only mounted by users with some trust, but it results in arbitrary code execution on the Jenkins controller.
 
 SECURITY-162 is rated *critical*. This attack can be only mounted by users with some trust, but it results in the exposure of sensitive information.
 
@@ -40,7 +40,7 @@ SECURITY-163 is rated *medium*, as it results in the loss of functionality.
 
 SECURITY-165 is rated *critical*. This attack is easy to mount, and it results in the exposure of sensitive information.
 
-SECURITY-166 is rated *critical*. For users who use the affected feature, this attack results in arbitrary code execution on the master.
+SECURITY-166 is rated *critical*. For users who use the affected feature, this attack results in arbitrary code execution on the Jenkins controller.
 
 SECURITY-167 is rated *critical*. This attack is easy to mount, and it results in the exposure of sensitive information.
 

--- a/content/security/advisory/2015-03-23.adoc
+++ b/content/security/advisory/2015-03-23.adoc
@@ -15,9 +15,9 @@ An attacker without any access to Jenkins can navigate the user to a carefully c
 The part of Jenkins that issues a new API token was not adequately protected against anonymous attackers. This allows an attacker to escalate privileges on Jenkins .
 
 == Severity
-SECURITY-171/SECURITY-177 is rated *high*. It is a passive attack, but it can result in a compromise of Jenkins master or loss of data.
+SECURITY-171/SECURITY-177 is rated *high*. It is a passive attack, but it can result in a compromise of the Jenkins controller or loss of data.
 
-SECURITY-180 is rated *critical*. This attack can be mounted by any unauthenticated user, and it results in a compromise of Jenkins master or loss of data.
+SECURITY-180 is rated *critical*. This attack can be mounted by any unauthenticated user, and it results in a compromise of the Jenkins controller or loss of data.
 
 == Affected Versions
 * All Jenkins releases \<= 1.605

--- a/content/security/advisory/2015-11-11.adoc
+++ b/content/security/advisory/2015-11-11.adoc
@@ -30,7 +30,7 @@ When creating a job using the create-job CLI command, external entities are not 
 === Secret key not verified when connecting an agent
 *SECURITY-184 / CVE-2015-5320*
 
-JNLP agent connections did not verify that the correct secret was supplied, which allowed malicious users to connect their own machines as agents to Jenkins knowing only the name of the agent. This enables attackers to take over Jenkins (unless the agent-to-master security subsystem is enabled) or gain access to private data like keys and source code.
+JNLP agent connections did not verify that the correct secret was supplied, which allowed malicious users to connect their own machines as agents to Jenkins knowing only the name of the agent. This enables attackers to take over Jenkins (unless the agent-to-controller security subsystem is enabled) or gain access to private data like keys and source code.
 
 
 === Queue API did show items not visible to the current user
@@ -57,10 +57,10 @@ Access to the `/jnlpJars/` URL was not limited to the specific JAR files users n
 API tokens of other users were exposed to admins by default. On instances that don't implicitly grant RunScripts permission to admins, this allowed admins to run scripts with another user's credentials.
 
 
-=== JNLP agents not subject to agent-to-master access control
+=== JNLP agents not subject to agent-to-controller access control
 *SECURITY-206 / CVE-2015-5325*
 
-Agents connecting via JNLP were not subject to the optional agent-to-master access control documented at https://jenkins-ci.org/security-144 (CVE-2014-3665).
+Agents connecting via JNLP were not subject to the optional agent-to-controller access control documented at https://jenkins-ci.org/security-144 (CVE-2014-3665).
 
 
 === Stored XSS vulnerability in agent offline status message
@@ -72,7 +72,7 @@ Users with the permission to take agent nodes offline can enter arbitrary HTML t
 === Remote code execution vulnerability due to unsafe deserialization in Jenkins remoting
 *SECURITY-218 / CVE-2015-8103*
 
-Unsafe deserialization allows unauthenticated remote attackers to run arbitrary code on the Jenkins master.
+Unsafe deserialization allows unauthenticated remote attackers to run arbitrary code on the Jenkins controller.
 
 
 == Severity

--- a/content/security/advisory/2016-02-24.adoc
+++ b/content/security/advisory/2016-02-24.adoc
@@ -13,7 +13,7 @@ This advisory announces multiple vulnerabilities in Jenkins.
 === Remote code execution vulnerability in remoting module
 *SECURITY-232 / CVE-2016-0788*
 
-A vulnerability in the Jenkins remoting module allowed unauthenticated remote attackers to open a JRMP listener on the server hosting the Jenkins master process, which allowed arbitrary code execution.
+A vulnerability in the Jenkins remoting module allowed unauthenticated remote attackers to open a JRMP listener on the server hosting the Jenkins controller process, which allowed arbitrary code execution.
 
 
 === HTTP response splitting vulnerability
@@ -47,7 +47,7 @@ Jenkins has several API endpoints that allow low-privilege users to POST XML fil
 * SECURITY-238 is considered *link:https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N[medium]* as it allows unprivileged attackers to send maliciously crafted links that result e.g. in XSS to victims.
 * SECURITY-241 is considered *link:https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H[high]* as it allows unprivileged attackers to brute-force valid login credentials.
 * SECURITY-245 is considered *link:https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N[medium]* as it allows unprivileged attackers to brute-force CSRF protection.
-* SECURITY-247 is considered *link:https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H[high]* as it allows low-privilege attackers to execute arbitrary code on the Jenkins master.
+* SECURITY-247 is considered *link:https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H[high]* as it allows low-privilege attackers to execute arbitrary code on the Jenkins controller.
 
 == Affected versions
 

--- a/content/security/advisory/2017-02-01.adoc
+++ b/content/security/advisory/2017-02-01.adoc
@@ -45,10 +45,10 @@ Users with the permission to configure jobs were able to inject JavaScript into 
 Jenkins bundled an outdated version of jbcrypt that was affected by CVE-2015-0886.
 
 
-=== Pipeline metadata files not excluded in agent-to-master security subsystem
+=== Pipeline metadata files not excluded in agent-to-controller security subsystem
 *SECURITY-358 / CVE-2017-2602*
 
-The Pipeline suite of plugins stored build metadata in the file `program.dat` and the directory `workflow/`. These were not excluded in the link:https://jenkins-ci.org/security-144[agent-to-master security subsystem] and could therefore be written to by malicious agents.
+The Pipeline suite of plugins stored build metadata in the file `program.dat` and the directory `workflow/`. These were not excluded in the link:https://jenkins-ci.org/security-144[agent-to-controller security subsystem] and could therefore be written to by malicious agents.
 
 
 === User data leak in disconnected agents' config.xml API
@@ -110,7 +110,7 @@ Jenkins allows the creation of users with less-than and greater-than characters 
 === Insufficient permission check for periodic processes
 *SECURITY-389 / CVE-2017-2611*
 
-The URLs `/workspaceCleanup` and `/fingerprintCleanup` did not perform permission checks, allowing users with read access to Jenkins to trigger these background processes (that are otherwise performed daily), possibly causing additional load on Jenkins master and agents.
+The URLs `/workspaceCleanup` and `/fingerprintCleanup` did not perform permission checks, allowing users with read access to Jenkins to trigger these background processes (that are otherwise performed daily), possibly causing additional load on Jenkins controller and agents.
 
 
 === Low privilege users were able to override JDK download credentials

--- a/content/security/advisory/2017-03-07.adoc
+++ b/content/security/advisory/2017-03-07.adoc
@@ -9,10 +9,10 @@ This advisory announces a vulnerability in the plugin:pipeline-maven[Maven Pipel
 
 == Description
 
-=== Maven Pipeline Plugin allows reading arbitrary files from the Jenkins master
+=== Maven Pipeline Plugin allows reading arbitrary files from the Jenkins controller
 *SECURITY-441*
 
-The Maven Pipeline Plugin allowed users to copy and read arbitrary files accessible from the Jenkins master process in a Pipeline script by specifying that file's path on the Jenkins master as `mavenSettingsFilePath` or `globalMavenSettingsFilePath`.
+The Maven Pipeline Plugin allowed users to copy and read arbitrary files accessible from the Jenkins controller process in a Pipeline script by specifying that file's path on the Jenkins controller as `mavenSettingsFilePath` or `globalMavenSettingsFilePath`.
 
 == Severity
 

--- a/content/security/advisory/2017-03-09.adoc
+++ b/content/security/advisory/2017-03-09.adoc
@@ -9,13 +9,13 @@ This advisory announces a vulnerability in the plugin:pipeline-maven[Maven Pipel
 
 == Description
 
-=== Maven Pipeline Plugin allows reading arbitrary files from the Jenkins master
+=== Maven Pipeline Plugin allows reading arbitrary files from the Jenkins controller
 *SECURITY-441*
 
 Due to an improperly performed plugin release, version 0.6 of the Maven Pipeline Plugin is still affected by the vulnerability originally announced in the link:/security/advisory/2017-03-07/[2017-03-07] security advisory:
 
 ____
-The Maven Pipeline Plugin allowed users to copy and read arbitrary files accessible from the Jenkins master process in a Pipeline script by specifying that file's path on the Jenkins master as `mavenSettingsFilePath` or `globalMavenSettingsFilePath`.
+The Maven Pipeline Plugin allowed users to copy and read arbitrary files accessible from the Jenkins controller process in a Pipeline script by specifying that file's path on the Jenkins controller as `mavenSettingsFilePath` or `globalMavenSettingsFilePath`.
 ____
 
 == Severity

--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -196,7 +196,7 @@ Therefore any script _containing but not equal to_ expandable variables will be 
 They will always be running in the sandbox.
 This is a known limitation.
 
-Any *template provided by a Jenkins administrator* (e.g. in the master's `scripts/` directory) will run as is outside the sandbox.
+Any *template provided by a Jenkins administrator* (e.g. in the Jenkins controller's `scripts/` directory) will run as is outside the sandbox.
 
 The behavior of *templates loaded from the build's workspace* depends on the type of template:
 
@@ -205,7 +205,7 @@ The behavior of *templates loaded from the build's workspace* depends on the typ
 
 *Script-based triggers* are configured to need whole-script approval on upgrading, but users configuring the job can choose to run them in the script sandbox instead.
 
-*Classpaths* no longer support variables, they need to be paths to files on the Jenkins master.
+*Classpaths* no longer support variables, they need to be paths to files on the Jenkins controller.
 
 Any failures to run these scripts will result in build failures.
 
@@ -575,20 +575,20 @@ Additionally, jobs configured through the UI will continue to run specified scri
 
 As of publication of this advisory, there is no fix.
 
-=== Environment Injector (EnvInject) Plugin allows low privilege users to access parts of arbitrary files on master
+=== Environment Injector (EnvInject) Plugin allows low privilege users to access parts of arbitrary files on controller
 *SECURITY-348*
 
-Environment Injector Plugin allowed users with Job/Configure permission to include properties files containing an environment definition from the master node.
+Environment Injector Plugin allowed users with Job/Configure permission to include properties files containing an environment definition from the Jenkins controller.
 
 This also allowed loading contents of files in other formats than Java properties files, with (parts of) the content made available as environment variables to subsequent build steps.
-This could be used to access secret information on the Jenkins master file system.
+This could be used to access secret information on the Jenkins controller file system.
 
 This has been addressed in Environment Injector Plugin 2.0.
 
-The plugin now has a new global option _Enable file loading from the master_.
+The plugin now has a new global option to enable file loading from the Jenkins controller.
 It is disabled by default.
 
-If disabled, any job previously configured to load a file from the master will fail.
+If disabled, any job previously configured to load a file from the Jenkins controller will fail.
 Once the option in the job has been unset, it's also removed from the UI so it cannot (accidentally) be enabled again.
 
 If enabled, the behavior is as before.

--- a/content/security/advisory/2017-04-26.adoc
+++ b/content/security/advisory/2017-04-26.adoc
@@ -23,7 +23,7 @@ The most notable ones:
 * SECURITY-416: Submit system configuration
 * SECURITY-417: Submit global security configuration
 * SECURITY-418, SECURITY-420: For Jenkins user database authentication realm: create an account if signup is enabled; or create an account if the victim is an administrator, possibly deleting the existing default "admin" user in the process
-* SECURITY-419: Create a new agent, possibly executing arbitrary shell commands on the master node by choosing the appropriate launch method
+* SECURITY-419: Create a new agent, possibly executing arbitrary shell commands on the Jenkins controller by choosing the appropriate launch method
 * SECURITY-420: Cancel a scheduled restart
 * SECURITY-420: Configure the global logging levels
 * SECURITY-420: Create a copy of an existing agent

--- a/content/security/advisory/2017-04-27.adoc
+++ b/content/security/advisory/2017-04-27.adoc
@@ -19,7 +19,7 @@ The temporary files typically are only on the file system for the duration of a 
 This change sets permissions on the temporary files to be readable only by the file owner.
 If a workspace is available, a temporary directory adjacent to the workspace is used instead of the system temporary directory.
 
-As a workaround, setting the system property `java.io.tmpdir` on Jenkins controller and agents to a directory only accessible by the Jenkins process's user would prevent this issue.
+As a workaround, setting the system property `java.io.tmpdir` on the Jenkins controller and agents to a directory only accessible by the Jenkins process's user would prevent this issue.
 
 == Severity
 

--- a/content/security/advisory/2017-04-27.adoc
+++ b/content/security/advisory/2017-04-27.adoc
@@ -19,7 +19,7 @@ The temporary files typically are only on the file system for the duration of a 
 This change sets permissions on the temporary files to be readable only by the file owner.
 If a workspace is available, a temporary directory adjacent to the workspace is used instead of the system temporary directory.
 
-As a workaround, setting the system property `java.io.tmpdir` on Jenkins master and agents to a directory only accessible by the Jenkins process's user would prevent this issue.
+As a workaround, setting the system property `java.io.tmpdir` on Jenkins controller and agents to a directory only accessible by the Jenkins process's user would prevent this issue.
 
 == Severity
 

--- a/content/security/advisory/2017-08-07.adoc
+++ b/content/security/advisory/2017-08-07.adoc
@@ -43,7 +43,7 @@ Access to view these files now requires sufficient permissions to configure the 
 *SECURITY-559 / CVE-2017-1000113*
 
 The Deploy to container Plugin stored passwords unencrypted as part of its configuration.
-This allowed users with Jenkins master local file system access, or users with Extended Read access to the jobs it is used in to retrieve the password, e.g. through the `config.xml` URL.
+This allowed users with Jenkins controller local file system access, or users with Extended Read access to the jobs it is used in to retrieve the password, e.g. through the `config.xml` URL.
 
 The Deploy to container Plugin now integrates with plugin:credentials[Credentials Plugin] to store passwords, and automatically migrates existing passwords.
 

--- a/content/security/advisory/2017-08-08.adoc
+++ b/content/security/advisory/2017-08-08.adoc
@@ -13,7 +13,7 @@ This advisory announces a vulnerability in the plugin:saml[SAML Plugin].
 *JENKINS-46007*
 
 The SAML Plugin stored passwords unencrypted as part of its configuration.
-This allowed users with Jenkins master local file system access and Jenkins administrators to retrieve the stored password.
+This allowed users with Jenkins controller local file system access and Jenkins administrators to retrieve the stored password.
 The latter could result in exposure of the passwords through browser extensions, cross-site scripting vulnerabilities, and similar situations.
 
 The SAML Plugin now stores passwords encrypted, and only transfers encrypted values as part of the configuration form after the initial configuration.

--- a/content/security/advisory/2017-10-11.adoc
+++ b/content/security/advisory/2017-10-11.adoc
@@ -13,11 +13,11 @@ This advisory announces multiple vulnerabilities in Jenkins (weekly and LTS), an
 
 == Description
 
-=== Arbitrary shell command execution on master by users with Agent-related permissions
+=== Arbitrary shell command execution on controller by users with Agent-related permissions
 *SECURITY-478 / CVE-2017-1000393*
 
 Users with permission to create or configure agents in Jenkins could configure a _launch method_ called _Launch agent via execution of command on master_.
-This allowed them to run arbitrary shell commands on the master node whenever the agent was supposed to be launched.
+This allowed them to run arbitrary shell commands on the Jenkins controller whenever the agent was supposed to be launched.
 
 Configuration of this launch method now requires the _Run Scripts_ permission typically only granted to administrators.
 

--- a/content/security/advisory/2017-10-23.adoc
+++ b/content/security/advisory/2017-10-23.adoc
@@ -55,7 +55,7 @@ Dependency graph modification now requires that users have the permission to con
 === Build-Publisher plugin stores Jenkins credentials unencrypted on disk, round-trips in unencrypted form
 *SECURITY-378 / CVE-2017-1000387*
 
-Build-Publisher plugin stores credentials to other Jenkins instances in the file `hudson.plugins.build_publisher.BuildPublisher.xml` in the Jenkins master home directory.
+Build-Publisher plugin stores credentials to other Jenkins instances in the file `hudson.plugins.build_publisher.BuildPublisher.xml` in the Jenkins controller home directory.
 These credentials were stored unencrypted, allowing anyone with local file system access to access them.
 
 Additionally, the credentials were also transmitted in plain text as part of the configuration form.
@@ -75,7 +75,7 @@ Multijob plugin 1.26 introduced a permission check requiring Overall/Administer.
 === SCP publisher plugin stores credentials unencrypted on disk, round-trips in unencrypted form
 *SECURITY-374*
 
-SCP publisher plugin stores SSH credentials in the file `be.certipost.hudson.plugin.SCPRepositoryPublisher.xml` in the Jenkins master home directory.
+SCP publisher plugin stores SSH credentials in the file `be.certipost.hudson.plugin.SCPRepositoryPublisher.xml` in the Jenkins controller home directory.
 These credentials are stored unencrypted, allowing anyone with local file system access to access them.
 
 Additionally, the credentials are also transmitted in plain text as part of the configuration form.

--- a/content/security/advisory/2017-12-06.adoc
+++ b/content/security/advisory/2017-12-06.adoc
@@ -12,10 +12,10 @@ This advisory announces a vulnerability in this Jenkins plugin:
 == Description
 
 
-=== Arbitrary shell command execution on master by users with Agent-related permissions in EC2 Plugin
+=== Arbitrary shell command execution on controller by users with Agent-related permissions in EC2 Plugin
 *SECURITY-643 / CVE-2017-1000502*
 
-Users with permission to create or configure agents in Jenkins could configure an EC2 agent to run arbitrary shell commands on the master node whenever the agent was supposed to be launched.
+Users with permission to create or configure agents in Jenkins could configure an EC2 agent to run arbitrary shell commands on the Jenkins controller whenever the agent was supposed to be launched.
 
 Configuration of these agents now requires the _Run Scripts_ permission typically only granted to administrators.
 

--- a/content/security/advisory/2017-12-11.adoc
+++ b/content/security/advisory/2017-12-11.adoc
@@ -15,7 +15,7 @@ This advisory announces a vulnerability in this Jenkins plugin:
 === Arbitrary file read vulnerability in Script Security Plugin
 *SECURITY-663 / CVE-2017-1000505*
 
-Users with the ability to configure sandboxed Groovy and Pipeline scripts, including those from SCM, are able to use a type coercion feature in Groovy to create new `File` objects from strings. This allowed reading arbitrary files on the Jenkins master file system.
+Users with the ability to configure sandboxed Groovy and Pipeline scripts, including those from SCM, are able to use a type coercion feature in Groovy to create new `File` objects from strings. This allowed reading arbitrary files on the Jenkins controller file system.
 
 Such a type coercion is now subject to sandbox protection and considered to be a call to the `new File(String)` constructor for the purpose of in-process script approval.
 

--- a/content/security/advisory/2018-01-22.adoc
+++ b/content/security/advisory/2018-01-22.adoc
@@ -97,7 +97,7 @@ issues:
 * *SECURITY-695 / CVE-2018-1000012* (Warnings)
 
 Multiple plugins based on plugin:analysis-core[Static Analysis Utilities] plugin are affected by an XML External Entity (XXE) processing vulnerability.
-This allows attacker to configure build processes such that one of these plugins parses a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+This allows attacker to configure build processes such that one of these plugins parses a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
 External entity resolution has been disabled for these plugins.
 

--- a/content/security/advisory/2018-02-05.adoc
+++ b/content/security/advisory/2018-02-05.adoc
@@ -62,7 +62,7 @@ resources:
 * *SECURITY-660 / CVE-2018-1000055* (Android Lint)
 
 Multiple plugins based on plugin:analysis-core[Static Analysis Utilities] plugin are affected by an XML External Entity (XXE) processing vulnerability.
-This allows an attacker to configure build processes such that one of these plugins parses a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+This allows an attacker to configure build processes such that one of these plugins parses a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
 External entity resolution has been disabled for these plugins.
 
@@ -72,7 +72,7 @@ External entity resolution has been disabled for these plugins.
 *SECURITY-521 / CVE-2018-1000056*
 
 JUnit plugin is affected by an XML External Entity (XXE) processing vulnerability.
-This allows an attacker to configure build processes such that JUnit plugin parses a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+This allows an attacker to configure build processes such that JUnit plugin parses a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
 External entity resolution has been adjusted to avoid XXE and still satisfy the existing features.
 
@@ -108,4 +108,4 @@ Deserialization of objects in Pipeline is now also subject to sandbox protection
 
 This change may cause existing scripts relying on the incomplete sandbox protection to start failing, and requiring additional script approval.
 
-NOTE: This change requires that Pipeline: Groovy plugin is also updated to version 2.44, otherwise Pipeline builds using untrusted (folder-scoped) libraries will not be able to resume after a Jenkins master restart.
+NOTE: This change requires that Pipeline: Groovy plugin is also updated to version 2.44, otherwise Pipeline builds using untrusted (folder-scoped) libraries will not be able to resume after a Jenkins controller restart.

--- a/content/security/advisory/2018-02-14.adoc
+++ b/content/security/advisory/2018-02-14.adoc
@@ -34,10 +34,10 @@ issues:
   cve: CVE-2018-6356
   description: |
     Jenkins did not properly prevent specifying relative paths that escape a base directory for URLs accessing plugin resource files.
-    This allowed users with Overall/Read permission to download files from the Jenkins master they should not have access to.
+    This allowed users with Overall/Read permission to download files from the Jenkins controller they should not have access to.
 
-    On Windows, any file accessible to the Jenkins master process could be downloaded.
-    On other operating systems, any file within the Jenkins home directory accessible to the Jenkins master process could be downloaded.
+    On Windows, any file accessible to the Jenkins controller process could be downloaded.
+    On other operating systems, any file within the Jenkins home directory accessible to the Jenkins controller process could be downloaded.
 
     Jenkins now prevents specifying paths containing `..` and other character sequences that could be used to access files outside the plugins resource directory.
 - id: SECURITY-717

--- a/content/security/advisory/2018-02-26.adoc
+++ b/content/security/advisory/2018-02-26.adoc
@@ -51,7 +51,7 @@ issues:
       previous: 1.10.0
   description: |
     The Coverity Plugin stored passwords unencrypted as part of its configuration.
-    This allowed users with Jenkins master local file system access and Jenkins administrators to retrieve the stored password.
+    This allowed users with Jenkins controller local file system access and Jenkins administrators to retrieve the stored password.
     The latter could result in exposure of the passwords through browser extensions, cross-site scripting vulnerabilities, and similar situations.
 
     The Coverity Plugin now integrates with plugin:credentials[Credentials Plugin] to store passwords, and automatically migrates existing passwords.

--- a/content/security/advisory/2018-03-26.adoc
+++ b/content/security/advisory/2018-03-26.adoc
@@ -18,7 +18,7 @@ issues:
       previous: 1.39.0
   description: |
     GitHub Pull Request Builder Plugin stored serialized objects in `build.xml` files that contained the credential used to poll Jenkins.
-    This can be used by users with master file system access to obtain GitHub credentials.
+    This can be used by users with Jenkins controller file system access to obtain GitHub credentials.
 
     Since 1.40.0, the plugin no longer stores serialized objects containing the credential on disk.
 
@@ -41,7 +41,7 @@ issues:
   description: |
     GitHub Pull Request Builder Plugin stored the webhook secret shared between Jenkins and GitHub in plain text.
 
-    This allowed users with Jenkins master local file system access and Jenkins administrators to retrieve the stored password.
+    This allowed users with Jenkins controller local file system access and Jenkins administrators to retrieve the stored password.
     The latter could result in exposure of the passwords through browser extensions, cross-site scripting vulnerabilities, and similar situations.
 
     GitHub Pull Request Builder Plugin 1.32.1 and newer stores the webhook secret encrypted on disk.
@@ -79,7 +79,7 @@ issues:
       previous: 1.3.36
   description: |
     Perforce Plugin encrypts its credentials using DES and an encryption key stored in its public source code, so it only serves as basic obfuscation.
-    This allowed users with Jenkins master local file system access and Jenkins administrators to retrieve the stored password.
+    This allowed users with Jenkins controller local file system access and Jenkins administrators to retrieve the stored password.
     The latter could result in exposure of the passwords through browser extensions, cross-site scripting vulnerabilities, and similar situations.
 
     As of publication of this advisory, there is no fix.
@@ -125,7 +125,7 @@ issues:
     These form validation methods now require POST requests and appropriate user permissions.
 
 - id: SECURITY-519
-  title: Liquibase Runner Plugin allows users to load arbitrary Java code into master JVM
+  title: Liquibase Runner Plugin allows users to load arbitrary Java code into controller JVM
   reporter: Yoann Dubreuil, CloudBees, Inc.
   cve: CVE-2018-1000146
   cvss:
@@ -136,7 +136,7 @@ issues:
       title: Liquibase Runner
       previous: 1.3.0
   description: |
-    Liquibase Runner Plugin allows users with Job/Configure permission to configure its build step in a way that loads arbitrary class files into the Jenkins master JVM, resulting in arbitrary code execution.
+    Liquibase Runner Plugin allows users with Job/Configure permission to configure its build step in a way that loads arbitrary class files into the Jenkins controller JVM, resulting in arbitrary code execution.
 
     As of publication of this advisory, there is no fix.
 
@@ -163,7 +163,7 @@ issues:
     We recommend that users of Perforce Plugin use the plugin:p4[P4 Plugin] instead.
 
 - id: SECURITY-545
-  title: Copy To Slave Plugin allows access to arbitrary files on the Jenkins master file system
+  title: Copy To Slave Plugin allows access to arbitrary files on the Jenkins controller file system
   reporter: Jesse Glick, CloudBees, Inc.
   cve: CVE-2018-1000148
   cvss:
@@ -174,7 +174,7 @@ issues:
       title: Copy To Slave
       previous: 1.4.4
   description: |
-    Copy To Slave Plugin allows users with Job/Configure permissions to configure it in such a way that it allows obtaining arbitrary files accessible to the Jenkins master process from the Jenkins master file system.
+    Copy To Slave Plugin allows users with Job/Configure permissions to configure it in such a way that it allows obtaining arbitrary files accessible to the Jenkins controller process from the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
 
@@ -210,7 +210,7 @@ issues:
   description: |
     Reverse Proxy Auth Plugin persisted a cache of granted authorities (group memberships) on disk.
 
-    This could allow users with local Jenkins master file system access to obtain group membership information of Jenkins users.
+    This could allow users with local Jenkins controller file system access to obtain group membership information of Jenkins users.
 
     Reverse Proxy Auth Plugin 1.6.0 and newer no longer store the cache of granted authorities on disk.
 

--- a/content/security/advisory/2018-04-16.adoc
+++ b/content/security/advisory/2018-04-16.adoc
@@ -86,6 +86,6 @@ issues:
       previous: 1.15
   description: |
     HTML Publisher Plugin allows specifying a name for the HTML reports it publishes.
-    This report name was used in the URL of the report and as a directory name on the Jenkins master without further processing, resulting in a path traversal vulnerability that allowed overriding files outside the build directory.
+    This report name was used in the URL of the report and as a directory name on the Jenkins controller without further processing, resulting in a path traversal vulnerability that allowed overriding files outside the build directory.
 
     Non-alphanumeric characters in report names are now escaped for use as part of a URL and as a directory name.

--- a/content/security/advisory/2018-05-09.adoc
+++ b/content/security/advisory/2018-05-09.adoc
@@ -43,14 +43,14 @@ issues:
 
 
 - id: SECURITY-788
-  title: Path traversal vulnerability in agent to master security subsystem
+  title: Path traversal vulnerability in agent to controller security subsystem
   reporter: Jesse Glick, CloudBees, Inc. and Kalle Niemitalo, Procomp Solutions Oy
   cve: CVE-2018-1000194
   cvss:
     severity: high
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |
-    The agent to master security subsystem ensures that the Jenkins master is protected from maliciously configured agents.
+    The agent to controller security subsystem ensures that the Jenkins controller is protected from maliciously configured agents.
     link:https://wiki.jenkins.io/display/JENKINS/Slave+To+Master+Access+Control[Learn more.]
 
     A path traversal vulnerability allowed agents to escape whitelisted directories to read and write to files they should not be able to access.
@@ -85,7 +85,7 @@ issues:
       previous: 1.4.2
   description: |
     Gitlab Hook Plugin does not encrypt the Gitlab API token used to access Gitlab.
-    This can be used by users with master file system access to obtain GitHub credentials.
+    This can be used by users with Jenkins controller file system access to obtain GitHub credentials.
 
     Additionally, the Gitlab API token round-trips in its plaintext form, and is displayed in a regular text field to users with Overall/Administer permission.
     This exposes the API token to people viewing a Jenkins administrator's screen, browser extensions, cross-site scripting vulnerabilities, etc.
@@ -128,7 +128,7 @@ issues:
       previous: 3.1.0
   description: |
     Black Duck Hub Plugin's `/descriptorByName/com.blackducksoftware.integration.hub.jenkins.PostBuildHubScan/config.xml` API endpoint was affected by an XML External Entity (XXE) processing vulnerability.
-    This allowed an attacker with Overall/Read access to have Jenkins parse a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allowed an attacker with Overall/Read access to have Jenkins parse a maliciously crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     Black Duck Hub Plugin 4.0.0 and newer no longer processes XML External Entitites in XML documents submitted to this endpoint.
 

--- a/content/security/advisory/2018-06-04.adoc
+++ b/content/security/advisory/2018-06-04.adoc
@@ -116,7 +116,7 @@ issues:
       fixed: 1.7.1
       previous: 1.7.0
   description: |
-    Kubernetes Plugin printed sensitive build variables, like passwords, to the build log and master log, when using pipeline steps like `withDockerRegistry`.
+    Kubernetes Plugin printed sensitive build variables, like passwords, to the build log and controller log, when using pipeline steps like `withDockerRegistry`.
 
     The plugin now applies masking of sensitive build variables to these pipeline steps.
 
@@ -142,7 +142,7 @@ issues:
 
 
 - id: SECURITY-807
-  title: CSRF vulnerability and missing permission checks in AbsInt Astrée Plugin allowed launching programs on the Jenkins master
+  title: CSRF vulnerability and missing permission checks in AbsInt Astrée Plugin allowed launching programs on the Jenkins controller
   reporter: Thomas de Grenier de Latour
   cve: CVE-2018-1000189
   cvss:
@@ -154,7 +154,7 @@ issues:
       previous: 1.0.5
   description: |
     AbsInt Astrée Plugin did not perform permission checks on a method implementing form validation.
-    This allowed users with Overall/Read access to Jenkins to run a user-specified program on the Jenkins master.
+    This allowed users with Overall/Read access to Jenkins to run a user-specified program on the Jenkins controller.
 
     Additionally, this form validation method did not require POST requests, resulting in a CSRF vulnerability.
 

--- a/content/security/advisory/2018-06-25.adoc
+++ b/content/security/advisory/2018-06-25.adoc
@@ -40,9 +40,9 @@ issues:
   description: |
     SSH Credentials Plugin allowed the creation of SSH credentials with keys "From a file on Jenkins master".
     Credentials Binding Plugin 1.13 and newer allows binding SSH credentials to environment variables.
-    In combination, these two features allow users with the permission to configure a job to read arbitrary files on the Jenkins master by creating an SSH credential referencing an arbitrary file on the Jenkins master, and binding it to an environment variable in a job.
+    In combination, these two features allow users with the permission to configure a job to read arbitrary files on the Jenkins controller by creating an SSH credential referencing an arbitrary file on the Jenkins controller, and binding it to an environment variable in a job.
 
-    SSH Credentials Plugin no longer supports SSH credentials from files on the Jenkins master file system, neither user-specified file paths nor `~/.ssh`.
+    SSH Credentials Plugin no longer supports SSH credentials from files on the Jenkins controller file system, neither user-specified file paths nor `~/.ssh`.
     Existing SSH credentials of these kinds are migrated to "directly entered" SSH credentials.
 
     NOTE: If plugin:blueocean[Blue Ocean] is installed, it needs to be updated to 1.5.1 or 1.6.1, or the creation of pipelines for plain Git will not work anymore after installing the fix for this issue.
@@ -115,8 +115,8 @@ issues:
       fixed: "1.20"
       previous: 1.19
   description: |
-    AWS CodeDeploy Plugin stored the AWS Secret Key in its configuration unencrypted in jobs' `config.xml` files and its global configuration file on the Jenkins master.
-    This key could be viewed by users with Extended Read permission, or access to the master file system.
+    AWS CodeDeploy Plugin stored the AWS Secret Key in its configuration unencrypted in jobs' `config.xml` files and its global configuration file on the Jenkins controller.
+    This key could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     While masked from view using a password form field, the AWS Secret Key was transferred in plain text to users when accessing the job configuration form.
 
@@ -137,8 +137,8 @@ issues:
       fixed: 0.27
       previous: 0.26
   description: |
-    AWS CodeBuild Plugin stored the AWS Secret Key in its configuration unencrypted in jobs' `config.xml` files on the Jenkins master.
-    This key could be viewed by users with Extended Read permission, or access to the master file system.
+    AWS CodeBuild Plugin stored the AWS Secret Key in its configuration unencrypted in jobs' `config.xml` files on the Jenkins controller.
+    This key could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     While masked from view using a password form field, the AWS Secret Key was transferred in plain text to users when accessing the job configuration form.
 
@@ -159,8 +159,8 @@ issues:
       fixed: 0.37
       previous: 0.36
   description: |
-    AWS CodePipeline Plugin stored the AWS Secret Key in its configuration unencrypted in jobs' `config.xml` files on the Jenkins master.
-    This key could be viewed by users with Extended Read permission, or access to the master file system.
+    AWS CodePipeline Plugin stored the AWS Secret Key in its configuration unencrypted in jobs' `config.xml` files on the Jenkins controller.
+    This key could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     While masked from view using a password form field, the AWS Secret Key was transferred in plain text to users when accessing the job configuration form.
 
@@ -197,7 +197,7 @@ issues:
       fixed: 2.0.5
       previous: 2.0.4
   description: |
-    CollabNet Plugin disabled SSL/TLS certificate validation for the entire Jenkins master JVM by default.
+    CollabNet Plugin disabled SSL/TLS certificate validation for the entire Jenkins controller JVM by default.
 
     CollabNet Plugin 2.0.5 and newer no longer does that.
     It instead requires users to opt in to disabling SSL/TLS certificate validation by setting the system property `hudson.plugins.collabnet.CollabNetPlugin.skipSslValidation` to `true`.
@@ -253,7 +253,7 @@ issues:
       previous: 1.2.6.1
   description: |
     IBM z/OS Connector Plugin did not encrypt password credentials stored in its configuration.
-    This could be used by users with master file system access to obtain the password.
+    This could be used by users with Jenkins controller file system access to obtain the password.
 
     While masked from view using a password form field, the AWS Secret Key was transferred in plain text to administrators when accessing the global configuration form.
 
@@ -292,7 +292,7 @@ issues:
       fixed: 0.8-alpha
       previous: 0.7-alpha
   description: |
-    Configuration as Code Plugin logged secrets set via its configuration to the Jenkins master system log in plain text.
+    Configuration as Code Plugin logged secrets set via its configuration to the Jenkins controller system log in plain text.
     This allowed users with access to the Jenkins log files to obtain these passwords and similar secrets.
 
     Secrets are now masked when logging configuration.

--- a/content/security/advisory/2018-07-18.adoc
+++ b/content/security/advisory/2018-07-18.adoc
@@ -42,7 +42,7 @@ issues:
     severity: high
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
   description: |
-    An arbitrary file read vulnerability in the Stapler web framework used by Jenkins allowed unauthenticated users to send crafted HTTP requests returning the contents of any file on the Jenkins master file system that the Jenkins master process has access to.
+    An arbitrary file read vulnerability in the Stapler web framework used by Jenkins allowed unauthenticated users to send crafted HTTP requests returning the contents of any file on the Jenkins controller file system that the Jenkins master process has access to.
 
     Input validation in Stapler has been improved to prevent this.
 
@@ -68,7 +68,7 @@ issues:
     severity: medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L
   description: |
-    The URL that initiates agent launches on the Jenkins master did not perform a permission check, allowing users with Overall/Read permission to initiate agent launches.
+    The URL that initiates agent launches on the Jenkins controller did not perform a permission check, allowing users with Overall/Read permission to initiate agent launches.
 
     Doing so canceled all ongoing launches for the specified agent, so this allowed attackers to prevent an agent from launching indefinitely.
 

--- a/content/security/advisory/2018-07-30.adoc
+++ b/content/security/advisory/2018-07-30.adoc
@@ -115,8 +115,8 @@ issues:
       fixed: "2.0"
       previous: 1.6.1
   description: |
-    Tinfoil Security Plugin stored the API Secret Key in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This key could be viewed by users with access to the master file system.
+    Tinfoil Security Plugin stored the API Secret Key in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This key could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now integrates with plugin:credentials[Credentials Plugin].
     Existing configurations are not migrated and will need to be reconfigured.
@@ -134,7 +134,7 @@ issues:
       fixed: 2.4
       previous: 2.3
   description: |
-    TraceTronic ECU-TEST Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins master JVM.
+    TraceTronic ECU-TEST Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     TraceTronic ECU-TEST Plugin 2.4 and newer no longer does that.
     It now has an option that allows disabling SSL/TLS certificate validation for specific connections by this plugin.
@@ -249,8 +249,8 @@ issues:
       fixed: 1.15 # July 6
       previous: 1.14
   description: |
-    meliora-testlab Plugin stored the API Key in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This key could be viewed by users with access to the master file system.
+    meliora-testlab Plugin stored the API Key in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This key could be viewed by users with access to the Jenkins controller file system.
 
     Additionally, the API key was not masked from view using a password form field.
 
@@ -290,8 +290,8 @@ issues:
       fixed: 1.0.17 # July 25
       previous: 1.0.16
   description: |
-    Anchore Container Image Scanner Plugin stored the password in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    Anchore Container Image Scanner Plugin stored the password in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the password encrypted in the configuration files on disk and no longer transfers it to users viewing the configuration form in plain text.
 
@@ -308,7 +308,7 @@ issues:
       previous: 0.8
       fixed: 1.0 # July 28
   description: |
-    Inedo ProGet Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins master JVM.
+    Inedo ProGet Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     The plugin now has an option, disabled by default, to disable SSL/TLS certificate validation that only applies to its own connections.
 
@@ -325,6 +325,6 @@ issues:
       previous: 1.3
       fixed: 2.0 # July 28
   description: |
-    Inedo ProGet Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins master JVM.
+    Inedo ProGet Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     The plugin now has an option, disabled by default, to disable SSL/TLS certificate validation that only applies to its own connections.

--- a/content/security/advisory/2018-09-25.adoc
+++ b/content/security/advisory/2018-09-25.adoc
@@ -234,8 +234,8 @@ issues:
       fixed: 2.0.1
       previous: 2.0.0
   description: |
-    Crowd 2 Integration Plugin stored the Crowd password unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    Crowd 2 Integration Plugin stored the Crowd password unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the password encrypted in the configuration files on disk and no longer transfers it to users viewing the configuration form in plain text.
 
@@ -338,8 +338,8 @@ issues:
       previous: 2.8
       fixed: 2.8.1
   description: |
-    SonarQube Scanner Plugin stored a server authentication token unencrypted in its global configuration file on the Jenkins master.
-    This token could be viewed by users with access to the master file system.
+    SonarQube Scanner Plugin stored a server authentication token unencrypted in its global configuration file on the Jenkins controller.
+    This token could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the token encrypted in the configuration files on disk and no longer transfers it to users viewing the configuration form in plain text.
 
@@ -375,8 +375,8 @@ issues:
       previous: 0.9.7
       fixed: 1.0.0
   description: |
-    Arachni Scanner Plugin stored its password unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    Arachni Scanner Plugin stored its password unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now integrates with plugin:credentials[Credentials Plugin].
     Existing configurations are migrated.
@@ -467,8 +467,8 @@ issues:
       previous: 0.8.14
       fixed: 0.8.15
   description: |
-    Dimensions Plugin stored a password unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    Dimensions Plugin stored a password unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the password encrypted in the configuration files on disk and no longer transfers it to users viewing the configuration form in plain text.
 
@@ -500,8 +500,8 @@ issues:
       previous: 1.2.4
       fixed: 1.2.5
   description: |
-    Publish Over Dropbox Plugin stored authorization code and access code unencrypted in its global configuration file on the Jenkins master.
-    These secrets could be viewed by users with access to the master file system.
+    Publish Over Dropbox Plugin stored authorization code and access code unencrypted in its global configuration file on the Jenkins controller.
+    These secrets could be viewed by users with access to the Jenkins controller file system.
 
     Additionally, the authorization code was not masked from view using a password form field.
 

--- a/content/security/advisory/2018-10-10.adoc
+++ b/content/security/advisory/2018-10-10.adoc
@@ -33,7 +33,7 @@ issues:
     # TODO possibly higher?
   description: |
     Users with Job/Configure permission could specify a relative path escaping the base directory in the file name portion of a file parameter definition.
-    This path would be used to archive the uploaded file on the Jenkins master, resulting in an arbitrary file write vulnerability.
+    This path would be used to archive the uploaded file on the Jenkins controller, resulting in an arbitrary file write vulnerability.
 
     File parameters that escape the base directory are no longer accepted and the build will fail.
 

--- a/content/security/advisory/2018-12-05.adoc
+++ b/content/security/advisory/2018-12-05.adoc
@@ -106,7 +106,7 @@ issues:
     link:/doc/book/managing/system-properties/[Learn more about system properties in Jenkins].
 
     NOTE: While the same component allows browsing archived artifacts, this fix does not apply to archived artifacts.
-    Valid symbolic links are archived as the files and directories they point to on the agent, while invalid symlinks cannot escape the root directory for archived artifacts on the Jenkins master.
+    Valid symbolic links are archived as the files and directories they point to on the agent, while invalid symlinks cannot escape the root directory for archived artifacts on the Jenkins controller.
     This was previously fixed as SECURITY-162 in the link:../2015-02-27/[2015-02-27 security advisory].
 
 - id: SECURITY-1193

--- a/content/security/advisory/2019-01-08.adoc
+++ b/content/security/advisory/2019-01-08.adoc
@@ -28,6 +28,6 @@ issues:
 
     Both the pipeline validation REST APIs and actual script/pipeline execution are affected.
 
-    This allowed users with Overall/Read permission, or able to control Jenkinsfile or sandboxed Pipeline shared library contents in SCM, to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users with Overall/Read permission, or able to control Jenkinsfile or sandboxed Pipeline shared library contents in SCM, to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     All known unsafe AST transformations in Groovy are now prohibited in sandboxed scripts.

--- a/content/security/advisory/2019-01-28.adoc
+++ b/content/security/advisory/2019-01-28.adoc
@@ -23,7 +23,7 @@ issues:
   description: |
     Script Security sandbox protection could be circumvented during the script compilation phase by applying AST transforming annotations such as `@Grab` to source code elements.
 
-    This affected an HTTP endpoint used to validate a user-submitted Groovy script that was not covered in the link:../2019-01-08/#SECURITY-1266[2019-01-08 fix for SECURITY-1266] and allowed users with Overall/Read permission to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This affected an HTTP endpoint used to validate a user-submitted Groovy script that was not covered in the link:../2019-01-08/#SECURITY-1266[2019-01-08 fix for SECURITY-1266] and allowed users with Overall/Read permission to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     The affected HTTP endpoint now applies a safe Groovy compiler configuration prohibiting unsafe AST transforming annotations.
 
@@ -41,7 +41,7 @@ issues:
       previous: "2.0"
   description: |
     Groovy Plugin has a form validation HTTP endpoint used to validate a user-submitted Groovy script through compilation, which was not subject to sandbox protection.
-    This allowed attackers with Overall/Read access to execute arbitrary code on the Jenkins master by applying AST transforming annotations such as `@Grab` to source code elements.
+    This allowed attackers with Overall/Read access to execute arbitrary code on the Jenkins controller by applying AST transforming annotations such as `@Grab` to source code elements.
 
     The affected HTTP endpoint now applies a safe Groovy compiler configuration preventing the use of unsafe AST transforming annotations.
 
@@ -59,7 +59,7 @@ issues:
   description: |
     Warnings Plugin has a form validation HTTP endpoint used to validate a user-submitted Groovy script through compilation, which was not subject to sandbox protection.
     The endpoint checked for the Overall/RunScripts permission, but did not require POST requests, so it was vulnerable to cross-site request forgery (CSRF).
-    This allowed attackers to execute arbitrary code on the Jenkins master by applying AST transforming annotations such as `@Grab` to source code elements.
+    This allowed attackers to execute arbitrary code on the Jenkins controller by applying AST transforming annotations such as `@Grab` to source code elements.
 
     The affected HTTP endpoint now applies a safe Groovy compiler configuration preventing the use of unsafe AST transforming annotations.
     Additionally, the form validation HTTP endpoint now requires that requests be sent via POST to prevent CSRF.
@@ -79,7 +79,7 @@ issues:
   description: |
     Warnings Next Generation Plugin has a form validation HTTP endpoint used to validate a Groovy script through compilation, which was not subject to sandbox protection.
     The endpoint checked for the Overall/RunScripts permission, but did not require POST requests, so it was vulnerable to cross-site request forgery (CSRF).
-    This allowed attackers to execute arbitrary code on the Jenkins master by applying AST transforming annotations such as `@Grab` to source code elements.
+    This allowed attackers to execute arbitrary code on the Jenkins controller by applying AST transforming annotations such as `@Grab` to source code elements.
 
     The affected HTTP endpoint now applies a safe Groovy compiler configuration preventing the use of unsafe AST transforming annotations.
     Additionally, the form validation HTTP endpoint now requires that requests be sent via POST to prevent CSRF.
@@ -212,7 +212,7 @@ issues:
     As a first step in this process, Job Import Plugin sends a request to another Jenkins instance, parsing XML REST API output to obtain a list of jobs that could be imported.
 
     Job Import Plugin did not configure the XML parser in a way that would prevent XML External Entity (XXE) processing.
-    This allowed attackers able to control either the server Jenkins will query, or the URL Jenkins queries, to have it parse a maliciously crafted XML response that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allowed attackers able to control either the server Jenkins will query, or the URL Jenkins queries, to have it parse a maliciously crafted XML response that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     External entity resolution has been disabled for the XML parser used in Job Import Plugin 3.0.
 

--- a/content/security/advisory/2019-02-19.adoc
+++ b/content/security/advisory/2019-02-19.adoc
@@ -26,7 +26,7 @@ issues:
     * Import aliasing
     * Referencing annotation types using their full class name
 
-    This allowed users with Overall/Read permission, or the ability to control Jenkinsfile or sandboxed Pipeline shared library contents in SCM, to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users with Overall/Read permission, or the ability to control Jenkinsfile or sandboxed Pipeline shared library contents in SCM, to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     Using `AnnotationCollector` is now newly prohibited in sandboxed scripts such as Pipelines.
     Importing any of the annotations considered unsafe will now result in an error.
@@ -135,7 +135,7 @@ issues:
       fixed: "1.1.5" # 2018-12-19
       previous: "1.1.4"
   description: |
-    ElectricFlow Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins master JVM.
+    ElectricFlow Plugin unconditionally disabled SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     ElectricFlow Plugin 1.1.5 and newer no longer do that.
 
@@ -151,8 +151,8 @@ issues:
       fixed: "1.1.0" # Released 2018-10-24
       previous: "1.0.0"
   description: |
-    Acunetix Plugin stored the API Key in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This key could be viewed by users with access to the master file system.
+    Acunetix Plugin stored the API Key in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This key could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now integrates with plugin:credentials[Credentials Plugin].
 
@@ -186,8 +186,8 @@ issues:
       fixed: "2.0" # Released 2018-11-14
       previous: "1.2.12"
   description: |
-    Arxan MAM Publisher Plugin stored the username and password connection credentials in its configuration unencrypted in jobs' `config.xml` files on the Jenkins master.
-    This key could be viewed by users with Extended Read permission, or access to the master file system.
+    Arxan MAM Publisher Plugin stored the username and password connection credentials in its configuration unencrypted in jobs' `config.xml` files on the Jenkins controller.
+    This key could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     While masked from view using a password form field, the password was transferred in plain text to users when accessing the job configuration form.
 

--- a/content/security/advisory/2019-03-06.adoc
+++ b/content/security/advisory/2019-03-06.adoc
@@ -48,7 +48,7 @@ issues:
   description: |
     Pipeline: Groovy sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This allowed users able to control the contents of a pipeline to bypass the sandbox protection and execute arbitrary code on the Jenkins mastcontrollerer.
+    This allowed users able to control the contents of a pipeline to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     Pipeline: Groovy Plugin now uses Script Security APIs that apply sandbox protection during these phases.
 

--- a/content/security/advisory/2019-03-06.adoc
+++ b/content/security/advisory/2019-03-06.adoc
@@ -26,7 +26,7 @@ issues:
 
     Script Security Plugin is now newly applying sandbox protection during these phases.
 
-    This affected both script execution (typically invoked from other plugins) as well as an HTTP endpoint providing script validation and allowed users with Overall/Read permission to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This affected both script execution (typically invoked from other plugins) as well as an HTTP endpoint providing script validation and allowed users with Overall/Read permission to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     The API `GroovySandbox#run(Script, Whitelist)` has been deprecated and now emits a warning to the system log about potential security problems.
     `GroovySandbox#run(GroovyShell, String, Whitelist)` replaces it.
@@ -48,7 +48,7 @@ issues:
   description: |
     Pipeline: Groovy sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This allowed users able to control the contents of a pipeline to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users able to control the contents of a pipeline to bypass the sandbox protection and execute arbitrary code on the Jenkins mastcontrollerer.
 
     Pipeline: Groovy Plugin now uses Script Security APIs that apply sandbox protection during these phases.
 
@@ -67,7 +67,7 @@ issues:
     Matrix Project Plugin supports a sandboxed Groovy expression to filter matrix combinations.
     Its sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This allowed users able to configure a Matrix project to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users able to configure a Matrix project to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     Matrix Project Plugin now uses Script Security APIs that apply sandbox protection during these phases.
 
@@ -86,7 +86,7 @@ issues:
     Email Extension Plugin supports sandboxed Groovy expressions for multiple features.
     Its sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This allowed users able to control the plugin's job-specific configuration to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users able to control the plugin's job-specific configuration to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     Email Extension Plugin now uses Script Security APIs that apply sandbox protection during these phases.
 
@@ -107,7 +107,7 @@ issues:
     Groovy Plugin supports sandboxed Groovy expressions for its "System Groovy" functionality.
     Its sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This affected both System Groovy script execution as well as an HTTP endpoint providing script validation, and allowed users with Overall/Read permission to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This affected both System Groovy script execution as well as an HTTP endpoint providing script validation, and allowed users with Overall/Read permission to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     Groovy Plugin now uses Script Security APIs that apply sandbox protection during these phases.
 
@@ -126,7 +126,7 @@ issues:
     Job DSL Plugin supports sandboxed Groovy expressions for Job DSL definitions.
     Its sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This allowed users able to control the Job DSL scripts to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users able to control the Job DSL scripts to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     Job DSL Plugin now uses Script Security APIs that apply sandbox protection during these phases.
 
@@ -207,8 +207,8 @@ issues:
       fixed: "1.2.5"
       previous: "1.2.4"
   description: |
-    Repository Connector Plugin stored the username and password in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    Repository Connector Plugin stored the username and password in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the password encrypted in the configuration files on disk and no longer transfers it to users viewing the configuration form in plain text.
 
@@ -227,8 +227,8 @@ issues:
       fixed: "1.0.15"
       previous: "1.0.14"
   description: |
-    AppDynamics Dashboard Plugin stored username and password in its configuration unencrypted in jobs' `config.xml` files on the Jenkins master.
-    This password could be viewed by users with Extended Read permission, or access to the master file system.
+    AppDynamics Dashboard Plugin stored username and password in its configuration unencrypted in jobs' `config.xml` files on the Jenkins controller.
+    This password could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     While masked from view using a password form field, the password was transferred in plain text to users when accessing the job configuration form.
 
@@ -249,8 +249,8 @@ issues:
       fixed: "1.2.0"
       previous: "1.0"
   description: |
-    Rabbit-MQ Publisher Plugin stored the username and password in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    Rabbit-MQ Publisher Plugin stored the username and password in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the password encrypted in the configuration files on disk and no longer transfers it to users viewing the configuration form in plain text.
 
@@ -283,8 +283,8 @@ issues:
       fixed: "1.0.11"
       previous: "1.0.10"
   description: |
-    OSF Builder Suite For Salesforce Commerce Cloud : : Deploy Plugin stored the HTTP proxy username and password in its configuration unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    OSF Builder Suite For Salesforce Commerce Cloud : : Deploy Plugin stored the HTTP proxy username and password in its configuration unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now integrates with plugin:credentials[Credentials Plugin] to store the HTTP proxy credentials.
 
@@ -299,7 +299,7 @@ issues:
       fixed: "2.70.0"
       previous: "2.69.1"
   description: |
-    A missing permission check in a method performing both form validation and saving new configuration in Bitbar Run-in-Cloud Plugin allowed users with Overall/Read permission to have Jenkins master connect to an attacker-specified host with attacker-specified credentials, and, if successful, save that as the new configuration for the plugin. This could then potentially result in future builds submitting their data to an unauthorized remote server.
+    A missing permission check in a method performing both form validation and saving new configuration in Bitbar Run-in-Cloud Plugin allowed users with Overall/Read permission to have Jenkins connect to an attacker-specified host with attacker-specified credentials, and, if successful, save that as the new configuration for the plugin. This could then potentially result in future builds submitting their data to an unauthorized remote server.
 
     Additionally, this method did not require POST requests, resulting in a CSRF vulnerability.
 

--- a/content/security/advisory/2019-03-25.adoc
+++ b/content/security/advisory/2019-03-25.adoc
@@ -90,8 +90,8 @@ issues:
     fixed: '1.0.1'
     previous: '1.0.0'
   description: |
-    ECS Publisher Plugin stored the API token unencrypted in jobs' `config.xml` files and its global configuration file on the Jenkins master.
-    This token could be viewed by users with Extended Read permission, or access to the master file system.
+    ECS Publisher Plugin stored the API token unencrypted in jobs' `config.xml` files and its global configuration file on the Jenkins controller.
+    This token could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     Additionally, the API token was not masked from view using a password form field.
 
@@ -129,8 +129,8 @@ issues:
     fixed: '3.1.2'
     previous: '3.1.0'
   description: |
-    PRQA Plugin stored a password unencrypted in its global configuration file on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    PRQA Plugin stored a password unencrypted in its global configuration file on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     The plugin now stores the password encrypted in the configuration files on disk.
 
@@ -150,8 +150,8 @@ issues:
     fixed: '1.1.4'
     previous: '1.1.3'
   description: |
-    Codebeamer Test Results Trend Updater Plugin stored username and password in its configuration unencrypted in jobs' `config.xml` files on the Jenkins master.
-    This password could be viewed by users with Extended Read permission, or access to the master file system.
+    Codebeamer Test Results Trend Updater Plugin stored username and password in its configuration unencrypted in jobs' `config.xml` files on the Jenkins controller.
+    This password could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     The plugin now integrates with https://plugins.jenkins.io/credentials[Credentials Plugin].
 

--- a/content/security/advisory/2019-04-03.adoc
+++ b/content/security/advisory/2019-04-03.adoc
@@ -18,8 +18,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.ircbot.IrcPublisher.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.ircbot.IrcPublisher.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: ircbot
     previous: 2.30
@@ -33,8 +33,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.awsbeanstalkpublisher.AWSEBPublisher.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.awsbeanstalkpublisher.AWSEBPublisher.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: aws-beanstalk-publisher-plugin
     previous: 1.7.4
@@ -48,8 +48,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: hockeyapp
     title: HockeyApp
@@ -64,8 +64,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: jenkins-jira-issue-updater
     previous: 1.18 # (4900 installs)
@@ -79,8 +79,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.zanox.hudson.plugins.FTPPublisher.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.zanox.hudson.plugins.FTPPublisher.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: ftppublisher
     previous: 1.2 # (3800 installs)
@@ -94,8 +94,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: websphere-deployer
     previous: 1.6.1
@@ -109,8 +109,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    Bitbucket Approve Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.bitbucket_approve.BitbucketApprover.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Bitbucket Approve Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.bitbucket_approve.BitbucketApprover.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: bitbucket-approve
     previous: 1.0.3 # (3000 installs)
@@ -140,8 +140,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stores Jira credentials unencrypted in its global configuration file `org.jenkinsci.plugins.zap.ZAPBuilder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores Jira credentials unencrypted in its global configuration file `org.jenkinsci.plugins.zap.ZAPBuilder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: zap
     previous: 1.1.0
@@ -155,8 +155,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: jenkins-cloudformation-plugin
     previous: 1.2
@@ -173,8 +173,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    AWS CloudWatch Logs Publisher Plugin stores credentials unencrypted in its global configuration file `jenkins.plugins.awslogspublisher.AWSLogsConfig.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    AWS CloudWatch Logs Publisher Plugin stores credentials unencrypted in its global configuration file `jenkins.plugins.awslogspublisher.AWSLogsConfig.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: aws-cloudwatch-logs-publisher
     previous: 1.2.0
@@ -188,8 +188,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.snsnotify.AmazonSNSNotifier.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.snsnotify.AmazonSNSNotifier.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: snsnotify
     previous: 1.13
@@ -203,8 +203,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.awsdevicefarm.AWSDeviceFarmRecorder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.awsdevicefarm.AWSDeviceFarmRecorder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: aws-device-farm
     previous: 1.25
@@ -218,8 +218,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    CloudShare Docker-Machine Plugin stores credentials unencrypted in its global configuration file `com.cloudshare.jenkins.CloudShareConfiguration.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    CloudShare Docker-Machine Plugin stores credentials unencrypted in its global configuration file `com.cloudshare.jenkins.CloudShareConfiguration.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: cloudshare-docker
     previous: 1.1.0
@@ -233,8 +233,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.bugzilla.BugzillaProjectProperty.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.bugzilla.BugzillaProjectProperty.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: bugzilla
     previous: 1.5
@@ -248,8 +248,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: trac-publisher-plugin
     previous: 1.3
@@ -263,8 +263,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: vmware-vrealize-automation-plugin
     previous: 1.2.3
@@ -278,8 +278,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    Aqua Security Scanner Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.aquadockerscannerbuildstep.AquaDockerScannerBuilder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Aqua Security Scanner Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.aquadockerscannerbuildstep.AquaDockerScannerBuilder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: aqua-security-scanner
     previous: 3.0.15
@@ -293,8 +293,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    veracode-scanner Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.veracodescanner.VeracodeNotifier.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    veracode-scanner Plugin stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.veracodescanner.VeracodeNotifier.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: veracode-scanner
     # This never had a proper display name
@@ -309,8 +309,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.octopusdeploy.OctopusDeployPlugin.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.octopusdeploy.OctopusDeployPlugin.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: octopusdeploy
     previous: 1.9.0
@@ -324,8 +324,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores deployment credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores deployment credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: wildfly-deployer
     previous: 1.0.2
@@ -339,8 +339,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: vsts-cd
     previous: 1.3
@@ -354,8 +354,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    Hyper.sh Commons Plugin stores credentials unencrypted in its global configuration file `sh.hyper.plugins.hypercommons.Tools.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Hyper.sh Commons Plugin stores credentials unencrypted in its global configuration file `sh.hyper.plugins.hypercommons.Tools.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: hyper-commons
     previous: 0.1.5
@@ -369,8 +369,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    Audit to Database Plugin stores database credentials unencrypted in its global configuration file `audit2db.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Audit to Database Plugin stores database credentials unencrypted in its global configuration file `audit2db.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: audit2db
     previous: 0.5
@@ -480,8 +480,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: fabric-beta-publisher
     previous: 2.1
@@ -495,8 +495,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: upload-pgyer
     previous: 1.31
@@ -542,8 +542,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    Open STF Plugin stores credentials unencrypted in its global configuration file `hudson.plugins.openstf.STFBuildWrapper.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Open STF Plugin stores credentials unencrypted in its global configuration file `hudson.plugins.openstf.STFBuildWrapper.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: open-stf
     previous: 1.0.9
@@ -557,8 +557,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    Perfecto Mobile Plugin stores credentials unencrypted in its global configuration file `com.perfectomobile.jenkins.ScriptExecutionBuilder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Perfecto Mobile Plugin stores credentials unencrypted in its global configuration file `com.perfectomobile.jenkins.ScriptExecutionBuilder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: perfectomobile
     previous: 2.62.0.3
@@ -572,8 +572,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: TestFairy
     previous: 4.16
@@ -587,8 +587,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    Crowd Integration Plugin stores credentials unencrypted in the global configuration file `config.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Crowd Integration Plugin stores credentials unencrypted in the global configuration file `config.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: crowd
     previous: 1.2
@@ -618,8 +618,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: starteam
     previous: 0.6.13
@@ -649,8 +649,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    Assembla Auth Plugin stores credentials unencrypted in the global configuration file `config.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    Assembla Auth Plugin stores credentials unencrypted in the global configuration file `config.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: assembla-auth
     previous: 1.11
@@ -667,8 +667,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.relution_publisher.configuration.global.StoreConfiguration.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.relution_publisher.configuration.global.StoreConfiguration.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: relution-publisher
     previous: 1.24
@@ -682,8 +682,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: klaros-testmanagement
     previous: 2.0.0
@@ -697,8 +697,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: mabl-integration
     previous: 0.0.12
@@ -712,8 +712,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: diawi-upload
     previous: 1.4
@@ -727,8 +727,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.minio.MinioUploader.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.minio.MinioUploader.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: minio-storage
     previous: 0.0.3
@@ -742,8 +742,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: deployhub
     previous: 8.0.13
@@ -757,8 +757,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stored credentials unencrypted in its global configuration file `org.jenkinsci.plugins.youtrack.YouTrackProjectProperty.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in its global configuration file `org.jenkinsci.plugins.youtrack.YouTrackProjectProperty.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores credentials encrypted.
   plugins:
@@ -775,8 +775,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `de.e_nexus.jabber.JabberBuilder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `de.e_nexus.jabber.JabberBuilder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: jabber-server-plugin
     previous: 1.9
@@ -809,8 +809,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored API tokens unencrypted in its global configuration file `com.netsparker.cloud.plugin.NCScanBuilder.xml` on the Jenkins master.
-    These API tokens could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored API tokens unencrypted in its global configuration file `com.netsparker.cloud.plugin.NCScanBuilder.xml` on the Jenkins controller.
+    These API tokens could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores API tokens encrypted.
   plugins:
@@ -843,8 +843,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: kmap-jenkins
     previous: 1.6
@@ -858,8 +858,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
   plugins:
   - name: crittercism-dsym
     previous: 1.1
@@ -873,8 +873,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.urbancode.ds.jenkins.plugins.serenarapublisher.UrbanDeployPublisher.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.urbancode.ds.jenkins.plugins.serenarapublisher.UrbanDeployPublisher.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: sra-deploy
     previous: 1.4.2.4
@@ -888,8 +888,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.sametime.im.transport.SametimePublisher.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.sametime.im.transport.SametimePublisher.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: sametime
     previous: 0.4
@@ -903,8 +903,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.koji.KojiBuilder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `org.jenkinsci.plugins.koji.KojiBuilder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: koji
     previous: 0.3
@@ -921,8 +921,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.cloudcoreo.plugins.jenkins.CloudCoreoBuildWrapper.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.cloudcoreo.plugins.jenkins.CloudCoreoBuildWrapper.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
   plugins:
   - name: cloudcoreo-deploytime
     previous: 0.2.3

--- a/content/security/advisory/2019-04-17.adoc
+++ b/content/security/advisory/2019-04-17.adoc
@@ -32,8 +32,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in its global configuration file `hudson.plugins.jira.JiraProjectProperty.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in its global configuration file `hudson.plugins.jira.JiraProjectProperty.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores credentials encrypted.
   plugins:
@@ -50,8 +50,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored the service management certificate unencrypted in `credentials.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored the service management certificate unencrypted in `credentials.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME has been deprecated.
     PLUGIN_NAME 1.5 no longer provides any user features and we recommend the plugin be uninstalled.
@@ -88,7 +88,7 @@ issues:
     PLUGIN_NAME supports sandboxed Groovy expressions.
     Its sandbox protection could be circumvented during parsing, compilation, and script instantiation by providing a crafted Groovy script.
 
-    This allowed users able to control the plugin’s job-specific configuration to bypass the sandbox protection and execute arbitrary code on the Jenkins master.
+    This allowed users able to control the plugin’s job-specific configuration to bypass the sandbox protection and execute arbitrary code on the Jenkins controller.
 
     PLUGIN_NAME now uses Script Security APIs that apply sandbox protection during these phases.
   plugins:

--- a/content/security/advisory/2019-04-30.adoc
+++ b/content/security/advisory/2019-04-30.adoc
@@ -35,7 +35,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins master JVM.
+    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     PLUGIN_NAME no longer does that.
     Instead, it now has an opt-in option to ignore SSL/TLS errors for each site check individually.
@@ -113,8 +113,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored the client secret unencrypted in the global `config.xml` configuration file on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored the client secret unencrypted in the global `config.xml` configuration file on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores the client secret encrypted.
   plugins:
@@ -131,8 +131,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -148,7 +148,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins master JVM.
+    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -183,8 +183,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in its global configuration file on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in its global configuration file on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores credentials encrypted.
   plugins:

--- a/content/security/advisory/2019-05-21.adoc
+++ b/content/security/advisory/2019-05-21.adoc
@@ -24,7 +24,7 @@ issues:
 
     The numeric placeholders in the messages above would be populated with the following values:
 
-    . The system user that the Jenkins master process is running as (usually `jenkins`)
+    . The system user that the Jenkins controller process is running as (usually `jenkins`)
     . The group owning `/etc/shadow`
     . The user owning `/etc/shadow`
 
@@ -43,13 +43,13 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    Credentials Plugin allowed the creation of Certificate credentials from a PKCS#12 file on the Jenkins master.
+    Credentials Plugin allowed the creation of Certificate credentials from a PKCS#12 file on the Jenkins controller.
     Users with permission to create or update credentials could use the associated form validation to confirm the existence of files with an attacker-specified path.
 
-    Additionally, they could create credentials from any valid PKCS#12 file on the Jenkins master.
+    Additionally, they could create credentials from any valid PKCS#12 file on the Jenkins controller.
     With the ability to configure jobs to access these credentials, they could obtain the certificate content.
 
-    Credentials Plugin no longer supports Certificate credentials from PKCS#12 files on the Jenkins master file system.
+    Credentials Plugin no longer supports Certificate credentials from PKCS#12 files on the Jenkins controller file system.
     Existing Certificate credentials of this kind are automatically migrated to _directly entered_ Certificate credentials during Jenkins startup.
 
     [NOTE]

--- a/content/security/advisory/2019-05-31.adoc
+++ b/content/security/advisory/2019-05-31.adoc
@@ -50,7 +50,7 @@ issues:
   description: |-
     PLUGIN_NAME did not configure its XML parser in a way that would prevent XML External Entity (XXE) processing.
 
-    This allowed attackers able to control the contents of a temporary directory on the agent that the Maven build is executing on to have Jenkins parse a maliciously crafted XML file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allowed attackers able to control the contents of a temporary directory on the agent that the Maven build is executing on to have Jenkins parse a maliciously crafted XML file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     PLUGIN_NAME no longer processes XML External Entities in XML documents.
   plugins:
@@ -87,8 +87,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored target passwords unencrypted in its global configuration file on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored target passwords unencrypted in its global configuration file on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores its passwords encrypted.
   plugins:

--- a/content/security/advisory/2019-06-11.adoc
+++ b/content/security/advisory/2019-06-11.adoc
@@ -35,7 +35,7 @@ issues:
     PLUGIN_NAME did not perform permission checks on a method implementing form validation.
     This allowed users with Overall/Read access to Jenkins to connect to an attacker-specified Kubernetes server and obtain information about an attacker-specified namespace.
     Doing so might also leak service account credentials used for the connection.
-    Additionally, it allowed attackers to obtain the value of any attacker-specified environment variable for the Jenkins master process.
+    Additionally, it allowed attackers to obtain the value of any attacker-specified environment variable for the Jenkins controller process.
 
     Additionally, this form validation method did not require POST requests, resulting in a cross-site request forgery vulnerability.
 
@@ -89,7 +89,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME unconditionally disabled SSL/TLS certificate validation for the entire Jenkins master JVM during the deployment/publication of an application.
+    PLUGIN_NAME unconditionally disabled SSL/TLS certificate validation for the entire Jenkins controller JVM during the deployment/publication of an application.
 
     PLUGIN_NAME no longer does that.
     Instead, the existing opt-in option to ignore SSL/TLS errors is used during deployment for the specific connection.

--- a/content/security/advisory/2019-07-11.adoc
+++ b/content/security/advisory/2019-07-11.adoc
@@ -74,8 +74,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored SonarQube credentials unencrypted on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored SonarQube credentials unencrypted on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these credentials encrypted.
   plugins:
@@ -93,8 +93,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials could be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores credentials encrypted.
   plugins:
@@ -130,8 +130,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -147,8 +147,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2019-07-17.adoc
+++ b/content/security/advisory/2019-07-17.adoc
@@ -21,7 +21,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N
   description: |-
     Users with Job/Configure permission could specify a relative path escaping the base directory in the file name portion of a file parameter definition. 
-    This path would be used to store the uploaded file on the Jenkins master, resulting in an arbitrary file write vulnerability.
+    This path would be used to store the uploaded file on the Jenkins controller, resulting in an arbitrary file write vulnerability.
 
     File parameters that escape the base directory are no longer accepted and the build will fail.
 

--- a/content/security/advisory/2019-07-31.adoc
+++ b/content/security/advisory/2019-07-31.adoc
@@ -18,7 +18,7 @@ issues:
     Sandbox protection in PLUGIN_NAME could be circumvented by casting crafted objects to other types.
     This allowed attackers able to specify sandboxed scripts to invoke constructors that weren't approved.
 
-    Additionally, this could be used to read arbitrary files on the Jenkins master.
+    Additionally, this could be used to read arbitrary files on the Jenkins controller.
 
     Casting collections to other types as an alternative syntax for constructor invocation is now only allowed when the collection type is defined in `java.util`, and prohibited otherwise.
     Casting files and enums to arrays is now intercepted by the sandbox and treated as the invocation of an equivalent method.
@@ -37,7 +37,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
     Sandbox protection in PLUGIN_NAME could be circumvented through crafted subexpressions used as arguments to method pointer expressions.
-    This allowed attackers able to specify sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
+    This allowed attackers able to specify sandboxed scripts to execute arbitrary code in the context of the Jenkins controller JVM.
 
     Method pointer subexpressions are now subject to sandbox protection.
   plugins:
@@ -132,8 +132,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in its global configuration file `org.jvnet.hudson.plugins.m2release.M2ReleaseBuildWrapper.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in its global configuration file `org.jvnet.hudson.plugins.m2release.M2ReleaseBuildWrapper.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores credentials encrypted.
   plugins:
@@ -299,8 +299,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials could be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores credentials encrypted.
   plugins:

--- a/content/security/advisory/2019-08-07.adoc
+++ b/content/security/advisory/2019-08-07.adoc
@@ -156,7 +156,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
   description: |-
-    PLUGIN_NAME allows users able to configure jobs to read arbitrary files from the Jenkins master, even if the job is running on an agent.
+    PLUGIN_NAME allows users able to configure jobs to read arbitrary files from the Jenkins controller, even if the job is running on an agent.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -206,8 +206,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.testlink.TestLinkBuilder.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `hudson.plugins.testlink.TestLinkBuilder.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -225,8 +225,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an API key unencrypted in its global configuration file `org.jenkinsci.plugins.gcm.im.GcmPublisher.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores an API key unencrypted in its global configuration file `org.jenkinsci.plugins.gcm.im.GcmPublisher.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -263,7 +263,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins master JVM.
+    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -279,7 +279,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins master JVM.
+    PLUGIN_NAME unconditionally disables SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -295,8 +295,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2019-08-28.adoc
+++ b/content/security/advisory/2019-08-28.adoc
@@ -57,7 +57,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
     PLUGIN_NAME has a form validation HTTP endpoint used to validate a user-submitted Groovy script through compilation, which was not subject to sandbox protection.
-    This allowed attackers with Overall/Read access to execute arbitrary code on the Jenkins master by applying AST transforming annotations such as `@Grab` to source code elements.
+    This allowed attackers with Overall/Read access to execute arbitrary code on the Jenkins controller by applying AST transforming annotations such as `@Grab` to source code elements.
 
     The affected HTTP endpoint now applies a safe Groovy compiler configuration preventing the use of unsafe AST transforming annotations.
   plugins:

--- a/content/security/advisory/2019-09-12.adoc
+++ b/content/security/advisory/2019-09-12.adoc
@@ -14,7 +14,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
     PLUGIN_NAME accepts user-specified values as argument to an invocation of `git ls-remote` to validate the existence of a Git repository at the specified URL.
-    This was implemented in a way that allowed attackers with Job/Configure permission to execute an arbitrary system command on the Jenkins master as the OS user that the Jenkins process is running as.
+    This was implemented in a way that allowed attackers with Job/Configure permission to execute an arbitrary system command on the Jenkins controller as the OS user that the Jenkins process is running as.
 
     PLUGIN_NAME now rejects repository URLs that do not appear to be valid URLs.
     Additionally, for versions of Git that support it, the repository URL argument is separated from option arguments using the `--` separator to prevent interpretation as an option.
@@ -41,7 +41,7 @@ issues:
     * Crafted property names in property expressions in increment and decrement expressions (CVE-2019-10399)
     * Crafted subexpressions in increment and decrement expressions not involving actual assignment (CVE-2019-10400)
 
-    This allowed attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
+    This allowed attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins controller JVM.
 
     These expressions are now subject to sandbox protection.
   plugins:
@@ -114,8 +114,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored the Beaker password unencrypted on the Jenkins master.
-    This password could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored the Beaker password unencrypted on the Jenkins controller.
+    This password could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these credentials encrypted.
   plugins:

--- a/content/security/advisory/2019-09-25.adoc
+++ b/content/security/advisory/2019-09-25.adoc
@@ -192,8 +192,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored registry credentials unencrypted in its global configuration file `io.jenkins.plugins.neuvector.NeuVectorBuilder.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored registry credentials unencrypted in its global configuration file `io.jenkins.plugins.neuvector.NeuVectorBuilder.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these credentials encrypted.
   plugins:
@@ -290,8 +290,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored a proxy password unencrypted in job `config.xml` files on the Jenkins master.
-    This password could be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stored a proxy password unencrypted in job `config.xml` files on the Jenkins controller.
+    This password could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores the proxy password encrypted.
     Existing jobs need to have their configuration saved for existing plain text proxy passwords to be overwritten.
@@ -309,8 +309,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored MediaWiki and Jira passwords unencrypted in job `config.xml` files on the Jenkins master.
-    These passwords could be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stored MediaWiki and Jira passwords unencrypted in job `config.xml` files on the Jenkins controller.
+    These passwords could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these passwords encrypted.
     Existing jobs need to have their configuration saved for existing plain text passwords to be overwritten.
@@ -328,8 +328,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored a private token unencrypted in its global configuration file `org.jenkinsci.plugins.gitlablogo.GitlabLogoProperty.xml` on the Jenkins master.
-    This token could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored a private token unencrypted in its global configuration file `org.jenkinsci.plugins.gitlablogo.GitlabLogoProperty.xml` on the Jenkins controller.
+    This token could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores the token encrypted.
   plugins:
@@ -346,8 +346,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored API tokens unencrypted in  job `config.xml` files and its global configuration file `org.jenkinsci.plugins.jvctgl.ViolationsToGitLabGlobalConfiguration.xml` on the Jenkins master.
-    These credentials could be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stored API tokens unencrypted in  job `config.xml` files and its global configuration file `org.jenkinsci.plugins.jvctgl.ViolationsToGitLabGlobalConfiguration.xml` on the Jenkins controller.
+    These credentials could be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these credentials encrypted.
     Existing jobs need to have their configuration saved for existing plain text credentials to be overwritten.
@@ -411,8 +411,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores the Application Director password unencrypted in its global configuration file `jfullam.vfabric.jenkins.plugin.ApplicationDirectorPostBuildDeployer.xml` on the Jenkins master.
-    This password can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores the Application Director password unencrypted in its global configuration file `jfullam.vfabric.jenkins.plugin.ApplicationDirectorPostBuildDeployer.xml` on the Jenkins controller.
+    This password can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -428,8 +428,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores the Assembla password unencrypted in its global configuration file `jenkins.plugin.assembla.AssemblaProjectProperty.xml` on the Jenkins master.
-    This password can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores the Assembla password unencrypted in its global configuration file `jenkins.plugin.assembla.AssemblaProjectProperty.xml` on the Jenkins controller.
+    This password can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -445,8 +445,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores the Azure Event Grid secret key unencrypted in job `config.xml` files on the Jenkins master.
-    This key can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores the Azure Event Grid secret key unencrypted in job `config.xml` files on the Jenkins controller.
+    This key can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -462,8 +462,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores a password unencrypted in job `config.xml` files on the Jenkins master.
-    This password can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores a password unencrypted in job `config.xml` files on the Jenkins controller.
+    This password can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -479,8 +479,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an API key unencrypted in its global configuration file `com.villagechief.codescan.jenkins.CodeScanBuilder.xml` on the Jenkins master.
-    This API key can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores an API key unencrypted in its global configuration file `com.villagechief.codescan.jenkins.CodeScanBuilder.xml` on the Jenkins controller.
+    This API key can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -497,8 +497,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores a password unencrypted in its global configuration file `com.technicolor.eloyente.ElOyente.xml` on the Jenkins master.
-    This password can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores a password unencrypted in its global configuration file `com.technicolor.eloyente.ElOyente.xml` on the Jenkins controller.
+    This password can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -514,8 +514,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores a calendar password unencrypted in job `config.xml` files on the Jenkins master.
-    This password can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores a calendar password unencrypted in job `config.xml` files on the Jenkins controller.
+    This password can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -531,8 +531,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an API key unencrypted in its global configuration file `net.arangamani.jenkins.gempublisher.GemPublisher.xml` on the Jenkins master.
-    This API key can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores an API key unencrypted in its global configuration file `net.arangamani.jenkins.gempublisher.GemPublisher.xml` on the Jenkins controller.
+    This API key can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2019-10-01.adoc
+++ b/content/security/advisory/2019-10-01.adoc
@@ -17,7 +17,7 @@ issues:
   description: |-
     Sandbox protection in PLUGIN_NAME could be circumvented through default parameter expressions in constructors.
 
-    This allowed attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
+    This allowed attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins controller JVM.
 
     These expressions are now subject to sandbox protection.
   plugins:
@@ -53,8 +53,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an access token unencrypted in job `config.xml` files on the Jenkins master.
-    This token can be viewed by users with Extended Read permission, or access to the master file system.
+    PLUGIN_NAME stores an access token unencrypted in job `config.xml` files on the Jenkins controller.
+    This token can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2019-10-16.adoc
+++ b/content/security/advisory/2019-10-16.adoc
@@ -15,8 +15,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
   description: |-
-    PLUGIN_NAME allowed the creation of credentials based on the content of files on the Jenkins master through a feature retaining backwards compatibility with earlier plugin releases.
-    This allowed users with the permission to configure jobs and credentials to read arbitrary files on the Jenkins master by creating a credential referencing an arbitrary file on the Jenkins master.
+    PLUGIN_NAME allowed the creation of credentials based on the content of files on the Jenkins controller through a feature retaining backwards compatibility with earlier plugin releases.
+    This allowed users with the permission to configure jobs and credentials to read arbitrary files on the Jenkins controller by creating a credential referencing an arbitrary file on the Jenkins controller.
 
     PLUGIN_NAME no longer allows a regular user to create credentials in the legacy format.
   plugins:
@@ -72,8 +72,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N 
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in its global configuration file `org.jenkinsci.plugins.neoload.integration.NeoGlobalConfig.xml` and in job `config.xml` files on the Jenkins master.
-    These credentials could be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in its global configuration file `org.jenkinsci.plugins.neoload.integration.NeoGlobalConfig.xml` and in job `config.xml` files on the Jenkins controller.
+    These credentials could be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these credentials encrypted.
   plugins:
@@ -108,8 +108,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials could be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials could be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     PLUGIN_NAME 1.1.5 and newer now stores these credentials encrypted.
   plugins:
@@ -158,7 +158,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME unconditionally disabled SSL/TLS certificate validation for the entire Jenkins master JVM.
+    PLUGIN_NAME unconditionally disabled SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     PLUGIN_NAME no longer does that.
     Instead, it now has an opt-in option to ignore SSL/TLS errors for its connections.
@@ -197,8 +197,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an API token unencrypted in job `config.xml` files on the Jenkins master.
-    This token can be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stores an API token unencrypted in job `config.xml` files on the Jenkins controller.
+    This token can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:
@@ -213,8 +213,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:
@@ -229,8 +229,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:
@@ -245,8 +245,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an access token unencrypted in the global `config.xml` configuration file on the Jenkins master.
-    This token can be viewed by users with access to the master file system.
+    PLUGIN_NAME stores an access token unencrypted in the global `config.xml` configuration file on the Jenkins controller.
+    This token can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:
@@ -261,8 +261,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.soasta.jenkins.CloudTestServer.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `com.soasta.jenkins.CloudTestServer.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:
@@ -277,8 +277,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an access token unencrypted in job `config.xml` files on the Jenkins master.
-    This token can be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stores an access token unencrypted in job `config.xml` files on the Jenkins controller.
+    This token can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:
@@ -293,8 +293,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials unencrypted in its global configuration file `io.jenkins.plugins.delphix.GlobalConfiguration.xml` on the Jenkins master.
-    These credentials could be viewed by users with access to the master file system.
+    PLUGIN_NAME stores credentials unencrypted in its global configuration file `io.jenkins.plugins.delphix.GlobalConfiguration.xml` on the Jenkins controller.
+    These credentials could be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory there is no fix.
   plugins:

--- a/content/security/advisory/2019-10-23.adoc
+++ b/content/security/advisory/2019-10-23.adoc
@@ -18,8 +18,8 @@ issues:
     Mattermost allows the definition of incoming (from the perspective of the service) webhook URLs.
     These contain what is effectively a secret token as part of the URL.
 
-    PLUGIN_NAME stored these webhook URLs as part of its global configuration file `jenkins.plugins.mattermost.MattermostNotifier.xml` and job `config.xml` files on the Jenkins master.
-    These URLs could be viewed by users with Extended Read permission (in the case of job `config.xml` files) or access to the master file system.
+    PLUGIN_NAME stored these webhook URLs as part of its global configuration file `jenkins.plugins.mattermost.MattermostNotifier.xml` and job `config.xml` files on the Jenkins controller.
+    These URLs could be viewed by users with Extended Read permission (in the case of job `config.xml` files) or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these URLs encrypted.
     As they combine configuration and secret token, they are still shown on the UI.
@@ -37,8 +37,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored a credential unencrypted in the global `config.xml` configuration file on the Jenkins master.
-    This credential could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored a credential unencrypted in the global `config.xml` configuration file on the Jenkins controller.
+    This credential could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores this credential encrypted.
   plugins:
@@ -55,8 +55,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored a credential unencrypted in its global configuration file `jenkins.plugins.zulip.ZulipNotifier.xml`, as well as in the legacy configuration file `hudson.plugins.humbug.HumbugNotifier.xml` on the Jenkins master.
-    This credential could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored a credential unencrypted in its global configuration file `jenkins.plugins.zulip.ZulipNotifier.xml`, as well as in the legacy configuration file `hudson.plugins.humbug.HumbugNotifier.xml` on the Jenkins controller.
+    This credential could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores this credential encrypted in its global configuration file.
     The legacy configuration file is deleted when saving the plugin configuration.
@@ -76,8 +76,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored a credential unencrypted in its global configuration file `com.dynatrace.jenkins.dashboard.TAGlobalConfiguration.xml` on the Jenkins master.
-    This credential could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored a credential unencrypted in its global configuration file `com.dynatrace.jenkins.dashboard.TAGlobalConfiguration.xml` on the Jenkins controller.
+    This credential could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores this credential encrypted.
   plugins:
@@ -131,7 +131,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME does not perform permission checks on a method implementing form validation.
-    This allows users with Overall/Read access to Jenkins to send an HTTP HEAD request to a user-specified URL, or confirm the existence of any file or directory on the Jenkins master.
+    This allows users with Overall/Read access to Jenkins to send an HTTP HEAD request to a user-specified URL, or confirm the existence of any file or directory on the Jenkins controller.
 
     Additionally, the form validation method does not require POST requests, resulting in a CSRF vulnerability.
 
@@ -169,8 +169,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores a credential unencrypted in job `config.xml` files on the Jenkins master if the 'Override Credentials' option is used.
-    This credential can be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stores a credential unencrypted in job `config.xml` files on the Jenkins controller if the 'Override Credentials' option is used.
+    This credential can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2019-11-21.adoc
+++ b/content/security/advisory/2019-11-21.adoc
@@ -17,7 +17,7 @@ issues:
   description: |-
     Sandbox protection in PLUGIN_NAME could be circumvented through closure default parameter expressions.
 
-    This allowed attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
+    This allowed attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins controller JVM.
 
     These expressions are now subject to sandbox protection.
   plugins:
@@ -35,7 +35,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
   description: |-
     PLUGIN_NAME did not validate the paths submitted for the "Delete Support Bundles" feature.
-    This allowed users to delete arbitrary files on the Jenkins master file system accessible to the OS user account running Jenkins.
+    This allowed users to delete arbitrary files on the Jenkins controller file system accessible to the OS user account running Jenkins.
 
     Additionally, this endpoint did not perform a permission check, allowing users with Overall/Read permission to delete support bundles, and any arbitrary other file, with a known name/path.
 
@@ -79,7 +79,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME stored an Anchore.io service password unencrypted in job `config.xml` files as part of its configuration.
-    This credential could be viewed by users with Extended Read permission or access to the master file system.
+    This credential could be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As the affected functionality has been deprecated, and the affected Anchore.io service has been shut down in late 2018, the affected feature has been removed.
     The password will be removed from the job configuration once it is saved again.
@@ -97,8 +97,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored a credential unencrypted in its global configuration file `com.inflectra.spiratest.plugins.SpiraBuilder.xml` on the Jenkins master.
-    This credential could be viewed by users with access to the master file system.
+    PLUGIN_NAME stored a credential unencrypted in its global configuration file `com.inflectra.spiratest.plugins.SpiraBuilder.xml` on the Jenkins controller.
+    This credential could be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores this credential encrypted once its configuration is saved again.
   plugins:
@@ -171,8 +171,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins master as part of its post-build step configuration.
-    This credential could be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME stored credentials unencrypted in job `config.xml` files on the Jenkins controller as part of its post-build step configuration.
+    This credential could be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     PLUGIN_NAME now stores these credentials encrypted once the job configuration is saved again.
   plugins:

--- a/content/security/advisory/2019-12-17.adoc
+++ b/content/security/advisory/2019-12-17.adoc
@@ -15,7 +15,7 @@ issues:
     While Jenkins users without Overall/Administer permission are not allowed to configure a custom Nexus URL, this could still be exploited via man-in-the-middle attacks, especially if it's not an HTTPS URL.
 
     Additionally, a connection test form validation method does not require POST requests, resulting in a cross-site request forgery vulnerability.
-    Combined, these two vulnerabilities allow attackers to have Jenkins parse crafted XML documents that use external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    Combined, these two vulnerabilities allow attackers to have Jenkins parse crafted XML documents that use external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     PLUGIN_NAME 0.16.2 configures its XML parser to prevent XML external entity (XXE) attacks.
     It also now requires that requests to the connection test form validation method are done via POST, which protects from cross-site request forgery attacks.
@@ -32,7 +32,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
   description: |-
     PLUGIN_NAME 2.30.1 and earlier does not perform permission checks in methods performing form validation.
-    This allows users with Overall/Read access to perform connection tests, connecting to an HTTP URL or SSH server using attacker-specified credentials, or determine whether files with an attacker-specified path exist on the Jenkins master file system.
+    This allows users with Overall/Read access to perform connection tests, connecting to an HTTP URL or SSH server using attacker-specified credentials, or determine whether files with an attacker-specified path exist on the Jenkins controller file system.
 
     Additionally, these form validation methods do not require POST requests, resulting in a CSRF vulnerability.
 
@@ -86,8 +86,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 3.6.5 and earlier stores credentials as part of its global configuration file `org.jenkinsci.plugins.rundeck.RundeckNotifier.xml` and job `config.xml` files on the Jenkins master.
-    These URLs could be viewed by users with Extended Read permission (in the case of job `config.xml` files) or access to the master file system.
+    PLUGIN_NAME 3.6.5 and earlier stores credentials as part of its global configuration file `org.jenkinsci.plugins.rundeck.RundeckNotifier.xml` and job `config.xml` files on the Jenkins controller.
+    These URLs could be viewed by users with Extended Read permission (in the case of job `config.xml` files) or access to the Jenkins controller file system.
 
     PLUGIN_NAME 3.6.6 stores credentials in its configuration encrypted once global and/or job configurations are saved again.
   plugins:
@@ -102,8 +102,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 2.0.3 and earlier stores credentials unencrypted in job `config.xml` files on the Jenkins master as part of its build step configuration.
-    These credentials can be viewed by users with Extended Read permission or access to the master file system.
+    PLUGIN_NAME 2.0.3 and earlier stores credentials unencrypted in job `config.xml` files on the Jenkins controller as part of its build step configuration.
+    These credentials can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     PLUGIN_NAME 2.0.4 stores its credentials encrypted once job configurations are saved again.
   plugins:
@@ -118,7 +118,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME 3.2.3 and earlier unconditionally disables SSL/TLS certificate validation for the entire Jenkins master JVM.
+    PLUGIN_NAME 3.2.3 and earlier unconditionally disables SSL/TLS certificate validation for the entire Jenkins controller JVM.
 
     PLUGIN_NAME 3.2.4 no longer disables SSL/TLS certificate validation.
   plugins:
@@ -134,7 +134,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
   description: |-
     PLUGIN_NAME 1.6.1 and earlier does not perform permission checks in methods performing form validation.
-    This allows users with Overall/Read access to perform connection tests, determine whether files with an attacker-specified path exist on the Jenkins master file system, and obtain limited information about the Jenkins and plugin configuration based on the responses.
+    This allows users with Overall/Read access to perform connection tests, determine whether files with an attacker-specified path exist on the Jenkins controller file system, and obtain limited information about the Jenkins and plugin configuration based on the responses.
     The latter include the ability to set plugin configuration options.
 
     Additionally, these form validation methods do not require POST requests, resulting in a CSRF vulnerability.
@@ -151,7 +151,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
   description: |-
-    PLUGIN_NAME 1.6.1 and earlier allows users with Overall/Read access to disable SSL/TLS certificate and hostname validation for the entire Jenkins master JVM, or specify a new Java keystore from a file stored on the Jenkins master filesystem.
+    PLUGIN_NAME 1.6.1 and earlier allows users with Overall/Read access to disable SSL/TLS certificate and hostname validation for the entire Jenkins controller JVM, or specify a new Java keystore from a file stored on the Jenkins controller filesystem.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -280,8 +280,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 1.0.1 and earlier stores a credential unencrypted in its global configuration file `org.jenkinsci.plugins.weibo.WeiboNotifier.xml` on the Jenkins master.
-    This credential can be viewed by users with access to the master file system.
+    PLUGIN_NAME 1.0.1 and earlier stores a credential unencrypted in its global configuration file `org.jenkinsci.plugins.weibo.WeiboNotifier.xml` on the Jenkins controller.
+    This credential can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2020-01-15.adoc
+++ b/content/security/advisory/2020-01-15.adoc
@@ -33,7 +33,7 @@ issues:
   description: |-
     PLUGIN_NAME 2.0.0 and earlier does not configure the XML parser to prevent XML external entity (XXE) attacks.
 
-    This allows a user able to control the input files for the 'Publish Robot Framework' post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allows a user able to control the input files for the 'Publish Robot Framework' post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     PLUGIN_NAME 2.0.1 disables external entity resolution for its XML parser.
   plugins:
@@ -66,7 +66,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 2.0.4 and earlier stores a NuGet API key unencrypted in job `config.xml` files as part of its configuration.
-    This credential could be viewed by users with Extended Read permission or access to the master file system.
+    This credential could be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     This is due to an incomplete fix of link:/security/advisory/2019-12-17/#SECURITY-1598[SECURITY-1598].
 

--- a/content/security/advisory/2020-01-29.adoc
+++ b/content/security/advisory/2020-01-29.adoc
@@ -18,11 +18,11 @@ issues:
     severity: High
     vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
   description: |-
-    Jenkins 2.213 and earlier, LTS 2.204.1 and earlier includes support for the Inbound TCP Agent Protocol/3 for communication between master and agents.
+    Jenkins 2.213 and earlier, LTS 2.204.1 and earlier includes support for the Inbound TCP Agent Protocol/3 for communication between controller and agents.
     While link:https://jenkins.io/changelog-old/#v2.128[this protocol has been deprecated in 2018] and was recently removed from Jenkins in 2.214, it could still easily be enabled in Jenkins LTS 2.204.1, 2.213, and older.
 
     This protocol incorrectly reuses encryption parameters which allow an unauthenticated remote attacker to determine the connection secret.
-    This secret can then be used to connect attacker-controlled Jenkins agents to the Jenkins master.
+    This secret can then be used to connect attacker-controlled Jenkins agents to the Jenkins controller.
 
     Jenkins 2.204.2 no longer allows for the use of Inbound TCP Agent Protocol/3 by default.
     The system property `jenkins.slaves.JnlpSlaveAgentProtocol3.ALLOW_UNSAFE` can be set to `true` to allow enabling the Inbound TCP Agent Protocol/3 in Jenkins 2.204.2, but doing so is strongly discouraged.
@@ -39,8 +39,8 @@ issues:
     Jenkins 2.218 and earlier, LTS 2.204.1 and earlier supports two network discovery services (UDP multicast/broadcast and DNS multicast) by default.
 
     The UDP multicast/broadcast service can be used in an amplification reflection attack, as very few bytes sent to the respective endpoint result in much larger responses:
-    A single byte request to this service would respond with more than 100 bytes of Jenkins metadata which could be used in a DDoS attack on a Jenkins master.
-    Within the same network, spoofed UDP packets could also be sent to make two Jenkins masters go into an infinite loop of replies to one another, thus causing a denial of service.
+    A single byte request to this service would respond with more than 100 bytes of Jenkins metadata which could be used in a DDoS attack on a Jenkins controller.
+    Within the same network, spoofed UDP packets could also be sent to make two Jenkins controllers go into an infinite loop of replies to one another, thus causing a denial of service.
 
     Jenkins 2.219, LTS 2.204.2 now disables both UDP multicast/broadcast and DNS multicast by default.
 
@@ -95,7 +95,7 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    Jenkins includes a feature that shows a JVM memory usage chart for the Jenkins master.
+    Jenkins includes a feature that shows a JVM memory usage chart for the Jenkins controller.
 
     Access to the chart in Jenkins 2.218 and earlier, LTS 2.204.1 and earlier requires no permissions beyond the general Overall/Read, allowing users who are not administrators to view JVM memory usage data.
 

--- a/content/security/advisory/2020-02-12.adoc
+++ b/content/security/advisory/2020-02-12.adoc
@@ -13,7 +13,7 @@ issues:
   description: |-
     Sandbox protection in PLUGIN_NAME 2.78 and earlier can be circumvented through default parameter expressions in CPS-transformed methods.
 
-    This allows attackers able to specify and run sandboxed Pipelines to execute arbitrary code in the context of the Jenkins master JVM.
+    This allows attackers able to specify and run sandboxed Pipelines to execute arbitrary code in the context of the Jenkins controller JVM.
 
     These expressions are subject to sandbox protection in PLUGIN_NAME 2.79.
   plugins:
@@ -31,7 +31,7 @@ issues:
     Sandbox protection in PLUGIN_NAME 1.69 and earlier can be circumvented during the script compilation phase by applying AST transforming annotations such as `@Grab` to imports or by using them inside of other annotations.
     This affects both script execution (typically invoked from other plugins like Pipeline) as well as HTTP endpoints providing sandboxed script validation.
 
-    Users with Overall/Read permission can exploit this to bypass sandbox protection and execute arbitrary code on the Jenkins master.
+    Users with Overall/Read permission can exploit this to bypass sandbox protection and execute arbitrary code on the Jenkins controller.
 
     This issue is due to an incomplete fix of https://jenkins.io/security/advisory/2019-01-08/#SECURITY-1266[SECURITY-1266].
 
@@ -100,7 +100,7 @@ issues:
   description: |-
     PLUGIN_NAME 0.25 and earlier does not configure the XML parser to prevent XML external entity (XXE) attacks.
 
-    This allows a user able to control the input files for its post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allows a user able to control the input files for its post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     PLUGIN_NAME 0.26 disables external entity processing for its XML parser.
   plugins:
@@ -171,7 +171,7 @@ issues:
   description: |-
     PLUGIN_NAME 1.30 and earlier does not configure the XML parser to prevent XML external entity (XXE) attacks.
 
-    This allows a user able to control the input files for its post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allows a user able to control the input files for its post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     PLUGIN_NAME 1.31 disables external entity processing for its XML parser.
   plugins:
@@ -238,7 +238,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.0.1 and earlier stores a Subversion password unencrypted in job `config.xml` files as part of its configuration.
-    This credential can be viewed by users with Extended Read permission or access to the master file system.
+    This credential can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -252,8 +252,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 1.6.11 and earlier stores a GPG passphrase unencrypted in its global configuration file `ru.yandex.jenkins.plugins.debuilder.DebianPackageBuilder.xml` on the Jenkins master.
-    This credential can be viewed by users with access to the master file system.
+    PLUGIN_NAME 1.6.11 and earlier stores a GPG passphrase unencrypted in its global configuration file `ru.yandex.jenkins.plugins.debuilder.DebianPackageBuilder.xml` on the Jenkins controller.
+    This credential can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -268,7 +268,7 @@ issues:
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.1 and earlier stores a token unencrypted in the global `config.xml` files as part of its configuration.
-    This credential can be viewed by users with access to the master file system.
+    This credential can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -282,8 +282,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 1.1 and earlier stores the RPD user token unencrypted in its global configuration file `com.bmc.rpd.jenkins.plugin.bmcrpd.configuration.RPDPluginConfiguration.xml` on the Jenkins master.
-    This credential can be viewed by users with access to the master file system.
+    PLUGIN_NAME 1.1 and earlier stores the RPD user token unencrypted in its global configuration file `com.bmc.rpd.jenkins.plugin.bmcrpd.configuration.RPDPluginConfiguration.xml` on the Jenkins controller.
+    This credential can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -298,7 +298,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.9 and earlier stores a service password unencrypted in job `config.xml` files as part of its configuration.
-    This credential can be viewed by users with Extended Read permission or access to the master file system.
+    This credential can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -312,8 +312,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 1.0.9 and earlier stores a password unencrypted in its global configuration file `com.bmc.rpd.jenkins.plugin.bmcrpd.configuration.RPDPluginConfiguration.xml` on the Jenkins master.
-    This credential can be viewed by users with access to the master file system.
+    PLUGIN_NAME 1.0.9 and earlier stores a password unencrypted in its global configuration file `com.bmc.rpd.jenkins.plugin.bmcrpd.configuration.RPDPluginConfiguration.xml` on the Jenkins controller.
+    This credential can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -327,8 +327,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 0.5.1 and earlier stores SCM passwords unencrypted in its global configuration file `hudson.plugins.harvest.HarvestSCM.xml` and in job `config.xml` files on the Jenkins master.
-    These credentials can be viewed by users with Extended Read permission (job `config.xml` only) or access to the master file system (both).
+    PLUGIN_NAME 0.5.1 and earlier stores SCM passwords unencrypted in its global configuration file `hudson.plugins.harvest.HarvestSCM.xml` and in job `config.xml` files on the Jenkins controller.
+    These credentials can be viewed by users with Extended Read permission (job `config.xml` only) or access to the Jenkins controller file system (both).
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -343,7 +343,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 2.14 and earlier stores a repository password unencrypted in job `config.xml` files as part of its configuration.
-    This credential can be viewed by users with Extended Read permission or access to the master file system.
+    This credential can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -358,7 +358,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.1 and earlier stores the Applatix password unencrypted in job `config.xml` files as part of its configuration.
-    This credential can be viewed by users with Extended Read permission or access to the master file system.
+    This credential can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2020-03-09.adoc
+++ b/content/security/advisory/2020-03-09.adoc
@@ -16,7 +16,7 @@ issues:
     * Crafted constructor calls and bodies (due to an incomplete fix of https://jenkins.io/security/advisory/2017-08-07/#super-constructor-calls[SECURITY-582])
     * Crafted method calls on objects that implement `GroovyInterceptable`
 
-    This allows attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins master JVM.
+    This allows attackers able to specify and run sandboxed scripts to execute arbitrary code in the context of the Jenkins controller JVM.
 
     PLUGIN_NAME 1.71 has additional restrictions and sanity checks to ensure that super constructors cannot be constructed without being intercepted by the sandbox.
     In addition, it also intercepts method calls on objects that implement `GroovyInterceptable` as calls to `GroovyObject#invokeMethod(String, Object)`, which is on the list of dangerous signatures and should not be approved for use in the sandbox.
@@ -68,7 +68,7 @@ issues:
   description: |-
     PLUGIN_NAME 1.15 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.
 
-    This allows a user able to control the input files for the 'Publish Cobertura Coverage Report' post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master or server-side request forgery.
+    This allows a user able to control the input files for the 'Publish Cobertura Coverage Report' post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.
 
     PLUGIN_NAME 1.16 disables external entity resolution for its XML parser.
   plugins:
@@ -85,7 +85,7 @@ issues:
   description: |-
     PLUGIN_NAME 1.15 and earlier does not validate file paths from the XML file it parses.
 
-    This allows attackers able to control the coverage report content to overwrite any file on the Jenkins master file system.
+    This allows attackers able to control the coverage report content to overwrite any file on the Jenkins controller file system.
 
     PLUGIN_NAME 1.16 sanitizes the file paths to prevent escape from the base directory.
   plugins:
@@ -135,7 +135,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials in its global configuration file `jenkins.plugins.logstash.LogstashConfiguration.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores credentials in its global configuration file `jenkins.plugins.logstash.LogstashConfiguration.xml` on the Jenkins controller as part of its configuration.
 
     While the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by PLUGIN_NAME 2.3.1 and earlier.
     This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -155,7 +155,7 @@ issues:
   description: |-
     PLUGIN_NAME 3.6.6 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.
 
-    This allows a user with Overall/Read access to have Jenkins parse a crafted HTTP request with XML data that uses external entities for extraction of secrets from the Jenkins master or server-side request forgery.
+    This allows a user with Overall/Read access to have Jenkins parse a crafted HTTP request with XML data that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.
 
     PLUGIN_NAME 3.6.7 disables external entity resolution for its XML parser.
   plugins:
@@ -171,7 +171,7 @@ issues:
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.9.1 and earlier stores its Zephyr password in plain text in the global configuration file `com.thed.zephyr.jenkins.reporter.ZeeReporter.xml`.
-    This password can be viewed by users with access to the Jenkins master file system.
+    This password can be viewed by users with access to the Jenkins controller file system.
 
     PLUGIN_NAME 1.10 integrates with plugin:credentials[Credentials Plugin].
   plugins:
@@ -220,7 +220,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials in its global configuration file `org.jvnet.hudson.plugins.repositoryconnector.RepositoryConfiguration.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores credentials in its global configuration file `org.jvnet.hudson.plugins.repositoryconnector.RepositoryConfiguration.xml` on the Jenkins controller as part of its configuration.
 
     While the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by PLUGIN_NAME 1.2.6 and earlier.
     This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -237,7 +237,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials in its global configuration file `org.quality.gates.jenkins.plugin.GlobalConfig.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores credentials in its global configuration file `org.quality.gates.jenkins.plugin.GlobalConfig.xml` on the Jenkins controller as part of its configuration.
 
     While the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by PLUGIN_NAME 1.3.1 and earlier.
     This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -254,7 +254,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials in its global configuration file `quality.gates.jenkins.plugin.GlobalConfig.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores credentials in its global configuration file `quality.gates.jenkins.plugin.GlobalConfig.xml` on the Jenkins controller as part of its configuration.
 
     While the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by PLUGIN_NAME 2.5 and earlier.
     This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -305,8 +305,8 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 1.5 and earlier stores Jira credentials unencrypted in its global configuration file `com.thed.zephyr.jenkins.reporter.ZfjReporter.xml` on the Jenkins master.
-    These credentials can be viewed by users with access to the master file system.
+    PLUGIN_NAME 1.5 and earlier stores Jira credentials unencrypted in its global configuration file `com.thed.zephyr.jenkins.reporter.ZfjReporter.xml` on the Jenkins controller.
+    These credentials can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -320,7 +320,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores credentials in its global configuration file `org.jenkinsci.plugins.openshift.DeployApplication.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores credentials in its global configuration file `org.jenkinsci.plugins.openshift.DeployApplication.xml` on the Jenkins controller as part of its configuration.
 
     While the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by PLUGIN_NAME 1.2.0 and earlier.
     This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -388,7 +388,7 @@ issues:
   description: |-
     PLUGIN_NAME 0.1.33 and earlier allows the configuration of an OS command to execute as part of its build step configuration.
 
-    This command will be executed on the Jenkins master as the OS user account running Jenkins, allowing user with Job/Configure permission to execute an arbitrary OS command on the Jenkins master.
+    This command will be executed on the Jenkins controller as the OS user account running Jenkins, allowing user with Job/Configure permission to execute an arbitrary OS command on the Jenkins controller.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2020-03-25.adoc
+++ b/content/security/advisory/2020-03-25.adoc
@@ -89,7 +89,7 @@ issues:
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     Artifactory Plugin 3.5.0 and earlier stores its Artifactory server password in plain text in the global configuration file `org.jfrog.hudson.ArtifactoryBuilder.xml`.
-    This password can be viewed by users with access to the Jenkins master file system.
+    This password can be viewed by users with access to the Jenkins controller file system.
 
     Artifactory Plugin 3.6.0 now stores the Artifactory server password encrypted.
     This change is effective once the global configuration is saved the next time.
@@ -100,7 +100,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores Artifactory server passwords in its global configuration file `org.jfrog.hudson.ArtifactoryBuilder.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores Artifactory server passwords in its global configuration file `org.jfrog.hudson.ArtifactoryBuilder.xml` on the Jenkins controller as part of its configuration.
 
     While the password is stored encrypted on disk since PLUGIN_NAME 3.6.0, it is transmitted in plain text as part of the configuration form by PLUGIN_NAME 3.6.0 and earlier.
     This can result in exposure of the password through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -198,7 +198,7 @@ issues:
   description: |-
     PLUGIN_NAME 4.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.
 
-    This allows a user able to control the input files for the 'RapidDeploy deployment package build' build or post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master, server-side request forgery, or denial-of-service attacks.
+    This allows a user able to control the input files for the 'RapidDeploy deployment package build' build or post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.
 
     PLUGIN_NAME 4.2.1 disables external entity resolution for its XML parser.
   plugins:

--- a/content/security/advisory/2020-04-07.adoc
+++ b/content/security/advisory/2020-04-07.adoc
@@ -12,7 +12,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
   description: |-
     PLUGIN_NAME 1.1.4 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.
-    This allows a user able to control the input files for the "Publish Coverage Report" post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master or server-side request forgery.
+    This allows a user able to control the input files for the "Publish Coverage Report" post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.
 
     PLUGIN_NAME 1.1.5 disables external entity resolution for its XML parser.
   plugins:

--- a/content/security/advisory/2020-04-16.adoc
+++ b/content/security/advisory/2020-04-16.adoc
@@ -12,7 +12,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 0.3 and earlier stores credentials unencrypted in job `config.xml` files as part of its configuration.
-    These credentials can be viewed by users with Extended Read permission or access to the master file system.
+    These credentials can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     PLUGIN_NAME 0.6.1 stores these credentials encrypted.
     This change is effective once the job configuration is saved the next time.
@@ -31,7 +31,7 @@ issues:
     PLUGIN_NAME implements a static analysis parser for various Parasoft products and integrates with plugin:warnings[Warnings Plugin] (10.4.1 and earlier) and plugin:warnings-ng[Warnings NG Plugin] (10.4.2 and newer).
 
     PLUGIN_NAME 10.4.3 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.
-    This allows a user able to control the input files for the Parasoft Findings parser to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins master or server-side request forgery.
+    This allows a user able to control the input files for the Parasoft Findings parser to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.
 
     PLUGIN_NAME 10.4.4 disables external entity resolution for its XML parser.
   plugins:

--- a/content/security/advisory/2020-06-03.adoc
+++ b/content/security/advisory/2020-06-03.adoc
@@ -107,7 +107,7 @@ issues:
     * Delete or replace the plugin configuration.
     * Start, stop, or restart Selenium configurations on specific nodes.
 
-    Through carefully chosen configuration parameters, these actions can result in OS command injection on the Jenkins master.
+    Through carefully chosen configuration parameters, these actions can result in OS command injection on the Jenkins controller.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -158,8 +158,8 @@ issues:
   description: |-
     A form validation endpoint in PLUGIN_NAME executes the `play` command to validate a given input file.
 
-    PLUGIN_NAME 1.0.2 and earlier lets users specify the path to the `play` command on the Jenkins master.
-    This results in an OS command injection vulnerability exploitable by users able to store such a file on the Jenkins master (e.g. through archiving artifacts).
+    PLUGIN_NAME 1.0.2 and earlier lets users specify the path to the `play` command on the Jenkins controller.
+    This results in an OS command injection vulnerability exploitable by users able to store such a file on the Jenkins controller (e.g. through archiving artifacts).
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2020-07-02.adoc
+++ b/content/security/advisory/2020-07-02.adoc
@@ -116,7 +116,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.7 and earlier stores a secret unencrypted in job `config.xml` files as part of its configuration.
-    This secret can be viewed by users with Extended Read permission or access to the master file system.
+    This secret can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -131,7 +131,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 2.4.1 and earlier stores a password unencrypted in job `config.xml` files as part of its configuration.
-    This password can be viewed by users with Extended Read permission or access to the master file system.
+    This password can be viewed by users with Extended Read permission or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -145,7 +145,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores Stash API passwords in its global configuration file `org.jenkinsci.plugins.StashBranchParameter.StashBranchParameterDefinition.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores Stash API passwords in its global configuration file `org.jenkinsci.plugins.StashBranchParameter.StashBranchParameterDefinition.xml` on the Jenkins controller as part of its configuration.
 
     While the password is stored encrypted on disk, it is transmitted in plain text as part of the configuration form by PLUGIN_NAME 0.3.0 and earlier.
     This can result in exposure of the password through browser extensions, cross-site scripting vulnerabilities, and similar situations.
@@ -180,7 +180,7 @@ issues:
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.8 and earlier stores a GitHub access token in plain text in its global configuration file `io.jenkins.plugins.gcr.PluginConfiguration.xml`.
-    This token can be viewed by users with access to the Jenkins master file system.
+    This token can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -194,8 +194,8 @@ issues:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 19.1.1 and earlier stores credentials in plain text as part of its global configuration file `org.whitesource.jenkins.pipeline.WhiteSourcePipelineStep.xml` and job `config.xml` files on the Jenkins master.
-    These credentials could be viewed by users with Extended Read permission (in the case of job `config.xml` files) or access to the master file system.
+    PLUGIN_NAME 19.1.1 and earlier stores credentials in plain text as part of its global configuration file `org.whitesource.jenkins.pipeline.WhiteSourcePipelineStep.xml` and job `config.xml` files on the Jenkins controller.
+    These credentials could be viewed by users with Extended Read permission (in the case of job `config.xml` files) or access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:
@@ -270,7 +270,7 @@ issues:
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
     PLUGIN_NAME 1.6 and earlier stores a password in plain text in its global configuration file `org.jenkinsci.plugins.qc.QualityCenterIntegrationRecorder.xml`.
-    This password can be viewed by users with access to the Jenkins master file system.
+    This password can be viewed by users with access to the Jenkins controller file system.
 
     As of publication of this advisory, there is no fix.
   plugins:

--- a/content/security/advisory/2020-08-12.adoc
+++ b/content/security/advisory/2020-08-12.adoc
@@ -58,7 +58,7 @@ issues:
     severity: Low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME stores an SMTP password in its global configuration file `hudson.plugins.emailext.ExtendedEmailPublisher.xml` on the Jenkins master as part of its configuration.
+    PLUGIN_NAME stores an SMTP password in its global configuration file `hudson.plugins.emailext.ExtendedEmailPublisher.xml` on the Jenkins controller as part of its configuration.
 
     While this password is stored encrypted on disk, it is transmitted and displayed in plain text as part of the configuration form by PLUGIN_NAME 2.72 and 2.73.
     This can result in exposure of the password.


### PR DESCRIPTION
Some of these I'm unsure about. We've used "Jenkins master" interchangeably for the system ("execute commands on the Jenkins master"), file system ("a file on the Jenkins master"), and the Java process.