### PR TITLE
Fixing terminology in 'Developer' documentation

### DIFF
--- a/content/doc/developer/publishing/releasing-experimental-updates.adoc
+++ b/content/doc/developer/publishing/releasing-experimental-updates.adoc
@@ -46,5 +46,5 @@ jenkins:
 
 === In official Docker images
 
-Official link:https://github.com/jenkinsci/docker[Jenkins master Docker image] includes plugin management scripts which allow preinstalling plugins from the Experimental update center.
+Official link:https://github.com/jenkinsci/docker[Jenkins Docker image] includes plugin management scripts which allow preinstalling plugins from the Experimental update center.
 See the documentation and examples link:https://github.com/jenkinsci/docker#preinstalling-plugins[here].

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -48,7 +48,7 @@ issue (and mention the one(s) you found in the description)._
 seems to fail for no reason, try to build your project outside Jenkins,
 but in the same general environment (e.g. same machine, same user
 account, ...). If Jenkins interacts with other systems, make sure that
-they're working. If the connections between Jenkins master and agents
+they're working. If the connections between Jenkins controller and agents
 fail, make sure the network is reliable.
 * *Check the changelogs* to see whether the issue has been fixed in
 newer versions of the affected component.


### PR DESCRIPTION
Fixes issue #3838 