### PR TITLE
Use JDK 11 and current Jenkins in install guides

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -91,7 +91,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.277.2-lts-jdk11
+FROM jenkins/jenkins:2.277.4-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -91,7 +91,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source]
 ----
-FROM jenkins/jenkins:2.277.2-lts-jdk11
+FROM jenkins/jenkins:2.277.4-lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -232,7 +232,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo yum upgrade
-sudo yum install jenkins java-1.8.0-openjdk-devel
+sudo yum install jenkins java-11-openjdk-devel
 sudo systemctl daemon-reload
 ----
 
@@ -247,7 +247,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo yum upgrade
-sudo yum install jenkins java-1.8.0-openjdk-devel
+sudo yum install jenkins java-11-openjdk-devel
 sudo systemctl daemon-reload
 ----
 


### PR DESCRIPTION
## Use JDK 11 and current Jenkins version in install guides

- Install Jenkins 2.277.4 in Docker instructions
- Use Java 11 on Red Hat Linux

Fixes https://github.com/jenkins-infra/jenkins.io/issues/4336