### PR TITLE
Replace a few wiki links in governance docs

### DIFF
--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -8,7 +8,7 @@ tags:
   - elections
 links:
   googlegroup: jenkinsci-board
-  meetings: https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Agenda
+  meetings: http://bit.ly/jenkins-governance-meeting
 ---
 
 :ruby

--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -8,7 +8,7 @@ tags:
   - elections
 links:
   googlegroup: jenkinsci-board
-  meetings: http://bit.ly/jenkins-governance-meeting
+  meetings: /project/governance-meeting/
 ---
 
 :ruby

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -369,7 +369,7 @@ In some cases, the supposed "temporary" patch sets became more permanent for var
 
 === Bringing in new plugins/tools/libraries
 
-If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See link:https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[Hosting Plugins] for more details.
+If you develop a plugin, we encourage you to co-host that with the Jenkins project so that other people in the community can participate. See link:/doc/developer/publishing/requesting-hosting/[Hosting Plugins] for more details.
 
 === Making changes to existing plugins
 
@@ -399,7 +399,7 @@ When making changes, use your common sense. For example, if you are thinking abo
 
 === Contributing localizations
 
-We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see link:https://wiki.jenkins.io/display/JENKINS/Internationalization[Internationalization] for the details of how to make changes.
+We are always looking for people who can help localize Jenkins to different languages. If you are interested in helping, drop us a note in the dev list to get commit access, and see link:/doc/developer/internationalization/[Internationalization] for the details of how to make changes.
 
 [[pull-request]]
 
@@ -410,7 +410,7 @@ As discussed above, Jenkins project uses pull requests as one of the main workfl
 * See link:https://help.github.com/articles/creating-a-pull-request/[the github online help] for how to create a pull request
 * We encourage you to file a ticket in link:https://issues.jenkins-ci.org/[the issue tracker] to describe the bug that you are fixing or the feature you are implementing. This creates a permanent record on our system that allows future developers to understand how the code came into the current shape. This is not a requirement (especially for small changes), but we appreciate if you do that.
 * Refer to the ticket in your commit message by using the notation `[JENKINS-1234]` where _JENKINS-1234_ is the ticket ID. This allows our scripts to understand the history and generate changelogs without human help. If you use the notation `[FIX JENKINS-1234]`, our bot will close the ticket automatically when the change is merged into the repository, and when the change is tested in our CI server. These notations create useful cross-references across systems, and are therefore highly recommended.
-* We encourage you to have a test case for the code you added to avoid future regressions. See link:https://wiki.jenkins.io/display/JENKINS/Unit+Test[Unit Test] for more details about how to write tests.
+* We encourage you to have a test case for the code you added to avoid future regressions. See link:/doc/developer/testing/[Testing] for more details about how to write tests.
 * Try to describe your changes so that other people understand what you did.
 * Make sure you didn’t modify portions that aren’t related to your changes (most often caused by IDE auto-fixing import statements and other code formats.)
 


### PR DESCRIPTION
## Replace a few wiki links in governance docs

The replacements are adequate for the needs, though in one case they include several links to the wiki.  One step at a time.