### PR TITLE
Marking `hudson.ClassicPluginStrategy.noBytecodeTransformer` as obsolete

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -54,11 +54,13 @@ properties:
 - name: hudson.ClassicPluginStrategy.noBytecodeTransformer
   tags:
   - escape hatch
+  - obsolete
   def: |
     `false`
   since: 1.538 # https://github.com/jenkinsci/jenkins/commit/f98c4627da3c21e37aff82c75c0ef7240e60b4da
   description: |
     Disable the bytecode transformer that retains compatibility at runtime after changing public Java APIs.
+    Has no effect since 2.296, as the bytecode transformer has been removed.
 
 - name: hudson.ClassicPluginStrategy.useAntClassLoader
   tags:


### PR DESCRIPTION
Obsoleted in jenkinsci/jenkins#5526.