### PR TITLE
Gsoc 21 work report update for Git Credentials Binding project

### DIFF
--- a/content/blog/2021/08/2021-08-19-git-credentials-binding-work-report.adoc
+++ b/content/blog/2021/08/2021-08-19-git-credentials-binding-work-report.adoc
@@ -56,7 +56,7 @@ Provides an API to perform tasks like OpenSSH private key encoding and decoding.
 *** https://github.com/jenkinsci/git-plugin/pull/1104[Add Git Credentials binding for Username and Password]
 *** https://github.com/jenkinsci/git-client-plugin/pull/724[Check the least command line git version required]
 *** https://github.com/jenkinsci/git-plugin/pull/1119/files[Git username password binding doc update in git-plugin]
-* https://github.com/jenkins-infra/jenkins.io/pull/4516[gitUsernamePassword binding explanation]
+* https://www.jenkins.io/projects/gsoc/2021/projects/git-credentials-binding/#git-username-and-password-binding[gitUsernamePassword binding explanation]
 * https://docs.google.com/presentation/d/1LCH0dXzWka_l-WQ3SVMCXfU7w7jQENXS-bdz2E5GIgU/edit?usp=sharing[Webinar slides]
 * https://www.jenkins.io/blog/2021/07/27/git-credentials-binding-phase-1/[Git username password binding released blog post]
 * Phase 1 demo and presentation:
@@ -90,7 +90,7 @@ video::_D0hiA1Cgz8[youtube,start=4068,width=800,height=420]
 ** https://github.com/jenkinsci/git-plugin/pull/1111[Add Git Credentials binding for SSH Private Key]
 *** https://github.com/jenkinsci/git-plugin/pull/1111/commits/828cc946442a0e6ab6944d2e2315c8c9d0a7b9d0[Last GSOC-2021 noted commit]
 ** https://github.com/jenkinsci/git-client-plugin/pull/727[Scope change of getSSHExecutable method]
-* https://github.com/jenkins-infra/jenkins.io/pull/4516[gitSshPrivateKey binding explanation]
+* https://www.jenkins.io/projects/gsoc/2021/projects/git-credentials-binding/#git-ssh-private-key-binding[gitSshPrivateKey binding explanation]
 
 == Achievements
 

--- a/content/blog/2021/08/2021-08-19-git-credentials-binding-work-report.adoc
+++ b/content/blog/2021/08/2021-08-19-git-credentials-binding-work-report.adoc
@@ -88,7 +88,7 @@ video::_D0hiA1Cgz8[youtube,start=4068,width=800,height=420]
 === Resources
 * Pull Requests
 ** https://github.com/jenkinsci/git-plugin/pull/1111[Add Git Credentials binding for SSH Private Key]
-*** https://github.com/jenkinsci/git-plugin/pull/1111/commits/828cc946442a0e6ab6944d2e2315c8c9d0a7b9d0[Last GSOC-2021 noted commit]
+*** https://github.com/jenkinsci/git-plugin/pull/1111/commits/dd86551cda93447090584407304f83ca3030f154[Last GSOC-2021 noted commit]
 ** https://github.com/jenkinsci/git-client-plugin/pull/727[Scope change of getSSHExecutable method]
 * https://www.jenkins.io/projects/gsoc/2021/projects/git-credentials-binding/#git-ssh-private-key-binding[gitSshPrivateKey binding explanation]
 


### PR DESCRIPTION
Updating GSOC-2021 work report for Git Credentials Binding project

1. Included

- Project link update
- Last GSOC-21 commit update for SSH Binding