### PR TITLE
clarify backporting criteria and eligibility.

### DIFF
--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -5,7 +5,7 @@ title: LTS Release Line
 :toc:
 
 The weekly Jenkins releases deliver bug fixes and new features rapidly to users and plugin developers who need them.
-But for more conservative users, it's preferable to stick to a release line which changes less often and only receives important bug fixes, even if such a release line lags behind in terms of features.
+But for more conservative users, it's preferable to stick to a release line which changes less often and only receives important bug and security related fixes, even if such a release line lags behind in terms of features.
 Several companies maintain their own private branches off of Jenkins for stabilization and internal customizations.
 We encourage everybody to shift a part of the effort to this release line.
 
@@ -92,7 +92,8 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 
 ## Backporting Process
 
-Any user can propose that a bug fix be backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
+Any user can propose that a issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
+For an issue to be eligable for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface, additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 
 Aside from the model set out above, backporters apply some subjective selection — for example whether a fix is easy and safe to backport, confidence in the fix, importance/impact of the problem, how much time is left until the end of backporting window and so on.

--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -93,7 +93,7 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 ## Backporting Process
 
 Any user can propose that a issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
-For an issue to be eligable for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface, additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).
+For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface, additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 
 Aside from the model set out above, backporters apply some subjective selection — for example whether a fix is easy and safe to backport, confidence in the fix, importance/impact of the problem, how much time is left until the end of backporting window and so on.

--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -93,7 +93,8 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 ## Backporting Process
 
 Any user can propose that a issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
-For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface, additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).
+For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface.
+Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).```
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 
 Aside from the model set out above, backporters apply some subjective selection — for example whether a fix is easy and safe to backport, confidence in the fix, importance/impact of the problem, how much time is left until the end of backporting window and so on.

--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -94,7 +94,7 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 
 Any user can propose that a issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
 For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface.
-Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).```
+Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/content/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 
 Aside from the model set out above, backporters apply some subjective selection — for example whether a fix is easy and safe to backport, confidence in the fix, importance/impact of the problem, how much time is left until the end of backporting window and so on.


### PR DESCRIPTION
note that the label can be applied to anything but only small well contained bug fixes are acceptable, along with a dependency bump should the library have a public CVE.