### PR TITLE
Include more self-hosted entries

### DIFF
--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -104,9 +104,11 @@ Here is a non-exhaustive list of services that we provide and maintain.
 | Service                                    | JIRA component(s)         | Repository and links
 | http://archives.jenkins-ci.org[Archives]   | `archives.jenkins-ci.org` | https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/manifests/archives.pp[Puppet Code]
 | https://ci.jenkins.io[Core and Plugin CI]  | `ci.jenkins.io`, `ci`     | https://github.com/jenkins-infra/documentation/blob/master/ci.adoc[User Docs], https://github.com/jenkins-infra/jenkins-infra[Deployment scripts]
-| http://mirrors.jenkins-ci.org/[Mirrors]    | `mirrors.jenkins.io`      | link:https://github.com/jenkins-infra/jenkins-infra[mirrors.jenkins.io Puppet scripts] (search for `mirrorbrain`), link:https://github.com/jenkins-infra/infra-mirror[Mirror scripts], link:http://mirrors.jenkins-ci.org/status.html[Status page], link:/download/mirrors/[Running a mirror]
+| https://get.jenkins.io/[Mirrors]           | `get.jenkins.io`          | link:https://github.com/jenkins-infra/charts/tree/master/charts/mirrorbits[Mirrorbits helm chart], link:https://get.jenkins.io/war-stable/latest/jenkins.war.sha256?mirrorlist[mirror list], link:https://get.jenkins.io/war-stable/latest/jenkins.war?mirrorstats[mirror stats], link:/download/mirrors/[Running a mirror]
+| http://mirrors.jenkins.io/[Old Mirrors]    | `mirrors.jenkins.io`      | link:https://github.com/jenkins-infra/jenkins-infra[old mirrors.jenkins.io Puppet scripts] (search for `mirrorbrain`), link:https://github.com/jenkins-infra/infra-mirror[old mirror scripts], link:http://mirrors.jenkins-ci.org/status.html[old status page]
+| https://pkg.jenkins.io[Downloads]          | `pkg.jenkins.io`          | https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/manifests/pkgrepo.pp[Puppet scripts]
 | https://stats.jenkins.io/[Stats]           |                           | https://github.com/jenkins-infra/infra-statistics[Code] published with GitHub pages
-| https://updates.jenkins.io[Update Center]  | `update-center`           | https://github.com/jenkins-infra/update-center2[Code]
+| https://updates.jenkins.io[Update Center]  | `updates.jenkins.io`      | https://github.com/jenkins-infra/update-center2[Code]
 | VPN                                        | `vpn`                     | https://github.com/jenkins-infra/openvpn[Code]
 | https://wiki.jenkins.io[Wiki] (deprecated) | `wiki`                    | https://github.com/jenkins-infra/confluence[Docker]
 |===


### PR DESCRIPTION
## Include more self-hosted entries in infra lists

﻿* Mirrors - get.jenkins.io - geographic distribution
* Downloads - pkg.jenkins.io - downloads site
* Updates - updates.jenkins.io - update center
