### PR TITLE
Propose git credentials pipeline step as GSoC project idea

### DIFF
--- a/content/projects/gsoc/2021/project-ideas/git-credentials-binding-for-pipeline.adoc
+++ b/content/projects/gsoc/2021/project-ideas/git-credentials-binding-for-pipeline.adoc
@@ -1,0 +1,88 @@
+---
+layout: gsocprojectidea
+title: "Git credentials binding for sh, bat, and powershell"
+goal: "Allow greater git flexibility from Jenkins Pipelines"
+category: Plugins
+year: 2021
+status: draft
+sig: platform
+mentors:
+- "markewaite"
+skills:
+- Java
+- Git
+links:
+  gitter: "jenkinsci/git-plugin"
+  draft: https://docs.google.com/document/d/1tu5g1bfwAY5vvL_2OoBIRDKfYaaOC6sDQdb7BIYBInY/edit?usp=sharing
+---
+
+Allow Jenkins Pipeline users to run authenticated git commands in sh, bat, and powershell.
+
+This project idea proposes to implement two new credential bindings that contribute files and environment variables to sh, bat, and powershell steps so that they can use command line git to perform authenticated operations.
+The Jira issue requesting support for authenticated git operations (JENKINS-28335) is one of the top five most highly voted Jenkins enhancement requests.
+
+The two credential bindings will be `gitSshPrivateKey` and `gitUsernamePassword`.
+They will be implemented in the git plugin with automated tests to confirm the bindings are behaving as expected on the wide range of command line git versions and operating systems supported by the git plugin.
+
+=== Rationale
+
+The Jenkins git plugin uses Jenkins credentials to fetch a repository and checkout a branch for freestyle, pipeline, and multibranch pipeline jobs.
+It is also able to use Jenkins credentials to push tags and commits back to the repository from a freestyle job.
+It supports a wide range of command line git versions, from git 1.8.3 (CentOS 7) through the current release of command line git (2.30.0, Debian testing, Windows, ...).
+It supports ssh private keys with and without passphrases for ssh protocol authentication and supports usernames and passwords or API tokens for https protocol authentication.
+
+The git plugin is not able to push tags or commits from a pipeline job or a multibranch pipeline job.
+It is not able to perform other git operations that require authentication like remote branch creation or deletion.
+The git plugin also does not provide authenticated access to all the command line options offered with the most recent versions of command line git.
+For example, there is no support in the git plugin for the `--single-branch` option or for the `--recurse-submodules` option.
+
+With the git credentials binding, Pipeline users will be able to push merge results, commits, and tags from a Pipeline job.
+They will be able to create and delete remote branches.
+They will be able to use the git command line options of their choice, including `--single-branch` and `--recurse-submodules`.
+Users will be able to run authenticated git commands in their Jenkins Pipelines without modifying the git plugin.
+
+=== Quickstart
+
+The project idea is expected to require changes in the git plugin.
+
+Install a git plugin development environment by following the link:https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc[contributing instructions].
+Compile the plugin, run its automated tests, and confirm that the automated tests are passing.
+Enable coverage reporting and review the coverage report.
+
+Install an integrated development environment (Netbeans, Eclipse, IntelliJ, ...).
+Run the git plugin in the development environment.
+Set a breakpoint and confirm that the breakpoint is reached in the development environment.
+
+Alternately, use the coverage report to identify an interesting area that has insufficient test coverage.
+Submit one or more tests to improve coverage.
+For example, more tests could be created for link:https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/jenkins/plugins/git/MergeWithGitSCMExtension.java[MergeWithGitSCMExtension]
+or more tests could be added to link:https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java[PreBuildMerge]
+or added to link:http://mark-pc2.markwaite.net:8080/job/Git-Folder/job/git-plugin/lastBuild/jacoco/hudson.plugins.git.extensions.impl/UserIdentity/[UserIdentity].
+
+=== Newbie-friendly issues
+
+Consider implementing a fix for one or more of the link:https://issues.jenkins.io/issues/?jql=(component%3Dgit-plugin%20OR%20component%20%3D%20git-client-plugin)%20and%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2CReopened)[newbie friendly issues].
+
+=== Implementation examples
+
+The `sshPrivateKey` and `usernamePassword` implementations in the credentials binding plugin provide examples that create environment variables and temporary files for use by sh, bat, and powershell steps.
+Use them as a reference implementation.
+The git credentials implementation will need environment variables for the ssh and https credentials.
+The git credentials implementation will need files for the ssh credentials.
+
+The `gitSshPrivateKey` implementation should take an additional argument, `cliGitBaseVersion`, that is a string providing the minimum CLI git version that will be used in the sh, bat, and powershell commands within the `withCredentials` block.
+If the `cliGitBaseVersion` is greater than 2.3, then the GIT_SSH_COMMAND environment variable should be set and should include arguments that provide the path to the private key.
+If the `cliGitBaseVersion` is less than 2.3, then the current ssh technique in the git plugin should be used instead (needs more details of the current technique).
+The SSH_ASKPASS environment variable should be set to point to a file that is accessible to the agent workspace.
+That SSH_ASKPASS script should echo the passphrase if a passphrase is defined on the private key, just as is done today within the git plugin.
+The credential binding should write the ssh private key to the agent file system in a workspace specific temporary location and should set environment variables to provide the location of the ssh private key.
+Alternately, passphrase protected private keys should be converted by the plugin to not use a passphrase and the private key without passphrase should be written to the workspace specific temporary location instead of writing the private key with passphrase.
+
+The gitUsernamePassword implementation should use the Jenkins username and password values to configure a git credential based on the git-credential documentation.
+
+=== Links
+
+* link:https://groups.google.com/g/jenkinsci-gsoc-all-public/c/VdUhhM1Noxc/m/Zk4yajsFAwAJ[Jenkins GSoC mailing list discussion of git credentials pipeline task]
+* link:https://issues.jenkins.io/browse/JENKINS-28335[JENKINS-28335] - Pipeline step to run Git commands with credentials & tool
+* link:https://issues.jenkins.io/browse/JENKINS-47733[JENKINS-47733] - Add a `withGit` pipeline step that provides git credentials
+* link:https://issues.jenkins.io/browse/JENKINS-36496[JENKINS-36496] - Support git publisher with Pipeline


### PR DESCRIPTION
Allow Jenkins Pipeline users to run authenticated git commands in sh, bat, and powershell.

Propose to implement https://issues.jenkins.io/browse/JENKINS-28335, one of the top 5 most voted Jenkins issues.
