### PR TITLE
Replace DevOps World with Contributor Summit

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -49,12 +49,12 @@ homepage: true
 -# Carousel Slides
 - slides = []
 
--# DevOps World 2021
-- slides << {:href => 'https://www.devopsworld.com/',
-  :title => 'DevOps World and Jenkins contributor summit',
-  :intro => "Join us at DevOps World September 28-30 for workshops, demos, and presentations. Make new connections with practitioners, thought leaders, and community contributors. Help define the future of Jenkins at the October 1 contributor summit.",
-  :image => {:src => expand_link('images/conferences/devops-world-2021.png'), :height => "300px"},
-  :call_to_action => {:text => 'Register for DevOps World', :href => 'https://www.cloudbees.com/devops-world-2021/registration'}}
+-# Contributor Summit Oct 2, 2021 and OCt 9, 2021 - replace register link with https://www.meetup.com/Jenkins-online-meetup/events/281089570/ after Oct 2, 2021
+- slides << {:href => '/events/contributor-summit/',
+  :title => 'Contributor Summit',
+  :intro => "Join us Oct 2, 2021 and Oct 9, 2021 for the Jenkins Contributor Summit. The Jenkins Contributor Summit brings together current and future contributors to the Jenkins project. It brings together community members to learn, meet, and help shape the future of Jenkins.",
+  :image => {:src => expand_link('images/conferences/contributor_summit.png'), :height => "300px"},
+  :call_to_action => {:text => 'Register for Contributor Summit', :href => 'https://www.meetup.com/Jenkins-online-meetup/events/281083403/'}}
 
 -# Hacktoberfest 2021
 - slides << {:href => 'https://hacktoberfest.digitalocean.com/',


### PR DESCRIPTION
## Replace DevOps World with Contributor Summit

DevOps World completed September 30, 2021.  Let's use the Jumbotron space to highlight the Contributor Summit.

![screencapture-mark-pc2-markwaite-net-4242-2021-09-30-17_18_06-edit](https://user-images.githubusercontent.com/156685/135542071-9201fa2b-9432-4cf8-8fa5-92b412c3ea05.png)
