### PR TITLE
Recommend specific core versions for the dependency

### DIFF
--- a/content/_layouts/corebaseline.html.haml
+++ b/content/_layouts/corebaseline.html.haml
@@ -1,0 +1,31 @@
+---
+layout: developersection
+---
+
+:ruby
+    oldest_weekly = site._generated[:core_tiers].weeklyCores[0]
+
+    # For this file, assume that the the entries are in increasing order and get the second column (which is the last pre-split version)
+    # TODO Figure out a way to obtain this content differently, this is terrible
+    split_versions = open('https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/resources/jenkins/split-plugins.txt').read.lines.select { |l| l.strip.length > 0 && !(l.strip =~ /^#/) }.map { |l| l.split(' ')[1] }
+    latest_split = split_versions[-1]
+
+    lts = site._generated[:core_tiers].stableCores
+    oldest_lts = lts[0]
+
+    lts_1 = lts.select { |v| v =~ /.1$/ }
+
+    oldest_lts_1 = 'undefined'
+    next_lts_1 = 'undefined'
+    # Iterate in reverse order over all split versions, and choose the first set of releases with at least 2 LTS.1 releases that are newer
+    # This attempts to balance wanting few implied dependencies, but also not requiring a very recent core
+    split_versions.reverse_each do |split_version|
+        lts_1_split = lts_1.select { |v| Gem::Version.new(v) > Gem::Version.new("#{split_version}.999") }
+        if lts_1_split.length > 1
+            oldest_lts_1 = lts_1_split[0]
+            next_lts_1 = lts_1_split[1]
+            break
+        end
+    end
+
+= page.content.gsub('PLACEHOLDER_SECOND_OLDEST_LTS_POINT_ONE', next_lts_1).gsub('PLACEHOLDER_OLDEST_LTS_POINT_ONE', oldest_lts_1).gsub('PLACEHOLDER_OLDEST_LTS', oldest_lts).gsub('PLACEHOLDER_OLDEST_WEEKLY', oldest_weekly).gsub('PLACEHOLDER_LATEST_SPLIT', latest_split)

--- a/content/_layouts/corebaseline.html.haml
+++ b/content/_layouts/corebaseline.html.haml
@@ -13,7 +13,7 @@ layout: developersection
     lts = site._generated[:core_tiers].stableCores
     oldest_lts = lts[0]
 
-    lts_1 = lts.select { |v| v =~ /.1$/ }
+    lts_1 = lts.select { |v| v =~ /[.]1$/ }
 
     oldest_lts_1 = 'undefined'
     next_lts_1 = 'undefined'

--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -1,7 +1,8 @@
 ---
-layout: developersection
+layout: corebaseline
 title: Choosing a Jenkins version to build against
 ---
+// This file contains placeholders that are replaced in the Ruby script that's part of the 'corebaseline' layout.
 
 Your plugin's POM controls which version of Jenkins it is building/testing against.
 
@@ -13,14 +14,22 @@ You need to balance compatibility and features:
 In particular, the LTS Release Line is based on slightly older releases to provide a more stable experience for conservative users.
 * *Building against recent Jenkins versions* allows you to use recently added core features and API from your plugin. 
 You will also use that newer version for `mvn hpi:run`, so it may be easier to test your plugin with newer Jenkins releases. 
-Additionally, since features are sometimes moved from core into plugins, depending on a more recent Jenkins version will make your plugin's dependencies on what used to be core features explicit, otherwise your plugin will not work.
-* *Use at least the minimum version supported by the update center*, the supported update center versions can be found at link:https://updates.jenkins.io[updates.jenkins.io], at the time of writing (2020-03) this is 2.164.x.
+* *Do not use versions no longer supported by the update center*, which is currently anything older than PLACEHOLDER_OLDEST_WEEKLY for weekly releases, and PLACEHOLDER_OLDEST_LTS for LTS releases.
+* *Prefer ".1" LTS releases over weekly versions and later releases within an LTS line* for greater compatibility.
+  LTS releases with the same baseline usually don't have differences that would matter to plugin developers, and if they do, they may well behave differently on supposedly compatible weekly releases published shortly after the LTS baseline.
+* *Prefer releases that no longer result in implied plugin dependencies*.
+  Sometimes Jenkins core features are moved into plugins, and any plugin with a dependency on an older core release will have an _implied_ dependency on the new plugin.
+  This makes plugin management more difficult for administrators, so core dependencies should ideally be chosen so that there are no, or few, implied dependencies.
+  See https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/split-plugins.txt[split-plugins.txt] for details.
+  At this time, a dependency on Jenkins versions *newer than PLACEHOLDER_LATEST_SPLIT* will not result in such implied dependencies.
 
 There are link:https://stats.jenkins.io/pluginversions/[statistics of core versions by plugin] that can help you decide.
-
 These are updated monthly.
+When updating the core dependency, choose the link:/changelog-stable/[newest LTS version] that doesn't exclude a majority of your existing users (by requiring a newer Jenkins than they have).
 
-General tip: When upgrading, choose the link:/changelog-stable/[newest LTS version] that doesn't alienate the majority of users of your latest few releases (by requiring a newer Jenkins than they have).
+## Currently recommended versions
+
+At the moment, the Jenkins releases *PLACEHOLDER_OLDEST_LTS_POINT_ONE* and *PLACEHOLDER_SECOND_OLDEST_LTS_POINT_ONE* make good core dependencies unless there are specific reasons, like new features, to choose a different release.
 
 ## Changing the minimum required version
 

--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -38,6 +38,6 @@ Set the `jenkins.version` property in `pom.xml` to the version you need to depen
 [source,xml]
 ----
 <properties>
-  <jenkins.version>2.204.2</jenkins.version>
+  <jenkins.version>PLACEHOLDER_SECOND_OLDEST_LTS_POINT_ONE</jenkins.version>
 </properties>
 ----

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -51,6 +51,12 @@ RESOURCES = [
     nil
   ],
   [
+    'https://updates.jenkins.io/tiers.json',
+    'content/_data/_generated/core_tiers.yml',
+    nil,
+    nil
+  ],
+  [
     'https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/lastSuccessfulBuild/artifact/*.adoc/*zip*/extension-indexer.zip',
     'content/_tmp/extension-indexer.zip',
     nil,


### PR DESCRIPTION
Alternative to / parts to be reused in #3630 by @uhafner.

I basically wrote this just to demonstrate that we're now able to get update site tier metadata to make more specific recommendations as mentioned in https://github.com/jenkins-infra/jenkins.io/pull/3630#discussion_r470459441. Then I added `split-plugins.txt` and now it's essentially a fully automated recommendation engine for core baselines.

I updated the text a bit to make sense "standalone" with the recommendations given, but the script parts could just as easily be integrated into #3630.

> ![Screenshot](https://user-images.githubusercontent.com/1831569/90700932-60c1d700-e287-11ea-85f3-c377c0e17cc8.png)
