### PR TITLE
Fix redirect URL for serialization of anonymous classes

### DIFF
--- a/content/redirect/serialization-of-anonymous-classes.adoc
+++ b/content/redirect/serialization-of-anonymous-classes.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes.adoc
+redirect_url: https://jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes/
 ---


### PR DESCRIPTION
#3378 accidentally broke the redirect URL when migrating the corresponding documentation from the wiki to jenkins.io.

The redirect link before this change (404): https://jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes.adoc

The redirect link after this change: https://jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes/

