### PR TITLE
fix(doc): replace "master" by "controller" and remove outdated warning

### DIFF
--- a/content/projects/remoting/index.adoc
+++ b/content/projects/remoting/index.adoc
@@ -23,7 +23,7 @@ The Remoting sub-project includes the Remoting library itself, package for agent
 == Remoting Usage in Jenkins
 
 * Agent executables (`remoting.jar` is a named `agent.jar` or `slave.jar` in Jenkins)
-* Master to Agent communication protocols being used in various Agent types, including Java Web Start (aka JNLP) and plugin:ssh-slaves[SSH] agents 
+* Controller to Agent communication protocols being used in various Agent types, including Java Web Start (aka JNLP) and plugin:ssh-slaves[SSH] agents 
 * link:/doc/book/managing/cli/[Jenkins CLI], Remoting mode is **deprecated since 2.54** (link:/blog/2017/04/11/new-cli/[announcement])
 * Communication with Maven instance in the plugin:maven-plugin[Maven Integration plugin].
 
@@ -72,6 +72,3 @@ via one of remoting protocols.
 * link:https://hub.docker.com/r/jenkins/inbound-agent/[Docker Inbound Agent]: Image, which can be used to connect agents using TCP (JNLP protocols) or WebSockets
 * Jenkins CLI executable (Requires Remoting CLI to be enabled on the Jenkins controller)
 * Swarm Agent Connector executable in link:https://plugins.jenkins.io/swarm[Swarm Plugin]
-
-WARNING: Docker Agent Images will be moved to the `jenkins` organization instead soon
-(jira:JENKINS-42846[]).


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-42846 has been resolved, there is no need to keep the warning about the docker location change.