### PR TITLE
Fix #4136 with site local link

### DIFF
--- a/content/doc/book/installing/war-file.adoc
+++ b/content/doc/book/installing/war-file.adoc
@@ -41,7 +41,7 @@ The Jenkins Web application ARchive (WAR) file can be started from the command l
   link:../../book/managing[**Manage Jenkins**] >
   link:../../book/managing/plugins/[**Manage Plugins**] page in Jenkins. Read
   more about the specifics for installing Blue Ocean on the
-  link:../../book/blueocean/getting-started/[Getting started with Blue Ocean]
+  link:/doc/book/blueocean/getting-started/[Getting started with Blue Ocean]
   page.
 * You can change the port by specifying the `--httpPort` option when you run the
   `java -jar jenkins.war` command. For example, to make Jenkins accessible


### PR DESCRIPTION
# Fix #4136 with site local link

No need for a directory relative link when a site local link provides the same simple navigation and works as expected.
