### PR TITLE
List components on top of the advisory

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -49,6 +49,9 @@ notitle: true
         - else
           = plugin.title || plugin.name
           Plugin
+    - components.each do | c |
+      %li
+        = c.title || c.name
 
 
 - described_issues = page.issues.dup.keep_if { |i| i.title && i.description }


### PR DESCRIPTION
Forgot to do this as part of https://github.com/jenkins-infra/jenkins.io/commit/58ceb03b30a604b7adab1c8d4238ff8aa2fff016 and so https://www.jenkins.io/security/advisory/2020-12-03/? doesn't list PIMT on top.

This PR fixes the problem.