### PR TITLE
Remove platformlabeler from Hacktoberfest list

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -170,21 +170,6 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:/projects/[subprojects], and plugins.
   You can also contribute new graphics to plugins.
 
-| link:https://github.com/jenkinsci/platformlabeler-plugin[Jenkins Platform Labeler Plugin]
-| Java
-| Contribute to the Platform Labeler plugin.
-  The plugin automatically labels agents by their operating system name, version, and processor architecture.
-  Add support for additional platforms
-  link:https://issues.jenkins-ci.org/browse/JENKINS-59478[Clear Linux],
-  link:https://issues.jenkins-ci.org/browse/JENKINS-59481[Fedora Linux],
-  link:https://issues.jenkins-ci.org/browse/JENKINS-59565[Linux Mint],
-  link:https://issues.jenkins-ci.org/browse/JENKINS-59566[Scientific Linux],
-  link:https://issues.jenkins-ci.org/browse/JENKINS-59479[Red Hat Enterprise Linux]. and
-  link:https://issues.jenkins-ci.org/browse/JENKINS-59480[SUSE Linux Enterprise Server].
-
-  link:https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md[Contributing],
-  link:https://github.com/jenkinsci/platformlabeler-plugin/blob/master/README.md[documentation],
-
 |=========================================================
 
 === Experienced developers


### PR DESCRIPTION
Last year's Hacktoberfest pull requests resolved the open issues and provided many more platforms in the plugin.

Please delete the branch after the merge