### PR TITLE
Add forum to community menu

### DIFF
--- a/content/_partials/legacy/navbar.html.haml
+++ b/content/_partials/legacy/navbar.html.haml
@@ -13,6 +13,9 @@
         %a{:href => "/", :title => ""}
           Participate
         %ul.menu
+          %li.leaf
+            %a{:href => "https://community.jenkins.io/", :title => "Forum"}
+              Forum
           %li.leaf.first
             %a{:href => "/content/mailing-lists", :title => "Browse Jenkins mailing list archives and/or subscribe to lists"}
               Mailing Lists

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -77,6 +77,8 @@
             Meet
           %a.dropdown-item.feature{:href => expand_link('events')}
             Events
+          %a.dropdown-item.feature{:href => "https://community.jenkins.io/"}
+            Forum
           %a.dropdown-item.feature{:href => "https://issues.jenkins.io/"}
             Issue Tracker
           %a.dropdown-item.feature{:href => expand_link('mailing-lists'),

--- a/content/participate/help.adoc
+++ b/content/participate/help.adoc
@@ -15,6 +15,7 @@ There are many platforms and channels where you can help jenkins users.
 ==== Mailing Lists, Chats/Interest Groups, How-To Guides
 
 - link:/mailing-lists[Mailing Lists]
+- link:https://community.jenkins.io[Forum]
 - link:/chat/[Gitter rooms and IRC channels]
 - link:/sigs/[Special Interest Groups]
 - link:/participate/how-to-guides/[How-To Guides]
@@ -27,6 +28,7 @@ There are many platforms and channels where you can help jenkins users.
 ==== Professional Sites
 
 - https://stackoverflow.com/tags/jenkins[Jenkins on StackOverflow]
+- link:https://community.jenkins.io[Jenkins Forum]
 - https://issues.jenkins.io/secure/BrowseProjects.jspa[Jenkins Projects]
 - https://community.atlassian.com/t5/tag/jenkins/tg-p[Jenkins on Atlassian Community]
 - https://www.quora.com/topic/Jenkins[Jenkins on Quora]


### PR DESCRIPTION
## Add forum to more locations

* Add Forum to Community dropdown menu
* Add Forum to legacy menu just in case it is used
* Add Forum to 'Help other users' page

Menu now looks like this:

![added-forum-to-community-dropdown](https://user-images.githubusercontent.com/156685/135775869-acc26d19-e5cc-4710-a361-e7815d6c7414.png)


