### PR TITLE
ISO format has two digits

### DIFF
--- a/content/_data/events/2020-01-30-fosdem.adoc
+++ b/content/_data/events/2020-01-30-fosdem.adoc
@@ -2,7 +2,7 @@
 
 title: "Jenkins at FOSDEM"
 location: "Brussels, Belgium"
-date: "2020-01-30T8:30:00"
+date: "2020-01-30T08:30:00"
 endDate: "2020-02-02T17:00:00"
 link: "/events/fosdem"
 


### PR DESCRIPTION
Minor minor fix, but javascript's new Date() function won't handle this as is.