### PR TITLE
Fix #4036 - icon overlays plugin text on solutions page

### DIFF
--- a/content/_partials/plugins.html.haml
+++ b/content/_partials/plugins.html.haml
@@ -10,13 +10,11 @@
         %ul.ji-dated-list.ji-item-list.plugins
           - page.plugins.each do |link, title, description|
             %li.post
-              %a.body.article{:href => link}
+              %a.article{:href => link}
                 - if legacy?
                   = title
                 - else
                   %h6.title= title
                   %p.url= description
-                  .icon.card.date
-                    .icon-plug
               - if legacy?
                 %p.url= description


### PR DESCRIPTION
Thanks to @rcrocomb for the suggestion that it would be enough to remove the plugin icons.  Removing the icons makes the content readable again.

## Before the change

![screencapture-jenkins-io-solutions-github-2020-12-18-10_52_55-edit](https://user-images.githubusercontent.com/156685/102645697-1a3e9500-4120-11eb-8955-5e1003d27492.png)


## After the change

![screencapture-localhost-4242-solutions-github-2020-12-18-10_53_38-edit](https://user-images.githubusercontent.com/156685/102645704-1d398580-4120-11eb-862d-d79973b68f16.png)
