### PR TITLE
Terminology cleanup: Docs for built-in node migration

### DIFF
--- a/content/doc/book/managing/built-in-node-migration.adoc
+++ b/content/doc/book/managing/built-in-node-migration.adoc
@@ -1,0 +1,49 @@
+---
+layout: documentation
+title: Built-In Node Name and Label Migration
+---
+
+As part of the link:https://groups.google.com/g/jenkinsci-dev/c/x5vdlJDvntw[terminology cleanup effort], the built-in node was renamed from "master node" to "built-in node" in Jenkins 2.TODO(version).
+This is not just a change affecting the UI and documentation:
+The node name affects the implicitly assigned label of the node (and consequently the `NODE_LABELS` environment variable), as well as the `NODE_NAME` environment variable.
+
+== Affected Features
+
+Jenkins features using node labels are therefore potentially impacted by any such changes.
+These features include:
+
+* Label assignments of various project types, both on the top level (e.g. Freestyle jobs) and within jobs (e.g. `node` statements in Scripted Pipeline, `label` parameters to `agent` sections in Declarative Pipeline, or plugin:matrix-project[Matrix Project] axes).
+* Label assignments of features like custom tool auto-installers, typically used to distinguish OS platforms.
+* Any custom build scripts whose behavior is different based on the `NODE_NAME` or `NODE_LABELS` environment variables (or their `env` global variable equivalent in Pipeline).
+* Any similar features in plugins.
+
+== Migration
+
+Due to the potential impact to build behavior, instances upgrading Jenkins to version 2.TODO(version) or newer do not automatically get these behavior changes applied.
+Instead, an administrative monitor informs administrators about this change and allows them to apply it.
+
+// Screenshot here? Is this useful?
+
+Before applying the built-in node name and label migration, administrators are advised to review their configuration and build scripts to assess the impact to their instance and jobs.
+
+Most problems with label assignments can likely be worked around by manually assigning the label `master` to the built-in node and then migrating affected configuration incrementally to not need this workaround.
+
+== Plugin Compatibility
+
+=== Known Incompatible Plugins
+
+// I wonder how quickly we'll need to delete this paragraph:
+As of TODO(date), we are unaware of any plugins affected by this change.
+
+Use https://issues.jenkins.io/issues/?jql=labels%3Dbuilt-in-node-migration-regression[this Jira query] to find compatibility issues tracked in the Jenkins Jira.
+
+Review issues mentioning this https://github.com/jenkinsci/jenkins/pull/5425[Jenkins pull request] (they appear in the history) to find compatibility issues tracked on GitHub.
+// This sucks, is there a less terrible way (ideally without requiring heavyweight workarounds like Projects)?
+
+=== Reporting Incompatible Plugins
+
+Please report problems in the respective plugin's issue tracker.
+
+If the affected plugin uses the Jenkins Jira to track issues, please add the label `built-in-node-migration-regression`.
+
+If the affected plugin tracks issues on GitHub, please make sure to mention the https://github.com/jenkinsci/jenkins/pull/5425[Jenkins pull request] that implemented the change in your issue.

--- a/content/doc/book/managing/built-in-node-migration.adoc
+++ b/content/doc/book/managing/built-in-node-migration.adoc
@@ -3,7 +3,7 @@ layout: documentation
 title: Built-In Node Name and Label Migration
 ---
 
-As part of the link:https://groups.google.com/g/jenkinsci-dev/c/x5vdlJDvntw[terminology cleanup effort], the built-in node was renamed from "master node" to "built-in node" in Jenkins 2.TODO(version).
+As part of the link:https://groups.google.com/g/jenkinsci-dev/c/x5vdlJDvntw[terminology cleanup effort], the built-in node was renamed from "master node" to "built-in node" in Jenkins 2.307.
 This is not just a change affecting the UI and documentation:
 The node name affects the implicitly assigned label of the node (and consequently the `NODE_LABELS` environment variable), as well as the `NODE_NAME` environment variable.
 
@@ -19,7 +19,7 @@ These features include:
 
 == Migration
 
-Due to the potential impact to build behavior, instances upgrading Jenkins to version 2.TODO(version) or newer do not automatically get these behavior changes applied.
+Due to the potential impact to build behavior, instances upgrading Jenkins to version 2.307 or newer do not automatically get these behavior changes applied.
 Instead, an administrative monitor informs administrators about this change and allows them to apply it.
 
 // Screenshot here? Is this useful?
@@ -33,7 +33,7 @@ Most problems with label assignments can likely be worked around by manually ass
 === Known Incompatible Plugins
 
 // I wonder how quickly we'll need to delete this paragraph:
-As of TODO(date), we are unaware of any plugins affected by this change.
+As of August 15, 2021, we are unaware of any plugins affected by this change.
 
 Use https://issues.jenkins.io/issues/?jql=labels%3Dbuilt-in-node-migration-regression[this Jira query] to find compatibility issues tracked in the Jenkins Jira.
 

--- a/content/doc/book/managing/built-in-node-migration.adoc
+++ b/content/doc/book/managing/built-in-node-migration.adoc
@@ -37,8 +37,7 @@ As of TODO(date), we are unaware of any plugins affected by this change.
 
 Use https://issues.jenkins.io/issues/?jql=labels%3Dbuilt-in-node-migration-regression[this Jira query] to find compatibility issues tracked in the Jenkins Jira.
 
-Review issues mentioning this https://github.com/jenkinsci/jenkins/pull/5425[Jenkins pull request] (they appear in the history) to find compatibility issues tracked on GitHub.
-// This sucks, is there a less terrible way (ideally without requiring heavyweight workarounds like Projects)?
+Use https://github.com/search?q=%22https%3A%2F%2Fgithub.com%2Fjenkinsci%2Fjenkins%2Fpull%2F5425%22+-repo%3Ajenkinsci%2Fjenkins&type=Issues&ref=advsearch&l=&l=[this GitHub query] to find compatibility issues tracked on GitHub.
 
 === Reporting Incompatible Plugins
 

--- a/content/redirect/built-in-node-migration.adoc
+++ b/content/redirect/built-in-node-migration.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /doc/book/managing/built-in-node-migration/
+---


### PR DESCRIPTION
Add redirect and docs page for the built-in node name and label migration, corresponds to https://github.com/jenkinsci/jenkins/pull/5425.

Deliberately not linked from the menu as this is basically "ephemeral" documentation -- it won't have much value in a year or two. The entry point is the admin monitor in Jenkins.
