### PR TITLE
Note that 2.310 release was not delivered

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -12427,6 +12427,19 @@
   # pull: 5681 (PR title: Bump spotless-maven-plugin from 2.12.2 to 2.12.3)
   # pull: 5695 (PR title: Update at-since up to 2.308)
 
+  - version: '2.310'
+    date: 2021-09-07
+    banner: >
+      This release build failed while release uploads were blocked.
+      Installers, native packages, and jenkins.war were not published.
+    changes:
+      - type: bug
+        category: internal
+        authors:
+          - MarkEWaite
+        message: |-
+          Jenkins 2.310 was not placed in the artifact repository or on the download site.
+
   - version: '2.311'
     date: 2021-09-09
     changes:


### PR DESCRIPTION
## Jenkins 2.310 was not delivered

Add a 2.310 entry to the weekly changelog that notes 2.310 was not delivered.

![jenkins-2 310-not-delivered](https://user-images.githubusercontent.com/156685/133173808-a42bc89b-fa94-4590-a121-72a87682c6bf.png)
