### PR TITLE
Update 2020-05-25-read-only-jenkins-announcement.adoc

### DIFF
--- a/content/blog/2020/05/2020-05-25-read-only-jenkins-announcement.adoc
+++ b/content/blog/2020/05/2020-05-25-read-only-jenkins-announcement.adoc
@@ -37,7 +37,7 @@ Read-only Jenkins is split into three permissions:
 * **Agent/ExtendedRead** - Read-only access to agent configurations
   - existed since 2013 but it was undocumented and only allowed access to API and no UI
   - UI support added in Jenkins 2.238
-* **Overall/SystemRead** - System-wide read-only access.
+* **Overall/SystemRead** - Read-only access to Jenkins system configuration.
      It is very useful for Jenkins instances managed as code, e.g. with help of the plugin:configuration-as-code[Jenkins Configuration as Code Plugin].
   - Introduced in Jenkins 2.222 as a part of jep:224[Readonly system configuration]
 


### PR DESCRIPTION
SystemRead does not grant "System-Wide" access.  System-wide is all of the Jenkins instance including job configuration.  it is scoped to just the Management.