### PR TITLE
Fix Fedora install guide

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -153,8 +153,8 @@ It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum r
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
-    http://pkg.jenkins-ci.org/redhat/jenkins.repo
-sudo rpm --import https://jenkins-ci.org/redhat/jenkins-ci.org.key
+    https://pkg.jenkins.io/redhat/jenkins.repo
+sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo dnf upgrade
 sudo dnf install jenkins java-devel chkconfig
 ----

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -142,6 +142,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo dnf upgrade
+# Add required dependencies for the jenkins package
 sudo dnf install chkconfig java-devel
 sudo dnf install jenkins
 ----

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -163,6 +163,13 @@ sudo dnf install jenkins
 
 === Start Jenkins
 
+Register the Jenkins service with the command:
+
+[source,bash]
+----
+sudo systemctl daemon-reload
+----
+
 You can start the Jenkins service with the command:
 
 [source,bash]

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -142,7 +142,8 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo dnf upgrade
-sudo dnf install jenkins java-devel chkconfig
+sudo dnf install chkconfig java-devel
+sudo dnf install jenkins
 ----
 
 === Weekly release
@@ -156,7 +157,8 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo dnf upgrade
-sudo dnf install jenkins java-devel chkconfig
+sudo dnf install chkconfig java-devel
+sudo dnf install jenkins
 ----
 
 === Start Jenkins


### PR DESCRIPTION
## Fix Fedora install guide based on #4308

See https://github.com/jenkins-infra/jenkins.io/pull/4308#issuecomment-829607890

- Use https for Fedora pkg repo in weekly
- Install chkconfig and java-devel before Jenkins
- Reload before launching Jenkins service

@mabuze does this look better?  Can you confirm that it works?