### PR TITLE
Add classname for download list

### DIFF
--- a/content/templates/downloads.html.haml
+++ b/content/templates/downloads.html.haml
@@ -36,4 +36,4 @@ uneditable: true
 .container
   %h1.mt-3 {{ title }}
   .subtitle.mb-2 {{ subtitle }}
-  %ul {{ content }}
+  %ul.artifact-list {{ content }}


### PR DESCRIPTION
Follow-up for #4286 , a CSS class name got lost when I translated HTML to haml.