### PR TITLE
Use correct repo for Debian weekly instructions

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -49,10 +49,10 @@ It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt re
 
 [source,bash]
 ----
-curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee \
+curl -fsSL https://pkg.jenkins.io/debian/jenkins.io.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
 echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  https://pkg.jenkins.io/debian binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update
 sudo apt-get install jenkins


### PR DESCRIPTION
## Use correct repo for Debian install of Jenkins weekly

Sorry that I missed correcting the repository name in my update proposal.  Thanks for the contribution @TobiX!
