### PR TITLE
Remove superflous `a`

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -343,7 +343,7 @@ describes the steps to be run in this `stage`.
 <5> `sh` is a Pipeline link:syntax#steps[step] (provided by the
 plugin:workflow-durable-task-step[Pipeline: Nodes and Processes plugin]) that
 executes the given shell command.
-<6> `junit` is another a Pipeline link:syntax#steps[step] (provided by the
+<6> `junit` is another Pipeline link:syntax#steps[step] (provided by the
 plugin:junit[JUnit plugin]) for aggregating test reports.
 <7> `node` is Scripted Pipeline-specific syntax that instructs Jenkins to
 execute this Pipeline (and any stages contained within it), on any available


### PR DESCRIPTION
I am not a native speaker, but I am pretty confident, that the `a` is wrong/not needed there :)