### PR TITLE
Replace obsolete terminology in changelog

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -265,7 +265,7 @@
         Disable SSH server by default.
       issue: 33595
     - type: bug
-      message: <code>Computer#addAction</code> would throw an <code>UnsupportedOperationException</code> since Jenkins 2.30. Such a call site was released in SSH Slaves Plugin 1.15 for SECURITY-161.
+      message: <code>Computer#addAction</code> would throw an <code>UnsupportedOperationException</code> since Jenkins 2.30. Such a call site was released in SSH Build Agents Plugin 1.15 for SECURITY-161.
       references:
         - issue: 42969
         - url: https://jenkins.io/security/advisory/2017-03-20/
@@ -350,11 +350,11 @@
     <strong>2.60.1 is the first Jenkins LTS release that requires Java 8 to run.</strong>
     If you're using the Maven Project type, please note that it needs to use a JDK capable of running Jenkins, i.e. JDK 8 or up.
     If you configure an older JDK in a Maven Project, Jenkins will attempt to find a newer JDK and use that automatically.
-    If your SSH Slaves fail to start and you have the plugin install the JRE to run them, make sure to update SSH Slaves Plugin to at least version 1.17 (1.20 recommended).
+    If your SSH Build Agents fail to start and you have the plugin install the JRE to run them, make sure to update SSH Build Agents Plugin to at least version 1.17 (1.20 recommended).
   lts_changes:
     - type: major rfe
       message: >
-        <strong>Jenkins (master and agents) now requires Java 8 to run.</strong>
+        <strong>Jenkins (controller and agents) now requires Java 8 to run.</strong>
       references:
         - issue: 27624
         - issue: 42709
@@ -393,7 +393,7 @@
       message: >
         Windows services:
         Enable <a href="https://github.com/kohsuke/winsw/blob/master/doc/extensions/runawayProcessKiller.md">Runaway Process Killer</a>
-        by default in new Agent and Master installations.
+        by default in new agent and controller installations.
       issue: 39231
       pull: 2765
     - type: rfe
@@ -552,7 +552,7 @@
   changes:
     - type: bug
       message: >
-        Contributions to the PATH environment variable could result in malformed values on agents on a platform different from master's.
+        Contributions to the PATH environment variable could result in malformed values on agents on a platform different from controller's.
       issue: 14807
       pull: 2936
     - type: bug
@@ -938,7 +938,7 @@
       pull: 2950
     - type: rfe
       message: >
-        Restart agent communication related threads on both master and agents when encountering an unhandled exception, if possible, to improve stability.
+        Restart agent communication related threads on both controller and agents when encountering an unhandled exception, if possible, to improve stability.
       issue: 38711
       pull: 3017 # and 3061
 
@@ -1469,7 +1469,7 @@
         Fix a race condition in the Setup Wizard that could lead to it being skipped on the first startup when groovy scripts or init scripts are pre-installed.
     - type: bug
       message: >
-        In rare configurations, agents tried to load unloadable classes from the master, resulting in <code>ClassNotFoundException: javax.servlet.ServletContextListener</code> on agents.
+        In rare configurations, agents tried to load unloadable classes from the controller, resulting in <code>ClassNotFoundException: javax.servlet.ServletContextListener</code> on agents.
       pull: 3067
       issue: 46386
     - type: bug
@@ -1880,7 +1880,7 @@
       title: Remoting 3.22 changelog
     pull: 3514 # and 3530
     message: >
-      Upgrade Remoting from 3.21.1 to 3.25 to have agents check availability of the master's TCP Agent Listener port when connecting over TCP.
+      Upgrade Remoting from 3.21.1 to 3.25 to have agents check availability of the controller's TCP Agent Listener port when connecting over TCP.
 
   - type: rfe
     pull: 3513
@@ -3004,7 +3004,7 @@
       authors:
         - lgoenner
       message: |-
-        Prevent 'zombie' executors on master by removing one-off executors in Computer.removeExecutor.
+        Prevent 'zombie' executors on master node by removing one-off executors in Computer.removeExecutor.
     - type: bug
       pull: 4357
       issue: 60167

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -117,9 +117,9 @@
         Upgrade the Windows Agent Installer module from <code>1.6</code> to <code>1.7</code>.
         This change picks major updates in Windows service management logic.
         <strong>This fix caused a critical regression in the
-        <a href="https://plugins.jenkins.io/windows-slaves">Windows Slaves Plugin</a>
+        <a href="https://plugins.jenkins.io/windows-slaves">WMI Windows Agents Plugin</a>
         (<a href="https://issues.jenkins.io/browse/JENKINS-42724">JENKINS-42724</a>).
-        Update to Windows Slaves 1.3.1 in order to get the fix applied.
+        Update to WMI Windows Agents 1.3.1 in order to get the fix applied.
         </strong>
       references:
         - url: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#17
@@ -211,7 +211,7 @@
     - type: major bug
       pull: 2803
       issue: 42724
-      message: Restore Windows Slaves Plugin 1.2 compatibility by restoring <code>windows-service/jenkins.xml</code>, regression in 2.50.
+      message: Restore WMI Windows Agents Plugin 1.2 compatibility by restoring <code>windows-service/jenkins.xml</code>, regression in 2.50.
     - type: rfe
       pull: 2796
       message: >
@@ -251,7 +251,7 @@
   date: 2017-03-26
   changes:
     - type: bug
-      message: <code>Computer#addAction</code> would throw an <code>UnsupportedOperationException</code> since Jenkins 2.30. Such a call site was released in SSH Slaves Plugin 1.15 for SECURITY-161.
+      message: <code>Computer#addAction</code> would throw an <code>UnsupportedOperationException</code> since Jenkins 2.30. Such a call site was released in SSH Build Agents Plugin 1.15 for SECURITY-161.
       references:
         - issue: 42969
         - url: https://jenkins.io/security/advisory/2017-03-20/
@@ -570,7 +570,7 @@
           url: "https://github.com/eclipse/jetty.project/issues/592"
     - type: rfe
       message: >
-        Update the Mailer plugin version installed when updating from very old Jenkins releases to include the fix for SECURITY-372, the SSH Slaves plugin for SECURITY-161, and the Script Security plugin for SECURITY-258.
+        Update the Mailer plugin version installed when updating from very old Jenkins releases to include the fix for SECURITY-372, the SSH Build Agents plugin for SECURITY-161, and the Script Security plugin for SECURITY-258.
       references:
         - url: https://jenkins.io/security/advisory/2017-03-20/
           title: SECURITY-372
@@ -2858,7 +2858,7 @@
       issue: 48480
       message: >
         The deprecated Jenkins CLI Protocol versions 1 and 2, and Java Web Start Agent Protocol versions 1, 2, and 3 have been disabled.
-        If you still use these protocols (e.g. remoting-based CLI, or old <code>slave.jar</code>s on agents), you need to re-enable these protocols after upgrade, or upgrade the clients.
+        If you still use these protocols (e.g. remoting-based CLI, or old <code>agent.jar</code>s on agents), you need to re-enable these protocols after upgrade, or upgrade the clients.
         The same recommendations as in <a href="https://jenkins.io/doc/upgrade-guide/2.121/#remoting-update">The 2.121.x upgrade guide for remoting changes</a> apply here.
     - type: rfe
       references:

--- a/content/_partials/changelog-old.html
+++ b/content/_partials/changelog-old.html
@@ -272,7 +272,7 @@
 <h3 id=v2.33>What's new in 2.33 (2016/11/20)</h3>
 <ul class=image>
   <li class="rfe">
-    Reduce size of Jenkins WAR file by not storing identical copies of <code>remoting.jar</code>/<code>slave.jar</code> there.
+    Reduce size of Jenkins WAR file by not storing identical copies of <code>remoting.jar</code>/<code>agent.jar</code> there.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2633">pull 2633</a>)
   <li class="major bug">
     Prevent early deallocation of process references by Garbage Collector when starting a remote process.
@@ -413,7 +413,7 @@
     <code>JNLPComputerLauncher</code> (e.g. from Slave Setup, vSphere Cloud and other plugins).
     No the connection is accepted from launchers implementing other proxying and filtering <code>Launcher</code> implementations.
     Particular plugins may require setting up the
-    <code>jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification</code> system property in the master JVM to allow connecting agents.
+    <code>jenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification</code> system property in the controller JVM to allow connecting agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-39232">issue 39232</a>, regression in 2.28)
   <li class="bug">
     Prevent resource leak in <code>hudson.XmlFile#readRaw()</code> in the case of encoding issues.
@@ -427,7 +427,7 @@
     Raw changes are listed <a href="https://github.com/stapler/stapler/compare/stapler-parent-1.243...stapler-parent-1.246">here</a>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2593">pull 2593</a>)
   <li class="rfe">
-    Internal: Start defining APIs that are for the master JVM only.
+    Internal: Start defining APIs that are for the controller JVM only.
     (<a href="https://issues.jenkins.io/browse/JENKINS-38370">issue 38370</a>)
   <li class="rfe">
     Internal: Update Guice dependency from <code>4.0-beta</code> to <code>4.0</code>.
@@ -704,7 +704,7 @@
     (<a href="https://issues.jenkins.io/browse/JENKINS-36717">issue 36717</a>,
     <a href="https://github.com/jenkinsci/jenkins/pull/2459">PR #2459</a>)
   <li class="bug">
-    Remoting 2.61: JNLP Slave connection issue with JNLP3-connect
+    Remoting 2.61: JNLP agent connection issue with JNLP3-connect
     when the generated encrypted cookie contains a newline symbols.
     (<a href="https://issues.jenkins.io/browse/JENKINS-37140">issue 37140</a>)
   <li class="bug">
@@ -927,13 +927,13 @@
     Remoting 2.60: Proper handling of the <code>no_proxy</code> environment variable.
     (<a href="https://issues.jenkins.io/browse/JENKINS-32326">issue 32326</a>)
   <li class=bug>
-    Remoting 2.60: Do not invoke PingFailureAnalyzer for agent=>master ping failures.
+    Remoting 2.60: Do not invoke PingFailureAnalyzer for agent=>controller ping failures.
     (<a href="https://issues.jenkins.io/browse/JENKINS-35190">issue 35190</a>)
   <li class=bug>
     Remoting 2.60: <code>hudson.Remoting.Engine#waitForServerToBack</code> now uses credentials for connection.
     (<a href="https://issues.jenkins.io/browse/JENKINS-31256">issue 31256</a>)
   <li class=bug>
-    Remoting 2.60: Fix potential file handle leaks during the build agent (FKA slave) startup.
+    Remoting 2.60: Fix potential file handle leaks during the build agent startup.
     <a href="https://issues.jenkins.io/browse/JENKINS-35190">issue 35190</a>)
   <li class=rfe>
     Internal: Upgrade Groovy to 2.4.7 to finalize the fix in Jenkins 2.7.
@@ -954,7 +954,7 @@
     Explicitly declare compatibility of Windows build agent service with .NET Framework 4.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2386">PR #2386</a>)
   <li class=rfe>
-    API: Introduce new listener extension point for slave creation/update/deletion.
+    API: Introduce new listener extension point for agent creation/update/deletion.
     (<a href="https://issues.jenkins.io/browse/JENKINS-33780">issue 33780</a>)
   <li class=rfe>
     Lossless optimization sizes of PNG images in Jenkins.
@@ -987,7 +987,7 @@
     see <a href="https://issues.apache.org/jira/browse/GROOVY-7826">GROOVY-7826</a> for more info.
     (<a href="https://issues.jenkins.io/browse/JENKINS-34751">issue 34751</a>)
   <li class="bug">
-    Do not invoke <code>PingFailureAnalyzer</code> for agent=>master ping failures.
+    Do not invoke <code>PingFailureAnalyzer</code> for agent=>controller ping failures.
     (<a href="https://issues.jenkins.io/browse/JENKINS-35190">issue 35190</a>)
   <li class="bug">
     Fix keyboard navigation in setup wizard.
@@ -1282,7 +1282,7 @@
     Check if job is buildable before showing 'Build with parameters' page.
     (<a href="https://issues.jenkins.io/browse/JENKINS-34146">issue 34146</a>)
   <li class="bug">
-    Fixed race condition in slave offline cause.
+    Fixed race condition in agent offline cause.
     (<a href="https://issues.jenkins.io/browse/JENKINS-34448">issue 34448</a>)
   <li class="bug">
     Allow enabling disabled dependencies in the plugin manager to fix broken configurations.
@@ -1424,7 +1424,7 @@
 <h3 id=v1.653>What's new in 1.653 (2016/03/13)</h3>
 <ul class=image>
   <li class="major rfe">
-    Support encrypted communication between master and JNLP slaves.
+    Support encrypted communication between controller and JNLP agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-26580">issue 26580</a>)
   <li class="bug">
     Fix argument masking for sensitive build variables on Windows.
@@ -1558,7 +1558,7 @@
     Allow retrying core update when the first attempt failed.
     (<a href="https://issues.jenkins.io/browse/JENKINS-11016">issue 11016</a>)
   <li class="rfe">
-    Allow specifying the default TCP slave agent listener port via system property.
+    Allow specifying the default TCP agent listener port via system property.
     (<a href="https://github.com/jenkinsci/jenkins/commit/653fbdb65024b1b528e21f682172885f7111bba9">commit 653fbdb</a>)
 </ul>
 <h3 id=v1.642>What's new in 1.642 (2015/12/13)</h3>
@@ -1608,7 +1608,7 @@
     “Form too large” errors from Jetty when submitting massive forms.
     (<a href="https://issues.jenkins.io/browse/JENKINS-20327">issue 20327</a>)
   <li class="bug">
-    Multiple workspace browser features broken on Windows masters since 1.634.
+    Multiple workspace browser features broken on Windows controllers since 1.634.
     (<a href="https://issues.jenkins.io/browse/JENKINS-31015">issue 31015</a>)
 </ul>
 <h3 id=v1.638>What's new in 1.638 (2015/11/11)</h3>
@@ -1835,7 +1835,7 @@
 <h3 id=v1.620>What's new in 1.620 (2015/07/12)</h3>
 <ul class=image>
   <li class=bug>
-    Display system info even when slave is temporarily offline.
+    Display system info even when agent is temporarily offline.
     (<a href="https://issues.jenkins.io/browse/JENKINS-29300">issue 29300</a>)
 </ul>
 <h3 id=v1.619>What's new in 1.619 (2015/07/05)</h3>
@@ -1887,7 +1887,7 @@
     Regression in build-history causing ball to not open console
     (<a href="https://issues.jenkins.io/browse/JENKINS-28704">issue 28704</a>)
   <li class=bug>
-    JNLP slaves did not pick up changes to environment variables.
+    JNLP agents did not pick up changes to environment variables.
     (<a href="https://issues.jenkins.io/browse/JENKINS-27739">issue 27739</a>)
   <li class=bug>
     <code>NullPointerException</code> in <code>AbstractProject</code> constructor
@@ -1904,7 +1904,7 @@
 <ul class=image>
   <li class=bug>
     Improper calculation of queue length in <code>UnlabeledLoadStatistics</code>
-    causing overheads in Cloud slave provisioning
+    causing overheads in Cloud agent provisioning
     (<a href="https://issues.jenkins.io/browse/JENKINS-28446">issue 28446</a>)
   <li class=bug>
     Category titles in Available Plugins list appear wrong in reverse sort order
@@ -1934,7 +1934,7 @@
     <code>NullPointerException</code> computing load statistics under some conditions.
     (<a href="https://issues.jenkins.io/browse/JENKINS-28384">issue 28384</a>)
   <li class=bug>
-    Plugins using class loader masking did not work properly over the slave channel.
+    Plugins using class loader masking did not work properly over the agent channel.
     (<a href="https://issues.jenkins.io/browse/JENKINS-27289">issue 27289</a>)
   <li class=bug>
     DefaultJnlpSlaveReceiver now returns true when rejecting a takeover.
@@ -1977,7 +1977,7 @@
     Under rare conditions Executor.getProgress() can throw a Division by zero exception.
     (<a href="https://issues.jenkins.io/browse/JENKINS-28115">issue 28115</a>)
   <li class=bug>
-    The Run from the command line option for launching a JNLP slave should display the
+    The Run from the command line option for launching a JNLP agent should display the
     configured JVM options.
     (<a href="https://issues.jenkins.io/browse/JENKINS-28111">issue 28111</a>)
 </ul>
@@ -1993,10 +1993,10 @@
     Revert changes in 1.610 made to resolve <a href="https://issues.jenkins.io/browse/JENKINS-10629">issue 10629</a>.
     (<a href="https://issues.jenkins.io/browse/JENKINS-28012">issue 28012</a>, <a href="https://issues.jenkins.io/browse/JENKINS-28013">issue 28013</a>)
   <li class=rfe>
