### PR TITLE
Use blue ocean 1.24.4 in Docker install guide

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -100,7 +100,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins blueocean:1.24.3
+RUN jenkins-plugin-cli --plugins blueocean:1.24.4
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -99,7 +99,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins blueocean:1.24.3
+RUN jenkins-plugin-cli --plugins blueocean:1.24.4
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +


### PR DESCRIPTION
## Use Blue Ocean 1.24.4 instead of 1.24.3

Blue Ocean 1.24.4 was released to remove the explicit depdendency on the Blue Ocean Jira plugin.

@vsilverman I checked that the instructions work as expected on my Linux computer running Docker.  There was a comment in the [docs feedback page](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) yesterday that reported failure to download a plugin while the docker image was being built.  I don't see that failure.  However, if a mirror is misbehaving, that might be the result to the user.