### PR TITLE
Update some URL rewrites

### DIFF
--- a/docker/default.conf
+++ b/docker/default.conf
@@ -62,7 +62,7 @@ server {
 
   # permalinks
   # - this one is referenced from 1.395.1 "sign post" release
-  rewrite ^/why$            https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=53608972 permanent;
+  rewrite ^/why$            https://www.jenkins.io/ permanent;
   # baked in the help file to create account on Oracle for JDK downloads
   rewrite ^/oracleAccountSignup$    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
   # to the donation page

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -45,15 +45,15 @@ server {
   rewrite ^/debian/(.*) https://pkg.jenkins.io/debian/$1 permanent;
 
   # convenient short URLs
-  rewrite ^/issue/(.+)          https://issues.jenkins-ci.org/browse/JENKINS-$1 permanent;
+  rewrite ^/issue/(.+)          https://issues.jenkins.io/browse/JENKINS-$1 permanent;
   rewrite ^/commit/core/(.+)    https://github.com/jenkinsci/jenkins/commit/$1 permanent;
   rewrite ^/commit/(.+)/(.+)    https://github.com/jenkinsci/$1/commit/$2 permanent;
   rewrite ^/pull/(.+)/([0-9]+)  https://github.com/jenkinsci/$1/pull/$2 permanent;
 
   rewrite ^/maven-site/hudson-core /maven-site/jenkins-core permanent;
 
-  # https://issues.jenkins-ci.org/browse/INFRA-351
-  rewrite ^/maven-hpi-plugin(.*) http://jenkinsci.github.io/maven-hpi-plugin/$1 permanent;
+  # https://issues.jenkins.io/browse/INFRA-351
+  rewrite ^/maven-hpi-plugin(.*) https://jenkinsci.github.io/maven-hpi-plugin/$1 permanent;
 
   # Probably not needed but, rating code moved a while ago
   rewrite ^/rate/(.*) https://rating.jenkins.io/$1 permanent;

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -66,22 +66,22 @@ server {
   # baked in the help file to create account on Oracle for JDK downloads
   rewrite ^/oracleAccountSignup$    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
   # to the donation page
-  rewrite ^/donate$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+  rewrite ^/donate$        https://www.jenkins.io/donate/ permanent;
   # CLA links used in the CLA forms
-  rewrite ^/license$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
-  rewrite ^/licenses$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
+  rewrite ^/license$        https://www.jenkins.io/project/governance/#GovernanceDocument-cla permanent;
+  rewrite ^/licenses$        https://www.jenkins.io/project/governance/#GovernanceDocument-cla permanent;
   # used to advertise the project meeting
-  rewrite ^/meetings/$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda permanent;
+  rewrite ^/meetings/$        https://www.jenkins.io/project/governance-meeting/ permanent;
   # used from friends of Jenkins plugin to link to the thank you page
-  rewrite ^/friend$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+  rewrite ^/friend$        https://www.jenkins.io/donate/ permanent;
   # used by Gradle JPI plugin to include fragment
   rewrite ^/gradle-jpi-plugin/latest$    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install permanent;
   # used when encouraging people to subscribe to security advisories
-  rewrite ^/advisories$        https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories permanent;
+  rewrite ^/advisories$        https://www.jenkins.io/security/ permanent;
   # used in slides and handouts to refer to survey
   rewrite ^/survey$        http://s.zoomerang.com/s/JenkinsSurvey permanent;
   # used by RekeySecretAdminMonitor in Jenkins
-  rewrite ^/rekey$            https://wiki.jenkins-ci.org/display/SECURITY/Re-keying permanent;
+  rewrite ^/rekey$            https://www.jenkins.io/security/advisory/2013-01-04/re-keying/ permanent;
   # persistent Google hangout link
   rewrite ^/hangout$        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38 permanent;
   # .16.203.43 repo.jenkins-ci.org


### PR DESCRIPTION
## Update some URL rewrites

- Redirect to issues.jenkins.io, not issues.jenkins-ci.org
- Redirect /why to root of jenkins.io
- Avoid extra levels of redirection through wiki
