### PR TITLE
Add Docker install workaround

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -97,6 +97,18 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
+
+# Choose the download mirror nearest you
+ENV JENKINS_UC_DOWNLOAD=http://mirrors.jenkins.io/
+ENV JENKINS_UC_DOWNLOAD=https://ftp-chi.osuosl.org/pub/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://ftp.halifax.rwth-aachen.de/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://ftp-nyc.osuosl.org/pub/jenkins
+ENV JENKINS_UC_DOWNLOAD=https://ftp.yz.yamagata-u.ac.jp/pub/misc/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirror.esuni.jp/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirror.gruenehoelle.nl/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirrors.tuna.tsinghua.edu.cn/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirror.xmission.com/jenkins/
+
 RUN jenkins-plugin-cli --plugins blueocean:1.24.3
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -99,6 +99,18 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
+
+# Choose the download mirror nearest you
+ENV JENKINS_UC_DOWNLOAD=http://mirrors.jenkins.io/
+ENV JENKINS_UC_DOWNLOAD=https://ftp-chi.osuosl.org/pub/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://ftp.halifax.rwth-aachen.de/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://ftp-nyc.osuosl.org/pub/jenkins
+ENV JENKINS_UC_DOWNLOAD=https://ftp.yz.yamagata-u.ac.jp/pub/misc/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirror.esuni.jp/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirror.gruenehoelle.nl/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirrors.tuna.tsinghua.edu.cn/jenkins/
+ENV JENKINS_UC_DOWNLOAD=https://mirror.xmission.com/jenkins/
+
 RUN jenkins-plugin-cli --plugins blueocean:1.24.3
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":


### PR DESCRIPTION
While https://get.jenkins.io/ is down, this workaround allows the user to install Jenkins plugins in their Docker image without accessing the default download location.

It requires that the user make their own decision of which mirror they should use.  The geographically selected mirrors provided by https://get.jenkins.io/ are a much better choice when they are available again.

I'm not confident this change is worth merging.  I hope it will be very short-lived.  I wanted to document the technique after I'd confirmed that it works with several of the mirrors included in the list.

The helm charts repository includes the [list of current mirrors](https://github.com/jenkins-infra/charts/tree/master/charts/mirrorbits#configuration).