### PR TITLE
Explain how to deactivate security with JCasc

### DIFF
--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -101,7 +101,8 @@ jenkins:
 
 === Using a Groovy Script
 
-If you are using a Groovy Script, you should locate the script setting up the Authorization strategy.
+If you are using a Groovy Script or a link:/doc/book/managing/groovy-hook-scripts/[Groovy Init Hook] to configure your authorization strategy,
+you should locate the script setting is up.
 There are multiple ways where it could be set, but essentially you should find a line like `Jenkins.instance.authorizationStrategy = myStrategy` or `setAuthorizationStrategy(myStrategy)`.
 
 Once you have located the configuration:

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -89,7 +89,15 @@ Review https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/REA
 
 Once you have located the file:
 
-. Remove the `authorizationStrategy` section.
+. Modify the `authorizationStrategy` section, so that it configures an unsecured realm:
++
+[source, yaml]
+----
+jenkins:
+  authorizationStrategy:
+    unsecured
+----
++
 . Restart your Jenkins instance.
 
 === Using a Groovy Script

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -87,3 +87,9 @@ When this happens, you can fix this by the following steps:
   access to the system.
 
 If this is still not working, trying renaming or deleting `config.xml`.
+
+[IMPORTANT] 
+.Using configuration as code
+====
+In case you are configuring your security realm / authorization using JCasc or Groovy init scripts, you will also need to deactivate JCasc or your Groovy init scripts so that they do not override the security part of the `config.xml`.
+====

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -94,8 +94,7 @@ Once you have located the file:
 [source, yaml]
 ----
 jenkins:
-  authorizationStrategy:
-    unsecured
+  authorizationStrategy: unsecured
 ----
 +
 . Restart your Jenkins instance.

--- a/content/doc/book/system-administration/security.adoc
+++ b/content/doc/book/system-administration/security.adoc
@@ -74,22 +74,41 @@ The following topics discuss other security features that are on by default. You
 One may accidentally set up a security realm / authorization in such a way that
 you may no longer be able to reconfigure Jenkins.
 
-When this happens, you can fix this by the following steps:
+When this happens, the steps to deactivate the Authorization realm depend on the way you manage your configuration.
+
+[WARNING]
+====
+After following the next sections, when Jenkins comes back, it will be in an unsecured mode where everyone gets full
+access to the system.
+====
+
+=== Using JCasc
+
+Locate your configuration as code file, default is `$JENKINS_HOME/jenkins.yaml` but it can be located in a number of places.
+Review https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md[the Jenkins Configuration as Code plugin for details].
+
+Once you have located the file:
+
+. Remove the `authorizationStrategy` section.
+. Restart your Jenkins instance.
+
+=== Using a Groovy Script
+
+If you are using a Groovy Script, you should locate the script setting up the Authorization strategy.
+There are multiple ways where it could be set, but essentially you should find a line like `Jenkins.instance.authorizationStrategy = myStrategy` or `setAuthorizationStrategy(myStrategy)`.
+
+Once you have located the configuration:
+
+* Comment out the line setting up the strategy.
+* Restart your instance.
+
+=== Using `config.xml` (ie you manage your controller configuration in the UI)
 
 . Stop Jenkins (the easiest way to do this is to stop the servlet container.)
 . Go to `$JENKINS_HOME` in the file system and find `config.xml` file.
 . Open this file in the editor.
 . Look for the `<useSecurity>true</useSecurity>` element in this file.
 . Replace `true` with `false`
-. Remove the elements `authorizationStrategy` and `securityRealm`
 . Start Jenkins
-. When Jenkins comes back, it will be in an unsecured mode where everyone gets full
-  access to the system.
 
 If this is still not working, trying renaming or deleting `config.xml`.
-
-[IMPORTANT] 
-.Using configuration as code
-====
-In case you are configuring your security realm / authorization using JCasc or Groovy init scripts, you will also need to deactivate JCasc or your Groovy init scripts so that they do not override the security part of the `config.xml`.
-====


### PR DESCRIPTION
This is just a proposal, I can see two ways of doing this:
* the one I documented.
* simply modifying the Groovy init script/JCasc configuration to push the Unsecure realm.

Not sure which one is the best one, but I think we should at least mention one as the current approach seems misleading for some people.