### PR TITLE
Define controller, node, agent, executor

### DIFF
--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -14,6 +14,78 @@ endif::[]
 
 = Managing Nodes
 
+== Components of Distributed builds
+
+Builds in a
+link:/doc/book/scaling/architecting-for-scale/#distributed-builds-architecture[Distributed Builds Architecture]
+use nodes, agents, and executors which are distinct from the Jenkins controller itself.
+Understanding what each of these components are is useful when managing nodes:
+
+////
+Add link to "How Jenkins executes a Pipeline" after
+https://github.com/jenkins-infra/jenkins.io/pull/4612 is merged
+////
+
+Jenkins controller::
+
+The Jenkins controller is the Jenkins service itself
+and is where Jenkins is installed.
+It is a webserver that also acts as a "brain"
+for deciding how, when and where to run tasks.
+Management tasks (configuration, authorization, and authentication)
+are executed on the controller, which serves HTTP requests.
+Files written when a Pipeline executes are written to the filesystem on the controller
+unless they are off-loaded to an artifact repository such as Nexus or Artifactory.
+
+Nodes::
+
+Nodes are the "machines" on which build agents run.
+Jenkins monitors each attached node for
+disk space, free temp space, free swap,
+clock time/sync and response time.
+A node is taken offline if any of these values
+go outside the configured threshold.
+
+The Jenkins controller itself runs on a special _built-in node_.
+It is possible to run agents and executors on this built-in node
+although this can degrade performance, reduce scalability of the Jenkins instance, and create serious security problems
+and is strongly discouraged, especially for production environments.
+
+Agents::
+
+Agents manage the task execution on behalf of the Jenkins controller
+by using executors.
+An agent is actually a small (170KB single jar) Java client process
+that connects to a Jenkins controller and is assumed to be unreliable.
+An agent can use any operating system that supports Java.
+Tools required for builds and tests are installed on the node where the agent runs;
+they can be installed directly or in a container (Docker or Kubernetes).
+Each agent is effectively a process with its own PID (Process Identifier) on the host machine.
+
+In practice, nodes and agents are essentially the same but it is good to remember that they are conceptually distinct.
+
+Executors::
+
+An executor is a slot for execution of tasks;
+effectively, it is a thread in the agent.
+The number of executors on a node defines the number of concurrent tasks
+that can be executed on that node at one time.
+In other words, this determines the number of concurrent Pipeline `stages`
+that can execute on that node at one time.
+
+The proper number of executors per build node must be determined
+based on the resources available on the node
+and the resources required for the workload.
+When determining how many executors to run on a node,
+consider CPU and memory requirements
+as well as the amount of I/O and network activity:
+
+* One executor per node is the safest configuration.
+* One executor per CPU core may work well
+if the tasks being run are small.
+* Monitor I/O performance, CPU load, memory usage, and I/O throughput carefully
+when running multiple executors on a node.
+
 == Creating Agents
 
 Jenkins agents are the "workers" that perform operations requested by the Jenkins controller.

--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -14,7 +14,7 @@ endif::[]
 
 = Managing Nodes
 
-== Components of Distributed builds
+== Components of Distributed Builds
 
 Builds in a
 link:/doc/book/scaling/architecting-for-scale/#distributed-builds-architecture[Distributed Builds Architecture]


### PR DESCRIPTION
This adds a link to the "Distributed Builds Architecture" documentation and gives a brief definition of controller, node, agent, and executor as background to Darin's excellent video about creating and attaching an agent.  Currently, one opens the "Managing Nodes" page and is presented with a video about "Creating Agents", which is a bit confusing for the uninitiated.

I originally developed this for the "Distributed Builds" page in the Security section but it belongs on the "Managing Nodes" page.  After this PR is merged, I will pare the description in the Security chapter way down and reference this list.