### PR TITLE
Trademark: Update the intro text as suggested by the LF legal team

### DIFF
--- a/content/project/trademark/index.adoc
+++ b/content/project/trademark/index.adoc
@@ -6,10 +6,8 @@ section: project
 
 The name "Jenkins" is a registered trademark in the USA to protect the project and users from confusing use of the term: 
 link:https://trademarks.justia.com/854/47/jenkins-85447465.html[#4664929],
-held by _LF CHARITIES, Inc._
-(subsidiary of the link:[Linux Foundation]). 
-The
-link:https://www.linuxfoundation.org/trademark-usage/[Linux Foundation policy on trademark usage] applies to the usages of the Jenkins trademark.
+held by LF CHARITIES, Inc. (a 501(c)(3) nonprofit charity associated with the Linux Foundation).
+The Jenkins Community has adopted the link:https://www.linuxfoundation.org/trademark-usage/[Linux Foundation policy on trademark usage] for use of the Jenkins trademark.
 
 == When to apply for a trademark usage approval?
 


### PR DESCRIPTION
We are working on the EasyCLA adoption with the Linux Foundation Team, and they suggested changes in the first paragraph wording for the trademark. No changelog update needed for the page, it is a minor update