### PR TITLE
Reset the handbook chapters when initializing the handbook

### DIFF
--- a/content/_ext/handbook.rb
+++ b/content/_ext/handbook.rb
@@ -43,9 +43,7 @@ module Awestruct
       end
 
       def execute(site)
-        unless site[@name]
-          site[@name] = Handbook.new(@book_dir)
-        end
+        site[@name] = Handbook.new(@book_dir)
         # We need a map of source files to their Awestruct::Page to avoid
         # re-rendering things too much in the process of generating this page
         pagemap = site.pages.map { |p| [p.source_path, p] }.to_h


### PR DESCRIPTION
I've long wondered by handbook chapters proliferate while running the local `make run` development server and editing `_chapter.yml` files, and it seems to be this (unnecessary?) retention of state across handbook generator runs. This has been in there from the beginning, and I'm unsure why, perhaps @rtyler remembers why he did it like this in https://github.com/jenkins-infra/jenkins.io/pull/330?

<details>
<summary>Screenshot of the unexpected effect that is resolved by this change</summary>

![Screenshot_2021-04-29 System Administration](https://user-images.githubusercontent.com/1831569/116598677-6b109680-a927-11eb-8b64-0b2688c3d063.png)

</details>