### PR TITLE
Opened dind port 3000 to enable more tutorials

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -240,6 +240,7 @@ docker run --name jenkins-blueocean --rm --detach ^
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
   --volume jenkins-data:/var/jenkins_home ^
   --volume jenkins-docker-certs:/certs/client:ro ^
+  --volume "%HOMEDRIVE%%HOMEPATH%":/home ^
   --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -37,8 +37,9 @@ docker run \
   --env DOCKER_TLS_CERTDIR=/certs \# <7>
   --volume jenkins-docker-certs:/certs/client \# <8>
   --volume jenkins-data:/var/jenkins_home \# <9>
-  --publish 2376:2376 \# <10>
-  docker:dind# <11>
+  --publish 3000:3000 \# <10>
+  --publish 2376:2376 \# <11>
+  docker:dind# <12>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name to use for running the
 image. By default, Docker will generate a unique name for the container.
@@ -62,10 +63,11 @@ a Docker volume named `jenkins-docker-certs` as created above.
 volume named `jenkins-data`. This will allow for other Docker
 containers controlled by this Docker container's Docker daemon to mount data
 from Jenkins.
-<10> ( _Optional_ ) Exposes the Docker daemon port on the host machine. This is
+<10> Exposes the Docker daemon port, used by some of tutorials.
+<11> ( _Optional_ ) Exposes the Docker daemon port on the host machine. This is
 useful for executing `docker` commands on the host machine to control this
 inner Docker daemon.
-<11> The `docker:dind` image itself. This image can be downloaded before running
+<12> The `docker:dind` image itself. This image can be downloaded before running
 by using the command: `docker image pull docker:dind`.
 +
 *Note:* If copying and pasting the command snippet above does not work, try
@@ -78,6 +80,7 @@ docker run --name jenkins-docker --rm --detach \
   --env DOCKER_TLS_CERTDIR=/certs \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
+  --publish 3000:3000 \
   --publish 2376:2376 docker:dind
 ----
 . Customise official Jenkins Docker image, by executing below two steps:


### PR DESCRIPTION
This PR does the following:
- Fixes [Issue #31](https://github.com/jenkins-docs/simple-node-js-react-npm-app/issues/31) in Jenkins tutorials
- Enables creating more node js tutorials with default settings

Current PR affects only Jenkins in Docker installation for Tutorials without touching general Jenkins in Docker install instructions.