### PR TITLE
Add 2021 contributor awards to the Jumbotron + fix SheCodeAfrica and cdCon

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -48,12 +48,19 @@ homepage: true
 -# Carousel Slides
 - slides = []
 
+-# Jenkins 2021 awards
+- slides << {:href => 'blog/2021/04/23/jenkins-contributor-awards/',
+  :title => 'Jenkins Contributor Awards 2021',
+  :intro => "At cdCon we will announce the 2021 contributor awards: Most Valuable Contributor, Most Valuable Advocate, Security MVP. We will use a public nomination process this year. Please submit your nominations by April 30. Any Jenkins contributor is eligible!",
+  :image => {:src => expand_link('/images/post-images/2021/jenkins-awards-2021.png'), :height => "320px"},
+  :call_to_action => {:text => 'Nominate contributors!', :href => 'blog/2021/04/23/jenkins-contributor-awards/'}}
+
 -# SheCodeAfrica Contributhon
 - slides << {:href => expand_link('blog/2021/04/07/contributhon-participants/'),
   :title => 'SheCodeAfrica Contributhon',
   :intro => "The SheCodeAfrica Contributhon started April 1, 2021. Jenkins Project is mentoring women in Africa as they propose pull requests to improve Pipeline help and Pipeline examples. The participants include Onyinye Ezike, Sharon Jebitok, Esther Ejidike, Cynthia Iradukunda, and Lucy Karimi",
   :image => {:src => expand_link('images/post-images/2020-03-contributhon/she-code-africa-logo.svg'), :height => "300px"},
-  :call_to_action => {:text => 'More info', :href => expand_link('blog/2021/03/19/SheCodeAfrica-announcement/')}}
+  :call_to_action => {:text => 'More info', :href => expand_link('blog/2021/04/07/contributhon-participants/')}}
 
 -# Case Studies
 - slides << {:href => 'https://JenkinsIsTheWay.io/',
@@ -64,8 +71,8 @@ homepage: true
 
 -# cdCon
 - slides << {:href => 'https://events.linuxfoundation.org/cdcon/',
-  :title => 'cdCon',
-  :intro => "Join Jenkins at cdCon on June 22-25, 2021! The event is focused on improving the world's capacity to deliver software with security and speed. Become part of the conversation that drives continuous delivery by meeting peers, sharing ideas and talking to industry leaders on all things software delivery and DevOps.",
+  :title => 'cdCon and Jenkins contributor summit',
+  :intro => "Join Jenkins at cdCon on June 22-25, 2021! It is focused on improving the world's capacity to deliver software with security and speed. Become part of the conversation that drives CD by meeting peers, sharing ideas on software delivery and DevOps. We will also have a full-day contributor summit on Jun 25!",
   :image => {:src => expand_link('images/conferences/cdCon2021.jpg'), :height => "300px"},
   :call_to_action => {:text => 'Register for cdCon', :href => 'https://events.linuxfoundation.org/cdcon/register/'}}
 


### PR DESCRIPTION
Promotes the nominations a bit more + fixes the blog link in SheCodeAfrica. CC @MarkEWaite 

![image](https://user-images.githubusercontent.com/3000480/116042926-4be7df80-a66f-11eb-8f1e-3fb19b9a1df2.png)
