### PR TITLE
Use asciidoctor extension 0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'colorize'
 gem 'awestruct', '~> 0.6.1'
 gem 'awestruct-ibeams', '~> 0.4'
 gem 'asciidoctor', '~> 2.0.0'
-gem 'asciidoctor-jenkins-extensions', '~> 0.7.0'
+gem 'asciidoctor-jenkins-extensions', '~> 0.8.0'
 
 # Support for various template engines we use
 gem 'haml', '~> 5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ansi (1.5.0)
     asciidoctor (2.0.10)
-    asciidoctor-jenkins-extensions (0.7.0)
+    asciidoctor-jenkins-extensions (0.8.0)
       asciidoctor (>= 1.5.5)
       coderay (~> 1.1.1)
       colorize (~> 0.8.1)
@@ -122,7 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor (~> 2.0.0)
-  asciidoctor-jenkins-extensions (~> 0.7.0)
+  asciidoctor-jenkins-extensions (~> 0.8.0)
   awestruct (~> 0.6.1)
   awestruct-ibeams (~> 0.4)
   colorize


### PR DESCRIPTION
## Use asciidoctor extension 0.8.0 - Jira issue URL updated

﻿Previous version used https://issues.jenkins-ci.org/ while the new version uses https://issues.jenkins.io/

See https://github.com/jenkins-infra/asciidoctor-jenkins-extensions/releases/tag/v0.8.0
