### PR TITLE
Update JTE 2.0 to released on the roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -67,7 +67,7 @@ categories:
     initiatives:
     - name: Jenkins Templating Engine 2.0 
       description: "JTE enables the creation of tool-agnostic pipeline templates that can be shared across teams. Version 2.0 will have improved integration with the underlying pipeline engine and incorporate many of the community's top feature requests." 
-      status: current
+      status: released
       link: https://github.com/jenkinsci/templating-engine-plugin
       labels:
       - feature


### PR DESCRIPTION
Per @oleg-nenashev's comment in https://github.com/jenkins-infra/jenkins.io/pull/4372, updating the status to `released` for JTE 2.0