### PR TITLE
Remove unused CSS

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -504,90 +504,6 @@ body #sidebar ul.resources>li>a {
   font-weight: bold
 }
 
-#gutter-box {
-  position: relative;
-}
-
-.fixed>#gutter-peg {
-  position: fixed;
-  top: 3.5rem
-}
-
-#gutter {
-  position: absolute;
-  width: 3.25rem;
-  padding-left: .25rem;
-  top: 0;
-  bottom: 0;
-  font-size: 1rem;
-  text-align: right;
-  padding: 0;
-  box-shadow: inset -1px 0 3px #ddd;
-  border: 1px solid #ddd
-}
-
-#gutter #gutter-peg {
-  width: 2.60rem;
-  z-index: 2;
-  margin-left: .6rem
-}
-
-#gutter #gutter-peg>div {
-  background: #ddd;
-  border-top-left-radius: 5px;
-  border-bottom-left-radius: 5px;
-  margin: .5rem 0 .5rem .1rem;
-  text-align: center;
-  padding: .25rem
-}
-
-#gutter a {
-  display: block;
-  position: relative;
-  height: 1.75rem;
-  width: 1.75rem;
-  line-height: 1.75rem;
-  text-align: center;
-  background: #999;
-  background: #335061;
-  color: #fff;
-  border-radius: 50%;
-  margin: .25rem 0
-}
-
-#gutter a>div {
-  display: inline
-}
-
-#gutter .side-tab>.hover-text {
-  width: 0;
-  text-indent: .25rem;
-  line-height: 1.75rem;
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  color: #555;
-  display: block;
-  font-size: .75rem;
-  text-align: left;
-  left: 2.25rem;
-  background: #fff;
-  z-index: 3;
-  box-shadow: inset 0 0 0 1px #ccc, 0 1px 3px #ddd;
-  -webkit-transition: width .5s ease-out;
-  -moz-transition: width .5s ease-out;
-  -o-transition: width .5s ease-out;
-  transition: width .5s ease-out;
-}
-
-#gutter .side-tab:hover>.hover-text {
-  width: 7rem;
-}
-
-body .gutter {
-  padding-left: 3rem !important
-}
-
 body .ji-dated-list>.post {
   border-top: .1rem solid #ccc;
   margin-bottom: .5rem
@@ -1124,9 +1040,6 @@ z.f9f9f9.section .ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.
   box-shadow: none;
 }
 
-#gutter-box>#gutter {
-  display: none;
-}
 .brick-tops.footer {background:repeating-linear-gradient( 90deg, transparent, transparent 12px, #234 12px, #357 22px, #234 32px ); border-bottom:2px solid rgba(255,255,255,.1)}
 #ji-download .btn:hover .brick-tops{
  background: repeating-linear-gradient( 90deg, transparent, transparent 12px, #136 12px, #05a 22px, #136 32px );


### PR DESCRIPTION
* `gutter` class is used by plugins site, but is styled there. The `!important` style here makes it harder to style it properly.
* `gutter-box` and `gutter` IDs are unused and related styles can be safely removed