### PR TITLE
Pass values to ListBoxModel#add in correct order

### DIFF
--- a/content/doc/developer/forms/jelly-form-controls.adoc
+++ b/content/doc/developer/forms/jelly-form-controls.adoc
@@ -118,8 +118,8 @@ Basically the same as above. You need to define the following method in the desc
 public ListBoxModel doFillGoalTypeItems() {
     ListBoxModel items = new ListBoxModel();
     
-    items.add("buildGoal", "Build Goal");
-    items.add("spotBugsGoal", "SpotBugs goal");
+    items.add("Build Goal", "buildGoal");
+    items.add("SpotBugs goal", "spotBugsGoal");
 
     return items;
 }


### PR DESCRIPTION
The `ListBoxModel#add` method takes two parameters: `String displayName` and `String value`. The example was passing values in an incorrect order - `value, displayName` instead of `displayName, value`. This commit uses correct order.