### PR TITLE
Custom distro: fix links to blog posts

### DIFF
--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -10,6 +10,7 @@ mentors:
 - "linuxsuren"
 - "kwhetstone"
 - "baymac"
+- "martinda"
 advisors:
 - "oleg_nenashev"
 links:

--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -60,7 +60,7 @@ The main idea behind the project is to build a customizable Jenkins distribution
   - https://sladyn98.netlify.app/blog/gsoc_week3/[Third week]
   - https://sladyn98.netlify.app/blog/gsoc_week2/[Second week]
   - https://sladyn98.netlify.app/blog/gsoc_week1/[First week]
-  - https://www.jenkins.io/blog/2020/07/27/custom-distribution-service/[Mid-term report]
+  - link:/blog/2020/07/27/custom-distribution-service/[Mid-term report]
   . Demo: https://www.youtube.com/watch?v=HQLhakpx5mk
   . link:https://docs.google.com/presentation/d/1qjlpiabrRrYANHcCU9xwUZCfMuv5g0hbilAjglu98O0/edit?usp=sharing[Slides]
 
@@ -91,8 +91,8 @@ UI -> Config -> War Package
 ==== Resources
 
   . Blogs
-  - https://www.jenkins.io/blog/2020/07/27/custom-distribution-service/[Mid-term report]
-  - https://www.jenkins.io/blog/2020/08/09/custom-distribution-service-phase-2/[Phase two Blog]
+  - link:/blog/2020/07/27/custom-distribution-service/[Mid-term report]
+  - link:/blog/2020/08/09/custom-distribution-service-phase-2/[Phase two Blog]
   . Demo: https://www.youtube.com/watch?v=oSBvJwSXOVQ&t=360s
   . link:https://docs.google.com/presentation/d/1qjlpiabrRrYANHcCU9xwUZCfMuv5g0hbilAjglu98O0/edit?usp=sharing[Slides]
 
@@ -121,7 +121,7 @@ UI -> Config -> War Package
 ==== Resources
 
   . link:https://docs.google.com/presentation/d/1f7dtFCEtYYMkJkSX2LRvIKExTCWOPL47MgJhRljLxTo/edit?usp=sharing[Slides]
-  . link:https://github.com/jenkins-infra/jenkins.io/pull/3640[Blog Post]
+  . link:/blog/2020/08/31/custom-distribution-service/[Blog Post]
 
 === Roadmap 
 


### PR DESCRIPTION
1. Fixing the link to phase 3 blog post (was pointing to PR instead of blog post itself).
1. Made links to jenkins.io using relative links.
1. Add myself to list of mentors for the record

CC @sladyn98 @kwhetstone 