### PR TITLE
Reference JENKINS-36779 in guava update changelog entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -12921,6 +12921,7 @@
           - basil
         references:
           - pull: 5707
+          - issue: 36779
           - url: https://github.com/jenkinsci/jep/tree/master/jep/233
             title: JEP-233
           - url: https://guava.dev/


### PR DESCRIPTION
[JENKINS-36779](https://issues.jenkins.io/browse/JENKINS-36779) is the issue that tracked the Guava upgrade.  Record it in the changelog for reference