### PR TITLE
Include external storage fix in 2.276 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -9963,6 +9963,15 @@
   changes:
   - type: major bug
     category: regression
+    pull: 5191
+    issue: 64655
+    authors:
+    - jeffret-b
+    message: |-
+      Provide a default implementation of the "all files in zip" download link.
+      This is especially important for external storage plugin (regression in 2.275).
+  - type: major bug
+    category: regression
     pull: 5188
     issue: 64632
     authors:


### PR DESCRIPTION
## Include missing entry in 2.276 changelog

I missed the https://github.com/jenkinsci/jenkins/pull/5191 entry in the changelog because it was merged after the initial draft was completed and I did not reconstruct the changelog entry.
