### PR TITLE
Fixed link to plugin POM releases

### DIFF
--- a/content/doc/developer/plugin-development/build-process.adoc
+++ b/content/doc/developer/plugin-development/build-process.adoc
@@ -17,7 +17,7 @@ It does the heavy lifting, such as bundling plugins in the HPI/JPI archive forma
 
 Since version 2.0 of the plugin POM, it's possible to specify the core version dependency of the parent POM independent of its version.footnote:1.x[Up to Jenkins 1.645, the plugin POM was kept in sync with Jenkins releases, so that the minimum required Jenkins version for a plugin determined the versions of the tools used to build the plugin. These versions should no longer be used.]
 This allows plugins compatible with older Jenkins releases to benefit from fixes and improvements in the parent POM.
-The link:https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md[plugin POM changelog] provides more details.
+The link:https://github.com/jenkinsci/plugin-pom/releases[plugin POM changelog] provides more details.
 
 == Keeping up to date
 


### PR DESCRIPTION
Fixed the link to the changelog, since it is moved to GitHub releases.