### PR TITLE
Avoid space in item name

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -31,7 +31,7 @@ To get started quickly with Pipeline:
 . Copy one of the <<examples, examples below>> into your repository and name it `Jenkinsfile`
 . Click the *New Item* menu within Jenkins
 image:pipeline/classic-ui-left-column.png[alt="Classic UI left column",width=30%]
-. Provide a name for your new item (e.g. *My Pipeline*) and select *Multibranch Pipeline*
+. Provide a name for your new item (e.g. *My-Pipeline*) and select *Multibranch Pipeline*
 . Click the *Add Source* button, choose the type of repository you want to use and fill in the details.
 . Click the *Save* button and watch your first Pipeline run!
 


### PR DESCRIPTION
https://www.jenkins.io/doc/book/pipeline/getting-started/#through-the-classic-ui

Caution: Jenkins uses this item name to create directories on disk. It is recommended to avoid using spaces in item names, since doing so may uncover bugs in scripts that do not properly handle spaces in directory paths.