### PR TITLE
Undo failed cleanups

### DIFF
--- a/content/doc/developer/handling-requests/actions.adoc
+++ b/content/doc/developer/handling-requests/actions.adoc
@@ -28,7 +28,7 @@ public String doRun(String foo) throws Exception
 When the SECURITY-595 fix prevents access to a URL, a warning message is written to the Jenkins log that looks similar to the following:
 
 ----
-WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the allowlist: "method hudson.model.Hudson doExample". Learn more: link:/redirect/stapler-routing
+WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the whitelist: "method hudson.model.Hudson doExample". Learn more: https://www.jenkins.io/redirect/stapler-routing
 ----
 
 Administrators can follow the instructions to make the method or field work on their specific instance, but ideally the component is changed to prevent the problem in the first place:

--- a/content/doc/developer/handling-requests/stapler-accessible-type.adoc
+++ b/content/doc/developer/handling-requests/stapler-accessible-type.adoc
@@ -14,7 +14,7 @@ Starting in Jenkins 2.138.4 and 2.154, this is further restricted to address sev
 When the SECURITY-595 fix prevents access to a URL, a warning message is written to the Jenkins log that looks similar to the following:
 
 ----
-WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the allowlist: "method hudson.model.Hudson doExample". Learn more: link:/redirect/stapler-routing
+WARNING: New Stapler routing rules result in the URL "/example" no longer being allowed. If you consider it safe to use, add the following to the whitelist: "method hudson.model.Hudson doExample". Learn more: https://www.jenkins.io/redirect/stapler-routing
 ----
 
 Administrators can follow the instructions to make the method or field work on their specific instance, but ideally the component is changed to prevent the problem in the first place.


### PR DESCRIPTION
#3866 rewrote messages in log output provided as example, which makes no sense without a corresponding change to Jenkins. It's like changing UI label references without the UI changing, it just makes content more difficult to use.
#3113 rewrote URLs to Asciidoc syntax in blocks that aren't rendered in Asciidoc.
