### PR TITLE
Update _docker.adoc

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -91,7 +91,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-lts-jdk11
+FROM jenkins/jenkins:{jenkins-stable}-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \


### PR DESCRIPTION
It appears that this document indicates -lts is being dropped from Docker image names:

https://www.jenkins.io/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-1

So the documentation should reflect that.