### PR TITLE
Update docker.adoc

### DIFF
--- a/content/doc/book/installing/docker.adoc
+++ b/content/doc/book/installing/docker.adoc
@@ -48,9 +48,6 @@ and select the *Docker Community Edition* suitable
 for your operating system or cloud service. Follow the installation instructions
 on their website.
 
-Jenkins also runs on Docker Enterprise. You can learn more about
-link:https://hub.docker.com/editions/enterprise/docker-ee[*Docker Enterprise*] on Dockerhub.
-
 [CAUTION]
 ====
 If you are installing Docker on a Linux-based operating system, ensure


### PR DESCRIPTION
Docker removed Docker Enterprise from https://hub.docker.com/ .
It was done as a result of the Docker Enterprise acquisition announcement:
https://www.mirantis.com/blog/mirantis-acquires-docker-enterprise-platform-business/

Fix issue #4058 