### PR TITLE
Fix redirect to "Jenkins says my reverse proxy setup is broken"

### DIFF
--- a/content/doc/book/system-administration/_chapter.yml
+++ b/content/doc/book/system-administration/_chapter.yml
@@ -10,9 +10,10 @@ sections:
   - authenticating-scripted-clients
   - reverse-proxy-configuration-with-jenkins
   - reverse-proxy-configuration-apache
+  - reverse-proxy-configuration-nginx
   - reverse-proxy-configuration-haproxy
+  - reverse-proxy-configuration-squid
   - reverse-proxy-configuration-iis
   - reverse-proxy-configuration-iptables
-  - reverse-proxy-configuration-nginx
-  - reverse-proxy-configuration-squid
+  - reverse-proxy-configuration-troubleshooting
   - diagnosing-errors

--- a/content/doc/book/system-administration/reverse-proxy-configuration-troubleshooting.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-troubleshooting.adoc
@@ -1,0 +1,104 @@
+---
+layout: section
+---
+
+ifdef::backend-html5[]
+ifndef::env-github[:imagesdir: ../../resources/managing]
+:notitle:
+:description:
+:author:
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+endif::[]
+
+= Reverse proxy - Issues
+
+[[jenkins-says-my-reverse-proxy-setup-is-broken]]
+== Symptoms
+
+An error message is displayed in the "Manage Jenkins" page
+
+`+It appears that your reverse proxy setup is broken+`
+
+NOTE: This message can also appear if you don't access
+Jenkins through a reverse proxy: Make sure the Jenkins URL configured in
+the System Configuration matches the URL you're using to access Jenkins.
+
+[[troubleshooting]]
+== Background
+
+For a reverse proxy to work correctly, it needs to rewrite both the
+request and the response.
+Request rewriting involves receiving an inbound HTTP call and then making
+a forwarding request to Jenkins (sometimes with some HTTP headers modified, sometimes not).
+Failing to configure the request rewriting is easy to catch, because you
+just won't see any pages at all.
+
+But correct reverse proxying also involves *one of two options*, EITHER
+
+* *rewrite the response* with a "Location" header in the response, which is used during redirects.
+Jenkins sends `Location:{nbsp}\http://actual.server:8080/jenkins/foobar`
+and the reverse proxy must
+rewrite it to `Location:{nbsp}\http://nice.name/jenkins/foobar`.
+Unfortunately, failing to configure this correctly is harder to catch;
+OR
+* *set the headers* `+X-Forwarded-Host+` (and perhaps `+X-Forwarded-Port+`) on the forwarded request.
+Jenkins will parse those headers and generate all the redirects and other
+links on the basis of those headers.
+Depending on your reverse proxy it may be easier to set `+X-Forwarded-Host+`
+and `+X-Forwarded-Port+` to the hostname and port in the original `+Host+`
+header respectively or it may be easier to just pass the original `+Host+`
+header through as  `+X-Forwarded-Host+` and delete the `+X-Forwarded-Port+` #
+header from the request.
+You will also need to set the `+X-Forwarded-Proto+` header if your reverse
+proxy is changing from `+https+` to `+http+` or vice-versa.
+
+Jenkins has proactive monitoring to make sure this is configured correctly.
+It uses XmlHttpRequest to request a specific URL in Jenkins (via relative path,
+so this will always get through provided the request is properly rewritten),
+which will then redirect the user to another page in Jenkins (this only works
+correctly if you configured the response rewriting correctly), which then returns 200.
+
+This error message indicates that this test is failing - and the most
+likely cause is that the response rewriting is misconfigured.
+See the  link:../reverse-proxy-configuration-with-jenkins/[configuration examples] for additional tips about
+configuring a reverse proxy.
+
+Be sure to set the `+X-Forwarded-Proto+` header if your reverse proxy is
+accessed via HTTPS and then Jenkins itself is accessed via HTTP i.e.
+proxying HTTPS to HTTP.
+
+Changing the context path of Jenkins with a reverse proxy is fraught with danger.
+There are lots of URLs that you need to rewrite correctly,
+and even if you get the ones in HTML files you may miss some in
+javascript, CSS or XML resources.
+
+The recommendation is to ensure that Jenkins is running at the context
+path that your reverse proxy is serving Jenkins at.
+You will have the least pain if you keep to this principle.
+
+While it is technically possible to use rewrite rules to change the context path,
+you should be aware that it would be a lot of work to find and fix everything in
+your rewrite rules and the reverse proxy will spend most of its time rewriting
+responses from Jenkins.
+Much easier to change Jenkins to run at the context path your reverse proxy is
+expecting, e.g. if your reverse proxy is forwarding requests at
+\https://manchu.example.org/foobar/ to Jenkins then you could just use
+`+java -jar jenkins.war --prefix=/foobar+` to start jenkins using
+`+/foobar+` as the context path
+
+== Further Diagnosis
+
+For further diagnosis, try using cURL:
+
+[source,sh]
+----
+BASE=administrativeMonitor/hudson.diagnosis.ReverseProxySetupMonitor
+curl -iL -e http://your.reverse.proxy/jenkins/manage \
+            http://your.reverse.proxy/jenkins/${BASE}/test
+----
+
+(assuming your Jenkins is located at
+\http://your.reverse.proxy/jenkins/ - and is open to anonymous read
+access)

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
@@ -29,6 +29,8 @@ endif::[]
         "running-jenkins-behind-iptables": "/doc/book/system-administration/reverse-proxy-configuration-iptables/",
         "running-jenkins-behind-nginx": "/doc/book/system-administration/reverse-proxy-configuration-nginx/",
         "running-jenkins-behind-squid": "/doc/book/system-administration/reverse-proxy-configuration-squid/",
