### PR TITLE
Place Jenkins on IBM Cloud in the correct section of overview

### DIFF
--- a/content/doc/tutorials/index.adoc
+++ b/content/doc/tutorials/index.adoc
@@ -54,9 +54,12 @@ most familiar with:
 * link:build-a-node-js-and-react-app-with-npm[Build a Node.js and React app with npm]
 * link:build-a-python-app-with-pyinstaller[Build a Python app with PyInstaller]
 * link:build-a-labview-app[Build a LabVIEW app]
-* link:tutorial-for-installing-jenkins-on-IBM-Cloud[Get Jenkins on IBM Cloud]
 
 == More tutorials
+
+Cloud tutorials are available including:
+
+* link:tutorial-for-installing-jenkins-on-IBM-Cloud[Jenkins on IBM Cloud]
 
 You may find more tutorials in link:/node/tags/tutorial[Tutorial blogposts].
 


### PR DESCRIPTION
## Jenkins on IBM Cloud is not a "build tool"

The Jenkins on IBM Cloud tutorial was incorrectly placed in the "build tools" section of the tutorial overviews.  It needs to be placed in the "More Tutorials" section.﻿
