### PR TITLE
Update Google Season of Docs pages inside Docs SIG

### DIFF
--- a/content/sigs/docs/gsod/ideas.adoc
+++ b/content/sigs/docs/gsod/ideas.adoc
@@ -13,9 +13,9 @@ GSoD in Jenkins is organized by the link:/sigs/docs[Documentation special intere
 
 == Project ideas
 
-We invite technical writers to contribute to a major documentation update effort being coordinated in the documentation SIG.
-It includes a number of link:/sigs/docs/#ongoing-projects[ongoing projects],
-and technical writers are welcome to make their proposals in any area of the Jenkins documentation.
+We invite technical writers to contribute to a major documentation update effort being coordinated in the link:/sigs/docs/[Documentation SIG].
+It includes a number of link:/sigs/docs/#ongoing-projects[ongoing projects].
+Technical writers are welcome to make their proposals in any area of the Jenkins documentation.
 We encourage proposals based on a technical writer's expertise and interests.
 
 [frame="topbot",grid="all",options="header",cols="30%,15%,55%"]
@@ -49,7 +49,7 @@ link:/sigs/docs/#user-guide[More info]
 | AsciiDoc, Guide
 | Jenkins project has several link:/solutions/[solution pages] for various use-cases.
   We invite technical writers to create new solution pages for various use-cases (e.g. Documentation as code, Continuous Deployment, Static Analysis)
-  or technologies (Git, Gitlab, Kubernetes, etc.).
+  or technologies (Git, GitLab, Kubernetes, etc.).
   Existing pages were created several years ago, and they could be also updated.
   There are a lot of materials available on the web, but having dedicated solution pages could help users to discover such materials.
   link:/sigs/docs/#solution-pages[More info]

--- a/content/sigs/docs/gsod/ideas.adoc
+++ b/content/sigs/docs/gsod/ideas.adoc
@@ -1,0 +1,57 @@
+---
+layout: simplepage
+title: "Google Season of Docs Ideas"
+section: gsod
+---
+
+image:/images/gsod/gsod.png[Google Season of Docs, role=center, float=right]
+
+The https://developers.google.com/season-of-docs/[Google Season of Docs (GSoD)]
+program brings together open source and technical writers communities for the benefit of both.
+The program raises awareness of open source, of docs, and of technical writing.
+GSoD in Jenkins is organized by the link:/sigs/docs[Documentation special interest group].
+
+== Project ideas
+
+We invite technical writers to contribute to a major documentation update effort being coordinated in the documentation SIG.
+It includes a number of link:/sigs/docs/#ongoing-projects[ongoing projects],
+and technical writers are welcome to make their proposals in any area of the Jenkins documentation.
+We encourage proposals based on a technical writer's expertise and interests.
+
+[frame="topbot",grid="all",options="header",cols="30%,15%,55%"]
+|=========================================================
+|Project idea | Keywords | Description and links
+
+| Plugin documentation migration and update
+| Markdown, GitHub, Plugins, Rewrite, Copy-editing
+| Currently we are migrating our plugin documentation from link:https://wiki.jenkins.io/[Confluence] to GitHub,
+  see link:/blog/2019/10/21/plugin-docs-on-github/[this blog post] for announcement.
+  We have already moved hundreds of pages, but there are more than 1000 pages remaining.
+  Migration itself can be done with automated tools we provide, but the documentation usually needs a significant update due to new features.
+  We invite technical writers to select an area (e.g. "plugins for Docker"), and work closely with plugin maintainers to migrate and update documentation in such an area.
+  link:/sigs/docs/#plugin-documentation-on-github[More Info]
+
+| Document Jenkins on Kubernetes
+| AsciiDoc, Guide, Compilation, Kubernetes
+| Jenkins on Kubernetes is a popular theme for Jenkins users.
+  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need a central location for documentation describing Jenkins on Kubernetes.
+  We would like to create new documentation which would describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
+  link:/sigs/docs/#jenkins-on-kubernetes[More Info]
+
+| Jenkins user documentation reorganization and update
+| AsciiDoc, Guide, Rewrite
+| Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook], and are frequently received to improve the user documentation.
+Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
+The main aim of this project would be to  restructure content to make it more discoverable and easy to read.
+link:/sigs/docs/#user-guide[More info]
+
+| Create new solution pages for Jenkins use-cases
+| AsciiDoc, Guide
+| Jenkins project has several link:/solutions/[solution pages] for various use-cases.
+  We invite technical writers to create new solution pages for various use-cases (e.g. Documentation as code, Continuous Deployment, Static Analysis)
+  or technologies (Git, Gitlab, Kubernetes, etc.).
+  Existing pages were created several years ago, and they could be also updated.
+  There are a lot of materials available on the web, but having dedicated solution pages could help users to discover such materials.
+  link:/sigs/docs/#solution-pages[More info]
+
+|=========================================================

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -26,7 +26,7 @@ The Jenkins project is a mentoring organization in Google Season of Docs 2020.
 The writing project started September 14, 2020 and will conclude November 30, 2020.
 We're looking forward to the results from the writing project and our first experience as a Google Season of Docs mentoring organization.
 
