### PR TITLE
Update the Board and Officer election process doc

### DIFF
--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -54,14 +54,14 @@ In the case of rejection, a justification must be provided to the contributor wh
 The decision may be escalated to the link:/project/governance-meeting/[Jenkins governance meeting] and overridden by voting there.
 
 After receiving and vetting the nominations,
-the election committee is responsible to contact the nominees and to confirm whether they will be candidates in the upcoming elections.
-The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), and account/social media links which may help voters to get more information about the candidates and plans if they are elected to the role.
+the election committee is responsible for contacting the nominees and confirming whether they want to run in the election.
+The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), and account/social media links which may help voters to get more information about them and plans if they are elected to the role.
 This information is published by the election committee before the voting starts.
 
 ### Voter sign-up and eligibility
 
 Any Jenkins project and/or community contributor is eligible to vote in the election
-if there is a contribution made by this contributor before September 01 of the election year.
+if there is a contribution made before September 01 of the election year.
 _Contribution_ does not mean a _code contribution_,
 all contributions count:
 documentation patches,
@@ -102,7 +102,7 @@ In the case of rejection, one of the election committee members will send a reje
 ### Voting
 
 Voting happens through the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
-Once the voting starts, all voters will receive a voting notification to their emails specified in the sign-up form.
+Once the voting starts, all voters will receive a voting notification to the emails specified in the sign-up form.
 There will be separate emails for each role (board members and each officer) with more than 1 candidate.
 If you have not received an email within 24 hours from the voting starting date, please contact the Jenkins Governance Board.
 Every contributor must vote only once.

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -55,7 +55,7 @@ The decision may be escalated to the link:/project/governance-meeting/[Jenkins g
 
 After receiving and vetting the nominations,
 the election committee is responsible to contact the nominees and to confirm whether they will be candidates in the upcoming elections.
-The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), and account/social media links which may help voters to get more information about the candidates and plans if they get elected to the role.
+The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), and account/social media links which may help voters to get more information about the candidates and plans if they are elected to the role.
 This information is published by the election committee before the voting starts.
 
 ### Voter sign-up and eligibility

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -1,14 +1,14 @@
 ---
 layout: simplepage
-title: "Board election process"
+title: "Board and Officer election process"
 section: project
 ---
 
-This document outlines the link:/project/governance/#governance-board[Jenkins Governance Board] election process as discussed in governance meetings.
+This document outlines the link:/project/governance/#governance-board[Jenkins Governance Board] and link:/project/team-leads/[Jenkins officer] election process.
+The election process is driven by the Jenkins Governance board members who are not up for reelection (aka the _election committee_).
+More contributors might be added to the election committee if approved by the link:/project/governance-meeting/[regular governance meeting].
 
 The charter of the Jenkins board is to ensure the health of not only the software project, but of the communities of plugin developers and users. To do this effectively, members of the board must bring various perspectives to the table: what are the needs of users; of committers; of organizations, both large and small; of commercial interests. As the composition of the Jenkins board changes over time, we want to ensure that this balance of viewpoints is maintained. Current board members best understand this balance, and so are in the best position to select candidates for inclusion onto the board. A board comprised fully of write-in candidates runs the risk of being overweighed with one type of perspective over all others.
-
-The opinion of members of the community at large is highly valued, and the board welcomes additional nominations beyond who we might consider. If you feel that a particular person is well suited to help guide Jenkins, please submit a name and the reason for your nomination to jenkinsci-board@googlegroups.com. The current members of the board will review all submissions and compile a final list of candidates to be voted on by the community, for the seats up for election. The board reserves the right to leave nominations off the final ballot if they feel that a particular viewpoint is already well represented on the board.
 
 ## Goal
 
@@ -16,22 +16,120 @@ The opinion of members of the community at large is highly valued, and the board
 . Make sure that the board reflects the balance of different viewpoints — the needs of users; of committers; of organizations, both large and small; of commercial interests.
 . Maintain stability and avoid sudden direction changes.
 
