### PR TITLE
Use Jenkins 2.277.1 for install

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -88,7 +88,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.263.4-lts-jdk11
+FROM jenkins/jenkins:2.277.1-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -87,7 +87,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.263.4-lts-jdk11
+FROM jenkins/jenkins:2.277.1-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \


### PR DESCRIPTION
## Use Jenkins 2.277.1 in the Docker install guide

Need to automate this in the future.
