### PR TITLE
Reference Terminology Cleanup project in the Advocacy&Outreach SIG

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -189,17 +189,6 @@ categories:
       link: https://issues.jenkins.io/browse/INFRA-2328
       labels:
       - documentation
-    - name: Agent terminology cleanup
-      description: > 
-        In Jenkins 2.0 we deprecated the "slave" terminology and mandated usage of the "agent" or "node" terms instead.
-        There are still leftover occurrences in documentation, Web UI, localizations and API.
-        We want to clean them up.
-      status: current
-      link: https://issues.jenkins.io/browse/JENKINS-42816
-      labels:
-      - documentation
-      - feature
-      - policies
     - name: Add site search
       description: Add site search to www.jenkins.io and plugins.jenkins.io
       status: released
@@ -253,12 +242,16 @@ categories:
       link: https://issues.jenkins.io/browse/INFRA-2516
       labels:
       - infrastructure
-    - name: Inappropriate terminology deprecation and updates
+    - name: Non-inclusive terminology cleanup
       description: >
-        We would like to deprecate and replace the inappropriate "master", "whitelist" and "blacklist" terms.
+        In 2016, the Jenkins community decided to change the non-inclusive terminology within the project.
+        The “slave” term was deprecated and replaced by “agent” in Jenkins 2.0.
+        In July 2020 we also adopted the “controller” term instead of “master”, and deprecated the “whitelist/blacklist” terms.
+        There are many places where the old terminology still needs to be replaced.
+        We want to replace the deprecated terminology by new terms: “controller”, “agent”, “allowlist”, “denylist”, and “main” for branch names.
         Scope: documentation, Web UI, localizations, API, etc.
       status: current
-      link: https://groups.google.com/forum/#!topic/jenkinsci-dev/CLR55wMZwZ8
+      link: https://www.jenkins.io/sigs/advocacy-and-outreach/#inclusive-naming
       labels:
       - documentation
       - feature

--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -142,19 +142,16 @@ a| The plugin site is used to find information about 1700+ plugins available in 
   link:https://github.com/jenkinsci/tekton-client-plugin/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues],
   link:https://github.com/jenkinsci/tekton-client-plugin/issues[All open issues]
 
-| Terminology cleanup
-| Java, Web UI, Asciidoc, Markdown, Java
+| Non-inclusive Terminology cleanup
+| Java, Documentation, Web UI, Asciidoc, Markdown, Localization
 a| In 2016, the Jenkins community started changing the potentially offensive terminology within the project.
   The "slave" term was deprecated and replaced by "agent".
   In July 2020 we also link:https://cd.foundation/blog/2020/08/25/jenkins-terminology-changes/[adopted] the "controller" term instead of "master", and deprecated the "whitelist/blacklist" terms.
   There are many places where the old terminology still needs to be replaced.
+  We invite contributors to join us and participate in cleaning up Jenkins documentation, Web and CLI interfaces, localizations, and the codebase:
 
-We invite contributors to join us and participate in cleaning up Jenkins documentation,
-Web and CLI interfaces, and the codebase:
-
-  * jira:JENKINS-42816[] - Agent terminology cleanup - open issues and contributor guidelines
-  * Guidelines in the issue above can be also used for other terms
-
+  * link:https://community.jenkins.io/t/jenkins-terminology-cleanup-initiative-coordination/180[Contributing guidelines and newcomer issue links] 
+  * link:/sigs/advocacy-and-outreach/#inclusive-namingg[Inclusive naming project by Jenkins Advocacy&Outreach SIG]
 
 | link:/artwork[Jenkins Artwork]
 | Design

--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -80,6 +80,29 @@ including but not limited to link:https://twitter.com/jenkinsci[Twitter], link:h
 If you would like to share any content about Jenkins on these platforms,
 please contact us and we will try to help.
 
+=== Inclusive naming
+
+The SIG coordinates adoption of inclusive naming in Jenkins,
+including the cleanup of former non-inclusive terms and growing awareness among end users and content creators.
+In 2016, the Jenkins community decided to change the non-inclusive terminology within the project.
+The “slave” term was deprecated and replaced by “agent” in Jenkins 2.0.
+In July 2020 we also adopted the “controller” term instead of “master”, and deprecated the “whitelist/blacklist” terms. 
+
+There are many places where the old terminology still needs to be replaced.
+We invite Jenkins contributors and end users to join us and participate in cleaning up 
+our documentation, Web and CLI interfaces, localizations, codebase, and all other occurrences.
+We want to replace the deprecated terminology by new terms: “controller”, “agent”, “allowlist”, “denylist”, and “main” for branch names.
+We also encourage everyone to spread the word about new terminology inside their companies and communities,
+and to reach out to content creators to facilitate cleanup of old terminology.
+
+References:
+
+* link:https://community.jenkins.io/t/jenkins-terminology-cleanup-initiative-coordination/180[Contributing to the initiative and discussion] - 
+  contributing guidelines and issue links are there
+* link:https://cd.foundation/blog/2020/08/25/jenkins-terminology-changes/[Jenkins Terminology Updates] by link:/blog/authors/slide_o_mix[Alex Earl], CDF Blog, August 2021
+* link:https://inclusivenaming.org/[Inclusive Naming Initiative] - global initiative focused on 
+  helping projects and companies make consistent, responsible choices to remove harmful language.
+
 == Meetings
 
 * Schedule: one meeting every 2 weeks, usually on Thursdays. See the link:/event-calendar/[Event Calendar] for the schedule


### PR DESCRIPTION
This change updates the terminology cleanup initiative.

- [x] Officially reference "Inclusive Naming" from the Advocacy&Outreach SIG which has been an umbrella SIG for this effort. Originally @markyjackson-taulia and @slide were going to add the item last summer, so just closing the old action item. I expanded the scope to Inclusive Naming, because it goes beyond just cleaning up the terminology. It is also about spreading word and reaching out to content creators. This is pretty aligned with what the SIG is doing
- [x] Reference https://community.jenkins.io/t/jenkins-terminology-cleanup-initiative-coordination/180 that aggregates all the info and contributor guidelines for the initiative
- [x] Update roadmap to have only one initiative and to reference the new locations. "master" to "main" renaming of GitHub branches might be a separate initiative though
- [x] Update the Hacktoberfest page so that it keeps actual info and does not confuse people   