### PR TITLE
Add update center as a self-hosted service

### DIFF
--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -108,6 +108,7 @@ Here is a non-exhaustive list of services that we provide and maintain.
 | https://issues.jenkins-ci.org[Jira]        | `jira`                    | https://github.com/jenkins-infra/jira[Docker]
 | http://mirrors.jenkins-ci.org/[Mirrors]    | `mirrors.jenkins.io`      | link:https://github.com/jenkins-infra/jenkins-infra[mirrors.jenkins.io Puppet scripts] (search for `mirrorbrain`), link:https://github.com/jenkins-infra/infra-mirror[Mirror scripts], link:http://mirrors.jenkins-ci.org/status.html[Status page], link:/download/mirrors/[Running a mirror]
 | https://stats.jenkins.io/[Stats]           |                           | https://github.com/jenkins-infra/infra-statistics[Code] published with GitHub pages
+| https://updates.jenkins.io[Update Center]  | `update-center`           | https://github.com/jenkins-infra/update-center2[Code]
 | VPN                                        | `vpn`                     | https://github.com/jenkins-infra/openvpn[Code]
 | https://wiki.jenkins.io[Wiki] (deprecated) | `wiki`                    | https://github.com/jenkins-infra/confluence[Docker]
 |===


### PR DESCRIPTION
Link to the GitHub repository for source code and to the update center site from the service name.