### PR TITLE
add --storage-driver option for linux build

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -39,7 +39,8 @@ docker run \
   --volume jenkins-data:/var/jenkins_home \# <9>
   --publish 3000:3000 \# <10>
   --publish 2376:2376 \# <11>
-  docker:dind# <12>
+  docker:dind \# <12>
+  --storage-driver overlay2 # <13>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name to use for running the
 image. By default, Docker will generate a unique name for the container.
@@ -69,6 +70,9 @@ useful for executing `docker` commands on the host machine to control this
 inner Docker daemon.
 <12> The `docker:dind` image itself. This image can be downloaded before running
 by using the command: `docker image pull docker:dind`.
+<13> The storage driver for the Docker volume. See
+link:https://docs.docker.com/storage/storagedriver/select-storage-driver["Docker storage drivers"] for supported
+options.
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
@@ -80,8 +84,7 @@ docker run --name jenkins-docker --rm --detach \
   --env DOCKER_TLS_CERTDIR=/certs \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
-  --publish 3000:3000 \
-  --publish 2376:2376 docker:dind
+  --publish 2376:2376 docker:dind --storage-driver overlay2
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
 .. Create Dockerfile with the following content:

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -71,7 +71,7 @@ inner Docker daemon.
 <11> The `docker:dind` image itself. This image can be downloaded before running
 by using the command: `docker image pull docker:dind`.
 <12> The storage driver for the Docker volume. See
-https://docs.docker.com/storage/storagedriver/select-storage-driver for supported
+link:https://docs.docker.com/storage/storagedriver/select-storage-driver["Docker storage drivers"] for supported
 options.
 +
 *Note:* If copying and pasting the command snippet above does not work, try

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -40,7 +40,8 @@ docker run \
   --volume jenkins-docker-certs:/certs/client \# <8>
   --volume jenkins-data:/var/jenkins_home \# <9>
   --publish 2376:2376 \# <10>
-  docker:dind# <11>
+  docker:dind \# <11>
+  --storage-driver overlay2# <12>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name to use for running the
 image. By default, Docker will generate a unique name for the container.
@@ -69,6 +70,9 @@ useful for executing `docker` commands on the host machine to control this
 inner Docker daemon.
 <11> The `docker:dind` image itself. This image can be downloaded before running
 by using the command: `docker image pull docker:dind`.
+<12> The storage driver for the Docker volume. See
+https://docs.docker.com/storage/storagedriver/select-storage-driver for supported
+options.
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
@@ -80,7 +84,7 @@ docker run --name jenkins-docker --rm --detach \
   --env DOCKER_TLS_CERTDIR=/certs \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
-  --publish 2376:2376 docker:dind
+  --publish 2376:2376 docker:dind --storage-driver overlay2
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
 .. Create Dockerfile with the following content:


### PR DESCRIPTION
this PR adds the --storage-driver overlay2 in the default command for Linux installation. The description points to the docker documentation for available driver options. 

ping @dduportal