### PR TITLE
zsh-friendly kubernetes install commands

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -263,18 +263,18 @@ REVISION: 1
 
 [source,bash]
 ----
-$ path="{.data.jenkins-admin-password}"
-$ secret=$(kubectl get secret -n jenkins jenkins -o jsonpath=$path)
+$ jsonpath="{.data.jenkins-admin-password}"
+$ secret=$(kubectl get secret -n jenkins jenkins -o jsonpath=$jsonpath)
 $ echo $(echo $secret | base64 --decode)
 ----
 2. Get the Jenkins URL to visit by running these commands in the same shell:
 +
 [source,bash]
 ----
-$ path="{.spec.ports[0].nodePort}"
-$ NODE_PORT=$(kubectl get -n jenkins -o jsonpath=$path services jenkins)
-$ path="{.items[0].status.addresses[0].address}"
-$ NODE_IP=$(kubectl get nodes -n jenkins -o jsonpath=$path)
+$ jsonpath="{.spec.ports[0].nodePort}"
+$ NODE_PORT=$(kubectl get -n jenkins -o jsonpath=$jsonpath services jenkins)
+$ jsonpath="{.items[0].status.addresses[0].address}"
+$ NODE_IP=$(kubectl get nodes -n jenkins -o jsonpath=$jsonpath)
 $ echo http://$NODE_IP:$NODE_PORT/login
 ----
 3. Login with the password from step 1 and the username: admin
@@ -309,8 +309,8 @@ Run the following command:
 +
 [source,bash]
 ----
-$ path="{.data.jenkins-admin-password}"
-$ secret=$(kubectl get secret -n jenkins jenkins -o jsonpath=$path)
+$ jsonpath="{.data.jenkins-admin-password}"
+$ secret=$(kubectl get secret -n jenkins jenkins -o jsonpath=$jsonpath)
 $ echo $(echo $secret | base64 --decode)
 ----
 +
@@ -332,8 +332,8 @@ Run the following command:
 +
 [source,bash]
 ----
-$ path="{.data.jenkins-admin-password}"
-$ kubectl get secret -n jenkins jenkins -o jsonpath=$path
+$ jsonpath="{.data.jenkins-admin-password}"
+$ kubectl get secret -n jenkins jenkins -o jsonpath=$jsonpath
 ----
 +
 The output should be a **base64 encoded string** like this:


### PR DESCRIPTION
zsh uses the path variable to store parts of PATH, so the commands listed on the kubernetes install page will break the environment in zsh by changing PATH, e.g.:
```
$ echo $SHELL
/bin/zsh
$ echo $path
usr/local/bin /usr/bin /bin /usr/sbin /sbin
$ echo $PATH # built dynamically from the parts of $path
/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
$ # enter example commands from the kubernetes installation page
$ path="{.data.jenkins-admin-password}"
secret=$(kubectl get secret -n jenkins jenkins -o jsonpath=$path)
echo $(echo $secret | base64 --decode)
zsh: command not found: kubectl
zsh: command not found: base64
$ echo $PATH
{.data.jenkins-admin-password}
```
Replacing path with jsonpath in these commands eliminates this possibility while keeping the structure of the commands the same.