### PR TITLE
Document the Hosting check command in the IRCBot

### DIFF
--- a/content/projects/infrastructure/ircbot.adoc
+++ b/content/projects/infrastructure/ircbot.adoc
@@ -223,7 +223,7 @@ hosting requests for new Jenkins plugins, libraries and other components.
 
 This command will launch the automatic hosting request checker.
 It will verify the hosting ticket in Jira and check the links supplied in the `HOSTING` tickets.
-Then it will also verify the Maven pom.xml settings and existense of the expected files in the repository.
+Then it will also verify the Maven pom.xml settings and existence of the expected files in the repository.
 Other verification steps (e.g. security audiit) should be done manually by contributors.
 
 [source]

--- a/content/projects/infrastructure/ircbot.adoc
+++ b/content/projects/infrastructure/ircbot.adoc
@@ -216,7 +216,22 @@ jenkins-admin: Delete component COMPONENT1 and move its issues to COMPONENT2
 
 === Hosting Requests
 
-*Approve and initiate a plugin/library request from JIRA*
+The IRC Bot provides hosting management commands which are used by the link:/project/teams/hosting/[Jenkins Hosting Team] to process the 
+hosting requests for new Jenkins plugins, libraries and other components.
+
+*Verify the plugin/library hosting request from Jira*
+
+This command will launch the automatic hosting request checker.
+It will verify the hosting ticket in Jira and check the links supplied in the `HOSTING` tickets.
+Then it will also verify the Maven pom.xml settings and existense of the expected files in the repository.
+Other verification steps (e.g. security audiit) should be done manually by contributors.
+
+[source]
+----
+jenkins-admin: check hosting-XXXX
+----
+
+*Approve and initiate a plugin/library request from Jira*
 
 This command will fork the repository on GitHub, add all listed users as committers and create a JIRA component with the issue submitter as the default assignee. (hosting-XXXX is the JIRA item that was submitted for hosting)
 

--- a/content/projects/infrastructure/ircbot.adoc
+++ b/content/projects/infrastructure/ircbot.adoc
@@ -223,7 +223,7 @@ hosting requests for new Jenkins plugins, libraries and other components.
 
 This command will launch the automatic hosting request checker.
 It will verify the hosting ticket in Jira and check the links supplied in the `HOSTING` tickets.
-Then it will also verify the Maven pom.xml settings and existence of the expected files in the repository.
+Then it will also verify the Maven and Gradle settings and existence of the expected files in the repository.
 Other verification steps (e.g. security audiit) should be done manually by contributors.
 
 [source]


### PR DESCRIPTION
The new feature was added by @slide in https://github.com/jenkins-infra/ircbot/pull/86 , but it has never been documented on the website. Added some basic docs and a backlink to the Hosting team documentation.
