### PR TITLE
Add banner noting downloads are unavailable

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -4355,6 +4355,10 @@
       Developer: Make unavailable plugin background themeable.
 
 - version: '2.249.3'
+  banner: >
+    A storage timeout and mounting issue on Microsoft Azure has broken the Jenkins download mirror system.
+    Downloads of Jenkins core and Jenkins plugins are failing with a 503 error.
+    The Jenkins infrastructure team is working to resolve the issue.
   date: 2020-11-04
   changes:
   - type: major bug

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -9394,7 +9394,10 @@
 - version: '2.266'
   date: 2020-11-10
   banner: >
-    This release replaces several key components.
+    A storage timeout and mounting issue on Microsoft Azure has broken the Jenkins download mirror system.
+    Downloads of Jenkins core and Jenkins plugins are failing with a 503 error.
+    The Jenkins infrastructure team is working to resolve the issue.
+    <hr>This release replaces several key components.
     The Acegi security library used for authentication has been replaced by Spring Security (<a href="https://github.com/jenkinsci/jep/blob/master/jep/227/README.adoc">JEP-227</a>).
     A fork of the XStream library used to read and write XML files has been replaced by the upstream version of XStream (<a href="https://github.com/jenkinsci/jep/blob/master/jep/228/README.adoc">JEP-228</a>).
     Refer to the <a href="/blog/2020/11/10/spring-xstream/">Spring and XStream updates (breaking changes!)</a> blog post for more details.

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -55,6 +55,12 @@ title: Jenkins download and deployment
   Downloading Jenkins
 
 %p
+  %div{:style => "margin: 10px; padding: 10px; background-color: #FFFFCE;"}
+    A storage timeout and mounting issue on Microsoft Azure has broken the Jenkins download mirror system.
+    Downloads of Jenkins core and Jenkins plugins are failing with a 503 error.
+    The Jenkins infrastructure team is working to resolve the issue.
+
+%p
   Jenkins is distributed as WAR files, native packages, installers, and Docker images.
   Follow these installation steps:
 


### PR DESCRIPTION
## Add banners announcing downloads are unavailable

A Microsoft Azure storage issue (timeout and failure to mount) has broken the Jenkins mirror system.  This announces the issue in downloads page, weekly changelog, and LTS changelog.
