### PR TITLE
Remove duplicated content

### DIFF
--- a/content/doc/book/security/securing-jenkins.adoc
+++ b/content/doc/book/security/securing-jenkins.adoc
@@ -49,27 +49,3 @@ database, and perform access control based on the permission/user matrix.
 * https://wiki.jenkins.io/display/JENKINS/Matrix-based+security[Matrix-based security|Matrix-based security] --- Granting and denying finer-grained permissions
 
 In addition to access control of users, link:build-authorization[access control for builds] limits what builds can do, once started.
-
-== Protect users of Jenkins from other threats
-
-There are additional security subsystems in Jenkins that protect Jenkins and
-users of Jenkins from indirect attacks.
-
-The following topics discuss features that are *off by default*.
-We recommend you read them first and act on them immediately.
-
-* https://wiki.jenkins.io/display/JENKINS/Security+implication+of+building+on+master[Security implication of building on controller] --- protect Jenkins controller from malicious builds
-* https://wiki.jenkins.io/display/JENKINS/Securing+JENKINS_HOME[Securing JENKINS_HOME] --- protect Jenkins from users with local access
-* link:/doc/book/security/environment-variables[Handling Environment Variables] -- ensure that environment variables passed to build steps do not have unintended side effects
-
-The following topics discuss other security features that are on by default. You'll only need to look at them when they are causing problems.
-
-* link:/doc/book/security/csrf-protection[CSRF Protection] --- prevent a remote attack against Jenkins running inside your firewall.
-* link:/doc/book/security/controller-isolation/#agent-controller-access-control[Agent To Controller Access] --- protect Jenkins controller from malicious build agents
-* link:/doc/book/security/configuring-content-security-policy/[Configuring Content Security Policy] --- protect users of Jenkins from malicious builds
-* link:/doc/book/security/markup-formatter/[Markup Formatter] -- allow for rich formatting of descriptions in Jenkins while keeping users safe
-
-
-== Disabling Security
-
-See link:/doc/book/security/access-control/disable/[Disable Access Control].


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/pull/4608 reminded me that I wanted to remove this file entirely. This and https://github.com/jenkins-infra/jenkins.io/blob/master/content/doc/book/security/managing-security.adoc were migrated from other sections of the handbook to /doc/book/security, and were not yet fully integrated into the new structure.

To keep the wiki links around as a reminder to rewrite those parts on the site (i.e., specific guides how to set up common security setups), I'm just removing the part that's almost entirely a duplication of https://www.jenkins.io/doc/book/security/

"Securing JENKINS_HOME" is the only content without a corresponding page or overview link.