### PR TITLE
Add ability to use ruby without docker

### DIFF
--- a/scripts/ruby
+++ b/scripts/ruby
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+if [ -n "${USE_LOCAL_RUBY}" ]; then
+    if [ "$1" = "pull" ]; then
+        exit 0
+    fi
+
+    exec $@
+
+    exit
+fi
+
 CONTAINER_NAME=ruby:2.6
 source ./scripts/docker-env
 


### PR DESCRIPTION
Ruby 2.6 through docker on my mac m1 is currently seg faulting.

Can we add this or something similar to skip using it?
Saves me hacking around it locally

cc @zbynek

It would be good to update ruby to at least 2.7 if not 3.0 but I think awestruct needs some dependency updates. I tried 3.0 briefly but it didn't work