### PR TITLE
Archive GSoD 2020, prepare for GSoD 2021

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -650,6 +650,13 @@ categories:
       - feature
     - name: Google Season of Docs 2020
       status: released
+      link: https://www.jenkins.io/sigs/docs/gsod/2020/
+      labels:
+      - outreach-program
+      - documentation
+      - events
+    - name: Google Season of Docs 2021
+      status: near-term
       link: https://www.jenkins.io/sigs/docs/gsod/
       labels:
       - outreach-program

--- a/content/sigs/docs/gsod/2021/application.md
+++ b/content/sigs/docs/gsod/2021/application.md
@@ -1,0 +1,100 @@
+---
+:layout: simplepage
+:title: "Jenkins GSoD application draft, 2021"
+:tags:
+- gsod
+- gsod2021
+---
+
+<!-- This file uses Markdown intentionally.
+     The application is actually a plain text, but we use Markdown to follow the GSoC format which is likely to be adopted by GSoD later.
+ -->
+
+The data below represents the Google Season of Docs 2021 application draft.
+
+### Organization Profile
+
+* Name: Jenkins project
+* Website: https://jenkins.io/
+* Contact email for GSoD: jenkinsci-docs@googlegroups.com 
+* GSoD page link: http://jenkins.io/sigs/docs/gsod
+* Does your organization want to accept the mentor stipend? => Yes
+* Link to project ideas list: https://jenkins.io/sigs/docs/gsod#project-ideas 
+
+### Org admins
+
+* Primary: Mark Waite
+* Secondary: 
+
+### Org description
+
+Jenkins, originally founded in 2006 as "Hudson", is one of the leading automation servers.
+The project’s motto is "Build great things at any scale".
+Using extensible, plugin-based architecture developers have created hundreds of plugins to adapt Jenkins to a multitude of build, test, and deployment automation workloads.
+Jenkins is open-source, MIT License is used for most of the components.
+
+The project has thousands of active contributors working on Jenkins core, plugins, website, project infrastructure, localization activities, and, of course, documentation.
+We invite technical writers to join the community and contribute to the documentation being used by millions of Jenkins users worldwide.
+
+### What previous experience has your organization had in the documentation or collaborating with technical writers?
+
+> If you or any of your mentors have worked with technical writers before, or have developed documentation, mention this in your answer.
+> Describe the documentation that you produced and the ways in which you worked with the technical writer.
+> For example, describe any review processes that you used, or how the technical writer's skills were useful to your project.
+> Explain how this previous experience may help you to work with a technical writer in Season of Docs.
+
+In the Jenkins project, we believe that documentation is as important as code.
+In 2019, we introduced an official Documentation Officer role and started a Documentation special interest group (https://jenkins.io/sigs/docs/) 
+which, among other things, coordinates the Google Season of Docs application in the project.
+We have several documentation initiatives listed on our project roadmap: https://jenkins.io/project/roadmap/.
+The Documentation SIG facilitates documentation improvement across the organization.
+
+The Jenkins project mentored Zainab Abubkar as a Google Season of Docs 2020 writer.
+Her project, "Jenkins on Kubernetes" has been well received by the Jenkins community.
+
+We have extensive documentation on the jenkins.io website (https://jenkins.io/doc/) as well as the plugin site (http://plugins.jenkins.io/).
+This repository has a copy-editors team which assists submitters with reviews of their documentation.
+A large majority of Jenkins components and plugins also have documentation in GitHub and other resources, including user, administrator, developer, and contributor guidelines.
+The Jenkins project hosts a repository for technical specifications called the Jenkins Enhancement Proposals https://github.com/jenkinsci/jep.
+
+The Jenkins project follows the documentation-as-code approach for all new documentation,
+and we use industry-standard tools (Git/GitHub) and markup languages (AsciiDoc, GitHub Flavored Markdown) so that
+Jenkins contribution provides relevant and widely applicable experience to technical writers.
+
+The Jenkins project has a wealth of knowledge working with technical writers.
+A portion of the Jenkins documentation has been created by professional technical writers whose time was donated to the project by company contributors.
+We previously had several coordinated documentation initiatives, e.g. creation of new documentation for Jenkins Pipeline.
+We also facilitate documentation contributions and encourage newcomers to participate (https://jenkins.io/participate/#document), regardless of their experience with Jenkins and our tools.
+We also invest time in contributing guidelines for documentation contributors,
+e.g. here are our contributing guidelines for the website: https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc.
+
+Reviews: jenkins.io and GitHub documentation are managed and reviewed via pull requests.
+For example, there are contribution guidelines for jenkins.io: https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc.
+In the project, we also have a team of copy-editors who review the content: https://github.com/orgs/jenkins-infra/teams/copy-editors.
+Contributions to Jenkins component documentation (e.g. plugin docs) are usually reviewed by maintainers.
+
+We also have channels specifically dedicated to the documentation.
+These channels act as an additional contact point for technical writers in the community:
+
+* Mailing list: https://groups.google.com/forum/#!forum/jenkinsci-docs
+* Chat on Gitter: https://gitter.im/jenkinsci/docs
+* Regular Documentation SIG meetings: https://www.jenkins.io/sigs/docs/#meetings
+
+### What previous experience has your organization had mentoring individuals?
+
+> Comment: If you or any of your mentors have taken part in Google Summer of Code or a similar program that mentors individuals, mention this in your answer.
+> Describe your achievements in that program. Explain how this experience may influence the way you work in Season of Docs.
+
+Jenkins project has successfully participated in Google Summer of Code before, including 2020 and 2019 (https://jenkins.io/projects/gsoc/).
+We have used Outreachy and CommunityBridge for previous mentoring programs, in addition to Google Summer of Code and Google Season of Docs.
+In 2020 we had 8 mentees in total.
+In 2019 we had 12 mentees in total.
+The Jenkins project has also been selected for Google Summer of Code 2021.
+The project also has many contributors whose roles at work include mentoring people (university professors and advisors, training leads, developer relations, senior engineers and tech writers).
+As an organization, we do not have particular experience in mentoring technical writers,
+but we do have experience in onboarding documentation contributors to the community.
+We also work on onboarding programs for documentation contributors, e.g. for website copy-editors: https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#maintainer-guide.
+
+### How many technical writers does your organization want to mentor this year?
+
+1

--- a/content/sigs/docs/gsod/2021/application.md
+++ b/content/sigs/docs/gsod/2021/application.md
@@ -16,15 +16,15 @@ The data below represents the Google Season of Docs 2021 application draft.
 
 * Name: Jenkins project
 * Website: https://jenkins.io/
-* Contact email for GSoD: jenkinsci-docs@googlegroups.com 
+* Contact email for GSoD: jenkinsci-docs@googlegroups.com
 * GSoD page link: http://jenkins.io/sigs/docs/gsod
 * Does your organization want to accept the mentor stipend? => Yes
-* Link to project ideas list: https://jenkins.io/sigs/docs/gsod#project-ideas 
+* Link to project ideas list: https://jenkins.io/sigs/docs/gsod#project-ideas
 
 ### Org admins
 
 * Primary: Mark Waite
-* Secondary: 
+* Secondary:
 
 ### Org description
 
@@ -44,7 +44,7 @@ We invite technical writers to join the community and contribute to the document
 > Explain how this previous experience may help you to work with a technical writer in Season of Docs.
 
 In the Jenkins project, we believe that documentation is as important as code.
-In 2019, we introduced an official Documentation Officer role and started a Documentation special interest group (https://jenkins.io/sigs/docs/) 
+In 2019, we introduced an official Documentation Officer role and started a Documentation special interest group (https://jenkins.io/sigs/docs/)
 which, among other things, coordinates the Google Season of Docs application in the project.
 We have several documentation initiatives listed on our project roadmap: https://jenkins.io/project/roadmap/.
 The Documentation SIG facilitates documentation improvement across the organization.

--- a/content/sigs/docs/gsod/ideas.adoc
+++ b/content/sigs/docs/gsod/ideas.adoc
@@ -36,6 +36,7 @@ We encourage proposals based on a technical writer's expertise and interests.
 | Jenkins on Kubernetes is a popular theme for Jenkins users.
   There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need to expand the documentation describing Jenkins on Kubernetes.
   We would like to create documentation that describes the concepts, techniques, and choices for Kubernetes users running Jenkins.
+  See the 2020 project link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] for work areas and topics.
   link:/sigs/docs/#jenkins-on-kubernetes[More Info]
 
 | Jenkins user documentation reorganization and update

--- a/content/sigs/docs/gsod/ideas.adoc
+++ b/content/sigs/docs/gsod/ideas.adoc
@@ -34,8 +34,8 @@ We encourage proposals based on a technical writer's expertise and interests.
 | Document Jenkins on Kubernetes
 | AsciiDoc, Guide, Compilation, Kubernetes
 | Jenkins on Kubernetes is a popular theme for Jenkins users.
-  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need a central location for documentation describing Jenkins on Kubernetes.
-  We would like to create new documentation which would describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
+  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need to expand the documentation describing Jenkins on Kubernetes.
+  We would like to create documentation that describes the concepts, techniques, and choices for Kubernetes users running Jenkins.
   link:/sigs/docs/#jenkins-on-kubernetes[More Info]
 
 | Jenkins user documentation reorganization and update
@@ -50,7 +50,7 @@ link:/sigs/docs/#user-guide[More info]
 | Jenkins project has several link:/solutions/[solution pages] for various use-cases.
   We invite technical writers to create new solution pages for various use-cases (e.g. Documentation as code, Continuous Deployment, Static Analysis)
   or technologies (Git, GitLab, Kubernetes, etc.).
-  Existing pages were created several years ago, and they could be also updated.
+  Existing pages were created several years ago, and they could also be updated.
   There are a lot of materials available on the web, but having dedicated solution pages could help users to discover such materials.
   link:/sigs/docs/#solution-pages[More info]
 

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -20,16 +20,9 @@ program brings together open source and technical writers communities for the be
 The program raises awareness of open source, of docs, and of technical writing.
 GSoD in Jenkins is organized by the link:/sigs/docs[Documentation special interest group].
 
-== GSoD 2020
+== GSoD 2021
 
-The Jenkins project is a mentoring organization in Google Season of Docs 2020.
-The writing project started September 14, 2020 and concluded November 30, 2020.
-See the link:/blog/2020/12/04/gsod-project-report/[project report] by link:/blog/authors/zaycodes[Zainab Abubakar] for details of
-the writing project and our first experience as a Google Season of Docs mentoring organization.
-
-=== GSoD 2020 Project
-
-* link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar]
+The Docs SIG plans to apply as a mentoring organization in Google Season of Docs 2021.
 
 === Project Ideas
 
@@ -93,7 +86,7 @@ Once the projects are announced, other project-specific channels might be create
 * link:/participate/document/[Contributing to Jenkins documentation]
 * link:https://developers.google.com/season-of-docs/docs/tech-writer-guide[GSoD Technical Writer guide]
 * link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
-* link:/sigs/docs/gsod/2020/application[Our GSoD 2020 application]
+* link:/sigs/docs/gsod/2021/application[Our GSoD 2021 application]
 
 === Mentors
 
@@ -101,11 +94,11 @@ Once the projects are announced, other project-specific channels might be create
 * link:https://developers.google.com/season-of-docs/docs/timeline[GSoD Timeline]
 * link:https://developers.google.com/season-of-docs/docs/project-selection[Selecting projects]
 * link:https://developers.google.com/season-of-docs/docs/tech-writer-collaboration[Working with a technical writer]
-* link:/sigs/docs/gsod/2020/application[Our GSoD 2020 application]
+* link:/sigs/docs/gsod/2021/application[Our GSoD 2021 application]
 
 === Office Hours
 
-Google Season of Docs office hours are held each Monday and Thursday at *17:00 UTC*.
+Documentation office hours are held each Monday at *23:00 UTC* and each Thursday at *16:00 UTC*.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
 Participant links are also available in the link:/events[Jenkins event calendar].
@@ -113,6 +106,14 @@ Participant links are also available in the link:/events[Jenkins event calendar]
 [#archive]
 == Previous years
 
-* GSoD 2019 - not accepted
+[[GSoD-2020]]
+* **GSoD 2020** link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar]
++
+The Jenkins project was a mentoring organization in Google Season of Docs 2020.
+The writing project started September 14, 2020 and concluded November 30, 2020.
+See the link:/blog/2020/12/04/gsod-project-report/[project report] by link:/blog/authors/zaycodes[Zainab Abubakar] for details of
+the writing project and our first experience as a Google Season of Docs mentoring organization.
+
+* **GSoD 2019** - not accepted
 (link:https://docs.google.com/document/d/1ighqWo7gIDCnLQ-b6FouQKz-fvmHsnTsMfqBh_mVNbI/edit?usp=sharing[application form and project ideas],
 link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#heading=h.g4afeqolzwpj[retrospective])

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -28,6 +28,33 @@ overview: >
   The SIG encourages, creates, and reviews documentation contributions and improves documentation with contributors and external communities.
 ---
 
+[pass]
+++++
+<!-- Redirect anchor references with Javascript -->
+<!-- This is ONLY for anchor references like installing/#windows. -->
+<!-- Use redirects as described in the contributing guide for page level redirects. -->
+<!-- https://stackoverflow.com/questions/1305211/javascript-to-redirect-from-anchor-to-a-separate-page/21198129#21198129 -->
+<script>
+(function () {
+    var anchorMap = {
+        "jenkins-on-kubernetes": "/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/",
+    }
+    /*
+    * Best practice for extracting hashes:
+    * https://stackoverflow.com/a/10076097/151365
+    */
+    var hash = window.location.hash.substring(1);
+    if (hash) {
+        /*
+        * Best practice for javascript redirects:
+        * https://stackoverflow.com/a/506004/151365
+        */
+        window.location.replace(anchorMap[hash]);
+    }
+})();
+</script>
+++++
+
 The SIG offers a venue for all kinds of documentation creation, improvement, and delivery.
 
 The group focuses on documentation for Jenkins, including:
@@ -75,37 +102,7 @@ See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD
 Google Season of Docs brings together open source communities and technical writers for the benefit of both.
 The program raises awareness of open source, of documentation, and of technical writing.
 
-The Jenkins project has been accepted to link:https://developers.google.com/season-of-docs/docs/participants[Google Season of Docs (GSoD) 2020].
-The link:https://developers.google.com/season-of-docs/docs/participants/project-jenkins-zaycodes[Jenkins on Kubernetes project] is the 2020 Google Season of Docs project for Jenkins.
-
 See our link:/sigs/docs/gsod[Google Season of Docs status page] for documentation project ideas, contact information, and more.
-
-[[jenkins-on-kubernetes]]
-==== Jenkins on Kubernetes - GSoD 2020
-
-Jenkins on Kubernetes is the Google Season of Docs project selected for 2020.
-Jenkins on Kubernetes is a popular theme of Jenkins Meetups and presentations at conferences.
-The Jenkins on Kubernetes project will describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
-The project can refer to existing information from:
-
-* GSOD selected project (link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] by link:/blog/authors/zaycodes[Zainab Abubakar])
-* Jenkins online meetups (like
-link:https://www.youtube.com/watch?v=h4hKSXjCqyI[Jenkins on Kubernetes: Getting Started])
-* Cloud providers (like
-link:https://cloud.google.com/solutions/jenkins-on-kubernetes-engine[Google Cloud Platform],
-link:https://docs.microsoft.com/en-us/azure/architecture/solution-ideas/articles/container-cicd-using-jenkins-and-kubernetes-on-azure-container-service[Microsoft Azure],
-link:https://developer.ibm.com/technologies/containers/tutorials/deploy-and-run-jenkins-on-kubernetes-in-the-cloud/[IBM Cloud], and
-link:https://blogs.oracle.com/cloud-infrastructure/deploy-jenkins-on-oke[Oracle Cloud Platform])
-* Training labs (like
-link:https://www.qwiklabs.com/focuses/1104?parent=catalog[Google Cloud self-paced labs])
-* System providers (like
-link:https://code.vmware.com/samples/5160/Jenkins-CICD-Integration-with-PKS-provisioned-Kubernetes-Clusters[VMWare] and
-link:https://rancher.com/blog/2018/2018-11-27-scaling-jenkins/[Rancher])
-* Infrastructure as a Service providers (like
-link:https://platform9.com/blog/kubernetes-for-ci-cd-at-scale/[Platform9])
-* SCM providers (like
-link:https://bitbucket.org/blog/setting-up-a-ci-cd-pipeline-with-spring-mvc-jenkins-and-kubernetes-on-aws[Bitbucket])
-* link:https://kubernetes.io/blog/2018/04/30/zero-downtime-deployment-kubernetes-jenkins/[Kubernetes project]
 
 === Plugin site integration with GitHub
 


### PR DESCRIPTION
## Prepare for GSoD 2021, archive GSoD 2020

- Add GSoD 2021 to roadmap
- Redirect 2020 GSoD project to dedicated page
- Move GSoD 2020 to archive section
- Update GSoD ideas for 2021
