### PR TITLE
Migrate "launching agent from console" from wiki to docs site

### DIFF
--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -201,10 +201,10 @@ Finished: SUCCESS
 
 agent.jar is meant to be launched by Jenkins, typically through a remote
 shell like ssh/rsh. +
-Jenkins master then communicates with this slave through stdin and
+Jenkins controller then communicates with this agent through stdin and
 stdout.
 
-agent.jar is *not* meant to initiate a connection to the master on its
+agent.jar is *not* meant to initiate a connection to the controller on its
 own, so if you are trying to run +
 it from cron or as a service, you are misunderstanding how this works.
 
@@ -212,7 +212,7 @@ it from cron or as a service, you are misunderstanding how this works.
 % java -jar agent.jar
 WARNING: Are you running agent.jar from an interactive console?
 If so, you are probably using it incorrectly.
-See https://wiki.jenkins.io/display/JENKINS/Launching+agent+from+console
+See https://www.jenkins.io/doc/book/using/using-agents
 ....
 
 See

--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -196,3 +196,26 @@ Building remotely on agent1 in workspace /home/jenkins/workspace/First Job to Ag
 agent1
 Finished: SUCCESS
 ----
+
+=== Launching agent from console
+
+agent.jar is meant to be launched by Jenkins, typically through a remote
+shell like ssh/rsh. +
+Jenkins master then communicates with this slave through stdin and
+stdout.
+
+agent.jar is *not* meant to initiate a connection to the master on its
+own, so if you are trying to run +
+it from cron or as a service, you are misunderstanding how this works.
+
+....
+% java -jar agent.jar
+WARNING: Are you running agent.jar from an interactive console?
+If so, you are probably using it incorrectly.
+See https://wiki.jenkins.io/display/JENKINS/Launching+agent+from+console
+....
+
+See
+https://wiki.jenkins.io/display/JENKINS/Distributed+builds[Distributed
+builds] for more details.
+


### PR DESCRIPTION
This PR migrates the launching agent from console page to docs site

Fixes #3801 

Screenshot:
<img width="1279" alt="Screen Shot 2021-06-03 at 18 19 09" src="https://user-images.githubusercontent.com/37863089/120678580-89266500-c498-11eb-9904-5d8a663f4cc7.png">
