### PR TITLE
Fix 100k page.

### DIFF
--- a/content/blog/2015/2015-02-09-jenkins-celebration-day-is-february-26.adoc
+++ b/content/blog/2015/2015-02-09-jenkins-celebration-day-is-february-26.adoc
@@ -10,66 +10,36 @@
   - news
 :author: kohsuke
 ---
- +
+
 Congratulations! The Jenkins project officially went over the 100K active users mark sometime in January. As of January 31, https://stats.jenkins-ci.org/jenkins-stats/svg/total-jenkins.svg[we were at 102,992]. YOU are one of the 100K active users! +
- +
 
- +
 As discussed on http://meetings.jenkins-ci.org/jenkins/2015/[a couple recent project meetings], we have designated *February 26* as Jenkins Celebration Day. +
- +
-
- +
 To make some noise, here is what we are doing starting NOW: +
- +
 
-*  +
-Write a blog about anything related to Jenkins. Post your blog and Tweet out a link to it. Include the hashtag *#Jenkins100K* in your post. +
- +
-*  +
-On February 26, we will hold a raffle and pick four names at random. The grand prize winner will get a https://jenkins-ci.org/content/jenkins-figure-available-shapeways[3D Jenkins Butler model]. Five others will get their pick of Jenkins swag (up to $20) from https://www.cafepress.com/jenkinsci[the Jenkins online store]. +
- +
-
- +
- +
+* Write a blog about anything related to Jenkins. Post your blog and Tweet out a link to it. Include the hashtag *#Jenkins100K* in your post. +
+* On February 26, we will hold a raffle and pick four names at random. The grand prize winner will get a https://jenkins-ci.org/content/jenkins-figure-available-shapeways[3D Jenkins Butler model]. Five others will get their pick of Jenkins swag (up to $20) from https://www.cafepress.com/jenkinsci[the Jenkins online store]. +
 
 == OTHER WAYS TO CELEBRATE
 
- +
- +
-
- +
 There are a number of other things planned and we want YOU to be involved. This blog post is the central place to come for all things related to the celebration. +
- +
 
-*  +
-*Recording – Jenkins Governance Board* +
+* *Recording – Jenkins Governance Board* +
 Dean, Tyler, Andrew and I will get together this month and record some thoughts about the Jenkins project. We will share that recording with you from this page on February 26. +
- +
-*  +
-*https://jenkins-ci.org/sites/default/files/images/jenkins-100k-profile_4.jpg[Twitter Badge]* +
+
+* *https://jenkins-ci.org/sites/default/files/images/jenkins-100k-profile_4.jpg[Twitter Badge]* +
 For those of us on social media that want to proudly celebrate our community, we will have a special badge that you can use for your profile image on Twitter or any of the other social media forums. Feel free to use the badge as long as you want – but let’s get as many of us using it as possible between now and February 27. +
- +
-*  +
-*https://jenkins-ci.org/content/jenkins-100k-celebration-pictures[Social Media Images]* +
+
+* *https://jenkins-ci.org/content/jenkins-100k-celebration-pictures[Social Media Images]* +
 ** CloudBees is donating a series of images that we can all push out on social media (whatever platform(s) you use). +
 ** Pick your favorite(s) and push them out on Twitter, Facebook, G+ +
-+
- +
- +
-*  +
-*Certificate* (available on this blog post soon) +
+
+* *Certificate* (available on this blog post soon) +
 Download your very own “I am part of the Jenkins 100K” certificate. Print it out and proudly display it on the wall of your cube or office. +
- +
-*  +
-*Visibility* +
+
+* *Visibility* +
 The Community will also issue a press release on February 26 announcing our milestone news. +
- +
-*  +
-*Sign the “card”* +
+
+* *Sign the “card”* +
 Consider this blog a Congratulations card to the entire community. Share your thoughts in a comment on this blog about anything Jenkins-related that you wish! +
 
- +
- +
-
- +
 This is a big milestone for the Community and one you should be proud to be part of! Let’s make some noise… +


### PR DESCRIPTION
It seems like the old one had a bit of messy html which is probably why the auto conversion failed.

http://web.archive.org/web/20200813205301/https://www.jenkins.io/blog/2015/02/09/jenkins-celebration-day-is-february-26/

The github preview page looks good now