### PR TITLE
Add Jenkins events: Elections, Kubecon, Jenkins Day Japan, Dev.Wednesday, and FOSDEM

### DIFF
--- a/content/_data/events/2020-11-17-kubecon.adoc
+++ b/content/_data/events/2020-11-17-kubecon.adoc
@@ -1,0 +1,12 @@
+---
+
+title: "KubeCon + CloudNativeCon"
+location: "Virtual"
+date: "2020-11-17T10:00:00"
+endDate: "2020-11-20T18:00:00"
+link: "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/"
+
+---
+
+Meet the Jenkins community at KubeCon + CloudNativeCon!
+We will be at the Continuous Delivery Foundation booth.

--- a/content/_data/events/2020-11-24-jenkins-elections.adoc
+++ b/content/_data/events/2020-11-24-jenkins-elections.adoc
@@ -1,0 +1,12 @@
+---
+
+title: "Jenkins 2020 Elections"
+location: "Online"
+date: "2020-10-26T10:00:00"
+endDate: "2020-11-27T23:00:00"
+link: "/blog/2020/10/28/election-candidates"
+
+---
+
+In 2020 the Jenkins community will be electing two Governance Board Members and a new Release Officer.
+We encourage all community members to support the candidates and to participate in the elections!

--- a/content/_data/events/2020-11-25-swiss-devwednesday.adoc
+++ b/content/_data/events/2020-11-25-swiss-devwednesday.adoc
@@ -1,0 +1,12 @@
+---
+
+title: "Dev.Wednesday (Bern, CH)"
+location: "Online"
+date: "2020-11-25T17:00:00"
+link: "https://www.meetup.com/Dev-Wednesday/events/274073483/"
+
+---
+
+Way to the cloud - How We Moved Jenkins to GCP at Swisscom.
+Join this talk from Mattia Bordoni and Daniel Lorch, Senior DevOps Engineers at Swisscom,
+to learn about the engineering challenges they had to overcome in their journey to the cloud.

--- a/content/_data/events/2020-12-04-jenkins-day-japan.adoc
+++ b/content/_data/events/2020-12-04-jenkins-day-japan.adoc
@@ -1,0 +1,10 @@
+---
+
+title: "Jenkins Day Japan 2020"
+location: "Virtual"
+date: "2020-12-04T10:00:00"
+link: "https://cloudbees.techmatrix.jp/jenkins-day-japan2020/"
+
+---
+
+Jenkins Day Japan will be celebrating its 4th time this year, starting with the first holding in 2017. TechMatrix will introduce operations that utilize Jenkins, and introduce examples of companies that are systematically working on CI/CD and DevOps, not limited to Jenkins.

--- a/content/_data/events/2021-02-06-fosdem.adoc
+++ b/content/_data/events/2021-02-06-fosdem.adoc
@@ -8,4 +8,4 @@ link: "/events/fosdem"
 
 ---
 
-Meet the Jenkins community at FOSDEM 2020!
+Meet the Jenkins community at FOSDEM 2021!

--- a/content/_data/events/2021-02-06-fosdem.adoc
+++ b/content/_data/events/2021-02-06-fosdem.adoc
@@ -1,0 +1,11 @@
+---
+
+title: "FOSDEM 2021"
+location: "Virtual"
+date: "2021-02-06T10:00:00"
+endDate: "2021-02-07T18:00:00"
+link: "/events/fosdem"
+
+---
+
+Meet the Jenkins community at FOSDEM 2020!

--- a/content/events/fosdem/archive/2020.adoc
+++ b/content/events/fosdem/archive/2020.adoc
@@ -1,4 +1,35 @@
 ---
-layout: redirect
-redirect_url: /events/fosdem
+layout: project
+title: "Jenkins at FOSDEM 2020"
+sigId: "advocacy-and-outreach"
+tags:
+  - outreach-programs
+  - community
+  - events
+  - fosdem
+links:
+  gitter: jenkinsci/fosdem
 ---
