### PR TITLE
new location for list of supported versions

### DIFF
--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -14,7 +14,7 @@ In particular, the LTS Release Line is based on slightly older releases to provi
 * *Building against recent Jenkins versions* allows you to use recently added core features and API from your plugin. 
 You will also use that newer version for `mvn hpi:run`, so it may be easier to test your plugin with newer Jenkins releases. 
 Additionally, since features are sometimes moved from core into plugins, depending on a more recent Jenkins version will make your plugin's dependencies on what used to be core features explicit, otherwise your plugin will not work.
-* *Use at least the minimum version supported by the update center*, the supported update center versions can be found at link:https://updates.jenkins.io[updates.jenkins.io], at the time of writing (2020-03) this is 2.164.x.
+* *Use at least the minimum version supported by the update center*, the supported update center versions can be found at link:https://updates.jenkins.io/tiers.json[updates.jenkins.io/tiers.json], at the time of writing (2020-09-02) this is 2.176.2.
 
 There are link:https://stats.jenkins.io/pluginversions/[statistics of core versions by plugin] that can help you decide.
 


### PR DESCRIPTION
Following jenkins-infra/update-center2#424, the list of supported update center versions can't be found on https://updates.jenkins.io directly anymore (the Apache directory listing has been replaced by a documentation page).
The list can now be found in a `tiers.json` file instead.

Note that I've also updated the "*at the time of writing (2020-03) this is 2.164.x*" bit. I've used *2.176.2* rather than *2.176.x*, because it seems *2.176.1* is not in the supported versions list anymore, so *2.176.x* could have been misleading.

Which makes me think, btw, that it could be useful if this page could include a recommendation for the micro-version bit when picking an LTS Jenkins version: is it "better" to make my plugin depend on (for instance) *2.204.1* or *2.204.6*? (I don't have an answer, so I won't make a PR for that, just thinking aloud)