### PR TITLE
Refer to Java versions page for version info

### DIFF
--- a/content/doc/book/installing/other.adoc
+++ b/content/doc/book/installing/other.adoc
@@ -124,7 +124,7 @@ svcadm enable jenkins
 The common packaging integration for a standalone service will:
 
 * Create a `jenkins` user to run the service and to own the directory structures under `/var/lib/jenkins`.
-* Pull the OpenJDK8 and other packages required to execute Jenkins, including
+* Pull the Java package and other packages required to execute Jenkins, including
   the `jenkins-core-weekly` package with the latest `jenkins.war`.
 +
 CAUTION: Long-Term Support (LTS) Jenkins releases currently do not support OpenZFS-based
@@ -182,8 +182,8 @@ before updating, if needed.
 
 == Solaris, OmniOS, SmartOS, and other siblings
 
-Generally it should suffice to install Java 8 and link:/download[download] the
-`jenkins.war` and run it as a standalone process or under an application server
+Generally it should suffice to install a link:/doc/administration/requirements/java/[supported Java version], link:/download[download] the
+`jenkins.war`, and run it as a standalone process or under an application server
 such as link:https://tomcat.apache.org[Apache Tomcat].
 
 


### PR DESCRIPTION
## Refer to Java versions page for version info

Do not specify a Java version in the "Other Systems" page.

Fixes #4339
