### PR TITLE
Remove mirror reference to hudson-labs

### DIFF
--- a/content/download/mirrors.adoc
+++ b/content/download/mirrors.adoc
@@ -13,7 +13,9 @@ Currently releases are mirrored to the locations documented on the link:https://
 
 ### Running a mirror
 
-More mirrors are certainly welcome, Jenkins is primarily mirrored by the link:https://osuosl.org/services/hosting/details[Oregon State University Open Source Lab (OSUOSL)]. Both the hudson-labs and OSUOSL servers are primarily located within the United States, so international (Japan/UK/Germany) mirrors would be greatly appreciated.
-
+More mirrors are certainly welcome.
+Jenkins is mirrored by the link:https://osuosl.org/services/hosting/details[Oregon State University Open Source Lab (OSUOSL)] and by servers hosted by donors in the United States, Europe, China, and Japan.
+Worldwide mirrors reduce the load on individual servers, spread the bandwidth costs among multiple servers, and improve download performance for users.
 
 If you're interested in running a public mirror, drop an email to `jenkins-infra@googlegroups.com` and we can discuss space and bandwidth requirements.
+Mirrors on the Indian subcontinent, in South America, and in Africa would be great additions to the Jenkins mirrors.


### PR DESCRIPTION
## Remove mirror reference to hudson-labs

Encourage additional mirrors in areas where traffic is increasing, like India, South America, and Africa.