### PR TITLE
[2020 Elections] - Extend the voting sign-up until Nov 24

### DIFF
--- a/content/blog/2020/09/2020-09-24-board-elections.adoc
+++ b/content/blog/2020/09/2020-09-24-board-elections.adoc
@@ -34,8 +34,8 @@ image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://f
 * **Sep 24** - Nominations open, voting sign-up begins.
 * **Oct 15** - Board and officer nominations deadline.
 * **Oct 26** (or later) - List of candidates is published, including personal statements.
-* **Nov 08** - Voting sign-up is over.
 * **Nov 10** - Voting begins. link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] will be used for voting.
+* **Nov 24** - Voting sign-up is over.
 * **Nov 27** - Voting ends, 11PM UTC.
 * **Dec 03** - Election results are announced and take effect.
 
@@ -61,11 +61,11 @@ You can register to vote in one of two ways:
 2. Send an email to mailto:jenkins-2020-elections@googlegroups.com[jenkins-2020-elections@googlegroups.com].
    You will need to provide the information specified link:/project/board-election-process/#voter-sign-up-and-eligibility[here].
 
-Once sign-up is over, the election committee will process the form submissions and prepare a list of the registered voters.
+During the registration period, the election committee will process the form submissions and prepare a list of the registered voters.
 In the case of rejection, one of the election committee members will send a rejection email.
 Every individual contributor is expected to vote only once.
 
-Deadline for the voter registration is **November 08**.
+Deadline for the voter registration is **November 24**.
 
 == Nominating contributors
 

--- a/content/blog/2020/10/2020-10-28-election-candidates.adoc
+++ b/content/blog/2020/10/2020-10-28-election-candidates.adoc
@@ -40,8 +40,8 @@ image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://f
 
 == Key dates
 
-* **Nov 08** - Voting sign-up is over.
 * **Nov 10** - Voting begins. link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] will be used for voting.
+* **Nov 24** - Voting sign-up is over.
 * **Nov 27** - Voting ends, 11PM UTC.
 * **Dec 03** - Election results are announced and take effect.
 

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -51,7 +51,7 @@ homepage: true
 -# Elections
 - slides << {:href => 'blog/2020/10/28/election-candidates/',
   :title => '2020 Elections',
-  :intro => "We are happy to announce candidates for governance board and officer positions! We encourage community members to support the candidates and to participate in the elections! Voter registration is open until Nov 08.",
+  :intro => "We are happy to announce candidates for governance board and officer positions! We encourage community members to support the candidates and to participate in the elections! Voter registration is open until Nov 24.",
   :image => {:src => expand_link('images/logos/needs-you/Jenkins_Needs_You-transparent.png'), :height => "320px"},
   :call_to_action => {:text => 'Candidates and Registration', :href => expand_link('blog/2020/10/28/election-candidates/')}}
 

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -37,10 +37,10 @@ The terms of office for these elected positions are:
 * **Oct 15** - Nominations deadline
 ** After the deadline, the election committee will process nominations and notify the candidates
 * **Oct 26** or later - Election candidates are published, including personal statements
-* **Nov 08** - Voting sign-up is over
-** After this date, the election committee will verify the sign-up and prepare the final list of voters
 * **Nov 10** - Voting begins
 ** Email is distributed to all registered voters through link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service]
+* **Nov 08** - Voting sign-up is over
+** During the registration period, the election committee will monitor the sign-ups and update the list of voters.
 * **Nov 27** - Voting ends, 11PM UTC
 * **Dec 03** - Results are announced and take effect.
 


### PR DESCRIPTION
As it was discovered today and verified with @MarkEWaite @slide @uhafner , CIVS allows adding new voters in the current usage mode. It allows to extend the voter registration beyond Nov 08. Taking the low voting period duration and the relatively low registrations number at the moment, I see no reason to not extend the registration period.

Needs approval from @slide @uhafner before merging



