### PR TITLE
Fix for Jenkins install doc issue #3522

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -387,6 +387,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo yum upgrade
 sudo yum install jenkins java-1.8.0-openjdk-devel
+sudo systemctl daemon-reload
 ----
 
 ===== Weekly release
@@ -401,6 +402,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo yum upgrade
 sudo yum install jenkins java-1.8.0-openjdk-devel
+sudo systemctl daemon-reload
 ----
 
 ===== Start Jenkins


### PR DESCRIPTION
_Addition of step to run `sudo systemctl daemon-reload`_ 

This change includes addition of `sudo systemctl daemon-reload`  after `sudo yum install jenkins java-1.8.0-openjdk-devel` .  The `reload` will ask systemd to scan the system units as in this case, the installation of the Jenkins service did not cause systemctl to read the service.This is to fix [issue #3522] (https://github.com/jenkins-infra/jenkins.io/issues/3522)