### PR TITLE
Fix links to jenkinsci repos in table

### DIFF
--- a/content/doc/developer/publishing/source-code-hosting/forks.adoc
+++ b/content/doc/developer/publishing/source-code-hosting/forks.adoc
@@ -29,7 +29,7 @@ $(document).ready(function() {
             {
                 title: "Fork",
                 render: function(data, type, row, metadata) {
-                    return '<a href="https://github.com/jenkinsci/' + data + '" target="_blank">' + data + '</a>';
+                    return '<a href="https://github.com/' + data + '" target="_blank">' + data + '</a>';
                 }
             },
             {


### PR DESCRIPTION
The report already contains the org on the `jenkinsci` side, so adding this is redundant.

Thanks @aheritier for pointing it out.