### PR TITLE
Include epel-release repo in CentOS instructions

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -232,7 +232,8 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo yum upgrade
-sudo yum install jenkins java-11-openjdk-devel
+sudo yum install epel-release java-11-openjdk-devel
+sudo yum install jenkins
 sudo systemctl daemon-reload
 ----
 
@@ -247,7 +248,8 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat/jenkins.repo
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo yum upgrade
-sudo yum install jenkins java-11-openjdk-devel
+sudo yum install epel-release java-11-openjdk-devel
+sudo yum install jenkins
 sudo systemctl daemon-reload
 ----
 


### PR DESCRIPTION
Jenkins 2.306 weekly uses the `daemonize` program from EPEL to simplify the rpm based installation and process administration code.

Add the epel-release repository so that the rpm can be installed.

@basil this is the proposed documentation update.  Does not correct the downloads page, but does correct the install instructions page.

See jenkinsci/packaging#207