### PR TITLE
Add pipeline steps doc generator improvement idea

### DIFF
--- a/content/projects/gsoc/2021/project-ideas/pipeline-step-documentation-generator.adoc
+++ b/content/projects/gsoc/2021/project-ideas/pipeline-step-documentation-generator.adoc
@@ -1,0 +1,66 @@
+---
+layout: gsocprojectidea
+title: "Pipeline Step Documentation Generator improvements"
+goal: "Enhance the Jenkins Pipeline documentation generator to produce better documentation for thousands of Pipeline developers"
+category: Dev Tools
+year: 2021
+status: draft
+sig: docs
+skills:
+- Java
+- Jenkins Pipeline
+- HTML
+- CSS
+- Asciidoc
+- JavaScript
+mentors:
+- "kwhetstone"
+- "markewaite"
+links:
+  draft: https://docs.google.com/document/d/19hf1FSs7Y4z7YjfqjareqaWURpZ3Elkvh4XgLKdX6Ho
+---
+
+=== Background
+
+The Jenkins Pipeline Step reference is difficult to read, even to the initiated, mostly due to its format.
+This project aims to improve the way the documentation is formatted.
+
+For example, when you read the link:/doc/pipeline/steps/workflow-basic-steps/#readfile-read-file-from-workspace[readFile step documentation], the documentation format makes it difficult to see that the obvious usage is : `readFile('filename')`.
+When you read the link:/doc/pipeline/steps/workflow-scm-step/[checkout documentation], you are shown a single web page with collapsible sections that when expanded and printed would be 62 pages long.
+That is too large a page for usable navigation.
+We should consider logical partitions of that page, possibly with a single page per SCM provider (like checkout-git, checkout-p4, checkout-svn, checkout-cvs).
+Redirects would be needed within the checkout page to link users to the correct page per SCM provider.
+
+For this project, the student is expected to study the link:https://github.com/jenkins-infra/pipeline-steps-doc-generator/[documentation generator code base], the link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[documentation feedback from readers], and to propose enhancements to the documentation generator code to improve the format, layout, and readability of the documentation published on-line.
+The student is not expected to contribute to the content of the documentation, however, technical additions that enhance the discoverability of the documentation via annotations or other special markup are considered valid for a coding project.
+
+Many of the Pipeline step references include no documentation.
+Those pages could have a standard reference created that directs the reader to use the Pipeline Syntax snippet generator.
+See the link:https://plugins.jenkins.io/git/#pipelines[git plugin documentation] for one idea of a way to encourage use of the snippet generator.
+
+The student is also expected to study Stapler and Jelly, as these technologies are used to capture documentation as well.
+Documentation can be extracted from Stapler and Jelly.
+
+A potential stretch goal could  be something like an embedded pipeline steps generator, though that might be outside the scope of the website.
+
+=== Links
+
+* Pipeline documentation: link:/doc/book/pipeline/
+* Example of documentation for link:/doc/pipeline/steps/workflow-basic-steps/#code-readfile-code-read-file-from-workspace[readFile] step
+** https://github.com/jenkins-infra/pipeline-steps-doc-generator/
+** https://github.com/jenkins-infra/pipeline-library
+
+Examples of remote documentation:
+
+* Pipeline: AWS steps adds documentation to the README
+* JIRA Pipeline steps keeps their documentation in their repo, and displays it as a weblink.
+
+=== Newbie Friendly issues
+
+* List of issues related to link:https://issues.jenkins.io/browse/JENKINS-41667?jql=text%20~%20%22pipeline%20steps%20document%20generator%22%20and%20status%20not%20in%20(Closed%2C%20resolved%2C%20done)%20and%20labels%20%3D%20gsoc-2019-project-idea[documentation generation].
+** link:https://issues.jenkins.io/browse/INFRA-1717[INFRA-1717] - Javadoc landing page
+** https://github.com/jenkins-infra/pipeline-library/pull/22   Review and help merge the PR to generate Javadoc for Pipeline steps
+* Component Java Doc: https://javadoc.jenkins.io/component/
+* Core Java doc: https://javadoc.jenkins.io/component/
+* Plugin java docs: https://javadoc.jenkins.io/plugin/
+* The java docs cannot be searched easily (e.g. try to find org.jenkinsci.Symbol)


### PR DESCRIPTION
## Add Pipeline Steps Doc Generator improvement project

Good ideas for improvements and the doc generator code has received several improvements through @zbynek and @MarkEWaite since this idea was proposed in 2020.

Might fit very well in the 175 hour estimate of time for the Google Summer of Code contributions this year.

Assumed that @kwhetstone is willing to be a mentor for this project (with the assumption that we would not ask her to mentor more than one project).

### On the page:

![image](https://user-images.githubusercontent.com/156685/109368654-0cf80200-7857-11eb-8ae4-71c691eeb928.png)


### Inside the page

![screencapture-localhost-4242-projects-gsoc-2021-project-ideas-pipeline-step-documentation-generator-2021-02-26-17_22_07-edit](https://user-images.githubusercontent.com/156685/109368702-36189280-7857-11eb-961a-1d0094e0b952.png)
