### PR TITLE
Migrate Markup Formatter documentation to its own page

### DIFF
--- a/content/doc/book/security/_chapter.yml
+++ b/content/doc/book/security/_chapter.yml
@@ -10,3 +10,4 @@ sections:
 - configuring-content-security-policy
 - build-authorization
 - environment-variables
+- markup-formatter

--- a/content/doc/book/security/managing-security.adoc
+++ b/content/doc/book/security/managing-security.adoc
@@ -212,17 +212,8 @@ granted to "kohsuke", "developers", "administrators", "authenticated", and
 
 === Markup Formatter
 
-Jenkins allows user-input in a number of different configuration fields and
-text areas which can lead to users inadvertently, or maliciously, inserting
-unsafe HTML and/or JavaScript.
+See link:/doc/book/security/markup-formatter/[Markup Formatter].
 
-By default the *Markup Formatter* configuration is set to *Plain Text* which
-will escape unsafe characters such as `<` and `&` to their respective character
-entities.
-
-Using the *Safe HTML* Markup Formatter allows for users and
-administrators to inject useful and information HTML snippets into Project
-Descriptions and elsewhere.
 
 == Cross Site Request Forgery
 

--- a/content/doc/book/security/markup-formatter.adoc
+++ b/content/doc/book/security/markup-formatter.adoc
@@ -1,0 +1,35 @@
+---
+title: Markup Formatters
+layout: section
+---
+
+Jenkins allows users with the appropriate permissions to enter descriptions of various objects, like views, jobs, builds, etc.
+These descriptions are filtered by _markup formatters_.
+They serve two purposes:
+
+1. Allow users to use rich formatting for these descriptions
+2. Protect other users from https://en.wikipedia.org/wiki/Cross-site_scripting[Cross-Site Scripting] (XSS) attacks
+
+== Configuring the Markup Formatter
+
+The markup formatter can be configured in _Manage Jenkins » Configure Global Security » Markup Formatter_.
+
+The default markup formatter _Plain text_ renders all descriptions as entered:
+Unsafe HTML metacharacters like `<` and `&` are escaped, and line breaks are rendered as `<br/>` HTML tags.
+
+Another commonly installed markup formatter is _Safe HTML_, provided by the plugin:antisamy-markup-formatter[OWASP Markup Formatter Plugin].
+It allows the use of a basic, safe subset of HTML.
+
+== Security Considerations
+
+=== User Profile Descriptions
+
+Every user with an account and Overall/Read permission can edit their own user profile.
+This includes a description that is rendered using the configured markup formatter.
+
+Therefore it can be unsafe to configure a markup formatter allowing arbitrary HTML even when restricting permissions like _Job/Configure_ and _Build/Update_ to fully trusted users:
+Anyone with an account will be able to edit their own description and any other user accessing their profile may become victim of an XSS attack.
+
+This is particularly risky on publicly accessible Jenkins instances when the security realm is implemented using a service like GitHub, GitLab, or Google accounts, resulting in potentially anyone being able to log in to Jenkins and edit their own profile.
+
+// TODO: Discuss HTML fallback features in formatters with other markup languages

--- a/content/doc/book/security/securing-jenkins.adoc
+++ b/content/doc/book/security/securing-jenkins.adoc
@@ -67,7 +67,7 @@ We recommend you read them first and act on them immediately.
 The following topics discuss other security features that are on by default. You'll only need to look at them when they are causing problems.
 
 * link:configuring-content-security-policy/[Configuring Content Security Policy] --- protect users of Jenkins from malicious builds
-* https://wiki.jenkins.io/display/JENKINS/Markup+formatting[Markup formatting] --- protect users of Jenkins from malicious users of Jenkins
+* link:/doc/book/security/markup-formatter/[Markup Formatter] -- allow for rich formatting of descriptions in Jenkins while keeping users safe
 
 
 == Disabling Security


### PR DESCRIPTION
<details>
<summary>Screenshot</summary>

> <img width="853" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/116238121-48348580-a761-11eb-8505-006a9f33cad5.png">

</details>