### PR TITLE
Improve terminology

### DIFF
--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -64,7 +64,7 @@ When a Jenkins controller is running on Java 11, the Java Web Start button will 
 Agents for a Java 11 Jenkins server can't be launched from a `*.jnlp` file downloaded to a web browser.
 
 There are no plans to replace this functionality.
-Connect agents to Jenkins on Java 11 with plugins like plugin:ssh-slaves[SSH Slaves Plugin], with operating system command line calls to `java -jar agent.jar`, or by using containers.
+Connect agents to Jenkins on Java 11 with plugins like plugin:ssh-slaves[SSH Build Agents Plugin], with operating system command line calls to `java -jar agent.jar`, or by using containers.
 
 == JDK Tool Automatic installer
 

--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -95,21 +95,21 @@ for (agent in jenkins.getNodes()) {
    println "Checking computer ${computer.name}:"
    def isOK = (agentAccessible(computer) && !computer.offline)
    if (isOK) {
-     println "\t\tOK, got PATH back from slave ${computer.name}."
-     println('\tcomputer.isOffline: ' + slave.getComputer().isOffline());
-     println('\tcomputer.isTemporarilyOffline: ' + slave.getComputer().isTemporarilyOffline());
-     println('\tcomputer.getOfflineCause: ' + slave.getComputer().getOfflineCause());
+     println "\t\tOK, got PATH back from agent ${computer.name}."
+     println('\tcomputer.isOffline: ' + computer.isOffline());
+     println('\tcomputer.isTemporarilyOffline: ' + computer.isTemporarilyOffline());
+     println('\tcomputer.getOfflineCause: ' + computer.getOfflineCause());
      println('\tcomputer.offline: ' + computer.offline);
    } else {
      numberOfflineNodes ++
      println "  ERROR: can't get PATH from agent ${computer.name}."
-     println('\tcomputer.isOffline: ' + agent.getComputer().isOffline());
-     println('\tcomputer.isTemporarilyOffline: ' + agent.getComputer().isTemporarilyOffline());
-     println('\tcomputer.getOfflineCause: ' + agent.getComputer().getOfflineCause());
+     println('\tcomputer.isOffline: ' + computer.isOffline());
+     println('\tcomputer.isTemporarilyOffline: ' + computer.isTemporarilyOffline());
+     println('\tcomputer.getOfflineCause: ' + computer.getOfflineCause());
      println('\tcomputer.offline: ' + computer.offline);
-     sendMail(computer.name, agent.getComputer().getOfflineCause().toString())
-     if (agent.getComputer().isTemporarilyOffline()) {
-       if (!agent.getComputer().getOfflineCause().toString().contains("Disconnected by")) {
+     sendMail(computer.name, computer.getOfflineCause().toString())
+     if (computer.isTemporarilyOffline()) {
+       if (!computer.getOfflineCause().toString().contains("Disconnected by")) {
          computer.setTemporarilyOffline(false, agent.getComputer().getOfflineCause())
        }
      } else {

--- a/content/projects/gsoc/2018/remoting-over-message-bus.adoc
+++ b/content/projects/gsoc/2018/remoting-over-message-bus.adoc
@@ -28,7 +28,7 @@ The plugin source code can be found in https://github.com/jenkinsci/remoting-kaf
 === Benefits to the community
 The plugin provide useful features to the community:
 
-* Provide a new method to connect agent to master using Kafka besides existing methods such as JNLP or ssh-slaves-plugin.
+* Provide a new method to connect agent to master using Kafka besides existing methods such as JNLP or plugin:ssh-slaves[SSH Build Agents plugin].
 * Help to resolve the existing issues with the TCP protocol between master and agent communication in Jenkins.
 * Help to resolve traffic prioritization and multi-agent communications issue in Jenkins.
 


### PR DESCRIPTION
## Remove a few more uses of `slave`

- Replace slave term with agent in nodes.adoc groovy
- SSH build agents, not SSH slaves