-=== Projects
+=== GSoD 2020 Project
 
 * link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar]
 

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -10,7 +10,7 @@ tags:
 opengraph:
   image: /images/gsod/gsod_opengraph.png
 links:
-  meetings: "/projects/gsoc/#office-hours"
+  meetings: "/sigs/docs/gsod/#office-hours"
 ---
 
 image:/images/gsod/gsod.png[Google Season of Docs, role=center, float=right]
@@ -145,9 +145,10 @@ Once the projects are announced, other project-specific channels might be create
 
 === Office Hours
 
-Documentation office hours are held each Monday at *22:00 UTC*.
+Google Season of Docs office hours are held each Monday and Thursday at *17:00 UTC*.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are also available in the link:/events[Jenkins event calendar].
 
 [#archive]
 == Previous years

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -30,50 +30,9 @@ We're looking forward to the results from the writing project and our first expe
 
 * link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar]
 
-== Project ideas
+=== Project Ideas
 
-We invite technical writers to contribute to a major documentation update effort being coordinated in the documentation SIG.
-It includes a number of link:/sigs/docs/#ongoing-projects[ongoing projects],
-and technical writers are welcome to make their proposals in any area of the Jenkins documentation.
-We encourage proposals based on a technical writer's expertise and interests.
-
-[frame="topbot",grid="all",options="header",cols="30%,15%,55%"]
-|=========================================================
-|Project idea | Keywords | Description and links
-
-| Plugin documentation migration and update 
-| Markdown, GitHub, Plugins, Rewrite, Copy-editing
-| Currently we are migrating our plugin documentation from link:https://wiki.jenkins.io/[Confluence] to GitHub,
-  see link:/blog/2019/10/21/plugin-docs-on-github/[this blog post] for announcement.
-  We have already moved hundreds of pages, but there are more than 1000 pages remaining.
-  Migration itself can be done with automated tools we provide, but the documentation usually needs a significant update due to new features.
-  We invite technical writers to select an area (e.g. "plugins for Docker"), and work closely with plugin maintainers to migrate and update documentation in such an area.
-  link:/sigs/docs/#plugin-documentation-on-github[More Info]
-
-| Document Jenkins on Kubernetes
-| AsciiDoc, Guide, Compilation, Kubernetes
-| Jenkins on Kubernetes is a popular theme for Jenkins users.
-  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need a central location for documentation describing Jenkins on Kubernetes.
-  We would like to create new documentation which would describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
-  link:/sigs/docs/#jenkins-on-kubernetes[More Info]
-
-| Jenkins user documentation reorganization and update
-| AsciiDoc, Guide, Rewrite
-| Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook], and are frequently received to improve the user documentation.
-Common improvement themes include adding pipeline examples with each of the pipeline steps and additional tutorials for new users.
-The main aim of this project would be to  restructure content to make it more discoverable and easy to read.
-link:/sigs/docs/#user-guide[More info]
-
-| Create new solution pages for Jenkins use-cases
-| AsciiDoc, Guide
-| Jenkins project has several link:/solutions/[solution pages] for various use-cases.
-  We invite technical writers to create new solution pages for various use-cases (e.g. Documentation as code, Continuous Deployment, Static Analysis)
-  or technologies (Git, Gitlab, Kubernetes, etc.).
-  Existing pages were created several years ago, and they could be also updated.
-  There are a lot of materials available on the web, but having dedicated solution pages could help users to discover such materials. 
-  link:/sigs/docs/#solution-pages[More info]
-
-|=========================================================
+Significant documentation project opportunities are listed in the link:/sigs/docs/gsod/ideas[Google Season of Docs project ideas].
 
 === Getting started
 
@@ -110,7 +69,7 @@ Here are the common tools we use:
    You can find its sources link:https://github.com/jenkins-infra/jenkins.io/blob/master/content/sigs/docs/gsod/index.adoc[here].
 * SCM: link:https://git-scm.com/[Git]
 * Source Code Hosting: link:http://github.com/[github.com]
