### PR TITLE
Android lint plugin superseded by warnings-ng

### DIFF
--- a/content/_data/solutions/android.yml
+++ b/content/_data/solutions/android.yml
@@ -18,8 +18,8 @@ plugins:
   - 'Android Emulator plugin'
   - 'automate many Android tasks during a build, such as launching/destroying emulators'
 -
-  - 'https://plugins.jenkins.io/android-lint'
-  - 'Android Lint plugin'
+  - 'https://plugins.jenkins.io/warnings-ng'
+  - 'Warning next generation plugin'
   - 'parses output from the Android lint tool for display and analysis'
 -
   - 'https://plugins.jenkins.io/google-play-android-publisher'

--- a/content/blog/2018/01/2018-01-08-moving-from-buddybuild-for-android.adoc
+++ b/content/blog/2018/01/2018-01-08-moving-from-buddybuild-for-android.adoc
@@ -40,7 +40,7 @@ Once you have finished executing the tests, you can use the link:/doc/pipeline/s
 === Static Analysis
 Similar to other Java or Kotlin projects, you can scan your codebase using static analysis tools like FindBugs or Checkstyle.  Once again, Jenkins has plugin:analysis-core[analysis plugins] which can parse the output of these tools, and present you with the results and trend graphs, or optionally flag the build as unstable or failed if too many problems have been detected.
 
-The Android SDK provides a further useful static analysis tool called link:https://developer.android.com/studio/write/lint.html[Lint].  The output of this tool can be parsed by the plugin:android-lint[Android Lint Plugin], which will analyse the issues found, and provide you with a detailed report within Jenkins.  This functionality was link:https://www.youtube.com/watch?v=Erd2k6EKxCQ&t=53m32s[demonstrated by the Android Tools Team] at the Google I/O conference a few years back.
+The Android SDK provides a further useful static analysis tool called link:https://developer.android.com/studio/write/lint.html[Lint].  The output of this tool can be parsed by the plugin:warnings-ng[Warnings Next Generation Plugin], which will analyse the issues found, and provide you with a detailed report within Jenkins.  This functionality was link:https://www.youtube.com/watch?v=Erd2k6EKxCQ&t=53m32s[demonstrated by the Android Tools Team] at the Google I/O conference a few years back.
 
 === Securely signing and deploying Android apps
 In order to distribute an Android app, it needs to be signed with a private key, which you should keep safe (losing it means you won't be able to publish updates to your app!), and as secure as possible.


### PR DESCRIPTION
## The warnings-ng plugin supersedes android-lint

Fixes https://github.com/jenkins-infra/jenkins.io/issues/4128
