### PR TITLE
Add Docker image upgrade to Jenkins 2.263.4 guide

### DIFF
--- a/content/_data/upgrades/2-263-4.adoc
+++ b/content/_data/upgrades/2-263-4.adoc
@@ -1,1 +1,73 @@
-No notable changes requiring upgrade notes.
+==== Docker image update
+
+The Jenkins 2.263.4 Docker images labeled `jenkins/jenkins:2.263.4-lts`, `jenkins/jenkins:2.263.4`, and `jenkins/jenkins:lts` use the AdoptOpenJDK 8u282 release instead of using the OpenJDK 8u242 release from previous images.
+Those images also use Debian 10 (link:https://www.debian.org/releases/buster/["Buster"]) instead of the Debian 9 (link:https://www.debian.org/releases/stretch/["Stretch"]) release that was used in previous images.
+See the link:/blog/2021/02/08/docker-base-os-upgrade/[blog post] for a more detailed description of the change.
+
+The change from Debian 9 to Debian 10 removes several packages from the base Docker image.
+The `subversion`, `mercurial`, `bzr`, and `python` packages have been removed from the base images, along with other packages.
+The Dockerfile definitions of Jenkins installations that depend on specific operating system packages may need to be updated to use Jenkins 2.263.4 and later.
+
+Example Dockerfile definitions are provided below for:
+
+* <<Subversion>>
+* <<Mercurial>>
+* <<Bazaar>>
+* <<Python>>
+
+===== Subversion
+
+The following Docker image definition uses Jenkins 2.263.4 with the plugin:subversion[subversion plugin] and the operating system `subversion` package:
+
+[source]
+----
+FROM jenkins/jenkins:2.263.4-lts
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends subversion
+USER jenkins
+RUN jenkins-plugin-cli --plugins subversion:2.14.0
+----
+
+===== Mercurial
+
+The following Docker image definition uses Jenkins 2.263.4 with the plugin:mercurial[mercurial plugin] and the operating system `mercurial` package:
+
+[source]
+----
+FROM jenkins/jenkins:2.263.4
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends mercurial
+USER jenkins
+RUN jenkins-plugin-cli --plugins mercurial:2.12
+----
+
+===== Bazaar
+
+The following Docker image definition uses Jenkins 2.263.4 with the plugin:bazaar[bazaar plugin] and the operating system `bzr` package:
+
+[source]
+----
+FROM jenkins/jenkins:2.263.4-lts
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends bzr
+USER jenkins
+RUN jenkins-plugin-cli --plugins bazaar:1.22
+----
+
+===== Python
+
+The following Docker image definition uses Jenkins 2.263.4 with the operating system `python3` package (since Python 2 support ended in Jaunary 2020):
+
+[source]
+----
+FROM jenkins/jenkins:2.263.4
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3
+USER jenkins
+----
+
+If your Jenkins installation requires other operating system packages (like bzip2 or certain libraries), those packages can be installed from your Dockerfile with the `apt-get install` command.


### PR DESCRIPTION
## Upgrading from Debian 9 to 10 in Docker image

See https://www.jenkins.io/blog/2021/02/08/docker-base-os-upgrade/ for details.
