### PR TITLE
match docker tutorials to install instructions

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -8,105 +8,240 @@ the sibling file _docker.adoc (used in index.adoc).
 ////
 
 
-==== On macOS and Linux
+=== On macOS and Linux
 
 . Open up a terminal window.
+. Create a link:https://docs.docker.com/network/bridge/[bridge network] in
+  Docker using the following
+  link:https://docs.docker.com/engine/reference/commandline/network_create/[`docker network create`]
+  command:
++
+[source,bash]
+----
+docker network create jenkins
+----
+. In order to execute Docker commands inside Jenkins nodes, download and run
+  the `docker:dind` Docker image using the following
+  link:https://docs.docker.com/engine/reference/run/ [`docker run`]
+  command:
++
+[source,bash]
+----
+docker run \
+  --name jenkins-docker \# <1>
+  --rm \# <2>
+  --detach \# <3>
+  --privileged \# <4>
+  --network jenkins \# <5>
+  --network-alias docker \# <6>
+  --env DOCKER_TLS_CERTDIR=/certs \# <7>
+  --volume jenkins-docker-certs:/certs/client \# <8>
+  --volume jenkins-data:/var/jenkins_home \# <9>
+  --publish 2376:2376 \# <10>
+  docker:dind# <11>
+----
+<1> ( _Optional_ ) Specifies the Docker container name to use for running the
+image. By default, Docker will generate a unique name for the container.
+<2> ( _Optional_ ) Automatically removes the Docker container (the instance of
+the Docker image) when it is shut down.
+<3> ( _Optional_ ) Runs the Docker container in the background. This instance
+can be stopped later by running `docker stop jenkins-docker`.
+<4> Running Docker in Docker currently requires privileged access to function
+properly. This requirement may be relaxed with newer Linux kernel versions.
+// TODO: what versions of Linux?
+<5> This corresponds with the network created in the earlier step.
+<6> Makes the Docker in Docker container available as the hostname `docker`
+within the `jenkins` network.
+<7> Enables the use of TLS in the Docker server. Due to the use
+of a privileged container, this is recommended, though it requires the use of
+the shared volume described below. This environment variable controls the root
+directory where Docker TLS certificates are managed.
+<8> Maps the `/certs/client` directory inside the container to
+a Docker volume named `jenkins-docker-certs` as created above.
+<9> Maps the `/var/jenkins_home` directory inside the container to the Docker
+volume named `jenkins-data`. This will allow for other Docker
+containers controlled by this Docker container's Docker daemon to mount data
+from Jenkins.
+<10> ( _Optional_ ) Exposes the Docker daemon port on the host machine. This is
+useful for executing `docker` commands on the host machine to control this
+inner Docker daemon.
+<11> The `docker:dind` image itself. This image can be downloaded before running
+by using the command: `docker image pull docker:dind`.
++
+*Note:* If copying and pasting the command snippet above does not work, try
+copying and pasting this annotation-free version here:
++
+[source,bash]
+----
+docker run --name jenkins-docker --rm --detach \
+  --privileged --network jenkins --network-alias docker \
+  --env DOCKER_TLS_CERTDIR=/certs \
+  --volume jenkins-docker-certs:/certs/client \
+  --volume jenkins-data:/var/jenkins_home \
+  --publish 2376:2376 docker:dind
+----
 . Customise official Jenkins Docker image, by executing below two steps:
-.. Create Dockerfile with the folloing content:
+.. Create Dockerfile with the following content:
 +
 [source]
 ----
-FROM jenkins/jenkins:2.249.1-lts
+FROM jenkins/jenkins:2.249.2-slim
 USER root
-RUN apt-get update && apt-get install -y \
-       apt-transport-https \
-       ca-certificates \
-       curl \
-       gnupg2 \
+RUN apt-get update && apt-get install -y apt-transport-https \
+       ca-certificates curl gnupg2 \
        software-properties-common
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN apt-key fingerprint 0EBFCD88
 RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/debian \
-       $(lsb_release -cs) \
-       stable"
+       $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN /usr/local/bin/install-plugins.sh blueocean:1.24.0
-
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
+RUN java -jar /usr/lib/jenkins-plugin-manager.jar --plugins blueocean:1.24.2
 ----
