### PR TITLE
Document AssetManager

### DIFF
--- a/content/doc/developer/views/exposing-bundled-resources.adoc
+++ b/content/doc/developer/views/exposing-bundled-resources.adoc
@@ -92,3 +92,15 @@ This calls `#selectResourceByLocale` which ends up invoking `LocaleDrivenResourc
 See the section on core webapp resources for further details.
 
 These resources are available to users with _Overall/Read_ permissions.
+
+== Jenkins Core Assets
+
+Jenkins core exposes _assets_ (any static resource files visible to the Jenkins core classloader with the `asset/` package prefix) at the `/assets/` URL.
+This is implemented by the jenkinsdoc:AssetManager[`AssetManager`] class.
+
+These resources are available to any user without authentication, not requiring _Overall/Read_ permission.
+
+This was used from Jenkins 2.0 to 2.288 (inclusive) to serve JavaScript assets (jQuery, Handlebars, etc.).
+The infrastructure remains in place after 2.288.
+
+NOTE: Assets from plugins are served by reusing the plugin webapp resources serving feature `Plugin#doDynamic`.


### PR DESCRIPTION
Turns out there's another way to serve static files that I missed before. 😒 

> <img width="1430" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/116094047-7f466080-a6a7-11eb-9d59-95536fc3b062.png">
