### PR TITLE
[JENKINS-65169] Add section for agent name security fix

### DIFF
--- a/content/_data/upgrades/2-263-2.adoc
+++ b/content/_data/upgrades/2-263-2.adoc
@@ -86,6 +86,8 @@ If that is not possible, administrators may consider disabling this fix.
 
 Administrators can disable this fix by setting the link:/doc/book/managing/system-properties/#jenkins-model-nodes-enforcenamerestrictions[Java system property `jenkins.model.Nodes.enforceNameRestrictions`] to `false`.
 
+Doing so is discouraged, as this will reintroduce a security issue.
+
 ==== Security hardenings
 
 In addition to the security fixes listed above, multiple features of Jenkins received security improvements that are not considered fixes.

--- a/content/_data/upgrades/2-263-2.adoc
+++ b/content/_data/upgrades/2-263-2.adoc
@@ -71,6 +71,21 @@ A total area of 10 million pixels is now allowed by default (e.g. 4000 x 2500), 
 // /* package for test */ static /* non-final for script console */ int MAX_AREA = SystemProperties.getInteger(.class.getName() + ".maxArea", 10_000_000); // 4k*2.5k 
 This limit can be changed by setting the link:/doc/book/managing/system-properties/#hudson-util-graph-maxarea[Java system property `hudson.util.Graph.maxArea`] to the desired integer value.
 
+[#SECURITY-2021]
+===== Security fix for agent names
+
+link:/security/advisory/2021-01-13/#SECURITY-2021[SECURITY-2021]
+
+A security fix in Jenkins 2.275 and LTS 2.263.2 disallows agent names that could cause Jenkins to override unrelated `config.xml` files.
+
+Some plugins (like plugin:mesos[Mesos cloud]) allow unsafe characters (like ':') in agent names.
+Those plugins may fail to provision an agent due to the unsafe character in the agent name as reported in jira:JENKINS-65169[].
+
+It is much better to change the agent name in the plugin configuration to avoid unsafe characters.
+If that is not possible, administrators may consider disabling this fix.
+
+Administrators can disable this fix by setting the link:/doc/book/managing/system-properties/#jenkins-model-nodes-enforcenamerestrictions[Java system property `jenkins.model.Nodes.enforceNameRestrictions`] to `false`.
+
 ==== Security hardenings
 
 In addition to the security fixes listed above, multiple features of Jenkins received security improvements that are not considered fixes.

--- a/content/_data/upgrades/2-263-2.adoc
+++ b/content/_data/upgrades/2-263-2.adoc
@@ -78,10 +78,10 @@ link:/security/advisory/2021-01-13/#SECURITY-2021[SECURITY-2021]
 
 A security fix in Jenkins 2.275 and LTS 2.263.2 disallows agent names that could cause Jenkins to override unrelated `config.xml` files.
 
-Some plugins (like plugin:mesos[Mesos cloud]) allow unsafe characters (like ':') in agent names.
+Cloud plugins (like plugin:mesos[Mesos cloud]) allow unsafe characters (like ':') in agent name templates.
 Those plugins may fail to provision an agent due to the unsafe character in the agent name as reported in jira:JENKINS-65169[].
 
-It is much better to change the agent name in the plugin configuration to avoid unsafe characters.
+It is recommended to change the agent name template in the plugin configuration to avoid unsafe characters.
 If that is not possible, administrators may consider disabling this fix.
 
 Administrators can disable this fix by setting the link:/doc/book/managing/system-properties/#jenkins-model-nodes-enforcenamerestrictions[Java system property `jenkins.model.Nodes.enforceNameRestrictions`] to `false`.


### PR DESCRIPTION
## [JENKINS-65169](https://issues.jenkins.io/browse/JENKINS-65169) Add section for agent name security fix

Mention the specific [security advisory](https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-2021) in the upgrade guide.