### PR TITLE
Use jenkins-plugin-cli to install plugins in Docker

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -97,7 +97,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN java -jar /usr/lib/jenkins-plugin-manager.jar --plugins blueocean:1.24.2
+RUN jenkins-plugin-cli --plugins blueocean:1.24.2
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -99,7 +99,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN java -jar /usr/lib/jenkins-plugin-manager.jar --plugins blueocean:1.24.2
+RUN jenkins-plugin-cli --plugins blueocean:1.24.2
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +


### PR DESCRIPTION
## Use documented script to install plugins

﻿Calling the jar command directly is workable but is not how it is described in the documentation for the Docker image.
