### PR TITLE
Add agent tutorial videos to agent docs

### DIFF
--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -14,45 +14,53 @@ endif::[]
 
 = Managing Nodes
 
-=== Monitor and Restart Offline Agents
+== Creating Agents
+
+Jenkins agents are the "workers" that perform operations requested by the Jenkins controller.
+The Jenkins controller administers the agents and can manage the tooling on the agents.
+Jenkins agents may be statically allocated or they can be dynamically allocated through systems like Kubernetes, OpenShift, Amazon EC2, Azure, Google Cloud, IBM Cloud, Oracle Cloud, andd other cloud providers.
+
+This 30 minute tutorial from Darin Pope creates a Jenkins agent and connects it to a controller.
+
+.How to create an agent node in Jenkins
+video::99DddJiH7lM[youtube, width=640, height=360]
+
+== Monitor and Restart Offline Agents
 
 This script can monitor and restart offline nodes if they are not disconnected manually.
 It can be executed in the Jenkins Script Console or can run periodically as a Jenkins job with the plugin:groovy[Groovy plugin].
 
 Also see link:https://wiki.jenkins-ci.org/display/JENKINS/Display+Information+About+Nodes[Display Information About Nodes]
 
-
 [source,groovy]
 ----
 import hudson.node_monitors.*
 import hudson.slaves.*
 import java.util.concurrent.*
- 
+
 jenkins = Jenkins.instance
- 
+
 import javax.mail.internet.*;
 import javax.mail.*
 import javax.activation.*
- 
- 
+
 def sendMail (agent, cause) {
-   
+
  message = agent + " agent is down. Check http://JENKINS_HOSTNAME:JENKINS_PORT/computer/" + agent + "\nBecause " + cause
  subject = agent + " agent is offline"
  toAddress = "JENKINS_ADMIN@YOUR_DOMAIN"
  fromAddress = "JENKINS@YOUR_DOMAIN"
  host = "SMTP_SERVER"
  port = "SMTP_PORT"
- 
+
  Properties mprops = new Properties();
  mprops.setProperty("mail.transport.protocol","smtp");
  mprops.setProperty("mail.host",host);
  mprops.setProperty("mail.smtp.port",port);
- 
+
  Session lSession = Session.getDefaultInstance(mprops,null);
  MimeMessage msg = new MimeMessage(lSession);
- 
- 
+
  //tokenize out the recipients in case they came in as a list
  StringTokenizer tok = new StringTokenizer(toAddress,";");
  ArrayList emailTos = new ArrayList();
@@ -67,12 +75,11 @@ def sendMail (agent, cause) {
  msg.setFrom(new InternetAddress(fromAddress));
  msg.setSubject(subject);
  msg.setText(message)
- 
+
  Transport transporter = lSession.getTransport("smtp");
  transporter.connect();
  transporter.send(msg);
 }
-
 
 def getEnviron(computer) {
    def env

--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -23,6 +23,10 @@ The Jenkins controller administers the Jenkins agents and orchestrates their wor
 Agents may be connected to the Jenkins controller using either local or cloud computers.
 
 The agents require a Java installation and a network connection to the Jenkins controller.
+View the 3 minute video below for a brief explanation of Jenkins agents.
+
+.What is a Jenkins Agent
+video::4KghHJEz5no[youtube, width=640, height=360]
 
 == Configuring agents with Docker
 


### PR DESCRIPTION
## Add agent tutorial videos

@darinPope has been creating video segments on various Jenkins capabilities.  He's granted us permission to use his videos on the www.jenkins.io site.

- Add tutorial video on agent creation
- Include 'What is a Jenkins Agent?' video

Pages look like this:

## Using Agents

![screencapture-mark-pc2-markwaite-net-4242-doc-book-using-using-agents-2021-06-17-13_02_38-edit](https://user-images.githubusercontent.com/156685/122457876-61d99880-cf6c-11eb-83fd-4c072ae71ad4.png)

## Managing Nodes

![screencapture-mark-pc2-markwaite-net-4242-doc-book-managing-nodes-2021-06-17-13_03_47-edit](https://user-images.githubusercontent.com/156685/122457992-8897cf00-cf6c-11eb-85a6-15a2d1bf429e.png)
