### PR TITLE
Install docker-workflow plugin for tutorial use

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -100,7 +100,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins blueocean:1.24.5
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.5 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -99,7 +99,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins blueocean:1.24.5
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.5 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +


### PR DESCRIPTION
## Fix #4185 - Docker Pipeline plugin no longer installed

The Docker Pipeline plugin dependency was intentionally removed from blue ocean 1.24.5 so that users would be able to install blue ocean without requiring the Docker Pipeline plugin. We need the Docker Pipeline plugin for the tutorial, so we'll include it explicitly.

Still an issue: 4184 - mount point does not exist
