### PR TITLE
Fix images in upgrade guide

### DIFF
--- a/content/_data/upgrades/2-277-1.adoc
+++ b/content/_data/upgrades/2-277-1.adoc
@@ -23,9 +23,9 @@ It will effectively skip the Installation Wizard.
 It will not appear again after the restart,
 because Jenkins will create the required state file in the `JENKINS_HOME` directory.
 
-image:/images/changelog/uphgrade-guide-2.277.1/installationWizard_step1.png[Skipping Upgrade Wizard. Step 1, role=center]
+image:/images/changelog/upgrade-guide-2.277.1/installationWizard_step1.png[Skipping Upgrade Wizard. Step 1, role=center]
 
-image:/images/changelog/uphgrade-guide-2.277.1/installationWizard_step2.png[Skipping Upgrade Wizard. Step 2, role=center]
+image:/images/changelog/upgrade-guide-2.277.1/installationWizard_step2.png[Skipping Upgrade Wizard. Step 2, role=center]
 
 
 ==== Spring Security update


### PR DESCRIPTION
## Fix a typo in the upgrade guide image locations

![screencapture-localhost-4242-doc-upgrade-guide-2-277-2021-03-20-11_58_29-edit](https://user-images.githubusercontent.com/156685/111880926-c38d6500-8973-11eb-81ea-7c0785872dd9.png)
