### PR TITLE
Add a note about minikube permissions for persistent data.

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -55,6 +55,16 @@ NOTE: It’s worth noting that, in the above spec, hostPath uses the /data/jenki
 This approach is only suited for development and testing purposes.
 For production, you should provide a network resource like a Google Compute Engine persistent disk, or an Amazon Elastic Block Store volume.
 
+[NOTE]
+====
+Minikube configured for hostPath sets the permissions on /data to the root account only. Once the volume is created you will need to manually change the permissions to allow the jenkins account to write its data.
+[source,bash]
+----
+minikube ssh
+sudo chown -R 1000:1000 /data/jenkins-volume
+----
+====
+
 === Create a service account
 
 In Kubernetes, service accounts are used to provide an identity for pods.


### PR DESCRIPTION
I was struggling with following the documentation until I got my system into a state where I could figure out how to get the proper logs from the containers. I discovered permissions error that lead me to https://stackoverflow.com/questions/65072209/jenkins-on-kubernetes-permission-denied which pointed out two possible work arounds. I have updated the documentation to match the latest answer present at this time.