### PR TITLE
Cleanup terminology in the Nov 11 advisory

### DIFF
--- a/content/security/advisory/2020-11-04.adoc
+++ b/content/security/advisory/2020-11-04.adoc
@@ -145,7 +145,7 @@ issues:
     previous: '2.11'
     fixed: '2.12'
 - id: SECURITY-1646
-  title: Master environment variables accessible in PLUGIN_NAME
+  title: Controller environment variables accessible in PLUGIN_NAME
   cve: CVE-2020-2307
   cvss:
     severity: Medium
@@ -351,13 +351,13 @@ issues:
     previous: 1.0.0
 - id: SECURITY-2084
   reporter: Long Nguyen, Viettel Cyber Security
-  title: Password stored in plain text by PLUGIN_NAME
+  title: Password stored in plain text by VMware Lab Manager Agents Plugin
   cve: CVE-2020-2319
   cvss:
     severity: Low
     vector: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 0.2.8 and earlier stores a password unencrypted in the global `config.xml` file on the Jenkins controller as part of its configuration.
+    VMware Lab Manager Agents Plugin 0.2.8 and earlier stores a password unencrypted in the global `config.xml` file on the Jenkins controller as part of its configuration.
 
     This password can be viewed by users with access to the Jenkins controller file system.
 


### PR DESCRIPTION
It is a partial fix for "VMware Lab Manager Agents". Auto-generated entries will still use "slave" there