### PR TITLE
Add references to updated plugin docs

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -12696,6 +12696,16 @@
         pull: 5773
         authors:
           - basil
+        references:
+          - pull: 5773
+          - url: https://plugins.jenkins.io/workflow-api/
+            title: "Pipeline: API plugin"
+          - url: https://plugins.jenkins.io/workflow-step-api/
+            title: "Pipeline: Step API plugin"
+          - url: https://plugins.jenkins.io/scm-api/
+            title: "SCM API plugin"
+          - url: https://plugins.jenkins.io/structs/
+            title: "Structs plugin"
         pr_title: Upgrade detached plugins to versions with Guava compatibility fixes
         message: |-
           Update bundled versions of Pipeline: API, Pipeline: Step API, SCM API, and Structs plugins.


### PR DESCRIPTION
Plugin pages were referenced in the original changelog but it used markdown syntax for the hyperlinks.  Could either convert them to href or to references.  This converts them to references as discussed in Docs Office Hours.