-* Text editing: any text editor with AsciiDoc/Markdown support (e.g. link:https://code.visualstudio.com/[Visual Studio Code], link:https://notepad-plus-plus.org/[Notepad++]) or a specialized IDE 
+* Text editing: any text editor with AsciiDoc/Markdown support (e.g. link:https://code.visualstudio.com/[Visual Studio Code], link:https://notepad-plus-plus.org/[Notepad++]) or a specialized IDE
 
 Particular components may also require additional tools for documentation development.
 For example, the jenkins.io website requires Docker for being built and tested locally.
@@ -153,6 +112,6 @@ Participant links are also available in the link:/events[Jenkins event calendar]
 [#archive]
 == Previous years
 
-* GSoD 2019 - not accepted 
+* GSoD 2019 - not accepted
 (link:https://docs.google.com/document/d/1ighqWo7gIDCnLQ-b6FouQKz-fvmHsnTsMfqBh_mVNbI/edit?usp=sharing[application form and project ideas],
 link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#heading=h.g4afeqolzwpj[retrospective])

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -30,7 +30,7 @@ We're looking forward to the results from the writing project and our first expe
 
 * link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar]
 
-=== Project ideas
+== Project ideas
 
 We invite technical writers to contribute to a major documentation update effort being coordinated in the documentation SIG.
 It includes a number of link:/sigs/docs/#ongoing-projects[ongoing projects],

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -22,8 +22,9 @@ GSoD in Jenkins is organized by the link:/sigs/docs[Documentation special intere
 
 == GSoD 2020
 
-Jenkins project will be a mentoring organization in Google Season of Docs 2020.
-We invite technical writers to join the community and contribute to the documentation being used by millions of Jenkins users worldwide.
+The Jenkins project is a mentoring organization in Google Season of Docs 2020.
+The writing project started September 14, 2020 and will conclude November 30, 2020.
+We're looking forward to the results from the writing project and our first experience as a Google Season of Docs mentoring organization.
 
 === Projects
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -70,6 +70,43 @@ If you have any questions or ideas, please feel free to reach out to us using th
 This section lists some of the projects working under the direction of this SIG.
 See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
+=== Google Season of Docs
+
+Google Season of Docs brings together open source communities and technical writers for the benefit of both.
+The program raises awareness of open source, of documentation, and of technical writing.
+
+The Jenkins project has been accepted to link:https://developers.google.com/season-of-docs/docs/participants[Google Season of Docs (GSoD) 2020].
+The link:https://developers.google.com/season-of-docs/docs/participants/project-jenkins-zaycodes[Jenkins on Kubernetes project] is the 2020 Google Season of Docs project for Jenkins.
+
+See our link:/sigs/docs/gsod[Google Season of Docs status page] for documentation project ideas, contact information, and more.
+
+[[jenkins-on-kubernetes]]
+==== Jenkins on Kubernetes - GSoD 2020
+
+Jenkins on Kubernetes is the Google Season of Docs project selected for 2020.
+Jenkins on Kubernetes is a popular theme of Jenkins Meetups and presentations at conferences.
+The Jenkins on Kubernetes project will describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
+The project can refer to existing information from:
+
+* GSOD selected project (link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar])
+* Jenkins online meetups (like
+link:https://www.youtube.com/watch?v=h4hKSXjCqyI[Jenkins on Kubernetes: Getting Started])
+* Cloud providers (like
+link:https://cloud.google.com/solutions/jenkins-on-kubernetes-engine[Google Cloud Platform],
+link:https://docs.microsoft.com/en-us/azure/architecture/solution-ideas/articles/container-cicd-using-jenkins-and-kubernetes-on-azure-container-service[Microsoft Azure],
+link:https://developer.ibm.com/technologies/containers/tutorials/deploy-and-run-jenkins-on-kubernetes-in-the-cloud/[IBM Cloud], and
+link:https://blogs.oracle.com/cloud-infrastructure/deploy-jenkins-on-oke[Oracle Cloud Platform])
+* Training labs (like
+link:https://www.qwiklabs.com/focuses/1104?parent=catalog[Google Cloud self-paced labs])
+* System providers (like
+link:https://code.vmware.com/samples/5160/Jenkins-CICD-Integration-with-PKS-provisioned-Kubernetes-Clusters[VMWare] and
+link:https://rancher.com/blog/2018/2018-11-27-scaling-jenkins/[Rancher])
+* Infrastructure as a Service providers (like
+link:https://platform9.com/blog/kubernetes-for-ci-cd-at-scale/[Platform9])
+* SCM providers (like
+link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenkins-and-kubernetes-on-aws[Bitbucket])
+* link:https://kubernetes.io/blog/2018/04/30/zero-downtime-deployment-kubernetes-jenkins/[Kubernetes project]
+
 === Plugin site integration with GitHub
 
 link:https://plugins.jenkins.io/[Jenkins Plugin Site] currently uses Jenkins update center and link:https://wiki.jenkins.io/[Jenkins Wiki] as a main source of information to be displayed on the website.
@@ -125,32 +162,6 @@ Navigation can be improved for administrators by separating the administration t
 This project will create a separate Jenkins Administrator Guide with content specific for administrators.
 This project is tracked in the jira:WEBSITE-738[] EPIC.
 
-[[jenkins-on-kubernetes]]
-=== Jenkins on Kubernetes
-
-Jenkins on Kubernetes is a popular theme of Jenkins Meetups and presentations at conferences.
-The Jenkins on Kubernetes project will describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
-The project can refer to existing information from:
-
-* GSOD selected project (link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar])
-* Jenkins online meetups (like
-link:https://www.youtube.com/watch?v=h4hKSXjCqyI[Jenkins on Kubernetes: Getting Started])
-* Cloud providers (like
-link:https://cloud.google.com/solutions/jenkins-on-kubernetes-engine[Google Cloud Platform],
-link:https://docs.microsoft.com/en-us/azure/architecture/solution-ideas/articles/container-cicd-using-jenkins-and-kubernetes-on-azure-container-service[Microsoft Azure],
-link:https://developer.ibm.com/technologies/containers/tutorials/deploy-and-run-jenkins-on-kubernetes-in-the-cloud/[IBM Cloud], and
-link:https://blogs.oracle.com/cloud-infrastructure/deploy-jenkins-on-oke[Oracle Cloud Platform])
-* Training labs (like
-link:https://www.qwiklabs.com/focuses/1104?parent=catalog[Google Cloud self-paced labs])
-* System providers (like
-link:https://code.vmware.com/samples/5160/Jenkins-CICD-Integration-with-PKS-provisioned-Kubernetes-Clusters[VMWare] and
-link:https://rancher.com/blog/2018/2018-11-27-scaling-jenkins/[Rancher])
-* Infrastructure as a Service providers (like
-link:https://platform9.com/blog/kubernetes-for-ci-cd-at-scale/[Platform9])
-* SCM providers (like
-link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenkins-and-kubernetes-on-aws[Bitbucket])
-* link:https://kubernetes.io/blog/2018/04/30/zero-downtime-deployment-kubernetes-jenkins/[Kubernetes project]
-
 [[solution-pages]]
 === Solution Pages
 
@@ -173,22 +184,14 @@ This project is tracked in the jira:WEBSITE-742[] EPIC.
 * Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
 * link:https://plugins.jenkins.io/[Plugins site] improvements
 
-=== Google Season of Docs
-
-The https://developers.google.com/season-of-docs/[Google Season of Docs (GSoD)]
-program brings together open source and technical writers communities for the benefit of both.
-The program raises awareness of open source, of docs, and of technical writing.
-
-See link:/sigs/docs/gsod[this page] for more info.
-
 == Meetings
 
-Documentation office hours are held each Monday at *22:00 UTC*.
-Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
+Documentation office hours are held on demand each Monday at *22:00 UTC* and each Thursday at *14:00 UTC*.
+Office hours are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
 
 The Documentation SIG meets on the fourth Friday of each month at *13:00 UTC*.
-See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
+See the link:/event-calendar/[Jenkins Event Calendar] for the schedule and the meeting link.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -67,7 +67,7 @@ If you have any questions or ideas, please feel free to reach out to us using th
 [[ongoing-projects]]
 == Projects
 
-This sections lists some of the projects being done under umbrella of this SIG.
+This section lists some of the projects working under the direction of this SIG.
 See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
 === Plugin site integration with GitHub

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -15,13 +15,9 @@ leads:
 participants:
 - "oleg_nenashev"
 - "tracymiranda"
-- "tfoxnc"
 - "kwhetstone"
-- "warden"
-- "jha-cloudbees"
-- "petra-sargent"
-- "omehegan"
 - "stackscribe"
+- "vsilverman"
 - "linuxsuren"
 links:
   gitter: "jenkinsci/docs"

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -9,7 +9,6 @@ opengraph:
 tags:
   - docs
   - docs_sig
-  - docs-sig
   - documentation
 leads:
 - "markewaite"

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -184,11 +184,13 @@ This project is tracked in the jira:WEBSITE-742[] EPIC.
 * Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
 * link:https://plugins.jenkins.io/[Plugins site] improvements
 
-== Meetings
+== Office Hours
 
 Documentation office hours are held on demand each Monday at *22:00 UTC* and each Thursday at *14:00 UTC*.
 Office hours are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+
+== Meetings
 
 The Documentation SIG meets on the fourth Friday of each month at *13:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule and the meeting link.


### PR DESCRIPTION
## Update Google Season of Docs pages inside Docs SIG

Changes:

* Move Google Season of Docs to top of docs projects
* Refine intro paragraph to show project is in progress
* Update Docs SIG participants list