### PR TITLE
Documentation: Installing Jenkins in Kubernetes: added missed links

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -99,7 +99,7 @@ $ kubectl apply -f jenkins-sa.yaml
 === Install Jenkins
 
 We will deploy Jenkins including the Jenkins Kubernetes plugin.
-Here you can find the official chart.
+https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins[Here] you can find the official chart.
 
 . To enable persistence, we will create an override file and pass it as an argument to the
   Helm CLI.
@@ -181,7 +181,7 @@ $ echo http://$NODE_IP:$NODE_PORT/login
 ----
 3. Login with the password from step 1 and the username: admin
 4. Use Jenkins Configuration as Code by specifying configScripts in your values.yaml file.
-   See the configuration as code link:http:///configuration-as-code[documentation] and  https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples].
+   See the configuration as code https://plugins.jenkins.io/configuration-as-code/#documentation[documentation] and  https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples].
 
 Visit the link:https://cloud.google.com/solutions/jenkins-on-container-engine[Jenkins on Kubernetes solutions page] for more information on running Jenkins on Kubernetes.
 Visit the https://jenkins.io/projects/jcasc/[Jenkins Configuration as Code project] for more information on configuration as code.
@@ -352,7 +352,7 @@ jenkins    NodePort    10.103.31.217    <none>         8080:32664/TCP    59s
 
 So now we have created a deployment and service, how do we access Jenkins?
 
-From the output above we can see that the service has been exposed on port 322664.
+From the output above we can see that the service has been exposed on port 32664.
 We also know that because the service is of type NodeType the service will route
 requests made to any node on this port to the Jenkins pod.
 All that’s left for us is to determine the IP address of the minikube VM.

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -181,7 +181,7 @@ $ echo http://$NODE_IP:$NODE_PORT/login
 ----
 3. Login with the password from step 1 and the username: admin
 4. Use Jenkins Configuration as Code by specifying configScripts in your values.yaml file.
-   See the configuration as code https://plugins.jenkins.io/configuration-as-code/#documentation[documentation] and  https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples].
+   See the plugin:configuration-as-code[configuration as code documentation] and  https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples].
 
 Visit the link:https://cloud.google.com/solutions/jenkins-on-container-engine[Jenkins on Kubernetes solutions page] for more information on running Jenkins on Kubernetes.
 Visit the https://jenkins.io/projects/jcasc/[Jenkins Configuration as Code project] for more information on configuration as code.

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -99,7 +99,7 @@ $ kubectl apply -f jenkins-sa.yaml
 === Install Jenkins
 
 We will deploy Jenkins including the Jenkins Kubernetes plugin.
-https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins[Here] you can find the official chart.
+See the https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins[official chart] for more details.
 
 . To enable persistence, we will create an override file and pass it as an argument to the
   Helm CLI.


### PR DESCRIPTION
I found [here](https://www.jenkins.io/doc/book/installing/kubernetes/) some mistakes.
Added missed links.
Fixed typo in port number.

P.S.: I hope I used correct AsciiDoc syntax.