### PR TITLE
Add Jumbotron for 2020 Elections

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -55,12 +55,12 @@ homepage: true
   :image => {:src => expand_link('images/conferences/cdCon.png'), :height => "300px"},
   :call_to_action => {:text => 'Register for cdCon', :href => 'https://events.linuxfoundation.org/cdcon/register/'}}
 
--# CDF Blog
-- slides << {:href => 'https://cd.foundation',
-  :title => 'Meet the Continuous Delivery Foundation',
-  :intro => "The CDF serves as the vendor-neutral home of many of the fastest-growing projects for continuous delivery, including Jenkins, Jenkins&nbsp;X, Spinnaker, and Tekton.",
-  :image => {:src => expand_link('images/cdf/logo/cdf-logo-white.png'), :height => "250px"},
-  :call_to_action => {:text => 'Learn about CDF', :href => 'https://cd.foundation'}}
+-# Elections
+- slides << {:href => '2020/09/24/board-elections/',
+  :title => '2020 Elections',
+  :intro => "We are happy to announce the 2020 elections in Jenkins! Nominations are open for governance board and five officer positions. These roles are an essential part of the community governance and well-being. We invite community members to send nominations by Oct 15 and to register for voting by Nov 02.",
+  :image => {:src => expand_link('images/logos/needs-you/Jenkins_Needs_You-transparent.png'), :height => "320px"},
+  :call_to_action => {:text => 'More info', :href => expand_link('2020/09/24/board-elections/')}}
 
 -# Case Studies
 - slides << {:href => 'https://JenkinsIsTheWay.io/',


### PR DESCRIPTION
This change replaces the old CDF Announcement jumbotron by the elections announcement. We already have a cdCon announcement, and I believe we can remove the second CDF one until the conference is over

![image](https://user-images.githubusercontent.com/3000480/94445248-848e0c00-01a7-11eb-8511-e0cabd7643d1.png)
