### PR TITLE
Fix Java 11 docker syntax #4170

### DIFF
--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -14,9 +14,8 @@ NOTE: Production deployments should use only LTS versions of Jenkins.
 == Running Jenkins with Docker
 
 The easiest way to run Jenkins on Java 11 is with a Docker image.
-These images are based on the official link:https://hub.docker.com/r/_/openjdk/[openjdk:11-jdk] image maintained by the Docker Community.
 
-To use the latest weekly release of the Java 11-based images, use the `jdk11` tag. For other releases, append the `-jdk11` tag to the version (for example, `2.164-jdk11`).
+To use the latest weekly release of the Java 11-based images, use the `jdk11` tag. For other releases, append the `-jdk11` tag to the version (for example, `2.284-jdk11`).
 
 For example, this command starts Jenkins on Java 11 using the latest weekly release: 
 

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -43,8 +43,8 @@ Between June 2018 and February 2019, the community performed many exploratory te
 
 As a result, the community solved a lot of problems before announcing Java 11 support in Jenkins. However, it's still possible that some plugins haven't been updated to support Java 11.
 
-Compatibility issues are being tracked by the link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues Wiki page].
+Compatibility issues are being tracked in the Jenkins issue tracker as link:https://issues.jenkins.io/issues/?jql=labels%20%3D%20java11-compatibility%20and%20status%20not%20in%20(Closed%2CResolved)[Known Java 11 Compatibility Issues].
 
-If you discover a Java 11 incompatibility, please link:https://wiki.jenkins.io/display/JENKINS/How+to+report+an+issue[report the issues in the Jenkins bug tracker] using the `java11-compatibility` label. This helps us organize these issues so that they automatically appear on the Wiki page and get triaged.
+If you discover a Java 11 incompatibility, please link:/participate/report-issue/[report the issue] in the Jenkins bug tracker using the link:https://issues.jenkins.io/issues/?jql=labels%20%3D%20java11-compatibility%20and%20status%20not%20in%20(Closed%2CResolved)[`java11-compatibility` label].
 
 For security issues, please use the standard link:/security/#reporting-vulnerabilities[vulnerability reporting process].

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -5,8 +5,6 @@ title: Running Jenkins on Java 11
 
 If you are upgrading the Jenkins JVM version from Java 8 to Java 11, please link:/doc/administration/requirements/upgrade-java-guidelines[follow these guidelines].
 
-NOTE: Jenkins cores more recent than ``2.164+``footnote:[Although it's technically been possible to run Jenkins on Java 11 since version `2.155`, doing so is far more complex. Running any Jenkins version prior to `2.164` on Java 11 *is not recommended*] do not require a JVM upgrade.
-
 For simplicity, this document describes how to run the most recent version of Jenkins on Java 11.
 
 NOTE: Production deployments should use only LTS versions of Jenkins.

--- a/content/doc/administration/requirements/jenkins-on-java-11.adoc
+++ b/content/doc/administration/requirements/jenkins-on-java-11.adoc
@@ -24,7 +24,7 @@ For example, this command starts Jenkins on Java 11 using the latest weekly rele
 ----
 docker pull jenkins/jenkins:jdk11
 docker run --rm -ti \
-  -p 8080:8080 -p 50000:50000
+  -p 8080:8080 -p 50000:50000 \
   -v jenkins-home:/var/jenkins_home \
   jenkins/jenkins:jdk11
 ----


### PR DESCRIPTION
## Fix Java 11 instructions page

- Fix #4170 Add backslash to Java 11 docker command
- Use current weekly instead of old weekly
- Correct the Java 11 issue tracker links
- Remove note about outdated Jenkins versions
