### PR TITLE
Use extension 0.9.0 for Stapler javadoc URL creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'colorize'
 gem 'awestruct', '~> 0.6.1'
 gem 'awestruct-ibeams', '~> 0.4'
 gem 'asciidoctor', '~> 2.0.0'
-gem 'asciidoctor-jenkins-extensions', '~> 0.8.0'
+gem 'asciidoctor-jenkins-extensions', '~> 0.9.0'
 
 # Support for various template engines we use
 gem 'haml', '~> 5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ansi (1.5.0)
     asciidoctor (2.0.10)
-    asciidoctor-jenkins-extensions (0.8.0)
+    asciidoctor-jenkins-extensions (0.9.0)
       asciidoctor (>= 1.5.5)
       coderay (~> 1.1.1)
       colorize (~> 0.8.1)
@@ -124,7 +124,7 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor (~> 2.0.0)
-  asciidoctor-jenkins-extensions (~> 0.8.0)
+  asciidoctor-jenkins-extensions (~> 0.9.0)
   awestruct (~> 0.6.1)
   awestruct-ibeams (~> 0.4)
   colorize

--- a/content/blog/2015/2015-09-19-office-hour-on-form-handling-in-jenkins.md
+++ b/content/blog/2015/2015-09-19-office-hour-on-form-handling-in-jenkins.md
@@ -10,7 +10,7 @@
 ---
 **Update: This week's office hour has been canceled.**
 
