### PR TITLE
Sybversion -> Subversion in body text

### DIFF
--- a/content/security/advisory/2017-04-10.adoc
+++ b/content/security/advisory/2017-04-10.adoc
@@ -410,7 +410,7 @@ As of publication of this advisory, there is no fix.
 === Subversion Tagging Plugin
 *SECURITY-298*
 
-Sybversion Tagging Plugin allows specifying a Groovy `GString` expression to define the tag for the build.
+Subversion Tagging Plugin allows specifying a Groovy `GString` expression to define the tag for the build.
 This allows users with Job/Configure permission to run arbitrary Groovy code inside the Jenkins JVM, effectively elevating privileges to Overall/Run Scripts.
 
 This plugin also allowed users with Overall/Read access to Jenkins to invoke a form validation method that allowed them to run arbitrary Groovy code inside the Jenkins JVM, effectively elevating privileges to Overall/Run Scripts.


### PR DESCRIPTION
## Minor spelling fix

Minor spelling fix in security advisory.  Found while reviewing #4359
