### PR TITLE
Update UX SIG starting page

### DIFF
--- a/content/sigs/ux/index.adoc
+++ b/content/sigs/ux/index.adoc
@@ -11,16 +11,6 @@ tags:
   - ui
   - user_experience
   - user_interface
-leads:
-- "jphartley"
-participants:
-- "oleg_nenashev"
-- "markewaite"
-- "timja"
-- "uhafner"
-- "romenrg"
-- "sladyn98"
-- "wadeck"
 links:
   gitter: "jenkinsci/ux-sig"
   googlegroup: "jenkinsci-ux"
@@ -31,17 +21,18 @@ overview: >
   We will discuss alternatives, identify compromises, and test implementations to improve the Jenkins UI / UX.
 ---
 
-An overview of the Jenkins UX SIG documentation can be found by following this link:https://docs.google.com/document/d/1J3HsxYdNPDZpFzCz6HWGcIhsY3urOXOZmiMiGR1D-ew/edit?usp=sharing[link].
+An overview of previous results of the Jenkins UX SIG is available in an link:https://docs.google.com/document/d/1J3HsxYdNPDZpFzCz6HWGcIhsY3urOXOZmiMiGR1D-ew/edit?usp=sharing[external document].
+Most of these results have been integrated into Jenkins core in the meantime.
 
 == Topics
+
 * Reviewing new UI proposals
-* Discussing UI frameworks
+* Discussing UI frameworks, libraries and assets
 * Discussing impact of UI changes to existing plugins
 
 == Gitter Channel
-The UX SIG use Gitter as the primary way to discuss any relevant topics. Initially this used to be a CDF Slack channel but a decision was made to move to Gitter in early February 2020. 
-The room in Gitter used for this is jenkinsci/ux-sig. 
-Join the link:https://gitter.im/jenkinsci/ux-sig[Gitter room] for user experience SIG discussions.
+The UX SIG uses a link:https://gitter.im/jenkinsci/ux-sig[Gitter room] and the
+link:https://community.jenkins.io[Jenkins community] to discuss any relevant topics.
 
 == Contributing
 If you want to contribute we recommend that you join the Jenkins UX SIG. You can find details of when the next meetings are planned in the Jenkins Calendar or via the link:https://gitter.im/jenkinsci/ux-sig[jenkinsci/ux-sig Gitter room].
@@ -50,15 +41,13 @@ If you want to contribute we recommend that you join the Jenkins UX SIG. You can
 == Projects
 
 The special interest group drives a number of initiatives within the link:/project/roadmap/[Jenkins roadmap].
+Here are the most important ones:
 
 [[project-ui-look-and-feel]]
 === UI/UX: Jenkins Look and Feel updates
 
-The first UX SIG project is revamping the Jenkins UI look and feel.
-The initial focus will be on CSS changes and key Jenkins components: header, footer, side panels, etc.
-Once this project has been completed, a more thorough rewrite of the Jenkins UI will be planned.  
-
-See the jira:JENKINS-60919[] EPIC for more details about the scope.
+One UX SIG project is revamping the Jenkins UI look and feel.
+This is an ongoing effort, new features will be integrated step by step into the Jenkins weekly releases.
 
 [[project-ui-accessibility]]
 === UI/UX: Accessibility
@@ -69,42 +58,8 @@ In general, all Jenkins users would benefit from better navigation and layouts.
 
 See the jira:JENKINS-62268[] EPIC for more details about the scope.
 
-[[project-plugin-management-ui-ux]]
-=== Plugin management UI improvements
-
-This project aims to improve link:/doc/book/managing/plugins/[plugin management UI] user experience for Jenkins administrators so that they can easily discover plugins and make decisions about plugin upgrades.
-Scope: Plugin Manager in the Jenkins core,
-link:http://plugins.jenkins.io/[plugins.jenkins.io],
-link:https://github.com/jenkins-infra/update-center2[Jenkins Update Center] and other services.
-For non-UI plugin management, see the link:/sigs/platform/#plugin-management[Platform SIG initiatives].
-
-Goals:
-
-* Improve search, listing and categorization of plugins to help users to discover plugins they need. 
-* Provide more information about plugins in the UI
-* Help admins to make educated decisions about updating plugins by showing info about new versions: changelogs, reported issues, community ratings, security warnings, etc.
-
-This project might extend the Jenkins Update Center API and data structure to provide more information required for UI.
-Jenkins core logic will remain compatible with old update center APIs,
-but alternate update centers might need an update to give users access to the new features.
-
-Opportunities for contribution:
-
-* jira:WEBSITE-637[Plugin Site Update: Documentation and Changelogs from GitHub]
-* https://issues.jenkins.io/issues/?jql=component%20%3D%20core%20AND%20labels%20%3D%20plugin-manager%20and%20labels%20in%20(ux%2C%20ux-sig%2C%20ui%2C%20accessibility%2C%20user-experience)%20and%20resolution%20is%20empty[Plugin Manager UI/UX issues in Jenkins Jira]
-
-[[project-ui-overhaul]]
-=== Jenkins user interface overhaul
-
-Future project which targets a major redesign of the Jenkins user interface. 
-
-Goals:
-
-* Define Long Term Architecture for the Jenkins frontend
-* Overhaul of the user interface to provide better user experience to end users and administrators
-
 == Meetings
-We have regular meetings on Wednesday every two weeks, at *4PM UTC*.
+We have regular meetings on Wednesday every four weeks, at *4PM UTC*.
 See the link:/event-calendar[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded using Zoom and are archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaOnsIIsZHsv_fM9QhOcajWe[Jenkins UX SIG YouTube playlist].


### PR DESCRIPTION
Remove several sections and update the current list of topics:
- Removed the obsolete lead section, we have no lead anymore
- Removed the participants section, everybody is welcome to contribute and it makes no sense to update this web page every time the group sets changes
- Rephrased several sections since the information was outdated.
- Removed some projects since nobody is actually working on them