### PR TITLE
Update the 2.296 changelog to mark the Bytecode Compatibility Transfo…

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -11235,7 +11235,7 @@
     message: |-
       Developer: <code>View</code> is now a <code>DescriptorByNameOwner</code> allowing its use as <code>AncestorInPath</code>.
   - type: rfe
-    category: developer
+    category: rfe
     pull: 5526
     authors:
     - basil
@@ -11247,6 +11247,7 @@
     - url: "https://plugins.jenkins.io/slave-prerequisites/"
       title: Slave Prerequisites plugin
     message: |-
+      Remove the Bytecode Compatibility Transformer library and related code from Jenkins core.
       Developer:  Plugins that rely on the <code>hudson.model.Queue$Item#id</code> or <code>hudson.model.AbstractProject#triggers</code> fields must be updated to call the corresponding getters.
   - type: rfe
     category: developer


### PR DESCRIPTION
…rmer library as impacting end user.

Rational: reading the current changelog, end user would be under the assumption that the change is only impacting developers, while it has impacts on two plugins and has been marked as needing an lts upgrade guide.