### PR TITLE
[JENKINS-65069] Refer to AdoptOpenJDK CA issue for Debian 10 Docker image

### DIFF
--- a/content/_data/upgrades/2-263-4.adoc
+++ b/content/_data/upgrades/2-263-4.adoc
@@ -4,6 +4,9 @@ The Jenkins 2.263.4 Docker images labeled `jenkins/jenkins:2.263.4-lts`, `jenkin
 Those images also use Debian 10 (link:https://www.debian.org/releases/buster/["Buster"]) instead of the Debian 9 (link:https://www.debian.org/releases/stretch/["Stretch"]) release that was used in previous images.
 See the link:/blog/2021/02/08/docker-base-os-upgrade/[blog post] for a more detailed description of the change.
 
+The update from OpenJDK 8u242 on Debian 9 to AdoptOpenJDK 8u282 on Debian 10 includes a change in the management of certificate authority (CA) data.
+Please consult link:https://github.com/AdoptOpenJDK/openjdk-installer/issues/105[AdoptOpenJDK issue 105] for the most recent certificate management status if you're encountering SSL certificate issues with AdoptOpenJDK 8u282.
+
 The change from Debian 9 to Debian 10 removes several packages from the base Docker image.
 The `subversion`, `mercurial`, `bzr`, and `python` packages have been removed from the base images, along with other packages.
 The Dockerfile definitions of Jenkins installations that depend on specific operating system packages may need to be updated to use Jenkins 2.263.4 and later.


### PR DESCRIPTION
## Note the CA certificate issue in Debian 10 / AdoptOpenJDK 8u282

[JENKINS-65069](https://issues.jenkins.io/browse/JENKINS-65069) reports that the user was unable to register a custom certificate authority in the Docker image beginning with Jenkins 2.263.4.

The issue is known to AdoptOpenJDK and a fix is in progress.  See [Adoptium issue 105](https://github.com/AdoptOpenJDK/openjdk-installer/issues/105) for the latest status.

A workaround is provided in [issue 8243](https://github.com/jitsi/jitsi-meet/issues/8243#issuecomment-744181944) of the jitsi-meet project.

Special thanks to Oleg Nenashev for locating the work around and to Hashim for reporting the issue and investigating it so effectively.
