### PR TITLE
Remove MSI banner from 2.274 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -9871,9 +9871,6 @@
   # pull: 5142 (PR title: Bump release-drafter/release-drafter from v5.12.1 to v5.13.0)
 
 - version: '2.274'
-  banner: >
-    The Windows MSI package has not been released yet due to errors from the Windows code signing timestamp server.
-    As a workaround, please download jenkins.war manually and replace it in JENKINS_HOME.
   date: 2021-01-05
   changes:
   - type: rfe


### PR DESCRIPTION
## Remove MSI installer banner from 2.274 changelog

﻿The 2.274 MSI installer is now available.  Packaging script changes in https://github.com/jenkinsci/packaging/pull/205 and https://github.com/jenkinsci/packaging/pull/206.  Those packaging changes have been merged to the stable-2.263 branch as well.

## Before

![Screenshot 2021-01-06 093458](https://user-images.githubusercontent.com/156685/103795166-e362ed00-5002-11eb-808e-a1d59fd8a9d0.png)

## After

![Screenshot 2021-01-06 093426](https://user-images.githubusercontent.com/156685/103795153-df36cf80-5002-11eb-806e-1d3cc0efa6bb.png)


