### PR TITLE
Hactoberfest - Add link to the detailled remoting documentation.

### DIFF
--- a/content/doc/developer/architecture/remoting.adoc
+++ b/content/doc/developer/architecture/remoting.adoc
@@ -3,6 +3,7 @@ title: Remoting
 layout: developersection
 ---
 
-Jenkins remoting is an executable JAR, which implements communication layer in Jenkins automation server. It's being used for controller <=> agent and controller <=> CLI communications.
+Jenkins remoting is an executable JAR, which implements the communication layer in Jenkins.
+It's used for controller <=> agent and controller <=> CLI communications.
 
 The documentation is hosted in the https://github.com/jenkinsci/remoting/blob/master/README.md[dedicated library repository]


### PR DESCRIPTION
Remoting documentation is all on https://github.com/jenkinsci/remoting/blob/master/README.md, I think it's better to keep documentation at one place, and just do a link with a small intro (or remove the chapter, but I think people may search here before being redirected to remoting repository)