-[This Wednesday, Sep 23, at 11 am PDT](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Office+Hours&iso=20150923T11&p1=283&ah=1) I will host another office hour on [Stapler](https://stapler.kohsuke.org/), the web framework used in Jenkins. This time, I'll show you how structured form submission in Jenkins works, and how Stapler can help you with it.
+[This Wednesday, Sep 23, at 11 am PDT](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Office+Hours&iso=20150923T11&p1=283&ah=1) I will host another office hour on [Stapler](https://github.com/stapler/), the web framework used in Jenkins. This time, I'll show you how structured form submission in Jenkins works, and how Stapler can help you with it.
 
 As usual, the office hour will use Hangout on Air, and a limited number of people will be able to join and participate. The others will be able to watch the office hour live on YouTube. [Links to participate and watch will be posted before the event on the Office Hours wiki page](https://wiki.jenkins.io/display/JENKINS/Office+Hours).
 

--- a/content/blog/2016/2016-09-20-jom-plugin-development.adoc
+++ b/content/blog/2016/2016-09-20-jom-plugin-development.adoc
@@ -22,7 +22,7 @@ In the first part of his talk, Daniel presented how Stapler, the web framework u
 In the second part he was talking about creating new views using Jelly and Groovy, and how to add new content to existing views.
 
 *Keywords:*
-link:https://stapler.kohsuke.org/[Stapler],
+link:https://github.com/stapler/[Stapler],
 Jelly,
 Groovy-defined UIs
 

--- a/content/blog/2019/08/2019-08-23-introduce-react-plugin-template.adoc
+++ b/content/blog/2019/08/2019-08-23-introduce-react-plugin-template.adoc
@@ -95,7 +95,7 @@ if (crumbHeaderName) {
 
 Now you can customize your request pattern as you want, also we need to write a handler.
 
-Jenkins is using stapler to preprocess the requests, so if you need a request handler. For example and also in this template, you can use an `Action` class to create a sub-url, and then a `StaplerProxy` to proxy the request like a router. More info about a handler can be found here link:http://stapler.kohsuke.org/reference.html[Stapler Reference].
+Jenkins is using stapler to preprocess the requests, so if you need a request handler. For example and also in this template, you can use an `Action` class to create a sub-url, and then a `StaplerProxy` to proxy the request like a router. More info about handlers can be found in the link:https://github.com/stapler/stapler/blob/master/README.md[Stapler Reference].
 
 === Example handler
 

--- a/content/blog/2020/03/2020-03-17-ui-plugins.adoc
+++ b/content/blog/2020/03/2020-03-17-ui-plugins.adoc
@@ -542,7 +542,7 @@ image::forensics-view-model.png[Forensics view model]
 As already described in <<jenkins-reporter-model>> the plugin needs to attach a `BuildAction` to each build. The
 Forensics plugin attaches a `ForensicBuildAction` to the build. This action stores a `RepositoryStatistics` instance,
 that contains the repository results for a given build. This action delegates all Stapler requests to a new
-https://stapler.kohsuke.org/apidocs/org/kohsuke/stapler/StaplerProxy.html[Stapler proxy instance] so we can keep the
+link:https://javadoc.jenkins.io/component/stapler/org/kohsuke/stapler/StaplerProxy.html[Stapler proxy instance] so we can keep the
 action clean of user interface code. This `ForensicsViewModel` class then acts as view model that provides the server
 side model for the corresponding Jelly view given by the file `index.jelly`.
 

--- a/content/blog/2020/03/2020-03-17-ui-plugins.adoc
+++ b/content/blog/2020/03/2020-03-17-ui-plugins.adoc
@@ -542,7 +542,7 @@ image::forensics-view-model.png[Forensics view model]
 As already described in <<jenkins-reporter-model>> the plugin needs to attach a `BuildAction` to each build. The
 Forensics plugin attaches a `ForensicBuildAction` to the build. This action stores a `RepositoryStatistics` instance,
 that contains the repository results for a given build. This action delegates all Stapler requests to a new
-link:https://javadoc.jenkins.io/component/stapler/org/kohsuke/stapler/StaplerProxy.html[Stapler proxy instance] so we can keep the
+staplerdoc:org.kohsuke.stapler.StaplerProxy[Stapler proxy instance] so we can keep the
 action clean of user interface code. This `ForensicsViewModel` class then acts as view model that provides the server
 side model for the corresponding Jelly view given by the file `index.jelly`.
 

--- a/content/doc/book/using/referencing-another-project-by-name.adoc
+++ b/content/doc/book/using/referencing-another-project-by-name.adoc
@@ -122,4 +122,4 @@ mymultibranchproject/feature%2Fmyfeature
 
 == For developers of Jenkins and Jenkins Plugins
 
-See the https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getItem-java.lang.String-hudson.model.ItemGroup-[`+Jenkins::getItem()+`] function.
+See the https://javadoc.jenkins.io/jenkins/model/Jenkins.html#getItem-java.lang.String-hudson.model.ItemGroup-[`+Jenkins::getItem()+`] function.

--- a/content/doc/developer/architecture/web.adoc
+++ b/content/doc/developer/architecture/web.adoc
@@ -6,7 +6,7 @@ summary: How Jenkins uses the Stapler framework
 
 == Request Handling
 
-Jenkins classes are bound to URLs by using https://stapler.kohsuke.org[Stapler].
+Jenkins classes are bound to URLs by using https://github.com/stapler[Stapler].
 The singleton `jenkinsdoc:Jenkins[]` instance is bound to the context root (most of the time "/") URL, and the rest of the objects are bound according to their reachability from this root object.
 Stapler uses reflection to recursively determine how to process any given URL.
 A few examples of how the URL `/foo/bar` could be processed:

--- a/content/doc/developer/development-environment/taglibs.adoc
+++ b/content/doc/developer/development-environment/taglibs.adoc
@@ -6,5 +6,5 @@ title: Taglibs
 Documentation for jelly tag libraries is published in the following places:
 
 - link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html[Core]
-- link:https://stapler.kohsuke.org/jelly-taglib-ref.html[Stapler]
+- link:https://github.com/stapler/stapler/blob/master/docs/jelly-taglib-ref.adoc[Stapler]
 - link:https://commons.apache.org/proper/commons-jelly/tags.html[Jelly Core]

--- a/content/doc/developer/handling-requests/index.adoc
+++ b/content/doc/developer/handling-requests/index.adoc
@@ -4,6 +4,6 @@ summary: Explains how Jenkins routes HTTP requests, and what ways to respond exi
 layout: developerchapter
 references:
 - title: Stapler Reference Documentation
-  url: https://stapler.kohsuke.org/reference.html
+  url: https://github.com/stapler/stapler/blob/master/README.md
 wip: true
 ---

--- a/content/doc/developer/handling-requests/responses.adoc
+++ b/content/doc/developer/handling-requests/responses.adoc
@@ -6,6 +6,6 @@ wip: true
 references:
 - url: https://javadoc.jenkins.io/hudson/util/HttpResponses.html
   title: HttpResponses Javadoc
-- url: https://stapler.kohsuke.org/apidocs/org/kohsuke/stapler/interceptor/RespondSuccess.html
+- url: https://javadoc.jenkins.io/component/stapler/org/kohsuke/stapler/interceptor/RespondSuccess.html
   title: RespondSuccess Javadoc
 ---

--- a/content/doc/developer/handling-requests/routing.adoc
+++ b/content/doc/developer/handling-requests/routing.adoc
@@ -3,7 +3,7 @@ title: Routing Requests
 summary: How requests in Jenkins are routed to the objects ultimately responding to them
 layout: developersection
 references:
-- url: https://stapler.kohsuke.org/reference.html
+- url: https://github.com/stapler/stapler/blob/master/docs/reference.adoc
   title: Stapler URL Binding Reference
 - title: Figuring out URL binding in Stapler
   url: https://wiki.jenkins.io/display/JENKINS/Figuring+out+URL+binding+of+Stapler
@@ -35,7 +35,7 @@ Additionally, objects can implement several interfaces to further control how St
   If the designated override objects do not have a handler for the request, the host object (that implements `StaplerOverridable`) will handle the request.
 * `staplerdoc:org.kohsuke.stapler.StaplerFallback[]` allows delegating the processing of a URL to another object, similar to `StaplerProxy`, but has the *lowest priority* among all possible URL processing options.
 
-For more information on how Stapler binds (or staples) a Java Object Model to a URL hierarchy, see the link:https://stapler.kohsuke.org/reference.html[Stapler Reference Documentation].
+For more information on how Stapler binds (or staples) a Java Object Model to a URL hierarchy, see the link:https://github.com/stapler/stapler/blob/master/README.md[Stapler Reference Documentation].
 
 NOTE: Since Jenkins 2.138.4 and 2.154, Jenkins places restrictions not inherent to Stapler on which methods and fields are eligible for routing.
 link:../stapler-accessible-type/[Learn more]

--- a/content/doc/developer/internationalization/i18n-jelly-views.adoc
+++ b/content/doc/developer/internationalization/i18n-jelly-views.adoc
@@ -2,17 +2,18 @@
 title: Internationalizing Messages in Jelly Views
 layout: developersection
 references:
-- url: https://stapler.kohsuke.org/apidocs/org/kohsuke/stapler/jelly/InternationalizedStringExpression.html
-  title: API documentation for the InternationalizedStringExpression class in Stapler
+- url: https://github.com/stapler/stapler/blob/master/docs/i18n.adoc
+  title: Internalization support in Jelly
 - url: https://commons.apache.org/proper/commons-jexl/
   title: Apache JEXL
 ---
 
 == Introduction
 
-Jenkins uses the https://github.com/stapler/stapler-jetty[stapler-jelly] library to implement internationalization.
+Jenkins supports internationalizing messages in link:https://github.com/stapler/stapler/blob/master/docs/i18n.adoc[Jelly views].
 
-In Jenkins, you need add a similar `.properties` file with the `.jelly` file in the same directory. Any changes of `.properties` does not need restart Jenkins or plugins.
+In Jenkins, you add a `.properties` file with the `.jelly` file in the same directory.
+Any changes of `.properties` do not require a restart of Jenkins.
 
 == Example
 

--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -34,10 +34,9 @@ title: Javadoc
   Stapler Javadoc
 
 %p
-  %a{:href => 'https://stapler.kohsuke.org/apidocs/', :target => '_blank', :rel => 'noreferrer noopener'}
+  %a{:href => 'https://javadoc.jenkins.io/component/stapler/', :target => '_blank', :rel => 'noreferrer noopener'}
     Stapler Javadoc
-  is hosted on the Stapler site.
-  It describes the framework used by Jenkins to route requests to the objects handling them.
+  describes the framework used by Jenkins to route requests to the objects handling them.
   %a{:href => '/doc/developer/architecture/web/'}
     Learn more.
 

--- a/content/doc/developer/plugin-development/pipeline-integration.adoc
+++ b/content/doc/developer/plugin-development/pipeline-integration.adoc
@@ -453,7 +453,7 @@ NOTE: See the https://github.com/jenkinsci/workflow-basic-steps-plugin/blob/mast
 The metastep is `step`.
 
 To add support for use of a `Builder` or `Publisher` from a pipeline, depend on Jenkins `1.577+`, typically `1.580.1`.
-Then implement `SimpleBuildStep`, following the guidelines in https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html[its Javadoc].
+Then implement `SimpleBuildStep`, following the guidelines in https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html[its Javadoc].
 Also prefer ``@DataBoundSetter``s to a sprawling `@DataBoundConstructor` (see <<Constructor vs. setters>>).
 
 ==== Mandatory workspace context
@@ -513,7 +513,7 @@ goes into depth.
 
 Here the metastep is `wrap`.
 To add support for a `BuildWrapper`, depend on Jenkins `1.599+` (typically `1.609.1`), and implement `SimpleBuildWrapper`,
-following the guidelines in https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildWrapper.html[its Javadoc].
+following the guidelines in https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildWrapper.html[its Javadoc].
 
 Like `SimpleBuildStep`, wrappers written this way always require a workspace.
 If that would be constricting, consider writing a custom step instead.

--- a/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -88,4 +88,4 @@ There are many examples of such documentation on the web:
 * Java
 * REST API
 * OpenAPI specification details and automatic generators
-* Stapler http://stapler.kohsuke.org/ (more info:https://github.com/jenkins-infra/jenkins.io/pull/2157#issuecomment-471230609)
+* link:http://github.com/stapler/[Stapler] (more info: https://github.com/jenkins-infra/jenkins.io/pull/2157#issuecomment-471230609)

--- a/content/projects/gsoc/2021/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2021/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -90,4 +90,4 @@ There are many examples of such documentation on the web:
 * Java
 * REST API
 * OpenAPI specification details and automatic generators
-* Stapler http://stapler.kohsuke.org/ (more info:https://github.com/jenkins-infra/jenkins.io/pull/2157#issuecomment-471230609)
+* link:http://github.com/stapler/[Stapler] (more info:https://github.com/jenkins-infra/jenkins.io/pull/2157#issuecomment-471230609)


### PR DESCRIPTION
Previous version used https://stapler.kohsuke.org/apidocs/ while the new version uses https://javadoc.jenkins.io/component/stapler/

See https://github.com/jenkins-infra/asciidoctor-jenkins-extensions/releases/tag/v0.9.0

Fixes https://github.com/jenkins-infra/jenkins.io/issues/4410
