### PR TITLE
Roadmap: Update/Extend the Jenkins roadmap for Cloud Platforms

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -339,13 +339,14 @@ categories:
     description: >
       Initiatives focused on making Jenkins easy to deploy and run in cloud environments,
       including Kubernetes and various cloud providers.
+      It also includes integrations with cloud storage providers.
     link: /sigs/cloud-native
     initiatives:
     - name: 'JEP-219: Jenkins Kubernetes Operator'
       description: >
         Further evolution of a Kubernetes Native Operator which manages operations for Jenkins on Kubernetes.
         It has been built with Immutability and declarative Configuration as Code in mind.
-      status: preview
+      status: released
       link: https://github.com/jenkinsci/jep/tree/master/jep/219
       labels:
       - feature
@@ -381,7 +382,7 @@ categories:
       - feature
     - name: Document Jenkins on Kubernetes
       description: Describe the concepts, techniques, and choices available for Jenkins on Kubernetes
-      status: near-term
+      status: current
       link: https://jenkins.io/sigs/docs/#jenkins-on-kubernetes
       labels:
       - documentation
@@ -399,6 +400,37 @@ categories:
         Multi-Branch Pipeline, organization folders, pipeline browsers, etc.
       status: near-term
       link: https://github.com/tektoncd/pipeline
+      labels:
+      - feature
+    - name: 'Pluggable Build Log storage for Jenkins Pipeline'
+      description: >
+        Support for externalizing build logs in Jenkins Pipeline.
+        Includes streaming logs from agents directly to the storage, as well as support for log visualization in Jenkins.
+      status: preview
+      link: /sigs/cloud-native/pluggable-storage/#build-log-storage
+      labels:
+      - feature
+    - name: 'Pluggable Build Results Storage'
+      description: >
+        Support for storing build results in an external storage or a databases.
+        It includes build histories, metadata, and build actions which are stored in build.xml files.
+      status: future
+      link: https://www.jenkins.io/sigs/cloud-native/pluggable-storage/#status-summary
+      labels:
+      - feature
+    - name: 'Pluggable Unit Test Results Storage'
+      description: >
+        Support for storing unit test results in an external database or a test management system.
+      status: preview
+      link: https://github.com/jenkinsci/junit-plugin/issues/142
+      labels:
+      - feature
+    - name: 'Pluggable Build Log storage for all job types'
+      description: >
+        Support for externalizing logs for all build types, not just for Jenkins Pipeline.
+        Includes streaming logs from agents directly to the storage, as well as support for log visualization in Jenkins.
+      status: future
+      link: /sigs/cloud-native/pluggable-storage/#build-log-storage
       labels:
       - feature
     - name: 'External/Pluggable Data Storage'


### PR DESCRIPTION
This change updates the roadmap for Jenkins on Cloud Platforms:

- [x] - Move Jenkins Operator on Kubernetes to "Released". It reflects the fact that the original scope is largely delivered, though there is an open question about the next roadmap (https://github.com/jenkinsci/kubernetes-operator/pull/400) and open governance. CC @waveywaves @tomaszsek 
- [x] - Move "Document Jenkins on Kubernetes" to "in progress", @zaycodes is working on it together with @markyjackson-taulia @MarkEWaite @kwhetstone 
- [x] - Expand pluggable storage entries as agreed on Sep 16 during the roadmap review. In particular, it reflects the preview status of the Unit Test Result storage work by @timja and old Pluggable Build Log storage work by @jglick and me

## After

![image](https://user-images.githubusercontent.com/3000480/93869734-826e0e00-fccc-11ea-81eb-70c2872100bb.png)

## Before

![image](https://user-images.githubusercontent.com/3000480/93870246-31124e80-fccd-11ea-91f6-ebdf662dc492.png)
