### PR TITLE
Make sure redirects are not included in sitemap

### DIFF
--- a/content/_config/sitemap.yml
+++ b/content/_config/sitemap.yml
@@ -1,0 +1,4 @@
+---
+excluded_extensions:
+  - .jpeg
+  - .json

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -12,7 +12,6 @@ Awestruct::Extensions::Pipeline.new do
   # Register all our blog content under the `site.posts` variable
   extension YearPosts.new('/blog', :posts)
   extension Awestruct::Extensions::Indexifier.new
-  extension Awestruct::Extensions::Sitemap.new
 
   extension Awestruct::Extensions::Paginator.new(:posts,
                                                   '/node/index',
@@ -35,7 +34,7 @@ Awestruct::Extensions::Pipeline.new do
                                               '/node/tags',
                                               :per_page => 10)
 
-  extension Awestruct::Extensions::Sitemap.new
+  extension JenkinsSitemap.new
 
   extension Awestruct::IBeams::DataDir.new
 

--- a/content/_ext/sitemap.rb
+++ b/content/_ext/sitemap.rb
@@ -1,0 +1,10 @@
+class JenkinsSitemap < Awestruct::Extensions::Sitemap
+  def valid_sitemap_entry(page)
+    ret = super
+    if ret && page.layout == 'redirect'
+      # actually redirect pages should not be in sitemap
+      ret = false
+    end
+    ret
+  end
+end


### PR DESCRIPTION
```
ag 'layout:.*redirect' content | awk -F: '{print $1}' | xargs sed -i '/^layout:.*redirect/i sitemap_exclude: true'
```

Confirmed undesired behavior via
http://www.thesempost.com/google-avoid-including-redirected-urls-sitemaps/
(Also I just don't want them there)

based on #4698 