+## 2020 Elections schedule
+
+* **Sep 24** - Nominations open
+* **Sep 24** - Voting sign-up begins
+* **Oct 15** - Nominations deadline
+** After the deadline, the election committee will process nominations and reach out to candidates in order 
+* **Oct 22**: Election candidates are published, including personal statements
+* **Nov 02**: Voting sign-up is over
+** After this date, the election committee will verify the sign-up and prepare the final list of voters
+* **Nov 10**: Voting begins
+** Email is distributed to all registered voters through link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service]
+* **Nov 27**: Voting ends, 11PM UTC
+* **Dec 03**: Election results are announced and take effect.
+
 ## Process
 
 . The Governance Board includes 5 members
 ** link:/blog/authors/kohsuke[Kohsuke] holds a permanent board seat until such a time he decides to resign.
 ** 4 members are elected. If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected.
-. Have election every year, electing 2 people in each year (that means the term is 2 years, without term limit: you can be candidate and be re-elected indefinitely)
-. There'll be a period of 3 weeks designated for the board to encourage the community to send in the nominations. The board will meet in private to come up with the list of candidates at the end
+. Have election every year, normally electing 2 people in each year (that means the term is 2 years, without term limit: you can be a candidate and be re-elected indefinitely)
+. There will be a period of at least 3 weeks designated for the board to encourage the community to send in the nominations. The board will meet in private to come up with the list of candidates at the end
 . Any company should not dominate in the board (link:/project/board-election-process/#corporate-involvement[see below])
 .. The number of board members affiliated with one company must be less than 50%
 .. If a board member gets employed by a company and the limitation gets violated, somebody must step down and the board will follow the link:/project/board-election-process/#interim-procedures[#Interim Procedures]
 . Use link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] as the algorithm to elect multiple people in one vote.
-. You earn the voting right by having an account on jenkins-ci.org prior to the last election. (to avoid last minute rush since we have few other criteria for voters.) For the first election, we will create the election cut-off based on the date when this proposal is ratified.
 
-## Interim Procedures
+### Nominations
 
