### PR TITLE
Update participants of Chinese Localization SIG, remove alauda as a org

### DIFF
--- a/content/sigs/chinese-localization/index.adoc
+++ b/content/sigs/chinese-localization/index.adoc
@@ -14,13 +14,8 @@ tags:
 leads:
 - "linuxsuren"
 participants:
-- "shenyu_zheng"
-- "xuesea"
-- "node"
-- "donhui"
-organizations:
-- name: "Alauda"
-  github: "alauda"
+- "zhaoying818"
+- "yJunS"
 
 links:
   gitter: jenkinsci/chinese-localization-sig


### PR DESCRIPTION
Hi @zhaoying818 and @yJunS, thanks you guys for the long contributions. I'm going to add you two as the participants of Chinese Localization SIG.

Others are no longer active for a while. But welcome to join us any time.