### PR TITLE
Roadmap: Update the Jenkins packaging stories

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -475,13 +475,31 @@ categories:
       - feature
     - name: Custom Jenkins distribution build service
       description: >
-        We would like to create a new service which would allow users to configure and build their own Jenkins distributions,
+        A new service which would allow users to configure and build their own Jenkins distributions,
         with custom plugin sets and configurations included.
+        This would be a self-hosted service initially.
+      status: preview
+      link: https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
+      labels:
+      - feature
+      - tools
+    - name: "customize.jenkins.io"
+      description: >
+        Hosted versions of the Custom Jenkins distribution build service provided by the Jenkins project
       status: current
       link: https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
       labels:
       - feature
       - infrastructure
+    - name: Custom WAR/Docker Packager 2.0
+      description: >
+        New edition of Custom WAR Packager with a new configuration YAML format.
+        It also includes integrations with other Jenkins tools and services: Update Centers, Plugin Installation Manager, Jenkinsfile Runner Packager, etc.
+      status: preview
+      link: https://github.com/jenkinsci/custom-war-packager/blob/master/ROADMAP.adoc#custom-war-packager-2x
+      labels:
+      - feature
+      - tools
     - name: Java 15+ support
       description: >
         We would like to support future mainstream JVM versions (Java 15+).


### PR DESCRIPTION
Follow-up on the Governance Meeting. It splits the Custom Jenkins Build Distribution service to two initiatives, and adds Custom WAR Packager 2.0 as an entry.

![image](https://user-images.githubusercontent.com/3000480/93866878-8a2bb380-fcc8-11ea-9570-a0a381af30b5.png)

