### PR TITLE
Split remoting 4.11 into two items

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -12748,29 +12748,21 @@
         message: |-
           Screen Resolution cookie now has the <code>secure</code> flag set when Jenkins is running on HTTPS.
       - type: rfe
-        category: bug
+        category: rfe
         pull: 5821
-        issue: 61212
+        issue: 64831
         authors:
           - dependabot[bot]
-        pr_title: "[JENKINS-61212] - Fix Agent handshake when connecting them over\
-          \ Websocket on Java 11 + [JENKINS-64831] - Remoting 4.11: Deprecate the\
+        pr_title: "[JENKINS-64831] - Remoting 4.11: Deprecate the\
           \ -cp option in the agent.jar"
+        references:
+          - pull: 5821
+          - issue: 64831
+          - url: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.11
+            title: Remoting 4.11 changelog
         message: |-
-          [JENKINS-61212],bug - Fix Agent handshake when connecting them over Websocket on Java 11
-              Remoting 4.11 changelog: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.11
-           [JENKINS-64831],rfe - Remoting 4.11: Deprecate the -cp option in the agent.jar
-             Remoting 4.11 changelog: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.11
-      - type: bug
-        category: bug
-        pull: 5802
-        issue: 66854
-        authors:
-          - jglick
-        pr_title: "[JENKINS-66854] `AsyncPeriodicWork` should not touch its log file\
-          \ unless it has something to say"
-        message: |-
-          Reduce the amount of disk writes to <code>logs/tasks/\.log</code> when nothing interesting is happening.
+          Deprecate the <code>-cp</code> option in the remoting agent.jar command line.
+          Upgrade from Remoting 4.10 to Remoting 4.11.
       - type: bug
         category: bug
         pull: 5760
@@ -12780,6 +12772,32 @@
         pr_title: "[JENKINS-66753] Ongoing build disappears from build history"
         message: |-
           Display ongoing build in build history (regression in 2.314).
+      - type: bug
+        category: bug
+        pull: 5821
+        issue: 61212
+        authors:
+          - dependabot[bot]
+        pr_title: "[JENKINS-61212] - Fix Agent handshake when connecting them over\
+          \ Websocket on Java 11"
+        references:
+          - pull: 5821
+          - issue: 61212
+          - url: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.11
+            title: Remoting 4.11 changelog
+        message: |-
+          Fix agent handshake when connecting over Websocket on Java 11.
+          Upgrade from Remoting 4.10 to Remoting 4.11.
+      - type: bug
+        category: bug
+        pull: 5802
+        issue: 66854
+        authors:
+          - jglick
+        pr_title: "[JENKINS-66854] `AsyncPeriodicWork` should not touch its log file\
+          \ unless it has something to say"
+        message: |-
+          Reduce the amount of disk writes to <code>logs/tasks/*.log</code> when nothing interesting is happening.
 
   # pull: 5784 (PR title: Bump checkstyle from 9.0 to 9.0.1)
   # pull: 5785 (PR title: Hacktoberfest update the French translation Jenkins administration [JENKINS-66797])


### PR DESCRIPTION
# Update 2.317 changelog

Splits the remoting upgrade into two entries, one rfe for the deprecation and one bug for the Websocket fix.  Also moves the build history fix higher in the list because of the number of times it was mentioned in ratings.

![Screenshot 2021-10-19 073428](https://user-images.githubusercontent.com/156685/137921074-36de4187-a6a8-44ce-9645-7b684cfabfe3.png)

See #4631 comments for the explanation and see the notes from [Docs Office Hours](https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit#).