### PR TITLE
Tidy up instance info reporting

### DIFF
--- a/content/doc/book/system-administration/diagnosing-errors.adoc
+++ b/content/doc/book/system-administration/diagnosing-errors.adoc
@@ -70,13 +70,14 @@ Under *References*, right-click `this` and select *Show Nearest GC Root*. Right-
 
 For easier bug reporting, you can get the full list of plugins with this Groovy script that you can run in **Jenkins > Manage Jenkins > Script Console**:
 ```
-println("Jenkins: " + Jenkins.instance.getVersion())
-println("OS: " + System.getProperty('os.name') + " - " +System.getProperty('os.version'))
+println("Jenkins: ${Jenkins.instance.getVersion()}")
+println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")
 println "---"
 
 Jenkins.instance.pluginManager.plugins.each{
   plugin -> println ("${plugin.getShortName()}:${plugin.getVersion()}")
 }
+return
 ```
 
 link:/participate/report-issue[Report an issue]


### PR DESCRIPTION
Explicitly tell Groovy not to return the last statement

Also harmonize the style throughout the script (that was mixing string interpolation and concatenation).