### PR TITLE
Update contributor summit for part I/part II

### DIFF
--- a/content/events/contributor-summit/index.adoc
+++ b/content/events/contributor-summit/index.adoc
@@ -23,27 +23,40 @@ description: >
 The Jenkins Contributor Summit brings together current and future contributors to the Jenkins project.
 It brings together community members to learn, meet, and help shape the future of Jenkins.
 
-== Online Contributor Summit on Oct 02, 2021
+== Two Part Contributor Summit
 
-The next contributor summit will take place on Oct 02, 2021.
-It will be an online event
-co-located with link:https://www.devopsworld.com/[DevOps World] where Jenkins is also widely represented.
+The next contributor summit will be a two part event hosted online.
+Part I will happen on October 2, 2021, with part II on October 9, 2021.
+Both parts of the contributor summit will be hosted at times that are convenient for contributors from the Asia/Pacific regions.
 
-The summit will include short updates by the Governance Board, working and special interest groups.
-We will also organize breakout sessions to discuss key initiatives in the project and its roadmap.
-Topics include but not limited to:
-architecture changes, Jenkins Security, Cloud Native Jenkins, interoperability with CDF and CNCF projects, documentation, and user experience.
-We will have lightning talks and demos of the new and upcoming Jenkins features.
+=== Contributor Summit Part I - Oct 2, 2021
 
-We will also organize a track for newcomer contributors who want to participate in the project and link:/events/hacktoberfest[Hacktoberfest].
-During this track we will talk about contributing to Jenkins.
+The October 2, 2021 contributor summit will focus on welcoming new contributors and launching link:/events/hacktoberfest[Jenkins in Hacktoberfest 2021].
+Presentations and working sessions will focus on helping new contributors quickly and confidently assist with Jenkins.
 
-The Jenkins Contributor Summit is hosted by the Jenkins community.
-It is sponsored by CloudBees and the Continuous Delivery Foundation (CDF).
+Presentations will include:
 
-== Registration
+* Improving code coverage user experience - link:/blog/authors/uhafner/[Ullrich Hafner]
+* Migrating plugin documentation to GitHub - link:/blog/authors/markewaite[Mark Waite]
+* Implementing Content Security Policy (CSP) in Jenkins - link:/blog/authors/wadeck[Wadeck Follonier]
+* Modernizing plugins - link:/blog/authors/markewaite[Mark Waite]
 
-Coming soon
+After the presentations, we'll host question and answer sessions to assist new contributors with their specific issues and concerns.
+
+Register for part I of the contributor summit through the Jenkins online meetup site.
+
+image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://www.meetup.com/Jenkins-online-meetup/events/281083403/", role=center, height=48]
+
+=== Contributor Summit Part II - Oct 9, 2021
+
+The October 9, 2021 contributor summit will include short project updates and breakout unconference sessions where we will discuss key initiatives in the project and its roadmap.
+Then we will have lightning talks and demos of the new and upcoming Jenkins features, and afterparty.
+
+The Jenkins Contributor Summit is hosted by the Continuous Delivery Foundation (CDF) and the Jenkins community.
+
+Register for part II of the contributor summit through the Jenkins online meetup site.
+
+image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://www.meetup.com/Jenkins-online-meetup/events/281089570/", role=center, height=48]
 
 == Call for participation
 
@@ -51,59 +64,6 @@ Jenkins Contributor Summit is a community driven event.
 Our agenda is based on interest of contributors and community members.
 If you want to suggest a session, just suggest a change in this link:https://docs.google.com/document/d/1QLWXNG23ui-LvQXth3UREzOvLYgTMSZcv-El0H141a4/edit?usp=sharing[Google Doc].
 If you want to help with the event organization, reach out to us in the link:https://community.jenkins.io/t/jenkins-contributor-summit-oct-02-2021-apac-emea/203[Discourse].
