### PR TITLE
fix [jenkins-infra] correct link and sentences for the first good issues

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -37,7 +37,7 @@ You can also share your experiences with Jenkins by link:https://github.com/jenk
 Generally, any pull requests in GitHub would qualify.
 See the link:/participate/[Contribute and Participate] page for more information about how to contribute.
 
-NOTE: This page is based on Hacktoberfest 2020 rules and guidelines. 
+NOTE: This page is based on Hacktoberfest 2020 rules and guidelines.
 We will update it after Hacktoberfest 2021 organizers publish the materials.
 
 == Quick start
@@ -56,7 +56,7 @@ You are welcome to contribute to **any** repository in **any** of those organiza
 Repositories may have different contribution guidelines, review and merge policies.
 If you adopt Jenkins in your open-source projects (e.g. Jenkins Pipeline or Configuration as Code),
 it counts as well!
-Note that not all pull requests will automatically count towards Hacktoberfest in 2020. 
+Note that not all pull requests will automatically count towards Hacktoberfest in 2020.
 
 * link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+org%3Astapler+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest] -
   you can just submit pull requests, no extra steps needed.
@@ -154,7 +154,7 @@ a| In 2016, the Jenkins community started changing the potentially offensive ter
   There are many places where the old terminology still needs to be replaced.
   We invite contributors to join us and participate in cleaning up Jenkins documentation, Web and CLI interfaces, localizations, and the codebase:
 
-  * link:https://community.jenkins.io/t/jenkins-terminology-cleanup-initiative-coordination/180[Contributing guidelines and newcomer issue links] 
+  * link:https://community.jenkins.io/t/jenkins-terminology-cleanup-initiative-coordination/180[Contributing guidelines and newcomer issue links]
   * link:/sigs/advocacy-and-outreach/#inclusive-namingg[Inclusive naming project by Jenkins Advocacy&Outreach SIG]
 
 | link:/artwork[Jenkins Artwork]
@@ -208,12 +208,25 @@ The same is possible for other languages, let us know if you are interested!
   * If you want to participate to other language than French you are welcome ! However it would be great if you can find some other person speaking the target language for reviews.
   * Add terms for controller/agent/.. (and previous naming) in a speaking language you are mastering in tables https://github.com/jenkinsci/jep/blob/master/jep/16/README.adoc#translations
 
+| link:/projects/infrastructure/#pick-up-a-task[Jenkins Infrastructure]
+| Asciidoctor, Docker, Github Actions, Jenkins Pipeline, Kubernetes, Markdown, Packer, Puppet, Python, Shell, YAML
+a| An infrastructure is constantly moving forward: there are always dependencies to update,
+security issues to fix, new feature to release, tools to improve, etc.
+
+Any kind of contribution is welcome: from documentation to real life code.
+Either you are a beginner in this area, or a veteran of sytem administration,
+you are welcome to pick an issue and contribute!
+
+* You might want to read the Jenkins Infrastructure's link:/projects/infrastructure/#contributing[Contributing Guide,window="_blank"]
+* Ready for action? Look at the good first issues we have on the JIRA project at link:https://issues.jenkins.io/browse/INFRA-3074?jql=project%20%3D%20INFRA%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20%3D%20newbie-friendly[newbie-friendly,window="_blank"]
+* You can also browse the link:https://github.com/jenkins-infra[`https://github.com/jenkins-infra`,window="_blank"] GitHub organization and check for repositories and code.
+
 |=========================================================
 
 
 === Experienced developers
 
-If you are an established developer and want to create something new, 
+If you are an established developer and want to create something new,
 please don't let yourself to be blocked by the suggested topics!
 Feel free to contribute to any area of Jenkins.
 If you see any major functionality missing in Jenkins,

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -47,7 +47,7 @@ link:https://github.com/jenkins-infra/documentation/tree/main/meetings[jenkins-i
 The Jenkins project runs the most of its infrastructure on Azure, sponsored by link:https://cd.foundation/[Continuous Delivery Foundation].
 This infrastructure is provisioned from the repository https://github.com/jenkins-infra/azure[jenkins-infra/azure] using Terraform and using AKS link:https://github.com/jenkins-infra/charts/[charts].
 
-While we try to stick to Azure, we still have machines sponsored by different organizations such as OSUOSL, AWS, Rackspace or CloudBees. 
+While we try to stick to Azure, we still have machines sponsored by different organizations such as OSUOSL, AWS, Rackspace or CloudBees.
 
 === Configuration Management
 
@@ -140,7 +140,7 @@ Jenkins infrastructure also hosts some services for sub-projects and special int
 |===
 
 == Contributing
