### PR TITLE
Hacktoberfest: Migrated User Content from wiki to doc page

### DIFF
--- a/content/doc/book/managing/_chapter.yml
+++ b/content/doc/book/managing/_chapter.yml
@@ -13,3 +13,4 @@ sections:
   - script-approval
   - users
   - ui-themes
+  - user-content

--- a/content/doc/book/managing/user-content.adoc
+++ b/content/doc/book/managing/user-content.adoc
@@ -1,0 +1,25 @@
+---
+layout: section
+title: User Content
+---
+ifdef::backend-html5[]
+:description:
+:author:
+:email: jenkinsci-docs@googlegroups.com
+:sectanchors:
+:toc:
+:toclevels: 4
+:hide-uri-scheme:
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
+endif::[]
+
+= User Content
+
+Jenkins has a mechanism known as "User Content", where administrators can place files inside  `$JENKINS_HOME/userContent`,
+and these files are served from link:http://yourhost/jenkins/userContent[http://yourhost/jenkins/userContent]. This can be thought of as a mini HTTP server to serve
+images, stylesheets, and other static resources that you can use from various description fields inside Jenkins.
+
+* Note that these files are not subject to any access controls beyond requiring Overall/Read access.
+* See link:https://plugins.jenkins.io/git-userContent/[Git userContent plugin] for how to manage these files through a
+Git repository.

--- a/content/doc/book/managing/user-content.adoc
+++ b/content/doc/book/managing/user-content.adoc
@@ -17,7 +17,7 @@ endif::[]
 = User Content
 
 Jenkins has a mechanism known as "User Content", where administrators can place files inside  `$JENKINS_HOME/userContent`,
-and these files are served from link:http://yourhost/jenkins/userContent[http://yourhost/jenkins/userContent]. This can be thought of as a mini HTTP server to serve
+and these files are served from \http://yourhost/jenkins/userContent. This can be thought of as a mini HTTP server to serve
 images, stylesheets, and other static resources that you can use from various description fields inside Jenkins.
 
 * Note that these files are not subject to any access controls beyond requiring Overall/Read access.


### PR DESCRIPTION
Migrate: https://wiki.jenkins.io/display/JENKINS/User+Content
To: https://www.jenkins.io/doc/book/managing/user-content/

Fixes #3778 