### PR TITLE
March 2021 expected to be first LTS with table to div

### DIFF
--- a/content/doc/developer/views/table-to-div-migration.adoc
+++ b/content/doc/developer/views/table-to-div-migration.adoc
@@ -6,7 +6,9 @@ layout: developerguide
 NOTE: This is a documentation for a new feature in the Jenkins core.
 See jira:JENKINS-56109[Change Jenkins configuration UI from tables to divs] for details.
 
-Jenkins core changed its form layout from 'table' to 'div' in 2.264 (this will be released in the next LTS).
+Jenkins core changed its form layout from 'table' to 'div' in 2.264.
+The March 2021 LTS is expected to change its form layout from 'table' to 'div'.
+The December 2020, January 2021, and February 2021 LTS releases will *not* change their form layout from 'table' to 'div'.
 
 All core taglib's and views were updated in link:https://github.com/jenkinsci/jenkins/pull/3895[jenkins#3895]
 as part of jira:JENKINS-56109[].


### PR DESCRIPTION
Clarify that the first LTS to transition from table based form layout to div based form layout is expected to be March 2021﻿, not the "next" LTS.

Would like review from @jtnord and @timja to confirm the phrasing works for them
