### PR TITLE
Hacktoberfest - Update the page to reflect Hacktoberfest policy updates

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -37,17 +37,27 @@ See the link:/participate/[Contribute and Participate] page for more information
 1. Sign-up to Hacktoberfest on link:https://hacktoberfest.digitalocean.com[the event website].
 2. Join link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter channel].
 3. Everything is set, just start creating pull-requests!
-** This year Hacktoberfest does not require labeling pull requests,
-   but please mention Hacktoberfest in your pull requests so that they are reviewed quickly
-   (see link:/events/hacktoberfest/faq/#how-do-i-mark-my-pull-requests[FAQ: Marking Pull requests])
+** If a repository has no `hacktoberfest` topic set,
+   please mention Hacktoberfest in your pull requests so we can set repository topics
+   (see link:/events/hacktoberfest/faq/#how-do-i-mark-my-pull-requests[FAQ: Marking Pull requests]).
 
 == Where to contribute?
 
+NOTE: **Hacktoberfest 2020 update:** On Oct 03, the Hacktoberfest organizers link:https://hacktoberfest.digitalocean.com/hacktoberfest-update[made an update] to reduce spam and to introduce maintainer opt-in.
+We follow the same policy in the Jenkins community,
+and we do **NOT** require all maintainers to participate in Hacktoberfest.
+
 The Jenkins project is spread across several organizations on GitHub (`jenkinsci`, `jenkins-infra`, `jenkins-zh`).
-You are welcome to contribute to **any** repository in **any** of those organizations, or to any other Jenkins-related repository on GitHub.
-However various components in Jenkins have differing review and delivery velocity.
-If you adopt Jenkins in your own open-source projects (e.g. Jenkins Pipeline or Configuration as Code),
+You are welcome to contribute to **any** repository in **any** of those organizations, or any other Jenkins-related repository on GitHub.
+Repositories may have different contribution guidelines, review and merge policies.
+If you adopt Jenkins in your open-source projects (e.g. Jenkins Pipeline or Configuration as Code),
 it counts as well!
+Note that not all pull requests will automatically count towards Hacktoberfest in 2020. 
+
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+org%3Astapler+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest] -
+  you can just submit pull requests, no extra steps needed.
+* for other repositories, we will need to get the repo marked for Hacktoberfest so that your pull request counts towards the goal.
+  Please follow link:/events/hacktoberfest/faq/#how-do-i-mark-my-pull-requests[FAQ: Marking Pull requests].
 
 === Issue queries
 

--- a/content/events/hacktoberfest/faq.adoc
+++ b/content/events/hacktoberfest/faq.adoc
@@ -31,18 +31,20 @@ You can also submit your own issue and propose a fix.
 
 === How do I mark my pull requests?
 
-This year Hacktoberfest does not set any special requirements for marking pull request.
-Any pull requests submitted between Oct 01 and Oct 31 will be counted towards the goal, 
-unless they are marked as invalid by maintainers.
-Still, we ask contributors to mark their pull requests so that we can track Hacktoberfest statistics on the Jenkins side.
-There are three ways:
+On Oct 03, the Hacktoberfest organizers link:https://hacktoberfest.digitalocean.com/hacktoberfest-update[made an update] to reduce spam and to introduce maintainer opt-in.
+We follow the same policy in the Jenkins community,
+and we do **NOT** require all maintainers to participate in Hacktoberfest.
 
-* If you are not a member of the Jenkins organization,
-  put "Hacktoberfest" in your pull request titles
-* If you are a member of the Jenkins organization on GitHub, 
-  CC `@jenkinsci/hacktoberfest` or `@jenkins-infra/hacktoberfest` in your pull requests
-* If you have `Write` or `Triage` permissions in the repository,
-  just put the `hacktoberfest` label on the pull requests
+We ask contributors to mark their pull requests so that we can help with having proper labels set:
+
+* If a repository already has the `hacktoberfest` topic set,
+  no extra steps required. Just submit a pull request!
+** link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+org%3Astapler+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest]
+* If you are not a repository maintainer:
+.. Add "Hacktoberfest" to the beginning of your pull request title.
+.. Reference the pull request in link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter chat].
+   We will contact maintainers to get the GitHub topic set.
+* If you are a repository maintainer, just add the `hacktoberfest` GitHub topic.
 
 === I want to work on my own plugin, is it fine?
 


### PR DESCRIPTION
This change updates the guidelines so that they reflect https://hacktoberfest.digitalocean.com/hacktoberfest-update on Oct 03. It is a minimum viable fix, ideally there should be more changes made in maintainer and user guidelines.

CC @MarkEWaite @halkeye @markyjackson-taulia 