-. If a board member resigns, the board is allowed to appoint an interim board member to fulfill the remainder of the term, subject to blessing in a link:https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda[regular governance meeting].
+The opinion of members of the community at large is highly valued, and the board welcomes additional nominations beyond who we might consider.
+If you feel that a particular person is well suited to help guide Jenkins, please submit a name and the reason for your nomination to jenkinsci-board@googlegroups.com.
+
+The election committee will review all submissions and compile a final list of candidates to be voted on by the community, for the board member seats and officer roles up for election.
+The board reserves the right to leave nominations off the final ballot if they feel that a particular viewpoint is already well represented on the board,
+or if there are other reasons preventing a nominee from being effective in the target role.
+In the case of rejection, a justification must be provided to the contributor who submitted the nomination.
+The decision may be escalated to the link:/project/governance-meeting/[Jenkins governance meeting] and overridden by voting there.
+
+After receiving and vetting the nominations,
+the election committee is responsible to reach out to nominees and to confirm whether they will be candidates in the upcoming elections.
+The candidates should also provide their statements, list of affiliations (see _Corporate Disclosure_), and account/social media links which may help voters to get more information about the candidates and plans if they get elected to the role.
+This information is published by the election committee before the voting starts.
+
+### Voter sign-up and eligibility
+
+Any Jenkins project and/or community contributor is eligible to vote in the election
+if there is a contribution made by this contributor before September 01 of the election year.
+_Contribution_ does not mean a _code contribution_,
+all contributions count:
+documentation patches,
+code reviews,
+substantial issue reports,
+issues and mailing list responses,
+social media posts,
+testing,
+etc.
+Such a contribution should be public.
+
+Voting sign-up happens through a public Google Form which will be distributed using the Jenkins mailing list, blog, and social media accounts.
+A single form is used to sign up for all elections (board members and officers).
+The sign-up form will collect the following data:
+
+* **Emails** that are required to send ballots through the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
+These emails are deleted after the election and not used for any communications except the election matters.
+* **I agree with storing my email** -
+  Mandatory checkbox which gets consent for storing the email for the election process purposes.
+* **I agree with election terms** -
+  Mandatory checkbox which links this page and describes the key expectations
+  (e.g. submitting the form and voting only once) .
+* **Link to a contribution** -
+  Public link to a contribution that happened before Sep 01 of the election year.
+* **Jenkins account ID** (optional) -
+  User ID used to log into the Jenkins services like Jenkins Jira. 
+* **GitHub account ID** (optional) -
+  ID of the GitHub users for those who contribute through GitHub. 
+* **Contribution description** (optional) -
+  Free-form field which can be used to describe and justify the contribution(s) if the link is not enough.
+* Maybe: optional form entries selected by the election committee (e.g. election-related poll).
+* **Any feedback to the election committee** -
+  Additional entry where poll participants can provide any feedback.
+
+Once sign-up is over, the election committee will process the form submissions and prepare a list of the registered voters.
+In the case of rejection, one of the election committee members will send a rejection email.
+
+### Voting
+
+Voting happens through the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
+Once the voting starts, all voters will receive a voting notification to their emails specified in the sign-up form.
+There will be separate emails for each role (board members and each officer) with more than 1 candidate.
+If you have not received an email within 24 hours from the voting starting date, please contact the Jenkins Governance Board.
+Every contributor must vote only once.
+Intentional multiple votes will be considered as a violation and serious misbehavior subject to the link:/conduct[Jenkins Code of Conduct].
+
+Voters will have at least two weeks to submit their votes.
+Voting is anonymous.
+Each voter ranks a set of possible choices.
+Individual voter rankings are then combined into an anonymous overall ranking of the choices.
+See link:https://civs.cs.cornell.edu/[this page] for more information about the ranking algorithm.
+
+Once voting is over,
+the election committee will process the results, notify the elected candidates, and prepare the announcement.
+The results should be announced shortly after the elections in the Jenkins mailing lists.
+
+### Post-announcement
+
+Voting results take effect immediately after the announcement.
+Board members and former officers are responsible to organize knowledge and permission transfers for the newly elected contributors.
+The transition process is to be defined by former and newly elected contributors,
+with an expectation that the transition concludes within one month after the results announcement.
+
+The election committee is responsible to hold a retrospective for the elections and to make the results of it public.
+
+### Interim Procedures
+
+. If a board member resigns, the board is allowed to appoint an interim board member to fulfill the remainder of the term, subject to blessing in a link:/project/governance-meeting/[regular governance meeting].
 
 ## Corporate Involvement
 
@@ -54,7 +152,24 @@ There are several motivations behind the above proposal:
 . Odd number of people prevents the tie problem
 . Given the low bar for permission to commit, we couldn't identify precise criteria to define the right to vote in board elections.  At the same time, we wanted to preserve stability by limiting voting rights to only those with some involvement in the project.
 
+## Previous elections
+
+* 2019 -
+  link:/blog/2019/12/16/board-election-results/[results],
+  link:/blog/2019/09/25/board-elections/[announcement],
+  link:https://docs.google.com/document/d/1Htgjq2Gnojz6a-FE62kgjIq6AVR8ctPcARbd-m2KctQ/edit?usp=sharing[retrospective],
+  link:https://groups.google.com/forum/#!msg/jenkinsci-dev/vKi9JpxTQxY/2KgDsKUeAQAJ[dev list discussion]
+
 ## Change History
+
+### 2020-09-TODO
+
+In 2020 we made changes to address the link:https://docs.google.com/document/d/1Htgjq2Gnojz6a-FE62kgjIq6AVR8ctPcARbd-m2KctQ/edit?usp=sharing[2019 retrospective freedback].
+
+* Add officer election to the document.
+* Modify the voter eligibility definition: all contributors are eligible if they contributed before Sep 01, 2020.
+  Jenkins LDAP account is no longer required.
+* Document the two-stage voting process de-facto used in 2019.
 
 ### 2019-09-11
 

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -21,7 +21,7 @@ The charter of the Jenkins board is to ensure the health of not only the softwar
 * **Sep 24** - Nominations open
 * **Sep 24** - Voting sign-up begins
 * **Oct 15** - Nominations deadline
