### PR TITLE
Update Security Advisory Link

### DIFF
--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -20,7 +20,7 @@ We announce the publication of a new security advisory through multiple channels
 
 * We send an email notification to the public link:https://groups.google.com/forum/#!forum/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory.
 * We send an email notification to the link:https://oss-security.openwall.org/wiki/mailing-lists/oss-security[`oss-security`] mailing list with excerpts of the security advisory.
-* We publish an link:/security/advisories/rss[RSS feed for the jenkins.io/security/advisories/] page.
+* We publish an link:/security/advisories/rss.xml[RSS feed for the jenkins.io/security/advisories/] page.
 
 Additionally, Jenkins administrators are informed about published security issues directly in Jenkins if they have affected versions of Jenkins or plugins installed.
 


### PR DESCRIPTION
Update the security advisories link to https://www.jenkins.io/security/advisories/rss.xml