### PR TITLE
Fix maven and nodeJS tutorials

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -106,7 +106,7 @@ link:https://hub.docker.com/_/maven/[`maven` container],
 pipeline {
     agent {
         docker {
-            image '3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.1-adoptopenjdk-11'
             args '-v $HOME/.m2:/root/.m2'
         }
     }
@@ -121,7 +121,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('3.8.1-adoptopenjdk-11').inside('-v $HOME/.m2:/root/.m2') {
+    docker.image('maven:3.8.1-adoptopenjdk-11').inside('-v $HOME/.m2:/root/.m2') {
         stage('Build') {
             sh 'mvn -B'
         }
@@ -148,7 +148,7 @@ pipeline {
     stages {
         stage('Back-end') {
             agent {
-                docker { image '3.8.1-adoptopenjdk-11' }
+                docker { image 'maven:3.8.1-adoptopenjdk-11' }
             }
             steps {
                 sh 'mvn --version'
@@ -169,7 +169,7 @@ node {
     /* Requires the Docker Pipeline plugin to be installed */
 
     stage('Back-end') {
-        docker.image('3.8.1-adoptopenjdk-11').inside {
+        docker.image('maven:3.8.1-adoptopenjdk-11').inside {
             sh 'mvn --version'
         }
     }

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -174,13 +174,13 @@ accept Docker-based Pipelines, or on a node matching the optionally defined
 which may contain arguments to pass directly to a `docker run` invocation, and
 an `alwaysPull` option, which will force a `docker pull` even if the image
 name is already present.
-For example: `agent { docker '3.8.1-adoptopenjdk-11' }` or
+For example: `agent { docker 'maven:3.8.1-adoptopenjdk-11' }` or
 +
 [source,groovy]
 ----
 agent {
     docker {
-        image '3.8.1-adoptopenjdk-11'
+        image 'maven:3.8.1-adoptopenjdk-11'
         label 'my-defined-label'
         args  '-v /tmp:/tmp'
     }
@@ -345,7 +345,7 @@ This option is valid for `docker` and `dockerfile`.
 [source, groovy]
 ----
 pipeline {
-    agent { docker '3.8.1-adoptopenjdk-11' } // <1>
+    agent { docker 'maven:3.8.1-adoptopenjdk-11' } // <1>
     stages {
         stage('Example Build') {
             steps {
@@ -367,7 +367,7 @@ pipeline {
     agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker '3.8.1-adoptopenjdk-11' } // <2>
+            agent { docker 'maven:3.8.1-adoptopenjdk-11' } // <2>
             steps {
                 echo 'Hello, Maven'
                 sh 'mvn --version'

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -140,7 +140,7 @@ a Docker container (which will build your simple Java application). Also add a
 pipeline {
     agent {
         docker {
-            image '3.8.1-adoptopenjdk-11' // <1>
+            image 'maven:3.8.1-adoptopenjdk-11' // <1>
             args '-v /root/.m2:/root/.m2' // <2>
         }
     }
@@ -155,7 +155,7 @@ pipeline {
 ----
 <1> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/maven/[`3.8.1-adoptopenjdk-11` Docker image] (if it's not
+https://hub.docker.com/_/maven/[`maven:3.8.1-adoptopenjdk-11` Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Maven containers running locally in Docker.
@@ -251,7 +251,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image '3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.1-adoptopenjdk-11'
             args '-v /root/.m2:/root/.m2'
         }
     }
@@ -341,7 +341,7 @@ and add a `skipStagesAfterUnstable` option so that you end up with:
 pipeline {
     agent {
         docker {
-            image '3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.1-adoptopenjdk-11'
             args '-v /root/.m2:/root/.m2'
         }
     }

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -145,7 +145,7 @@ process.
 pipeline {
     agent {
         docker {
-            image 'node:6-alpine' // <1>
+            image 'node:lts-buster-slim' // <1>
             args '-p 3000:3000' // <2>
         }
     }
@@ -160,7 +160,7 @@ pipeline {
 ----
 <1> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/node/[`node:6-alpine` Docker image] (if it's not
+https://hub.docker.com/_/node/[`node:lts-buster-slim` Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Node containers running locally in Docker.
@@ -253,7 +253,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'node:6-alpine'
+            image 'node:lts-buster-slim'
             args '-p 3000:3000'
         }
     }
@@ -353,7 +353,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'node:6-alpine'
+            image 'node:lts-buster-slim'
             args '-p 3000:3000'
         }
     }


### PR DESCRIPTION
## Fix maven and nodeJS tutorials

- Use Docker image from a supported maven tag (broken by me in #4261)
- Use supported nodeJS docker image instead of nodeJS 6
