### PR TITLE
Add bullseye to 2.303.1 upgrade guide

### DIFF
--- a/content/_data/upgrades/2-303-1.adoc
+++ b/content/_data/upgrades/2-303-1.adoc
@@ -119,12 +119,12 @@ The transition looks like this:
 
 ==== Multi-architecture Docker images
 
-Jenkins Docker images now support multiple architectures, including `amd64`, `arm64`, `ppc64le`, and `s390x` from selected images.
+Jenkins Docker images now support multiple architectures, including `amd64` and `arm64` from selected images.
 The images with support for multiple architectures include:
 
-* latest, jdk11, and latest-jdk11 (`amd64`, `arm64`, `ppc64le`, and `s390x`)
-* rhel-ubi8-jdk11 (`amd64`, `arm64`, `ppc64le`, and `s390x`)
-* almalinux (`amd64`, `arm64`)
+* 2.303.1 and 2.303.1-jdk11
+* 2.303.1-rhel-ubi8-jdk11
+* 2.303.1-almalinux
 
 ==== Plugins that do not support Java 11
 

--- a/content/_data/upgrades/2-303-1.adoc
+++ b/content/_data/upgrades/2-303-1.adoc
@@ -185,6 +185,14 @@ Before updating to Jenkins 2.303.1, run the command:
 # yum install epel-release
 ----
 
+==== Debian upgrade in Docker images
+
+Docker controller images based on Debian, including `jenkins/jenkins:lts`, `jenkins/jenkins:lts-slim`, `jenkins/jenkins:2.303.1`, and `jenkins/jenkins:2.303.1-slim` are now based on link:https://www.debian.org/releases/bullseye/[Debian bullseye], the most recent Debian release.
+Debian bullseye was released August 14, 2021 after a long period of stabilization and testing.
+
+Some packages that had been included in the Debian buster images may not be installed in these images.
+If your installation needs one of those packages, you'll need to install it from inside your custom Dockerfile.
+
 ==== Removed Apache Commons Digester from the Jenkins core
 
 The Apache Commons Digester v2.1 has been removed from Jenkins core.


### PR DESCRIPTION
## Add bullseye to 2.303.1 upgrade guide

* Add Debian upgrade note to upgrade guide
* Update multi-arch support list
