### PR TITLE
Removing mention of system properties related to ZFSInstaller

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -685,22 +685,6 @@ properties:
   description: |
     How frequently to update node monitors by default, in minutes.
 
-- name: hudson.os.solaris.ZFSInstaller.disabled
-  tags:
-  - escape hatch
-  def: |
-    `false`
-  description: |
-    True to disable ZFS monitor on Solaris.
-
-- name: hudson.os.solaris.ZFSInstaller.migrate
-  tags:
-  - internal
-  def: undefined
-  description: |
-    Set by Jenkins itself when restarting Jenkins for a migration to a ZFS volume and contains the migration target dataset name.
-    There is no reason this would be set by administrators manually.
-
 - name: hudson.PluginManager.checkUpdateAttempts
   tags:
   - tuning


### PR DESCRIPTION
Deleted as of https://github.com/jenkinsci/jenkins/pull/5047.

There must be some more maintainable way to generate this list so that it stays in synch with reality automatically. An annotation processor?