### PR TITLE
Add redirect page to report issues in plugins

### DIFF
--- a/content/participate/report-issue/redirect.html.haml
+++ b/content/participate/report-issue/redirect.html.haml
@@ -1,0 +1,102 @@
+---
+layout: simplepage
+title: Report an issue in a plugin
+section: participate
+noanchors: true
+---
+
+:css
+    .bg-img {
+        background-size: cover;
+        min-height: 20px;
+        background-position: center;
+    }
+    .bg-img-bug {
+        background-color: red;
+    }
+    .btn-bug {
+        border: 1px solid red;
+        color: 
+    }
+    .btn-bug:hover {
+        background-color: red;
+        color: white;
+    }
+
+
+    .bg-img-rfe {
+        background-color: #99f;
+    }
+    .btn-rfe {
+        border: 1px solid #99f;
+    }
+    .btn-rfe:hover {
+        background-color: #99f;
+        color: white;
+    }
+
+
+    .bg-img-security {
+        background-color: #fa0;
+    }
+    .btn-security {
+        border: 1px solid #fa0;
+    }
+    .btn-security:hover {
+        background-color: #fa0;
+        color: white;
+    }
+
+
+    .bl {
+        position: absolute;
+        bottom: 8.6%;
+        left: 4.4%;
+    }
+    .p1 {
+        margin-bottom: 22%;
+    }
+
+%p
+    Choose the kind of issue you'd like to report below.
+    %strong
+        Please be sure to to follow the 
+        %a{:href => '/participate/report-issue/' }
+            advice on how to report great issues.
+
+.grid-container
+    .card
+        .bg-img.bg-img-bug
+        .content
+            %h3
+                Bug
+            %p.p1
+                Report that something is broken.
+            %a.btn.btn-bug.bl#link-bug{:href => 'https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10172&issuetype=1&priority=4' }
+                Continue
+    .card
+        .bg-img.bg-img-rfe
+        .content
+            %h3
+                Improvement
+            %p.p1
+                Request a new feature or improvement.
+            %a.btn.btn-rfe.bl#link-rfe{:href => 'https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10172&issuetype=2&priority=4' }
+                Continue
+    .card
+        .bg-img.bg-img-security
+        .content
+            %h3
+                Security Issue
+            %p.p1
+                Report a security issue privately.
+            %a.btn.btn-security.bl{:href => 'https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103&components=17329' }
+                Continue
+
+:javascript
+    // TODO Also pass the plugin name and show it on the UI, but for now this is simpler and probably safer.
+    var hash = window.location.hash.substring(1);
+    if (hash && /^\d+$/.test(hash)) {
+        document.getElementById('link-bug').href = document.getElementById('link-bug').href + "&components=" + hash;
+        document.getElementById('link-rfe').href = document.getElementById('link-rfe').href + "&components=" + hash;
+    }

--- a/content/participate/report-issue/redirect.html.haml
+++ b/content/participate/report-issue/redirect.html.haml
@@ -90,6 +90,8 @@ noanchors: true
                 Security Issue
             %p.p1
                 Report a security issue privately.
+                %a{:href => '/security/reporting/' }
+                    Learn more...
             %a.btn.btn-security.bl{:href => 'https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103&components=17329' }
                 Continue
 


### PR DESCRIPTION
It's a bit off center (should be 4 cards wide), but still looks reasonable.

Colors are from https://www.jenkins.io/changelog/ entry type colors and as such a lot brighter than https://www.jenkins.io/participate/ upstream's more muted colors. I think it's fine but feedback is welcome.

This is deliberately not linked from elsewhere on the site. The idea is to use this as the URL that gets referenced from [issue tracker metadata](https://github.com/jenkins-infra/repository-permissions-updater#managing-issue-trackers) and is linked from Jenkins (https://github.com/jenkinsci/jenkins/pull/5358) and the plugins site for plugins that track their issues in Jira. This will give plugins that track issues in Jira to have a landing page similar to https://github.com/jenkins-infra/jenkins.io/issues/new/choose (usually provided by https://github.com/jenkinsci/.github/tree/master/.github/ISSUE_TEMPLATE).

Without JavaScript enabled for jenkins.io, this page still links to a useful URL, but will not autofill the component field.

Requesting @Wadeck for security review. I think this is simple enough that I'm not doing something horribly wrong, but to be safe.

FYI @timja and @halkeye as other folks involved in this general effort.

![Screenshot](https://user-images.githubusercontent.com/1831569/116820370-fcc11380-ab74-11eb-8eda-ab5ef4037f60.png)

<details>
<summary>For comparison, the same with similar colors from the Participate page</summary>

![Screenshot](https://user-images.githubusercontent.com/1831569/116820378-0ea2b680-ab75-11eb-9c1c-1d8329ca0692.png)

</details>