### PR TITLE
Migrate obtaing a thread dump documentation

### DIFF
--- a/content/doc/book/system-administration/_chapter.yml
+++ b/content/doc/book/system-administration/_chapter.yml
@@ -17,3 +17,4 @@ sections:
   - reverse-proxy-configuration-iptables
   - reverse-proxy-configuration-troubleshooting
   - diagnosing-errors
+  - obtaining-a-thread-dump

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -1,6 +1,5 @@
 ---
 layout: section
-wip: true
 ---
 ifdef::backend-html5[]
 :notitle:

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -14,11 +14,11 @@ endif::[]
 
 = Obtaining a thread dump
 
-During the trouble-shooting of Jenkins, we often request that you obtain
-thread dumps of relevant Java VMs. Thread dumps concisely captures what
-every thread in a VM is doing at a given point in time, and therefore it
-is useful to diagnose hang problems, deadlocks, and performance issues.
-This page explains how you obtain it.
+During the troubleshooting of Jenkins, others may request that you obtain
+thread dumps of relevant Java VMs. Thread dumps concisely capture what
+every thread in a VM is doing at a given point in time.
+They are useful to diagnose hang problems, deadlocks, and performance issues.
+This page explains how you can obtain a thread dump.
 
 [[Obtainingathreaddump-FromJenkinsWebUI]]
 == From Jenkins Web UI
@@ -35,16 +35,13 @@ have the administrator permission on the system.
 == By using `+jstack+`
 
 If Jenkins is not responding to web UI, try
-http://download.oracle.com/javase/6/docs/technotes/tools/share/jstack.html[jstack]
+https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr016.html[jstack]
 to obtain the thread dump. For one reason or another that none of us
 quite understand well, one might have to add -F to get the dump. If that
 was the case, please mention that in the report as well.
 
 Make sure to run jstack as the same user that's running Jenkins itself
-instead of using the root user
-
-`+jstack+` isn't always reliable, and sometimes it fails to obtain
-thread dumps for no obvious reasons.
+instead of using the root user.
 
 [[Obtainingathreaddump-Bysendingsignal]]
 == By sending signal
@@ -65,7 +62,7 @@ JVM is normally redirected to a log file, so you need to hunt down where
 it is written to and pick up the dump from there. On Unix, you can look
 at `+/proc/PID/fd/1+` to figure out which file the stdout is being
 written to. On Windows, if you have
-https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+as+a+Windows+service[installed
+link:/doc/book/installing/windows/[installed
 Jenkins as a Windows service], check that page for whereabouts of the
 log files.
 

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -14,8 +14,8 @@ endif::[]
 = Obtaining a thread dump
 
 During the troubleshooting of Jenkins, others may request that you obtain
-thread dumps of relevant Java VMs. Thread dumps concisely capture what
-every thread in a VM is doing at a given point in time.
+thread dumps of relevant Java VMs.
+Thread dumps concisely capture what every thread in a VM is doing at a given point in time.
 They are useful to diagnose hang problems, deadlocks, and performance issues.
 This page explains how you can obtain a thread dump.
 
@@ -26,18 +26,18 @@ This is the simplest way of obtaining thread dumps.
 
 If Jenkins or its build agents are operating normally, you can obtain a
 thread dump remotely by going to
-`+http://your.jenkins.server/threadDump+`. For an agent named 'xyz', go
-to `+http://your.jenkins.server/computer/xyz/systemInfo+`. You need to
-have the administrator permission on the system.
+`+http://your.jenkins.server/threadDump+`.
+For an agent named 'xyz', go to `+http://your.jenkins.server/computer/xyz/systemInfo+`.
+You need to have the administrator permission on the system.
 
 [[Obtainingathreaddump-Byusingjstack]]
 == By using `+jstack+`
 
 If Jenkins is not responding to web UI, try
 https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr016.html[jstack]
-to obtain the thread dump. For one reason or another that none of us
-quite understand well, one might have to add -F to get the dump. If that
-was the case, please mention that in the report as well.
+to obtain the thread dump.
+You might have to add -F to get the dump.
+If that was the case, please mention that in the report as well.
 
 Make sure to run jstack as the same user that's running Jenkins itself
 instead of using the root user.
@@ -49,15 +49,15 @@ If the above two approaches do not work, you can still have the JVM
 print the thread dump to its stdout by sending it a signal.
 
 If you have a terminal or command prompt that's running the JVM, you can
-hit Ctrl+ + (Unix) or Ctrl+Break (Windows) to do this. If the JVM is running in
-background, you do this by `+kill -3 PID+` (Unix) or use
+hit Ctrl+ + (Unix) or Ctrl+Break (Windows) to do this.
+If the JVM is running in background, you do this by `+kill -3 PID+` (Unix) or use
 https://docs.oracle.com/javacomponents/jmc-5-5/jmc-user-guide/toc.htm/[a tool like this] to send a signal (Windows).
 
-Obviously, you must be on the same machine as the Jenkins controller when
-you run this command. In a situation like this, the standard output of
-JVM is normally redirected to a log file, so you need to hunt down where
-it is written to and pick up the dump from there. On Unix, you can look
-at `+/proc/PID/fd/1+` to figure out which file the stdout is being
+You need to be on the same machine as the Jenkins controller when
+you run this command.
+In a situation like this, the standard output of JVM is normally redirected to a log file,
+so you need to hunt down where it is written to and pick up the dump from there.
+On Unix, you can look at `+/proc/PID/fd/1+` to figure out which file the stdout is being
 written to.
 If you are running as a Windows service, see the link:/doc/book/installing/windows/[Windows installation instructions] for the log file location.
 

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -51,8 +51,7 @@ print the thread dump to its stdout by sending it a signal.
 If you have a terminal or command prompt that's running the JVM, you can
 hit Ctrl+ + (Unix) or Ctrl+Break (Windows) to do this. If the JVM is running in
 background, you do this by `+kill -3 PID+` (Unix) or use
-https://docs.oracle.com/javacomponents/jmc-5-5/jmc-user-guide/toc.htm/[a tool like
-this] to send a signal (Windows).
+https://docs.oracle.com/javacomponents/jmc-5-5/jmc-user-guide/toc.htm/[a tool like this] to send a signal (Windows).
 
 Obviously, you must be on the same machine as the Jenkins controller when
 you run this command. In a situation like this, the standard output of

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -61,10 +61,8 @@ you run this command. In a situation like this, the standard output of
 JVM is normally redirected to a log file, so you need to hunt down where
 it is written to and pick up the dump from there. On Unix, you can look
 at `+/proc/PID/fd/1+` to figure out which file the stdout is being
