### PR TITLE
Fixed link for "Handling Environment Variables"

### DIFF
--- a/content/doc/book/security/securing-jenkins.adoc
+++ b/content/doc/book/security/securing-jenkins.adoc
@@ -66,7 +66,7 @@ The following topics discuss other security features that are on by default. You
 
 * link:/doc/book/security/csrf-protection[CSRF Protection] --- prevent a remote attack against Jenkins running inside your firewall.
 * link:/doc/book/security/controller-isolation/#agent-controller-access-control[Agent To Controller Access] --- protect Jenkins controller from malicious build agents
-* link:configuring-content-security-policy/[Configuring Content Security Policy] --- protect users of Jenkins from malicious builds
+* link:/doc/book/security/configuring-content-security-policy/[Configuring Content Security Policy] --- protect users of Jenkins from malicious builds
 * link:/doc/book/security/markup-formatter/[Markup Formatter] -- allow for rich formatting of descriptions in Jenkins while keeping users safe
 
 

--- a/content/doc/book/security/securing-jenkins.adoc
+++ b/content/doc/book/security/securing-jenkins.adoc
@@ -60,7 +60,7 @@ We recommend you read them first and act on them immediately.
 
 * https://wiki.jenkins.io/display/JENKINS/Security+implication+of+building+on+master[Security implication of building on controller] --- protect Jenkins controller from malicious builds
 * https://wiki.jenkins.io/display/JENKINS/Securing+JENKINS_HOME[Securing JENKINS_HOME] --- protect Jenkins from users with local access
-* https://www.jenkins.io/doc/book/security/environment-variables[Handling Environment Variables] -- ensure that environment variables passed to build steps do not have unintended side effects
+* link:/doc/book/security/environment-variables[Handling Environment Variables] -- ensure that environment variables passed to build steps do not have unintended side effects
 
 The following topics discuss other security features that are on by default. You'll only need to look at them when they are causing problems.
 

--- a/content/doc/book/security/securing-jenkins.adoc
+++ b/content/doc/book/security/securing-jenkins.adoc
@@ -60,7 +60,7 @@ We recommend you read them first and act on them immediately.
 
 * https://wiki.jenkins.io/display/JENKINS/Security+implication+of+building+on+master[Security implication of building on controller] --- protect Jenkins controller from malicious builds
 * https://wiki.jenkins.io/display/JENKINS/Securing+JENKINS_HOME[Securing JENKINS_HOME] --- protect Jenkins from users with local access
-* link:environment-variables[Handling Environment Variables] -- ensure that environment variables passed to build steps do not have unintended side effects
+* https://www.jenkins.io/doc/book/security/environment-variables[Handling Environment Variables] -- ensure that environment variables passed to build steps do not have unintended side effects
 
 The following topics discuss other security features that are on by default. You'll only need to look at them when they are causing problems.
 


### PR DESCRIPTION
Original link for `Handling Environment Variables` resulted in a 404.

Link before went to: https://www.jenkins.io/doc/book/security/securing-jenkins/environment-variables
Link now goes to: https://www.jenkins.io/doc/book/security/environment-variables/