-
-== Agenda
-
-The contributor summit will be split into the following categories:
-State of the Union,
-Newcomer track,
-End user panel,
-Contributor track with many unconference sessions in breakout rooms,
-Ignite Talks and Demos,
-Happy hour and closing afterparty.
-See the full agenda link:https://docs.google.com/document/d/1QLWXNG23ui-LvQXth3UREzOvLYgTMSZcv-El0H141a4/edit?usp=sharing[here].
-
-State of the Union::
-anchor:state-of-the-union[]We’ll highlight key Jenkins initiatives there:
-* State of Jenkins, led by Jenkins officers and board members
-* link:/projects[Sub-project] and team updates
-* link:/sigs/[Special Interest Group Updates], leaded by SIG leaders we’ll highlight key initiatives there
-* Key announcements
-
-Newcomer track::
-anchor:newcomer-track[]Track for newcomer contributors and those who just want to start contributing to Jenkins or consider doing it.
-
-* Contributing to Jenkins
-* link:/events/hacktoberfest[Jenkins in Hacktoberfest 2021]
-* Jenkins outreach programs and how to participate
-
-End User Panel::
-anchor:end-user-panel[]Several Jenkins end users will talk about their experiences, issues they hit and expectations from Jenkins evolution.
-These are not demos sessions or feature/company presentations.
-Contributors will have an opportunity to ask questions and clarify some points.
-Confirmed companies/presenters:
-
-* To Be Announced! If you want to present your story, link:/events/contributor-summit/#chat[contact us]!
-
-Contributor Unconference:: 
-anchor:contributor-track[]The goal of the contributor track is to gather as many people as possible to discuss the next major initiatives.
-Several topics will be covered simultaneously in breakout rooms.
-We will follow the unconference format.
-Any topics about Jenkins are welcome, please submit them in advance as documented above.
-Examples of the currently submitted topics, all tentative depending on the planning and votes: 
-
-* Coming soon!
-
-Ignite Talks and Demos::
-anchor:ignite-talks[]Series of really short talks and demos, up to 5 minutes each.
-The idea is to pitch your project or an idea for future discussion at unconference, anything about Jenkins would work.
-
-We will be accepting demos until the very last minute, make suggestions link:https://docs.google.com/document/d/1JVbWudREipEF5UJn-bBRU5QIjKf8mzFP9iFdwWbgFB0/edit#heading=h.yofbvfe396v5[here]
-
-Closing and Happy Hour::
-anchor:closing[]Closing event and afterparty.
-There will be some fun activities!
-Details to be announced.
 
 == Discussion channels
 
@@ -139,7 +99,8 @@ For organization matters, please use the link:/mailing-lists/#jenkins-advocacy-a
 
 == References
 
-* Registration - coming soon
+* link:https://www.meetup.com/Jenkins-online-meetup/events/281083403/[Contributor Summit Part I Registration]
+* link:https://www.meetup.com/Jenkins-online-meetup/events/281089570/[Contributor Summit Part II Registration]
 * link:https://docs.google.com/document/d/1QLWXNG23ui-LvQXth3UREzOvLYgTMSZcv-El0H141a4/edit?usp=sharing[Coordination Google Doc]
 * link:https://community.jenkins.io/t/jenkins-contributor-summit-oct-02-2021-apac-emea/203[Announcement on community.jenkins.io Discourse site]
 * link:https://www.devopsworld.com/[DevOps World and co-located events on September 28-30]
@@ -149,7 +110,7 @@ For organization matters, please use the link:/mailing-lists/#jenkins-advocacy-a
 === Previous events
 
 * link:/events/contributor-summit/archive/2021-06[Online Contributor Summit on Jun 25, 2021]
-* link:/blog/2021/02/16/contributor-summit-online/[Online Contributor Summit on Feb 23-25, 2021] 
+* link:/blog/2021/02/16/contributor-summit-online/[Online Contributor Summit on Feb 23-25, 2021]
 * link:https://www.meetup.com/jenkinsmeetup/events/267684785/[2020 contributor summit at FOSDEM]
 * link:/blog/2019/08/25/jenkinsworld-contrib-summit-ask-the-expert-booth/[2019 contributor summit blog post]
 * link:/blog/2018/10/18/contributor-summit-summary/[2018 contributor summit summary]


### PR DESCRIPTION
## Update contributor summit for part I and part II

Include "Register Here" button to encourage readers to register for the events.  Include agenda text from the online meetup announcements.

See https://www.meetup.com/Jenkins-online-meetup/events/281083403/ to register for Part I.

See https://community.jenkins.io/t/hacktoberfest-2021-join-us/375 for discussions of Hacktoberfest in Jenkins.

See https://www.meetup.com/Jenkins-online-meetup/events/281089570/ to register for Part II.

See https://community.jenkins.io/t/jenkins-contributor-summit-oct-02-and-oct-09-2021-apac-emea/203 for discussions of the Contributor Summit.

![screencapture-mark-pc2-markwaite-net-4242-events-contributor-summit-2021-09-30-18_22_54-edit](https://user-images.githubusercontent.com/156685/135547618-87eb4ede-7733-48ff-9568-72bd464ac065.png)