### PR TITLE
Include LDAP 2.3 upgrade in 2.279 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -10197,13 +10197,29 @@
     - alecharp
     message: |-
       Include 'plugin-id' and 'plugin-version' data attributes in the <em>Available</em> plugins tab (regression in 2.270).
+  - type: rfe
+    category: rfe
+    pull: 5244
+    authors:
+    - basil
+    references:
+      - pull: 5244
+      - url: "https://github.com/jenkinsci/ldap-plugin/releases/tag/ldap-2.3"
+        title: LDAP 2.3 changelog
+      - url: "https://github.com/jenkinsci/ldap-plugin/releases/tag/ldap-2.2"
+        title: LDAP 2.2 changelog
+      - url: "https://github.com/jenkinsci/ldap-plugin/releases/tag/ldap-2.1"
+        title: LDAP 2.1 changelog
+      - url: "https://github.com/jenkinsci/ldap-plugin/releases/tag/ldap-2.0"
+        title: LDAP 2.0 changelog
+    message: |-
+      Upgrade LDAP plugin from 1.26 minimum to 2.3.
 
   # pull: 4407 (PR title: Clean up some Deprecation warnings)
   # pull: 5212 (PR title: Clean up VirtualFile after adding base implementation)
   # pull: 5220 (PR title: Deprecate hudson.util.RunList#filter(com.google.common.base.Predicate))
   # pull: 5240 (PR title: Stop overriding the parent pom for maven-deploy-plugin)
   # pull: 5243 (PR title: Bump parent POM from 1.62 to 1.63)
-  # pull: 5244 (PR title: Bump LDAP from 1.26 to 2.3)
   # pull: 5245 (PR title: Add log4j1 dependabot ignore entry)
   # pull: 5247 (PR title: Bump CloudBees Folder from 6.3 to 6.15)
   # pull: 5248 (PR title: Remove unused mock-javamail dependency)


### PR DESCRIPTION
## Include LDAP 2.3 in Jenkins 2.279 changelog

Missed it earlier.
