### PR TITLE
Fix the incorrect command-line instruction

### DIFF
--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -118,7 +118,7 @@ jenkins/ssh-agent:alpine
 $ VARS1="HOME=|USER=|MAIL=|LC_ALL=|LS_COLORS=|LANG="
 $ VARS2="HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_="
 $ VARS="${VARS1}|${VARS2}"
-$ docker exec agent1 sh -c "env | egrep -v "^(${VARS})" >> /etc/environment"
+$ docker exec agent1 sh -c "env | egrep -v '^(${VARS})' >> /etc/environment"
 ----
 +
 [NOTE]


### PR DESCRIPTION
In section "Creating your Docker agent", the regex used by egrep should be in single-quotes, or it causes syntax error.