### PR TITLE
Add statusFilter and alternate URL to 2.249.1 upgrade guide

### DIFF
--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -121,10 +121,10 @@ io.jenkins.plugins.casc.ConfiguratorException: 'statusFilter' is deprecated
 ==== Alternate URL removed from inbound agent
 
 Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch file (the `slave-agent.jnlp` file).
-Prior releases allowed the administrator to configure a second URL for inbound agents that was different from the Jenkins root URL.
-If the root URL was unreachable by the agent, the second URL was used.
+Prior releases included an alternate URL in the inbound agent launch file when the launch file was requested through a URL that is not the Jenkins root URL.
+If the Jenkins root URL was unreachable by the agent, the alternate URL was used.
 
-With Jenkins 2.249.1, the alternate URL must be provided as an argument to the `agent.jar` command.
+The alternate URL must be provided as an argument to the `agent.jar` command for Jenkins 2.249.1 and later.
 The inbound agent can connect to the alternate URL using commands like this:
 
 [source,bash]

--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -124,7 +124,28 @@ Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch fi
 Prior releases allowed the administrator to configure a second URL for inbound agents that was different from the Jenkins root URL.
 If the root URL was unreachable by the agent, the second URL was used.
 
-If the Jenkins root URL is not accessible to an inbound agent, the agent must connect through TCP using options available from `agent.jar`.
+With Jenkins 2.249.1, the alternate URL must be provided as an argument to the `agent.jar` command.
+The inbound agent can connect to the alternate URL using commands like this:
+
+[source,bash]
+----
+$ WORKDIR=<work-dir-from-agent-definition-page>
+$ ALTERNATE_URL=<alternate-url-used-to-access-Jenkins>
+$ SECRET_STRING=<secret-from-agent-definition-page>
+$ AGENT_NAME=<agent-name-from-agent-definition-page>
+$ java -cp agent.jar hudson.remoting.jnlp.Main \
+  -headless \
+  -workDir $WORKDIR \
+  -url $ALTERNATE_URL \
+  $SECRET_STRING \
+  $AGENT_NAME
+----
+
+////
+// This section describes a capability that is unchanged from previous releases.
+// Intentionally commented so it is not included in the document
+
+If an alternate URL is *not* accessible to an inbound agent, the agent must connect using the `-direct` TCP option available from `agent.jar`.
 TCP inbound agent connection is more complicated than the typical inbound agent connection because it requires the instance identity in addition to the usual inbound agent data.
 
 Obtain the instance identity from the link:/doc/book/managing/script-console/[Jenkins groovy script console] using the instructions in the link:https://github.com/jenkinsci/remoting/blob/master/docs/inbound-agent.md#connect-directly-to-tcp-port[inbound agent documentation].
@@ -136,14 +157,12 @@ def id=org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get()
 hudson.remoting.Base64.encode(id.getPublic().getEncoded())
 ----
 
-Obtain the secret string and agent name from the Jenkins agent definition page.
-
 Start the agent by using those values in a script like this:
 
 [source,bash]
 ----
-$ WORKDIR=/home/agent/workdir
-$ HOST_PORT=localhost:50000
+$ WORKDIR=<work-dir-from-agent-definition-page>
+$ HOST_PORT=<hostname-and-port-number-from-Jenkins-configuration>
 $ INSTANCE_IDENTITY=<value-from-groovy-script-console>
 $ SECRET_STRING=<secret-from-agent-definition-page>
 $ AGENT_NAME=<agent-name-from-agent-definition-page>
@@ -151,8 +170,10 @@ $ java -cp agent.jar hudson.remoting.jnlp.Main \
   -headless \
   -workDir $WORKDIR \
   -direct $HOST_PORT \
-  -protocols JNLP4-connect \
   -instanceIdentity $INSTANCE_IDENTITY \
   $SECRET_STRING \
   $AGENT_NAME
 ----
+
+// End of intentionally commented section
+////

