### PR TITLE
Minor fixes in changelog and advisory for 2.280

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -10228,7 +10228,7 @@
     message: Important security fix.
     references:
       - url: /security/advisory/2021-02-19/
-        title: 2021-02-19 security advisory
+        title: security advisory
   - type: major bug
     category: major bug
     pull: 5281

--- a/content/security/advisory/2021-02-19.adoc
+++ b/content/security/advisory/2021-02-19.adoc
@@ -15,10 +15,10 @@ issues:
     severity: High
     vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
   description: |-
-    Spring Security 5.4.3 and earlier has a vulnerability that unintentionally persisted temporarily elevated privileges in some circumstances in a user's session.
+    Spring Security 5.4.3 and earlier has a vulnerability that unintentionally persists temporarily elevated privileges in some circumstances in a user's session.
     This issue, CVE-2021-22112, is resolved in Spring Security 5.4.4.
 
-    Jenkins 2.266 through 2.279 (inclusive) included releases of Spring Security with this vulnerability.
+    Jenkins 2.266 through 2.279 (inclusive) includes releases of Spring Security with this vulnerability.
 
     We are aware of a sequence of operations in Jenkins 2.275 through 2.278 (inclusive) that allows attackers with Job/Workspace permission to exploit this to switch their identity to SYSTEM, an internal user with all permissions.
 


### PR DESCRIPTION
- only specify the advisory date when it's different from the release
- discuss older releases' behavior in present tense

Untested.