-.. Build a new docker image from this Dockerfile and assign the image meaningful name, e.g. "myjenkins:1.0":
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +
-[source]
+[source,bash]
 ----
-docker build -t "myjenkins:1.0" .
+docker build -t myjenkins-blueocean:1.1 .
 ----
-Keep in mind that described above process will automatically download official Jenkins Docker image 
+Keep in mind that the process described above will automatically download the official Jenkins Docker image 
 if this hasn't been done before.
 
-. Run your own `myjenkins:1.0` image as a container in Docker using the
+. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
-[source]
+[source,bash]
 ----
-docker run --rm -u root --name jenkins-tutorial \
-  --volume jenkins-data:/var/jenkins_home \ # <1>
-  --volume "$HOME":/home \ # <2>
-  --volume /var/run/docker.sock:/var/run/docker.sock \ # <3>
-  --publish 8080:8080 myjenkins:1.0
+docker run \
+  --name jenkins-blueocean \# <1>
+  --rm \# <2>
+  --detach \# <3>
+  --network jenkins \# <4>
+  --env DOCKER_HOST=tcp://docker:2376 \# <5>
+  --env DOCKER_CERT_PATH=/certs/client \
+  --env DOCKER_TLS_VERIFY=1 \
+  --publish 8080:8080 \# <6>
+  --publish 50000:50000 \# <7>
+  --volume jenkins-data:/var/jenkins_home \# <8>
+  --volume jenkins-docker-certs:/certs/client:ro \# <9>
+  --volume "$HOME":/home \# <10>
+  myjenkins-blueocean:1.1 # <11>
 ----
