### PR TITLE
Remove anchors from /participate

### DIFF
--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -2,6 +2,7 @@
 layout: simplepage
 title: Participate and Contribute
 section: participate
+noanchors: true
 ---
 
 :css


### PR DESCRIPTION
Discovered while working on #4323: https://www.jenkins.io/participate/ does not disable anchors for headers, which looks really weird on that page.