### PR TITLE
Use JDK 11, not JDK 8 for install & examples

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -88,7 +88,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.263.1-lts-slim
+FROM jenkins/jenkins:2.263.1-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -87,7 +87,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.263.1-lts-slim
+FROM jenkins/jenkins:2.263.1-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -525,7 +525,7 @@ spec:
   master:
     containers:
     - name: jenkins-master
-      image: jenkins/jenkins:lts
+      image: jenkins/jenkins:lts-jdk11
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 12

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -86,7 +86,7 @@ There are multiple Java implementations which you can use. link:https://openjdk.
 
 To install the Open Java Development Kit (OpenJDK) run the following:
 
-* Update the repositories 
+* Update the repositories
 [source,bash]
 ----
 sudo apt update
@@ -96,15 +96,15 @@ sudo apt update
 ----
 sudo apt search openjdk
 ----
-* Pick one option and install it: 
+* Pick one option and install it:
 [source,bash]
 ----
-sudo apt install openjdk-8-jdk
+sudo apt install openjdk-11-jdk
 ----
 * Confirm installation:
 [source,bash]
 ----
-sudo apt install openjdk-8-jdk 
+sudo apt install openjdk-11-jdk
 ----
 * checking installation:
 [source,bash]
@@ -114,9 +114,9 @@ java -version
 * the result must be something like:
 [source,bash]
 ----
-openjdk version "1.8.0_252"
-OpenJDK Runtime Environment (build 1.8.0_252-8u252-b09-1ubuntu1-b09)
-OpenJDK 64-Bit Server VM (build 25.252-b09, mixed mode)
+openjdk version "11.0.9.1" 2020-11-04
+OpenJDK Runtime Environment (build 11.0.9.1+1-post-Debian-1deb10u2)
+OpenJDK 64-Bit Server VM (build 11.0.9.1+1-post-Debian-1deb10u2, mixed mode, sharing)
 ----
 
 [NOTE]

--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml
@@ -15,7 +15,7 @@
         spec:
           containers:
           - name: jenkins
-            image: jenkins/jenkins:lts
+            image: jenkins/jenkins:lts-jdk11
             ports:
             - containerPort: 8080
             volumeMounts:


### PR DESCRIPTION
## Use JDK 11 for install and examples

﻿JDK 11 is the most recent Java long term support release and the most recent Java release supported by Jenkins.  Let's encourage people to use it rather than remaining with JDK 8.  JDK 11 support is better than JDK 8 on ARM and other specialized platforms and it is also well supported on the more common platforms like 64 bit Linux and 64 bit Windows.

Resolves #4050 
Resolves #4048