-<1> Maps the `/var/jenkins_home` directory in the container to the Docker
+<1> ( _Optional_ ) Specifies the Docker container name for this instance of
+the Docker image.
+<2> ( _Optional_ ) Automatically removes the Docker container when it is shut down.
+<3> ( _Optional_ ) Runs the current container in the background
+(i.e. "detached" mode) and outputs the container ID. If you do not specify this
+option, then the running Docker log for this container is output in the terminal
+window.
+<4> Connects this container to the `jenkins` network defined in the earlier
+step. This makes the Docker daemon from the previous step available to this
+Jenkins container through the hostname `docker`.
+<5> Specifies the environment variables used by `docker`, `docker-compose`, and
+other Docker tools to connect to the Docker daemon from the previous step.
+<6> Maps (i.e. "publishes") port 8080 of the current container to
+port 8080 on the host machine. The first number represents the port on the host
+while the last represents the container's port. Therefore, if you specified `-p
+49000:8080` for this option, you would be accessing Jenkins on your host machine
+through port 49000.
+<7> ( _Optional_ ) Maps port 50000 of the current container to
+port 50000 on the host machine. This is only necessary if you have set up one or
+more inbound Jenkins agents on other machines, which in turn interact with
+your `jenkins-blueocean` container (the Jenkins "controller").
+Inbound Jenkins agents communicate with the Jenkins
+controller through TCP port 50000 by default. You can change this port number on
+your Jenkins controller through the <<managing/security#,Configure Global Security>>
+page. If you were to change the *TCP port for inbound Jenkins agents* of your Jenkins controller
+to 51000 (for example), then you would need to re-run Jenkins (via this
+`docker run ...` command) and specify this "publish" option with something like
+`--publish 52000:51000`, where the last value matches this changed value on the
+Jenkins controller and the first value is the port number on the machine hosting
+the Jenkins controller. Inbound Jenkins agents communicate with the
+Jenkins controller on that port (52000 in this example).
+Note that WebSocket agents in Jenkins 2.217 do not need this configuration.
+<8> Maps the `/var/jenkins_home` directory in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
-`jenkins-data`.
-<2> Maps the `$HOME` directory on the host (i.e. your local) machine (usually
+`jenkins-data`. Instead of mapping the `/var/jenkins_home` directory to a Docker
+volume, you could also map this directory to one on your machine's local file
+system. For example, specifying the option +
+`--volume $HOME/jenkins:/var/jenkins_home` would map the container's
+`/var/jenkins_home` directory to the `jenkins` subdirectory within the `$HOME`
+directory on your local machine, which would typically be
+`/Users/<your-username>/jenkins` or `/home/<your-username>/jenkins`.
+Note that if you change the source volume or directory for this, the volume
+from the `docker:dind` container above needs to be updated to match this.
+<9> Maps the `/certs/client` directory to the previously created
+`jenkins-docker-certs` volume. This makes the client TLS certificates needed
+to connect to the Docker daemon available in the path specified by the
+`DOCKER_CERT_PATH` environment variable.
+<10> Maps the `$HOME` directory on the host (i.e. your local) machine (usually
 the `/Users/<your-username>` directory) to the `/home` directory in the
 container.
-<3> Enables socket communication for the docker image.
-
+<11> The name of the Docker image, which you built in the previous step.
 +
-*Note:* If copying and pasting the command snippet above doesn't work, try
+*Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
 +
-[source]
+[source,bash]
 ----
-docker run --rm -u root --name jenkins-tutorial \
+docker run --name jenkins-blueocean --rm --detach \
+  --network jenkins --env DOCKER_HOST=tcp://docker:2376 \
+  --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 \
+  --publish 8080:8080 --publish 50000:50000 \
   --volume jenkins-data:/var/jenkins_home \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "$HOME":/home --publish 8080:8080 myjenkins:1.0
+  --volume jenkins-docker-certs:/certs/client:ro \
+  --volume "$HOME":/home \
+  myjenkins-blueocean:1.1
 ----
-. Proceed to the <<setup-wizard,Setup wizard>>.
+. Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
 
-==== On Windows
+=== On Windows
 
 The Jenkins project provides a Linux container image, not a Windows container image.
 Be sure that your Docker for Windows installation is configured to run `Linux Containers` rather than `Windows Containers`.
 See the Docker documentation for instructions to link:https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers[switch to Linux containers].
 Once configured to run `Linux Containers`, the steps are:
 
-. Open up a command prompt window.
-. Customise official Jenkins Docker image using the <<on-macos-and-linux,macOS
-and Linux>> instructions above.
+. Open up a command prompt window and similar to the <<on-macos-and-linux,macOS and Linux>> instructions above do the following:
+. Create a bridge network in Docker
++
+[source,bash]
+----
+docker network create jenkins
+----
+. Run a docker:dind Docker image
++
+[source]
+----
+docker run --name jenkins-docker --rm --detach ^
+  --privileged --network jenkins --network-alias docker ^
+  --env DOCKER_TLS_CERTDIR=/certs ^
+  --volume jenkins-docker-certs:/certs/client ^
+  --volume jenkins-data:/var/jenkins_home ^
+  docker:dind
+----
+. Build a customised official Jenkins Docker image using above Dockerfile and `docker build` command.
 
-. Run your own `myjenkins:1.0` image as a container in Docker using the
-  following
+. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
 [source]
 ----
-docker run --rm -u root --name jenkins-tutorial ^
+docker run --name jenkins-blueocean --rm --detach ^
+  --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
+  --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
   --volume jenkins-data:/var/jenkins_home ^
-  --volume "%HOMEDRIVE%%HOMEPATH%":/home ^
-  --volume /var/run/docker.sock:/var/run/docker.sock ^
-  --publish 8080:8080 myjenkins:1.0
+  --volume jenkins-docker-certs:/certs/client:ro ^
+  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.
 
-
+[[accessing-the-jenkins-blue-ocean-docker-container]]
 ==== Accessing the Docker container
 
 If you have some experience with Docker and you wish or need to access your
@@ -118,4 +253,65 @@ That will access the Jenkins Docker container named "jenkins-tutorial".
 This means you could access your docker container (through a separate
 terminal/command prompt window) with a `docker exec` command like:
 
-`docker exec -it jenkins-tutorial bash`
+`docker exec -it jenkins-blueocean bash`
+
+
+== Accessing the Jenkins console log through Docker logs
+
+There is a possibility you may need to access the Jenkins console log, for
+instance, when <<unlocking-jenkins,Unlocking Jenkins>> as part of the
+<<setup-wizard,Post-installation setup wizard>>.
+
+The Jenkins console log is easily accessible through the terminal/command 
+prompt window from which you executed the `docker run ...` command.
+In case if needed you can also access the Jenkins console log through the
+link:https://docs.docker.com/engine/reference/commandline/logs/[Docker logs] of
+your container using the following command:
+
+`docker logs <docker-container-name>`
+
+Your `<docker-container-name>` can be obtained using the `docker ps` command.
+
+
+== Accessing the Jenkins home directory
+
+There is a possibility you may need to access the Jenkins home directory, for
+instance, to check the details of a Jenkins build in the `workspace`
+subdirectory.
+
+If you mapped the Jenkins home directory (`/var/jenkins_home`) to one on your
+machine's local file system (i.e. in the `docker run ...` command
+<<downloading-and-running-jenkins-in-docker,above>>), then you can access the
+contents of this directory through your machine's usual terminal/command prompt.
+
+Otherwise, if you specified the `--volume jenkins-data:/var/jenkins_home` option in
+the `docker run ...` command, you can access the contents of the Jenkins home
+directory through your container's terminal/command prompt using the
+link:https://docs.docker.com/engine/reference/commandline/container_exec/[`docker container exec`]
+command:
+
+`docker container exec -it <docker-container-name> bash`
+
+As mentioned <<accessing-the-jenkins-console-log-through-docker-logs,above>>,
+your `<docker-container-name>` can be obtained using the
+link:https://docs.docker.com/engine/reference/commandline/container_ls/[`docker container ls`]
+command. If you specified the +
+`--name jenkins-blueocean` option in the `docker container run ...`
+command above (see also
+<<accessing-the-jenkins-blue-ocean-docker-container,Accessing the Jenkins/Blue
+Ocean Docker container>>), you can simply use the `docker container exec` command:
+
+`docker container exec -it jenkins-blueocean bash`
+
+////
+Might wish to add explaining the `docker run -t` option, which was covered in
+the old installation instructions but not above.
+
+Also mention that spinning up a container of the `jenkins/jenkins` Docker
+image can be done so with all the same
+https://github.com/jenkinsci/docker#usage[configuration options] available to
+the other images published by the Jenkins project.
+
+Explain colon syntax on Docker image references like
+`jenkins/jenkins:latest'.
+////

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -8,7 +8,7 @@ the sibling file _docker.adoc (used in index.adoc).
 ////
 
 
