### PR TITLE
Replace all the refresh layouts with redirect

### DIFF
--- a/content/100k.adoc
+++ b/content/100k.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: "/content/jenkins-celebration-day-february-26"
+layout: redirect
+redirect_url: "/content/jenkins-celebration-day-february-26"
 ---

--- a/content/_layouts/refresh.html.haml
+++ b/content/_layouts/refresh.html.haml
@@ -1,9 +1,0 @@
-%html
-  %head
-    %meta{:'http-equiv' => 'content-type', :content => 'text/html; charset=utf-8'}/
-    %meta{:'http-equiv' => 'refresh', :content => "0;URL=#{page.refresh_to_post_id}"}/
-  %body
-    %center
-      This content has moved to
-      %a{:href => page.refresh_to_post_id}
-        = page.refresh_to_post_id

--- a/content/account.adoc
+++ b/content/account.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: 'https://accounts.jenkins.io'
+layout: redirect
+redirect_url: 'https://accounts.jenkins.io'
 ---

--- a/content/blog/2015/2015-11-04-jenkins-and-docker.adoc
+++ b/content/blog/2015/2015-11-04-jenkins-and-docker.adoc
@@ -1,4 +1,4 @@
 ---
-:layout: refresh
-:refresh_to_post_id: /solutions/docker
+layout: redirect
+redirect_url: /solutions/docker
 ---

--- a/content/blog/2016/2016-08-17-jenkins-world-speaker-blog-aquient.adoc
+++ b/content/blog/2016/2016-08-17-jenkins-world-speaker-blog-aquient.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/blog/2016/08/17/jenkins-world-speaker-blog-aquilent/'
+layout: redirect
+redirect_url: '/blog/2016/08/17/jenkins-world-speaker-blog-aquilent/'
 ---

--- a/content/blog/index.adoc
+++ b/content/blog/index.adoc
@@ -1,4 +1,4 @@
 ---
-:layout: refresh
-:refresh_to_post_id: /node
+layout: redirect
+redirect_url: /node
 ---

--- a/content/blog/take-2015-jenkins-survey.adoc
+++ b/content/blog/take-2015-jenkins-survey.adoc
@@ -1,4 +1,4 @@
 ---
-:layout: refresh
-:refresh_to_post_id: /blog/2015/09/01/take-the-2015-jenkins-survey
+layout: redirect
+redirect_url: /blog/2015/09/01/take-the-2015-jenkins-survey
 ---

--- a/content/conduct.adoc
+++ b/content/conduct.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/project/conduct/'
+layout: redirect
+redirect_url: '/project/conduct/'
 ---

--- a/content/doc/book/pipeline/overview.adoc
+++ b/content/doc/book/pipeline/overview.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/doc/book/pipeline/getting-started'
+layout: redirect
+redirect_url: '/doc/book/pipeline/getting-started'
 ---

--- a/content/doc/book/securing-jenkins.html.haml
+++ b/content/doc/book/securing-jenkins.html.haml
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/doc/book/system-administration/security/'
+layout: redirect
+redirect_url: '/doc/book/system-administration/security/'
 ---

--- a/content/doc/pipeline/index.adoc
+++ b/content/doc/pipeline/index.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/doc/book/pipeline'
+layout: redirect
+redirect_url: '/doc/book/pipeline'
 ---

--- a/content/friend.adoc
+++ b/content/friend.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/donate/'
+layout: redirect
+redirect_url: '/donate/'
 ---

--- a/content/welcome.adoc
+++ b/content/welcome.adoc
@@ -1,4 +1,4 @@
 ---
-layout: refresh
-refresh_to_post_id: '/'
+layout: redirect
+redirect_url: '/'
 ---


### PR DESCRIPTION
```
ag 'layout: refresh' | awk -F: '{print $1}' | xargs perl -pi -e 's/refresh_to_post_id:/redirect_url:/g; s/layout: refresh/layout: redirect/g'
```

Then went and cleaned up a few :layout to layout:

No need for two templates that do the same thing.