### PR TITLE
Add remoting 4.10 to 2.302 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -12038,9 +12038,19 @@
           - pull: 5603
         message: |-
           Developer: The <code>hudson.util.SubClassGenerator</code> and experimental <code>hudson.model.TreeView</code> class have been removed without replacement.
+      - type: rfe
+        category: internal
+        pull: 5607
+        authors:
+          - dependabot[bot]
+        references:
+          - pull: 5607
+          - url: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.10
+            title: Remoting 4.10 changelog
+        message: |-
+          Internal: Upgrade from Remoting 4.9 to Remoting 4.10 with bugfixes and dependency updates.
 
   # pull: 5602 (PR title: Exception test modernization / clean up)
-  # pull: 5607 (PR title: Bump remoting from 4.9 to 4.10)
   # pull: 5614 (PR title: Bump git-changelist-maven-extension from 1.0-beta-4 to 1.2)
 
   - version: '2.303'


### PR DESCRIPTION
## Add remoting 4.10 to 2.302 changelog

Requested in https://github.com/jenkinsci/jenkins/pull/5607#issuecomment-889563263

Remoting has been included in previous changelog entries.  Should have
ignored the `skip-changelog` label that was applied to the pull request.