--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -59,3 +59,31 @@ the following extra upgrade steps are required:
 2. Upgrade agents with .NET Framework 4.0+ by downloading the recent Windows Service Wrapper 2.x
   version from link:https://github.com/winsw/winsw/releases[WinSW GitHub Releases]
   and manually replacing the wrapper ".exe" files in the agent workspaces.
+
+==== View statusFilter removed from configuration as code
+
+As part of a performance improvement for list views, the `statusFilter` key has been removed from the Jenkins view configuration.
+Administrators with the `statusFilter` key in their link:https://plugins.jenkins.io/configuration-as-code/[configuration as code] YAML files will need to remove that key as part of their upgrade to Jenkins 2.249.1.
+
+If the  `statusFilter` key is not removed from the YAML file, Jenkins halts during startup with a stack trace.
+The initial section of the failure stack trace looks like this:
+
+.Configuration as code stack trace
+----
+SEVERE  jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
+io.jenkins.plugins.casc.ConfiguratorException: 'statusFilter' is deprecated
+        at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:321)
+        at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:270)
+        ...
+----
+
+==== Alternate URL removed from inbound agent
+
+Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch file.
+Prior releases allowed the administrator to configure a second URL for inbound agents that was different from the Jenkins root URL.
+If the root URL was unreachable by the agent, the second URL was used.
+
+Jenkins includes automatic reverse proxy configuration warnings if the root URL is not configured or is configured incorrectly.
+An alternate URL to connect to the Jenkins server should only be needed in very rare cases.
+
+When an alternate URL is required, the "Tunnel connection through" option that is part of "Advanced" agent configuration can provide an alternate address and port to be used instead of the Jenkins root URL.

--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -120,7 +120,7 @@ io.jenkins.plugins.casc.ConfiguratorException: 'statusFilter' is deprecated
 
 ==== Alternate URL removed from inbound agent
 
-Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch file (the "slave-agent.jnlp" file).
+Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch file (the `slave-agent.jnlp` file).
 Prior releases allowed the administrator to configure a second URL for inbound agents that was different from the Jenkins root URL.
 If the root URL was unreachable by the agent, the second URL was used.
 

--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -120,11 +120,39 @@ io.jenkins.plugins.casc.ConfiguratorException: 'statusFilter' is deprecated
 
 ==== Alternate URL removed from inbound agent
 
-Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch file.
+Jenkins 2.249.1 no longer provides a fallback URL in the inbound agent launch file (the "slave-agent.jnlp" file).
 Prior releases allowed the administrator to configure a second URL for inbound agents that was different from the Jenkins root URL.
 If the root URL was unreachable by the agent, the second URL was used.
 
-Jenkins includes automatic reverse proxy configuration warnings if the root URL is not configured or is configured incorrectly.
-An alternate URL to connect to the Jenkins server should only be needed in very rare cases.
+If the Jenkins root URL is not accessible to an inbound agent, the agent must connect through TCP using options available from `agent.jar`.
+TCP inbound agent connection is more complicated than the typical inbound agent connection because it requires the instance identity in addition to the usual inbound agent data.
 
-When an alternate URL is required, the "Tunnel connection through" option that is part of "Advanced" agent configuration can provide an alternate address and port to be used instead of the Jenkins root URL.
+Obtain the instance identity from the link:/doc/book/managing/script-console/[Jenkins groovy script console] using the instructions in the link:https://github.com/jenkinsci/remoting/blob/master/docs/inbound-agent.md#connect-directly-to-tcp-port[inbound agent documentation].
+An example groovy script to report instance identity looks like this:
+
+[source,groovy]
+----
+def id=org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get()
+hudson.remoting.Base64.encode(id.getPublic().getEncoded())
+----
+
+Obtain the secret string and agent name from the Jenkins agent definition page.
+
+Start the agent by using those values in a script like this:
+
+[source,bash]
+----
+$ WORKDIR=/home/agent/workdir
+$ HOST_PORT=localhost:50000
+$ INSTANCE_IDENTITY=<value-from-groovy-script-console>
+$ SECRET_STRING=<secret-from-agent-definition-page>
+$ AGENT_NAME=<agent-name-from-agent-definition-page>
+$ java -cp agent.jar hudson.remoting.jnlp.Main \
+  -headless \
+  -workDir $WORKDIR \
+  -direct $HOST_PORT \
+  -protocols JNLP4-connect \
+  -instanceIdentity $INSTANCE_IDENTITY \
+  $SECRET_STRING \
+  $AGENT_NAME
+----

