### PR TITLE
Fix the Tekton Client plugin links

### DIFF
--- a/content/blog/2021/04/2021-04-21-tekton-plugin.adoc
+++ b/content/blog/2021/04/2021-04-21-tekton-plugin.adoc
@@ -40,7 +40,7 @@ In such a case, you can use Tekton pipeline engine while getting all benefits fr
 
 == Introducing the Tekton Plugin for Jenkins
 
-The plugin:tekton-client[Tekton Client plugin for Jenkins] lets you easily use Jenkins to automate creating and running Tekton pipelines.
+The link:https://github.com/jenkinsci/tekton-client-plugin[Tekton Client plugin for Jenkins] lets you easily use Jenkins to automate creating and running Tekton pipelines.
 It bridges the Kubernetes learning gap and allows invoking Tekton Pipelines and resources through Jenkins.
 This allows users to not have much of the Kubernetes specific knowledge beforehand and work.
 
@@ -50,7 +50,7 @@ For background check out the  blog post link:https://cd.foundation/blog/2020/11/
 
 === Requirements
 
-The link:https://github.com/jenkinsci/tekton-client-plugin[tekton plugin for jenkins] assumes you have access to a kubernetes cluster.
+The link:https://github.com/jenkinsci/tekton-client-plugin[Tekton Client plugin for jenkins] assumes you have access to a kubernetes cluster.
 
 The kubernetes cluster should have link:https://tekton.dev/[Tekton pipelines] installed.
 
@@ -110,7 +110,7 @@ All of the above is implemented in reusable Tekton pipelines.
 
 So how can we reuse automated CI/CD pipelines from link:https://jenkins-x.io/[Jenkins X project] from Jenkins?
 
-Make sure you have the link:https://github.com/jenkinsci/tekton-client-plugin[tekton plugin for jenkins] installed in your Jenkins server.
+Make sure you have the link:https://github.com/jenkinsci/tekton-client-plugin[Tekton Client plugin for Jenkins] installed in your Jenkins server.
 
 ==== Using a working template
 
@@ -181,4 +181,4 @@ Though remember that tekton plugin doesn't take anything away; so you can mix an
 
 We are really excited about the combination of Jenkins, link:https://tekton.dev/[Tekton] and link:https://jenkins-x.io/[Jenkins X] letting developers pick the best tool for the job while becoming more cloud native and increasing the automation help reduce the amount of manual work creating and maintaining pipelines while also helping to improve the quality and practices of our CI/CD.
 
-Please try it out and link:https://github.com/jenkinsci/tekton-client-plugin/issues[let us know how you get on]
+Please try it out and link:https://github.com/jenkinsci/tekton-client-plugin/issues[let us know how you get on]!


### PR DESCRIPTION
The plugin is in alpha, so the `plugin` macro does not work. Sorry for misleading you @jstrachan 