### PR TITLE
Use consistent layout in install sections

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -116,7 +116,7 @@ node {
 
 // Declarative //
 pipeline {
-    agent docker: 'node:6.3'
+    agent docker: 'node:14-alpine'
     stages {
 	stage('Build') {
 	    sh 'npm install'

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -1,4 +1,4 @@
-==== Install Jenkins with Helm v3
+== Install Jenkins with Helm v3
 
 A typical Jenkins deployment consists of a controller node and, optionally, one or more agents. To simplify the deployment of Jenkins, we’ll use link:https://helm.sh/[Helm] to deploy Jenkins.
 Helm is a package manager for Kubernetes and its package format is called a chart.
@@ -6,16 +6,16 @@ Many community-developed charts are available on link:https://github.com/helm/ch
 
 Helm Charts provide “push button” deployment and deletion of apps, making adoption and development of Kubernetes apps easier for those with little container or microservices experience.
 
-===== Prerequisites
+=== Prerequisites
 
 Helm command line interface::
 If you don't have Helm command line interface installed and configured locally, see the sections below to <<Install Helm>> and <<Configure Helm>>.
 
-===== Install Helm
+=== Install Helm
 
 To install Helm CLI, follow the instructions from the link:https://helm.sh/docs/intro/install/[Installing Helm] page.
 
-===== Configure Helm
+=== Configure Helm
 Once Helm is installed and set up properly, add the Jenkins repo as follows:
 
 [source,bash]
@@ -31,7 +31,7 @@ The helm charts in the Jenkins repo can be listed with the command:
 $ helm search repo jenkinsci
 ----
 
-===== Create a persistent volume
+=== Create a persistent volume
 
 We want to create a link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/[persistent volume] for our Jenkins controller pod.
 This will prevent us from losing our whole configuration of the Jenkins controller and our jobs when we reboot our minikube.
@@ -75,7 +75,7 @@ NOTE: It’s worth noting that, in the above spec, hostPath uses the /data/jenki
 This approach is only suited for development and testing purposes.
 For production, you should provide a network resource like a Google Compute Engine persistent disk, or an Amazon Elastic Block Store volume.
 
-===== Create a service account
+=== Create a service account
 
 In Kubernetes, service accounts are used to provide an identity for pods.
 Pods that want to interact with the API server will authenticate with a
@@ -194,7 +194,7 @@ To bind a ClusterRole to all the namespaces in our cluster, we use a ClusterRole
 $ kubectl apply -f jenkins-sa.yaml
 ----
 
-===== Install Jenkins
+=== Install Jenkins
 
 We will deploy Jenkins including the Jenkins Kubernetes plugin.
 Here you can find the official chart.
@@ -362,12 +362,12 @@ Forwarding from [::1]:8080 -> 8080
 
 Visit http://127.0.0.1:8080/ and log in using `admin` as the username and the password you retrieved earlier.
 
-==== Install Jenkins with YAML files
+== Install Jenkins with YAML files
 
 This section describes how to use a set of YAML (Yet Another Markup Language) files to install Jenkins on a Kubernetes cluster.
 The YAML files are easily tracked, edited, and can be reused indefinitely.
 
-===== Create Jenkins deployment file
+=== Create Jenkins deployment file
 
 Use your preferred text editor to create a jenkins-deployment.yaml file in the “jenkins” namespace we created in this link:/doc/book/installing/#create-a-namespace-for-the-jenkins-deployment[section] above.
 
@@ -420,7 +420,7 @@ beyond the lifetime of a pod.
 
 Exit and save the changes once you add the content to the Jenkins deployment file.
 
-===== Deploy Jenkins
+=== Deploy Jenkins
 
 To create the deployment execute:
 
@@ -438,7 +438,7 @@ To validate that creating the deployment was successful you can invoke:
 $ kubectl get deployments -n jenkins
 ----
 
-===== Grant access to Jenkins service
+=== Grant access to Jenkins service
 
 We have a Jenkins instance deployed but it is still not accessible.
 The Jenkins Pod has been assigned an IP address that is internal to the Kubernetes cluster.
@@ -491,7 +491,7 @@ NAME       TYPE        CLUSTER-IP       EXTERNAL-IP    PORT(S)           AGE
 jenkins    NodePort    10.103.31.217    <none>         8080:32664/TCP    59s
 ----
 
-===== Access Jenkins dashboard
+=== Access Jenkins dashboard
 
 So now we have created a deployment and service, how do we access Jenkins?
 
@@ -553,6 +553,6 @@ This may also be found at:
 
 You have successfully installed Jenkins on your Kubernetes cluster and can use it to create new and efficient development pipelines.
 
-==== Install Jenkins with Jenkins Operator
+== Install Jenkins with Jenkins Operator
 
 NOTE: This section is a work in progress. Want to help? Check out the link:https://groups.google.com/forum/#!forum/jenkinsci-docs[jenkinsci-docs mailing list]. For other ways to contribute to the Jenkins project, link:https://www.jenkins.io/participate[see this page about participating and contributing].

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -14,8 +14,6 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== Kubernetes
-
 Kubernetes (K8s) is an open-source system for automating deployment, scaling,
 and management of containerized applications.
 
@@ -30,7 +28,7 @@ Note: the documented approach with Minikube is a Quickstart guide only suited fo
 It should not be used for production instances.
 Configure production instances based on the link:https://kubernetes.io/docs/setup/production-environment/[Kubernetes guidelines].
 
-=== Prerequisites
+== Prerequisites
 
 Docker::
 Refer to the link:https://docs.docker.com/engine/install/[Docker Engine installation instructions] for your platform.

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -14,8 +14,6 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== Linux
-
 Jenkins installers are available for several Linux distributions.
 
 * <<Debian/Ubuntu>>
@@ -24,11 +22,11 @@ Jenkins installers are available for several Linux distributions.
 
 include::doc/book/installing/_installation_requirements.adoc[]
 
-=== Debian/Ubuntu
+== Debian/Ubuntu
 
 On Debian and Debian-based distributions like Ubuntu you can install Jenkins through `apt`.
 
-==== Long Term Support release
+=== Long Term Support release
 
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
 It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-stable` apt repository].
@@ -42,7 +40,7 @@ sudo apt-get update
 sudo apt-get install jenkins
 ----
 
-==== Weekly release
+=== Weekly release
 
 A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
 It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt repository].
@@ -80,7 +78,7 @@ If your `/etc/init.d/jenkins` file fails to start Jenkins, edit the `/etc/defaul
 Here, "8081" was chosen but you can put another port available.
 ====
 
-==== Installation of Java
+=== Installation of Java
 
 Jenkins requires Java in order to run, yet certain distributions don't include this by default and  link:/doc/administration/requirements/java/[some Java versions are incompatible] with Jenkins.
 
@@ -129,11 +127,11 @@ It has a command structure that is similar to `apt-get` but was created to be a 
 Simple software management tasks like install, search and remove are easier with `apt`.
 ====
 
-=== Fedora
+== Fedora
 
 You can install Jenkins through `dnf`. You need to add the Jenkins repository from the Jenkins website to the package manager first.
 
-==== Long Term Support release
+=== Long Term Support release
 
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
 It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
@@ -161,7 +159,7 @@ sudo dnf upgrade
 sudo dnf install jenkins java-devel
 ----
 
-==== Start Jenkins
+=== Start Jenkins
 
 You can start the Jenkins service with the command:
 
@@ -208,12 +206,12 @@ firewall-cmd --reload
 
 ====
 
-=== Red Hat / CentOS
+== Red Hat / CentOS
 
 You can install Jenkins through `yum` on Red Hat Enterprise Linux, CentOS, and other Red Hat based distributions.
 You need to choose either the Jenkins Long Term Support release or the Jenkins weekly release.
 
-==== Long Term Support release
+=== Long Term Support release
 
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
 It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
@@ -243,7 +241,7 @@ sudo yum install jenkins java-1.8.0-openjdk-devel
 sudo systemctl daemon-reload
 ----
 
-==== Start Jenkins
+=== Start Jenkins
 
 You can start the Jenkins service with the command:
 

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -80,7 +80,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'node:6.3' } }
+    agent { docker { image 'node:14-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -94,7 +94,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('node:6.3').inside {
+        docker.image('node:14-alpine').inside {
             sh 'npm --version'
         }
     }


### PR DESCRIPTION
## Use consistent layout in install sections

The Kubernetes and Linux sections included an extra heading and were using a different heading depth than the other install sections.  Top level topics should be placed at the left of the contents so that it is obvious they 
are top level topics.

- Indent Kubernetes table of contents
- Fix Linux install indent


## Before Kubernetes

![Screenshot 2020-11-05 162530](https://user-images.githubusercontent.com/156685/98307722-b43cea80-1f83-11eb-8836-5f018b878fd1.png)


## After Kubernetes

![Screenshot 2020-11-05 162629](https://user-images.githubusercontent.com/156685/98307728-b737db00-1f83-11eb-97bb-5b38c3f52fea.png)

## After Linux

![image](https://user-images.githubusercontent.com/156685/98307888-139afa80-1f84-11eb-88f0-41dbc3478057.png)
