### PR TITLE
Fix broken image reference to Google Season of Docs

### DIFF
--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -34,7 +34,7 @@ link:blueocean[*Learn more*]
 
 == Document Jenkins on Kubernetes
 
-image:image:/images/gsod/gsod.png["Google Season of Docs", role=left]
+image:/images/gsod/gsod.png["Google Season of Docs", role=left]
 
 Kubernetes is a platform-agnostic container orchestration tool created 
 by Google and heavily supported by the open-source community as a project 


### PR DESCRIPTION
## Before

![screencapture-jenkins-io-projects-2020-10-14-22_50_25-edit](https://user-images.githubusercontent.com/156685/96078622-1cf6e280-0e70-11eb-998a-68bd779cff1d.png)

## After

![screencapture-localhost-4242-projects-2020-10-14-22_52_00-edit](https://user-images.githubusercontent.com/156685/96078732-65160500-0e70-11eb-9b64-def97a59a4b5.png)
