### PR TITLE
fix(ui): better contrast for the "report" icon in footer

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -3,7 +3,7 @@
 :css
   i.icon-report::before {
     content: "\f071";
-    color: #F46C1F;
+    color: #FFA91B;
     font-family: FontAwesome !important;
     font-size: 20px;
     vertical-align: middle;


### PR DESCRIPTION
Followup of https://github.com/jenkins-infra/jenkins.io/pull/4648#issuecomment-949587560

Used https://contrastchecker.com/

Before (#F46C1F):
<img width="555" alt="image" src="https://user-images.githubusercontent.com/91831478/138315234-3690903b-e570-44a3-ad13-d87c3b46078d.png">

After (#FFA91B):
<img width="557" alt="image" src="https://user-images.githubusercontent.com/91831478/138456258-f4b23611-d5cf-4042-8bf8-c987a935a0d3.png">