### PR TITLE
GSoC21 Remoting page: Add a new mentor and link

### DIFF
--- a/content/_data/authors/cyrille-leclerc.adoc
+++ b/content/_data/authors/cyrille-leclerc.adoc
@@ -1,0 +1,4 @@
+---
+name: Cyrille Le Clerc
+github: cyrille-leclerc
+---

--- a/content/projects/gsoc/2021/projects/remoting-monitoring.adoc
+++ b/content/projects/gsoc/2021/projects/remoting-monitoring.adoc
@@ -16,6 +16,7 @@ mentors:
 - "oleg_nenashev"
 - "darshank15"
 - "stellargo"
+- "cyrille-leclerc"
 links:
   chat: /projects/gsoc/2021/projects/remoting-monitoring/#chat
   draft: TODO
@@ -53,5 +54,6 @@ Office hours are scheduled each Thursday at 14:00 UTC, with regular link:https:/
 
 * Remoting library: https://github.com/jenkinsci/remoting
 * Remoting sub-project: https://jenkins.io/projects/remoting/
+* OpenTelemetry https://opentelemetry.io/
 * Prometheus: https://prometheus.io/
 * Grafana: https://grafana.com/


### PR DESCRIPTION
### Update GSoC2021 Remoting Monitoring project page with

- Welcome new mentor! @cyrille-leclerc 
- Link to OpenTelemetry

Target page
https://www.jenkins.io/projects/gsoc/2021/projects/remoting-monitoring/

@cyrille-leclerc 
I've created your page like [this](https://www.jenkins.io/blog/authors/aki-7/) with empty contents.
Please check it!