### PR TITLE
Update GSOC 2021 Conventional Commits Project Page

### DIFF
--- a/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
+++ b/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
@@ -16,9 +16,9 @@ mentors:
 - "olblak"
 - "dohbedoh"
 links:
-  chat: TODO
-  draft: TODO
-  idea: /projects/gsoc/2021/project-ideas/conventional-commits-plugin
+  gitter: "jenkinsci/conventional-commits-plugin"
+  draft: https://docs.google.com/document/d/1E0FdxdXP1JZb88-sDqmilmz2gJ0qp4BANCTLlXJOaTQ/edit#
+  idea: /projects/gsoc/2021/project-ideas/semantic-release-version
   meetings: "/projects/gsoc/2021/projects/conventional-commits-plugin/#office-hours"
 ---
 
@@ -56,6 +56,11 @@ This can be extended in the future to support other methods of determining the v
 === Office hours
 
 TODO
+
+=== Getting the Code
+
+The code for Conventional Commits Plugin can be found link:https://github.com/jenkinsci/conventional-commits-plugin/[here on Github].
+_Note: The project is under active development._ 
 
 === References
 


### PR DESCRIPTION
This patch updates the conventional commits project page with the following information:
- link to the gitter channel
- link to the proposal
- link to the project repository 
- link of the original project-idea



Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>