### PR TITLE
Explain why GitHub team links seem broken

### DIFF
--- a/content/participate/review-changes.adoc
+++ b/content/participate/review-changes.adoc
@@ -28,7 +28,7 @@ If you are interested to join a reviewers team,
 you can request membership in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Jenkins Developer mailing list].
 You can also request membership in the GitHub web interface if you are already a member of the respective GitHub organization.
 
-Reviewer team links:
+Reviewer team links (GitHub permissions required to view teams):
 
 * link:https://github.com/orgs/jenkins-infra/teams/copy-editors[Copy Editors team] - Jenkins website and documentation hosted there
 * link:https://github.com/orgs/jenkinsci/teams/code-reviewers[Code Reviewers team] - Jenkins plugins and other components


### PR DESCRIPTION
Resolve issue #4018

[Dead links report](https://github.com/jenkins-infra/jenkins.io/issues/4018)
