### PR TITLE
Script Security introduction is reworded.

### DIFF
--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -28,7 +28,7 @@ Groovy scripts _in_ Jenkins. These scripting capabilities are provided by:
 To protect Jenkins from execution of malicious scripts, these plugins execute
 user-provided scripts in a <<groovy-sandbox>> that limits what internal APIs
 are accessible. This protection is provided by the plugin:script-security[Script Security plugin]. As soon as unsafe method is used in any of the scripts, the "In-process Script Approval"
-action should appear in "Manage Jenkins" to allow Administrators to make decision about
+action should appear in "Manage Jenkins" to allow Administrators to make a decision about
 which unsafe methods, if any, should be allowed in the Jenkins environment.
 
 image::managing/manage-inprocess-script-approval.png["Entering the In-process Script Approval configuration", role=center]

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -27,8 +27,8 @@ Groovy scripts _in_ Jenkins. These scripting capabilities are provided by:
 
 To protect Jenkins from execution of malicious scripts, these plugins execute
 user-provided scripts in a <<groovy-sandbox>> that limits what internal APIs
-are accessible.  Administrators can then use the "In-process Script Approval"
-page, provided by the plugin:script-security[Script Security plugin], to manage
+are accessible. This protection is provided by the plugin:script-security[Script Security plugin]. As soon as unsafe method is used in any of the scripts, the "In-process Script Approval"
+action should appear in "Manage Jenkins" to allow Administrators to make decision about
 which unsafe methods, if any, should be allowed in the Jenkins environment.
 
 image::managing/manage-inprocess-script-approval.png["Entering the In-process Script Approval configuration", role=center]


### PR DESCRIPTION
"In-process Script Approval" is not visible if no approvals were made or pending. This is explicitly stated in the introduction now.