### PR TITLE
Add the Release team to the list of teams in /project

### DIFF
--- a/content/project/index.adoc
+++ b/content/project/index.adoc
@@ -27,5 +27,6 @@ This page provides some links to pages describing the project structure and its 
 ** link:/security/#team[Security]
 ** link:/projects/infrastructure/[Infrastructure]
 ** link:/project/teams/hosting/[Hosting]
+** link:https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc#team[Release]
 * link:/sigs/[Special Interest Groups]
 * link:/projects/[Sub-projects]


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc#team should be a good link for that for now, no need to create a jenkins.io entry right away IMHO