### PR TITLE
Add notes about the behavior of Pipeline: Nodes and Processes

### DIFF
--- a/content/doc/book/managing/built-in-node-migration.adoc
+++ b/content/doc/book/managing/built-in-node-migration.adoc
@@ -7,6 +7,9 @@ As part of the link:https://groups.google.com/g/jenkinsci-dev/c/x5vdlJDvntw[term
 This is not just a change affecting the UI and documentation:
 The node name affects the implicitly assigned label of the node (and consequently the `NODE_LABELS` environment variable), as well as the `NODE_NAME` environment variable.
 
+NOTE: The `NODE_NAME` environment variable in Pipelines is set by the plugin:workflow-durable-task-step[Pipeline: Nodes and Processes] plugin.
+As of plugin version 2.39, this value is always `master`.
+
 == Affected Features
 
 Jenkins features using node labels are therefore potentially impacted by any such changes.
@@ -14,7 +17,8 @@ These features include:
 
 * Label assignments of various project types, both on the top level (e.g. Freestyle jobs) and within jobs (e.g. `node` statements in Scripted Pipeline, `label` parameters to `agent` sections in Declarative Pipeline, or plugin:matrix-project[Matrix Project] axes).
 * Label assignments of features like custom tool auto-installers, typically used to distinguish OS platforms.
-* Any custom build scripts whose behavior is different based on the `NODE_NAME` or `NODE_LABELS` environment variables (or their `env` global variable equivalent in Pipeline).
+* Any custom build scripts whose behavior is different based on the `NODE_NAME` or `NODE_LABELS` environment variables.
+//(or their `env` global variable equivalent in Pipeline) -- TODO restore once https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/168 is released
 * Any similar features in plugins.
 
 == Migration
@@ -32,8 +36,7 @@ Most problems with label assignments can likely be worked around by manually ass
 
 === Known Incompatible Plugins
 
-// I wonder how quickly we'll need to delete this paragraph:
-As of August 15, 2021, we are unaware of any plugins affected by this change.
+* plugin:workflow-durable-task-step[Pipeline: Nodes and Processes] always sets the `NODE_NAME` to `master` in Pipelines as of version 2.39.
 
 Use https://issues.jenkins.io/issues/?jql=labels%3Dbuilt-in-node-migration-regression[this Jira query] to find compatibility issues tracked in the Jenkins Jira.
 


### PR DESCRIPTION
This documents that Pipelines don't get the new `NODE_NAME` (yet).

Calling it "incompatible" may be a bit much, but it kinda makes sense?

See https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/168 for the PR aiming to change the behavior.