### PR TITLE
Change the Governance meeting time to 7PM UTC

### DIFF
--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -15,7 +15,7 @@ If a decision cannot be made at the governance meeting, the project's link:/proj
 
 === How to join the meetings?
 
-The governance meeting commonly happens every two weeks on Wednesdays, 8PM UTC.
+The governance meeting commonly happens every two weeks on Wednesdays, 7PM UTC.
 We hold the meeting as a recorded video call.
 The meetings calendar with links is available link:/event-calendar[here].
 

--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -15,7 +15,7 @@ If a decision cannot be made at the governance meeting, the project's link:/proj
 
 === How to join the meetings?
 
-The governance meeting commonly happens every two weeks on Wednesdays, 7PM UTC.
+The governance meeting commonly happens every two weeks on Wednesdays, see the link:/events[event calendar] for exact times and subscription.
 We hold the meeting as a recorded video call.
 The meetings calendar with links is available link:/event-calendar[here].
 


### PR DESCRIPTION
Changing the governance meeting time as agreed yesterday.
Maybe we should remove explicit time from the documentation ad refer the event calendar.