### PR TITLE
Warn users about declarative pipeline loc limit

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -71,6 +71,12 @@ link:../getting-started/#directive-generator[Declarative Directive Generator]
 to help you get started with configuring the directives and sections in your
 Declarative Pipeline.
 
+=== Limitations
+
+There is currently an link:https://issues.jenkins.io/browse/JENKINS-37984[open issue] 
+which limits the maximum size of the code within the `pipeline{}` block. This limitation 
+does not apply to Scripted pipelines.
+
 [[declarative-sections]]
 === Sections
 


### PR DESCRIPTION
this pr updates the declarative pipeline docs to warn users about the pipeline limit documented here: https://issues.jenkins.io/browse/JENKINS-37984