### PR TITLE
Remove the Hacktoberfest Jumbotron, use the Participate one

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -62,21 +62,13 @@ homepage: true
   :image => {:src => expand_link('images/post-images/jenkins-is-the-way/jenkins-is-the-way.png'), :height => "285px"},
   :call_to_action => {:text => 'More info', :href => 'https://JenkinsIsTheWay.io/'}}
 
--# Hacktoberfest
-- slides << {:href => 'events/hacktoberfest',
-  :title => 'Join us at Hacktoberfest!',
-  :intro => "Hacktoberfest is a month long celebration of open source software in October. We invite everyone to contribute to Jenkins, regardless of your experience. Newcomers and experienced contributors are welcome! You can work on code or documentation, help to localize Jenkins, or create new artwork.",
-  :image => {:src => expand_link('images/hacktoberfest/2020_badge_small.png'), :height => "300px"},
-  :call_to_action => {:text => 'More info', :href => expand_link('events/hacktoberfest')}}
-
 // Permanent
-// TODO: Restore once Hacktoberfest is over
-//-# Participate
-//- slides << {:href => expand_link('participate'),
-//  :title => 'Participate and Contribute!',
-//  :intro => "Jenkins is a community-driven project. We invite everyone to join us and move it forward. Any contribution matters: code, documentation, localization, blog posts, artwork, meetups, and anything else. If you have five minutes or a few hours, you can help!",
-//  :image => {:src => expand_link('images/logos/needs-you/Jenkins_Needs_You-transparent.png'), :height => "320px"},
-//  :call_to_action => {:text => 'More info', :href => expand_link('participate')}}
+-# Participate
+- slides << {:href => expand_link('participate'),
+  :title => 'Participate and Contribute!',
+  :intro => "Jenkins is a community-driven project. We invite everyone to join us and move it forward. Any contribution matters: code, documentation, localization, blog posts, artwork, meetups, and anything else. If you have five minutes or a few hours, you can help!",
+  :image => {:src => expand_link('images/logos/needs-you/Jenkins_Needs_You-transparent.png'), :height => "320px"},
+  :call_to_action => {:text => 'More info', :href => expand_link('participate')}}
 
 -# Carousel
 = partial('projectcarousel.html.haml',


### PR DESCRIPTION
Restores the .participate jumbotron. There is a collision with the Elections jumbotron image we need to resolve, but it can be done as a follow-up