### PR TITLE
Fix DSL footnote

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -120,7 +120,7 @@ take advantage of the many features of Pipeline:
 * *Versatile*: Pipelines support complex real-world CD requirements, including
   the ability to fork/join, loop, and perform work in parallel.
 * *Extensible*: The Pipeline plugin supports custom extensions to its DSL
-  footnote:dsl:[] and multiple options for integration with other plugins.
+  footnote:dsl[] and multiple options for integration with other plugins.
 
 While Jenkins has always allowed rudimentary forms of chaining Freestyle Jobs
 together to perform sequential tasks,


### PR DESCRIPTION
Fix DSL footnote (reference to existing footnote) on [Pipeline](https://www.jenkins.io/doc/book/pipeline/#why) page.

![image](https://user-images.githubusercontent.com/34318921/121169045-e5e89d80-c853-11eb-963f-e83ee21bf486.png)
