### PR TITLE
Fix link to k8s namespace creation instructions

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -278,7 +278,7 @@ Copy the contents link:https://raw.githubusercontent.com/jenkins-infra/jenkins.i
 * The Deployment specifies a single replica. This ensures one and only one instance
 will be maintained by the Replication Controller in the event of failure.
 * The container image name is jenkins and version is 2.32.2
-*The list of ports specified within the spec are a list of ports to expose from
+* The list of ports specified within the spec are a list of ports to expose from
 the container on the Pods IP address.
 ** Jenkins running on (http) port 8080.
 ** The Pod exposes the port 8080 of the jenkins container.

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -272,7 +272,7 @@ The YAML files are easily tracked, edited, and can be reused indefinitely.
 
 === Create Jenkins deployment file
 
-Copy the contents link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml[here] into your preferred text editor and create a jenkins-deployment.yaml file in the “jenkins” namespace we created in this link:/doc/book/installing/#create-a-namespace-for-the-jenkins-deployment[section] above.
+Copy the contents link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml[here] into your preferred text editor and create a jenkins-deployment.yaml file in the “jenkins” namespace we created in this link:/doc/book/installing/kubernetes/#create-a-namespace[section] above.
 
 * This link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml[deployment file] is defining a Deployment as indicated by the `kind` field.
 * The Deployment specifies a single replica. This ensures one and only one instance


### PR DESCRIPTION
Link points to the wrong location in deployed site.  See the "section" reference in the [Create Jenkins deployment file](https://www.jenkins.io/doc/book/installing/kubernetes/#create-jenkins-deployment-file) page.