+        "troubleshooting": "/doc/book/system-administration/reverse-proxy-configuration-troubleshooting/",
+        "jenkins-says-my-reverse-proxy-setup-is-broken": "/doc/book/system-administration/reverse-proxy-configuration-troubleshooting/",
     }
     /*
     * Best practice for extracting hashes:
@@ -53,8 +55,8 @@ The alternate provider may offload some work from Jenkins, like delivering stati
 == General Guidelines
 
 Jenkins actively monitors reverse proxy configuration.
-Jenkins reports <<Jenkins says my reverse proxy setup is broken,"Your reverse proxy setup is broken">> when it detects a reverse proxy configuration problem.
-See the <<troubleshooting>> section if Jenkins is reporting that your reverse proxy setup is broken.
+Jenkins reports link:../reverse-proxy-configuration-troubleshooting/["`+Your reverse proxy setup is broken+`"] when it detects a reverse proxy configuration problem.
+See the link:../reverse-proxy-configuration-troubleshooting/[troubleshooting] section if Jenkins is reporting that your reverse proxy setup is broken.
 
 === Background
 
@@ -67,12 +69,12 @@ Refer to <<Configuration Examples,configuration examples>> if your reverse proxy
 
 A reverse proxy must handle the HTTP response by either rewriting the response or setting HTTP headers on the forwarded request.
 When HTTP response handling is misconfigured, Jenkins may fail to show updated information on a page or it may ignore changes submitted through web pages.
-See the <<troubleshooting>> section if Jenkins is reporting that your reverse proxy setup is broken or pages are not behaving as expected.
+See the link:../reverse-proxy-configuration-troubleshooting/[troubleshooting] section if Jenkins is reporting that your reverse proxy setup is broken or pages are not behaving as expected.
 
 == Configuration Examples
 
 Jenkins works with many different reverse proxies.
-This page provides examples for specific reverse proxies, though much of the information also applies to other reverse proxies.
+This section provides examples for specific reverse proxies, though much of the information also applies to other reverse proxies.
 
 * link:../reverse-proxy-configuration-apache[Running Jenkins with Apache]
 * link:../reverse-proxy-configuration-nginx[Running Jenkins with Nginx]
@@ -80,93 +82,3 @@ This page provides examples for specific reverse proxies, though much of the inf
 * link:../reverse-proxy-configuration-squid[Running Jenkins with Squid]
 * link:../reverse-proxy-configuration-iis[Running Jenkins with IIS]
 * link:../reverse-proxy-configuration-iptables[Running Jenkins with iptables]
-
-== Troubleshooting
-
-=== Jenkins says my reverse proxy setup is broken
-
-NOTE: This message can also appear if you don't access
-Jenkins through a reverse proxy: Make sure the Jenkins URL configured in
-the System Configuration matches the URL you're using to access Jenkins.
-
-==== Symptoms
-
-An error message is displayed in the "Manage Jenkins" page - "It appears
-that your reverse proxy set up is broken"
-
-==== Background
-
-For a reverse proxy to work correctly, it needs to rewrite both the
-request and the response.
-Request rewriting involves receiving an inbound HTTP call and then making
-a forwarding request to Jenkins (sometimes with some HTTP headers modified, sometimes not).
-Failing to configure the request rewriting is easy to catch, because you
-just won't see any pages at all.
-
-But correct reverse proxying also involves *one of two options*, EITHER
-
-* *rewrite the response* with a "Location" header in the response, which is used during redirects.
-Jenkins sends `Location:{nbsp}\http://actual.server:8080/jenkins/foobar`
-and the reverse proxy must to
-rewrite it to `Location:{nbsp}\http://nice.name/jenkins/foobar`.
-Unfortunately, failing to configure this correctly is harder to catch;
-OR
-* *set the headers* `+X-Forwarded-Host+` (and perhaps `+X-Forwarded-Port+`) on the forwarded request.
-Jenkins will parse those headers and generate all the redirects and other
-links on the basis of those headers.
-Depending on your reverse proxy it may be easier to set `+X-Forwarded-Host+`
-and `+X-Forwarded-Port+` to the hostname and port in the original `+Host+`
-header respectively or it may be easier to just pass the original `+Host+`
-header through as  `+X-Forwarded-Host+` and delete the `+X-Forwarded-Port+` #
-header from the request.
-You will also need to set the `+X-Forwarded-Proto+` header if your reverse
-proxy is changing from `+https+` to `+http+` or vice-versa.
-
-Jenkins has proactive monitoring to make sure this is configured correctly.
-It uses XmlHttpRequest to request a specific URL in Jenkins (via relative path,
-so this will always get through provided the request is properly rewritten),
-which will then redirect the user to another page in Jenkins (this only works
-correctly if you configured the response rewriting correctly), which then returns 200.
-
-This error message indicates that this test is failing - and the most
-likely cause is that the response rewriting is misconfigured.
-See the  <<Configuration Examples,configuration examples>> for additional tips about
-configuring a reverse proxy.
-
-Be sure to set the `+X-Forwarded-Proto+` header if your reverse proxy is
-accessed via HTTPS and then Jenkins itself is accessed via HTTP i.e.
-proxying HTTPS to HTTP.
-
-Changing the context path of Jenkins with a reverse proxy is fraught with danger.
-There are lots of URLs that you need to rewrite correctly,
-and even if you get the ones in HTML files you may miss some in
-javascript, CSS or XML resources.
-
-The recommendation is to ensure that Jenkins is running at the context
-path that your reverse proxy is serving Jenkins at.
-You will have the least pain if you keep to this principle.
-
-While it is technically possible to use rewrite rules to change the context path,
-you should be aware that it would be a lot of work to find and fix everything in
-your rewrite rules and the reverse proxy will spend most of its time rewriting
-responses from Jenkins.
-Much easier to change Jenkins to run at the context path your reverse proxy is
-expecting, e.g. if your reverse proxy is forwarding requests at
-\https://manchu.example.org/foobar/ to Jenkins then you could just use
-`java -jar jenkins.war --prefix=/foobar` to start jenkins using
-`/foobar` as the context path
-
-==== Further Diagnosis
-
-For further diagnosis, try using cURL:
-
-[source,sh]
-----
-BASE=administrativeMonitor/hudson.diagnosis.ReverseProxySetupMonitor
-curl -iL -e http://your.reverse.proxy/jenkins/manage \
-            http://your.reverse.proxy/jenkins/${BASE}/test
-----
-
-(assuming your Jenkins is located at
-`http://your.reverse.proxy/jenkins/` - and is open to anonymous read
-access)

--- a/content/redirect/troubleshooting/broken-reverse-proxy.adoc
+++ b/content/redirect/troubleshooting/broken-reverse-proxy.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: "/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#jenkins-says-my-reverse-proxy-setup-is-broken"
+redirect_url: /doc/book/system-administration/reverse-proxy-configuration-troubleshooting/
 ---


### PR DESCRIPTION
The redirect from inside Jenkins core uses https://www.jenkins.io/redirect/troubleshooting/broken-reverse-proxy to provide diagnostic hints to the user.  Without this fix, that redirect is broken.

This change also splits the reverse proxy configuration page into two pages, one with the general introduction and navigation links and the other with the troubleshooting section. It includes additional redirects in case there are pages that link from internal page references to the original page.

Thanks to @DaGeRe for reporting the issue
