### PR TITLE
Update using-credentials.adoc

### DIFF
--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -138,8 +138,8 @@ image:../../../images/using/system_global_credentials.png[image,title="System_gl
     Certificate* fields.
 . In the *ID* field, specify a meaningful credential ID value - for example,
   `jenkins-user-for-xyz-artifact-repository`. The inbuilt (default) credentials provider
-  you can use upper- or lower-case letters for the credential ID, as well as any valid separator character, 
-  other Credential providers may apply furth restrictions on allowed characters or lengths.
+  can use upper- or lower-case letters for the credential ID, as well as any valid separator character, 
+  other credential providers may apply further restrictions on allowed characters or lengths.
   However, for the benefit of all users on your Jenkins instance, it is best to
   use a single and consistent convention for specifying credential IDs. +
   *Note:* This field is optional. If you do not specify its value, Jenkins

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -137,8 +137,9 @@ image:../../../images/using/system_global_credentials.png[image,title="System_gl
     details into the *Client Key*, *Client Certificate* and *Server CA
     Certificate* fields.
 . In the *ID* field, specify a meaningful credential ID value - for example,
-  `jenkins-user-for-xyz-artifact-repository`. You can use upper- or lower-case
-  letters for the credential ID, as well as any valid separator character.
+  `jenkins-user-for-xyz-artifact-repository`. The inbuilt (default) credentials provider
+  you can use upper- or lower-case letters for the credential ID, as well as any valid separator character, 
+  other Credential providers may apply furth restrictions on allowed characters or lengths.
   However, for the benefit of all users on your Jenkins instance, it is best to
   use a single and consistent convention for specifying credential IDs. +
   *Note:* This field is optional. If you do not specify its value, Jenkins


### PR DESCRIPTION
Not all credentials providers can use the same characters for credential IDs.