### PR TITLE
Update roadmap with latest results

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -581,7 +581,7 @@ categories:
       description: >
         This Bill of materials can be used by plugin developers to more easily manage dependencies on other common plugins.
         It includes a cross-verified set of plugins compatible with a particular Jenkins core baseline.
-      status: preview
+      status: released
       link: https://github.com/jenkinsci/bom
       labels:
       - tools


### PR DESCRIPTION
## Update roadmap with latest results

Updates that I saw included:

* IBM s390x Docker images are released
* Docker image support for Arm is released
* Multi-platform Docker images are preview (no PowerPC yet)
* Tables to divs released in Jenkins 2.277.1
* Java 17 preview available in Docker images
* Google Summer of Code 2021 is completed
* ci.jenkins.io as code is being developed now
* Adoptium instead of AdoptOpenJDK in roadmap item
* Jenkins plugin BOM is in use and "current" rather than preview

Now looks like this:

![screencapture-mark-pc2-markwaite-net-4242-project-roadmap-2021-10-08-09_22_28-edit](https://user-images.githubusercontent.com/156685/136583007-6f9a7147-bb23-48e2-81d8-e4ace2e88a06.png)

