### PR TITLE
Add WMI Windows agent plugin ref to 2.249.1 upgrade guide

### DIFF
--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -60,6 +60,13 @@ the following extra upgrade steps are required:
   version from link:https://github.com/winsw/winsw/releases[WinSW GitHub Releases]
   and manually replacing the wrapper ".exe" files in the agent workspaces.
 
+==== WMI Windows agents plugin
+
+The plugin:windows-slaves[WMI Windows Agents] plugin version 1.7 has been released for Jenkins 2.248 and later.
+Prior versions of the plugin will report a null pointer exception and the agent will fail to connect to Jenkins 2.249.1.
+
+Jenkins 2.249.1 users of the plugin:windows-slaves[WMI Windows Agents] plugin should upgrade to version 1.7.
+
 [[view-statusfilter-removed-from-configuration-as-code]]
 ==== View job status filter
 

--- a/content/_data/upgrades/2-249-1.adoc
+++ b/content/_data/upgrades/2-249-1.adoc
@@ -62,7 +62,7 @@ the following extra upgrade steps are required:
 
 ==== WMI Windows agents plugin
 
-The plugin:windows-slaves[WMI Windows Agents] plugin version 1.7 has been released for Jenkins 2.248 and later.
+The plugin:windows-slaves[WMI Windows Agents] plugin version 1.7 has been released for Jenkins 2.249.1 and later.
 Prior versions of the plugin will report a null pointer exception and the agent will fail to connect to Jenkins 2.249.1.
 
 Jenkins 2.249.1 users of the plugin:windows-slaves[WMI Windows Agents] plugin should upgrade to version 1.7.


### PR DESCRIPTION
## Add WMI Windows agent plugin ref to 2.249.1 upgrade guide

Avoid null pointer exceptions when Windows agents attempt to connnect to Jenkins 2.248 and later.  See the [changelog](https://github.com/jenkinsci/windows-slaves-plugin/releases/tag/windows-slaves-1.7) and [JENKINS-63223](https://issues.jenkins-ci.org/browse/JENKINS-63223) for more details.