### PR TITLE
Fix minor carriage return issue on Architecting for Scale page

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -95,7 +95,6 @@ of builds will be delegated to the agents. With this configuration it is
 possible to horizontally scale an architecture, which allows a single Jenkins
 installation to host a large number of projects and build environments.
 
-[[master/agent-communication-protocols]]
 
 === Agent communications
 

--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -96,6 +96,7 @@ possible to horizontally scale an architecture, which allows a single Jenkins
 installation to host a large number of projects and build environments.
 
 [[master/agent-communication-protocols]]
+
 === Agent communications
 
 In order for a machine to be recognized as an agent, it needs to run a specific


### PR DESCRIPTION
Hello,

I noticed that while reading the [Architecting for Scale](https://www.jenkins.io/doc/book/scaling/architecting-for-scale/) page, the "Agent communications" header was not properly being recognized. I've added a carriage return which seems to do the trick.

![image](https://user-images.githubusercontent.com/4888402/105765189-a90fb000-5f1d-11eb-86b0-a0edb7eadf44.png)
