### PR TITLE
Use blue ocean 1.24.6 in Docker install

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.5 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.6 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -91,7 +91,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.277.1-lts-jdk11
+FROM jenkins/jenkins:2.277.2-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.5 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.6 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -91,7 +91,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.277.1-lts-jdk11
+FROM jenkins/jenkins:2.277.2-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -106,7 +106,7 @@ link:https://hub.docker.com/_/maven/[`maven` container],
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine'
+            image '3.8.1-adoptopenjdk-11'
             args '-v $HOME/.m2:/root/.m2'
         }
     }
@@ -121,7 +121,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('maven:3-alpine').inside('-v $HOME/.m2:/root/.m2') {
+    docker.image('3.8.1-adoptopenjdk-11').inside('-v $HOME/.m2:/root/.m2') {
         stage('Build') {
             sh 'mvn -B'
         }
@@ -148,7 +148,7 @@ pipeline {
     stages {
         stage('Back-end') {
             agent {
-                docker { image 'maven:3-alpine' }
+                docker { image '3.8.1-adoptopenjdk-11' }
             }
             steps {
                 sh 'mvn --version'
@@ -169,7 +169,7 @@ node {
     /* Requires the Docker Pipeline plugin to be installed */
 
     stage('Back-end') {
-        docker.image('maven:3-alpine').inside {
+        docker.image('3.8.1-adoptopenjdk-11').inside {
             sh 'mvn --version'
         }
     }

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -174,13 +174,13 @@ accept Docker-based Pipelines, or on a node matching the optionally defined
 which may contain arguments to pass directly to a `docker run` invocation, and
 an `alwaysPull` option, which will force a `docker pull` even if the image
 name is already present.
-For example: `agent { docker 'maven:3-alpine' }` or
+For example: `agent { docker '3.8.1-adoptopenjdk-11' }` or
 +
 [source,groovy]
 ----
 agent {
     docker {
-        image 'maven:3-alpine'
+        image '3.8.1-adoptopenjdk-11'
         label 'my-defined-label'
         args  '-v /tmp:/tmp'
     }
@@ -345,7 +345,7 @@ This option is valid for `docker` and `dockerfile`.
 [source, groovy]
 ----
 pipeline {
-    agent { docker 'maven:3-alpine' } // <1>
+    agent { docker '3.8.1-adoptopenjdk-11' } // <1>
     stages {
         stage('Example Build') {
             steps {
@@ -356,7 +356,7 @@ pipeline {
 }
 ----
 <1> Execute all the steps defined in this Pipeline within a newly created container
-of the given name and tag (`maven:3-alpine`).
+of the given name and tag (`3.8.1-adoptopenjdk-11`).
 =====
 
 .Stage-level Agent Section
@@ -367,7 +367,7 @@ pipeline {
     agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker 'maven:3-alpine' } // <2>
+            agent { docker '3.8.1-adoptopenjdk-11' } // <2>
             steps {
                 echo 'Hello, Maven'
                 sh 'mvn --version'

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -140,7 +140,7 @@ a Docker container (which will build your simple Java application). Also add a
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine' // <1>
+            image '3.8.1-adoptopenjdk-11' // <1>
             args '-v /root/.m2:/root/.m2' // <2>
         }
     }
@@ -155,7 +155,7 @@ pipeline {
 ----
 <1> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/maven/[`maven:3-alpine` Docker image] (if it's not
+https://hub.docker.com/_/maven/[`3.8.1-adoptopenjdk-11` Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Maven containers running locally in Docker.
@@ -251,7 +251,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine'
+            image '3.8.1-adoptopenjdk-11'
             args '-v /root/.m2:/root/.m2'
         }
     }
@@ -341,7 +341,7 @@ and add a `skipStagesAfterUnstable` option so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine'
+            image '3.8.1-adoptopenjdk-11'
             args '-v /root/.m2:/root/.m2'
         }
     }


### PR DESCRIPTION
Blue Ocean 1.24.6 released a week or two ago.  I've been using it since shortly after release.  Good to update the install guide so that users don't immediately see warnings about plugin updates.