### PR TITLE
Use blue ocean 1.25.0 instead of 1.24.7

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.8 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.0 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.8 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.8 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.0 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -103,7 +103,7 @@ RUN add-apt-repository \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.24.8 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +


### PR DESCRIPTION
##  Use blue ocean 1.25.0 in sample Docker images

Blue Ocean 1.25.0 was released 3 days ago with a fix for a downstream build link.  I've been running it successfully on my instance for the last several days without any issue.  Let's use the latest release so that tutorial users do not have so many warnings for plugin upgrades.

https://github.com/jenkinsci/blueocean-plugin/releases/tag/blueocean-parent-1.25.0 provides more details of the content of the release.

https://issues.jenkins.io/browse/JENKINS-60995 is the issue that was fixed by the release.
