### PR TITLE
Add developer documentation topic to Website feature

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -93,6 +93,11 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[Contributing guidelines],
   link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22[Good first issues]
 
+  Additionally, we invite new and experienced Jenkins developers to help improve the link:/doc/developer/[developer documentation].
+  If you want to learn a Jenkins development topic and share your new knowledge with others, or want to help someone else learn, you're welcome to contribute here.
+
+  link:https://github.com/jenkins-infra/jenkins.io/projects/3[Board], https://gitter.im/jenkinsci/docs[chat]
+
 | link:https://github.com/jenkinsci/jenkins[Jenkins Core]
 | Java
 | There is always something to improve in Jenkins core itself.


### PR DESCRIPTION
Given the inclusiveness of the first entry it seemed to make sense to add this topic directly to its description. @MarkEWaite signed off on the use of the board and chat for this topic.

> <img width="848" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/135591767-2be748cb-6335-4352-92e5-947610a8da0b.png">

FYI @megathaum 