### PR TITLE
Clarify Java requirements

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -9,13 +9,13 @@ There are separate run and job execution requirements for Jenkins installations.
 
 Modern Jenkins versions have the following Java requirements:
 
-* Java 8 runtime environments, both 32-bit and 64-bit versions are supported
-* Since Jenkins `2.164` and `2.164.1` footnote:[since `2.155` but it was made easier in `2.164`], Java 11 runtime environments are supported
-** Running Jenkins with Java 11 is documented link:/doc/administration/requirements/jenkins-on-java-11[here] 
-** There are some precautions to take when upgrading from Java 8 to Java 11 in Jenkins, please link:/doc/administration/requirements/upgrade-java-guidelines[follow these guidelines].
-* Older versions of Java are not supported
-* Java 9 and Java 10 are not supported
-* Java 12 is not supported
+* Java 8 runtime environments are supported in both 32-bit and 64-bit versions
+* Java 11 runtime environments are supported
+** Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
+** See the link:/doc/administration/requirements/upgrade-java-guidelines[Java 8 to Java 11 upgrade guidelines] for additional upgrade instructions
+* Java 7 and prior are not supported
+* Java 9 and 10 are not supported
+* Java 12, 13, 14, 15, and 16 are not supported
 
 These requirements apply to all components of the Jenkins system including Jenkins controller,
 all types of agents, CLI clients, and other components.
@@ -48,8 +48,7 @@ versions of such bundled Java must be equal to the version of the controller
 
 ## Monitoring Java versions
 
-Modern versions of Jenkins controller and agents verify Java requirements
-and notify users when they are launched with unsupported version.
+Modern versions of Jenkins controllers and Jenkins agents verify Java requirements
+and notify users when they are launched with an unsupported version.
 
-In order to do fine-grain monitoring of Java versions on agents,
-you can use plugin:versioncolumn[Jenkins Versions Node Monitors plugin] to setup Java version monitoring across the Jenkins system.
+The plugin:versioncolumn[Jenkins Versions Node Monitors plugin] provides detailed Java version monitoring.


### PR DESCRIPTION
## Simplify Java requirements page

- Remove old Jenkins version number references
- Note that newer Java versions are not supported
- Link to Docker install instructions