-=== On macOS and Linux
+==== On macOS and Linux
 
 . Open up a terminal window.
 . Create a link:https://docs.docker.com/network/bridge/[bridge network] in
@@ -199,7 +199,7 @@ docker run --name jenkins-blueocean --rm --detach \
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
 
-=== On Windows
+==== On Windows
 
 The Jenkins project provides a Linux container image, not a Windows container image.
 Be sure that your Docker for Windows installation is configured to run `Linux Containers` rather than `Windows Containers`.
@@ -256,7 +256,7 @@ terminal/command prompt window) with a `docker exec` command like:
 `docker exec -it jenkins-blueocean bash`
 
 
-== Accessing the Jenkins console log through Docker logs
+=== Accessing the Jenkins console log through Docker logs
 
 There is a possibility you may need to access the Jenkins console log, for
 instance, when <<unlocking-jenkins,Unlocking Jenkins>> as part of the
@@ -273,7 +273,7 @@ your container using the following command:
 Your `<docker-container-name>` can be obtained using the `docker ps` command.
 
 
-== Accessing the Jenkins home directory
+=== Accessing the Jenkins home directory
 
 There is a possibility you may need to access the Jenkins home directory, for
 instance, to check the details of a Jenkins build in the `workspace`

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -105,7 +105,7 @@ RUN java -jar /usr/lib/jenkins-plugin-manager.jar --plugins blueocean:1.24.2
 ----
 docker build -t myjenkins-blueocean:1.1 .
 ----
-Keep in mind that the process described above will automatically download the official Jenkins Docker image 
+Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
 
 . Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the
@@ -262,7 +262,7 @@ There is a possibility you may need to access the Jenkins console log, for
 instance, when <<unlocking-jenkins,Unlocking Jenkins>> as part of the
 <<setup-wizard,Post-installation setup wizard>>.
 
