### PR TITLE
Use archiveArtifacts instead of deprecated archive

### DIFF
--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -111,7 +111,7 @@ image:blueocean/pipeline-run-details/tests-fixed.png[Test Results for Fixed Run,
 
 === Artifacts
 
-The "Artifacts" tabs show a list of any artifacts saved using the "Archive Artifacts" (`archive`) step.
+The "Artifacts" tabs show a list of any artifacts saved using the "Archive Artifacts" (`archiveArtifacts`) step.
 Clicking on a item in the list will download it.
 The full output log from the Run can be downloaded from this list.
 


### PR DESCRIPTION
Refer to https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#archive-archive-artifacts

archive: Archive artifacts
Archives build output artifacts for later use. As of Jenkins 2.x, this step is deprecated in favor of the more configurable archiveArtifacts. 