### PR TITLE
Fix broken link in remote-access-api page

### DIFF
--- a/content/doc/book/using/remote-access-api.adoc
+++ b/content/doc/book/using/remote-access-api.adoc
@@ -73,8 +73,7 @@ and match the *File location* field in the Jenkins job configuration with the ke
 == Remote API and security
 
 When your Jenkins is secured, you can use HTTP BASIC authentication to authenticate remote API requests. 
-See link:../system-administration/authenticating-scripted-clients[Authenticating
-scripted clients] for more details.
+See link:/doc/book/system-administration/authenticating-scripted-clients/[Authenticating scripted clients] for more details.
 
 [[RemoteaccessAPI-CSRFProtection]]
 == CSRF Protection


### PR DESCRIPTION
Reported in the [docs feedback sheet](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) row 1191
