### PR TITLE
Add more links to roadmap

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -152,8 +152,8 @@
                         %a{:href => 'https://issues.jenkins.io'}
                           Issue tracker
                       %li
-                        %a{:href => 'https://wiki.jenkins.io'}
-                          Wiki
+                        %a{:href => expand_link("project/roadmap")}
+                          Roadmap
                       %li
                         %a{:href => 'https://github.com/jenkinsci'}
                           GitHub

--- a/content/_partials/legacy/navbar.html.haml
+++ b/content/_partials/legacy/navbar.html.haml
@@ -55,8 +55,8 @@
             %a{:href => "https://wiki.jenkins-ci.org/display/JENKINS/Issue+Tracking", :title => "JIRA for Jenkins"}
               Bug Tracker
           %li.leaf
-            %a{:href => "https://wiki.jenkins-ci.org/", :title => "Jenkins Wiki"}
-              Wiki
+            %a{:href => "/project/roadmap", :title => "Jenkins Roadmap"}
+              Roadmap
           %li.leaf.last
             %a{:href => "https://ci.jenkins.io/", :title => "Jenkins own Jenkins install"}
               CI

--- a/content/_partials/legacy/resources.html.haml
+++ b/content/_partials/legacy/resources.html.haml
@@ -7,8 +7,8 @@
         %a{:href => '/calendar'}
           Calendar
       %p
-        %a{:href => 'https://wiki.jenkins-ci.org/'}
-          Wiki
+        %a{:href => '/project/roadmap'}
+          Roadmap
       %p
         %a{:href => 'https://issues.jenkins.io/'}
           Issues

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -80,8 +80,8 @@
           %a.dropdown-item.feature{:href => expand_link('mailing-lists'),
                             :title => "Browse Jenkins mailing list archives and/or subscribe to lists"}
             Mailing Lists
-          %a.dropdown-item.feature{:href => "https://wiki.jenkins.io/"}
-            Wiki
+          %a.dropdown-item.feature{:href => expand_link('project/roadmap')}
+            Roadmap
           %a.dropdown-item.feature{:href => "https://accounts.jenkins.io/", :title => "Create/manage your account for accessing wiki, issue tracker, etc"}
             Account Management
 
@@ -110,6 +110,8 @@
         = partial("dropdown.html.haml", :name => "About")
 
         .dropdown-menu
+          %a.dropdown-item{:href => expand_link('project/roadmap')}
+            Roadmap
           %a.dropdown-item{:href => expand_link('security')}
             Security
           %a.dropdown-item{:href => expand_link('press')}


### PR DESCRIPTION
## Add more links to roadmap

### About dropdown menu

![About-includes-roadmap](https://user-images.githubusercontent.com/156685/109367108-6e69a200-7852-11eb-8b55-8ac5630c9c9d.png)

### Community dropdown menu

![community-includes-roadmap](https://user-images.githubusercontent.com/156685/109367112-7295bf80-7852-11eb-93ef-f933bea67d09.png)

### Project section in page footer

![project-includes-roadmap](https://user-images.githubusercontent.com/156685/109367122-775a7380-7852-11eb-935b-dee4421b9240.png)


@StackScribe and @halkeye this was one of the ideas discussed in the Docs track of the Contributor Summit