### PR TITLE
Remove OpenJ9 JVM support from roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -474,12 +474,6 @@ categories:
       link: https://issues.jenkins.io/browse/JENKINS-61774
       labels:
       - feature
-    - name: OpenJ9 Docker images
-      status: current
-      description: We would like to provide official images based on OpenJ9 JVM
-      link: https://issues.jenkins.io/browse/JENKINS-62150
-      labels:
-      - feature
     - name: Docker images for ARM 64
       status: near-term
       description: Docker image support for ARM 64 running Java 8 and Java 11

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -104,7 +104,6 @@ Scope of interest:
 
 * Maintaining Java 11 support in Jenkins and driving its adoption
 * Migration to link:https://adoptopenjdk.net/[AdoptOpenJDK] in Docker images
-* Docker images based on the OpenJ9 JVM
 * Support for future mainstream JVM versions (Java 14+)
 * Support for perspective virtual machines like link:https://www.graalvm.org/[GraalVM] or link:https://quarkus.io/[Quarkus], including native executable packaging
 


### PR DESCRIPTION
The hotspot JVM is available for JDK 11 on all the platforms currently of interest to the Jenkins Platform SIG.  It is available for:

* AMD64/Intel64
* Arm64
* PowerPC64
* s390x

The prototype OpenJ9 image generation has been removed from the Jenkins Docker images.  Work is now proceeding to create multi-architecture Docker images using `docker bake`.

See https://github.com/jenkinsci/docker/pull/1134 for details.

No further progress is expected on support of the OpenJ9 virtual machine in the Jenkins project.  Let's remove the entry from the roadmap.
