### PR TITLE
Cobertura plugin was never actually affected

### DIFF
--- a/content/_data/upgrades/2-303-3.adoc
+++ b/content/_data/upgrades/2-303-3.adoc
@@ -94,17 +94,19 @@ Failed to discover context of access to build directory
 
 The link:/doc/book/system-administration/viewing-logs/[Jenkins system log] will contain more detailed information.
 
-The following plugins are known to be affected by this security fix:
+As of 2021-11-08, no plugins are known to be affected by this security fix.
 
-|===
-| Plugin | Affected Functionality | Workaround | Fix Version
+// The following plugins are known to be affected by this security fix:
 
-| https://plugins.jenkins.io/cobertura/[Cobertura]
-| Integration with Maven job type
-| None
-| n/a
+// |===
+// | Plugin | Affected Functionality | Workaround | Fix Version
 
-|===
+// | https://plugins.jenkins.io/TODO/[TODO]
+// | TODO
+// | TODO
+// | TODO
+
+// |===
 
 This security fix can be disabled by setting the Java system property link:/doc/book/managing/system-properties/#jenkins-security-s2m-runningbuildfilepathfilter-skip[`jenkins.security.s2m.RunningBuildFilePathFilter.SKIP`] to `true`.
 


### PR DESCRIPTION
https://github.com/jenkinsci/cobertura-plugin/pull/130#discussion_r743133431 identified that this integration has never worked, so it could not have been affected by this change in practice (even though the code looked like it was).