### PR TITLE
[JENKINS-55813] Document support for user validity

### DIFF
--- a/content/doc/developer/security/index.adoc
+++ b/content/doc/developer/security/index.adoc
@@ -109,7 +109,7 @@ Users can still hit the URL directly, so you still need to protect the operation
 
 === Authentication ways
 
-In Jenkins the security engine that is used is Acegi Security (ancestor of Spring Security).
+In Jenkins the security engine that is used is Spring Security.
 Without any special plugins to manage authentication, an instance of Jenkins is packaged
 with the following authentication ways:
 
@@ -168,6 +168,14 @@ It shares the same verifier with the Native CLI way.
 The plugin have the possibility to propose a new `SecurityRealm` or implements some ``ExtensionPoint``s
 (like https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/security/QueueItemAuthenticator.java[QueueItemAuthenticator])
 in order to provide new ways for a user to authenticate.
+
+=== Support for Locked/Disabled/Expired Accounts
+
+Some authentication providers support additional account validity attributes such as whether or not the account is locked, disabled, or expired.
+Normally, these sorts of account validity checks are performed by the underlying authentication provider itself when authenticating a user with their password.
+However, _until a user attempts to log in with their password, Jenkins is never notified of account status changes!_
+This means that without explicit support from its corresponding Jenkins authentication provider plugin, Jenkins will otherwise continue to allow the account to authenticate through the above-mentioned authentication methods (SSH keys, API tokens) until the account is also deleted or disabled in Jenkins by an administrator.
+Authentication providers that can implement account validity checks through means other than attempting to log the user in should throw a subtype of `org.springframework.security.authentication.AccountStatusException` in `SecurityRealm.loadUserByUsername2`.
 
 ////
 https://wiki.jenkins.io/display/JENKINS/Making+your+plugin+behave+in+secured+Jenkins


### PR DESCRIPTION
Relates to recent changes made in LDAP plugin and subsequently also being introduced in Active Directory plugin.

@jeffret-b @Wadeck @daniel-beck @jglick 