### PR TITLE
Moved platform SIG meetings to Fridays 13:00 UTC

### DIFF
--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -122,7 +122,7 @@ Scope of interest:
 
 == Meetings
 
-We have regular meetings on Thursdays every two weeks, at *12:00 UTC*.
+We have regular meetings on Fridays every two weeks, at *15:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded via Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].


### PR DESCRIPTION
Doodle poll had responses that were OK with either this time or with the current time.
Since the new time is a little easier on me personally, I chose the new time,
Friday at 13:00 UTC.﻿
