### PR TITLE
Update Governance meeting documentation and add participation guidelines

### DIFF
--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -4,15 +4,27 @@ title: "Jenkins Governance Meeting"
 section: project
 ---
 
-As per the Jenkins link:/project/governance/[Governance Document],
-the project holds a bi-weekly governance meeting on the `#jenkins-meeting` link:/chat[IRC Channel] on Freenode.
-Jenkins Governance Meeting is open for everyone to participate and vote.
-The meetings calendar is available link:/event-calendar[here].
-
+As per the Jenkins link:/project/governance/[Governance Document], the community holds a regular governance meeting.
 This meeting is used to make decisions about the project: budget approvals, key decisions sign-off, voting on proposals if there is no consensus, etc.
-The topics are usually discussed in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[developer mailing list], and contributors can cast their votes there ahead of the meeting.
+It is open for everyone to participate and vote.
+The topics are usually discussed in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[developer mailing list] ahead of the meeting,
+so contributors can share their feedback and cast votes asynchronously.
+
 This meeting is rarely used for technical decisions, for that purpose we use the developer mailing list and link:https://github.com/jenkinsci/jep/[Jenkins Enhancement Proposals].
 If a decision cannot be made at the governance meeting, the project's link:/project/board[governance board] takes priority.
+
+=== How to join the meetings?
+
+The governance meeting commonly happens every two weeks on Wednesdays, 6PM UTC.
+We hold the meeting as a recorded video call or as a chat in the `#jenkins-meeting` link:/chat[IRC Channel] on Freenode.
+The meetings calendar with links is available link:/event-calendar[here].
+
+=== How to propose a topic?
+
+1. Start a discussion with your proposal in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[developer mailing list]
+2. Wait for initial feedback in the mailing list.
+   If there is a strong consensus among community members and no formal approval needed, the mailing list thread might be enough.
+3. Suggest a change to the agenda document linked below.
 
 === Agenda
 


### PR DESCRIPTION
I noticed that the Governance Meeting page still hardcodes IRC while we switched to Zoom by default.  In this patch I updated the description to focus more on the meeting's purpose and on contributing to the meeting.

Needs approval from board members before merging