### PR TITLE
Include statusFilter upgrade content provided with pull request

### DIFF
--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -60,10 +60,22 @@ the following extra upgrade steps are required:
   version from link:https://github.com/winsw/winsw/releases[WinSW GitHub Releases]
   and manually replacing the wrapper ".exe" files in the agent workspaces.
 
-==== View statusFilter removed from configuration as code
+[[view-statusfilter-removed-from-configuration-as-code]]
+==== View job status filter
 
 As part of a performance improvement for list views, the `statusFilter` key is now an optional, separate item in the Jenkins view configuration.
-The `statusFilter` key in link:https://plugins.jenkins.io/configuration-as-code/[configuration as code] view definitions will need to be removed or replaced with a new entry as part of the upgrade to Jenkins 2.249.1.
+
+The job status filter has been moved to be a Job View Filter.
+The order of this filter matters as its interaction with various other filters will affect what jobs are shown in the view.
+If the status filter is the *first* filter (filtering only enabled jobs) and a later filter adds a disabled job. the disabled job will be visible.
+If the status filter is *last* in the same scenario, the disabled job will *not* be visible.
+
+NOTE: The job status filter defined on views from previous Jenkins versions is *not* migrated in Jenkins 2.249.1
+Refer to link:https://issues.jenkins-ci.org/browse/JENKINS-62661[JENKINS-62661].
+
+===== Configuration as code statusFilter
+
+The `statusFilter` key in link:https://plugins.jenkins.io/configuration-as-code/[configuration as code] view definitions must be removed or replaced with a new entry as part of the upgrade to Jenkins 2.249.1.
 
 Previous configuration::
 The previous configuration looked like this:


### PR DESCRIPTION
## Include statusFilter upgrade content provided with pull request

I should have used this in the original upgrade guide.  I incorrectly ignored the upgrade guide entry in the original upgrade guide pull request.

@res0nance , sorry that I missed your recommended upgrade guide text from the [pull request](https://github.com/jenkinsci/jenkins/pull/4466)  .  I'll try to not make that mistake in the future.