### PR TITLE
Marking `hudson.util.Digester2.UNSAFE` as obsolete

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1170,6 +1170,7 @@ properties:
   tags:
   - security
   - escape hatch
+  - obsolete
   def: |
     `false`
   since: 2.263.2 / 2.275
@@ -1177,6 +1178,7 @@ properties:
     Opts out of a change in default behavior that disables the processing of XML external entities (XXE) for the `Digester2` class in Jenkins if set to `true`.
     This system property can be changed while Jenkins is running and the change is effective immediately.
     See link:/doc/upgrade-guide/2.263/#digester2[2.263.2 upgrade guide].
+    Has no effect since 2.297, as the `Digester2` class has been removed.
 
 - name: hudson.util.FormValidation.applyContentSecurityPolicyHeaders
   tags:


### PR DESCRIPTION
Obsoleted in jenkinsci/jenkins#5320.