### PR TITLE
Correct the summit start time 15:00 UTC

### DIFF
--- a/content/blog/2021/02/2021-02-16-contributor-summit-online.adoc
+++ b/content/blog/2021/02/2021-02-16-contributor-summit-online.adoc
@@ -25,7 +25,7 @@ Contributors will meet to discuss specific topics in smaller groups at times tha
 
 === Opening session
 
-The opening session will start Tuesday, February 23, 2021 at 13:00 UTC.
+The opening session will start Tuesday, February 23, 2021 at 15:00 UTC.
 After an initial welcome and overview, we'll hear from leaders in the Jenkins project as they share the results from the previous 12 months and outline ideas for the next 12 months.
 
 image::/images/post-images/2021/2021-02-16-contributor-summit.png[role=right]
@@ -52,7 +52,7 @@ A track leader will organize the track meeting, facilitate discussions in the tr
 
 === Closing session
 
-The opening session will start Thursday, February 25, 2021 at 13:00 UTC.
+The opening session will start Thursday, February 25, 2021 at 15:00 UTC.
 After an initial welcome and overview, we'll hear from track leaders as they share the results from their track meetings.
 
 We'll identify items that should be added to the link:/project/roadmap/[Jenkins roadmap], items that should be further investigated by link:/sigs/[special interest groups], and items that need further discussion elsewhere.


### PR DESCRIPTION
## Fix the Contributor Summit start time

Still an early morning hour for the U.S. west coast, but not as painful as 13:00 UTC.
