### PR TITLE
Fixed term in 'Dev' section of docs

### DIFF
--- a/content/doc/developer/handling-requests/actions.adoc
+++ b/content/doc/developer/handling-requests/actions.adoc
@@ -28,7 +28,7 @@ public String doRun(String foo) throws Exception
 When the SECURITY-595 fix prevents access to a URL, a warning message is written to the Jenkins log that looks similar to the following:
 
 ----
-WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the whitelist: "method hudson.model.Hudson doExample". Learn more: link:/redirect/stapler-routing
+WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the allowlist: "method hudson.model.Hudson doExample". Learn more: link:/redirect/stapler-routing
 ----
 
 Administrators can follow the instructions to make the method or field work on their specific instance, but ideally the component is changed to prevent the problem in the first place:

--- a/content/doc/developer/handling-requests/stapler-accessible-type.adoc
+++ b/content/doc/developer/handling-requests/stapler-accessible-type.adoc
@@ -14,7 +14,7 @@ Starting in Jenkins 2.138.4 and 2.154, this is further restricted to address sev
 When the SECURITY-595 fix prevents access to a URL, a warning message is written to the Jenkins log that looks similar to the following:
 
 ----
-WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the whitelist: "method hudson.model.Hudson doExample". Learn more: link:/redirect/stapler-routing
+WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the allowlist: "method hudson.model.Hudson doExample". Learn more: link:/redirect/stapler-routing
 ----
 
 Administrators can follow the instructions to make the method or field work on their specific instance, but ideally the component is changed to prevent the problem in the first place.

--- a/content/doc/developer/publishing/documentation.adoc
+++ b/content/doc/developer/publishing/documentation.adoc
@@ -71,8 +71,8 @@ If you use git tag for releases, you can make sure the plugin site loads a snaps
 === Using GitHub topics
 
 Plugin labels are assigned to plugin repositories by their maintainers as link:https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics[GitHub topics].
-GitHub topics that match entries from the link:https://github.com/jenkins-infra/update-center2/blob/master/resources/allowed-github-topics.properties[plugin label whitelist] are displayed on the link:/plugins/[plugin site].
-Developers are encouraged to submit pull requests to the link:https://github.com/jenkins-infra/update-center2/blob/master/resources/allowed-github-topics.properties[plugin label whitelist] when they detect gaps in the list.
+GitHub topics that match entries from the link:https://github.com/jenkins-infra/update-center2/blob/master/resources/allowed-github-topics.properties[plugin label allowlist] are displayed on the link:/plugins/[plugin site].
+Developers are encouraged to submit pull requests to the link:https://github.com/jenkins-infra/update-center2/blob/master/resources/allowed-github-topics.properties[plugin label allowlist] when they detect gaps in the list.
 
 Plugin maintainers are encouraged to apply GitHub topics to the plugins they maintain.
 Topics should be assigned to plugins when the plugin relationship to the label is well above average.

--- a/content/doc/developer/publishing/plugin-site.adoc
+++ b/content/doc/developer/publishing/plugin-site.adoc
@@ -64,7 +64,7 @@ See link:../requesting-hosting/#categorize-the-plugin[categorize the plugin] for
 === How are plugins labeled?
 
 Plugin labels are assigned to plugin repositories by their maintainers as link:https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics[GitHub topics].
-GitHub topics that match entries from the link:https://github.com/jenkins-infra/update-center2/blob/master/resources/allowed-github-topics.properties[plugin label whitelist] are displayed on the plugin site.
+GitHub topics that match entries from the link:https://github.com/jenkins-infra/update-center2/blob/master/resources/allowed-github-topics.properties[plugin label allowlist] are displayed on the plugin site.
 The link:../documentation[plugin documentation guide] includes instructions for link:../documentation#documenting-plugins[documenting], categorizing, and link:../documentation#labeling-plugins[labeling] plugins.
 
 === Where does the description of the plugin come from?


### PR DESCRIPTION
Fixes #3862 

The files:
content/doc/developer/extensions/jenkins-core.adoc
content/doc/developer/extensions/script-security.adoc
content/doc/developer/extensions/yaml-project.adoc
are retained, since their change will require modification of code and will break existing links.