### PR TITLE
Add a redirect for info about building on controller.

### DIFF
--- a/content/redirect/building-on-controller.adoc
+++ b/content/redirect/building-on-controller.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://wiki.jenkins.io/display/JENKINS/Security+implication+of+building+on+master
+---


### PR DESCRIPTION
Redirect from building-on-controller to old page Security+implication+of+building+on+master. For now. The page needs to be rewritten and moved elsewhere and then the redirect target link updated.

See jenkinsci/jenkins#5337. This is intended to be used as additional information for two new admin monitors warning people against building on the controller.