### PR TITLE
Add Plugin Site, Jenkinsfile Runner and Terminology cleanup as featured projects

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -86,7 +86,43 @@ who have committed to assist contributors and to provide quick turnaround in pul
   and add new features there.
 
   link:https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md[Contributing],
-  link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newbie-friendly issues]
+  link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newcomer-friendly issues]
+
+| link:http://plugins.jenkins.io/[Jenkins Plugin Site]
+| Javascript, Java, React, Gatsby
+a| The plugin site is used to find information about 1700+ plugins available in Jenkins.
+   It provides plugin documentation, changelogs, open issues, and other data needed for Jenkins admins and end users.
+   We are interested to keep improving the plugin site's UI/UX,
+   provide more search options, and to provide deeper integration with GitHub and other services.
+
+  * Repositories: link:https://github.com/jenkins-infra/plugin-site[Plugin site], link:https://github.com/jenkins-infra/plugin-site-api/[Plugin site API]
+  * Issues: link:https://github.com/jenkins-infra/plugin-site/issues[Plugin Site], link:https://github.com/jenkins-infra/plugin-site-api/issues[Plugin Site API], link:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20WEBSITE%20AND%20component%20%3D%20plugin-site%20AND%20status%20%3D%20%22To%20Do%22%20%20[Jira tickets]
+
+| link:https://github.com/jenkinsci/jenkinsfile-runner[Jenkinsfile Runner]
+| Java, Docker
+| Jenkinsfile Runner is a portable Jenkins Pipeline execution engine, currently in preview.
+  It can run as a standalone CLI tool or as a Docker container.
+  We invite Hacktoberfest participants to evaluate the tool,
+  work on adding new features and demos,
+
+
+  link:https://github.com/jenkinsci/jenkinsfile-runner/blob/master/CONTRIBUTING.adoc[Contributing],
+  link:https://github.com/jenkinsci/jenkinsfile-runner/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues],
+  link:https://github.com/jenkinsci/jenkinsfile-runner/issues[All open issues]
+
+
+| Terminology cleanup
+| Java, Web UI, Asciidoc, Markdown, Java
+a| In 2016, the Jenkins community started changing the potentially offensive terminology within the project.
+  The "slave" term was deprecated and replaced by "agent".
+  In July 2020 we also link:https://cd.foundation/blog/2020/08/25/jenkins-terminology-changes/[adopted] the "controller" term instead of "master", and deprecated the "whitelist/blacklist" terms.
+  There are many places where the old terminology still needs to be replaced.
+
+We invite contributors to join us and participate in cleaning up Jenkins documentation,
+Web and CLI interfaces, and the codebase:
+
+  * jira:JENKINS-42816[] - Agent terminology cleanup - open issues and contributor guidelines
+  * Guidelines in the issue above can be also used for other terms
 
 
 | link:/artwork[Jenkins Artwork]
@@ -94,6 +130,8 @@ who have committed to assist contributors and to provide quick turnaround in pul
 | Create new images and logos for link:/projects/jam/[Jenkins area meetups],
   link:/projects/[subprojects], and plugins.
   You can also contribute new graphics to plugins.
+
+  link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-a-logo[Adding a logo]
 
 |=========================================================
 


### PR DESCRIPTION
Spent some time to create more featured project entries and to make the list more technology-diverse

![image](https://user-images.githubusercontent.com/3000480/94702230-cd77c900-033d-11eb-8770-81af5fa75feb.png)
