### PR TITLE
Add an overview of the sections of the security chapter to the index

### DIFF
--- a/content/doc/book/security/index.adoc
+++ b/content/doc/book/security/index.adoc
@@ -1,16 +1,13 @@
 ---
 layout: chapter
+title: Securing Jenkins
 ---
 ifdef::backend-html5[]
-:notitle:
 :description:
 :author:
 :email: jenkinsci-users@googlegroups.com
 :sectanchors:
-:toc: left
 endif::[]
-
-= Jenkins Security
 
 Jenkins is used everywhere from workstations on corporate intranets, to high-powered servers connected to the public internet.
 To safely support this wide spread of security and threat profiles, Jenkins offers many configuration options for enabling, customizing, or disabling various security features.
@@ -19,3 +16,48 @@ Many of the security options are enabled by default when passing the interactive
 Others involve environment-specific setup and trade-offs and depend on specific use cases supported in individual Jenkins instances.
 
 This chapter will introduce the various security options available to Jenkins administrators and users, explaining the protections offered, and trade-offs to disabling some of them.
+
+// TODO the following only makes sense on the web site, not the PDF. Can it be disabled there?
+
+== Basic Setup
+
+link:controller-isolation[Controller Isolation]::
+Builds should not be executed on the master node, but that is just the beginning:
+This section discusses what other steps can be taken to protect the controller from being impacted by running builds. +
+*This needs to be configured according to the needs of your environment.*
+
+link:access-control[Access Control]::
+By default, Jenkins does not allow anonymous access, and a single admin user exists.
+This chapter discusses which level of access is provided by permissions and how to safely grant access to more users. +
+_This is set up securely by the setup wizard. If the setup wizard is disabled on first launch, this may not be configured securely by default._
+
+
+== Build Behavior
+
+link:build-authorization[Access Control for Builds]::
+Learn how to restrict what individual builds can do in Jenkins once they're running. +
+*This needs to be configured according to the needs of your environment.*
+
+link:environment-variables[Handling Environment Variables]::
+Improperly written build scripts may be tricked into behaving differently than intended due to special environment variable names or values being injected as build parameters.
+This section discusses how to protect your builds. +
+*This needs to be configured according to the needs of your environment.*
+
+
+== User Interface
+
+link:csrf-protection[CSRF Protection]::
+Jenkins protects from cross-site request forgery (CSRF) by default.
+This chapter explains how to work around any problems this may cause. +
+_This is set up securely by default._
+// TODO Confirm that skipping the setup wizard in 2.222 does no longer disable CSRF protection
+
+link:markup-formatter[Markup Formatter]::
+The default markup formatter renders text as entered (i.e. escaping HTML metacharacters).
+This chapter explains how to switch to a different markup formatter and explains what admins need to be aware of. +
+_This is set up securely by default._
+
+link:configuring-content-security-policy[Configuring Content Security Policy]::
+By default, Jenkins strictly limits the features useable in user content (files from workspaces, archived artifacts, etc.) it serves.
+This chapter discusses how to customize this and make HTML reports and similar content both functional and safe to view. +
+_This is set up securely by default._


### PR DESCRIPTION
Also renames it to "Securing Jenkins", which is kind of weird with the legacy subsection, but that'll be gone soon enough.

<details>
<summary>Screenshot</summary>

![Screenshot_2021-04-29 Securing Jenkins](https://user-images.githubusercontent.com/1831569/116531281-4b558000-a8df-11eb-8d81-1e57d1a0b666.png)

</details>