### PR TITLE
Writing the roadmap statuses left to right

### DIFF
--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -35,7 +35,7 @@ tags:
       = label.displayName
 
 - statuses = []
-- site.roadmap[:roadmap].statuses.each do | status |
+- site.roadmap[:roadmap].statuses.reverse.each do | status |
   - if status.hide
   - else
     - statuses << status
@@ -53,7 +53,7 @@ tags:
           %span
             = category.name
       %tr.category-initiatives
-        - statuses.each do | status |
+        - statuses.reverse.each do | status |
           %td{:class => "status #{status.id}", "data-header" => status.displayName}
             - category.initiatives.each do | initiative |
               - if initiative.status == status.id


### PR DESCRIPTION
In English text is read left to right. Most project planning tools order lanes/statuses from future work -> completed, not completed -> future work.

So reversing the order of statuses on the roadmap page.