### PR TITLE
Responsive layout for download template

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -5,7 +5,8 @@ h3[id]:before,
 h4[id]:before,
 h5[id]:before,
 h6[id]:before,
-dt[id]:before {
+dt[id]:before,
+.artifact-list li:before {
   display: block;
   content: " ";
 

--- a/content/templates/downloads.html.haml
+++ b/content/templates/downloads.html.haml
@@ -15,9 +15,7 @@ uneditable: true
   .artifact-list li {
     list-style: none;
     margin-bottom: .5rem;
-    display: flex;
     align-items: center;
-    flex-wrap: wrap;
   }
   .artifact-list .version {
     background-image: url(https://www.jenkins.io/images/jar.png);
@@ -31,6 +29,20 @@ uneditable: true
   }
   .subtitle {
     color: #999;
+  }
+
+  @media (min-width: 768px) {
+    .artifact-list {
+      display: table;
+    }
+    .artifact-list li {
+      display: table-row;
+    }
+    .version {
+      display: table-cell;
+      padding-left: 2rem;
+      vertical-align: middle;
+    }
   }
 
 .container


### PR DESCRIPTION
Follow-up for https://github.com/jenkins-infra/update-center2/pull/469#issuecomment-860071693 (same style change as in UC repo, just a different breakpoint) + add `:before` element to artifacts to compensate for fixed header when linking to a specific version via location hash.

CC @daniel-beck 