### PR TITLE
Use correct caps for example

### DIFF
--- a/content/blog/2021/07/2021-07-27-git-credentials-binding-phase-1.adoc
+++ b/content/blog/2021/07/2021-07-27-git-credentials-binding-phase-1.adoc
@@ -56,21 +56,21 @@ The link:/doc/pipeline/steps/credentials-binding/#withcredentials-bind-credentia
 
 .Shell example
 ```groovy
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   sh 'git fetch --all'
 }
 ```
 
 .Batch example
 ```groovy
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   bat 'git submodule update --init --recursive'
 }
 ```
 
 .Powershell example
 ```groovy
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   powershell 'git push'
 }
 ```


### PR DESCRIPTION
## Use correct symbol capitalization

4.8.0 released with incorrect symbol capitalization for GitUsernamePassword

4.8.1 corrected the mistake and shows it as gitUsernamePassword
