### PR TITLE
Add namespace for ServiceAccount

### DIFF
--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-sa.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-sa.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: jenkins
+  namespace: jenkins
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Add namespace `jenkins` for ServiceAccount, then the ServiceAccount will be created in `jenkins` namespace, or it maybe creted in other namespace.

Reference:
https://www.jenkins.io/doc/book/installing/kubernetes/#create-a-service-account