-** After the deadline, the election committee will process nominations and reach out to candidates in order 
+** After the deadline, the election committee will process nominations and notify the candidates
 * **Oct 22**: Election candidates are published, including personal statements
 * **Nov 02**: Voting sign-up is over
 ** After this date, the election committee will verify the sign-up and prepare the final list of voters
@@ -36,7 +36,7 @@ The charter of the Jenkins board is to ensure the health of not only the softwar
 ** link:/blog/authors/kohsuke[Kohsuke] holds a permanent board seat until such a time he decides to resign.
 ** 4 members are elected. If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected.
 . Have election every year, normally electing 2 people in each year (that means the term is 2 years, without term limit: you can be a candidate and be re-elected indefinitely)
-. There will be a period of at least 3 weeks designated for the board to encourage the community to send in the nominations. The board will meet in private to come up with the list of candidates at the end
+. There will be a period of at least 3 weeks designated for the board to encourage the community to submit nominations. The board will meet in private to select final candidates
 . Any company should not dominate in the board (link:/project/board-election-process/#corporate-involvement[see below])
 .. The number of board members affiliated with one company must be less than 50%
 .. If a board member gets employed by a company and the limitation gets violated, somebody must step down and the board will follow the link:/project/board-election-process/#interim-procedures[#Interim Procedures]
@@ -48,14 +48,14 @@ The opinion of members of the community at large is highly valued, and the board
 If you feel that a particular person is well suited to help guide Jenkins, please submit a name and the reason for your nomination to jenkinsci-board@googlegroups.com.
 
 The election committee will review all submissions and compile a final list of candidates to be voted on by the community, for the board member seats and officer roles up for election.
-The board reserves the right to leave nominations off the final ballot if they feel that a particular viewpoint is already well represented on the board,
+The board reserves the right to omit nominations from the final ballot if they feel that a particular viewpoint is already well represented on the board,
 or if there are other reasons preventing a nominee from being effective in the target role.
 In the case of rejection, a justification must be provided to the contributor who submitted the nomination.
 The decision may be escalated to the link:/project/governance-meeting/[Jenkins governance meeting] and overridden by voting there.
 
 After receiving and vetting the nominations,
-the election committee is responsible to reach out to nominees and to confirm whether they will be candidates in the upcoming elections.
-The candidates should also provide their statements, list of affiliations (see _Corporate Disclosure_), and account/social media links which may help voters to get more information about the candidates and plans if they get elected to the role.
+the election committee is responsible to contact the nominees and to confirm whether they will be candidates in the upcoming elections.
+The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), and account/social media links which may help voters to get more information about the candidates and plans if they get elected to the role.
 This information is published by the election committee before the voting starts.
 
 ### Voter sign-up and eligibility
@@ -129,7 +129,7 @@ The election committee is responsible to hold a retrospective for the elections 
 
 ### Interim Procedures
 
-. If a board member resigns, the board is allowed to appoint an interim board member to fulfill the remainder of the term, subject to blessing in a link:/project/governance-meeting/[regular governance meeting].
+. If a board member resigns, the board is allowed to appoint an interim board member to fulfill the remainder of the term, subject to approval in a link:/project/governance-meeting/[regular governance meeting].
 
 ## Corporate Involvement
 


### PR DESCRIPTION
This is a follow-up to the Aug 26 and Sep 16 Jenkins governance meetings where we were discussing changes to the Jenkins Board and Officer election process towards the 2020 elections ([meeting notes and recording links](https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit#heading=h.cgd8zbewht8o)). Developer mailing list thread: https://groups.google.com/g/jenkinsci-dev/c/NQg-_xhrT-0

- [x] - Document the two-stage election process
- [x] - Document the election phases
- [x] - Update the voter eligibility definition

On hold until Governance board members approve it