-Our infrastructure is an open infrastructure project made by and for the Jenkins community. 
+Our infrastructure is an open infrastructure project made by and for the Jenkins community.
 In other words, it's a contributors driven project.
 While we can't share publicly everything like secrets, certificates,... we still try to be as transparent as possible so that everybody can understand and improve our infrastructure without having privileged accesses.
 If you have any idea that could help the infra or interest the community, feel free to make suggestions.
@@ -151,7 +151,7 @@ Before going further, we assume that:
 * You already created a Jenkins account on https://accounts.jenkins.io[accounts.jenkins.io]
 * You registered to the Jenkins Infra mailing list link:/mailing-lists/#jenkins-infra-googlegroups-com[jenkins-infra@googlegroups.com]
 * You have access to our ticket system https://issues.jenkins.io[issues.jenkins.io]
-* You already said "Hi" on IRC channel: link:/chat/#jenkins-infra[#jenkins-infra] 
+* You already said "Hi" on IRC channel: link:/chat/#jenkins-infra[#jenkins-infra]
 ****
 
 
@@ -164,19 +164,28 @@ Pick up a task => Communicate => Implement => Deploy => Review
 ----
 
 === Pick Up A Task
-In order to keep track of the work that needs to be done on the Jenkins infrastructure project, we use the project "INFRA" on https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA[Jira].
-Therefor the first thing to do before any contribution is to find the right ticket, assign it to you, then communicate about it. 
+To keep track of the work that needs to be done on the Jenkins infrastructure project, we use a JIRA project named "INFRA" at https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA[Jira].
+If you want to contribute, the first step is to find the JIRA issue in this project that you want to work on, assign it to you,
+then communicate about it (see <<Communicate>>).
 
-If you can't find an appropriate ticket, please create a new ticket with a clear description of what needs to be done and why.
-Some jenkins-infra git repository references can help to understand the context.
+If you can't find an appropriate issue, please create a new one with a clear description:
+
+- Why (what is the problem to solve - high level value)?
+- What (what your proposal to solve the problem)?
+- How (what are the technical changes to do)?
+
 You may also specify components and finally you can communicate about it, using the suggestions from the next section.
 
+[TIP]
+.Good First Issues
+====
+If you want to start contributing on the Jenkins infrastructure,
+you can find a list of "first good issues" to be considered (they all have the label `newbie-friendly`)
+on the following page:
+link:https://issues.jenkins.io/browse/INFRA-3074?jql=project%20%3D%20INFRA%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20%3D%20newbie-friendly[newbie-friendly,window="_blank"].
+====
 
-Remark:::
-
-While a ticket can have different components assigned to it, we also use the label https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA%20AND%20labels%20%3D%20[newbie-friendly] to identify task which can be done by a new contributor. 
-
-=== Communicate 
+=== Communicate
 Before any implementation, it's important to verify that first, there is (still) a need for some implementation and then that no work has been done in the past.
 The best way for that is to either look after similar Jira tickets, ask on IRC or on the mailing list.
 You can also join our weekly meetings to discuss and coordinate the changes.
@@ -207,7 +216,7 @@ Anyway keep in mind that it's always better to have too much information than to
      |                         +------------------------------------------+    |
      | If the topic is too big                                                 |
      |                                                                         |
-     |                    +-------------------------------------------+        | 
+     |                    +-------------------------------------------+        |
      |                    |                                           |        |
      +--------------------> IEP: https://github.com/jenkins-infra/iep |--------+
                           |                                           |
@@ -257,7 +266,7 @@ Fork project -> Create Feature Branch -> Open Pull Request -> Ask Review -> Merg
 The deployment step is the only moment where we need approval from someone with elevated permission. As already mentioned, even if we try to be as open as possible, we don't want to share privileged accesses with every contributors even if we trust them and that mainly for security reasons.
 
 
-== Link 
+== Link
 Various link which can helpful when looking at the Jenkins infra project
 
 * https://github.com/orgs/jenkins-infra[Github Organization]


### PR DESCRIPTION
With the upcoming hacktoberfest, the Infrastructure team want to expose some "first good issues".

This PR:

- Fixes the links and language of the "Contribution" section of the Infrastucture's project page

<img width="917" alt="Capture d’écran 2021-09-30 à 16 16 58" src="https://user-images.githubusercontent.com/1522731/135472574-a8d1981a-a9ff-4ba5-84f2-bc64bf346d35.png">


- Adds the infrastructure as one of the projects for hacktoberfest

<img width="1047" alt="Capture d’écran 2021-09-30 à 16 17 19" src="https://user-images.githubusercontent.com/1522731/135472599-1c9d51d4-19c2-4e6f-af83-e789cb95543d.png">


