### PR TITLE
Also list plugins that was not served anymore already

### DIFF
--- a/content/blog/2021/06/2021-06-04-digester-removal.adoc
+++ b/content/blog/2021/06/2021-06-04-digester-removal.adoc
@@ -30,6 +30,11 @@ They will start to break with the weekly on the 7th of June, expected to be the 
 * link:https://plugins.jenkins.io/harvest[harvest]
 * link:https://plugins.jenkins.io/cmvc[cmvc]
 
+In addition to these still-served plugins, a few others will break.
+Note however that these were _already_ suspended footnote:[this means these plugins are not served anymore by the Jenkins Project's hosting service.
+Even if they were released, the releases would not show up until additional issues are fixed.] for various reasons, so we do recommend to move away from using them or step up as maintainers.
+The IDs for these plugins are: `tfs`, `svn-release-mgr`, `cpptest`, `cflint`, `script-scm`, `rtc`.
+
 [NOTE]
 ====
 It is always a good idea to update all your plugins _before_ upgrading Jenkins core.


### PR DESCRIPTION
Followup for the digester blog. I think listing also the plugins that were not served too will avoid people missing this... 