### PR TITLE
Support for embedding Discourse topics in blogposts and project pages

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -42,3 +42,5 @@ layout: default
           About the Authors
         - page.authors.each do |author|
           = partial("author.html.haml", :author => author)
+
+      = partial('discuss.html.haml', :links => page.links)

--- a/content/_layouts/project.html.haml
+++ b/content/_layouts/project.html.haml
@@ -25,6 +25,7 @@ layout: default
         = page.title
       = content
 
+      = partial('discuss.html.haml', :links => page.links)
 
     .col-lg-3
       .sidebar-nav

--- a/content/_partials/discuss.html.haml
+++ b/content/_partials/discuss.html.haml
@@ -1,0 +1,16 @@
+
+- if page.links && page.links.discourse
+  // Support both topic IDs and full URLs
+  // TODO: Check number validity
+  - discourseTopicId = page.links.discourse.gsub(/\/\s*$/, '').gsub(/.*\//, '')
+  %b.title
+    Discuss
+  %div{:id => 'discourse-comments'}
+    :javascript
+        window.DiscourseEmbed = { discourseUrl: 'https://community.jenkins.io/',
+                                  topicId: "#{discourseTopicId}" };
+        (function() {
+            var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+            d.src = window.DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+        })();

--- a/content/blog/2021/06/2021-06-10-jenkins-is-the-way-ebook-2.adoc
+++ b/content/blog/2021/06/2021-06-10-jenkins-is-the-way-ebook-2.adoc
@@ -13,6 +13,8 @@ description: >
   The book is sponsored by CloudBees.
 opengraph:
   image: /images/post-images/jenkins-is-the-way/ebook/ebook2_opengraph.png
+links:
+  discourse: https://community.jenkins.io/t/new-ebook-jenkins-is-the-way-for-it-and-software-developers/136
 ---
 
 image:/images/post-images/jenkins-is-the-way/ebook/ebook2_front.png["Jenkins Is The Way. User Stories IT-eBook",role=right,width=300]

--- a/content/events/contributor-summit/index.adoc
+++ b/content/events/contributor-summit/index.adoc
@@ -8,6 +8,7 @@ tags:
   - events
 links:
   gitter: jenkinsci/jenkins
+  discourse: https://community.jenkins.io/t/jenkins-contributor-summit-on-june-25-2021-call-for-topics-and-ideas/46
 opengraph:
   image: /images/conferences/contributor_summit.png
 description: >

--- a/content/projects/gsoc/2021/projects/remoting-monitoring.adoc
+++ b/content/projects/gsoc/2021/projects/remoting-monitoring.adoc
@@ -22,6 +22,7 @@ links:
   draft: TODO
   idea: /projects/gsoc/2021/project-ideas/remoting-monitoring
   meetings: "/projects/gsoc/2021/projects/remoting-monitoring/#office-hours"
+  discourse: https://community.jenkins.io/t/gsoc21-remoting-monitoring-end-user-survey/118
 ---
 
 In Jenkins, we have a remoting module, which implements a communication layer in the Jenkins automation server.


### PR DESCRIPTION
This change allows embedding Discourse discussions. This approach does not auto-create stories, but nstead embeds the existing threads which should be created by users. See the discussion with @halkeye in https://community.jenkins.io/t/category-for-blogs-books-discussions/111/6

The implementation uses standard styling at the moment

## Jenkins Event Page (downstream of project)

![image](https://user-images.githubusercontent.com/3000480/122308732-38d5eb00-cf0d-11eb-9819-547fcd07112f.png)

## GSoC page (downstream of project)

![image](https://user-images.githubusercontent.com/3000480/122309389-7f781500-cf0e-11eb-9309-3d11a5cfbc23.png)


## Blog example - TODO

![image](https://user-images.githubusercontent.com/3000480/122309180-1a242400-cf0e-11eb-81cd-ae0e6404da93.png)

