### PR TITLE
Replace deprecated apt-key usage

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -35,9 +35,9 @@ It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-
 ----
 curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-sudo sh -c 'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-  https://pkg.jenkins.io/debian-stable binary/ > \
-  /etc/apt/sources.list.d/jenkins.list'
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update
 sudo apt-get install jenkins
 ----

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -51,9 +51,9 @@ It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt re
 ----
 curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-sudo sh -c 'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-  deb https://pkg.jenkins.io/debian binary/ > \
-  /etc/apt/sources.list.d/jenkins.list'
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update
 sudo apt-get install jenkins
 ----

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -33,9 +33,11 @@ It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-
 
 [source,bash]
 ----
-wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
-sudo sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > \
-    /etc/apt/sources.list.d/jenkins.list'
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+sudo sh -c 'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/ > \
+  /etc/apt/sources.list.d/jenkins.list'
 sudo apt-get update
 sudo apt-get install jenkins
 ----
@@ -47,9 +49,11 @@ It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt re
 
 [source,bash]
 ----
-wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | sudo apt-key add -
-sudo sh -c 'echo deb https://pkg.jenkins.io/debian binary/ > \
-    /etc/apt/sources.list.d/jenkins.list'
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+sudo sh -c 'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  deb https://pkg.jenkins.io/debian binary/ > \
+  /etc/apt/sources.list.d/jenkins.list'
 sudo apt-get update
 sudo apt-get install jenkins
 ----


### PR DESCRIPTION
Switch to explicitly using signed-by in sources.list.

Let's try to get the discussion going: This seems to represent the current best practice, see for example

- https://unix.stackexchange.com/a/463140/498490
- https://wiki.debian.org/DebianRepository/UseThirdParty

I'm personally not convinced that specifying "signed-by" in the sources.list file adds much in terms of security over just adding the key in trusted.gpg.d (see also the warning block at the top of the Debian wiki page)

(This should fix the warning noted in #4237)