### PR TITLE
Clarify example based on user feedback

### DIFF
--- a/content/doc/book/system-administration/authenticating-scripted-clients.adoc
+++ b/content/doc/book/system-administration/authenticating-scripted-clients.adoc
@@ -43,8 +43,8 @@ The `curl` command is available for most operating systems including Linux, macO
 
 [source,sh]
 ----
-curl -X POST -L --user jenkins:apiToken \
-    https://jenkins.yourcompany.com/job/your_job/build
+curl -X POST -L --user your-user-name:apiToken \
+    https://jenkins.example.com/job/your_job/build
 ----
 
 == Shell with wget
@@ -56,7 +56,7 @@ to authenticate to Jenkins:
 ----
 wget --auth-no-challenge \
     --user=user --password=apiToken \
-    http://jenkins.yourcompany.com/job/your_job/build
+    http://jenkins.example.com/job/your_job/build
 ----
 
 == Groovy script using cdancy/jenkins-rest


### PR DESCRIPTION
Reader recommended that we make the username more explicit.

Switched to RFC compliant example hostnames in the same change.

Branch on the jenkins.io repository, please remove the PR branch after merging.