### PR TITLE
Remove duplicate install section headings

### DIFF
--- a/content/doc/book/installing/initial-settings.adoc
+++ b/content/doc/book/installing/initial-settings.adoc
@@ -14,13 +14,11 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== Initial Settings
-
 Most Jenkins configuration changes can be made through the Jenkins user interface or through the plugin:configuration-as-code[configuration as code plugin].
 There are some configuration values that can only be modified while Jenkins is starting.
 This section describes those settings and how you can use them.
 
-=== Jenkins Parameters
+== Jenkins Parameters
 
 Jenkins initialization can also be controlled by run time parameters passed as arguments.
 Command line arguments can adjust networking, security, monitoring, and other settings.

--- a/content/doc/book/installing/macos.adoc
+++ b/content/doc/book/installing/macos.adoc
@@ -14,8 +14,6 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== macOS
-
 The macOS installer for Jenkins is maintained outside the Jenkins project.
 Refer to documentation based on the version of Jenkins to be run.
 

--- a/content/doc/book/installing/offline.adoc
+++ b/content/doc/book/installing/offline.adoc
@@ -14,8 +14,6 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== Offline Installations
-
 This section describes how to install Jenkins on a machine
 that does not have an internet connection.
 

--- a/content/doc/book/installing/offline.adoc
+++ b/content/doc/book/installing/offline.adoc
@@ -24,15 +24,21 @@ include::doc/book/installing/_installation_requirements.adoc[]
 
 === Offline plugin installation
 
-Plugins are a different matter, due to dependency requirements. 
+Offline plugin installations require additional effort due to dependency requirements.
 
-The recommended approach is to use link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool].
+The link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool] is the recommended tool for offline plugin installation.
+It downloads user specified plugins and all dependencies of the user specified plugins.
+The link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool] also reports available plugin updates and plugin security warnings.
+It is included in the official link:https://github.com/jenkinsci/docker/blob/master/README.md#plugin-installation-manager-cli-preview[Jenkins Docker images].
+It is also used to install plugins as part of the link:/doc/book/installing/docker/[Docker install instructions].
+Refer to the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[Gitter chat channel] for questions and answers
 
 If you want to transfer the individual plugins, you'll need to retrieve
 all dependencies as well. There are several dependency retrieval scripts and tools
 on Github. For example:
 
-* link:https://github.com/jenkinsci/docker/blob/master/install-plugins.sh[install-plugins.sh] - Bash script for managing plugins from the official Docker image for Jenkins
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/blob/master/README.md[Plugin installation manager tool] - Java command line utility to install Jenkins plugins and their dependencies.
+* link:https://github.com/jenkinsci/docker/blob/master/install-plugins.sh[install-plugins.sh] - Bash script to download plugins
 * link:https://github.com/samrocketman/jenkins-bootstrap-shared[samrocketman/jenkins-bootstrap-shared] - Java is
 required; packages Jenkins and plugins into an immutable package
 installer.  Supported formats include: RPM, DEB, Docker. Can proxy

--- a/content/doc/book/installing/other.adoc
+++ b/content/doc/book/installing/other.adoc
@@ -14,13 +14,14 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== Other Operating Systems
+[[other-systems]]
+[[other-operating-systems]]
 
-=== FreeBSD
+== FreeBSD
 
 Jenkins can be installed on FreeBSD using the standard FreeBSD package manager, `pkg`.
 
-==== Long Term Support release
+=== Long Term Support release
 
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
 It can be installed from the FreeBSD `pkg` package manager.
@@ -37,7 +38,7 @@ The Jenkins package for FreeBSD is NOT officially supported by the Jenkins proje
 but it is actively used by the link:https://www.freebsd.org/[FreeBSD project] at https://ci.freebsd.org/ .
 ====
 
-==== Weekly release
+=== Weekly release
 
 A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
 It can be installed from the FreeBSD `pkg` package manager.
@@ -54,7 +55,7 @@ The long term support package `jenkins-lts` and the weekly package installation 
 * Direct console log output to the file `/var/log/jenkins.log`. Check this file when troubleshooting Jenkins
 * Set Jenkins to listen on port 8180 from the path `/jenkins`.  Open \http://localhost:8180/jenkins to login to Jenkins
 
-==== Start Jenkins
+=== Start Jenkins
 
 You can start the Jenkins service with the command:
 
@@ -77,7 +78,7 @@ You can stop the Jenkins service with the command:
 # service jenkins stop
 ----
 
-==== Enable Jenkins
+=== Enable Jenkins
 
 Add the following to `/etc/rc.conf` to start Jenkins automatically on system boot:
 
@@ -97,7 +98,7 @@ Other configuration values that can be set in `/etc/rc.conf` or in `/etc/rc.conf
 Refer to the link:https://wiki.freebsd.org/Jenkins[Jenkins page] on the link:https://wiki.freebsd.org/[FreeBSD wiki] for more information specific to Jenkins on FreeBSD.
 
 
-=== OpenIndiana Hipster
+== OpenIndiana Hipster
 
 On a system running link:https://www.openindiana.org/[OpenIndiana Hipster]
 Jenkins can be installed in either the local or global zone using the
@@ -179,7 +180,7 @@ before updating, if needed.
 ====
 
 
-=== Solaris, OmniOS, SmartOS, and other siblings
+== Solaris, OmniOS, SmartOS, and other siblings
 
 Generally it should suffice to install Java 8 and link:/download[download] the
 `jenkins.war` and run it as a standalone process or under an application server

--- a/content/doc/book/installing/war-file.adoc
+++ b/content/doc/book/installing/war-file.adoc
@@ -14,15 +14,13 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 endif::[]
 
-== WAR files
-
 The Web application ARchive (WAR) file version of Jenkins can be installed on
 any operating system or platform that runs a version of Java supported by Jenkins.
 See the link:/doc/administration/requirements/java[Java Requirements] page for details.
 
 include::doc/book/installing/_installation_requirements.adoc[]
 
-=== Run the WAR file
+== Run the WAR file
 
 The Jenkins Web application ARchive (WAR) file can be started from the command line like this:
 


### PR DESCRIPTION
## Remove duplicate headings from install guide

Heading is already provided by the title of the page, no need for an additional opening heading

## Before the change

![before-Screenshot 2020-11-06 162505](https://user-images.githubusercontent.com/156685/98423753-e0706e00-204c-11eb-9792-5e53f0127b31.png)

## After the change

![after-Screenshot 2020-11-06 162547](https://user-images.githubusercontent.com/156685/98423760-e49c8b80-204c-11eb-92e0-f5e03f4dca67.png)
