### PR TITLE
Add RSS feed for security advisories

### DIFF
--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -17,6 +17,11 @@ section: security
   .row
     %p
       This page lists all security advisories that have been published so far.
+  .row
+    %p
+      This index is also available as an
+      %a{:href => '/security/advisories/rss.xml'}
+        RSS feed.
 
   - years.reverse_each do |year|
     .row

--- a/content/security/advisories/rss.xml.haml
+++ b/content/security/advisories/rss.xml.haml
@@ -1,0 +1,52 @@
+!!! XML
+%rss(version="2.0"
+     xmlns:content="https://purl.org/rss/1.0/modules/content/"
+     xmlns:atom="http://www.w3.org/2005/Atom")
+
+  :ruby
+    require 'asciidoctor'
+    advisories_dir = File.expand_path(File.dirname(__FILE__) + '/../advisory')
+    pages_by_path = site.pages.map { |p| [p.source_path, p] }.to_h
+    adocs = Dir.glob(File.join(advisories_dir, '*.{ad,adoc}'))
+
+    Plugin = Struct.new(:name, :title)
+
+  %channel
+    %title
+      Jenkins Security Advisories
+    %link
+      https://www.jenkins.io/security/advisories/
+    %atom:link(href="#{absolute_link(page.url)}" rel="self" type="application/rss+xml")
+    %description
+      Security advisories published by the Jenkins project
+    %lastBuildDate
+      #{DateTime.now.rfc822}
+    - advisories = Dir.glob(File.join(advisories_dir, '202*.{ad,adoc}'))
+    - advisories.sort.reverse_each do |advisory|
+      - page = pages_by_path[advisory]
+
+      %item
+        %title
+          = page.title
+        %date
+          #{(DateTime.strptime(page.title,"Jenkins Security Advisory %Y-%m-%d") + 0.5).rfc822}
+        %link
+          = "https://www.jenkins.io#{ expand_link(page.url) }"
+        %description
+          - if page.issues or page.index_details
+            - if page.index_details
+              = Asciidoctor.convert(page.index_details, safe: :safe).encode( { :xml => :text } )
+            - else
+              = "<ul>".encode( { :xml => :text } )
+              - if page.core
+                = "<li>Affects Jenkins Core</li>".encode( { :xml => :text } )
+              - plugins = page.issues.collect { |issue| issue.plugins }.flatten.keep_if { |p| p }.collect { |p| Plugin.new(p.name, p.title) }.uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
+              - plugins.each do | plugin |
+                - if site._generated[:update_center].plugins[plugin.name]
+                  = "<li>Affects plugin: <a href='https://plugins.jenkins.io/#{plugin.name}'>#{site._generated[:update_center].plugins[plugin.name].title}</a></li>".encode( { :xml => :text } )
+                - else
+                  = "<li>Affects plugin: #{plugin.title || plugin.name}".encode( { :xml => :text } )
+              - components = page.issues.collect { |issue| issue.components }.flatten.keep_if { |c| c }
+              - components.each do | component |
+                = "<li>Affects #{component.title || component.name}</li>"
+              = "</ul>".encode( { :xml => :text } )

--- a/content/security/for-administrators.adoc
+++ b/content/security/for-administrators.adoc
@@ -53,14 +53,12 @@ In the Jenkins project, we publish all security advisories link:/security/adviso
 // Copied from index.adoc
 We announce the publication of a new security advisory through multiple channels:
 
-* We send an email notification to the public `jenkinsci-advisories` Google group with a short overview of affected components and a link to the security advisory:
-
-  - link:https://groups.google.com/forum/#!forum/jenkinsci-advisories[`jenkinsci-advisories` list archive]
-  - link:https://feeds.feedburner.com/jenkins-security-advisories[`jenkinsci-advisories` RSS feed]
-
+* We send an email notification to the public link:https://groups.google.com/forum/#!forum/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory.
 * We send an email notification to the link:https://oss-security.openwall.org/wiki/mailing-lists/oss-security[`oss-security`] mailing list with excerpts of the security advisory.
+* We publish an link:/security/advisories/rss[RSS feed for the jenkins.io/security/advisories/] page.
 
 Additionally, Jenkins administrators are informed about published security issues directly in Jenkins if they have affected versions of Jenkins or plugins installed.
+// Copy from index.adoc end
 
 
 == What Information Do Security Advisories Provide?

--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -18,12 +18,9 @@ You can find all past security advisories in our link:/security/advisories/[secu
 
 We announce the publication of a new security advisory through multiple channels:
 
-* We send an email notification to the public `jenkinsci-advisories` Google group with a short overview of affected components and a link to the security advisory:
-
-  - link:https://groups.google.com/forum/#!forum/jenkinsci-advisories[`jenkinsci-advisories` list archive]
-  - link:https://feeds.feedburner.com/jenkins-security-advisories[`jenkinsci-advisories` RSS feed]
-
+* We send an email notification to the public link:https://groups.google.com/forum/#!forum/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory.
 * We send an email notification to the link:https://oss-security.openwall.org/wiki/mailing-lists/oss-security[`oss-security`] mailing list with excerpts of the security advisory.
+* We publish an link:/security/advisories/rss[RSS feed for the jenkins.io/security/advisories/] page.
 
 Additionally, Jenkins administrators are informed about published security issues directly in Jenkins if they have affected versions of Jenkins or plugins installed.
 


### PR DESCRIPTION
The Google-provided RSS feed for the jenkinsci-advisories Google Group (and probably all Google Groups per https://support.google.com/groups/thread/118690869/when-will-googlegroups-rss-feed-be-back-online?hl=en) no longer exists.

This PR adds an RSS feed to `/security/advisories/rss.xml` and links it from the the advisories overview as well as from documentation that previously linked to the Google Groups RSS feed.

The RSS code is largely copied from the corresponding feed code for the changelog, adapted to security advisory content (largely copied from the advisories overview page).

As feed readers tend to cache items, I decided against inlining entire advisories, instead limiting descriptions to affected components (which do not change after publication).

Entry publication times are at noon UTC of the given day to have the best chance for the dates to match in almost all time zones (while we don't have actual publication times recorded).