### PR TITLE
Use Jenkins 2.263.3 in docker install instructions

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -88,7 +88,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.263.2-lts-jdk11
+FROM jenkins/jenkins:2.263.3-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -87,7 +87,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.263.2-lts-jdk11
+FROM jenkins/jenkins:2.263.3-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \


### PR DESCRIPTION
## Use latest Jenkins LTS in install instructions

Jenkins 2.263.3 released today.  Let's use it in the docker install.

CC: @vsilverman, @StackScribe 