-The Jenkins console log is easily accessible through the terminal/command 
+The Jenkins console log is easily accessible through the terminal/command
 prompt window from which you executed the `docker run ...` command.
 In case if needed you can also access the Jenkins console log through the
 link:https://docs.docker.com/engine/reference/commandline/logs/[Docker logs] of

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -161,7 +161,7 @@ to 51000 (for example), then you would need to re-run Jenkins (via this
 Jenkins controller and the first value is the port number on the machine hosting
 the Jenkins controller. Inbound Jenkins agents communicate with the
 Jenkins controller on that port (52000 in this example).
-Note that WebSocket agents in Jenkins 2.217 do not need this configuration.
+Note that link:/blog/2020/02/02/web-socket/[WebSocket agents] do not need this configuration.
 <8> Maps the `/var/jenkins_home` directory in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
 `jenkins-data`. Instead of mapping the `/var/jenkins_home` directory to a Docker

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -255,8 +255,8 @@ terminal/command prompt window) with a `docker exec` command like:
 
 `docker exec -it jenkins-blueocean bash`
 
-
-=== Accessing the Jenkins console log through Docker logs
+[[accessing-the-jenkins-console-log-through-docker-logs]]
+==== Accessing the Docker logs
 
 There is a possibility you may need to access the Jenkins console log, for
 instance, when <<unlocking-jenkins,Unlocking Jenkins>> as part of the
@@ -273,7 +273,7 @@ your container using the following command:
 Your `<docker-container-name>` can be obtained using the `docker ps` command.
 
 
-=== Accessing the Jenkins home directory
+==== Accessing the Jenkins home directory
 
 There is a possibility you may need to access the Jenkins home directory, for
 instance, to check the details of a Jenkins build in the `workspace`

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -100,18 +100,18 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN java -jar /usr/lib/jenkins-plugin-manager.jar blueocean:1.24.2
+RUN java -jar /usr/lib/jenkins-plugin-manager.jar --plugins blueocean:1.24.2
 ----
-.. Build a new docker image from this Dockerfile and assign the image some meaningful name:
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +
 [source,bash]
 ----
-docker build -t myjenkins-blueocean:1,1 .
+docker build -t myjenkins-blueocean:1.1 .
 ----
 Keep in mind that the process described above will automatically download the official Jenkins Docker image 
 if this hasn't been done before.
 
-. Run your own `myjenkins-blueocean:1,1` image as a container in Docker using the
+. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
@@ -130,7 +130,7 @@ docker run \
   --publish 50000:50000 \# <7>
   --volume jenkins-data:/var/jenkins_home \# <8>
   --volume jenkins-docker-certs:/certs/client:ro \# <9>
-  myjenkins-blueocean:1,1 # <10>
+  myjenkins-blueocean:1.1 # <10>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name for this instance of
 the Docker image.
@@ -191,7 +191,7 @@ docker run --name jenkins-blueocean --rm --detach \
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
-  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1,1
+  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
@@ -223,7 +223,7 @@ docker run --name jenkins-docker --rm --detach ^
 ----
 . Build a customised official Jenkins Docker image using above Dockerfile and `docker build` command.
 
-. Run your own `myjenkins-blueocean:1,1` image as a container in Docker using the following
+. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
@@ -234,10 +234,9 @@ docker run --name jenkins-blueocean --rm --detach ^
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
   --volume jenkins-data:/var/jenkins_home ^
   --volume jenkins-docker-certs:/certs/client:ro ^
-  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1,1
+  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.
-. Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
 [[accessing-the-jenkins-blue-ocean-docker-container]]
 ==== Accessing the Docker container

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -107,7 +107,7 @@ RUN java -jar /usr/lib/jenkins-plugin-manager.jar --plugins blueocean:1.24.2
 ----
 docker build -t myjenkins-blueocean:1.1 .
 ----
-Keep in mind that the process described above will automatically download the official Jenkins Docker image 
+Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
 
 . Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the
@@ -239,7 +239,7 @@ docker run --name jenkins-blueocean --rm --detach ^
 . Proceed to the <<setup-wizard,Setup wizard>>.
 
 [[accessing-the-jenkins-blue-ocean-docker-container]]
