### PR TITLE
Amend changelogs based on 2.249.3 backporting review

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -9059,7 +9059,7 @@
       SSHD module 2.7: Remove deprecated key exchange and MAC algorithms.
     references:
       - pull: 4951
-      - url: https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27
+      - url: "https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27"
         title: SSHD module 2.7 changelog
   - type: rfe
     category: rfe
@@ -9070,7 +9070,7 @@
       SSHD module 2.7: Allow configuring disabled key exchange and MAC algorithms through system properties.
    references:
       - pull: 4951
-      - url: https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27
+      - url: "https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27"
         title: SSHD module 2.7 changelog
   - type: rfe
     category: rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -9068,7 +9068,7 @@
     - daniel-beck
     message: >
       SSHD module 2.7: Allow configuring disabled key exchange and MAC algorithms through system properties.
-   references:
+    references:
       - pull: 4951
       - url: "https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27"
         title: SSHD module 2.7 changelog

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -8841,13 +8841,13 @@
     message: |-
       Name the first breadcrumb "Dashboard" for clarity.
   - type: bug
-    category: developer
+    category: bug
     pull: 4517
     issue: 43889
     authors:
     - thomasgl-orange
     message: |-
-      Developer: Remove test environments more consistently.
+      Make sure <code>Environment</code>s are always torn down in <code>AbstractBuild</code>.
   - type: rfe
     category: developer
     pull: 4517
@@ -9050,13 +9050,28 @@
     message: |-
       Introduce LowResourceMonitor from Jetty by upgrading to Winstone 5.11.
       Bump jetty.version from 9.4.30.v20200611 to 9.4.32.v20200930.
+  - type: major rfe
+    category: rfe
+    pull: 4951
+    authors:
+    - daniel-beck
+    message: >
+      SSHD module 2.7: Remove deprecated key exchange and MAC algorithms.
+    references:
+      - pull: 4951
+      - url: https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27
+        title: SSHD module 2.7 changelog
   - type: rfe
     category: rfe
     pull: 4951
     authors:
     - daniel-beck
-    message: |-
-      Update SSHD module from 2.6 to 2.7 which allows configuring disabled key exchange and MAC algorithms through system properties, removing deprecated algorithms by default.
+    message: >
+      SSHD module 2.7: Allow configuring disabled key exchange and MAC algorithms through system properties.
+   references:
+      - pull: 4951
+      - url: https://github.com/jenkinsci/sshd-module/blob/master/CHANGELOG.md#27
+        title: SSHD module 2.7 changelog
   - type: rfe
     category: rfe
     pull: 4957


### PR DESCRIPTION
* Fixes categorization of https://github.com/jenkinsci/jenkins/pull/4517
* Adds changelog references in https://github.com/jenkinsci/jenkins/pull/4951 , highlights removal of deprecated protocols