-    Advertise JNLP slave agents to the correct host name, even in the presence of a reverse proxy.
+    Advertise JNLP agents to the correct host name, even in the presence of a reverse proxy.
     (<a href="https://issues.jenkins.io/browse/JENKINS-27218">issue 27218</a>)
   <li class=rfe>
-    Advertised TCP slave agent port number is made tweakable.
+    Advertised TCP agent port number is made tweakable.
   <li class=bug>
     Correctly identify Channel listener onClose propagated exceptions
     (<a href="https://issues.jenkins.io/browse/JENKINS-28062">issue 28062</a>
@@ -2030,7 +2030,7 @@
     PeepholePermalink RunListenerImpl oncompleted should be triggered before downstream builds are triggered.
     (<a href="https://issues.jenkins.io/browse/JENKINS-20989">issue 20989</a>)
   <li class=bug>
-    NPE when /script used on offline slave.
+    NPE when /script used on offline agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-26751">issue 26751</a>)
   <li class=rfe>
     Make periodic workspace cleanup configurable through system properties.
@@ -2065,8 +2065,8 @@
   <li class=rfe>
     Refactor the Queue and Nodes to use a consistent locking strategy
     (<a href="https://issues.jenkins.io/browse/JENKINS-27565">issue 27565</a>)
-    <strong>Note</strong> that this change involved moving slave definitions outside the main <code>config.xml</code> file.
-    If you downgrade after this, your slave settings will be lost.
+    <strong>Note</strong> that this change involved moving agent definitions outside the main <code>config.xml</code> file.
+    If you downgrade after this, your agent settings will be lost.
   <li class=bug>
     Makes the Jenkins is loading screen not block on the extensions loading lock
     (<a href="https://issues.jenkins.io/browse/JENKINS-27563">issue 27563</a>)
@@ -2098,10 +2098,10 @@
     Jenkins CLI doesn't handle arguments with equal signs
     (<a href="https://issues.jenkins.io/browse/JENKINS-21160">issue 21160</a>)
   <li class=bug>
-    master/slave communication ping reacts badly if a clock jumps.
+    controller/agent communication ping reacts badly if a clock jumps.
     (<a href="https://issues.jenkins.io/browse/JENKINS-21251">issue 21251</a>)
   <li class=rfe>
-    JNLP slaves can now connect to master through HTTP proxy.
+    JNLP agents can now connect to controller through HTTP proxy.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6167">issue 6167</a>)
   <li class='major bug'>
     Fixes to several security vulnerabilities.
@@ -2371,7 +2371,7 @@
     JNA update for deprecated JNA-POSIX library.
     (<a href="https://issues.jenkins.io/browse/JENKINS-24527">issue 24527</a>)
   <li class='major bug'>
-    Introduced slave-to-master security mechanism to defend a master from slaves.
+    Introduced agent-to-controller security mechanism to defend a controller from agents.
     (<a href="https://jenkins-ci.org/security-144">SECURITY-144</a>)
 </ul>
 <h3 id=v1.586>What's new in 1.586 (2014/10/26)</h3>
@@ -2402,7 +2402,7 @@
     Fixed memory leak occurring on pages producing incremental output with a progress bar.
     (<a href="https://issues.jenkins.io/browse/JENKINS-25081">issue 25081</a>)
   <li class=bug>
-    Updated SSH Slaves plugin to 1.8.
+    Updated SSH Build Agents plugin to 1.8.
   <li class=bug>
     Due to the reaction, default umask in debian package is set back to 022
     (<a href="https://issues.jenkins.io/browse/JENKINS-25065">issue 25065</a>)
@@ -2425,7 +2425,7 @@
     Do not disable projects, which do not support such operation (like Matrix configurations)
     (<a href="https://issues.jenkins.io/browse/JENKINS-24340">issue 24340</a>)
   <li class=rfe>
-    Improved the scalability of SSH slaves plugin caused by global lock in <tt>SecureRandom</tt>
+    Improved the scalability of SSH Build Agents plugin caused by global lock in <tt>SecureRandom</tt>
     (<a href="https://issues.jenkins.io/browse/JENKINS-20108">issue 20108</a>)
   <li class=bug>
     Incorporated a fix for "Poodle" (CVE-2014-3566) vulnerability in the HTTPS connector of "java -jar jenkins.war"
@@ -2461,7 +2461,7 @@
     Channel reader thread can end up consuming 100% CPU.
     (<a href="https://issues.jenkins.io/browse/JENKINS-23471">issue 23471</a>)
   <li class=bug>
-    CancelledKeyException can cause all JNLP slaves to disconnect (and the problem remains until restart).
+    CancelledKeyException can cause all JNLP agents to disconnect (and the problem remains until restart).
     (<a href="https://issues.jenkins.io/browse/JENKINS-24050">issue 24050</a>)
   <li class=bug>
     Consider dynamic label assignments for label load statistics.
@@ -2476,7 +2476,7 @@
     Character encoding problem in form submission when file parameters are present.
     (<a href="https://issues.jenkins.io/browse/JENKINS-11543">issue 11543</a>)
   <li class=rfe>
-    Improved error handling and "in-progress" UI feedback in JNLP slave to service installation.
+    Improved error handling and "in-progress" UI feedback in JNLP agent to service installation.
   <li class=rfe>
     Winstone 2.4: reverse proxy support in the logging, request header size limit control, and different private key password from keystore password.
     (<a href="https://issues.jenkins.io/browse/JENKINS-23665">issue 23665</a>)
@@ -2656,7 +2656,7 @@
     Should not stop a build from finishing just to compute JUnit result difference to a prior build which is still running.
     (<a href="https://issues.jenkins.io/browse/JENKINS-10234">issue 10234</a>)
   <li class="bug">
-    Do not show link to System Information page for offline slaves, make page more robust when offline.
+    Do not show link to System Information page for offline agents, make page more robust when offline.
     (<a href="https://issues.jenkins.io/browse/JENKINS-23041">issue 23041</a>)
   <li class="bug">
     Fix link to SCM polling log from downstream job cause.
@@ -2717,7 +2717,7 @@
 <h3 id=v1.571>What's new in 1.571 (2014/07/07)</h3>
 <ul class=image>
   <li class=bug>
-    <code>IllegalArgumentException</code> from <code>AbstractProject.getEnvironment</code> when trying to get environment variables from an offline slave.
+    <code>IllegalArgumentException</code> from <code>AbstractProject.getEnvironment</code> when trying to get environment variables from an offline agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-23517">issue 23517</a>)
   <li class=bug>
     Overall.READ is sufficient to access /administrativeMonitor/hudsonHomeIsFull/
@@ -2885,7 +2885,7 @@
   <li class="bug">
     Updated component used by the swap space monitor to better support Debian and AIX.
   <li class="bug">
-    SSH slave connections die after the slave outputs 4MB of stderr, usually during findbugs analysis
+    SSH build agent connections die after the agent outputs 4MB of stderr, usually during findbugs analysis
     (<a href="https://issues.jenkins.io/browse/JENKINS-22938">issue 22938</a>)
   <li class="bug">
     Polling no longer triggers builds (regression 1.560)
@@ -3002,7 +3002,7 @@
     Linebreak project names less aggressively.
     (<a href="https://issues.jenkins.io/browse/JENKINS-22670">issue 22670</a>)
   <li class=rfe>
-    Added a new extension point for more pluggable JNLP slave handling
+    Added a new extension point for more pluggable JNLP agent handling
   <li class=bug>
     Don't ask for confirmation when it doesn't make any sense.
     (<a href="https://issues.jenkins.io/browse/JENKINS-21720">issue 21720</a>)
@@ -3046,7 +3046,7 @@
     Deadlocks in concurrent builds under some conditions since 1.556.
     (<a href="https://issues.jenkins.io/browse/JENKINS-22560">issue 22560</a>)
   <li class=rfe>
-    JNLP slaves are now handled through NIO-based remoting channels for better scalability.
+    JNLP agents are now handled through NIO-based remoting channels for better scalability.
   <li class=rfe>
     Integrated codemirror v2.38.
     (<a href="https://issues.jenkins.io/browse/JENKINS-22582">issue 22582</a>)
@@ -3077,7 +3077,7 @@
 <h3 id=v1.559>What's new in 1.559 (2014/04/13)</h3>
 <ul class=image>
   <li class=rfe>
-    Slaves connected via Java Web Start now restart themselves when a connection to Jenkins is lost.
+    Agents connected via Java Web Start now restart themselves when a connection to Jenkins is lost.
     (<a href="https://issues.jenkins.io/browse/JENKINS-19055">issue 19055</a>)
   <li class=bug>
     Fixed NPE from <code>Slave.createLauncher</code>.
@@ -3112,7 +3112,7 @@
     Added <code>RobustMapConverter</code>.
     (<a href="https://issues.jenkins.io/browse/JENKINS-22398">issue 22398</a>)
   <li class='major bug'>
-    JNLP slaves now satisfies stricter requirements imposed by JDK7u45.
+    JNLP agents now satisfies stricter requirements imposed by JDK7u45.
     (<a href="https://issues.jenkins.io/browse/JENKINS-20204">issue 20204</a>)
   <li class=bug>
     Fixed NPE executing <tt>Pipe.EOF</tt> with <tt>ProxyWriter</tt>
@@ -3187,10 +3187,10 @@
     After restarting Jenkins, users known only from changelogs could be shown as <code>First Last _first.last@some.org_</code>, breaking mail delivery.
     (<a href="https://issues.jenkins.io/browse/JENKINS-16332">issue 16332</a>)
   <li class=bug>
-    CLI <code>build -s -v</code> command caused 100% CPU usage on the master.
+    CLI <code>build -s -v</code> command caused 100% CPU usage on the controller.
     (<a href="https://issues.jenkins.io/browse/JENKINS-20965">issue 20965</a>)
   <li class=rfe>
-    Slave started from Java Web Start can now install itself as a systemd service.
+    Agent started from Java Web Start can now install itself as a systemd service.
   <li class=rfe>
     Split the “raw HTML” markup formatter out of core into a bundled plugin.
   <li class=bug>
@@ -3223,7 +3223,7 @@
     Valentine's day security release that contains more than a dozen security fixes.
     (<a href="/security/advisory/2014-02-14">security advisory</a>)
   <li class='major bug'>
-    Regression in Windows slaves since 1.547.
+    Regression in Windows agents since 1.547.
     (<a href="https://issues.jenkins.io/browse/JENKINS-21373">issue 21373</a>)
   <li class=bug>
     Using <code>java -jar jenkins-core.jar folder/external-monitor-job cmd …</code> did not work.
@@ -3235,7 +3235,7 @@
     f:combobox is narrow.
     (<a href="https://issues.jenkins.io/browse/JENKINS-21612">issue 21612</a>)
   <li class=bug>
-    The workspace cleanup thread failed to handle the modern workspace location on master, and mishandled folders.
+    The workspace cleanup thread failed to handle the modern workspace location on controller file system, and mishandled folders.
     (<a href="https://issues.jenkins.io/browse/JENKINS-21023">issue 21023</a>)
   <li class=bug>
     Fixed missing help items on "Configure Global Security" page
@@ -3317,7 +3317,7 @@
 <h3 id=v1.547>What's new in 1.547 (2014/01/12)</h3>
 <ul class=image>
   <li class=rfe>
-    Split Windows slave functionality into its own plugin.
+    Split Windows agent functionality into its own plugin.
   <li class="major bug">
     NPE since 1.545 when using aggregated test result publisher without specifying downstream jobs explicitly.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18410">issue 18410</a>)
@@ -3361,7 +3361,7 @@
     RingBufferLogHandler throws ArrayIndexOutOfBoundsException after int-overflow.
     (<a href="https://issues.jenkins.io/browse/JENKINS-9120">issue 9120</a>)
   <li class=bug>
-    Hudson shows 0GB free space when space available drops below 1GB.
+    Jenkins shows 0GB free space when space available drops below 1GB.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7776">issue 7776</a>)
   <li class=rfe>
     Added filter field for installed plugins tab.
@@ -3469,7 +3469,7 @@
     Fixed issue where CLI required giving Overall read permission to anonymous.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8815">issue 8815</a>)
   <li class=bug>
-    Jar cache option wasn't taking effect on JNLP slaves.
+    Jar cache option wasn't taking effect on JNLP agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-20093">issue 20093</a>)
   <li class=bug>
     Interrupting remote class loading can lead to <tt>NoClassDefFoundError: Could not initialize class</tt>.
@@ -3508,7 +3508,7 @@
     Improved the /cli help screen.
     (<a href="https://issues.jenkins.io/browse/JENKINS-20023">issue 20023</a>)
   <li class=bug>
-    Polling-triggered jobs get scheduled en-mass on start-up if slaves aren't online yet.
+    Polling-triggered jobs get scheduled en-mass on start-up if agents aren't online yet.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8408">issue 8408</a>)
   <li class=bug>
     Fixed the handling of nested variable expansion.
@@ -3533,7 +3533,7 @@
 <h3 id=v1.537>What's new in 1.537 (2013/10/27)</h3>
 <ul class=image>
   <li class='rfe'>
-    Upgrade bundled plugin versions: ssh-slaves to 1.5, and credentials to 1.9.1
+    Upgrade bundled plugin versions: SSH Build Agents to 1.5, and Credentials to 1.9.1
     (<a href="https://issues.jenkins.io/browse/JENKINS-20071">issue 20071</a>)
   <li class=bug>
     Build button column was broken in 1.535 for parameterized builds.
@@ -3569,14 +3569,14 @@
     (<a href="https://issues.jenkins.io/browse/JENKINS-18629">issue 18629</a>)
   <li class='major bug'>
     Upgrade Trilead SSH client library to version that does not cause connection loss when
-    there is a lot of logging on the build slave and the performance improvements in
-    ssh-slaves 0.27+ are enabled (
+    there is a lot of logging on the build agent and the performance improvements in
+    SSH Build Agents Plugin 0.27+ are enabled (
     <a href="https://issues.jenkins.io/browse/JENKINS-18836">issue 18836</a>,
     <a href="https://issues.jenkins.io/browse/JENKINS-18879">issue 18879</a>,
     <a href="https://issues.jenkins.io/browse/JENKINS-19619">issue 19619</a>)
   <li class='major rfe'>
-    Upgrade bundled iplugin versions: ssh-slaves to 1.4, ssh-credentials to 1.5.3 and
-    credentials to 1.8.3
+    Upgrade bundled iplugin versions: SSH Build Agents to 1.4, SSH Credentials to 1.5.3 and
+    Credentials to 1.8.3
     (<a href="https://issues.jenkins.io/browse/JENKINS-19945">issue 19945</a>)
   <li class='major rfe'>
     Executor threads are now created only on demand.
@@ -3626,7 +3626,7 @@
     As of 1.532 download of artifact ZIPs was broken.
     (<a href="https://issues.jenkins.io/browse/JENKINS-19752">issue 19752</a>)
   <li class='major bug'>
-    Old copies of <code>maven3-agent.jar</code> on slaves were not being reliably updated, leading to errors.
+    Old copies of <code>maven3-agent.jar</code> on agents were not being reliably updated, leading to errors.
     (<a href="https://issues.jenkins.io/browse/JENKINS-19251">issue 19251</a>)
   <li class='rfe'>
     Add option to disable "Remember me on this computer" checkbox in login screen.
@@ -3671,7 +3671,7 @@
     Deleting an external run did not immediately remove it from build list, leading to errors from log rotation.
     (<a href="https://issues.jenkins.io/browse/JENKINS-19377">issue 19377</a>)
   <li class=bug>
-    When copying a directory from master to slave fails due to an error on the slave, properly report it.
+    When copying a directory from controller to agent fails due to an error on the agent, properly report it.
     (<a href="https://issues.jenkins.io/browse/JENKINS-9540">issue 9540</a>)
   <li class=bug>
     Identify user agent for Internet Explorer 11.
@@ -3695,7 +3695,7 @@
 <h3 id=v1.530>What's new in 1.530 (2013/09/09)</h3>
 <ul class=image>
   <li class=bug>
-    Send Maven agent JARs to slaves on demand, not unconditionally upon connection.
+    Send Maven agent JARs to agents on demand, not unconditionally upon connection.
     (<a href="https://issues.jenkins.io/browse/JENKINS-16261">issue 16261</a>)
   <li class=bug>
     Occasional race condition during startup.
@@ -3805,7 +3805,7 @@
     <code>JENKINS_DEBUG_LEVEL</code> misinterpreted by Winstone, causing excessive logging.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18701">issue 18701</a>)
   <li class='major bug'>
-    Since 1.520, Jenkins requires Java 6 or later, breaking Maven builds set to use JDK 5. Now falls back to JVM of slave agent but sets compile/test flags to use defined JDK.
+    Since 1.520, Jenkins requires Java 6 or later, breaking Maven builds set to use JDK 5. Now falls back to JVM of agent but sets compile/test flags to use defined JDK.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18403">issue 18403</a>)
   <li class='major bug'>
     Since 1.517, Maven projects using Maven 2 could not build projects using extensions depending on Apache Commons Codec.
@@ -3845,7 +3845,7 @@
     NPE in MavenFingerprinter.getArtifactRepositoryMaven21.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18441">issue 18441</a>)
   <li class=rfe>
-    More reliability improvement in remote slave reconnection.
+    More reliability improvement in remote agent reconnection.
   <li class="major bug">
     Do not load disabled plugins as dependencies for other plugins.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18654">issue 18654</a>)
@@ -3868,7 +3868,7 @@
     Improved memory efficiency in parsing test reports with large stdio output files.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15382">issue 15382</a>)
   <li class=rfe>
-    Node monitoring now happens concurrently across all the slaves, so it'll be affected less by problematic slaves.
+    Node monitoring now happens concurrently across all the agents, so it'll be affected less by problematic agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18438">issue 18438</a>)
   <li class=bug>
     Deadlock during Maven builds Parsing POM step
@@ -3885,12 +3885,12 @@
     Access denied error results in ERR_CONTENT_DECODING_FAILED on most browsers, masking the root cause.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15437">issue 15437</a>)
   <li class=bug>
-    Fixed the master/slave handshake problem when a slave runs on non-ASCII compatible encoding (such as EBCDIC.)
+    Fixed the controller/agent handshake problem when an agent runs on non-ASCII compatible encoding (such as EBCDIC.)
   <li class=rfe>
     Added a diagnosis for <tt>StreamCorruptedException</tt> problem
     (<a href="https://issues.jenkins.io/browse/JENKINS-8856">issue 8856</a>)
   <li class=rfe>
-    Matrix project's parent can be now tied to labels/slaves.
+    Matrix project's parent can be now tied to labels/agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7825">issue 7825</a>)
   <li class=bug>
     Clean up fingerprint records that correspond to the deleted build recods
@@ -3911,7 +3911,7 @@
 <h3 id=v1.520>What's new in 1.520 (2013/06/25)</h3>
 <ul class=image>
   <li class=bug>
-    Slave launch thread should have the background activity credential.
+    Agent launch thread should have the background activity credential.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15578">issue 15578</a>)
   <li class=bug>
     “Build Now” link did not work for multijobs.
@@ -3926,7 +3926,7 @@
     Fixed API incompatibility since 1.489.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18356">issue 18356</a>)
   <li class=bug>
-    “Projects tied to slave” shows unrelated Maven module jobs.
+    “Projects tied to agent” shows unrelated Maven module jobs.
     (<a href="https://issues.jenkins.io/browse/JENKINS-17451">issue 17451</a>)
   <li class=bug>
     Fixed file descriptor leak in fingerprint computation.
@@ -3975,17 +3975,17 @@
     Fingerprint action deserialization problem fixed.
     (<a href="https://issues.jenkins.io/browse/JENKINS-17125">issue 17125</a>)
   <li class='rfe'>
-    Updating the master computer's configuration from the slave list UI had no immediate effect.
+    Updating the master computer's configuration from the agent list UI had no immediate effect.
     (<a href="https://issues.jenkins.io/browse/JENKINS-17276">issue 17276</a>)
   <li class='rfe'>
     Improved the tracking of queued jobs and their eventual builds in the REST API.
   <li class='rfe'>
-    Configured log recorders can now pick up messages logged from slaves.
+    Configured log recorders can now pick up messages logged from agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18274">issue 18274</a>)
   <li class='rfe'>
     Added a new extension point to contribute custom plexus components into Maven for the maven project type.
   <li class='major rfe'>
-    Remoting classloader performance improvement upon reconnection to the same slave.
+    Remoting classloader performance improvement upon reconnection to the same agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15120">issue 15120</a>)
 </ul>
 <h3 id=v1.518>What's new in 1.518 (2013/06/11)</h3>
@@ -4118,7 +4118,7 @@
 <h3 id=v1.513>What's new in 1.513 (2013/04/28)</h3>
 <ul class=image>
   <li class=rfe>
-    Slave status monitor page shows when the data is last obtained
+    Agent status monitor page shows when the data is last obtained
   <li class=rfe>
     Delete button to highlight what it is going to delete.
   <li class=bug>
@@ -4199,7 +4199,7 @@
     executors available.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7291">issue 7291</a>)
   <li class='major bug'>
-    Download tool installations directly from the slave when possible, since this is much faster than going through the master.
+    Download tool installations directly from the agent when possible, since this is much faster than going through the controller.
     (<a href="https://issues.jenkins.io/browse/JENKINS-17330">issue 17330</a>)
   <li class=bug>
     Improved UI for implicitly locked builds.
@@ -4232,7 +4232,7 @@
     Master node mode not correctly displayed in <code>/computer/(master)/configure</code>.
     (<a href="https://issues.jenkins.io/browse/JENKINS-17263">issue 17263</a>)
   <li class='major rfe'>
-    Performance improvement in master/slave communication throughput
+    Performance improvement in controller/agent communication throughput
     (<a href="https://issues.jenkins.io/browse/JENKINS-7813">issue 7813</a>)
   <li class=bug>
     Quoted label expression can result into dead executors (throwing exception)
@@ -4293,7 +4293,7 @@
     External build directories not updated by job rename/delete.
     (<a href="https://issues.jenkins.io/browse/JENKINS-17138">issue 17138</a>)
   <li class=bug>
-    JNA-related error from Windows slave monitoring thrown repeatedly.
+    JNA-related error from Windows agent monitoring thrown repeatedly.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15796">issue 15796</a>)
   <li class=bug>
     New JSON library corrects problems such as form values starting with <code>[</code>.
@@ -4403,7 +4403,7 @@
     Maven 3 builds ignored quiet (-q) and debug (-X) options
     (<a href="https://issues.jenkins.io/browse/JENKINS-16843">issue 16843</a>)
   <li class=rfe>
-    JNLP slave installers can now work transparently with secured Jenkins.
+    JNLP agent installers can now work transparently with secured Jenkins.
     (SECURITY-54 / despite the ticket marker, this is not a security vulnerability)
   <li class=rfe>
     "Discard old build records" behavior is now pluggable, allowing plugins to define custom logic.
@@ -4498,7 +4498,7 @@
     Rekeying operation (from SECURITY-49 fix in 1.498) failed on Windows.
     (<a href="https://issues.jenkins.io/browse/JENKINS-16319">issue 16319</a>)
   <li class=bug>
-    JNLP slave index page failed to explain how to pass <code>-jnlpCredentials</code>.
+    JNLP agent index page failed to explain how to pass <code>-jnlpCredentials</code>.
     (<a href="https://issues.jenkins.io/browse/JENKINS-16273">issue 16273</a>)
   <li class=bug>
     Links should preserve used protocol
@@ -4566,7 +4566,7 @@
     Using file parameters could cause build records to not load.
     (<a href="https://issues.jenkins.io/browse/JENKINS-13536">issue 13536</a>)
   <li class=bug>
-    Possible race condition in RemoteClassLoader renders slave unusable.
+    Possible race condition in RemoteClassLoader renders agent unusable.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6604">issue 6604</a>)
   <li class=bug>
     If the CLI client is aborted during "build -s", abort the build.
@@ -4591,7 +4591,7 @@
 <h3 id=v1.493>What's new in 1.493 (2012/12/09)</h3>
 <ul class=image>
   <li class=bug>
-    Slave's Name should be trimmed of spaces at the beginning and end of the Name on Save.
+    Agent's Name should be trimmed of spaces at the beginning and end of the Name on Save.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15836">issue 15836</a>)
   <li class=rfe>
     Added new switch to ignore post-commit hooks in SCM polling triggers.
@@ -4617,12 +4617,12 @@
     Jenkins kicks off the wrong downstream builds for Maven.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15367">issue 15367</a>)
   <li class=bug>
-    Rotation of slave agent launch logs is broken for Windows masters.
+    Rotation of agent launch logs is broken for Windows controllers.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15408">issue 15408</a>)
   <li class=bug>
     Failure to initialize the SSH daemon shouldn't fail the boot.
   <li class=rfe>
-    Added new GUI-based slave installer for upstart
+    Added new GUI-based agent installer for upstart
   <li class=bug>
     Duplicated / multiple "Jenkins CLI" entries under "Manage Jenkins".
     (<a href="https://issues.jenkins.io/browse/JENKINS-15732">issue 15732</a>)
@@ -4666,7 +4666,7 @@
     When installing plugins with overlapping dependencies, Jenkins downloads the duplicate plugins multiple times.
     (<a href="https://issues.jenkins.io/browse/JENKINS-10569">issue 10569</a>)
   <li class=rfe>
-    Disable Nagle's algorithm for TCP/IP slave connection
+    Disable Nagle's algorithm for TCP/IP agent connection
 </ul>
 <h3 id=v1.489>What's new in 1.489 (2012/11/04)</h3>
 <ul class=image>
@@ -4688,11 +4688,11 @@
 <h3 id=v1.487>What's new in 1.487 (2012/10/23)</h3>
 <ul class=image>
   <li class=rfe>
-    JNLP Slave agent on OS X can install itself as a launchd service.
+    JNLP agent on OS X can install itself as a launchd service.
   <li class=rfe>
     Using the bottom-sticking "OK" button in more places
   <li class=rfe>
-    Slave logs are put into sub-directories to avoid cluttering $JENKINS_HOME
+    Agent logs are put into sub-directories to avoid cluttering $JENKINS_HOME
   <li class=bug>
     <code>/computer/*/doDelete</code> should try harder to remove even “zombie” <code>Computer</code>s.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15369">issue 15369</a>)
@@ -4729,7 +4729,7 @@
 <h3 id=v1.485>What's new in 1.485 (2012/10/07)</h3>
 <ul class=image>
   <li class=bug>
-    NPE deleting a slave.
+    NPE deleting an agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15369">issue 15369</a>)
   <li class=bug>
     Deadlock involving views.
@@ -4771,7 +4771,7 @@
     Invalid warning message when the config-file-provider plugin is not installed
     (<a href="https://issues.jenkins.io/browse/JENKINS-15207">issue 15207</a>)
   <li class=bug>
-    JDK installation failed on some slaves with <code>InvalidClassException: hudson.tools.JDKInstaller$Platform$1; local class incompatible: …</code>
+    JDK installation failed on some agents with <code>InvalidClassException: hudson.tools.JDKInstaller$Platform$1; local class incompatible: …</code>
     (<a href="https://issues.jenkins.io/browse/JENKINS-14667">issue 14667</a>)
   <li class=rfe>
     Provide symlink support on all possible platforms when using Java 7+, including newer versions of Windows.
@@ -4792,7 +4792,7 @@
     Fixed the lock contention problem on <tt>Queue.getItems()</tt>
     (<a href="https://issues.jenkins.io/browse/JENKINS-16468">issue 16468</a>)
   <li class=rfe>
-    Put slave back online automatically, if there's enough disk space again
+    Put agent back online automatically, if there's enough disk space again
     (<a href="https://github.com/jenkinsci/jenkins/pull/514">pull 514</a>)
   <li class=rfe>
     Track and verify plugins used in configuration XML
@@ -4804,7 +4804,7 @@
     Job created by posting <code>config.xml</code> to <code>/createItem</code> does not set GitHub webhook.
     (<a href="https://issues.jenkins.io/browse/JENKINS-14759">issue 14759</a>)
   <li class=bug>
-    “Took…on master” shown for a build which ran on a slave which was since deleted.
+    “Took…on master” shown for a build which ran on an agent which was since deleted.
     (<a href="https://issues.jenkins.io/browse/JENKINS-15042">issue 15042</a>)
   <li class=rfe>
     Report root causes of UpstreamCause in log and status pages.
@@ -4932,7 +4932,7 @@
     Add a setter for node label string.
     (<a href="https://issues.jenkins.io/browse/JENKINS-14327">issue 14327</a>)
   <li class=rfe>
-    Option to set java executable path for managed windows slaves
+    Option to set java executable path for managed windows agents
   <li class=rfe>
     Added new extension point for transient user actions, and displays user properties if they are also Actions.
 </ul>
@@ -4981,7 +4981,7 @@
 <h3 id=v1.472>What's new in 1.472 (2012/06/24)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed a synchronization problem between master/slave data communication.
+    Fixed a synchronization problem between controller/agent data communication.
     (<a href="https://issues.jenkins.io/browse/JENKINS-11251">issue 11251</a>)
   <li class=rfe>
     Added a mechanism to filter extension points as they are discovered.
@@ -5034,7 +5034,7 @@
     Winstone wasn't handling downloads bigger than 2GB.
     (<a href="https://issues.jenkins.io/browse/JENKINS-12854">issue 12854</a>)
   <li class=bug>
-    With 'on-demand' retention strategy, wrong slave can be started for jobs restricted to specific slave.
+    With 'on-demand' retention strategy, wrong agent can be started for jobs restricted to specific agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-13735">issue 13735</a>)
   <li class=bug>
     Fixed encoding handling in e-mail headers.
@@ -5069,7 +5069,7 @@
     Allow file parameters to be viewed as plain text.
     (<a href="https://issues.jenkins.io/browse/JENKINS-13640">issue 13640</a>)
   <li class=rfe>
-    CLI connection to the master is now encrypted.
+    CLI connection to the controller is now encrypted.
   <li class=rfe>
     Improve the low disk space warning message.
     (<a href="https://issues.jenkins.io/browse/JENKINS-13826">issue 13826</a>)
@@ -5098,7 +5098,7 @@
 <h3 id=v1.465>What's new in 1.465 (2012/05/21)</h3>
 <ul class=image>
   <li class=bug>
-    Artifact archiving from an ssh slave fails if symlinks are present
+    Artifact archiving from an SSH build agent fails if symlinks are present
     (<a href="https://issues.jenkins.io/browse/JENKINS-13202">issue 13202</a>)
 </ul>
 <h3 id=v1.464>What's new in 1.464 (2012/05/14)</h3>
@@ -5307,7 +5307,7 @@
     Integrated prototype.js 1.7
     (<a href="https://groups.google.com/forum/#!topic/jenkinsci-dev/rzHstHyK9Lo/discussion">discussion</a>)
   <li class=rfe>
-    Supported programmatic retrieval/update of slave <tt>config.xml</tt>
+    Supported programmatic retrieval/update of agent <tt>config.xml</tt>
   <li class=rfe>
     Breadcrumb now supports drop-down menu for faster navigation
     (<a href="https://groups.google.com/forum/#!topic/jenkinsci-dev/j9uCKnQB-Xw/discussion">discussion</a>)
@@ -5423,7 +5423,7 @@
     month should not be 0.
     (<a href="https://issues.jenkins.io/browse/JENKINS-12356">issue 12356</a>)
   <li class=bug>
-    "Create a new slave" page didn't auto-complete for copying.
+    "Create a new agent" page didn't auto-complete for copying.
     (<a href="https://issues.jenkins.io/browse/JENKINS-12490">issue 12490</a>)
   <li class=bug>
     Fixed a bug in the auto-overwrite of bundled plugins.
@@ -5484,7 +5484,7 @@
     <tt>.jpi</tt> is now supported as well as <tt>.hpi</tt> as a plugin extension.
     (<a href="https://github.com/jenkinsci/jenkins/pull/331">pull #331</a>)
   <li class="rfe">
-    Windows service slave launcher now supports more generalized user account option.
+    Windows service agent launcher now supports more generalized user account option.
     (<a href="https://github.com/jenkinsci/jenkins/pull/328">pull #328</a>)
   <li class="rfe">
     OSX installer now checks for the existence of JVM and open the browser in the end.
@@ -5514,7 +5514,7 @@
     Link to user profile from console output should go to the user ID, not the user name
     (<a href="https://issues.jenkins.io/browse/JENKINS-12279">issue 12279</a>)
   <li class=bug>
-    Copy artifacts fails on windows slaves due to failing to set a timestamp.
+    Copy artifacts fails on windows agents due to failing to set a timestamp.
     (<a href="https://issues.jenkins.io/browse/JENKINS-11073">issue 11073</a>)
 </ul>
 <h3 id=v1.446>What's new in 1.446 (2012/01/02)</h3>
@@ -5645,7 +5645,7 @@
     Sorting "diff" in test result requires 2 clicks
     (<a href="https://issues.jenkins.io/browse/JENKINS-5460">issue 5460</a>)
   <li class=bug>
-    java.io.IOException: Unexpected termination of the channel - SEVERE: I/O error in channel Chunked connection when using jenkins-cli.jar (works on older Hudson version)
+    java.io.IOException: Unexpected termination of the channel - SEVERE: I/O error in channel Chunked connection when using jenkins-cli.jar
     (<a href="https://issues.jenkins.io/browse/JENKINS-11130">issue 11130</a>)
   <li class=bug>
     Debian init script now returns the proper exit code from the 'status' command.
@@ -5660,7 +5660,7 @@
     Sortable table wasn't "stable" when there are same values in different rows
     (<a href="https://issues.jenkins.io/browse/JENKINS-11551">issue 11551</a>)
   <li class=rfe>
-    Managed windows slaves can be now run as a specific user account
+    Managed windows agents can be now run as a specific user account
     (<a href="https://github.com/jenkinsci/jenkins/pull/289">pull #289</a>)
   <li class=rfe>
     Description field now has the preview button to test it inline.
@@ -5900,7 +5900,7 @@
     Fixed a possible NPE during the boot sequence
     (<a href="https://issues.jenkins.io/browse/JENKINS-10799">issue 10799</a>)
   <li class=rfe>
-    stdin/stdout based remote slaves, such as ones launched via SSH or script, now does a better redirect to avoid interference with JVM output to stdout.
+    stdin/stdout based remote agents, such as ones launched via SSH or script, now does a better redirect to avoid interference with JVM output to stdout.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8856">issue 8856</a>)
   <li class=bug>
     Project names in fingerprint records weren't updated when a project is renamed.
@@ -5950,7 +5950,7 @@
     Fixed NPE in trying to diagnose undefined job error.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7826">issue 7826</a>)
   <li class=bug>
-    Disable auto refresh in slave markOffline screen
+    Disable auto refresh in agent markOffline screen
     (<a href="https://issues.jenkins.io/browse/JENKINS-10608">issue 10608</a>)
   <li class=bug>
     Workspace-cleanup thread shouldn't delete custom workspace directories
@@ -5975,7 +5975,7 @@
     Added an option in CLI build command to check for SCM changes before carrying out a build
     (<a href="https://issues.jenkins.io/browse/JENKINS-9968">issue 9968</a>)
   <li class=rfe>
-    If CLI fails to connect via a JNLP Slave port, fall back to HTTP full-duplex.
+    If CLI fails to connect via a JNLP agent port, fall back to HTTP full-duplex.
     (<a href="https://issues.jenkins.io/browse/JENKINS-10611">issue 10611</a>)
   <li class=rfe>
     Added two CLI commands to manipulate job by its XML definition.
@@ -6048,7 +6048,7 @@
     Updated JDK installer to reflect changes in Oracle download server
     (<a href="https://issues.jenkins.io/browse/JENKINS-10511">issue 10511</a>)
   <li class='major bug'>
-    Fixed memory leak in the master/slave communication.
+    Fixed memory leak in the controller/agent communication.
     (<a href="https://issues.jenkins.io/browse/JENKINS-10424">issue 10424</a>)
   <li class='bug'>
     Fixed a problem in the core that prevents CLI users from authenticating with Crowd plugin (and others like it.)
@@ -6072,7 +6072,7 @@
     Fixed an occasional NPE when running Maven jobs
     (<a href="https://issues.jenkins.io/browse/JENKINS-9822">issue 9822</a>)
   <li class=rfe>
-    Added a new hudson.model.Computer.CREATE permission to limit who can create new slaves.
+    Added a new hudson.model.Computer.CREATE permission to limit who can create new agents.
 </ul>
 <h3 id=v1.421>What's new in 1.421 (2011/07/17)</h3>
 <ul class=image>
@@ -6191,7 +6191,7 @@
     Improve the column sorting behaviours
     (<a href="https://github.com/jenkinsci/jenkins/pull/174">pull request #174</a>)
   <li class=rfe>
-    Managed Windows slave launcher now lets you define a host name separately from the slave name.
+    Managed Windows agent launcher now lets you define a host name separately from the agent name.
     (<a href="https://issues.jenkins.io/browse/JENKINS-10099">issue 10099</a>)
 </ul>
 <h3 id=v1.418>What's new in 1.418 (2011/06/27)</h3>
@@ -6273,7 +6273,7 @@
   <li class=rfe>
     Plugins can now override where jobs are executed.
   <li class=rfe>
-    Rotate the slave log files instead of deleting them.
+    Rotate the agent log files instead of deleting them.
   <li class=rfe>
     Added a mechanism to control the XML parser behaviour
     (<a href="https://github.com/jenkinsci/jenkins/pull/67">pull request #67</a>)
@@ -6466,7 +6466,7 @@
     Zip/tar files created by Jenkins now properly retains Unix file modes.
     (<a href="https://issues.jenkins.io/browse/JENKINS-9397">issue 9397</a>)
   <li class=rfe>
-    Added two new CLI commands "wait-node-online" and "wait-node-offline" to block until a slave becomes online/offline.
+    Added two new CLI commands "wait-node-online" and "wait-node-offline" to block until an agent becomes online/offline.
   <li class=rfe>
     Move Jenkins URL setting from E-mail Notification to its own section in the main configuration.
   <li class=rfe>
@@ -6576,7 +6576,7 @@
   <li class=bug>
     Maven builds didn't work in JBoss 6.
   <li class=rfe>
-    Ping setup for detecting bad master/slave communication is done more consistently now
+    Ping setup for detecting bad controller/agent communication is done more consistently now
     (<a href="https://issues.jenkins.io/browse/JENKINS-8990">issue 8990</a>)
   <li class=rfe>
     Expand environment variables in fingerprint targets
@@ -6618,7 +6618,7 @@
     Upstream culprits did include culprits of an old build.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8567">issue 8567</a>)
   <li class=bug>
-    Shell Task on Windows Slave Uses Incorrect /bin/sh.
+    Shell Task on Windows Agent Uses Incorrect /bin/sh.
     <a href="https://issues.jenkins.io/browse/JENKINS-8449">issue 8449</a>)
   <li class=bug>
     NPE during run - fingerprint cleanup thread.
@@ -6685,7 +6685,7 @@
   <li class=rfe>
     Added autocompletion to "Build after other projects" textbox, with support for "autoCompleteField" on textboxes without a true field.
   <li class=rfe>
-      Include OS type and version of slave in the system information page.
+      Include OS type and version of agent in the system information page.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8996">issue 8996</a>)
 </ul>
 <h3 id=v1.402>What's new in 1.402 (2011/03/20)</h3>
@@ -6711,7 +6711,7 @@
     Added Manage Jenkins link in sidepanel of Plugin Manager and Update Center.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8780">issue 8780</a>)
   <li class=rfe>
-    Thread dump now reports all the threads from all the slaves, not just the master.
+    Thread dump now reports all the threads from all the agents, not just the controller.
   <li class=rfe>
     Made the extension point implementation discovery logic customizable by a plugin
     (<a href="https://issues.jenkins.io/browse/JENKINS-8897">issue 8897</a>)
@@ -6807,7 +6807,7 @@
 <h3 id=v1.397>What's new in 1.397 (2011/02/12)</h3>
 <ul class=image>
   <li class='major bug'>
-    Fixed a master/slave communication problem since 1.378 that often manifests as "Not in GZIP format"
+    Fixed a controller/agent communication problem since 1.378 that often manifests as "Not in GZIP format"
     (<a href="https://issues.jenkins.io/browse/JENKINS-7745">issue 7745</a>)
   <li class=bug>
     When run as "java -jar jenkins.war", "~/.hudson" was still used as default.
@@ -6822,7 +6822,7 @@
     Fixed a log rotation configuration problem on Red Hat
     (<a href="https://issues.jenkins.io/browse/JENKINS-5784">issue 5784</a>)
   <li class=bug>
-    Windows XP slave stopped working in 1.396 (related to name change)
+    Windows XP agent stopped working in 1.396 (related to name change)
     (<a href="https://issues.jenkins.io/browse/JENKINS-8676">issue 8676</a>)
   <li class=bug>
     Unnecessary log messages if a remote pipe is not read until EOF
@@ -6851,12 +6851,12 @@
     Fixed a bug in crontab "day of week" handling in locales where a week starts from Monday.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8401">issue 8401</a>)
   <li class=bug>
-    If a master fails to ping a slave, it should be hard-disconnected.
+    If a controller fails to ping an agent, it should be hard-disconnected.
   <li class=bug>
     "java -jar hudson.war --daemon" was forcing umask 027. This includes Debian/redhat packages.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5114">issue 5114</a>)
   <li class=rfe>
-    If the JNLP-connected slave drops out without the master not noticing, allow the reconnection
+    If the JNLP-connected agent drops out without the controller not noticing, allow the reconnection
     without rejecting it.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5055">issue 5055</a>)
   <li class='major rfe'>
@@ -6871,12 +6871,12 @@
     M2 and M3 builds behave differently when tests fail.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8415">issue 8415</a>)
   <li class=bug>
-    Hudson was failing to record the connection termination problem in slave logs.
+    Hudson was failing to record the connection termination problem in agent logs.
   <li class=bug>
     Node names can be edited to include slashes and then cannot be removed.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8438">issue 8437</a>)
   <li class=bug>
-    Fix temporarily offline slaves not showing active jobs
+    Fix temporarily offline agents not showing active jobs
     (<a href="https://issues.jenkins.io/browse/JENKINS-8546">issue 8546</a>)
   <li class=rfe>
     Startup performance improvement
@@ -6891,7 +6891,7 @@
     MavenReporter#postExecute parameter Throwable error is always empty in case of mojo failure
     (<a href="https://issues.jenkins.io/browse/JENKINS-8493">issue 8493</a>)
   <li class=rfe>
-    Improved the error diagnosis if a build fails because of the slave connectivity problem.
+    Improved the error diagnosis if a build fails because of the agent connectivity problem.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5073">issue 5073</a>)
 </ul>
 <h3 id=v1.394>What's new in 1.394 (2011/01/15)</h3>
@@ -6993,7 +6993,7 @@
     Fixed an <tt>AbstractMethodError</tt> in listing up executors.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8106">issue 8106</a>)
   <li class=bug>
-    Slaves launched by JNLP fail to reprot their version numbers.
+    Agents launched by JNLP fail to reprot their version numbers.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8060">issue 8060</a>)
   <li class=bug>
     Restarting Hudson via debian init script didn't wait for the process to really terminate.
@@ -7067,7 +7067,7 @@
     Fix serialization of array containing null elements.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8006">issue 8006</a>)
   <li class=rfe>
-    Update bundled subversion plugin to version 1.20 and ssh-slaves to version 0.14.
+    Update bundled Subversion plugin to version 1.20 and SSH Build Agents to version 0.14.
 </ul>
 <h4 id=v1.385><s>What's new in 1.385 (2010/11/15)</s></h4>
 <ul class=image>
@@ -7175,7 +7175,7 @@
 <h3 id=v1.378>What's new in 1.378 (2010/09/25)</h3>
 <ul class=image>
   <li class='major bug'>
-    Improving the master/slave communication to avoid pipe clogging problem.
+    Improving the controller/agent communication to avoid pipe clogging problem.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5977">issue 5977</a>)
   <li class='major bug'>
     Rolling back to Ant 1.8.0 due to bug in Ant 1.8.1 file copy with large files.
@@ -7320,7 +7320,7 @@
     JUnit report archiving now captures stdout of tests run in Surefire.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4158">issue 4158</a>)
   <li class=rfe>
-    Updated bundled ssh-slaves plugin to version 0.13.
+    Updated bundled SSH Build Agents plugin to version 0.13.
 </ul>
 <h3 id=v1.372>What's new in 1.372 (2010/08/13)</h3>
 <ul class=image>
@@ -7362,7 +7362,7 @@
     NPE on build after incremental Maven builds are aborted.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6429">issue 6429</a>)
   <li class=bug>
-    On-demand slaves would launch even when "only for tied jobs" is set.
+    On-demand agents would launch even when "only for tied jobs" is set.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7054">issue 7054</a>)
   <li class=bug>
     Fix links to ant targets in console output view that were added in 1.367.
@@ -7387,7 +7387,7 @@
     for build via authentication token, just as <tt>/build</tt> does.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7004">issue 7004</a>)
   <li class=bug>
-    Auto install of JDK when master/slave are different platforms would fail.
+    Auto install of JDK when controller/agent are different platforms would fail.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6880">issue 6880</a>)
   <li class=bug>
     Modified to work with Tomcat 7.
@@ -7445,11 +7445,11 @@
   <li class=bug>
     "Hudson is loading" page didn't take the user back to the same page.
   <li class=rfe>
-    Hudson can now remotely install JDK on Windows slaves when connecting via the
-    "Let Hudson control this Windows slave as a Windows service" mode.
+    Hudson can now remotely install JDK on Windows agents when connecting via the
+    "Let Hudson control this Windows agent as a Windows service" mode.
   <li class=rfe>
-    The "Let Hudson control this Windows slave as a Windows service" mode now allows the same Windows slave
-    to be used by multiple Hudson masters.
+    The "Let Hudson control this Windows agent as a Windows service" mode now allows the same Windows agent
+    to be used by multiple Hudson controllers.
 </ul>
 <h3 id=v1.365>What's new in 1.365 (2010/07/05)</h3>
 <ul class=image>
@@ -7546,7 +7546,7 @@
     Add <tt>autocomplete="off"</tt> for LDAP managerDN and managerPassword fields.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3586">issue 3586</a>)
   <li class=bug>
-    Set a TCP timeout when slaves connect to the master.
+    Set a TCP timeout when agents connect to the controller.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6262">issue 6262</a>)
   <li class=bug>
     File parameter builds started with the CLI command no longer throw an NPE.
@@ -7677,7 +7677,7 @@
     Fixed garbled response of XML API if xpath is specified.
     (<a href="https://n4.nabble.com/Hudson-API-XML-td1723766.html#a1723766">ja@hudson.dev.javanet</a>)
   <li class=bug>
-    Fix broken links for stopping jobs in executor list on pages for slave nodes or filtered views.
+    Fix broken links for stopping jobs in executor list on pages for agents or filtered views.
   <li class=bug>
     Fixed <tt>NoSuchMethodError</tt> with Maven and Ivy plugins.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6311">issue 6311</a>)
@@ -7701,10 +7701,10 @@
     Fixed a bug where a job created via XML didn't properly receive upstream/downstream computation.
     (<a href="https://n4.nabble.com/Hudson-API-td1747758.html#a1747758">report</a>)
   <li class=bug>
-    Argument masking wasn't working correctly for commands run on slaves
+    Argument masking wasn't working correctly for commands run on agents
     (<a href="https://n4.nabble.com/Password-masking-when-running-commands-on-a-slave-tp1753033p1753033.html">report</a>)
   <li class=rfe>
-    Added the slave retention strategy based on a schedule.
+    Added the agent retention strategy based on a schedule.
   <li class=rfe>
     Added to configure charset option of Mailer.
 </ul>
@@ -7722,7 +7722,7 @@
     Raw console output contains garbage.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6034">issue 6034</a>)
   <li class=bug>
-    Fixed a file handle leak in the slave connection.
+    Fixed a file handle leak in the agent connection.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6137">issue 6137</a>)
   <li class=bug>
     Quiet period wasn't taking effect properly when doing parameterized builds.
@@ -7766,7 +7766,7 @@
     Fixed a bug where Hudson can put a wrong help file link.
     (<a href="https://n4.nabble.com/Resolution-of-help-files-in-jelly-entries-tp1592533p1592533.html">report</a>)
   <li class=bug>
-    Fixed Maven site goal archiving from slaves.
+    Fixed Maven site goal archiving from agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5943">issue 5943</a>)
   <li class=bug>
     Fixed a regression with NetBeans Hudson plugin progressive console output.
@@ -7827,7 +7827,7 @@
     On RPM/DEB/etc installation, don't offer the self upgrade. It should be done by the native package manager.
     (<a href="https://n4.nabble.com/RPM-for-Hudson-1-345-does-not-Upgrade-Automatically-tp1579580p1579580.html">report</a>)
   <li class=bug>
-    Fixed a possible lock up of slaves.
+    Fixed a possible lock up of agents.
   <li class=rfe>
     Added advanced option to LogRotator to allow for removing artifacts from old builds
     without removing the logs, history, etc.
@@ -7892,7 +7892,7 @@
     Improved the form validation mechanism to support multiple controls.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5610">issue 5610</a>)
   <li class=rfe>
-    Added message to slave log when it has successfully come online.
+    Added message to agent log when it has successfully come online.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5630">issue 5630</a>)
 </ul>
 <h3 id=v1.346>What's new in 1.346 (2010/02/12)</h3>
@@ -7995,7 +7995,7 @@
     Move form to adjust logging levels to its own page and include table of configured levels.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2210">issue 2210</a>)
   <li class=rfe>
-    Allow the administrator to control the host names via a system property "host.name" per slave,
+    Allow the administrator to control the host names via a system property "host.name" per agent,
     in case auto-detection fails.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5373">issue 5373</a>)
   <li class=rfe>
@@ -8015,7 +8015,7 @@
 <h3 id=v1.342>What's new in 1.342 (2010/01/22)</h3>
 <ul class=image>
   <li class=bug>
-    Commands run on slaves (such as SCM operations) were not printed to the log
+    Commands run on agents (such as SCM operations) were not printed to the log
     the way they would be when run on master.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5296">issue 5296</a>)
   <li class=bug>
@@ -8153,7 +8153,7 @@
     Exceptions in one publisher shouldn't block all other publishers from running.
     (<a href="https://issues.jenkins.io/browse/JENKINS-5023">issue 5023</a>)
   <li class=bug>
-    Fixed <tt>OutOfMemoryError</tt> in JNLP slaves that are running for too long.
+    Fixed <tt>OutOfMemoryError</tt> in JNLP agents that are running for too long.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3406">issue 3406</a>)
   <li class=bug>
     Auto installer for Maven couldn't be configured after the fact.
@@ -8186,16 +8186,16 @@
     when a build is deleted.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1986">issue 1986</a>)
   <li class=bug>
-    In-demand strategy could not relaunch slave nodes since 1.302.
+    In-demand strategy could not relaunch agent nodes since 1.302.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3890">issue 3890</a>)
   <li class=bug>
-    Actual cause for slave going offline was always masked by channel-terminated cause.
+    Actual cause for agent going offline was always masked by channel-terminated cause.
   <li class=bug>
-    Improved display of why a slave is offline (don't incorrectly say "failed to launch").
+    Improved display of why an agent is offline (don't incorrectly say "failed to launch").
   <li class=bug>
-    Improved the error diagnostics on the failure to establish connection with JNLP slaves early on.
+    Improved the error diagnostics on the failure to establish connection with JNLP agents early on.
   <li class=bug>
-    Fix so configure-slave permission actually allows configuration of slaves.
+    Fix so configure-agent permission actually allows configuration of agents.
   <li class=bug>
     User pages showed add/edit description link to users without permission to edit,
     and guests were allowed to edit the user profile for anonymous user.
@@ -8265,7 +8265,7 @@
     Fixed a possible exception in submitting forms and obtaining update center metadata with Winstone in 1.333.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4804">issue 4804</a>)
   <li class='major bug'>
-    Remoting layer was unable to kill remote processes. Prevented Mercurial plugin from implementing poll timeout on slaves.
+    Remoting layer was unable to kill remote processes. Prevented Mercurial plugin from implementing poll timeout on agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4611">issue 4611</a>)
   <li class=bug>
     Display of console output as plain text did not work in browsers since 1.323.
@@ -8345,7 +8345,7 @@
   <li class=rfe>
     Added "delete-builds" CLI command for bulk build record deletion.
   <li class=rfe>
-    Supported a relative path in the custom workspace directory, which resolves from FS root of the slave.
+    Supported a relative path in the custom workspace directory, which resolves from FS root of the agent.
   <li class='major bug'>
     Fixed another <tt>NotExportableException</tt> when making a remote API call on a project.
     Broke NetBeans integration and possibly others.
@@ -8452,7 +8452,7 @@
 <h3 id=v1.327>What's new in 1.327 (2009/10/02)</h3>
 <ul class=image>
   <li class=bug>
-    Worked around a possible Windows slave hang on start up.
+    Worked around a possible Windows agent hang on start up.
     (<a href="https://wiki.jenkins.io/display/JENKINS//Windows+slaves+fail+to+start+via+ssh">details</a>)
   <li class=bug>
     Inability to access <tt>hudson.dev.java.net</tt> shouldn't prevent Hudson from working.
@@ -8520,7 +8520,7 @@
     Javadoc location is now subject to the variable expansions.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3942">issue 3942</a>)
   <li class=rfe>
-    JNLP clients now report the reason when the connection is rejected by the master.
+    JNLP clients now report the reason when the connection is rejected by the controller.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3889">issue 3889</a>)
 </ul>
 <h3 id=v1.324>What's new in 1.324 (2009/09/18)</h3>
@@ -8535,7 +8535,7 @@
     Run sequentially option for Matrix project was not visible unless Axes was checked.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4366">issue 4366</a>)
   <li class=bug>
-    Fix launching Windows slave for slave name with space or other characters needed encoding.
+    Fix launching Windows agent for agent name with space or other characters needed encoding.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4392">issue 4392</a>)
   <li class=bug>
     Support authentication when running java -jar hudson-core-*.jar using username/password
@@ -8557,7 +8557,7 @@
   <li class=bug>
     Fixed some field validators to work for values including + character.
   <li class=bug>
-    Fixed the charset encoding handling when different encodings are involved between the master and slaves.
+    Fixed the charset encoding handling when different encodings are involved between the controller and agents.
     (<a href="https://www.nabble.com/Build-log%27s-charset-problem.-td25424831.html">patch</a>)
   <li class=bug>
     Fixed a bug in the workspace archive support.
@@ -8678,7 +8678,7 @@
     Dynamic label computation wasn't re-done properly for the master node.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4235">issue 4235</a>)
   <li class=bug>
-    Form validation for the remote FS root of slaves was not functioning.
+    Form validation for the remote FS root of agents was not functioning.
   <li class=bug>
     Privilege escalation on Solaris without username was not working.
   <li class=bug>
@@ -8743,7 +8743,7 @@
   <li class=rfe>
     Added <tt>create-job</tt> CLI command.
   <li class=rfe>
-    Hudson now tracks why a slave is put offline.
+    Hudson now tracks why an agent is put offline.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2431">issue 2431</a>)
   <li class='rfe'>
     User-settable descriptions for tests.
@@ -8775,7 +8775,7 @@
     Moved Maven help files to maven-plugin.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3527">issue 3527</a>)
   <li class=bug>
-    Hudson shouldn't immediately launch a slave newly created via copy.
+    Hudson shouldn't immediately launch an agent newly created via copy.
     <a href="https://www.nabble.com/copying-slave-td24791624.html">report</a>
   <li class=rfe>
     Added support for optional alternate Maven settings file for use
@@ -8833,7 +8833,7 @@
     Actions can now contribute environment variables.
     (<a href="https://www.nabble.com/Plugin-dev%3A-Builder-and-the-exporting-of-environment-variables.-td24676833.html">report</a>)
   <li class=rfe>
-    Modified the reconnection logic for slaves connecting via JNLP so that it works better with protected Hudson.
+    Modified the reconnection logic for agents connecting via JNLP so that it works better with protected Hudson.
     (<a href="https://www.nabble.com/more-lenient-retry-logic-in-Engine.waitForServerToBack-td24703172.html">report</a>)
 </ul>
 <h3 id=v1.317>What's new in 1.317 (2009/07/24)</h3>
@@ -8854,7 +8854,7 @@
     Fixed <tt>LinkageError</tt> in PAM authentication on Solaris.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3546">issue 3546</a>)
   <li class=bug>
-    Fixed a JDK path separator issue between Windows master and Unix slaves.
+    Fixed a JDK path separator issue between Windows controller and Unix agents.
   <li class=bug>
     Fixed a memory leak in the remoting layer.
     (<a href="https://issues.jenkins.io/browse/JENKINS-4045">issue 4045</a>)
@@ -8867,12 +8867,12 @@
   <li class=rfe>
     Improved the error diagnosis of "Processing failed due to a bug in the code"
   <li class=rfe>
-    Slaves expose more information via the remote API now.
+    Agents expose more information via the remote API now.
   <li class=rfe>
     Exported BUILD_ID to the remote API.
     (<a href="https://www.nabble.com/How-get-BUILD_ID-from-other-project-in-Hudson-td24588627.html">report</a>)
   <li class=rfe>
-    Don't let the slave TCP/IP connection port failure to prevent Hudson start up.
+    Don't let the agent TCP/IP connection port failure to prevent Hudson start up.
     (<a href="https://www.nabble.com/%22java.net.BindException%3A-Address-already-in-use%22-blocks-Hudson-td24549943.html">report</a>)
   <li class=rfe>
     If the user sets up "Hudson's own" security realm, UI now asks the first admin user to be created.
@@ -8899,7 +8899,7 @@
     The <tt>--logfile</tt> option stopped working on Windows.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3272">issue 3272</a>)
   <li class=bug>
-    On-demand retention policy almost immediately turns off slaves.
+    On-demand retention policy almost immediately turns off agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3972">issue 3972</a>)
   <li class=bug>
     Fixed "incomplete LifecycleExecutor" warning with Maven 2.2
@@ -8947,7 +8947,7 @@
     were in the middle.
     (<a href="https://www.nabble.com/Losing-build-state-after-aborts--td24335949.html">report</a>)
   <li class=bug>
-    TCP/IP hostname calculation of slaves may fail due in high latency network.
+    TCP/IP hostname calculation of agents may fail due in high latency network.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3981">issue 3981</a>)
   <li class=bug>
     Expose MAVEN_OPTS as env. var, in addition to set it to Maven JVM.
@@ -8963,13 +8963,13 @@
   <li class=rfe>
     Added ability to exclude by author and revision property with Subversion polling trigger.
   <li class=rfe>
-    CLI slave agents show details of how it failed to connect.
+    CLI agents show details of how it failed to connect.
     (<a href="https://www.nabble.com/Can%27t-start-a-slave-via-JNLP-td24363116.html">report</a>)
 </ul>
 <h3 id=v1.314>What's new in 1.314 (2009/07/02)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed a possible "Cannot create a file when that file already exists" error in managed Windows slave launcher.
+    Fixed a possible "Cannot create a file when that file already exists" error in managed Windows agent launcher.
     <a href="https://www.nabble.com/%22Cannot-create-a-file-when-that-file-already-exists%22---huh--td23949362.html#a23950643">report</a>
   <li class=bug>
     Made Hudson more robust in parsing <tt>CVS/Entries</tt>
@@ -9041,7 +9041,7 @@
   <li class=rfe>
     Subversion support is moved into a plugin to isolate SVNKit that has GPL-like license.
   <li class=rfe>
-    Fixed a performance problem in master/slave file copy.
+    Fixed a performance problem in controller/agent file copy.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3799">issue 3799</a>)
   <li class=rfe>
     Set time out to avoid infinite hang when SMTP servers don't respond in time.
@@ -9114,7 +9114,7 @@
     External job monitoring was ignoring the possible encoding difference between Hudson and the remote machine that executed the job.
     (<a href="https://www.nabble.com/windows%E3%81%AEhudson%E3%81%8B%E3%82%89ssh%E3%82%B9%E3%83%AC%E3%83%BC%E3%83%96%E3%82%92%E4%BD%BF%E3%81%86%E3%81%A8%E3%81%8D%E3%81%AE%E6%96%87%E5%AD%97%E3%82%B3%E3%83%BC%E3%83%89%E5%8F%96%E3%82%8A%E6%89%B1%E3%81%84%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6-td23583532.html">report</a>)
   <li class=bug>
-    Slave launch log was doing extra buffering that can prevent error logs (and so on) from showing up instantly.
+    Agent launch log was doing extra buffering that can prevent error logs (and so on) from showing up instantly.
     (<a href="https://www.nabble.com/Selenium-Grid-Plugin-tp23481283p23486010.html">report</a>)
   <li class=bug>
     Some failures in Windows batch files didn't cause Hudson to fail the build.
@@ -9123,16 +9123,16 @@
 <h3 id=v1.306>What's new in 1.306 (2009/05/16)</h3>
 <ul class=image>
   <li class=bug>
-    Maven 2.1 support was not working on slaves.
+    Maven 2.1 support was not working on agents.
     (<a href="https://www.nabble.com/1.305-fully-break-native-maven-support-td23575755.html">report</a>)
 </ul>
 <h3 id=v1.305>What's new in 1.305 (2009/05/16)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed a bug that caused Hudson to delete slave workspaces too often.
+    Fixed a bug that caused Hudson to delete agent workspaces too often.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3653">issue 3653</a>)
   <li class=bug>
-    If distributed build isn't enabled, slave selection drop-down shouldn't be displayed in the job config.
+    If distributed build isn't enabled, agent selection drop-down shouldn't be displayed in the job config.
   <li class=bug>
     Added support for Svent 2.x SCM browsers.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3357">issue 3357</a>)
@@ -9185,7 +9185,7 @@
     The elusive 'Not in GZIP format' exception is finally fixed thanks to <tt>cristiano_k</tt>'s great detective work
     (<a href="https://issues.jenkins.io/browse/JENKINS-2154">issue 2154</a>)
   <li class='bug'>
-    Hudson kept relaunching the slave under the "on-demand" retention strategy.
+    Hudson kept relaunching the agent under the "on-demand" retention strategy.
     (<a href="https://www.nabble.com/SlaveComputer.connect-Called-Multiple-Times-td23208903.html">report</a>)
   <li class=bug>
     Extra slash (/) included in path to workspace copy of svn external.
@@ -9219,7 +9219,7 @@
     Workspace with symlink causes svn exception when updating externals.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3532">issue 3532</a>)
   <li class=rfe>
-    Hudson now started bundling ssh-slaves plugin out of the box.
+    Hudson now started bundling SSH Build Agents plugin out of the box.
   <li class=rfe>
     Added an extension point to programmatically contribute a Subversion authentication credential.
     (<a href="https://www.nabble.com/Subversion-credentials-extension-point-td23159323.html">report</a>)
@@ -9241,7 +9241,7 @@
     Javadoc browsing broken since 1.297.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3444">issue 3444</a>)
   <li class=bug>
-    Fixed a JNLP slave problem on JDK6u10 (and later)
+    Fixed a JNLP agent problem on JDK6u10 (and later)
   <li class='bug'>
     Added @ExportedBean to DiskSpaceMonitorDescriptor#DiskSpace so that Remote API(/computer/api/) works
   <li class=bug>
@@ -9265,7 +9265,7 @@
     support for run parameters. Allows you to pick one run from a configurable project,
     and exposes the url of that run to the build.
   <li class=rfe>
-    JVM arguments of JNLP slaves can be now controlled.
+    JVM arguments of JNLP agents can be now controlled.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3398">issue 3398</a>)
   <li class=rfe>
     <tt>$HUDSON_HOME/userContent/</tt> is now exposed under <tt>https://server/hudson/userContent/</tt>.
@@ -9331,7 +9331,7 @@
     Fixed an infinite loop (eventually leading to OOME) if Subversion client SSL certificate authentication fails.
     (<a href="https://www.nabble.com/OutOfMemoryError-when-uploading-credentials-td22430818.html">report</a>)
   <li class=bug>
-    NPE from artifact archiver when a slave is down.
+    NPE from artifact archiver when an agent is down.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3330">issue 3330</a>)
   <li class=rfe>
     Hudson now monitors the disk consumption of <tt>HUDSON_HOME</tt> by itself.
@@ -9351,7 +9351,7 @@
     Improved JUnit result display to handle complex suite setups involving non-unique class names.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2988">issue 2988</a>)
   <li class=bug>
-    If the master is on Windows and slave is on Unix or vice versa, PATH environment variable was not
+    If the controller is on Windows and agent is on Unix or vice versa, PATH environment variable was not
     properly handled.
   <li class=rfe>
     Improved the access denied error message to be more human readable.
@@ -9396,8 +9396,8 @@
     Fixed a regression in the fingerprinter &amp; archiver interaction in the matrix project
     (<a href="https://www.nabble.com/1.286-version-and-fingerprints-option-broken-.-td22236618.html">report</a>)
   <li class=rfe>
-    Added usage screen to <tt>slave.jar</tt>. Slaves now also do ping by default to proactively
-    detect failures in the master.
+    Added usage screen to <tt>slave.jar</tt>. Agents now also do ping by default to proactively
+    detect failures in the controller.
     (from IRC)
 </ul>
 <h3 id=v1.289>What's new in 1.289 (2009/03/05)</h3>
@@ -9418,10 +9418,10 @@
     Add back LDAP group query on <tt>uniqueMember</tt> (lost in 1.280) and fix <tt>memberUid</tt> query
     (<a href="https://issues.jenkins.io/browse/JENKINS-2256">issue 2256</a>)
   <li class=bug>
-    Adding a slave node was not possible in French locale
+    Adding an agent node was not possible in French locale
     (<a href="https://issues.jenkins.io/browse/JENKINS-3156">issue 3156</a>)
   <li class=bug>
-    External builds were shown in Build History of all slave nodes
+    External builds were shown in Build History of all agent nodes
   <li class=bug>
     Renewed the certificate for signing <tt>hudson.war</tt>
     (<a href="https://www.nabble.com/1.287%3A-java.lang.IllegalStateException%3A-zip-file-closed-td22272400.html">report</a>)
@@ -9481,7 +9481,7 @@
     Improved the error handling behaviors when non-serializable exceptions are involved in distributed operations.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1041">issue 1041</a>)
   <li class=bug>
-    Allow unassigning a job from a node after the last slave node is deleted.
+    Allow unassigning a job from a node after the last agent node is deleted.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2905">issue 2905</a>)
   <li class=bug>
     Fix "Copy existing job" autocomplete on new job page if any existing job names have a quote character.
@@ -9494,7 +9494,7 @@
   <li class=rfe>
     Added RemoteCause for triggering build remotely.
   <li class=rfe>
-    Hudson is now capable of launching Windows slave headlessly and remotely.
+    Hudson is now capable of launching Windows agent headlessly and remotely.
   <li class='major rfe'>
     Better SVN polling support - Trigger a build for changes in certain regions.
     (<a href="https://issues.jenkins.io/browse/JENKINS-3124">issue 3124</a>)
@@ -9590,7 +9590,7 @@
   <li class=bug>
     Matrix security username/groupname validation required admin permission even in project-specific permissions
   <li class=bug>
-    Fixed a JavaScript bug in slave configuration page when locale is French.
+    Fixed a JavaScript bug in agent configuration page when locale is French.
     (<a href="https://www.nabble.com/Javascript-problem-for-french-version-td21875477.html">report</a>)
   <li class=bug>
     File upload from HTML forms doesn't work with Internet Explorer.
@@ -9686,7 +9686,7 @@
     Top level People page showed no project information since 1.269.
     (<a href="https://www.nabble.com/N-A-in-%22Last-Active%22-column-in--people-page.-tp21553593p21553593.html">report</a>)
   <li class=bug>
-    Slave configuration page always showed "Utilize as much as possible" instead of saved value since 1.271.
+    Agent configuration page always showed "Utilize as much as possible" instead of saved value since 1.271.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2878">issue 2878</a>)
   <li class=bug>
     Require build permission to submit results for an external job.
@@ -9720,7 +9720,7 @@
   <li class=bug>
     Saving main Hudson config failed if more than one plugin used Plugin/config.jelly.
   <li class=rfe>
-    Added a scheduled slave availability.
+    Added a scheduled agent availability.
   <li class=rfe>
     Hudson supports auto-upgrade on Solaris when managed by <a href="https://docs.sun.com/app/docs/doc/819-2252/smf-5?a=view">SMF</a>.
   <li class=rfe>
@@ -9756,7 +9756,7 @@
     Artifact archiver and workspace browser didn't handle filenames with spaces since 1.269.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2793">issue 2793</a>)
   <li class=bug>
-    The executor status and build queue weren't updated asynchronously in the "manage slaves" page.
+    The executor status and build queue weren't updated asynchronously in the "Manage Nodes" page.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2821">issue 2821</a>)
   <li class=rfe>
     If SCM polling activities gets clogged, Hudson shows a warning in the management page.
@@ -9781,7 +9781,7 @@
     If for some reason "All" view is deleted, allow people to create it again.
     (<a href=https://www.nabble.com/all-view-disappeared-tt21380658.html>report</a>)
   <li class=bug>
-    JNLP slave agents is made more robust in the face of configuration errors.
+    JNLP agents is made more robust in the face of configuration errors.
     (<a href="https://d.hatena.ne.jp/w650/20090107/1231323990">report</a>)
   <li class=rfe>
     Upgraded JNA to 3.0.9 to support installation as a service on 64bit Windows.
@@ -9802,9 +9802,9 @@
     SecurityRealms can now better control the servlet filter chain.
     (<a href="https://www.nabble.com/proposed-patch-to-expose-filters-through-SecurityRealms-tt21062397.html">report</a>)
   <li class=rfe>
-    Configuration of slaves are moved to individual pages.
+    Configuration of agents are moved to individual pages.
   <li class=rfe>
-    Hudson now tracks the load statistics on slaves and labels.
+    Hudson now tracks the load statistics on agents and labels.
   <li class=rfe>
     Labels can be now assigned to the master.
     (<a href="https://issues.jenkins.io/browse/JENKINS-754">issue 754</a>)
@@ -9947,7 +9947,7 @@
     Removed some links from the computer page if the current user lacks permissions.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2730">issue 2730</a>)
   <li class=rfe>
-    Show description on slave node status page
+    Show description on agent node status page
     (<a href="https://issues.jenkins.io/browse/JENKINS-1061">issue 1061</a>)
   <li class=rfe>
     Views should show display actions contributed to the top page.
@@ -9979,7 +9979,7 @@
     Fixed a problem in handling of '\' introduced in 1.260.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2584">issue 2584</a>)
   <li class=bug>
-    Fixed possible NPE when rendering a build history after a slave removal.
+    Fixed possible NPE when rendering a build history after an agent removal.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2622">issue 2622</a>)
   <li class=bug>
     JNLP descriptor shouldn't rely on the manually configured root URL for HTTP access.
@@ -10007,7 +10007,7 @@
     Use Project Security setting wasn't being persisted.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2305">issue 2305</a>)
   <li class=bug>
-    Slave installed as a Windows service didn't attempt automatic reconnection when initiail connection fails.
+    Agent installed as a Windows service didn't attempt automatic reconnection when initiail connection fails.
     (<a href="https://www.nabble.com/Loop-Slave-Connection-Attempts-td20471873.html">report</a>)
   <li class=rfe>
     Maven builder has the advanced section in the freestyle job, just like Ant builder.
@@ -10081,7 +10081,7 @@
 <h3 id=v1.257>What's new in 1.257 (2008/10/28)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed an encoding issue when the master and a slave use incompatible encodings.
+    Fixed an encoding issue when the controller and an agent use incompatible encodings.
   <li class=bug>
     Permission matrix was missing tooltip text.
     (<a href="https://www.nabble.com/Missing-hover-text-for-matrix-security-permissions--td20140205.html">report</a>)
@@ -10103,7 +10103,7 @@
     Fixed NPE in case of <tt>changelog.xml</tt> data corruption
     (<a href="https://issues.jenkins.io/browse/JENKINS-2428">issue 2428</a>)
   <li class=rfe>
-    Improved the error detection when a Windows path is given to a Unix slave.
+    Improved the error detection when a Windows path is given to a Unix agent.
     (<a href="https://www.nabble.com/windows-32-bit-hudson-talking-to-linux-64-bit-slave--td19755708.html">report</a>)
   <li class=rfe>
     Automatic dependency management for Maven projects can be now disabled.
@@ -10123,7 +10123,7 @@
     Timer-scheduled build shouldn't honor the quiet period.
     (<a href="https://www.nabble.com/Build-periodically-Schedule-time-difference-vs-actual-execute-time-td19736583.html">report</a>)
   <li class=rfe>
-    Hudson slave launched from JNLP is now capable of installing itself as a Windows service.
+    Hudson agent launched from JNLP is now capable of installing itself as a Windows service.
 </ul>
 <h3 id=v1.254>What's new in 1.254 (2008/09/26)</h3>
 <ul class=image>
@@ -10176,17 +10176,17 @@
   <li class=rfe>
     Improvements in French and Japanese localization.
   <li class=rfe>
-    JNLP slaves now support port tunneling for security-restricted environments.
+    JNLP agents now support port tunneling for security-restricted environments.
   <li class=rfe>
-    <tt>slave.jar</tt> now supports a proactive connection initiation (like JNLP slaves.)
-    This can be used to replace JNLP slaves, especially when you want to run it as a service.
+    <tt>slave.jar</tt> now supports a proactive connection initiation (like JNLP agents.)
+    This can be used to replace JNLP agents, especially when you want to run it as a service.
     (<a href="https://issues.jenkins.io/browse/JENKINS-779">issue 779</a>)
   <li class=rfe>
     Added a new extension to define permalinks
   <li class=rfe>
     Supported a file submission as one of the possible parameters for a parameterized build.
   <li class=rfe>
-    The logic to disable slaves based on its response time is made more robust, to ignore temporary spike.
+    The logic to disable agents based on its response time is made more robust, to ignore temporary spike.
   <li class=rfe>
     Improved the robustness of the loading of persisted records to simplify plugin evolution.
 </ul>
@@ -10216,7 +10216,7 @@
 <h3 id=v1.250>What's new in 1.250 (08-22-2008)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed NPE in the workspace clean up thread when the slave is offline.
+    Fixed NPE in the workspace clean up thread when the agent is offline.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2221">issue 2221</a>)
   <li class=bug>
     Hudson was still using deprecated <tt>configure</tt> methods on some of the extension points.
@@ -10231,7 +10231,7 @@
 <h3 id=v1.249>What's new in 1.249 (08-19-2008)</h3>
 <ul class=image>
   <li class=bug>
-    JNLP slave agent fails to launch when the anonymous user doesn't have a read access.
+    JNLP agent fails to launch when the anonymous user doesn't have a read access.
     (<a href="https://www.nabble.com/Launching-slave-by-JNLP-with-Active-Directory-plugin-and-matrix-security-problem-td18980323.html">report</a>)
   <li class=bug>
     Trying to access protected resources anonymously now results in 401 status code,
@@ -10262,10 +10262,10 @@
     (<a href="https://issues.jenkins.io/browse/JENKINS-2194">issue 2194</a>)
   <li class=rfe>
     Added a callback so that SCMs (like Perforce) can properly delete the workspace when
-    workspaces on slaves are garbage collected.
+    workspaces on agents are garbage collected.
     (<a href="https://www.nabble.com/Workspace-deleted-td18843492.html">discussion</a>)
   <li class=rfe>
-    Added a new extension point to listen to slave connection/disconnection activity.
+    Added a new extension point to listen to agent connection/disconnection activity.
   <li class=rfe>
     Added a new RSS feed type that only shows the latest builds.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1569">issue 1569</a>)
@@ -10317,7 +10317,7 @@
   <li class=rfe>
     Progress in Japanese localization.
   <li class=rfe>
-    Monitor the response time of slaves and cut unresponsive ones out.
+    Monitor the response time of agents and cut unresponsive ones out.
 </ul>
 <h3 id=v1.242>What's new in 1.242 (08-01-2008)</h3>
 <ul class=image>
@@ -10375,17 +10375,17 @@
     Quiet period implementation is changed to work like what most people would expect.
     (<a href="https://www.nabble.com/Quite-period%2C-base-clearcase-td18627947.html">discussion</a>)
   <li class=bug>
-    TCP port configuration on the master for JLNP slave agents was not taking effect.
+    TCP port configuration on the controller for JLNP agents was not taking effect.
     (<a href="https://www.nabble.com/JNLP-slave-port-ignored-at-startup-td18604908.html">discussion</a>)
   <li class=bug>
     Fixed a regression in the Debian package introduced in 1.237.
     (<a href="https://issues.jenkins.io/browse/JENKINS-2090">issue 2090</a>)
   <li class=bug>
-    Fixed "java.lang.SecurityException Changing the SecurityManager is not allowed" when launcing JNLP slaves
+    Fixed "java.lang.SecurityException Changing the SecurityManager is not allowed" when launcing JNLP agents
     on some systems.
     (<a href="https://d.hatena.ne.jp/tueda_wolf/20080723">report</a>)
   <li class=rfe>
-    Improved the error diagnostics when the text mode communication between the master and slave
+    Improved the error diagnostics when the text mode communication between the controller and agent
     sees illegal characters.
   <li class=rfe>
     Simplified the form field validation logic in plugins.
@@ -10400,7 +10400,7 @@
     Fixed a possible NPE in parallel module builds in Maven.{noformat}
     (<a href="https://issues.jenkins.io/browse/JENKINS-2041">issue 2041</a>)
   <li class=bug>
-    If the remote shell that Hudson uses to launch a slave hangs, Hudson ended up forking a lot of remote shells.
+    If the remote shell that Hudson uses to launch an agent hangs, Hudson ended up forking a lot of remote shells.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1705">issue 1705</a>)
   <li class=bug>
     If e-mail delivery test fails, report a stack trace, not just the error message.
@@ -10488,9 +10488,9 @@
   <li class=rfe>
     Adding a mechanism for plugins to contribute to the global configuration page directly.
   <li class=rfe>
-    Hudson can now monitor the swap space of slaves.
+    Hudson can now monitor the swap space of agents.
   <li class=rfe>
-    Take the clock difference between master and the slave into account when collecting test reports.
+    Take the clock difference between controller and the agent into account when collecting test reports.
     (<a href="https://www.nabble.com/clock-difference---figuring-out-if-tests-results-are-new-or-old-td18319363.html">report</a>)
 </ul>
 <h3 id=v1.232>What's new in 1.232 (07-03-2008)</h3>
@@ -10520,7 +10520,7 @@
     <tt>Publisher.prebuild</tt> wasn't called for Maven builds.
     (<a href="https://www.nabble.com/prebuild-method-in-Publisher-class-tt18189531.html">report</a>)
   <li class=bug>
-    Fixed a bug in JNLP slave agent connection problems if the server runs behind a reverse proxy.
+    Fixed a bug in JNLP agent connection problems if the server runs behind a reverse proxy.
     (<a href="https://www.nabble.com/JNLP-file-with-Apache-proxy-tt18116198.html">report</a>)
   <li class=bug>
     Fixed possible NPE in attempting to save <tt>https://server/hudson/configureExecutors</tt>
@@ -10540,13 +10540,13 @@
     Javadoc archiver now has an option to keep javadoc for every successful build.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1947">issue 1947</a>)
   <li class=rfe>
-    When the slave has less than 1GB available disk space, Hudson will automatically mark the node as temporarily offline.
+    When the agent has less than 1GB available disk space, Hudson will automatically mark the node as temporarily offline.
     (<a href="https://www.nabble.com/builds-that-failed-because-of-space-constraints-tt18217298.html">discussion</a>)
 </ul>
 <h3 id=v1.230>What's new in 1.230 (06-27-2008)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed a bug in launching JNLP slaves when reverse proxy is involved.
+    Fixed a bug in launching JNLP agents when reverse proxy is involved.
     (<a href="https://www.nabble.com/JNLP-file-with-Apache-proxy-tt18116198.html">report</a>)
   <li class=bug>
     Upstream pseudo-trigger wasn't updating upstream m2 jobs correctly (or matrix job, for that matter.)
@@ -10599,7 +10599,7 @@
     If an SVN update fails because of pre-existing local files, revert to fresh check out.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1882">issue 1882</a>)
   <li class=bug>
-    Fixed issue where slave configuration could not be saved.
+    Fixed issue where agent configuration could not be saved.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1913">issue 1913</a>)
   <li class=rfe>
     Hudson checks if the container uses UTF-8 to decode URls.
@@ -10664,7 +10664,7 @@
     You can now use "#!/bin/perl" (or anything else) in shell script to run it with different script interpreters.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1812">issue 1812</a>)
   <li class=rfe>
-    On systems with slaves you can now configure the utilization mode of master.
+    On systems with agents you can now configure the utilization mode of master.
     (<a href="https://www.nabble.com/Master-Usage%2C-Execution-Plot%2C-Build-Visualizer-tt17883797.html">report</a>)
   <li class=rfe>
     You can now check when the update center obtained data from our server, as well as
@@ -10799,7 +10799,7 @@
 <h3 id=v1.218>What's new in 1.218 (05-21-2008)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed NPE when launching a new slave.
+    Fixed NPE when launching a new agent.
     <a href="https://www.nabble.com/hudson-1.217-issue--%22-Please-wait-while-hudson-is-getting-ready-to-work...%22-tt17374433.html">discussion</a>
   <li class=rfe>
     The Hudson Webstart application can now be started in a headless environment by setting
@@ -10821,7 +10821,7 @@
     Fixed a bug in handling svn:external
     (<a href="https://issues.jenkins.io/browse/JENKINS-1539">issue 1539</a>)
   <li class=bug>
-    When Hudson fails to sucessfully launch a slave, terminate the pending connection.
+    When Hudson fails to sucessfully launch an agent, terminate the pending connection.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1705">issue 1705</a>)
   <li class=rfe>
     <tt>java -jar hudson.war</tt> no longer uses a temporary directory to avoid interferance
@@ -10838,7 +10838,7 @@
     Improved the robustness of CVS version parsing.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1696">issue 1696</a>)
   <li class="major rfe">
-    Slave start methods are now an extension point.
+    Agent start methods are now an extension point.
     (This is required to fix <a href="https://issues.jenkins.io/browse/JENKINS-877">issue 877</a>)
   <li class="major rfe">
     Configuration of the executors is split out from system configuration.
@@ -10847,7 +10847,7 @@
 <h3 id=v1.215>What's new in 1.215 (05-16-2008)</h3>
 <ul class=image>
   <li class='major bug'>
-    Slave configuration fails to persist.
+    Agent configuration fails to persist.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1704">issue 1704</a>)
   <li class=bug>
     Browser with JavaScript disabled should still be able to create a new job.
@@ -10867,10 +10867,10 @@
     Workspace no longer throws NPE when showing folders or files that Hudson does not have permission to read.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1633">issue 1633</a>)
   <li class=bug>
-    Workspace no longer throws NPE if the last used slave for a job is offline.
+    Workspace no longer throws NPE if the last used agent for a job is offline.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1657">issue 1657</a>)
   <li class=bug>
-    Master on Java6 + slaves on Java5 shouldn't cause NoSuchMethodError.
+    Controller on Java6 + agents on Java5 shouldn't cause NoSuchMethodError.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1657">issue 1568</a>)
   <li class=bug>
     Fixed incorrect test result links when project name contains spaces.
@@ -10897,7 +10897,7 @@
     Maven projects now support build wrappers.
     (<a href="https://www.nabble.com/BuildWrapper-plugin-support-for-m2-jobs--tt16728753.html">patch</a>)
   <li class=rfe>
-    Improved marking of mandatory fields in Add slave page.
+    Improved marking of mandatory fields in Add agent page.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1530">issue 1530</a>)
   <li class=rfe>
     Added View workspace permission to the matrix-based security.
@@ -10907,7 +10907,7 @@
 <ul class=image>
   <li class=bug>
     Starting this version, Hudson no longer installs remotely built Maven artifacts
-    into the master's <tt>~/.m2</tt> repository.
+    into the controller's <tt>~/.m2</tt> repository.
   <li class=bug>
     Fixed a possible infinite loop in class loading.
   <li class=bug>
@@ -10932,7 +10932,7 @@
     Hudson disables a project with Subversion too eagerly, when the user makes a mistake in the SVN URL.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1567">issue 1567</a>)
   <li class=bug>
-    Fixed a possible NPE when renaming a slave.
+    Fixed a possible NPE when renaming an agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1564">issue 1564</a>)
   <li class=bug>
     In some circumstance, a cancelled build can also kill its next build.
@@ -11066,7 +11066,7 @@
     on some container.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1491">issue 1491</a>)
   <li class=rfe>
-    Added script console for slaves.
+    Added script console for agents.
   <li class=rfe>
     When Hudson is preparing to shut down, always display the message.
     (<a href="https://issues.jenkins.io/browse/JENKINS-942">issue 942</a>)
@@ -11117,7 +11117,7 @@
     Work around <a href="https://issues.apache.org/bugzilla/show_bug.cgi?id=26947">the trailing slash issue in ANT_HOME</a>
     (<a href="https://issues.jenkins.io/browse/JENKINS-1452">issue 1452</a>)
   <li class=rfe>
-    Hudson starts monitoring slaves little more eagerly, so that by the time a human comes
+    Hudson starts monitoring agents little more eagerly, so that by the time a human comes
     to <tt>https://server/hudson/computer/</tt> the information is ready.
   <li class=rfe>
     Added a switch to disable CVS changelog computation.
@@ -11232,7 +11232,7 @@
   <li class=bug>
     After-the-fact deployment of Maven artifacts shouldn't kick in if a build failed or is unstable.
   <li class=rfe>
-    Added remote API support for master and slave nodes
+    Added remote API support for master and agent nodes
     (<a href="https://issues.jenkins.io/browse/JENKINS-1315">issue 1315</a>)
   <li class=rfe>
     More progress on Turkish localization.
@@ -11323,7 +11323,7 @@
     Possibly fixed a performance problem on some system regarding the use of fingerprint.
     (<a href="https://www.nabble.com/Maven-job-5-times-slower-than-a-free-style-job--tt14651245.html">discussion</a>)
   <li class=rfe>
-    Hudson now tries to automatically attempt to reconnect slaves after a failure
+    Hudson now tries to automatically attempt to reconnect agents after a failure
     (<a href="https://issues.jenkins.io/browse/JENKINS-1364">issue 1364</a>)
   <li class=rfe>
     Initial Turkish localization, thanks to O&#x011F;uz Da&#x011F;.
@@ -11510,7 +11510,7 @@
 <h3 id=v1.179>What's new in 1.179 (02-03-2008)</h3>
 <ul class=image>
   <li class='major bug'>
-    JNLP slave agents stopped working since 1.175.
+    JNLP agents stopped working since 1.175.
     (<a href="https://issues.jenkins.io/browse/JENKINS-1237">issue 1237</a>)
   <li class=bug>
     Improved JUnit report file parsing robustness.
@@ -11538,7 +11538,7 @@
   <li class=rfe>
     JUnit test results are now exposed through the remote API
   <li class=rfe>
-    Slave listing page now includes the architecture and OS of the slaves.
+    Agent listing page now includes the architecture and OS of the agents.
   <li class="major rfe">
     <tt>Publisher</tt>s are now available to the native m2 job type.
 </ul>
@@ -11612,7 +11612,7 @@
 <h3 id=v1.173>What's new in 1.173 (01-17-2008)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed an HTML rendering issue in the slave list page.
+    Fixed an HTML rendering issue in the agent list page.
   <li class=bug>
     Fixed an assertion error when security is enabled with Tomcat.
     (<a href="https://www.nabble.com/Matrix-authorization-problem-tt14602081.html#a14886312">report</a>)
@@ -11684,7 +11684,7 @@
     The native m2 job type now handles profile activation correctly during initial POM parsing.
     (<a href="https://issues.jenkins.io/browse/JENKINS-470">issue 470</a>)
   <li class=bug>
-    Fixed a possible race condition that causes a sudden death of slaves.
+    Fixed a possible race condition that causes a sudden death of agents.
     (<a href="https://www.nabble.com/my-slave-is-dead-td14760029.html">report</a>)
   <li class=bug>
     Don't show "create new jobs" link to users who don't have permission to create jobs.
@@ -11741,7 +11741,7 @@
     Fixed sidebar links on people page.
     (<a href="https://hudson.dev.java.net/issues/show_bug_cgu?id=1142">issue 1142</a>)
   <li class=rfe>
-    Improved the performance of subversion updates on slaves
+    Improved the performance of subversion updates on agents
     (<a href="https://www.nabble.com/subversion-checkout-is-very-slow-tt13228583.html#a13228583">report</a>)
   <li class=rfe>
     The remote API now supports the optional <tt>depth</tt> parameter, which can be used to control
@@ -11783,7 +11783,7 @@
     <tt>hudson.tasks.MailMessageIdAction@12524b0 returned null from the getUrlName()</tt>
       (<a href="https://www.nabble.com/Cobertura-Hudson-Plugin-0.8.4---100--coverage--to14457572.html">report</a>)
   <li class=bug>
-    Fixed a problem where JNLP slaves occasionally fail to reconnect to the server.
+    Fixed a problem where JNLP agents occasionally fail to reconnect to the server.
     (<a href="https://www.nabble.com/slave-not-surviving-server-reboot-to14452705.html">report</a>)
   <li class=bug>
     Fixed problem with "New Job" and "People" links in side bar.
@@ -11830,7 +11830,7 @@
     Fixed the wrong time zone use in some HTTP headers.
     (<a href="https://www.nabble.com/downloading-with-wget%2C-time-stamp-invalid--tf4935871.html">report</a>)
   <li class=bug>
-    Fixed a bug where path to Ant is computed incorrectly if the master and the slave are on different OS.
+    Fixed a bug where path to Ant is computed incorrectly if the controller and the agent are on different OS.
   <li class=bug>
     Fixed a bug in the resource lock controller
     (<a href="https://issues.jenkins.io/browse/JENKINS-1080">issue 1080</a>)
@@ -11987,7 +11987,7 @@
     Reject job names that contain ':' and ';' as an error
     (<a href="https://issues.jenkins.io/browse/JENKINS-970">issue 970</a>)
   <li class=bug>
-    JNLP slave agent now has the headless support.
+    JNLP agent now has the headless support.
     (<a href="https://issues.jenkins.io/browse/JENKINS-973">issue 973</a>)
   <li class=bug>
     Fixed a bug where the build status image after aborted build is incorrect.
@@ -12105,7 +12105,7 @@
 <h3 id=v1.146>What's new in 1.146 (10-09-2007)</h3>
 <ul class=image>
   <li class=bug>
-    Disk space monitoring on slaves was not working
+    Disk space monitoring on agents was not working
   <li class=bug>
     Fixed a bug where Hudson fails to recognize a JUnit test failure when a test failed to load.
     (<a href="https://issues.jenkins.io/browse/JENKINS-899">issue 899</a>)
@@ -12248,7 +12248,7 @@
     Added <a href="https://websvn.tigris.org/">WebSVN</a> support.
     (<a href="https://issues.jenkins.io/browse/JENKINS-617">issue 617</a>)
   <li class=rfe>
-    Slave log now shows timestamps.
+    Agent log now shows timestamps.
     (<a href="https://issues.jenkins.io/browse/JENKINS-791">issue 791</a>)
   <li class=rfe>
     Hudson now displays a dedicated UI during the initialization and reloading.
@@ -12277,7 +12277,7 @@
   <li class='major bug'>
     Additional JavaScript memory leak fix.
   <li class=bug>
-    Slave thread dump was not working in JDK5.
+    Agent thread dump was not working in JDK5.
     (<a href="https://issues.jenkins.io/browse/JENKINS-792">issue 792</a>)
   <li class="bug">
     Using local file path as <tt>HUDSON_HOME</tt> for monitoring external job is now obsoleted.
@@ -12363,7 +12363,7 @@
 <h3 id=v1.133>What's new in 1.133 (08-28-2007)</h3>
 <ul class=image>
   <li class=bug>
-    Fixed a bug in the free-style maven/ant invocations when the master and slave run
+    Fixed a bug in the free-style maven/ant invocations when the controller and agent run
     in different OSes.
     (<a href="https://www.nabble.com/Maven-module-build-order-has-resorted-in-need-to-fall-back-to-freestyle-BUT...-tf4315716.html">report</a>)
   <li class=bug>
@@ -12423,7 +12423,7 @@
     and when different builds use different versions of plugins.
     (<a href="https://issues.jenkins.io/browse/JENKINS-740">issue 740</a>)
   <li class=bug>
-    Slaves launched through JNLP couldn't launch the native maven2 builds.
+    Agents launched through JNLP couldn't launch the native maven2 builds.
     (<a href="https://issues.jenkins.io/browse/JENKINS-539">issue 539</a>)
   <li class=rfe>
     Archived Maven2 artifacts should honor the &lt;finalName> POM entry.
@@ -12435,7 +12435,7 @@
     Fixed a memory leak bug in distributed operations.
     (<a href="https://www.nabble.com/Possible-memory-leak-in-hudson.remoting.ExportTable-tf4218077.html">report</a>)
   <li class=bug>
-    Fixed a bad interaction between subversion repository browser vs master/slave operation.
+    Fixed a bad interaction between subversion repository browser vs controller/agent operation.
     (<a href="https://issues.jenkins.io/browse/JENKINS-702">issue 702</a>)
   <li class=bug>
     In workspace browsing pages, HTML title was incorrect.
@@ -12464,7 +12464,7 @@
 <h3 id=v1.128>What's new in 1.128 (08-10-2007)</h3>
 <ul class=image>
   <li class=bug>
-    System log and slave log were not secured.
+    System log and agent log were not secured.
     (<a href="https://issues.jenkins.io/browse/JENKINS-716">issue 716</a>)
   <li class=bug>
     Fixed a bug where the console output could get truncated incorrectly.
@@ -12492,7 +12492,7 @@
   <li class=bug>
     Fixed the problem where upgrade of Hudson often used to require clearing the browser cache.
   <li class=bug>
-    Hudson now detects Windows/Unix of slaves more reliably.
+    Hudson now detects Windows/Unix of agents more reliably.
     (<a href="https://www.nabble.com/setting-up-ant-on-solaris-slave-tf4208376.html">report</a>)
   <li class=rfe>
     Hudson didn't check the client CVS version to see if the '-S' option can be used for computing changelog.
@@ -12519,7 +12519,7 @@
     Fixed the character set handling in AJAX job/view description update
     (<a href="https://issues.jenkins.io/browse/JENKINS-654">issue 654</a>)
   <li class=bug>
-    Missing JavaScript files was making it impossible to configure slaves in the matrix project
+    Missing JavaScript files was making it impossible to configure agents in the matrix project
   (<a href="https://issues.jenkins.io/browse/JENKINS-706">issue 706</a>)
   <li class=rfe>
     Improved the form validation and error diagnosis when JDK paths are not configured at all
@@ -12566,7 +12566,7 @@
     Extended the remote API to support job submission.
     (<a href="https://www.nabble.com/How-to-create-and-modify-tasks--tf4160527.html">report</a>)
   <li class=rfe>
-    Added extensible slave monitoring mechanism. Initially this comes with clock difference
+    Added extensible agent monitoring mechanism. Initially this comes with clock difference
     monitoring and free disk space monitoring. Linked from "Manage Hudson" page.
   <li class=rfe>
     Health/weather reports did not display the description under Safari. The fix allows
@@ -12660,7 +12660,7 @@
     Improved the algorithm that detects e-mail address from user name.
     (<a href="https://issues.jenkins.io/browse/JENKINS-636">issue 636</a>)
   <li class=rfe>
-    Improved slave Unix/Windows detection
+    Improved agent Unix/Windows detection
     (<a href="https://issues.jenkins.io/browse/JENKINS-631">issue 631</a>)
 </ul>
 <h3 id=v117>What's new in 1.117 (07-13-2007)</h3>
@@ -12679,7 +12679,7 @@
     (<a href="https://issues.jenkins.io/browse/JENKINS-553">issue 553</a>,
      <a href="https://issues.jenkins.io/browse/JENKINS-596">issue 596</a>)
   <li class=bug>
-    Fixed a subversion&amp;slave related memory leak.
+    Fixed a subversion&amp;agent related memory leak.
     (<a href="https://www.nabble.com/OutOfMemroyError-tf4002294.html">report</a>)
   <li class=rfe>
     Added a command to delete all disabled modules from a m2 project in one click.
@@ -12875,12 +12875,12 @@
 
   <li class=rfe>
     Clock check on the system configuration now runs asynchronously to improve the user experience
-    with large number of slaves.
+    with large number of agents.
   <li class=rfe>
     Improved error handling when failed to create HUDSON_HOME.
     (<a href="https://issues.jenkins.io/browse/JENKINS-558">issue 558</a>)
   <li class='major rfe'>
-    Slaves can now have labels, and jobs can be tied to labels.
+    Agents can now have labels, and jobs can be tied to labels.
 </ul>
 <h3 id=v106>What's new in 1.106 (05-14-2007)</h3>
 <ul class=image>
@@ -12955,7 +12955,7 @@
     SVNKit doesn't like '.' in the file path durin "svn info", so Hudson works around that problem.
     (<a href="https://issues.jenkins.io/browse/JENKINS-474">issue 474</a>)
   <li class="bug">
-    Fixed a problem where SVN polling doesn't work on slaves
+    Fixed a problem where SVN polling doesn't work on agents
     (<a href="https://www.nabble.com/Re%3A-poll-SCM-doesn%27t-work-p10168656.html">report</a>)
   <li class="bug">
     Fixed NPE in maven2 support in site generation
@@ -13010,7 +13010,7 @@
     Fixed a bug where CVS modules area did not work when multiline textarea
     (<a href="https://issues.jenkins.io/browse/JENKINS-496">issue 496</a>)
   <li class="bug">
-    Fixed a bug where Unix master fails to set proper PATH on Windows slaves, and vice
+    Fixed a bug where Unix controller fails to set proper PATH on Windows agents, and vice
     versa, when JDK is configured.
     (<a href="https://issues.jenkins.io/browse/JENKINS-452">issue 452</a>)
   <li class="bug">
@@ -13061,7 +13061,7 @@
     Wrong link to changelog was generated.
     (<a href="https://issues.jenkins.io/browse/JENKINS-477">issue 477</a>)
   <li class="bug">
-    Fixed a bug where Subversion SSH authentication doesn't work on slaves
+    Fixed a bug where Subversion SSH authentication doesn't work on agents
     (<a href="https://issues.jenkins.io/browse/JENKINS-474">issue 474</a>)
   <li class=rfe>
     Supported multiple CVS tags on the same build.
@@ -13101,7 +13101,7 @@
     User object is exposed to the remote API.
     (<a href="https://issues.jenkins.io/browse/JENKINS-468">issue 468</a>)
   <li class="rfe">
-    JNLP slave agent TCP listener port is now configurable when the security is enabled.
+    JNLP agent TCP listener port is now configurable when the security is enabled.
     (<a href="https://www.nabble.com/distributed-build-with-slaves-in-vpn-tf3553582.html">discussion</a>)
 </ul>
 <h3 id=v101>What's new in 1.101 (04-12-2007)</h3>
@@ -13134,7 +13134,7 @@
 <h3 id=v100>What's new in 1.100 (04-11-2007)</h3>
 <ul class=image>
   <li class="major bug">
-    Fixed a bug in running Subversion SCM on a slave.
+    Fixed a bug in running Subversion SCM on an agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-447">issue 447</a>)
   <li class="major bug">
     Fixed a bug in the native m2 support where the association between project build
@@ -13154,7 +13154,7 @@
 <h3>What's new in 1.99 (04-10-2007)</h3>
 <ul class=image>
   <li class="major bug">
-    JNLP slave agent stopped working as of 1.97 is now fixed.
+    JNLP agent stopped working as of 1.97 is now fixed.
     (<a href="https://issues.jenkins.io/browse/JENKINS-442">issue 442</a>)
   <li class="bug">
     Hudson now correctly assigns build numbers to the native m2 builds
@@ -13199,7 +13199,7 @@
 <ul>
   <li><b>Hudson now requires Java 1.5</b>
   <li>Native m2 support can now work with Maven 2.0.6.
-  <li>Improved file transfer performance between slaves and master
+  <li>Improved file transfer performance between agents and controller
       especially when latency is big.
   <li>Build history is now asynchronously updated to reflect status changes
       in the server.
@@ -13208,7 +13208,7 @@
       <a href="http://www.szegedi.org/articles/memleak.html">beware of commons-logging</a>)
   <li>Supported <tt>svn+ssh</tt> authentication
   <li>Performance improvement in the native m2 build. This should be especially effective
-      in the master/slave environment.
+      in the controller/agent environment.
   <li>Fixed a bug where the javadoc link in the job top page becomes broken
       when the javadoc archiving is configured but no javadoc has built yet.
       (<a href="https://issues.jenkins.io/browse/JENKINS-433">issue 433</a>)
@@ -13237,7 +13237,7 @@
 </ul>
 <h3>What's new in 1.95 (03-31-2007)</h3>
 <ul>
-  <li>Performance improvement in the master/slave communciation.
+  <li>Performance improvement in the controller/agent communciation.
   <li>Fixed JavaScript errors that occure when there's no entries for repetable form fields
       (typically during the fresh install.)
   <li>Hudson now warns the lack of MAVEN2_HOME configuration upfront when job is being configured,
@@ -13247,7 +13247,7 @@
   <li>Fixed the problem where external job monitoring doesn't collectly persist
       the build duration.
       (<a href="https://issues.jenkins.io/browse/JENKINS-402">issue 402</a>)
-  <li>Implemented the computre view for the master so that you can check what jobs
+  <li>Implemented the computer view for the master so that you can check what jobs
       are tied to the master.
       (<a href="https://issues.jenkins.io/browse/JENKINS-401">issue 401</a>)
   <li>Hudson now shows a tooltip for a pending build to explain why it's pending
@@ -13261,12 +13261,12 @@
 <h3>What's new in 1.94 (03-29-2007)</h3>
 <ul>
   <li>M2 project now shows build queue for modules.
-  <li>Improved exception propagation with master/slave mode.
+  <li>Improved exception propagation with controller/agent mode.
   <li>E-mail notification (and other build settings) can be now configured at
       the M2 project level, as well as individual module level. (I thought I fixed this long time ago)
   <li>The build time trend chart no longer displays the on-going build.
       (<a href="https://issues.jenkins.io/browse/JENKINS-399">issue 399</a>)
-  <li>Allowed admin to forcibly disconnect a slave.
+  <li>Allowed admin to forcibly disconnect a agent.
       (<a href="https://issues.jenkins.io/browse/JENKINS-400">issue 400</a>)
   <li>Fixed a problem where too many build records make the chart look too crowded.
       (<a href="https://issues.jenkins.io/browse/JENKINS-214">issue 214</a>)
@@ -13347,7 +13347,7 @@
       (<a href="https://issues.jenkins.io/browse/JENKINS-382">issue 382</a>)
   <li>Hudson now sends out a correct MIME type for ATOM feed
       (<a href="https://issues.jenkins.io/browse/JENKINS-378">issue 378</a>)
-  <li>Fixed a bug where CVS/SVN polling doesn't work correctly when jobs are configured on slaves.
+  <li>Fixed a bug where CVS/SVN polling doesn't work correctly when jobs are configured on agents.
       (<a href="https://www.nabble.com/CVS-Polling-not-working-tf3443888.html">report</a>)
   <li>Improved the config submission handling to fix various issues.
       (<a href="https://issues.jenkins.io/browse/JENKINS-383">issue 383</a>)
@@ -13414,9 +13414,9 @@
       (<a href="https://issues.jenkins.io/browse/JENKINS-295">issue 295</a>,
        <a href="https://issues.jenkins.io/browse/JENKINS-312">issue 312</a>,
        <a href="https://issues.jenkins.io/browse/JENKINS-308">issue 308</a>,)
-  <li>Fixed an NPE (and the disappearance of the executors box) when a slave is removed.
+  <li>Fixed an NPE (and the disappearance of the executors box) when an agent is removed.
       (<a href="https://issues.jenkins.io/browse/JENKINS-149">issue 149</a>)
-  <li>Fixed a bug where JNLP fails to launch if slave names contains space or
+  <li>Fixed a bug where JNLP fails to launch if agent names contains space or
       non-ASCII characters.
       (<a href="https://issues.jenkins.io/browse/JENKINS-321">issue 321</a>)
   <li>When a build is tagged, mark the build as keep automatically.
@@ -13432,7 +13432,7 @@
   <li>Fixed a NPE in computing Subversion changelog with JDK 1.4
       (<a href="https://issues.jenkins.io/browse/JENKINS-306">issue 306</a>)
   <li>Fixed a bug where <tt>hudson</tt> shell script was not working due to the lack of <tt>Main-Class</tt> entry in jar.
-  <li>Fixed a bug where copying multiple files from Windows slave to Unix master
+  <li>Fixed a bug where copying multiple files from Windows agent to Unix controller
       had a file name separator translation issue.
       (<a href="https://issues.jenkins.io/browse/JENKINS-331">issue 331</a>)
   <li>[EMMA 1.4] Fixed a problem in parsing floating point character problem in some locales.
@@ -13443,7 +13443,7 @@
       (<a href="https://issues.jenkins.io/browse/JENKINS-319">issue 319</a>)
   <li>Fixed a bug in handling missing index.html when serving javadoc.
       (<a href="https://issues.jenkins.io/browse/JENKINS-316">issue 316</a>)
-  <li>Fixed a bug where slaves launched by JNLP agents cause LinkageError
+  <li>Fixed a bug where agents launched by JNLP agents cause LinkageError
       (<a href="https://issues.jenkins.io/browse/JENKINS-320">issue 320</a>)
 </ul>
 <h3>What's new in 1.83 (02-21-2007)</h3>
@@ -13456,8 +13456,8 @@
       and the user is not logged in (clicking it was causing 403, so this is not
       a security hole fix.)
       (<a href="https://issues.jenkins.io/browse/JENKINS-311">issue 311</a>)
-  <li>Modified to report Win32 error message even if the master is on Unix,
-      in case it's reporting errors from slaves.
+  <li>Modified to report Win32 error message even if the controller is on Unix,
+      in case it's reporting errors from agents.
   <li>Fixed a bug in the "new job" UI where the OK button don't become active when copying a job.
       (<a href="https://issues.jenkins.io/browse/JENKINS-318">issue 318</a>)
   <li>Modified not to display javadoc link when no javadoc is built yet.
@@ -13468,7 +13468,7 @@
   <li>Fixed the initial welcome text for the native m2 support
       (<a href="https://issues.jenkins.io/browse/JENKINS-296">issue 296</a>)
   <li>Fixed a bug where disabled projects were still performing SCM polling.
-  <li>Fixed a bug in the master/slave support where SVN credential checks on slaves
+  <li>Fixed a bug in the controller/agent support where SVN credential checks on agents
       are not working correctly.
   <li>Fixed a problem where form value checks were not working correctly with non-ASCII characters.
       (<a href="https://issues.jenkins.io/browse/JENKINS-301">issue 301</a>)
@@ -13487,7 +13487,7 @@
   <li><tt>hudson.war</tt> file is now executable as <tt>java -jar hudson.war</tt> thanks to
       Winstone.
       (<a href="https://issues.jenkins.io/browse/JENKINS-137">issue 137</a>)
-  <li>Slave agents can be now launched via JNLP, making it easier to connect Windows slaves.
+  <li>Agents can be now launched via JNLP, making it easier to connect Windows agents.
   <li>Fixed a <tt>ClassCastException</tt> in the native maven2 support when POMs include
       report plugins.
   <li>When "default maven" is chosen for the build, Hudson now sniffs the workspace
@@ -13498,7 +13498,7 @@
 </ul>
 <h3>What's new in 1.80 (02-10-2007)</h3>
 <ul>
-  <li>Fixed a bug in launching Ant on Windows slave from Unix master
+  <li>Fixed a bug in launching Ant on Windows agent from Unix controller
       (<a href="https://issues.jenkins.io/browse/JENKINS-280">issue 280</a>)
   <li>Triggers are now fully integrated into the native maven2 support.
   <li>Various pages didn't have proper titles. Fixed hopefully all of them.
@@ -13524,7 +13524,7 @@
 <ul>
   <li>[JAVANET-UPLOADER 1.4] Supported wildcards and multiple file match.
       (<a href="https://issues.jenkins.io/browse/JENKINS-258">issue 258</a>)
-  <li>Fixed a problem where svn operations fail to work properly on slaves.
+  <li>Fixed a problem where svn operations fail to work properly on agents.
   <li>Fixed a problem in the subversion remote revision computation.
       (<a href="https://issues.jenkins.io/browse/JENKINS-265">issue 265</a>)
   <li>Re-implemented the new job creation page so that it has more information.
@@ -13560,7 +13560,7 @@
 </ul>
 <h3>What's new in 1.75 (01-24-2007)</h3>
 <ul>
-  <li>Fixed a memory leak in the slave agent program.
+  <li>Fixed a memory leak in the agent program.
   <li>Made cvs binary location configurable.
       (<a href="https://issues.jenkins.io/browse/JENKINS-242">issue 242</a>)
   <li>Improved the error reporting on failed "cvs --version" invocation from the system config screen.
@@ -13573,7 +13573,7 @@
       (<a href="https://issues.jenkins.io/browse/JENKINS-235">issue 235</a>)
   <li>Removed a bug in the caching of fingerprint records, which caused unnecessary
       slow down in busy Hudson.
-  <li>Fixed a bug where a shutdown of Hudson doesn't terminate ssh used for slave agents
+  <li>Fixed a bug where a shutdown of Hudson doesn't terminate ssh used for agents
       (<a href="https://issues.jenkins.io/browse/JENKINS-246">issue 246</a>)
 </ul>
 <h3>What's new in 1.74 (01-17-2007)</h3>
@@ -13674,14 +13674,14 @@
 <ul>
   <li>The build history panel now shows build descriptions, if any
       (<a href="https://issues.jenkins.io/browse/JENKINS-148">issue 148</a>)
-  <li>System configuration can be now saved even if some slaves are down.
+  <li>System configuration can be now saved even if some agents are down.
   <li>Fixed a race condition which could cause changes made to large CVS projects to not be reported
       in the build changelog. Now all CVS checkouts and updates use timestamps.
       (<a href="https://issues.jenkins.io/browse/JENKINS-192">issue 192</a>)
   <li>Improved detection of deleted files when using CVS.
   <li>Added a link to the build time trend in the build history.
       (<a href="https://issues.jenkins.io/browse/JENKINS-197">issue 197</a>)
-  <li>Fixed a bug where the build time trend report always show "master", not the actual slave
+  <li>Fixed a bug where the build time trend report always show "master", not the actual agent
       (<a href="https://issues.jenkins.io/browse/JENKINS-198">issue 198</a>)
   <li>Fixed a bug where the labels of charts are often unnecessarily truncated.
       (<a href="https://issues.jenkins.io/browse/JENKINS-199">issue 199</a>)
@@ -13775,7 +13775,7 @@
       (<a href="https://issues.jenkins.io/browse/JENKINS-162">issue 162</a>)
   <li>Form validation was added to the "build other projects" and "Build after other projects are built".
       It even suggests what you might have intended.
-  <li>Added form validation to slave configurations.
+  <li>Added form validation to agent configurations.
       (<a href="https://issues.jenkins.io/browse/JENKINS-150">issue 150</a>)
   <li>[JAVANET-UPLOADER] fixed broken links to help pages.
   <li>[JAVANET-UPLOADER] added macro substitution support for configuration.
@@ -13799,7 +13799,7 @@
 </ul>
 <h3>What's new in 1.61 (11-13-2006)</h3>
 <ul>
-  <li>Fixed a bug where removing the slave from configuration causes NPE
+  <li>Fixed a bug where removing the agent from configuration causes NPE
       (<a href="https://issues.jenkins.io/browse/JENKINS-149">issue 149</a>)
   <li>When a build is marked to be kept, the build history now shows an icon indicating so.
       (<a href="https://issues.jenkins.io/browse/JENKINS-147">issue 147</a>)
@@ -13979,10 +13979,10 @@
   <li>Implemented a mechanism to prevent new builds from being executed, so that a busy
       Hudson can be safely shutdown.
   <li>Scrollbar is slowed down to avoid drawing attention too much
-  <li>Modified to periodically clean up unused workspaces on slaves.
+  <li>Modified to periodically clean up unused workspaces on agents.
       (<a href="https://issues.jenkins.io/browse/JENKINS-91">issue 91</a>)
   <li>[JAVANET-UPLOADER] Don't post to java.net if a build failed.
-  <li>System config screen now displays the clock difference between master and slave nodes
+  <li>System config screen now displays the clock difference between controller and agent nodes
       (<a href="https://issues.jenkins.io/browse/JENKINS-84">issue 84</a>)
 </ul>
 <h3>What's new in 1.46</h3>
@@ -14060,7 +14060,7 @@
   <li>Improved the error recovery from X11 connection problem.
       (<a href="https://issues.jenkins.io/browse/JENKINS-93">issue 93</a>)
   <li>Fixed a bug where CVS invocation doesn't handle whitespaces in directory names correctly.
-  <li>Fixed a bug where master/slave communication doesn't carry whitespaces in directory names
+  <li>Fixed a bug where controller/agent communication doesn't carry whitespaces in directory names
       correctly.
   <li>Modified to display a progress bar even if no previous records are available
       (<a href="https://issues.jenkins.io/browse/JENKINS-88">issue 88</a>)
@@ -14198,7 +14198,7 @@
   <li>Implemented the 'fingerprint' recording. See <a href="https://hudson.dev.java.net/fingerprint.html">
       a separate document</a> for more details.
   <li>Fixed a problem where "tag this build" pages don't show the left task bar.
-  <li>Slave can be now marked as "temporarily offline" to avoid builds to be scheduled on it
+  <li>Agent can be now marked as "temporarily offline" to avoid builds to be scheduled on it
   <li>Implemented a new switch on the e-mail notification to avoid sending out
       e-mails on every unstable build. Useful for those lazy projects where test failures are the norm.
 </ul>
@@ -14227,8 +14227,8 @@
   <li>Introduced the "unstable" state to represent test failures.
   <li>More help documents.
   <li>build notice e-mail now includes a link to the website.
-  <li>Started adding page for each slave (<a href="https://issues.jenkins.io/browse/JENKINS-35">issue 35</a>)
-  <li>Slaves can now be configured so that they can be reserved
+  <li>Started adding page for each agent (<a href="https://issues.jenkins.io/browse/JENKINS-35">issue 35</a>)
+  <li>Agents can now be configured so that they can be reserved
       for certain jobs.
   <li>Fixed URL assignment to test failures, so that an URL to a test result
       of the last successful build can point to the same test across builds.
@@ -14253,7 +14253,7 @@
   <li>Next/Previous build link now cycles through the same page between builds.
       So if you are reading the console output page, just clicking "previous build" will
       take you to the console output of the previous build.
-  <li>Implemented master/slave support
+  <li>Implemented controller/agent support
   <li>When a large number of build artifacts are archived,
       Hudson won't show a very long list of bullet lists.
   <li>Changed the icon that kills an on-going build to 'x' icon.

--- a/content/_partials/changelog-old.html
+++ b/content/_partials/changelog-old.html
@@ -6993,7 +6993,7 @@
     Fixed an <tt>AbstractMethodError</tt> in listing up executors.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8106">issue 8106</a>)
   <li class=bug>
-    Agents launched by JNLP fail to reprot their version numbers.
+    Agents launched by JNLP fail to report their version numbers.
     (<a href="https://issues.jenkins.io/browse/JENKINS-8060">issue 8060</a>)
   <li class=bug>
     Restarting Hudson via debian init script didn't wait for the process to really terminate.


### PR DESCRIPTION
Rules mostly adhered to:

* Change "master" to "controller" when in scope of the mid 2020 decision (i.e. exclude the "master node", which is what has a launcher, labels, retention policy, can be offline, runs flyweight tasks, etc.), unless specifically referring to a UI label, error message, class or field name, system property, or file name that wasn't "agent" as of the changelog entry (some recent `slave.jar` references got changed, many others did not).
* Change "slave" or "slave agent" to "agent" 
* Change Hudson to Jenkins when referring to the application in entries for 1.396 and newer.
* Replace references to the plugins ssh-slaves and windows-slaves with their new labels SSH Build Agents and WMI Windows Agents; perhaps change surroundings for label consistency.