### PR TITLE
Add simple discourse support

### DIFF
--- a/content/_partials/discuss.html.haml
+++ b/content/_partials/discuss.html.haml
@@ -1,14 +1,15 @@
 
 - if page.links && page.links.discourse
-  // Support both topic IDs and full URLs
-  // TODO: Check number validity
-  - discourseTopicId = page.links.discourse.gsub(/\/\s*$/, '').gsub(/.*\//, '')
+  - embedOptions = { discourseUrl: 'https://community.jenkins.io/' }
+  - if page.links.discourse != true
+    // Support both topic IDs and full URLs
+    // TODO: Check number validity
+    - embedOptions['topicId'] = page.links.discourse.gsub(/\/\s*$/, '').gsub(/.*\//, '')
   %b.title
     Discuss
   %div{:id => 'discourse-comments'}
     :javascript
-        window.DiscourseEmbed = { discourseUrl: 'https://community.jenkins.io/',
-                                  topicId: "#{discourseTopicId}" };
+        window.DiscourseEmbed = #{embedOptions.to_json}; #{"window.DiscourseEmbed.discourseEmbedUrl = window.location.toString();" if page.links.discourse == true}
         (function() {
             var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
             d.src = window.DiscourseEmbed.discourseUrl + 'javascripts/embed.js';

--- a/content/blog/2021/09/2021-09-04-wiki-attacked.adoc
+++ b/content/blog/2021/09/2021-09-04-wiki-attacked.adoc
@@ -10,6 +10,8 @@ authors:
 description: >
   The Jenkins infrastructure team identified a successful attack against our deprecated Confluence service.
   This blog post describes our responses.
+links:
+  discourse: true
 ---
 
 Earlier this week the Jenkins infrastructure team identified a successful attack against our deprecated Confluence service.


### PR DESCRIPTION
* Allow simple "True" mode for discourse embedding, for those that want comments but don't want to pre-create topics
* Enable (as example) comments on new wiki attacked page