### PR TITLE
Update reporting/account signup info after Jira change

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -10,16 +10,12 @@ section: security
 Thanks for your interest in reporting vulnerabilities to the Jenkins project!
 
 Please report them in the issue tracker under the link:https://issues.jenkins.io/browse/SECURITY[SECURITY project]. 
-
-NOTE: If you do not have an account yet, please signup for one in the link:https://accounts.jenkins.io/[Account application] that is used to manage the authentication within the Jenkins project. Registering an account directly in Jira will not work.
-
 This project is configured in such a way that only the reporter and the security team can see the details.
 By restricting access to this potentially sensitive information, we can work on a fix and deliver it before the method of attack becomes well-known.
 
-If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
+IMPORTANT: If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
 `jenkinsci-cert@googlegroups.com`
 We will then file an issue on your behalf.
-
 
 == Scope
 


### PR DESCRIPTION
While writing https://www.jenkins.io/participate/report-issue/redirect/ I was confused about the advice on https://www.jenkins.io/security/reporting/ -- turns out https://github.com/jenkins-infra/jenkins.io/pull/4012 was merged despite my negative feedback.

I fixed Jira to add a reference to the account app on the login form, and made this part of the page less broken looking.

## Before

> <img width="860" alt="Screenshot 2021-05-04 at 10 12 57" src="https://user-images.githubusercontent.com/1831569/116976381-5898b300-acc1-11eb-8a06-d66d454216d2.png">

## After

> <img width="853" alt="Screenshot 2021-05-04 at 10 13 04" src="https://user-images.githubusercontent.com/1831569/116976443-7108cd80-acc1-11eb-9ff3-f36ebc770df3.png">