-written to. On Windows, if you have
-link:/doc/book/installing/windows/[installed
-Jenkins as a Windows service], check that page for whereabouts of the
-log files.
+written to.
+If you are running as a Windows service, see the link:/doc/book/installing/windows/[Windows installation instructions] for the log file location.
 
 This approach is platform specific, but it tends to be more reliable
 even when JVM is in a dire state.

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -1,0 +1,73 @@
+---
+layout: section
+wip: true
+---
+ifdef::backend-html5[]
+:notitle:
+:description:
+:author:
+:email: jenkinsci-users@googlegroups.com
+ifdef::env-github[:imagesdir: ../resources]
+ifndef::env-github[:imagesdir: ../../resources]
+:toc: left
+endif::[]
+
+= Obtaining a thread dump
+
+During the trouble-shooting of Jenkins, we often request that you obtain
+thread dumps of relevant Java VMs. Thread dumps concisely captures what
+every thread in a VM is doing at a given point in time, and therefore it
+is useful to diagnose hang problems, deadlocks, and performance issues.
+This page explains how you obtain it.
+
+[[Obtainingathreaddump-FromJenkinsWebUI]]
+== From Jenkins Web UI
+
+This is the simplest way of obtaining thread dumps.
+
+If Jenkins or its build agents are operating normally, you can obtain a
+thread dump remotely by going to
+`+http://your.jenkins.server/threadDump+`. For an agent named 'xyz', go
+to `+http://your.jenkins.server/computer/xyz/systemInfo+`. You need to
+have the administrator permission on the system.
+
+[[Obtainingathreaddump-Byusingjstack]]
+== By using `+jstack+`
+
+If Jenkins is not responding to web UI, try
+http://download.oracle.com/javase/6/docs/technotes/tools/share/jstack.html[jstack]
+to obtain the thread dump. For one reason or another that none of us
+quite understand well, one might have to add -F to get the dump. If that
+was the case, please mention that in the report as well.
+
+Make sure to run jstack as the same user that's running Jenkins itself
+instead of using the root user
+
+`+jstack+` isn't always reliable, and sometimes it fails to obtain
+thread dumps for no obvious reasons.
+
+[[Obtainingathreaddump-Bysendingsignal]]
+== By sending signal
+
+If the above two approaches do not work, you can still have the JVM
+print the thread dump to its stdout by sending it a signal.
+
+If you have a terminal or command prompt that's running the JVM, you can
+hit Ctrl+ +
+(Unix) or Ctrl+Break (Windows) to do this. If the JVM is running in
+background, you do this by `+kill -3 PID+` (Unix) or use
+https://docs.oracle.com/javacomponents/jmc-5-5/jmc-user-guide/toc.htm/[a tool like
+this] to send a signal (Windows).
+
+Obviously, you must be on the same machine as the Jenkins controller when
+you run this command. In a situation like this, the standard output of
+JVM is normally redirected to a log file, so you need to hunt down where
+it is written to and pick up the dump from there. On Unix, you can look
+at `+/proc/PID/fd/1+` to figure out which file the stdout is being
+written to. On Windows, if you have
+https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+as+a+Windows+service[installed
+Jenkins as a Windows service], check that page for whereabouts of the
+log files.
+
+This approach is platform specific, but it tends to be more reliable
+even when JVM is in a dire state.

--- a/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
+++ b/content/doc/book/system-administration/obtaining-a-thread-dump.adoc
@@ -50,8 +50,7 @@ If the above two approaches do not work, you can still have the JVM
 print the thread dump to its stdout by sending it a signal.
 
 If you have a terminal or command prompt that's running the JVM, you can
-hit Ctrl+ +
-(Unix) or Ctrl+Break (Windows) to do this. If the JVM is running in
+hit Ctrl+ + (Unix) or Ctrl+Break (Windows) to do this. If the JVM is running in
 background, you do this by `+kill -3 PID+` (Unix) or use
 https://docs.oracle.com/javacomponents/jmc-5-5/jmc-user-guide/toc.htm/[a tool like
 this] to send a signal (Windows).


### PR DESCRIPTION
See  #3760
`install Jenkins as a Windows service` documentation is in it's earlier form but I did found a updated version of it [here](https://jenkins-le-guide-complet.github.io/html/sect-windows-service.html), probably change the url after the documentation is migrated

And www.latenighthacking.com/projects/2003/sendsignal/ from `a tool like this` is no longer working so I replaced it with Java Mission Control  from oracle [here](https://docs.oracle.com/javacomponents/jmc-5-5/jmc-user-guide/toc.htm/) 

Also changed master to controller as mentioned in issue,

