### PR TITLE
Include Docker instructions for Windows

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -230,7 +230,33 @@ docker run --name jenkins-docker --rm --detach ^
   --volume jenkins-data:/var/jenkins_home ^
   docker:dind
 ----
-. Build a customised official Jenkins Docker image using above Dockerfile and `docker build` command.
+. Customise official Jenkins Docker image, by executing below two steps:
+.. Create Dockerfile with the following content:
++
+[source,subs="attributes+"]
+----
+FROM jenkins/jenkins:{jenkins-stable}-lts-jdk11
+USER root
+RUN apt-get update && apt-get install -y apt-transport-https \
+       ca-certificates curl gnupg2 \
+       software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN apt-key fingerprint 0EBFCD88
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       $(lsb_release -cs) stable"
+RUN apt-get update && apt-get install -y docker-ce-cli
+USER jenkins
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26"
+----
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
++
+[source,bash]
+----
+docker build -t myjenkins-blueocean:1.1 .
+----
+Keep in mind that the process described above will automatically download the official Jenkins Docker image
+if this hasn't been done before.
 
 . Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.6 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.6 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -225,7 +225,34 @@ docker run --name jenkins-docker --rm --detach ^
   --volume jenkins-data:/var/jenkins_home ^
   docker:dind
 ----
-. Build a customised official Jenkins Docker image using above Dockerfile and `docker build` command.
+. Customise official Jenkins Docker image, by executing below two steps:
+.. Create Dockerfile with the following content:
++
+[source,subs="attributes+"]
+----
+FROM jenkins/jenkins:{jenkins-stable}-lts-jdk11
+USER root
+RUN apt-get update && apt-get install -y apt-transport-https \
+       ca-certificates curl gnupg2 \
+       software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN apt-key fingerprint 0EBFCD88
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       $(lsb_release -cs) stable"
+RUN apt-get update && apt-get install -y docker-ce-cli
+USER jenkins
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26"
+----
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
++
+[source,bash]
+----
+docker build -t myjenkins-blueocean:1.1 .
+----
+Keep in mind that the process described above will automatically download the official Jenkins Docker image
+if this hasn't been done before.
+
 
 . Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]


### PR DESCRIPTION
## Include Docker instructions for Windows

Feedback from a reader noted that step 4 in the Windows instructions for Docker was relying on the reader to page backwards in the document to find step 4 in the Linux/macOS instructions.  That's unclear to readers and makes the experience difficult.

Better to include the content directly in the text so that the user consistently scrolls through the instructions rather than needing to backtrack into a section for a platform that may not be interesting to them.

Same change has been made in the Docker tutorials.  I confirmed that the instructions work on my Windows 10 computer running the latest Docker Desktop for Windows.
