### PR TITLE
Reference 2021-02-19 security advisory in 2.280 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -10224,6 +10224,11 @@
 - version: '2.280'
   date: 2021-02-16
   changes:
+  - type: security
+    message: Important security fix.
+    references:
+      - url: /security/advisory/2021-02-19/
+        title: 2021-02-19 security advisory
   - type: major bug
     category: major bug
     pull: 5281


### PR DESCRIPTION
> <img width="1310" alt="Screenshot 2021-02-19 at 18 05 51" src="https://user-images.githubusercontent.com/1831569/108536777-1e805d80-72dd-11eb-8c60-713a3dafe77c.png">
