### PR TITLE
Avoid double redirects

### DIFF
--- a/content/redirect/cli-command-requires-channel.adoc
+++ b/content/redirect/cli-command-requires-channel.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/book/managing/cli/#remoting-connection-mode
+redirect_url: /doc/book/managing/cli/#remoting-connection-mode
 ---

--- a/content/redirect/cli-http-connection-mode.adoc
+++ b/content/redirect/cli-http-connection-mode.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/book/managing/cli/#http-connection-mode
+redirect_url: /doc/book/managing/cli/#http-connection-mode
 ---

--- a/content/redirect/contribute.adoc
+++ b/content/redirect/contribute.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/participate/
+redirect_url: /participate/
 ---

--- a/content/redirect/crumb-cannot-be-used-for-script.md
+++ b/content/redirect/crumb-cannot-be-used-for-script.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/upgrade-guide/2.176/#SECURITY-626
+redirect_url: /doc/upgrade-guide/2.176/#SECURITY-626
 ---

--- a/content/redirect/find-jenkins-logs.adoc
+++ b/content/redirect/find-jenkins-logs.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/book/system-administration/viewing-logs/
+redirect_url: /doc/book/system-administration/viewing-logs/
 ---

--- a/content/redirect/log-levels.adoc
+++ b/content/redirect/log-levels.adoc
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Logger+Configuration
+redirect_url: /doc/book/system-administration/viewing-logs/
 localized_urls:
   ja: https://wiki.jenkins.io/display/JA/Logger+Configuration
 ---

--- a/content/redirect/log-recorders.adoc
+++ b/content/redirect/log-recorders.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/book/system-administration/viewing-logs/#logs-in-jenkins
+redirect_url: /doc/book/system-administration/viewing-logs/#logs-in-jenkins
 
 ---

--- a/content/redirect/logging.adoc
+++ b/content/redirect/logging.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/book/system-administration/viewing-logs/#logs-in-jenkins
+redirect_url: /doc/book/system-administration/viewing-logs/#logs-in-jenkins
 
 ---

--- a/content/redirect/rekey.adoc
+++ b/content/redirect/rekey.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/security/advisory/2013-01-04/
+redirect_url: /security/advisory/2013-01-04/
 ---

--- a/content/redirect/serialization-of-anonymous-classes.adoc
+++ b/content/redirect/serialization-of-anonymous-classes.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes/
+redirect_url: /doc/developer/extensibility/serialization-of-anonymous-classes/
 ---

--- a/content/redirect/setting-system-properties.adoc
+++ b/content/redirect/setting-system-properties.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/doc/book/managing/system-properties/
+redirect_url: /doc/book/managing/system-properties/
 ---

--- a/content/redirect/troubleshooting/executor-starvation.adoc
+++ b/content/redirect/troubleshooting/executor-starvation.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Executor+Starvation
+redirect_url: /doc/book/using/executor-starvation/
 ---

--- a/content/redirect/user-content-directory.adoc
+++ b/content/redirect/user-content-directory.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/User+Content
+redirect_url: /doc/book/managing/user-content/
 ---


### PR DESCRIPTION
Some redirects point to Wiki pages that have been moved to jennkins.io, some others use absolute URLs without www which also causes  extra redirect.