### PR TITLE
Fix --prefix arg usage in reverse proxy doc

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
@@ -152,9 +152,9 @@ your rewrite rules and the reverse proxy will spend most of its time rewriting
 responses from Jenkins.
 Much easier to change Jenkins to run at the context path your reverse proxy is
 expecting, e.g. if your reverse proxy is forwarding requests at
-https://manchu.example.org/foobar/ to Jenkins then you could just use
-`+java -jar jenkins.war --prefix /foobar+` to start jenkins using
-`+/foobar+` as the context path
+\https://manchu.example.org/foobar/ to Jenkins then you could just use
+`java -jar jenkins.war --prefix=/foobar` to start jenkins using
+`/foobar` as the context path
 
 ==== Further Diagnosis
 


### PR DESCRIPTION
Reported by gitter user @DaGeRe

﻿Also avoid converting the example URL into a clickable URL and don't use bold text for the examples.
