### PR TITLE
Adapt Java upgrade instructions to recent changes

### DIFF
--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -13,14 +13,10 @@ As with any upgrade, we recommend backing up `JENKINS_HOME` and testing the upgr
 
 == Upgrading Jenkins
 
-NOTE: In production environments, you should use only LTS versions of Jenkins.
-Java 11 is supported in Jenkins 2.164.1 and later.
-All Jenkins LTS versions since 2.164.1 support Java 11.
-
 If you need to upgrade Jenkins as well as the JVM, we recommend that you:
 
 . Back up `JENKINS_HOME`
-. Upgrade Jenkins to version `2.164` or higher
+. Upgrade Jenkins to the most recent version
   ** How you upgrade Jenkins depends on how you installed Jenkins in the first place. 
   ** We recommend that you use the package manager of your system (such as `apt` or `yum`).
 . Validate the upgrade to confirm that all plugins and jobs are loaded
@@ -31,19 +27,21 @@ If you need to upgrade Jenkins as well as the JVM, we recommend that you:
   ** Use a package manager to install the new JVM.
   ** Make sure the default JVM is the newly installed version. If it is not, use the correct `java` command in the Jenkins startup scripts (`/etc/default/jenkins` or `/etc/init.d/jenkins`).
 
-If you use Docker containers to run Jenkins, you should follow the same process and change the Java version by appending `-jdk11` to the Docker image tag.
+If you use Docker containers to run Jenkins, the default Docker containers use Java 11 beginning with link:/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-1[Jenkins 2.303.1].
+If you need to remain with Java 8 in a Docker container, append `-jdk8` to the Docker image tag.
 
 == Upgrading Plugins
 
 It’s important not just to upgrade Jenkins and the JVM but also to upgrade the plugins which support Java 11.
-
-The list of plugins compatible with Java 11 is on the link:https://wiki.jenkins.io/display/JENKINS/Known+Java+11+Compatibility+issues[Known Java 11 Compatibility Issues Wiki page].
+Plugin upgrades assure compatibility with the most recent Jenkins releases.
 
 NOTE: If you discover a previously unreported issue, please let us know: read <<./jenkins-on-java-11#discovering-issues-with-java-11,how to report a Java 11 Compatibility issue>> for guidance.
 
-One of the most important plugin upgrades is the plugin:workflow-support[Pipeline: Support plugin]: make sure that the version of the plugin is at least `3.0`. 
-
-NOTE: Stop all Pipeline jobs before upgrading this plugin because this upgrade changes the serialization of Pipeline builds. As a general rule, even though Pipeline jobs are supposed to survive a Jenkins restart, it's always a better option to make sure that no Pipeline builds are in progress before any scheduled Jenkins maintenance.
+// Commented because pipeline support plugin 3.0 is over 3 years old and has 8+ later releases
+//
+// One of the most important plugin upgrades is the plugin:workflow-support[Pipeline: Support plugin]: make sure that the version of the plugin is at least `3.0`.
+//
+// NOTE: Stop all Pipeline jobs before upgrading this plugin because this upgrade changes the serialization of Pipeline builds. As a general rule, even though Pipeline jobs are supposed to survive a Jenkins restart, it's always a better option to make sure that no Pipeline builds are in progress before any scheduled Jenkins maintenance.
 
 == Javax XML Bind libraries
 


### PR DESCRIPTION
## [WEBSITE-783](https://issues.jenkins.io/browse/WEBSITE-783) Update Java 11 upgrade guidelines

* Upgrade Jenkins to the most recent version (no benefit saying that 2.164 is the first version to support Java 11 because that is over two years ago and is not a maintained release)
* Docker images are Java 11 by default
* Upgrade plugins because upgrades improve compatibility
* Hide the comment about workflow support plugin 3.0.  It was released 3 years ago and has 8 following releases that supersede it

I removed the wiki link because the wayback machine copy of the page showed that it contained no information that would be useful to a current user.