### PR TITLE
Update table-to-div-migration.adoc - link to more blockWrapper examples, and note compatibility with older Jenkins core versions

### DIFF
--- a/content/doc/developer/views/table-to-div-migration.adoc
+++ b/content/doc/developer/views/table-to-div-migration.adoc
@@ -60,6 +60,9 @@ it would be good to contribute fixes or enhancements to core rather than doing t
 
 == Maintaining support for tables and div layout
 
+Maintaining such support is preferred where it is easily possible, to allow plugins to be updated and used
+on Jenkins deployments with older core versions (including current LTS 2.263.x at the time of this writing).
+
 There is a jelly property set on Jenkins instances that use div's for form layout called `divBasedFormLayout`,
 so you can adapt your plugin UI based on the presence of this property.
 

--- a/content/doc/developer/views/table-to-div-migration.adoc
+++ b/content/doc/developer/views/table-to-div-migration.adoc
@@ -96,7 +96,7 @@ Jelly example:
 
 This will use a table on Jenkins instances that don't have `divBasedFormLayout` and will use a div when it is set.
 
-_Note: You will likely need more tags to adapt the `tr` and `td` tags to divs see link:https://github.com/jenkinsci/multiple-scms-plugin/pull/25[multiple-scms-plugin#25] for a full example._
+_Note: You will likely need more tags to adapt the `tr` and `td` tags to divs see link:https://github.com/jenkinsci/multiple-scms-plugin/pull/25[multiple-scms-plugin#25] for a full example, or link:https://github.com/jenkinsci/notification-plugin/pull/40/files[notification-plugin#40] for an even more extensive example of different wrapper types (note they are shipped in separate files, included from the jelly files to edit with references like `xmlns:p="/lib/notification"` with a path part relative to `src/main/resources/` directory)._
 
 Groovy example:
 


### PR DESCRIPTION
Linked to example at https://github.com/jenkinsci/notification-plugin/pull/40/files with more blockWrapper style variants provided in additional files.