### PR TITLE
Using consistent number of the plugin count

### DIFF
--- a/content/doc/developer/index.html.haml
+++ b/content/doc/developer/index.html.haml
@@ -5,7 +5,7 @@ noanchors: true
 ---
 
 %p
-  Jenkins is an extensible automation server with more than 1000 plugins
+  Jenkins is an extensible automation server with more than 1500 plugins
   providing integrations for hundreds of tools and services. The resources below
   will teach you how to
   %em extend


### PR DESCRIPTION
The page https://plugins.jenkins.io/ says there're over 1500 plugins