### PR TITLE
Documentation: Handbook: Using Docker with Pipeline: Keep workspace synchronized (reuseNode)

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -82,6 +82,45 @@ v14.15.0
 [Pipeline] }
 ----
 
+=== Keep workspace synchronized
+
+Short: if it is important to keep workspace synchronized with other stages, use `reuseNode true`.
+Otherwise, dockerized stage can be run on any other agent or on the same agent, but in temporary workspace.
+
+By default, for containerized stage, Jenkins does:
+
+* pick any agent,
+* create new empty workspace,
+* clone pipeline code into it,
+* mount this new workspace into container.
+
+If you have multiple Jenkins agents, your containerized stage can be started on any of them.
+
+When `reuseNode` set to `true`: no new workspace will be created, and current workspace from current agent will be mounted into container, and container will be started at the same node, so whole data will be synchronized.
+
+[pipeline]
+----
+// Declarative //
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            agent {
+                docker {
+                    image 'gradle:6.7-jdk11'
+                    // Run the container on the node specified at the top-level of the Pipeline, in the same workspace, rather than on a new node entirely:
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'gradle --version'
+            }
+        }
+    }
+}
+----
+
+
 === Caching data for containers
 
 Many build tools will download external dependencies and cache them locally for

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -118,6 +118,8 @@ pipeline {
         }
     }
 }
+// Script //
+// Option "reuseNode true" currently unsupported in scripted pipeline
 ----
 
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -82,7 +82,7 @@ v14.15.0
 [Pipeline] }
 ----
 
-=== Keep workspace synchronized
+=== Workspace synchronization
 
 Short: if it is important to keep workspace synchronized with other stages, use `reuseNode true`.
 Otherwise, dockerized stage can be run on any other agent or on the same agent, but in temporary workspace.


### PR DESCRIPTION
Update for this documentation: https://www.jenkins.io/doc/book/pipeline/docker/

Background: I spent almost whole day trying to find: how is it better to synchronize workspace inside container with workspace for another stages without container.

I think it is very important to include into the Handbook information about how docker agent workspace synchronized (or not) with workspace out of container.

Please check before merge:

* English grammar
* text style
* AsciiDoc syntax
* code logic: for example, I'm not sure this section will work for `agent: none`.

Maybe this new documentation section is connected with [JENKINS-41118](https://issues.jenkins.io/browse/JENKINS-41118).

Thanks for idea: https://stackoverflow.com/a/64249727/5287257

P.S.: this is my second contribution in Jenkins documentation, here is the first: https://github.com/jenkins-infra/jenkins.io/pull/4069