### PR TITLE
update system-properties.adoc documentation for historyWidget.descriptionLimit

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1254,6 +1254,18 @@ properties:
   description: |
     How many builds to show in the build history side panel widget.
 
+- name: historyWidget.descriptionLimit
+  tags:
+  - feature
+  - UI
+  def: |
+    `100`
+  since: 2.223
+  description: |
+    Defines a limit for the characters shown in the description field for each build row at the Build History column.
+    A positive Integer value (e.g. `300`) will define the limit, after that limit is reached (...) will be shown.
+    Value `-1` is for unlimited characters (disable). And `0` means No Description is shown.
+
 - name: HUDSON_HOME
   def: n/a
   tags:

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1262,9 +1262,11 @@ properties:
     `100`
   since: 2.223
   description: |
-    Defines a limit for the characters shown in the description field for each build row at the Build History column.
-    A positive Integer value (e.g. `300`) will define the limit, after that limit is reached (...) will be shown.
-    Value `-1` is for unlimited characters (disable). And `0` means No Description is shown.
+    Defines a limit for the characters shown in the description field for each build row in the Build History column.
+    A positive integer (e.g. `300`) will define the limit.
+    After the limit is reached (...) will be shown.
+    The value `-1` disables the limit and allows unlimited characters in the build description.
+    The value `0` shows no description.
 
 - name: HUDSON_HOME
   def: n/a


### PR DESCRIPTION
## Doc historyWidget.descriptionLimit ([JENKINS-61004](https://issues.jenkins-ci.org/browse/JENKINS-61004), [JENKINS-60299](https://issues.jenkins-ci.org/browse/JENKINS-60299), [PR-4529](https://github.com/jenkinsci/jenkins/pull/4529) )

since v2.223 this system property was set, and I could not find any documentation in which I could check what happened to all my truncated description builds since the update. I hope my contribution is helpful