-==== Accessing the Docker container
+== Accessing the Docker container
 
 If you have some experience with Docker and you wish or need to access your
 Docker container through a terminal/command prompt using the
@@ -252,14 +252,14 @@ terminal/command prompt window) with a `docker exec` command like:
 
 `docker exec -it jenkins-blueocean bash`
 
-
-== Accessing the Jenkins console log through Docker logs
+[[accessing-the-jenkins-console-log-through-docker-logs]]
+== Accessing the Docker logs
 
 There is a possibility you may need to access the Jenkins console log, for
 instance, when <<unlocking-jenkins,Unlocking Jenkins>> as part of the
 <<setup-wizard,Post-installation setup wizard>>.
 
-The Jenkins console log is easily accessible through the terminal/command 
+The Jenkins console log is easily accessible through the terminal/command
 prompt window from which you executed the `docker run ...` command.
 In case if needed you can also access the Jenkins console log through the
 link:https://docs.docker.com/engine/reference/commandline/logs/[Docker logs] of

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -47,8 +47,7 @@ image. By default, Docker will generate a unique name for the container.
 <2> ( _Optional_ ) Automatically removes the Docker container (the instance of
 the Docker image) when it is shut down.
 <3> ( _Optional_ ) Runs the Docker container in the background. This instance
-can be stopped later by running `docker stop jenkins-docker` and
-started again with `docker start jenkins-docker`.
+can be stopped later by running `docker stop jenkins-docker`.
 <4> Running Docker in Docker currently requires privileged access to function
 properly. This requirement may be relaxed with newer Linux kernel versions.
 // TODO: what versions of Linux?
@@ -189,9 +188,10 @@ copying and pasting this annotation-free version here:
 docker run --name jenkins-blueocean --rm --detach \
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 \
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 \
+  --publish 8080:8080 --publish 50000:50000 \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
-  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
+  myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -162,7 +162,7 @@ to 51000 (for example), then you would need to re-run Jenkins (via this
 Jenkins controller and the first value is the port number on the machine hosting
 the Jenkins controller. Inbound Jenkins agents communicate with the
 Jenkins controller on that port (52000 in this example).
-Note that WebSocket agents in Jenkins 2.217 do not need this configuration.
+Note that link:/blog/2020/02/02/web-socket/[WebSocket agents] do not need this configuration.
 <8> Maps the `/var/jenkins_home` directory in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
 `jenkins-data`. Instead of mapping the `/var/jenkins_home` directory to a Docker

--- a/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
+++ b/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
@@ -30,7 +30,7 @@ page",width=100%]
 +
 [source]
 ----
-docker logs jenkins-tutorial
+docker logs jenkins-blueocean
 ----
 . From your terminal/command prompt window again, copy the
   automatically-generated alphanumeric password (between the 2 sets of
@@ -72,13 +72,16 @@ Finally, Jenkins asks you to create your first administrator user.
 ==== Stopping and restarting Jenkins
 
 Throughout the remainder of this tutorial, you can stop your 
-Docker container by running `docker stop jenkins jenkins-docker`.
+Docker container by running:
+
+[source,bash]
+----
+docker stop jenkins-blueocean jenkins-docker
+----
 
 To restart your Docker container:
 
-. Run the same `docker run ...` command you ran for <<on-macos-and-linux,macOS,
-  Linux>> or <<on-windows,Windows>> above. +
-  *Note:* This process also updates your Docker image, if
-  an updated one is available.
+. Run the same `docker run ...` commands you ran for <<on-macos-and-linux,macOS, Linux>> or
+  <<on-windows,Windows>> above. +
 . Browse to `\http://localhost:8080`.
 . Wait until the log in page appears and log in.

--- a/content/doc/book/installing/docker.adoc
+++ b/content/doc/book/installing/docker.adoc
@@ -21,7 +21,7 @@ changes against the procedures documented in the
 Jenkins Documentation.
 ////
 
-link:https://docs.docker.com/engine/docker-overview/[Docker] is a platform for
+link:https://docs.docker.com/get-started/overview/[Docker] is a platform for
 running applications in an isolated environment called a "container" (or Docker
 container). Applications like Jenkins can be downloaded as read-only "images"
 (or Docker images), each of which is run in Docker as a container. A Docker
@@ -43,13 +43,13 @@ To install Docker on your operating system, follow "prerequisits" section of the
 link:/doc/pipeline/tour/getting-started/#prerequisites[Guided Tour page]
 
 As an alternative solution you can visit the
-link:https://store.docker.com/search?type=edition&offering=community[Docker
-store] website and click the *Docker Community Edition* box which is suitable
+link:https://hub.docker.com/search?type=edition&offering=community[Dockerhub]
+and select the *Docker Community Edition* suitable
 for your operating system or cloud service. Follow the installation instructions
 on their website.
 
-Jenkins can also run on Docker Enterprise Edition, which you can access through
-*Docker EE* on the Docker store website.
+Jenkins also runs on Docker Enterprise. You can learn more about
+link:https://hub.docker.com/editions/enterprise/docker-ee[*Docker Enterprise*] on Dockerhub.
 
 [CAUTION]
 ====

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -76,7 +76,7 @@ container and execute the defined steps within it:
 [Pipeline] sh
 [guided-tour] Running shell script
 + node --version
-v14.5.0
+v14.15.0
 [Pipeline] }
 [Pipeline] // stage
 [Pipeline] }

