### PR TITLE
[JENKINS-66490] Note rpm dependency added in 2.303.1 installer

### DIFF
--- a/content/_data/upgrades/2-303-1.adoc
+++ b/content/_data/upgrades/2-303-1.adoc
@@ -168,6 +168,23 @@ Ruby runtime plugins with less than 100 installations:
 * plugin:pry[pry]
 * plugin:Yammer[Yammer]
 
+==== New RPM package manager dependency
+
+The Jenkins 2.303.1 RPM package has been made more consistent with the Debian Jenkins packaging.
+It uses the `daemonize` program to run the Java process of the Jenkins controller as a daemon.
+The `daemonize` program is available from the `epel-release` repository for most RPM based distributions.
+
+Some distributions based on the RPM package manager do not enable the 'epel-release' repository by default.
+Instructions to enable the epel-release repository are included in the Jenkins installation guide instructions for link:/doc/book/installing/linux/#red-hat-centos[Red Hat Enterprise Linux / CentOS].
+
+Before updating to Jenkins 2.303.1, run the command:
+
+.Red Hat Enterprise Linux / CentOS
+[source,bash]
+----
+# yum install epel-release
+----
+
 ==== Removed Apache Commons Digester from the Jenkins core
 
 The Apache Commons Digester v2.1 has been removed from Jenkins core.


### PR DESCRIPTION
The `daemonize` program is required by the Jenkins rpm package.  It is available from the `epel-release` repository.  The `epel-release` repository is enabled by default with Fedora but is not enabled by default with Red Hat Enterprise Linux or with CentOS.  

Enable the `epel-release` repository with the command:

```
# yum install epel-release
```