--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -62,10 +62,51 @@ the following extra upgrade steps are required:
 
 ==== View statusFilter removed from configuration as code
 
-As part of a performance improvement for list views, the `statusFilter` key has been removed from the Jenkins view configuration.
-Administrators with the `statusFilter` key in their link:https://plugins.jenkins.io/configuration-as-code/[configuration as code] YAML files will need to remove that key as part of their upgrade to Jenkins 2.249.1.
+As part of a performance improvement for list views, the `statusFilter` key is now an optional, separate item in the Jenkins view configuration.
+The `statusFilter` key in link:https://plugins.jenkins.io/configuration-as-code/[configuration as code] view definitions will need to be removed or replaced with a new entry as part of the upgrade to Jenkins 2.249.1.
 
-If the  `statusFilter` key is not removed from the YAML file, Jenkins halts during startup with a stack trace.
+Previous configuration::
+The previous configuration looked like this:
++
+----
+  views:
+  - list:
+      columns:
+      - "status"
+      - "weather"
+      - "jobName"
+      description: "Jobs failing recently"
+      jobFilters:
+      - jobStatusFilter:
+          aborted: true
+          failed: true
+          includeExcludeTypeString: "includeMatched"
+      name: "Failed Jobs"
+      statusFilter: true # This must be removed
+----
+
+New configuration::
+The new configuration looks like this:
++
+----
+  views:
+  - list:
+      columns:
+      - "status"
+      - "weather"
+      - "jobName"
+      description: "Jobs failing recently"
+      jobFilters:
+      - jobStatusFilter:
+          aborted: true
+          failed: true
+          includeExcludeTypeString: "includeMatched"
+      - statusFilter: # This is the replacement section
+          statusFilter: true
+      name: "Failed Jobs"
+----
+
+If the  `statusFilter` key is not updated or removed from the YAML file, Jenkins halts during startup with a stack trace.
 The initial section of the failure stack trace looks like this:
 
 .Configuration as code stack trace


### PR DESCRIPTION
## Add [statusFilter](https://issues.jenkins-ci.org/browse/JENKINS-63656) and [alternate URL](https://issues.jenkins-ci.org/browse/JENKINS-63646) notes to [2.249.1 upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.249/#upgrading-to-jenkins-lts-2-249-1)

[JENKINS-63656](https://issues.jenkins-ci.org/browse/JENKINS-63656) reports that agents cannot connect to Jenkins 2.249.1 if they rely on the second URL that was previously provided to inbound agents.  The second URL has been intentionally removed in [PR-4839](https://github.com/jenkinsci/jenkins/pull/4839) for websocket compatibility.  Users will need to change their agent configuration to use the "Tunnel connection through" option in the "Advanced" section of the inbound agent configuration.

[JENKINS-63646](https://issues.jenkins-ci.org/browse/JENKINS-63646) reports that the `statusFilter` key has been removed from the configuration as code definition.  It was removed as part of list view performance improvements in [PR-4466](https://github.com/jenkinsci/jenkins/pull/4466).  Administrators will need to remove that key and its value from their configuration as code files before they run Jenkins 2.249.1.

I'd appreciate a review from @res0nance and @jglick to assure that I've correctly described the upgrade paths.

This is how the page renders on my screen:

![screencapture-localhost-4242-doc-upgrade-guide-2-249-2020-09-17-06_12_33](https://user-images.githubusercontent.com/156685/93469261-7d185a00-f8ad-11ea-8bdf-6c53984d77dc.png)
