### PR TITLE
Include Jenkins Minute video in Pipeline Editor page

### DIFF
--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -1,7 +1,6 @@
 ---
 layout: section
 title: Pipeline Editor
-wip: true
 ---
 ifdef::backend-html5[]
 :description:
@@ -27,7 +26,7 @@ as a `Jenkinsfile`.  If the Pipeline needs to be changed again,
 Blue Ocean makes it easy to jump back in into the visual editor to modify the
 Pipeline at any time.
 
-image:blueocean/editor/overview.png[Pipeline Editor, role=center]
+video::FhDomw6BaHU[youtube, width=640, height=360, align="center"]
 
 == Starting the editor
 


### PR DESCRIPTION
## Include Jenkins Minute video in Pipeline Editor page

Docs feedback asked for more clear instructions

These instructions already exist and show step by step how to create a Pipeline in less than 2 minutes.

@bitwiseman are we allowed to use this video in the Jenkins documentation?

## Pipeline Editor page

![screencapture-localhost-4242-doc-book-blueocean-pipeline-editor-2021-02-26-22_23_50-edit](https://user-images.githubusercontent.com/156685/109376400-6d9c3480-7881-11eb-95d2-2dd0a3f98e2e.png)

