### PR TITLE
[GSoC Project Page] Add phase 3 blog post link to the project page

### DIFF
--- a/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
+++ b/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
@@ -126,7 +126,7 @@ This phase marked the release of the git plugin with all of the performance impr
   - link:https://github.com/jenkinsci/git-plugin/pull/931[GitToolChooser]
   - link:https://github.com/jenkinsci/git-client-plugin/pull/594[Add UnsupportedCommand to the git client plugin]
   - link:https://github.com/jenkinsci/git-client-plugin/pull/601[Bug fix related to UnsupportedCommand]
-. Blog: TBA
+. link:/blog/2020/08/29/git-performance-improvement-phase3/[Coding phase 3 and releases blog]
 . link:https://docs.google.com/presentation/d/1rAjjF_pBjtGDaaC8rgReqVzd9WJ4Z0jZTvaPHabk3SI/edit?usp=sharing[Slides]
 . Phase 3 presentation and results
 


### PR DESCRIPTION
Update the GSoC 2020 Git Plugin Performance Improvement Project Page with the latest blog post link.