### PR TITLE
[JENKINS-65107] old password encoding support removed

### DIFF
--- a/content/_data/upgrades/2-277-1.adoc
+++ b/content/_data/upgrades/2-277-1.adoc
@@ -101,3 +101,10 @@ None of the Jenkins official distributions sets these properties by default.
 
 If your instance any of the listed properties in the startup configuration,
 please use `jenkins.model.Jenkins.`-prefixed properties instead.
+
+=== Old passwords not supported (JENKINS-65107)
+
+This release drops support for passwords that were stored with Jenkins versions prior to 2013.
+Passwords created with Jenkins prior to the September 2012 introduction of bcrypt based password hashing will need to change their password before the upgrade.
+If the upgrade has already been completed, then an administrator can login and change the password of the affected users with "Manage Users" from the "Manage Jenkins" page.
+If no administrator user is available after the upgrade, please refer to link:/doc/book/system-administration/security/#disabling-security[disabling security] for alternatives.


### PR DESCRIPTION
## 2012 password support removed

Note in the 2.277.1 upgrade guide passwords encoded with Jenkins before 1.480.1 are no longer supported.  Users with passwords that have not been changed since that time will need to update their passwords before they upgrade to Jenkins 2.277.1.

See [JENKINS-65107](https://issues.jenkins.io/browse/JENKINS-65107) for more details.

CC: @jglick for review if available