### PR TITLE
Document suspended plugins

### DIFF
--- a/content/security/plugins.adoc
+++ b/content/security/plugins.adoc
@@ -87,3 +87,4 @@ reviewboard - depends on perforce
 gcm-notification
 xltestview-plugin
 play-autotest-plugin
+////

--- a/content/security/plugins.adoc
+++ b/content/security/plugins.adoc
@@ -55,6 +55,7 @@ This typically is the case when plugins have particularly severe security vulner
 * Literate (`literate`): link:/security/advisory/2020-03-09/#SECURITY-1750[SECURITY-1750]
 * Nerrvana (`nerrvana`): link:/security/advisory/2020-10-08/#SECURITY-2097[SECURITY-2097]
 * Persona (`persona`): link:/security/advisory/2020-10-08/#SECURITY-2046[SECURITY-2046]
+* Pipeline: Classpath Step (`pipeline-classpath`): https://www.jenkins.io/security/advisory/2017-03-20/#pipeline-classpath-step-plugin-allowed-script-security-sandbox-bypass[SECURITY-336]
 * Puppet Enterprise Pipeline (`puppet-enterprise-pipeline`): link:/security/advisory/2019-10-16/#SECURITY-918[SECURITY-918]
 * Reactor (`reactor`): link:/security/advisory/2017-04-10/#reactor-plugin[SECURITY-487]
 * Script SCM (`scriptscm`): link:/security/advisory/2017-04-10/#script-scm-plugin[SECURITY-461]

--- a/content/security/plugins.adoc
+++ b/content/security/plugins.adoc
@@ -15,7 +15,7 @@ If they decline (or otherwise fail) to fix the vulnerability, or don't respond i
 
 . Publish a security advisory about the plugin, describing the nature of the vulnerability, but noting that there is no fix other than no longer using the plugin.
   If there are workarounds, explain them.
-. In some cases of high severity vulnerabilities, stop publishing the vulnerable plugin on the Jenkins update site.
+. In some cases of high severity vulnerabilities, link:#suspensions[stop publishing the vulnerable plugin on the Jenkins update sites].
 . Add metadata to the plugin site indicating vulnerable plugins to inform administrators who may already have the plugin installed.
 
 [[followup]]
@@ -31,3 +31,59 @@ We will update the security warnings metadata that is shown to administrators in
 Maintainers can inform us through Jira or email about a fix or https://github.com/jenkins-infra/update-center2/#security-warnings[file a pull request updating the warnings metadata] themselves.
 Once we confirm the fix is correct and complete, we will update the published warnings metadata.
 This will remove the active security warning from the plugin entry on the plugins site and from the plugin manager directly in Jenkins.
