### PR TITLE
Fix #4167 Redirect Algolia search id into same page

### DIFF
--- a/content/doc/book/installing/index.adoc
+++ b/content/doc/book/installing/index.adoc
@@ -20,6 +20,8 @@ endif::[]
 <script>
 (function () {
     var anchorMap = {
+        "ji-toolbar" : "/doc/book/installing/", /* Algolia search redirect to stay on same page */
+
         "accessing-the-jenkins-blue-ocean-docker-container": "/doc/book/installing/docker#accessing-the-jenkins-blue-ocean-docker-container",
         "accessing-the-jenkins-console-log-through-docker-logs": "/doc/book/installing/docker#accessing-the-jenkins-console-log-through-docker-logs",
         "accessing-the-jenkins-home-directory": "/doc/book/installing/docker/#accessing-the-jenkins-home-directory",

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins.adoc
@@ -23,6 +23,8 @@ endif::[]
 <script>
 (function () {
     var anchorMap = {
+        "ji-toolbar" : "/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/", /* Algolia search redirect to stay on same page */
+
         "running-jenkins-behind-apache": "/doc/book/system-administration/reverse-proxy-configuration-apache/",
         "running-jenkins-behind-haproxy": "/doc/book/system-administration/reverse-proxy-configuration-haproxy/",
         "running-jenkins-behind-iis": "/doc/book/system-administration/reverse-proxy-configuration-iis/",


### PR DESCRIPTION
# Fix incorrect search result redirect

The Javascript that redirects references from inside one page (like installing#windows) to another page (like installing/windows) will redirect the user to a page "undefined" (ike installing/undefined).  This is an experiment that hopes to redirect the search result to the same page.

Works in my local test environment, but won't be 100% confident until I've seen it work on the jenkins.io site.
