### PR TITLE
[GSoC 2020] - Park GSoC pages and update the project statuses

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -53,14 +53,6 @@ homepage: true
   :image => {:src => expand_link('images/cdf/logo/cdf-logo-white.png'), :height => "250px"},
   :call_to_action => {:text => 'Learn about CDF', :href => 'https://cd.foundation'}}
 
-// TODO(oleg-nenashev): Replace on May 4 with announcement link
--# GSoC 2020
-- slides << {:href => expand_link('projects/gsoc/'),
-  :title => 'GSoC 2020 projects are announced!',
-  :intro => "We will have 7 Google Summer of Code projects: GitHub Checks API integrations, Git Plugin Performance, plugins for Machine Learning, External Fingerprint Storage, Windows Services, Custom Jenkins Distribution build service and Jenkins X. Please welcome all GSoC students and mentors!",
-  :image => {:src => expand_link('images/gsoc/jenkins-gsoc-transparent.png'), :height => "300px"},
-  :call_to_action => {:text => 'More info', :href => expand_link('projects/gsoc/')}}
-
 -# Case Studies
 - slides << {:href => 'https://JenkinsIsTheWay.io/',
   :title => 'Jenkins is the Way!',

--- a/content/projects/gsoc/2020/index.adoc
+++ b/content/projects/gsoc/2020/index.adoc
@@ -1,4 +1,59 @@
 ---
-layout: redirect
-redirect_url: /projects/gsoc
+layout: project
+title: "Jenkins in Google Summer of Code 2020"
+tags:
+- gsoc
+- gsoc2020
+project: gsoc
 ---
+
+The Jenkins project participated in Google Summer of Code 2020.
+This page contains an archive of the 2019-specific information.
+See the link:/projects/gsoc/[main GSoC page] for the actual information.
+
+== Projects
+
+All seven projects have been successfully completed in 2020.
+You can find the project information on the project pages:
+
+* link:/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service[Custom Jenkins distribution build service] by link:/blog/authors/sladyn98[Sladyn Nunes]
+* link:/projects/gsoc/2020/projects/external-fingerprint-storage[External Fingerprint Storage] by link:/blog/authors/stellargo[Sumit Sarin]
+* link:/projects/gsoc/2020/projects/git-plugin-performance[Git Plugin Performance Improvements] by link:/blog/authors/rishabhbudhouliya[Rishabh Budhouliya]
+* link:/projects/gsoc/2020/projects/github-checks[GitHub Checks API for Jenkins Plugins] by link:/blog/authors/XiongKezhi[Kezhi Xiong]
+* link:/projects/gsoc/2020/projects/jenkins-x-apps-consolidation[Jenkins X: Apps/Addons consolidation] by link:/blog/authors/nodece[Zixuan Liu]
+* link:/projects/gsoc/2020/projects/machine-learning[Machine Learning Plugins for Data Science] by link:/blog/authors/loghijiaha[Loghi Perinpanayagam]
+* link:/projects/gsoc/2020/projects/winsw-yaml-configs[Jenkins Windows Services: YAML Configuration Support] by link:/blog/authors/buddhikac96[Buddhika Chathuranga]
+
+== Demos and results
+
+* link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNZ9rU46k0uT14KAcq3_z68[Final project demos]
+* link:https://docs.google.com/presentation/d/13vbGLENYbZI1cP4AdLz0G_NwRV4Z_y_FeRNsPqsWQEs/edit?usp=sharing[GSoC 2020 summary slides]
+* Summary blogpost is coming soon
+
+== Retrospective
+
+Organization-level retrospective is available in link:https://docs.google.com/document/d/1NIszUtuXmHiu8X2WrgAEQFK6aVodsmM4I0RSNRf4TS0/edit?usp=sharing[this document].
+Project-level retrospectives were conducted by the project teams,
+and they are not public unless referenced from the project pages.
+
+[#orgadmin]
+== Org admins
+
+GSoC Organization admins in 2020 (the list is a subject to change):
+link:/blog/authors/martinda[Martin d'Anjou],
+link:/blog/authors/markyjackson-taulia/[Marky Jackson],
+link:/blog/authors/oleg_nenashev[Oleg Nenashev],
+link:/blog/authors/marckk[Kara de la Marck].
+
+Jenkins Org Admins mailing list: `jenkins-gsoc2020-org-admins@googlegroups.com`.
+Use this mailing list if you need to discuss something privately with org admins, such as communication difficulties
+with mentors, students, or other org admins.
+For all other use-cases,
+use public contacts listed link:/projects/gsoc/#contacts[here].
+
+== Other materials
+
+* link:/projects/gsoc/2020/project-ideas[GSoC 2020 project ideas]
+* link:/projects/gsoc/2020/application[GSoC 2020 application and organization profile]
+* link:/blog/2019/12/20/call-for-mentors/[Call for project ideas and mentors]
+* link:https://summerofcode.withgoogle.com/organizations/4945163270488064/[Jenkins organization page on the GSoC 2020 website]

--- a/content/projects/gsoc/2020/index.adoc
+++ b/content/projects/gsoc/2020/index.adoc
@@ -8,7 +8,7 @@ project: gsoc
 ---
 
 The Jenkins project participated in Google Summer of Code 2020.
-This page contains an archive of the 2019-specific information.
+This page contains an archive of the 2020-specific information.
 See the link:/projects/gsoc/[main GSoC page] for the actual information.
 
 == Projects
@@ -39,7 +39,7 @@ and they are not public unless referenced from the project pages.
 [#orgadmin]
 == Org admins
 
-GSoC Organization admins in 2020 (the list is a subject to change):
+GSoC Organization admins in 2020:
 link:/blog/authors/martinda[Martin d'Anjou],
 link:/blog/authors/markyjackson-taulia/[Marky Jackson],
 link:/blog/authors/oleg_nenashev[Oleg Nenashev],

--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -4,7 +4,7 @@ title: "Custom Jenkins distribution build service"
 goal: "Provide an out of the box solution for packaging Jenkins distributions as WAR files or Docker images"
 category: Tools
 year: 2020
-status: "Active"
+status: "Completed"
 student: sladyn98
 mentors:
 - "linuxsuren"

--- a/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
+++ b/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
@@ -5,7 +5,7 @@ goal: "Extend Jenkins to support storing artifact usage history in external data
 category: Core
 year: 2020
 sig: cloud-native
-status: "Active"
+status: "Completed"
 student: stellargo
 mentors:
 - "oleg_nenashev"

--- a/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
+++ b/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
@@ -4,7 +4,7 @@ title: "Git Plugin Performance Improvements"
 goal: "Enhance user experience by enabling faster checkouts"
 category: Plugins
 year: 2020
-status: "Active"
+status: "Completed"
 sig: platform
 tags:
 - gsoc2020

--- a/content/projects/gsoc/2020/projects/github-checks.adoc
+++ b/content/projects/gsoc/2020/projects/github-checks.adoc
@@ -4,7 +4,7 @@ title: "GitHub Checks API for Jenkins Plugins"
 goal: "Create a new plugin API so that plugins can publish GitHub checks status messages"
 category: Plugins
 year: 2020
-status: "Active"
+status: "Completed"
 sig: platform
 student: XiongKezhi
 mentors:

--- a/content/projects/gsoc/2020/projects/jenkins-x-apps-consolidation.adoc
+++ b/content/projects/gsoc/2020/projects/jenkins-x-apps-consolidation.adoc
@@ -4,7 +4,7 @@ title: "Jenkins X: Consolidate the use of Apps / Addons"
 goal: "Consolidate Apps and Addons inside Jenkins X"
 category: Jenkins X
 year: 2020
-status: "Active"
+status: "Completed"
 student: nodece
 mentors:
 - "marckk"

--- a/content/projects/gsoc/2020/projects/machine-learning.adoc
+++ b/content/projects/gsoc/2020/projects/machine-learning.adoc
@@ -4,7 +4,7 @@ title: "Machine Learning Plugins for Data Science"
 goal: "Create a new plugin for integrating Jenkins with one of Machine Learning tools (e.g. Jupyter Python, TensorBoard, or Sacred)"
 category: Plugins
 year: 2020
-status: "Active"
+status: "Completed"
 sig: pipeline-authoring
 student: loghijiaha
 mentors:

--- a/content/projects/gsoc/2020/projects/winsw-yaml-configs.adoc
+++ b/content/projects/gsoc/2020/projects/winsw-yaml-configs.adoc
@@ -4,7 +4,7 @@ title: "Jenkins Windows Services: YAML Configuration Support"
 goal: "Enhance Jenkins master and agent service management on Windows by offering new configuration file formats and improving settings validation"
 category: Core, Tools
 year: 2020
-status: "Active"
+status: "Completed"
 sig: platform
 student: buddhikac96
 mentors:

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -89,7 +89,7 @@ project proposal questions and discussions, process and timeline related questio
 difficulties with mentors, students, or org admins, please use the admin mailing list shown link:#orgadmin[below].
 
 1. To start, you need a Google or Gmail account
-2. After clicking above the link, a "Sign in" button appears in top-right of the page
+2. After clicking the link, a "Sign in" button appears in the top-right of the page
 3. After sign in, a "Join group" button appears in the middle of the page
 4. To learn more about joining a Google Group, please see https://support.google.com/groups/answer/1067205
 

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -28,10 +28,15 @@ in completing their summer projects.
 
 == GSoC 2020
 
-Jenkins participates in the GSoC program in 2020.
+Jenkins participated in the GSoC program in 2020.
 Below you can find links to the ongoing projects and other materials.
 
-== Projects
+NOTE: **Google Sumer of Code 2020 is over!** 
+Join us for GSoC 2021 next year, this page will be updated soon to reflect information for this year.
+If you are interested to propose a project idea as a potential mentor or a student, no need to wait.
+Follow the guidelines link:/projects/gsoc/proposing-project-ideas[here]. 
+
+=== Projects
 
 * link:/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service[Custom Jenkins distribution build service] by link:/blog/authors/sladyn98[Sladyn Nunes]
 * link:/projects/gsoc/2020/projects/external-fingerprint-storage[External Fingerprint Storage] by link:/blog/authors/stellargo[Sumit Sarin]
@@ -43,9 +48,14 @@ Below you can find links to the ongoing projects and other materials.
 
 You can also find these projects on the link:https://summerofcode.withgoogle.com/organizations/4945163270488064/[GSoC website].
 
+=== References
+
+* link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNZ9rU46k0uT14KAcq3_z68[Final project demos]
+* link:https://docs.google.com/presentation/d/13vbGLENYbZI1cP4AdLz0G_NwRV4Z_y_FeRNsPqsWQEs/edit?usp=sharing[GSoC 2020 summary slides]
+* Summary blogpost is coming soon
+
 == Students
 
-* link:/projects/gsoc/2020/project-ideas[GSoC 2020 project ideas]
 * link:/projects/gsoc/students[Information and application guidelines for students]
 * Online Meetup: Introduction to Jenkins in GSoC 
 (link:http://bit.ly/jenkins-gsoc2020-intro[slides],
@@ -56,14 +66,9 @@ link:https://youtu.be/qokQu7QbbZA[video])
 == Mentors
 
 * link:/projects/gsoc/mentors[Information for mentors]
-* link:/blog/2019/12/20/call-for-mentors/[Call for mentors]
 * link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
 * link:/projects/gsoc/roles-and-responsibilities[Roles and Responsibilities]
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
-
-== Other information
-
-* link:/projects/gsoc/2020/application[GSoC 2020 application and organization profile]
 
 == Contacts
 
@@ -84,53 +89,35 @@ project proposal questions and discussions, process and timeline related questio
 difficulties with mentors, students, or org admins, please use the admin mailing list shown link:#orgadmin[below].
 
 1. To start, you need a Google or Gmail account
-2. After clicking above link, a "Sign in" button appears in top-right of page
-3. After sign in, a "Join group" button appears in middle of page
+2. After clicking above the link, a "Sign in" button appears in top-right of the page
+3. After sign in, a "Join group" button appears in the middle of the page
 4. To learn more about joining a Google Group, please see https://support.google.com/groups/answer/1067205
 
 === Chats
 
-** link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topics
-** Project chats for project idea discussions.
-   Each project idea references a recommended chat in the description.
-** link:/chat/[Common developer chats] for technical topics
+* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topics
+* Project-specific chats, see project and project idea pages
+* link:/chat/[Common developer chats] for technical topics
 
 === Office hours
 
 Although we use mailing lists as the main communication channel,
 we also have regular "office hours" video calls.
 During these timeslots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
+Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
 
 Before the announcement of accepted projects,
 we will be using a weekly link:/sigs/gsoc[GSoC SIG] meeting as the office hours slot (3PM UTC on Wednesdays).
 You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
-
-More slots may be added in the future, e.g. for project-specific discussions.
-We post links in link:https://gitter.im/jenkinsci/gsoc-sig[our Gitter channel]
-before the meeting starts.
-Meetings are recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
+More slots may be added on-demand, e.g. for project-specific discussions.
 
 In addition to these organization-wide meetings,
 each GSoC project has regular meetings during community bonding and coding phases.
 See the project pages for the schedule.
 
-[#orgadmin]
-== Org admins
-
-GSoC Organization admins in 2020 (the list is a subject to change):
-link:/blog/authors/martinda[Martin d'Anjou],
-link:/blog/authors/markyjackson-taulia/[Marky Jackson],
-link:/blog/authors/oleg_nenashev[Oleg Nenashev],
-link:/blog/authors/marckk[Kara de la Marck].
-
-Jenkins Org Admins mailing list: `jenkins-gsoc2020-org-admins@googlegroups.com`.
-Use this mailing list if you need to discuss something privately with org admins, such as communication difficulties
-with mentors, students, or other org admins.
-For all other use-cases,
-use public contacts listed link:/projects/gsoc/#contacts[here].
-
 == Previous years
 
+* link:/projects/gsoc/2020[GSoC 2020] - 7 student projects
 * link:/projects/gsoc/2019[GSoC 2019] - 7 student projects
 * link:/projects/gsoc/2018[GSoC 2018] - 3 student projects
 * link:/projects/gsoc/gsoc2017[GSoC 2017] - not accepted
@@ -141,8 +128,6 @@ use public contacts listed link:/projects/gsoc/#contacts[here].
 
 You can find more information about GSoC in Jenkins below.
 
-* link:https://summerofcode.withgoogle.com/organizations/4945163270488064/[Jenkins organization page on the GSoC website]
 * link:/sigs/gsoc[Jenkins GSoC Special Interest Group]
 * link:/sigs/advocacy-and-outreach/outreach-programs/[Other outreach programs in Jenkins]
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
-


### PR DESCRIPTION
- [x] - Park Google Summer of Code 2020, archive the year-specific information 
- [x] - Update project statuses
- [x] - Remove obslete jumbotron