### PR TITLE
GSOC-21 update conventional commits project page

### DIFF
--- a/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
+++ b/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
@@ -48,6 +48,28 @@ The conventional commits plugin is a Jenkins plugin to automatically determine t
 
 Taking in various sources of input, like the commit history of the repository, the latest tagged version, and the version information read from various configuration files of the project, the plugin outputs the next semantic version.
 
+The plugin is best used in a Jenkins Pipeline Project.
+
+For exmaple:
+
+```
+pipeline {
+    agent any
+
+    environment {
+        NEXT_VERSION = nextVersion()
+    }
+
+    stages {
+        stage('Hello') {
+            steps {
+                echo "next version = ${NEXT_VERSION}"
+            }
+        }
+    }
+}
+```
+
 For more details please see the following Resources section.
 
 === Resources

--- a/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
+++ b/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
@@ -70,6 +70,8 @@ pipeline {
 }
 ```
 
+More examples for the Declarative and the Scripted Pipeline can be found in the project's link:https://github.com/jenkinsci/conventional-commits-plugin[README].
+
 For more details please see the following Resources section.
 
 === Resources

--- a/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
+++ b/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
@@ -19,16 +19,15 @@ links:
   gitter: "jenkinsci/conventional-commits-plugin"
   draft: https://docs.google.com/document/d/1E0FdxdXP1JZb88-sDqmilmz2gJ0qp4BANCTLlXJOaTQ/edit#
   idea: /projects/gsoc/2021/project-ideas/semantic-release-version
-  meetings: "/projects/gsoc/2021/projects/conventional-commits-plugin/#office-hours"
 ---
 
 === Background
 
-As the CI/CD world is moving more towards automation and minimal human interaction, the ability to full automate a release, including the determination of the "next" release version becomes desirable.
+As the CI/CD world is moving more towards automation and minimal human interaction, the ability to fully automate a release, including the determination of the "next" release version becomes desirable.
 
-Semantic/Conventional commits is one way of programatically understanding the changes made between releases 
+Semantic/Conventional commits is one way of programmatically understanding the changes made between releases 
 
-For a existing project released at `1.0.0`, the following commit messages would bump the version as follows:
+For an existing project released at `1.0.0`, the following commit messages would bump the version as follows:
 
 |===
 |Commit Message|Next Version 
@@ -45,26 +44,29 @@ For a existing project released at `1.0.0`, the following commit messages would 
 
 ==== Project Details
 
-This project idea proposes to implement a Jenkins plugin which will allow the `nextVersion` to be determined from the commit log.
+The conventional commits plugin is a Jenkins plugin to automatically determine the next semantic version for a git repository using the Conventional Commits (C.C) system.
 
-The project requires the student to start with plugin development from scratch and then work with understanding how to integrate this plugin into a Jenkins pipeline.
+Taking in various sources of input, like the commit history of the repository, the latest tagged version, and the version information read from various configuration files of the project, the plugin outputs the next semantic version.
 
-In the beginning, the student can work on understanding the Jenkins plugin development by writing code for creating a simple Build Step which determines the current version from the latest tag.
+For more details please see the following Resources section.
 
-This can be extended in the future to support other methods of determining the version e.g. `Chart.yaml` / `pom.xml` / `build.gradle` or `package.json`
+=== Resources
 
-=== Office hours
-
-TODO
+  . Blog
+  - link:/blog/2021/07/2021-07-30-introducing-conventional-commits-plugin-for-jenkins[Mid-term report]
+  . Demo
+  - link:https://youtu.be/_D0hiA1Cgz8?t=3218[Mid-term demo]
 
 === Getting the Code
 
 The code for Conventional Commits Plugin can be found link:https://github.com/jenkinsci/conventional-commits-plugin/[here on Github].
-_Note: The project is under active development._ 
+_Note: The project is under active development._
+
+=== Roadmap 
+
+The roadmap for the future can be found link:https://github.com/jenkinsci/conventional-commits-plugin/projects/1[here].
 
 === References
-
-There are many examples of such documentation on the web:
 
 * link:https://semver.org/[Semantic Versioning]
 * link:https://www.conventionalcommits.org/en/v1.0.0/[Conventional Commits]


### PR DESCRIPTION
This PR updates the project page of the "Conventional Commits Plugin for Jenkins" GSoC project.

Following changes have been made:
* Updated description of the project
* Add links to demo and blogs
* Add roadmap

PS: Not the 2nd blog :)

Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>