### PR TITLE
Fix pipeline library blog link

### DIFF
--- a/content/blog/2020/10/2020-10-21-a-sustainable-pattern-with-shared-library.adoc
+++ b/content/blog/2020/10/2020-10-21-a-sustainable-pattern-with-shared-library.adoc
@@ -109,14 +109,12 @@ def call(effectiveConfig = [:]) {
     deleteDir()
     checkout([$class: 'GitSCM', 
       branches: [[name: '*/branchName']],
-      doGenerateSubmoduleConfigurations: false,
       extensions: [
           [$class: 'SparseCheckoutPaths',
             sparseCheckoutPaths:
             [[$class:'SparseCheckoutPath', path:'package.json,pom.xml']]
           ]
       ],
-      submoduleCfg: [],
       userRemoteConfigs: [[credentialsId: 'someID',
       url: 'git@link.git']]
     ])

--- a/content/blog/2020/10/2020-10-21-a-sustainable-pattern-with-shared-library.adoc
+++ b/content/blog/2020/10/2020-10-21-a-sustainable-pattern-with-shared-library.adoc
@@ -36,7 +36,7 @@ Large **Jenkinsfiles in every repository containing duplicated code**. It seems 
 
 == The Solution ==
 
-My solution is a pattern that is inspired by how the link:https://github.com/jenkinsci:[Jenkins organization on GitHub] does it with its link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[buildPlugin()]. But it is not exactly the same.
+My solution is a pattern that is inspired by how the link:https://github.com/jenkinsci[Jenkins organization on GitHub] does it with its link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[buildPlugin()]. But it is not exactly the same.
 
 === Shared Library ===
 


### PR DESCRIPTION
## Fix link to jenkinsci GitHub org

Resolve https://github.com/jenkins-infra/jenkins.io/issues/3971 that reports the bad link.

##  Remove default values for GitSCM class

`doGenerateSubmoduleConfigurations: false` is the default.
`doGenerateSubmoduleConfigurations: true` is untested and unlikely to work.

We hope in a future release of the git plugin to stop suggesting it as an option in the pipeline syntax generator without breaking backwards compatibility.

submoduleCfg: [] is the default.
It is only honored if `doGenerateSubmoduleConfigurations: true` is set.

