### PR TITLE
Match how 'active_href' checks the current URL

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -38,7 +38,7 @@ section: doc
           - site.handbook.chapters.each do |chapter|
             %li
               = active_href(File.join('doc/book', chapter.key), chapter.title, :fuzzy => true)
-              - if (chapter.key == chapter_key) && section_key
+              - if page.output_path.match(File.join('doc/book', chapter.key))
                 %small
                   %ul{:style => 'padding-left: 1rem;'}
                     - chapter.sections.each do |s|


### PR DESCRIPTION
This came up in #4357: The check in the handbook sidebar whether we're currently in a chapter makes assumptions about file hierarchy that aren't necessarily true. This makes it more flexible by using the same approach `active_href` is using (when fuzzy) to determine whether to mark a link as active.

Related to #4357 in that this is probably only effective on that PR's newly added page so far, and improves that PR's presentation, but they can be merged independently.

<details>

<summary>Screenshots</summary>

### Before

![Disable Access Control](https://user-images.githubusercontent.com/1831569/118325385-aacca600-b503-11eb-8b45-cb3988d48233.png)

### After

![Disable Access Control](https://user-images.githubusercontent.com/1831569/118325397-b15b1d80-b503-11eb-8c6a-2d035be8524e.png)

</details>