### PR TITLE
Hacktoberfest - Architecture, adding a high level view of internal Jenkins application

### DIFF
--- a/content/doc/developer/architecture/model.adoc
+++ b/content/doc/developer/architecture/model.adoc
@@ -31,11 +31,11 @@ layout: developersection
  │                                                                                        │
  ├────────────────────────────────────────────────────────────────────────────────────────┤
  │                                                                                        │
- │                      Storage layer: xml files on JENKINS_HOME                          │
+ │                      Storage layer: XML files on JENKINS_HOME                          │
  │                                                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────┘
 
- Some references to dive deeper:
+Some references to dive deeper:
 
  - https://github.com/jenkinsci/remoting/blob/master/README.md[Remoting]
  - link:../../handling-requests/[Stapler, request handling and routing]


### PR DESCRIPTION
The goal of this view, is to put some "keyword" that you have to know to navigate in documentation like "Stapler" "Remoting".

I had in mind to see Jenkins as an application with layer, usually in web application you have database > function/bussiness layer > REST Apis > UI (like javascript SPA).

I am also trying to do it as "ascii art" so I can search the documentations pages on remoting or stapler to link them inside.

I would love to have something with a bit more detail in the middle, so feel free to propose some boxes.

My first idea what to make links inside the picture, but then the source is hard to read, so i have put them after in the end.

I have run `make all ` and `make run` and this seems to render correctly.

![arch layers](https://user-images.githubusercontent.com/3634942/137730621-31bf5e87-95e2-4691-b4d5-3940be0e74af.png)


