### PR TITLE
Link to Security section from security mention in Distributed Arch

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -78,6 +78,11 @@ issue: the "jenkins" user that Jenkins uses to run the jobs would have full
 permissions on all Jenkins resources on the controller. This means that, with a
 simple script, a malicious user can have direct access to private information
 whose integrity and privacy could not be, thus,  guaranteed.
+See
+link:/doc/book/security/controller-isolation/[Distributed Builds]
+in the
+link:/doc/book/security/[Securing Jenkins]
+chapter for more information.
 
 For all these reasons Jenkins supports agents, where the
 workload of building projects are delegated to multiple agents.


### PR DESCRIPTION
The existing material mentions the security advantages of a Distributed Builds Architecture.  This PR adds a link back to the discussion of Distributed Builds in the Security section.  Note that the security/controller-isolation.adoc page is renamed in https://github.com/jenkins-infra/jenkins.io/pull/4612 and this text uses the new title but, until that PR is merged, it shows a different title than what is referenced.

@daniel-beck @Wadeck @MarkEWaite 