### PR TITLE
Properly reference the default branch

### DIFF
--- a/content/security/fixing.adoc
+++ b/content/security/fixing.adoc
@@ -15,7 +15,7 @@ While it's annoying for administrators to have to downgrade a regular release be
 
 ### Independently released
 
-Security updates in plugins should not pick up whatever changes on master are still unreleased.
+Security updates in plugins should not pick up whatever changes on the default branch are still unreleased.
 This would increase the risk of regressions that force administrators to choose between a functional and a secure configuration.
 Security fixes should be developed against the latest release.
 Security updates should only contain security fixes, and no other changes.

--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -127,7 +127,7 @@ Make sure to follow instructions provided by the Jenkins security team if they d
 === Merge the Fix
 
 First, prepare the release branch:
-If there are unrelated, unreleased changes on the master branch, create a new branch based on the previous release (specifically the `prepare for next development iteration` commit).
+If there are unrelated, unreleased changes on the default branch, create a new branch based on the previous release (specifically the `prepare for next development iteration` commit).
 
 Next, use the Git command line to *squash-merge pull request branches* in the private jenkinsci-cert repository (`git merge --squash <BRANCH>`).
 


### PR DESCRIPTION
Since many more repos now have a non-`master` default branch (usually `main`, GitHub's new default), use a more general term here.