--- a/content/doc/pipeline/tour/agents.adoc
+++ b/content/doc/pipeline/tour/agents.adoc
@@ -80,7 +80,7 @@ container and execute the defined steps within it:
 [Pipeline] sh
 [guided-tour] Running shell script
 + node --version
-v14.5.0
+v14.15.0
 [Pipeline] }
 [Pipeline] // stage
 [Pipeline] }

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -45,7 +45,8 @@ include::doc/book/installing/_run-jenkins-in-docker.adoc[]
 
 
 [[fork-sample-repository]]
-=== Fork and clone the sample repository on GitHub
+[[fork-and-clone-the-sample-repository-on-github]]
+=== Fork and clone the sample repository
 
 Obtain the simple "Hello world!" Java application from GitHub, by forking the
 sample repository of the application's source code into your own GitHub account

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -52,7 +52,8 @@ include::doc/book/installing/_run-jenkins-in-docker.adoc[]
 
 
 [[fork-sample-repository]]
-=== Fork and clone the sample repository on GitHub
+[[fork-and-clone-the-sample-repository-on-github]]
+=== Fork and clone the sample repository
 
 Obtain the simple "Welcome to React" Node.js and React application from GitHub,
 by forking the sample repository of the application's source code into your own

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -48,7 +48,8 @@ include::doc/book/installing/_run-jenkins-in-docker.adoc[]
 
 
 [[fork-sample-repository]]
-=== Fork and clone the sample repository on GitHub
+[[fork-and-clone-the-sample-repository-on-github]]
+=== Fork and clone the sample repository
 
 Obtain the simple "Welcome to React" Node.js and React application from GitHub,
 by forking the sample repository of the application's source code into your own

--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -55,7 +55,8 @@ include::doc/book/installing/_run-jenkins-in-docker.adoc[]
 
 
 [[fork-sample-repository]]
-=== Fork and clone the sample repository on GitHub
+[[fork-and-clone-the-sample-repository-on-github]]
+=== Fork and clone the sample repository
 
 Obtain the simple "add" Python application from GitHub, by forking the sample
 repository of the application's source code into your own GitHub account and


### PR DESCRIPTION
## Match Docker tutorial instructions to install guide

The tutorial instructions need to mount the user home directory for easy access to a local fork of a GitHub repository.  They may also need to grant access to port 3000 for the NodeJS tutorial runtime testing.  Currently, the NodeJS runtime testing on port 3000 does not work.  This change does not make it any more broken than it already is.


* Update Dockerhub hyperlinks
* Update node output value in sample
* Use correct Docker name for tutorial stop command
* Fix errors in Docker install instructions
* Sync Docker tutorial with Docker install guide
* Reduce diffs between _docker.adoc & _docker-for-tutorials.adoc
* Remove trailing white space
* Move log and dir access to correct level
* Reduce length of Fork header in tutorial
