### PR TITLE
Use correct method in example @DataBoundSetter

### DIFF
--- a/content/doc/developer/plugin-development/pipeline-integration.adoc
+++ b/content/doc/developer/plugin-development/pipeline-integration.adoc
@@ -140,7 +140,7 @@ public String getStuff() {
 
 @DataBoundSetter
 public void setStuff(@CheckForNull String stuff) {
-    this.stuff = Util.fixNull(stuff);
+    this.stuff = Util.fixEmpty(stuff);
 }
 ----
 


### PR DESCRIPTION
If a plugin is wanting an optional field to be null if it's not set, it
will need to use Util.fixEmpty (which will coerce a null or empty
string to null) instead of Util.fixNull (which will coerce a null string
to an empty string). Fix the example so it works properly.