### PR TITLE
Docker for Windows installation commands updated

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -218,11 +218,11 @@ docker network create jenkins
 +
 [source]
 ----
-docker run --name jenkins-docker --rm --detach ^
-  --privileged --network jenkins --network-alias docker ^
-  --env DOCKER_TLS_CERTDIR=/certs ^
-  --volume jenkins-docker-certs:/certs/client ^
-  --volume jenkins-data:/var/jenkins_home ^
+docker run --name jenkins-docker --rm --detach `
+  --privileged --network jenkins --network-alias docker `
+  --env DOCKER_TLS_CERTDIR=/certs `
+  --volume jenkins-docker-certs:/certs/client `
+  --volume jenkins-data:/var/jenkins_home `
   docker:dind
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
@@ -260,11 +260,11 @@ if this hasn't been done before.
 +
 [source]
 ----
-docker run --name jenkins-blueocean --rm --detach ^
-  --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
-  --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
-  --volume jenkins-data:/var/jenkins_home ^
-  --volume jenkins-docker-certs:/certs/client:ro ^
+docker run --name jenkins-blueocean --rm --detach `
+  --network jenkins --env DOCKER_HOST=tcp://docker:2376 `
+  --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 `
+  --volume jenkins-data:/var/jenkins_home `
+  --volume jenkins-docker-certs:/certs/client:ro `
   --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.


### PR DESCRIPTION
Line break escapes changed from ^ to backtick (`) in the case of long commands, because PowerShell is able to interpret only that. Now these commands are really copy-paste compatibles.