### PR TITLE
Template for download pages

### DIFF
--- a/content/templates/downloads.html.haml
+++ b/content/templates/downloads.html.haml
@@ -1,0 +1,39 @@
+---
+layout: default
+title: "{{ title }}"
+description: "{{ description }}"
+opengraph:
+  image: "{{ opengraphImage }}"
+uneditable: true
+---
+- # This page is required by the download index pages at updates.jenkins.io --
+
+:css
+  .artifact-list {
+    padding: 0;
+  }
+  .artifact-list li {
+    list-style: none;
+    margin-bottom: .5rem;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .artifact-list .version {
+    background-image: url(https://www.jenkins.io/images/jar.png);
+    background-position: left center;
+    background-repeat: no-repeat;
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+  .artifact-list .checksums {
+    font-size: .7rem;
+  }
+  .subtitle {
+    color: #999;
+  }
+
+.container
+  %h1.mt-3 {{ title }}
+  .subtitle.mb-2 {{ subtitle }}
+  %ul {{ content }}


### PR DESCRIPTION
To make the download index pages a bit nicer (see https://github.com/jenkins-infra/update-center2/pull/469 ) we'd need to have a template in this repository. Per @daniel-beck 's suggestion this PR adds a specific template so that the download pages and plugin site templates are independent.