### PR TITLE
Add "Jenkins is the Way" video to root page

### DIFF
--- a/content/_partials/video.html.haml
+++ b/content/_partials/video.html.haml
@@ -1,0 +1,21 @@
+- video_id = rand(1000)
+
+:css
+  .video_#{video_id} {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 */
+    height: 0;
+  }
+  .video_#{video_id} iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #ProjectVideo_#{video_id} {
+    background: #{video_background};
+  }
+
+.video.slide#ProjectVideo{:id => video_id, :class => "video_#{video_id}"}
+  %iframe{:src => "https://www.youtube.com/embed/_MXtbjwsz3A"}

--- a/content/_partials/video.html.haml
+++ b/content/_partials/video.html.haml
@@ -13,9 +13,6 @@
     width: 100%;
     height: 100%;
   }
-  #ProjectVideo_#{video_id} {
-    background: #{video_background};
-  }
 
-.video.slide#ProjectVideo{:id => video_id, :class => "video_#{video_id}"}
-  %iframe{:src => "https://www.youtube.com/embed/_MXtbjwsz3A"}
+.video#ProjectVideo{:class => "video_#{video_id}"}
+  %iframe{:src => "https://www.youtube.com/embed/_MXtbjwsz3A", :width => 1261, :height => 621, :frameborder => 0, :allow => "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"}

--- a/content/_partials/video.html.haml
+++ b/content/_partials/video.html.haml
@@ -1,4 +1,5 @@
 - video_id = rand(1000)
+- allow_attribs = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
 
 :css
   .video_#{video_id} {
@@ -15,4 +16,4 @@
   }
 
 .video#ProjectVideo{:class => "video_#{video_id}"}
-  %iframe{:src => "https://www.youtube.com/embed/_MXtbjwsz3A", :width => 1261, :height => 621, :frameborder => 0, :allow => "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"}
+  %iframe{:src => "https://www.youtube.com/embed/_MXtbjwsz3A", :width => 1261, :height => 621, :frameborder => 0, :allow => allow_attribs}

--- a/content/_partials/video.html.haml
+++ b/content/_partials/video.html.haml
@@ -15,5 +15,5 @@
     height: 100%;
   }
 
-.video#ProjectVideo{:class => "video_#{video_id}"}
+.video{:class => "video_#{video_id}"}
   %iframe{:src => "https://www.youtube.com/embed/_MXtbjwsz3A", :width => 1261, :height => 621, :frameborder => 0, :allow => allow_attribs}

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -96,7 +96,7 @@ homepage: true
             Easy installation
           %p
             Jenkins is a self-contained Java-based program, ready to run
-            out-of-the-box, with packages for Windows, Mac OS X and other
+            out-of-the-box, with packages for Windows, Linux, macOS and other
             Unix-like operating systems.
 
       .col-md-6.col-lg-4

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -88,7 +88,6 @@ homepage: true
             As an extensible automation server, Jenkins can be used as a simple
             CI server or turned into the continuous delivery hub for any project.
 
-
       .col-md-6.col-lg-4
         .box.install
           %i.icon-download
@@ -136,6 +135,8 @@ homepage: true
             Jenkins can easily distribute work across multiple machines,
             helping drive builds, tests and deployments across multiple
             platforms faster.
+
+= partial('video.html.haml')
 
 .container
   .section.events

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -88,6 +88,7 @@ homepage: true
             As an extensible automation server, Jenkins can be used as a simple
             CI server or turned into the continuous delivery hub for any project.
 
+
       .col-md-6.col-lg-4
         .box.install
           %i.icon-download


### PR DESCRIPTION
## Add Jenkins is the Way video to root page

The Jenkins Governance Board meeting Oct 21, 2020 approved that the video may be placed on the root page of https://jenkins.io below the Jumbotron.

The video is intentionally placed below the features segment and above the events calendar.  It is "edge to edge" to match the Jumbotron layout and provide visual separation for the calendar and blog content that follows the video.

See the [meeting notes](https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit#) and [video recording of the meeting](https://youtu.be/zBOwRubg7FE?list=PLN7ajX_VdyaMsOs5pRWGByvIcuJOpHpC6&t=1034) for more details.

CC: @alyssat , @slide , @uhafner , @halkeye , @markyjackson-taulia , @oleg-nenashev 

Also corrects an error in the name of macOS.

## Wide screen (1152x864)

![screencapture-localhost-4242-2020-12-11-21_10_27-edit](https://user-images.githubusercontent.com/156685/101973503-e4685080-3bf5-11eb-9ab0-a295b109dfa6.png)

## Small screen (640x480)

![screencapture-localhost-4242-2020-12-11-21_12_01-edit](https://user-images.githubusercontent.com/156685/101973495-dd414280-3bf5-11eb-87f4-bf64ee4803dc.png)