+
+[[suspensions]]
+== Suspended Plugins
+
+Distribution of the following plugins was suspended in conjunction with the publication of a security advisory announcing unresolved security issues.
+The Jenkins security team believes that most use cases would be negatively impacted by these security vulnerabilites and it is better for the Jenkins ecosystem to no longer distribute these plugins in their current form to prevent harm to users.
+This typically is the case when plugins have particularly severe security vulnerabilities, deliberately bypass or disable protection mechanisms, or offer little benefit to users anyway.
+
+* Adaptive DSL (`AdaptivePlugin`): link:/security/advisory/2017-04-10/#adaptive-dsl-plugin[SECURITY-457]
+* Build Flow (`build-flow-plugin`): link:/security/advisory/2017-04-10/#build-flow-plugin[SECURITY-293]
+* CAS protocol version 1 (`cas1`): link:/security/advisory/2017-04-10/#cas-protocol-version-1-plugin[SECURITY-491]
+* Copy To Slave (`copy-to-slave`): link:/security/advisory/2018-03-26/#SECURITY-545[SECURITY-545]
+* CryptoMove (`cryptomove`): link:/security/advisory/2020-03-09/#SECURITY-1635[SECURITY-1635]
+* CVS Tagging (`cvs-tag`): link:/security/advisory/2017-04-10/#cvs-tagging-plugin[SECURITY-459]
+* Dynamic Parameter (`dynamicparameter`): link:/security/advisory/2017-04-10/#dynamic-parameter-plugin[SECURITY-462]
+* ElasticBox Jenkins Kubernetes CI/CD (`kubernetes-ci`): link:/security/advisory/2020-07-02/#SECURITY-1738[SECURITY-1738]
+* Grails (`grails`): link:/security/advisory/2017-04-10/#grails-plugin[SECURITY-458]
+* GroovyAxis (`groovyaxis`): link:/security/advisory/2017-04-10/#groovyaxis-plugin[SECURITY-460]
+* JS Games (`jsgames`): link:/security/advisory/2020-09-01/#SECURITY-1905[SECURITY-1905]
+* Kubernetes :: Pipeline :: Arquillian Steps (`kubernetes-pipeline-arquillian-steps`): link:/security/advisory/2019-09-25/#SECURITY-920%20(2)[SECURITY-920 (2)]
+* Kubernetes :: Pipeline :: Kubernetes Steps (`kubernetes-pipeline-steps`): link:/security/advisory/2019-09-25/#SECURITY-920%20(1)[SECURITY-920 (1)]
+* Literate (`literate`): link:/security/advisory/2020-03-09/#SECURITY-1750[SECURITY-1750]
+* Nerrvana (`nerrvana`): link:/security/advisory/2020-10-08/#SECURITY-2097[SECURITY-2097]
+* Persona (`persona`): link:/security/advisory/2020-10-08/#SECURITY-2046[SECURITY-2046]
+* Puppet Enterprise Pipeline (`puppet-enterprise-pipeline`): link:/security/advisory/2019-10-16/#SECURITY-918[SECURITY-918]
+* Reactor (`reactor`): link:/security/advisory/2017-04-10/#reactor-plugin[SECURITY-487]
+* Script SCM (`scriptscm`): link:/security/advisory/2017-04-10/#script-scm-plugin[SECURITY-461]
+* `scripttrigger`: link:/security/advisory/2017-04-10/#scripttrigger-plugin[SECURITY-456]
+* Simple Travis Pipeline Runner (`simple-travis-runner`): link:/security/advisory/2019-08-07/#SECURITY-922[SECURITY-922]
+* Speaks! (`speaks`): link:/security/advisory/2017-10-11/#arbitrary-code-execution-vulnerability-in-speaks-plugin[SECURITY-623]
+* Subversion Tagging (`svn-tag`): link:/security/advisory/2017-04-10/#subversion-tagging-plugin[SECURITY-298]
+* `tcl`: link:/security/advisory/2017-04-10/#tcl-plugin[SECURITY-379]
+* ZAP Pipeline (`zap-pipeline`): link:/security/advisory/2020-07-02/#SECURITY-1811[SECURITY-1811]
+
+Unless the security issue is inherent to what the plugin does while not making this the sole _purpose_ of the plugin, the Jenkins security team welcomes efforts to fix the vulnerabilities and have plugin distribution restored.
+
+In addition to plugins suspended for security reasons, the following plugins that require suspended plugins to run are also suspended, as they would not be installable:
+
+* Build Automation Management Tool (`build-configurator`) depends on `copy-to-slave`
+* `build-flow-extensions-plugin` depends on `build-flow-plugin`
+* `build-flow-test-aggregator` depends on `build-flow-plugin`
+* `build-flow-toolbox-plugin` depends on `build-flow-plugin`
+* External Resource Dispatcher (`externalresource-dispatcher`) depends on `build-flow-plugin`
+* Kubernetes :: Pipeline :: Aggregator (`kubernetes-pipeline-aggregator`) depends on `kubernetes-pipeline-arquillian-steps` and `kubernetes-pipeline-steps`
+* `lsf-cloud` depends on `copy-to-slave`
+* SGE Cloud Plugin (`sge-cloud-plugin`) depends on `copy-to-slave`
+* XTrigger (`xtrigger`) depends on `scripttrigger`
+
+////
+These plugins are excluded from this page, as the security issue wasn't the reason for suspension, but only triggered it:
+azure-slave-plugin
+perforce
+reviewboard - depends on perforce
+gcm-notification
+xltestview-plugin
+play-autotest-plugin


### PR DESCRIPTION
As discussed with @zbynek in https://github.com/jenkins-infra/update-center2/pull/522 we needed a good reference for suspended plugins.

Review of content for completeness/correctness and whether the introduction makes sense would be very welcome here 🙏 

<details>
<summary>Screenshot</summary>

> ![Handling Vulnerabilities in Plugins](https://user-images.githubusercontent.com/1831569/118331468-00578180-b509-11eb-9dba-1ee72a29838b.png)

</details>