### PR TITLE
Make these documentation pages proper 'sections' of the doc

### DIFF
--- a/content/doc/book/security/build-authorization.adoc
+++ b/content/doc/book/security/build-authorization.adoc
@@ -1,6 +1,6 @@
 ---
 title: Access Control for Builds
-layout: documentation
+layout: section
 ---
 
 Similar to access control for users, builds in Jenkins run with an associated user authorization.

--- a/content/doc/book/security/configuring-content-security-policy.adoc
+++ b/content/doc/book/security/configuring-content-security-policy.adoc
@@ -1,6 +1,6 @@
 ---
 title: Configuring Content Security Policy
-layout: documentation
+layout: section
 ---
 ifdef::backend-html5[]
 :toc: left


### PR DESCRIPTION
Amends #4283: I linked these in the sidebar, but forgot to change the page type accordingly.