### PR TITLE
Better phrasing of JDK change and fix a typo

### DIFF
--- a/content/blog/2021/02/2021-02-08-docker-base-os-upgrade.adoc
+++ b/content/blog/2021/02/2021-02-08-docker-base-os-upgrade.adoc
@@ -11,7 +11,7 @@ opengraph:
 ---
 
 Beginning with Jenkins 2.279 and Jenkins 2.263.4, the Jenkins project is upgrading the base operating system and Java version used in the `jenkins/jenkins:latest` and `jenkins/jenkins:lts` images.
-The update replaces OpenJDK 8u242 with AdoptOpenJDK 8u282 and replaces Debian 9 (link:https://www.debian.org/releases/stretch/["Stretch"]) with (Debian 10 (link:https://www.debian.org/releases/buster/["Buster"]).
+The update replaces OpenJDK 8u242 with AdoptOpenJDK 8u282 and replaces Debian 9 (link:https://www.debian.org/releases/stretch/["Stretch"]) with Debian 10 (link:https://www.debian.org/releases/buster/["Buster"]).
 
 image:/images/docker/dockerJenkins.png[Jenkins and Docker, role=center, float=right, height=224]
 
@@ -34,8 +34,9 @@ The Debian 9 Docker images were based on the link:https://hub.docker.com/layers/
 The last update to that image was one year ago with the release of JDK 8u242.
 We need a maintained Docker base image that keeps pace with JDK releases and operating system updates so that the controller is running the most recent Java updates and most recent operating system updates.
 
-Other Jenkins controller images have switched from using `openjdk` base images to instead use base images provided by link:https://projects.eclipse.org/projects/adoptium[Eclipse Adoptium].
+Other Jenkins controller images have already switched from using `openjdk` base images to instead use base images provided by link:https://projects.eclipse.org/projects/adoptium[Eclipse Adoptium].
 link:https://projects.eclipse.org/projects/adoptium[Eclipse Adoptium] is the Eclipse project formed when link:https://blog.adoptopenjdk.net/2020/06/adoptopenjdk-to-join-the-eclipse-foundation/[AdoptOpenJDK joined the Eclipse Foundation].
+This change adapts the `jenkins/jenkins:latest` and `jenkins/jenkins:lts` images to use the Adoptium JDK images in the same pattern as is already used for the Jenkins JDK 11 Docker images like `jenkins/jenkins:lts-jdk11`.
 The Jenkins Platform SIG has enjoyed very good results in our interactions with the Eclipse Adoptium project.
 We look forward to continuing our collaboration with them.
 


### PR DESCRIPTION
## Better phrasing of JDK change

The phrasing for the JDK change from OpenJDK to AdoptOpenJDK was not clear enough.  We've already switched from OpenJDK to AdoptOpenJDK for JDK 11.  This change is making JDK 8 consistent with JDK 11.

Does not mention the additional benefit from updating package versions in the operating system.  For example, there are valuable performance improvements in the transition from command line git 2.11 (Debian 9) to command line git 2.20 (Debian 10).
