### PR TITLE
Remove docker requirement for node and ruby by checking local versions

### DIFF
--- a/scripts/node
+++ b/scripts/node
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME=node:alpine
+VERSION=15.11
+
+if command -v node &> /dev/null; then
+    # going to assume some version of ruby is installed for this comparison
+    if [ $(ruby -e "puts Gem::Version.new('$(node -v | cut -c2- )') >= Gem::Version.new('$VERSION')") == "true" ]; then
+        exec node "$@"
+    fi
+fi
+CONTAINER_NAME=node:${VERSION}-alpine
 source ./scripts/docker-env
 
 exec docker run --rm \
@@ -8,4 +16,4 @@ exec docker run --rm \
     -e HOME="${PWD}" \
     -v "${PWD}":"${PWD}"${DELEGATED} \
     -w "${PWD}" \
-    "${CONTAINER_NAME}" $@
+    "${CONTAINER_NAME}" "$@"

--- a/scripts/node
+++ b/scripts/node
@@ -5,7 +5,8 @@ VERSION=15.11
 if command -v node &> /dev/null; then
     # going to assume some version of ruby is installed for this comparison
     if [ $(ruby -e "puts Gem::Version.new('$(node -v | cut -c2- )') >= Gem::Version.new('$VERSION')") == "true" ]; then
-        exec node "$@"
+        if [ "$1" == "pull" ]; then exit 0; fi
+        exec "$@"
     fi
 fi
 CONTAINER_NAME=node:${VERSION}-alpine

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME=ruby:2.6
+VERSION=2.6
+
+export LANG=C.UTF-8
+export GEM_HOME="${PWD}/vendor/gems"
+export BUNDLE_PATH="${PWD}/vendor/gems"
+export BUNDLE_APP_CONFIG="${PWD}/vendor/gems/.bundle"
+export BUNDLE_DISABLE_SHARED_GEMS=true
+
+if command -v ruby &> /dev/null; then
+    if [ $(ruby -e "puts Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('$VERSION')") == "true" ]; then
+        exec ruby "$@"
+    fi
+fi
+
+CONTAINER_NAME=ruby:${VERSION}
 source ./scripts/docker-env
 
 if [ ! -z ${LISTEN+x} ]; then
@@ -12,10 +26,10 @@ exec docker run --rm \
     -u $(id -u):$(id -g) \
     -e LANG=C.UTF-8 \
     -e HOME="${PWD}" \
-    -e  GEM_HOME="${PWD}/vendor/gems" \
-    -e  BUNDLE_PATH="${PWD}/vendor/gems" \
-    -e  BUNDLE_APP_CONFIG="${PWD}/vendor/gems/.bundle" \
-    -e  BUNDLE_DISABLE_SHARED_GEMS=true \
+    -e GEM_HOME="${PWD}/vendor/gems" \
+    -e BUNDLE_PATH \
+    -e BUNDLE_APP_CONFIG \
+    -e BUNDLE_DISABLE_SHARED_GEMS \
     -v "${PWD}":"${PWD}"${DELEGATED} \
     -w "${PWD}" \
-    "${CONTAINER_NAME}" $@
+    "${CONTAINER_NAME}" "$@"

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -10,7 +10,8 @@ export BUNDLE_DISABLE_SHARED_GEMS=true
 
 if command -v ruby &> /dev/null; then
     if [ $(ruby -e "puts Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('$VERSION')") == "true" ]; then
-        exec ruby "$@"
+        if [ "$1" == "pull" ]; then exit 0; fi
+        exec "$@"
     fi
 fi
 


### PR DESCRIPTION
Tested with:

./scripts/node -e 'console.log("foo")'
./scripts/ruby -e 'puts "hi"'

The node:alpine image is latest, which is 15+, 14 is lts so might want to change the version, but I didn't want to make the assumption