### PR TITLE
Sort plugins and don't return the list of plugins

### DIFF
--- a/content/doc/book/system-administration/diagnosing-errors.adoc
+++ b/content/doc/book/system-administration/diagnosing-errors.adoc
@@ -74,9 +74,12 @@ println("Jenkins: ${Jenkins.instance.getVersion()}")
 println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")
 println "---"
 
-Jenkins.instance.pluginManager.plugins.each{
-  plugin -> println ("${plugin.getShortName()}:${plugin.getVersion()}")
-}
+Jenkins.instance.pluginManager.plugins
+    .collect()
+    .sort { it.getShortName() }
+    .each {
+        plugin -> println("${plugin.getShortName()}:${plugin.getVersion()}")
+    }
 return
 ```
 

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -129,9 +129,13 @@ println("Jenkins: " + Jenkins.instance.getVersion())
 println("OS: " + System.getProperty('os.name') + " - " +System.getProperty('os.version'))
 println "---"
 
-Jenkins.instance.pluginManager.plugins.each{
-  plugin -> println ("${plugin.getShortName()}:${plugin.getVersion()}")
-}
+Jenkins.instance.pluginManager.plugins
+  .collect()
+	.sort { it.getShortName() }
+	.each {
+  		plugin -> println ("${plugin.getShortName()}:${plugin.getVersion()}")
+	}
+return
 ```
 * Whether you're *running Jenkins directly or in a container* like
 Tomcat (which one, in which version?)

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -130,11 +130,11 @@ println("OS: " + System.getProperty('os.name') + " - " +System.getProperty('os.v
 println "---"
 
 Jenkins.instance.pluginManager.plugins
-        .collect()
-        .sort { it.getShortName() }
-        .each {
-            plugin -> println("${plugin.getShortName()}:${plugin.getVersion()}")
-        }
+    .collect()
+    .sort { it.getShortName() }
+    .each {
+        plugin -> println("${plugin.getShortName()}:${plugin.getVersion()}")
+    }
 return
 ```
 * Whether you're *running Jenkins directly or in a container* like

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -130,11 +130,11 @@ println("OS: " + System.getProperty('os.name') + " - " +System.getProperty('os.v
 println "---"
 
 Jenkins.instance.pluginManager.plugins
-  .collect()
-	.sort { it.getShortName() }
-	.each {
-  		plugin -> println ("${plugin.getShortName()}:${plugin.getVersion()}")
-	}
+        .collect()
+        .sort { it.getShortName() }
+        .each {
+            plugin -> println("${plugin.getShortName()}:${plugin.getVersion()}")
+        }
 return
 ```
 * Whether you're *running Jenkins directly or in a container* like


### PR DESCRIPTION
Previously a:

```
Result: [Plugin:workflow-job, Plugin:translation, Plugin:bootstrap4-api, Plugin:branch-api, Plugin:junit-attachments, Plugin:variant, Plugin:beer, Plugin:handlebars, Plugin:build-timeout, Plugin:forensics-api, Plugin:display-url-api, Plugin:pipeline-utility-steps, Plugin:script-security, Plugin:pipeline-stage-view, Plugin:basic-branch-build-strategies, Plugin:lockable-resources, Plugin:azure-vm-agents, Plugin:pipeline-github-lib, Plugin:blueocean-personalization, Plugin:matrix-auth, Plugin:jaxb, Plugin:git-forensics, Plugin:mercurial, Plugin:credentials-binding, Plugin:external-monitor-job, Plugin:pipeline-model-extensions, Plugin:jacoco, Plugin:warnings-ng, Plugin:data-tables-api, Plugin:cloud-stats, Plugin:jdk-tool, Plugin:azure-credentials, Plugin:blueocean-jwt, Plugin:blueocean-config, Plugin:blueocean-pipeline-scm-api, Plugin:support-core, Plugin:ant, Plugin:azure-sdk, Plugin:toolenv, Plugin:jackson2-api, Plugin:workflow-step-api, Plugin:blueocean-jira, Plugin:blueocean, Plugin:node-iterator-api, Plugin:scm-api, Plugin:ec2, Plugin:pipeline-model-api, Plugin:github-branch-source, Plugin:structs, Plugin:plugin-util-api, Plugin:azure-container-agents, Plugin:git, Plugin:cvs, Plugin:cloudbees-folder, Plugin:pipeline-milestone-step, Plugin:github-checks, Plugin:ansicolor, Plugin:favorite, Plugin:aws-java-sdk, Plugin:kubernetes-client-api, Plugin:command-launcher, Plugin:blueocean-pipeline-editor, Plugin:jquery, Plugin:analysis-model-api, Plugin:blueocean-bitbucket-pipeline, Plugin:disable-github-multibranch-status, Plugin:echarts-api, Plugin:apache-httpcomponents-client-4-api, Plugin:blueocean-rest-impl, Plugin:pipeline-stage-tags-metadata, Plugin:workflow-scm-step, Plugin:javadoc, Plugin:sse-gateway, Plugin:pipeline-rest-api, Plugin:pipeline-graph-view, Plugin:workflow-basic-steps, Plugin:jjwt-api, Plugin:mapdb-api, Plugin:junit, Plugin:pipeline-build-step, Plugin:jira, Plugin:buildtriggerbadge, Plugin:jsch, Plugin:authentication-tokens, Plugin:sshd, Plugin:handy-uri-templates-2-api, Plugin:blueocean-web, Plugin:timestamper, Plugin:dark-theme, Plugin:bouncycastle-api, Plugin:workflow-aggregator, Plugin:groovy, Plugin:pubsub-light, Plugin:kubernetes, Plugin:docker-workflow, Plugin:windows-slaves, Plugin:blueocean-commons, Plugin:workflow-multibranch, Plugin:code-coverage-api, Plugin:okhttp-api, Plugin:jquery-detached, Plugin:keyboard-shortcuts-plugin, Plugin:token-macro, Plugin:caffeine-api, Plugin:workflow-cps-global-lib, Plugin:ssh-credentials, Plugin:windows-azure-storage, Plugin:git-client, Plugin:workflow-api, Plugin:popper-api, Plugin:pipeline-githubnotify-step, Plugin:metrics, Plugin:blueocean-events, Plugin:copyartifact, Plugin:plain-credentials, Plugin:pipeline-input-step, Plugin:mailer, Plugin:workflow-support, Plugin:blueocean-autofavorite, Plugin:ssh-slaves, Plugin:bootstrap5-api, Plugin:pipeline-stage-step, Plugin:http_request, Plugin:pam-auth, Plugin:kubernetes-credentials, Plugin:run-condition, Plugin:parallel-test-executor, Plugin:aws-credentials, Plugin:matrix-project, Plugin:popper2-api, Plugin:blueocean-git-pipeline, Plugin:jquery3-api, Plugin:blueocean-rest, Plugin:blueocean-i18n, Plugin:credentials, Plugin:git-server, Plugin:blueocean-dashboard, Plugin:workflow-durable-task-step, Plugin:durable-task, Plugin:extended-read-permission, Plugin:cloudbees-bitbucket-branch-source, Plugin:ssh-agent, Plugin:jobConfigHistory, Plugin:blueocean-core-js, Plugin:ace-editor, Plugin:junit-realtime-test-reporter, Plugin:snakeyaml-api, Plugin:parameterized-trigger, Plugin:font-awesome-api, Plugin:blueocean-display-url, Plugin:throttle-concurrents, Plugin:checks-api, Plugin:blueocean-github-pipeline, Plugin:github-api, Plugin:configuration-as-code, Plugin:jenkins-design-language, Plugin:pipeline-model-definition, Plugin:antisamy-markup-formatter, Plugin:workflow-cps, Plugin:momentjs, Plugin:ldap, Plugin:docker-commons, Plugin:theme-manager, Plugin:htmlpublisher, Plugin:conditional-buildstep, Plugin:github, Plugin:trilead-api, Plugin:subversion, Plugin:blueocean-pipeline-api-impl, Plugin:pipeline-graph-analysis, Plugin:maven-plugin, Plugin:embeddable-build-status]
```

was showing up
