### PR TITLE
Add SheCodeAfrica Contributhon to Jumbotron

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -48,6 +48,13 @@ homepage: true
 -# Carousel Slides
 - slides = []
 
+-# SheCodeAfrica Contributhon
+- slides << {:href => expand_link('blog/2021/03/19/SheCodeAfrica-announcement/'),
+  :title => 'SheCodeAfrica Contributhon',
+  :intro => "The Jenkins project will be a mentoring organization in the April 2021 SheCodeAfrica Contributhon. We'll be mentoring women in Africa as they propose pull requests to improve Pipeline help and Pipeline examples.",
+  :image => {:src => expand_link('images/post-images/2020-03-contributhon/she-code-africa-logo.svg'), :height => "300px"},
+  :call_to_action => {:text => 'More info', :href => expand_link('blog/2021/03/19/SheCodeAfrica-announcement/')}}
+
 -# GSoC 2020
 - slides << {:href => expand_link('projects/gsoc/'),
   :title => 'GSoC 2021: Call for student proposals',


### PR DESCRIPTION
## Add SheCodeAfrica Contributhon to the Jumbotron

Short term addition to the Jumbotron.  Event starts April 1, 2021 and concludes April 30, 2021.

![screencapture-localhost-4242-2021-03-27-17_24_11-edit](https://user-images.githubusercontent.com/156685/112737625-75eb9c00-8f21-11eb-8a34-17369a944223.png)
