### PR TITLE
Update time for contributor summit part 2

### DIFF
--- a/content/_data/events/2021-10-09-contributor-summit-part-2.adoc
+++ b/content/_data/events/2021-10-09-contributor-summit-part-2.adoc
@@ -1,7 +1,7 @@
 ---
 title: "Jenkins Contributor Summit Part 2"
 location: "Online"
-date: "2021-10-09 EMEA Timezone"
+date: "2021-10-09T07:00:00"
 link: "/events/contributor-summit/"
 
 ---


### PR DESCRIPTION
## Use correct time for Contributor Summit part 2

https://www.meetup.com/Jenkins-online-meetup/events/281089570/ shows the same start time as contributor summit part 1.  Make them match in the event view as well.
