### PR TITLE
Remove some of the old irc webchat links from the governance pages

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -56,16 +56,6 @@ link:/projects/infrastructure/ircbot/[Learn more].
 link:/project/board[Board members and officers] typically have _op_ (@) in this channel.
 Established contributors typically have _voice_ (+) in this channel.
 
-[[meeting]]
-=== `#jenkins-meeting`
-
-We conduct the project governance meetings in this channel (every two week).
-These meetings are open to everyone.
-link:/project/governance-meeting[Learn more about the project governance meeting].
-Meetings are logged, see the referenced page for the agenda and meeting note links.
-
-The channel is used ONLY for meetings, and it is moderated during the rest of the time.
-
 === `#jenkins-infra`
 
 Discussions of the link:/projects/infrastructure/[Jenkins project infrastructure], i.e. most services running on `jenkins.io`, `jenkins-ci.org`, and related domains.

--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -15,8 +15,8 @@ If a decision cannot be made at the governance meeting, the project's link:/proj
 
 === How to join the meetings?
 
-The governance meeting commonly happens every two weeks on Wednesdays, 6PM UTC.
-We hold the meeting as a recorded video call or as a chat in the `#jenkins-meeting` link:/chat[IRC Channel] on Freenode.
+The governance meeting commonly happens every two weeks on Wednesdays, 8PM UTC.
+We hold the meeting as a recorded video call.
 The meetings calendar with links is available link:/event-calendar[here].
 
 === How to propose a topic?
@@ -35,14 +35,11 @@ Everyone is welcome to add a topic for one of the incoming meetings by suggestin
 <iframe src="https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg?embedded=true" width="100%" height="600px"></iframe>
 ++++
 
-=== Meeting notes
-
-Minutes and raw conversation history for each meeting can be found in full on link:http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
-The meeting minutes also contain the list of action items defined at the meeting.
-
 === Archived Meetings
 
 Older agendas, minutes and IRC logs are archived on these pages:
+
+Minutes and raw conversation history for each meeting can be found in full on link:http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
 
 * link:./archives/2019[Governance Meeting Archive 2019]
 * link:./archives/2018[Governance Meeting Archive 2018]
@@ -53,13 +50,3 @@ Older agendas, minutes and IRC logs are archived on these pages:
 * link:./archives/2013[Governance Meeting Archive 2013]
 * link:./archives/2012[Governance Meeting Archive 2012]
 * link:./archives/2011[Governance Meeting Archive 2011]
-
-== Useful links
-
-* https://webchat.freenode.net/#jenkins-meeting[Direct IRC Webchat link]
-
-== IRC Tips
-
-The meeting is run with http://meetbot.debian.net/Manual.html[the moderation of a bot].
-You can use the `+#info+` and `+#idea+` commands to flag info and ideas as such, which will be noted in the meeting minutes. 
-Further commands are documented http://meetbot.debian.net/Manual.html#commands[here].


### PR DESCRIPTION
They are not actually used anymore, so lets not direct people there.