### PR TITLE
Revert "Work around 2021-06-30 Artifactory issues (#4448)"

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -94,7 +94,7 @@ title: Jenkins download and deployment
               Generic Java package (.war)
               %div{:style => 'font-size: x-small;'}
                 SHA-256:
-                = open('https://repo.jenkins-ci.org/releases-20210630/org/jenkins-ci/main/jenkins-war/' + site.jenkins.stable + '/jenkins-war-' + site.jenkins.stable + '.war.sha256').read()
+                = open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.stable + '/jenkins-war-' + site.jenkins.stable + '.war.sha256').read()
           %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins'}
             %span.icon
             %span.title
@@ -153,7 +153,7 @@ title: Jenkins download and deployment
             Generic Java package (.war)
             %div{:style => 'font-size: x-small;'}
               SHA-256:
-              = open('https://repo.jenkins-ci.org/releases-20210630/org/jenkins-ci/main/jenkins-war/' + site.jenkins.latest + '/jenkins-war-' + site.jenkins.latest + '.war.sha256').read()
+              = open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.latest + '/jenkins-war-' + site.jenkins.latest + '.war.sha256').read()
         %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins/'}
           %span.icon
           %span.title


### PR DESCRIPTION
This reverts the workaround from #4448.

**DO NOT MERGE** until 2.300 and 2.289.2 are in `releases` (or no longer the newest releases 😅 ).