### PR TITLE
Add JSON list of contents for the pipeline reference

### DIFF
--- a/content/doc/pipeline/steps/contents.json.haml
+++ b/content/doc/pipeline/steps/contents.json.haml
@@ -1,0 +1,2 @@
+- steps_dir = File.expand_path(File.dirname(__FILE__))
+= sections_from(steps_dir).map{|section| File.basename(section[1][:path], ".*")}.to_json


### PR DESCRIPTION
Adds a JSON file at jenkins.io/doc/pipeline/steps/contents.json that can be consumed by the plugin site so that each plugin page can link to the list of pipeline steps provided by the plugin.