### PR TITLE
Add 'PR-5685 - xstream 1.4.18' to 2.309 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -12426,6 +12426,19 @@
           as parallel-capable
         message: |-
           Internal: <code>AntClassLoader</code> (and its subclass <code>PluginFirstClassLoader</code>) and <code>MaskingClassLoader</code> register themselves as parallel-capable.
+      - type: rfe
+        category: rfe
+        pull: 5685
+        issue: 66507
+        authors:
+          - basil
+        references:
+          - pull: 5685
+          - issue: 66507
+          - url: https://x-stream.github.io/changes.html#1.4.18
+            title: XStream 1.4.18
+        message: |-
+          Upgrade from xstream 1.4.17 to 1.4.18.
 
   # pull: 5583 (PR title: Automate jenkins.io changelog)
   # pull: 5681 (PR title: Bump spotless-maven-plugin from 2.12.2 to 2.12.3)


### PR DESCRIPTION
# Add 'PR-5685 - xstream 1.4.18' to 2.309 changelog

The entry for 'PR-5685 - xstream 1.4.18' was added to the weekly changelog by the automated changelog generator script in PR-4525, then removed as part of the same PR by my commit 48f338d.

Commit 48f338d is titled "Changes from docs office hours review" but the commit date is about 15 hours after Docs office hours completed.  The change was made after Docs office hours by me alone.

Our current preferred process is to correct the original pull request during the Docs office hours review so that all the participants in Docs office hours see and review the change.  The next merge to Jenkins core then applies corrections made during Docs office hours.

In this case, 15 hours after the Docs office hours, I modified the weekly.yml file for 2.309 release. That was after the release of 2.309, so the edit of the weekly changelog was made in the correct location, but the edit was incorrect. It should have retained and improved the reference to PR-5685 rather than deleting it.
