### PR TITLE
add aiojenkins (async python client) to documentation

### DIFF
--- a/content/doc/book/using/remote-access-api.adoc
+++ b/content/doc/book/using/remote-access-api.adoc
@@ -129,9 +129,10 @@ See `+.../api/+` on your Jenkins server for more up-to-date details.
 [[RemoteaccessAPI-PythonAPIwrappers]]
 == Python API wrappers
 
-https://pypi.python.org/pypi/jenkinsapi[JenkinsAPI] and
+https://pypi.python.org/pypi/jenkinsapi[JenkinsAPI],
 https://pypi.python.org/pypi/python-jenkins/[Python-Jenkins],
-https://pypi.org/project/api4jenkins/[api4jenkins] are
+https://pypi.org/project/api4jenkins/[api4jenkins],
+https://pypi.org/project/aiojenkins/[aiojenkins] are
 object-oriented python wrappers for the Python REST API which aim to
 provide a more conventionally pythonic way of controlling a Jenkins server. 
 It provides a higher-level API containing a number of convenience functions. 


### PR DESCRIPTION
Hi there!

I am maintainer of aiojenkins and wish to add it package to documentation
https://github.com/pbelskiy/aiojenkins

PS: it's would be quite good to rewrite this four packages to a new one which will support both sync and async adapters.