+
+Jenkins project has participated in FOSDEM 2020.
+This event is coordinated by the link:/sigs/advocacy-and-outreach/[Jenkins Advocacy and Outreach SIG].
+Current plan:
+
+* **Jan 30** - Jenkins Pipeline Fundamentals training led by link:/blog/authors/MarkEWaite/[Mark Waite] (link:https://www.eventbrite.com/e/jenkins-pipeline-fundamentals-training-tickets-87080214265[Register here])
+* **Jan 31** - Jenkins Contributor Summit (link:https://www.meetup.com/jenkinsmeetup/events/267684785/[RSVP here])
+** This is a small event for active contributors and those who are interested in working on foundation projects: key architecture changes (UX, JCasC, Cloud native Jenkins, etc.), governance and infrastructure
+* **Feb 01-02** - Conference dates (no registration needed)
+** We will have a link:https://fosdem.org/2020/stands/[Jenkins stand] during the entire conference
+** On Sunday there will be a link:https://fosdem.org/2020/schedule/track/continuous_integration_and_continuous_deployment/[Continuous Integration and Continuous Deployment devroom] led by link:https://github.com/olblak[Olivier Vernin].
+   There will be talks about Jenkins there 
+** See the full agenda link:https://fosdem.org/[here]
+
+==== FOSDEM 2020 Details
+
+The detailed agenda is available in this Google Doc:
+
+++++
+<iframe src="https://docs.google.com/document/d/1AqmosxJ-HiUsiw9IhObA4sdFF5xBVOXEP5dDmanXRdw?embedded=true" width="100%" height="600px"></iframe>
+++++
+
+Also see link:https://groups.google.com/forum/#!topic/jenkinsci-dev/PUgV5xxHMwg[this thread] in the developer mailing list.

--- a/content/events/fosdem/archive/2021.adoc
+++ b/content/events/fosdem/archive/2021.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /events/fosdem
+---

--- a/content/events/fosdem/index.adoc
+++ b/content/events/fosdem/index.adoc
@@ -15,33 +15,17 @@ link:https://fosdem.org/[FOSDEM] is a regular event for open-source projects dev
 It happens every year in Brussels (late January or early February).
 Jenkins project regularly participates in this event and organizes additional events around the FOSDEM dates.
 
-=== FOSDEM 2020
+=== FOSDEM 2021
 
-Jenkins project will participate in FOSDEM.
-This event is coordinated by the link:/sigs/advocacy-and-outreach/[Jenkins Advocacy and Outreach SIG].
-Current plan:
-
-* **Jan 30** - Jenkins Pipeline Fundamentals training led by link:/blog/authors/MarkEWaite/[Mark Waite] (link:https://www.eventbrite.com/e/jenkins-pipeline-fundamentals-training-tickets-87080214265[Register here])
-* **Jan 31** - Jenkins Contributor Summit (link:https://www.meetup.com/jenkinsmeetup/events/267684785/[RSVP here])
-** This is a small event for active contributors and those who are interested in working on foundation projects: key architecture changes (UX, JCasC, Cloud native Jenkins, etc.), governance and infrastructure
-* **Feb 01-02** - Conference dates (no registration needed)
-** We will have a link:https://fosdem.org/2020/stands/[Jenkins stand] during the entire conference
-** On Sunday there will be a link:https://fosdem.org/2020/schedule/track/continuous_integration_and_continuous_deployment/[Continuous Integration and Continuous Deployment devroom] led by link:https://github.com/olblak[Olivier Vernin].
-   There will be talks about Jenkins there 
-** See the full agenda link:https://fosdem.org/[here]
-
-==== FOSDEM 2020 Details
-
-The detailed agenda is available in this Google Doc:
-
-++++
-<iframe src="https://docs.google.com/document/d/1AqmosxJ-HiUsiw9IhObA4sdFF5xBVOXEP5dDmanXRdw?embedded=true" width="100%" height="600px"></iframe>
-++++
-
-Also see link:https://groups.google.com/forum/#!topic/jenkinsci-dev/PUgV5xxHMwg[this thread] in the developer mailing list.
+The conference will take place on Feb 06-07.
+As usual, many Jenkins community members plan to participate in the event.
+This year the event will be virtual, and the format will change.
+Many traditional events like Jenkins Contributor Summit are likely to be scheduled to other dates.
+More details will be announced in the coming week.
 
 === Previous years
 
+* link:./archive/2020[2020]
 * link:./archive/2019[2019]
 * link:./archive/2018[2018]
 * link:./archive/2017[2017]


### PR DESCRIPTION
Adds calendar events for known Jenkins events and meetups. It also updates the FOSDEM page and archives the 2020 content