### PR TITLE
Remove AJP documentation

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -42,15 +42,6 @@ It is defined by the Jenkins URL specified in the global configuration.
 |Runs Jenkins to include the $PREFIX at the end of the URL.
 For example, set _--prefix=/jenkins_ to make Jenkins accessible at _\http://myServer:8080/jenkins_
 
-|`--ajp13Port=$AJP_PORT`
-|Runs Jenkins listener on port $AJP_PORT using standard _AJP13_ protocol.
-The default is port 8009.
-To disable (because you're using _https_), use port `+-1+`.
-
-|`--ajp13ListenAddress=$AJP_ADDR`
-|Binds Jenkins to the IP address represented by $AJP_HOST.
-The default is 0.0.0.0 — i.e. listening on all available interfaces.
-
 |`--sessionTimeout=$TIMEOUT`
 |Sets the http session timeout value
 to $SESSION_TIMEOUT minutes. Default to what webapp specifies, and then

--- a/content/doc/book/system-administration/reverse-proxy-configuration-apache.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-apache.adoc
@@ -30,8 +30,6 @@ Choose the technique that best meets your needs:
 
 * <<mod_proxy>>
 * <<mod_proxy with HTTPS>>
-* <<mod_ajp or mod_proxy_ajp>>
-* <<mod_proxy_ajp with SSL>>
 * <<mod_rewrite>>
 
 == mod_proxy
@@ -250,114 +248,6 @@ NameVirtualHost *:443
     RequestHeader set X-Forwarded-Port "443"
 </VirtualHost>
 ----
-
-== mod_ajp or mod_proxy_ajp
-
-Jenkins can be configured to use mod_ajp or mod_proxy_ajp so that Jenkins runs in a different workspace than the typical Tomcat server, but both are available via the Apache web server.
-
-Configure Jenkins to use a different web and ajp port than Tomcat:
-
-[source]
-----
-HTTP_PORT=9080
-AJP_PORT=9009
-...
-nohup java -jar "$WAR" \
-           --httpPort=$HTTP_PORT \
-           --ajp13Port=$AJP_PORT \
-           --prefix=/jenkins >> "$LOG" 2>&1 &
-----
-
-Then setup Apache so that it knows that the prefix `+/jenkins+` is being
-served by AJP in the httpd.conf file:
-
-[source]
-----
-LoadModule jk_module          libexec/httpd/mod_jk.so
-
-AddModule     mod_jk.c
-
-#== AJP hooks ==
-JkWorkersFile /etc/httpd/workers.properties
-JkLogFile     /private/var/log/httpd/mod_jk.log
-JkLogLevel    info
-JkLogStampFormat "[%a %b %d %H:%M:%S %Y] "
-JkOptions     +ForwardKeySize +ForwardURICompat -ForwardDirectories
-JkRequestLogFormat     "%w %V %T"
-# Here are 3 sample applications - 2 that are being served by Tomcat, and Jenkins
-JkMount  /friki/* worker1
-JkMount  /pebble/* worker1
-JkMount  /jenkins/* worker2
-----
-
-Then finally the workers.conf file specified above, that just tells AJP
-which port to use for which web application:
-
-[source]
-----
-# Define 2 real workers using ajp13
-worker.list=worker1,worker2
-# Set properties for worker1 (ajp13)
-worker.worker1.type=ajp13
-worker.worker1.host=localhost
-worker.worker1.port=8009
-worker.worker1.lbfactor=50
-worker.worker1.cachesize=10
-worker.worker1.cache_timeout=600
-worker.worker1.socket_keepalive=1
-# Set properties for worker2 (ajp13)
-worker.worker2.type=ajp13
-worker.worker2.host=localhost
-worker.worker2.port=9009
-worker.worker2.lbfactor=50
-worker.worker2.cachesize=10
-worker.worker2.cache_timeout=600
-worker.worker2.socket_keepalive=1
-worker.worker2.recycle_timeout=300
-----
-
-== mod_proxy_ajp with SSL
-
-AJP is an arguably cleaner alternative for an SSL-enabled reverse proxy,
-since Jenkins will get all pertinent HTTP headers untouched.
-Configuration is a snap too, in three simple steps:
-
-{empty}1. Configure an AJP port for Jenkins (as mentioned above)
-
-[source]
-----
-HTTP_PORT=-1
-AJP_PORT=9009
-...
-nohup java -jar "$WAR" \
-           --httpPort=$HTTP_PORT \
-           --ajp13Port=$AJP_PORT \
-           --prefix=/jenkins >> "$LOG" 2>&1 &
-----
-
-{empty}2. Enable mod_proxy_ajp in Apache:
-
-[source]
-----
-# a2enmod proxy_ajp
-----
-
-{empty}3. Include the following snippet in your SSL-enabled VirtualHost:
-
-[source]
-----
-<VirtualHost *:443>
-...
-    SSLEngine on
-...
-    AllowEncodedSlashes NoDecode
-    ProxyRequests Off
-    ProxyPass /jenkins ajp://localhost:9009/jenkins nocanon
-</VirtualHost>
-----
-
-Note the use of `+AllowEncodedSlashes+` and `+ProxyPass...nocanon+` to
-persuade Apache to leave PATH_INFO alone.
 
 == mod_rewrite
 


### PR DESCRIPTION
Jenkins hasn't supported AJP since 2.0, so remove documentation leftovers.

The Apache documentation could actually be useful, if someone goes all the way to run Jenkins inside Tomcat. If any reviewer thinks this is still valuable, I would be willing to rework the documentation for that usecase instead of outright removing it...