### PR TITLE
GSoC 2021: Update the main page to reflect the current status, add org admin links, remove jumbotron

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -55,13 +55,6 @@ homepage: true
   :image => {:src => expand_link('images/post-images/2020-03-contributhon/she-code-africa-logo.svg'), :height => "300px"},
   :call_to_action => {:text => 'More info', :href => expand_link('blog/2021/03/19/SheCodeAfrica-announcement/')}}
 
--# GSoC 2020
-- slides << {:href => expand_link('projects/gsoc/'),
-  :title => 'GSoC 2021: Call for student proposals',
-  :intro => "Jenkins project will be a mentoring organization in Google Summer of Code 2021. We are looking for students and mentors, join us! Applications close on April 13.",
-  :image => {:src => expand_link('images/gsoc/jenkins-gsoc-transparent.png'), :height => "300px"},
-  :call_to_action => {:text => 'More info', :href => expand_link('projects/gsoc/')}}
-
 -# Case Studies
 - slides << {:href => 'https://JenkinsIsTheWay.io/',
   :title => 'Jenkins is the Way!',

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -28,20 +28,22 @@ in completing their summer projects.
 
 == GSoC 2021
 
-We intend to participate in Google Summer of Code 2021.
-Currently we are looking for mentors, org admins and project ideas.
+We will participate in Google Summer of Code 2021 under the umbrella of the Continuous Delivery Foundation.
+Currently we are revieweing the student proposals and forming the mentoring teams.
 Please link:/projects/gsoc#contacts[contact us] if you are interested!
-Potential students are also welcome to start exploring the project and the available project ideas.
+The accepted projects will be announced on May 13th.
 
 * link:./2021/project-ideas[GSoC 2021 project ideas]
+* link:https://summerofcode.withgoogle.com/organizations/5542063241691136/[CDF page on the GSoC website]
 * link:/blog/2021/03/17/gsoc2021-announcement[GSoC 2021 announcement]
 * link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
 * link:/projects/gsoc/mentors[Information for mentors]: guidelines and expectations
 
-NOTE: There will be some changes in how GSoC 2021 is organized, including duration of the projects.
+NOTE: There are some changes in how GSoC 2021 is organized, including duration of the projects.
 Jenkins GSoC documentation may be outdated in some places,
 please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.
-Our documentation will be updated over time to reflect the changes in the GSoC program.
+Our documentation will be updated over time to reflect the changes in the GSoC program,
+please report any issues you discover.
 
 == GSoC 2020
 
@@ -82,6 +84,11 @@ link:https://youtu.be/qokQu7QbbZA[video])
 * link:/projects/gsoc/roles-and-responsibilities[Roles and Responsibilities]
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
 
+== Org Admins
+
+* link:https://docs.google.com/document/d/1AeeIBfzst3VeI-hdRNlfPvp8NgcGneqI2uEkQoZ88q4/edit?usp=sharing[Org Admin runbook for the Jenkins project]
+* link:https://developers.google.com/open-source/gsoc/help/oa-tips[Org Admin tips by Google]
+
 == Contacts
 
 * We use the link:/sigs/gsoc[GSoC SIG] for communications about GSoC.
@@ -107,7 +114,8 @@ difficulties with mentors, students, or org admins, please use the admin mailing
 
 === Chats
 
-* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topics
+* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topicsrelated to Jenkins in GSoC
+* `#gsoc` channel in the CDF Slack workspace for organization-wide topics (link:/chat/#continuous-delivery-foundation[how to join])
 * Project-specific chats, see project and project idea pages
 * link:/chat/[Common developer chats] for technical topics
 
@@ -119,7 +127,8 @@ During these timeslots Jenkins GSoC org admins and mentors are available for any
 Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
 
 Before the announcement of accepted projects,
-we will be using a weekly link:/sigs/gsoc[GSoC SIG] meeting as the office hours slot (3PM UTC on Wednesdays).
+we will be using a weekly link:/sigs/gsoc[GSoC SIG] meeting on Wednesdays as the office hours slot.
+This meeting will be used for Q&A with students and mentors.
 You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
 More slots may be added on-demand, e.g. for project-specific discussions.
 

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -114,7 +114,7 @@ difficulties with mentors, students, or org admins, please use the admin mailing
 
 === Chats
 
-* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topicsrelated to Jenkins in GSoC
+* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
 * `#gsoc` channel in the CDF Slack workspace for organization-wide topics (link:/chat/#continuous-delivery-foundation[how to join])
 * Project-specific chats, see project and project idea pages
 * link:/chat/[Common developer chats] for technical topics


### PR DESCRIPTION
Just a quick update of the landing to update the status