### PR TITLE
Fix link

### DIFF
--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -85,6 +85,6 @@ kube-public       Active   50m
 kube-system       Active   50m
 ----
 
-include::doc/book/installing/_kubernetes.adoc[]
+include::_kubernetes.adoc[]
 
-include::doc/book/installing/_setup-wizard.adoc[]
+include::_setup-wizard.adoc[]


### PR DESCRIPTION
Wrong links at the bottom of https://github.com/jenkins-infra/jenkins.io/blob/master/content/doc/book/installing/kubernetes.adoc 