### PR TITLE
Updating documentation to reflect jenkinsci/jenkins#5047.

### DIFF
--- a/content/doc/book/installing/other.adoc
+++ b/content/doc/book/installing/other.adoc
@@ -126,9 +126,6 @@ The common packaging integration for a standalone service will:
 * Create a `jenkins` user to run the service and to own the directory structures under `/var/lib/jenkins`.
 * Pull the Java package and other packages required to execute Jenkins, including
   the `jenkins-core-weekly` package with the latest `jenkins.war`.
-+
-CAUTION: Long-Term Support (LTS) Jenkins releases currently do not support OpenZFS-based
-systems, so no packaging is provided at this time.
 * Set up Jenkins as an SMF service instance (`svc:/network/http:jenkins`) which
   can then be enabled with the `svcadm` command demonstrated above.
 * Set up Jenkins to listen on port 8080.
@@ -194,29 +191,5 @@ Some caveats apply:
   link:https://wiki.jenkins.io/display/JENKINS/Jenkins+got+java.awt.headless+problem[issues
   running the headless JVM], because Jenkins needs some fonts to render certain
   pages.
-* ZFS-related JVM crashes: When Jenkins runs on a system detected as a `SunOS`,
-  it tries to load integration for advanced ZFS features using the bundled
-  `libzfs.jar` which maps calls from Java to native `libzfs.so` routines
-  provided by the host OS. Unfortunately, that library was made for binary
-  utilities built and bundled by the OS along with it at the same time, and was
-  never intended as a stable interface exposed to consumers. As the forks of
-  Solaris legacy, including ZFS and later the OpenZFS initiative evolved, many
-  different binary function signatures were provided by different host
-  operating systems - and when Jenkins `libzfs.jar` invoked the wrong
-  signature, the whole JVM process crashed. A solution was proposed and
-  integrated in `jenkins.war` since weekly release 2.55 (and not yet in any LTS
-  to date) which enables the administrator to configure which function
-  signatures should be used for each function known to have different variants,
-  apply it to their application server initialization options and then run and
-  update the generic `jenkins.war` without further workarounds. See
-  link:https://github.com/kohsuke/libzfs4j[the libzfs4j Git repository] for
-  more details, including a script to try and "lock-pick" the configuration
-  needed for your particular distribution (in particular if your kernel updates
-  bring a new incompatible `libzfs.so`).
-
-Also note that forks of the OpenZFS initiative may provide ZFS on various
-BSD, Linux, and macOS distributions. Once Jenkins supports detecting ZFS
-capabilities, rather than relying on the `SunOS` check, the above caveats for
-ZFS integration with Jenkins should be considered.
 
 include::doc/book/installing/_setup-wizard.adoc[]


### PR DESCRIPTION
ZFS support in Jenkins was ripped out in jenkinsci/jenkins#5047, so any references to the old `libzfs`-related workarounds in the documentation are no longer necessary and can be removed.