### PR TITLE
Update redirect URL

### DIFF
--- a/content/redirect/remoting-security-workaround.adoc
+++ b/content/redirect/remoting-security-workaround.adoc
@@ -1,6 +1,5 @@
 ---
 layout: redirect
-redirect_url: https://updates.jenkins.io/download/plugins/remoting-security-workaround/
-# TODO (early alternative) Use URL https://github.com/jenkinsci/remoting-security-workaround-plugin once available
-# TODO (preferred) Use URL https://plugins.jenkins.io/remoting-security-workaround once available
+redirect_url: https://github.com/jenkinsci/remoting-security-workaround-plugin
+# TODO Use URL https://plugins.jenkins.io/remoting-security-workaround once available
 ---


### PR DESCRIPTION
Link to GitHub repo now that it is live.

Once update site is live, link there instead.