### PR TITLE
Update getting-started.adoc

### DIFF
--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -17,8 +17,7 @@ For this tour, you will require:
 ** 10 GB of drive space (for Jenkins and your Docker image)
 * The following software installed:
 ** Java 8 or 11 (either a JRE or Java Development Kit (JDK) is fine)
-** https://docs.docker.com/[Docker] (navigate to *Get Docker* at the top of the
-   website to access the Docker download that's suitable for your platform)
+** https://docs.docker.com/[Docker] (navigate to https://docs.docker.com/get-docker/[*Get Docker*] site to access the Docker download that's suitable for your platform)
 
 === Download and run Jenkins
 


### PR DESCRIPTION
Layout of the https://docs.docker.com/ had changed and *Get Docker* is no longer at the top of the website and is called differently.

Updated the wording and providing direct *Get Docker* link