### PR TITLE
Replaced offensive terminology in documentation ('master' -> 'controller')

### DIFF
--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -80,10 +80,10 @@ Blue Ocean cannot find any `Jenkinsfile`, you will be prompted to begin creating
 one through the <<pipeline-editor#,Pipeline editor>>.
 
 Local repositories are typically limited to file system access. They are usually
-only visible from the master node.  Local repositories are also known
+only visible from the controller node.  Local repositories are also known
 to require more complicated path names on Windows computers than most
 users want to manage.  Users are advised to run jobs on agents rather
-than running them directly on the master.  For those reasons, use a
+than running them directly on the controller.  For those reasons, use a
 remote repository rather than a local repository for the best Blue
 Ocean experience.
 

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -60,7 +60,7 @@ Jenkins can store the following types of credentials:
 == Credential security
 
 To maximize security, credentials configured in Jenkins are stored in an
-encrypted form on the master Jenkins instance (encrypted by the Jenkins
+encrypted form on the controller Jenkins instance (encrypted by the Jenkins
 instance ID) and are only handled in Pipeline projects via their credential IDs.
 
 This minimizes the chances of exposing the actual credentials themselves to

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -50,7 +50,7 @@ Node::
 Stage::
     A “stage” is a step that calls supported APIs. Pipeline syntax is comprised of stages. Each stage can have one or more build steps within it.
 
-Familiarity with Jenkins  terms such as “controller,” “agent,” and “executor” also helps with understanding how pipelines work. These terms are not specific to pipelines:
+Familiarity with Jenkins terms such as “controller,” “agent”, and “executor” also helps with understanding how pipelines work. These terms are not specific to pipelines:
 
 * controller - A “controller” is the basic installation of Jenkins on a computer; it handles tasks for your build system. Pipeline scripts are parsed on controllers, and steps wrapped in node blocks are performed on available executors.
 * agent - An “agent” (formerly "slave")  is a computer set up to offload particular projects from the controller. Your configuration determines the number and scope of operations that an agent can perform. Operations are performed by executors.

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -15,7 +15,7 @@ In contrast to freestyle jobs, pipelines enable you to define the whole applicat
 
 Accordingly, pipeline functionality is:
 
-* Durable: Pipelines can survive both planned and unplanned restarts of your Jenkins master.
+* Durable: Pipelines can survive both planned and unplanned restarts of your Jenkins controller.
 * Pausable: Pipelines can optionally stop and wait for human input or approval before completing the jobs for which they were built.
 * Versatile: Pipelines support complex real-world CD requirements, including the ability to fork or join, loop, and work in parallel with each other.
 * Efficient: Pipelines can restart from any of several saved checkpoints.
@@ -45,16 +45,16 @@ Node::
     * Creates a workspace, meaning a file directory specific to a particular job, where resource-intensive processing can occur without negatively impacting your pipeline performance. Workspaces last for the duration of the tasks assigned to them.
 
 
-(In Jenkins generally, a “node” means any computer that is part of your Jenkins installation, whether that computer is used as a master or as an agent).
+(In Jenkins generally, a “node” means any computer that is part of your Jenkins installation, whether that computer is used as a controller or as an agent).
 
 Stage::
     A “stage” is a step that calls supported APIs. Pipeline syntax is comprised of stages. Each stage can have one or more build steps within it.
 
-Familiarity with Jenkins  terms such as “master,” “agent,” and “executor” also helps with understanding how pipelines work. These terms are not specific to pipelines:
+Familiarity with Jenkins  terms such as “controller,” “agent,” and “executor” also helps with understanding how pipelines work. These terms are not specific to pipelines:
 
-* master - A “master” is the basic installation of Jenkins on a computer; it handles tasks for your build system. Pipeline scripts are parsed on masters, and steps wrapped in node blocks are performed on available executors.
-* agent - An “agent” (formerly "slave")  is a computer set up to offload particular projects from the master. Your configuration determines the number and scope of operations that an agent can perform. Operations are performed by executors.
-* executor - An “executor” is a computational resource for compiling code. It can run on master or agent machines, either by itself or in parallel with other executors. Jenkins assigns a _java.lang.Thread_ to each executor.
+* controller - A “controller” is the basic installation of Jenkins on a computer; it handles tasks for your build system. Pipeline scripts are parsed on controllers, and steps wrapped in node blocks are performed on available executors.
+* agent - An “agent” (formerly "slave")  is a computer set up to offload particular projects from the controller. Your configuration determines the number and scope of operations that an agent can perform. Operations are performed by executors.
+* executor - An “executor” is a computational resource for compiling code. It can run on controller or agent machines, either by itself or in parallel with other executors. Jenkins assigns a _java.lang.Thread_ to each executor.
 
 == Preparing Jenkins to Run Pipelines
 


### PR DESCRIPTION
Fixed terminology in "Pipeline" tutorials (issue #3837)