### PR TITLE
Make sure we use just the url, no anchors or query string for comments

### DIFF
--- a/content/_partials/discuss.html.haml
+++ b/content/_partials/discuss.html.haml
@@ -9,7 +9,7 @@
     Discuss
   %div{:id => 'discourse-comments'}
     :javascript
-        window.DiscourseEmbed = #{embedOptions.to_json}; #{"window.DiscourseEmbed.discourseEmbedUrl = window.location.toString();" if page.links.discourse == true}
+        window.DiscourseEmbed = #{embedOptions.to_json}; #{"window.DiscourseEmbed.discourseEmbedUrl = [location.protocol, '//', location.host, location.pathname].join('');" if page.links.discourse == true}
         (function() {
             var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
             d.src = window.DiscourseEmbed.discourseUrl + 'javascripts/embed.js';


### PR DESCRIPTION
@MarkEWaite Just realized it that windows.location.toString() will be the entire url, so any anchors or query string will make it a new url (maybe).

Just make it explicit that its only the url part (is there an awestruct way of getting the cannonical url? i couldn't get absolute_link(page.url) to output anything)