### PR TITLE
Fix some broken wiki refs

### DIFF
--- a/content/events/fosdem/archive/2016.adoc
+++ b/content/events/fosdem/archive/2016.adoc
@@ -42,7 +42,7 @@ Who's coming?
 (attendance, organizing)
 * https://github.com/orrc[Christopher Orr (orrc)]
 (attendance)
-* https://wiki.jenkins.io/display/~fredg[(fredg)]
+* (fredg)
 (attendance)
 * https://github.com/aheritier[Arnaud Héritier (aheritier)]
 (attendance)
@@ -50,7 +50,7 @@ Who's coming?
 (attendance)
 * https://github.com/ydubreuil[Yoann Dubreuil (ydubreuil)]
 (attendance)
-* https://wiki.jenkins.io/display/~jgbiii[(jgbiii)]
+* (jgbiii)
 (attendance)
 * https://github.com/fbelzunc[Felix Belzunce Arcos (fbelzunc)]
 (attendance)

--- a/content/events/fosdem/archive/2016.adoc
+++ b/content/events/fosdem/archive/2016.adoc
@@ -45,7 +45,7 @@ Who's coming?
 (attendance, organizing)
 * https://github.com/orrc[Christopher Orr (orrc)]
 (attendance)
-* https://wiki.jenkins.io/display/~fredg[Unknown User (fredg)]
+* https://wiki.jenkins.io/display/~fredg[ (fredg)]
 (attendance)
 * https://github.com/aheritier[Arnaud Héritier (aheritier)]
 (attendance)
@@ -53,7 +53,7 @@ Who's coming?
 (attendance)
 * https://github.com/ydubreuil[Yoann Dubreuil (ydubreuil)]
 (attendance)
-* https://wiki.jenkins.io/display/~jgbiii[Unknown User (jgbiii)]
+* https://wiki.jenkins.io/display/~jgbiii[ (jgbiii)]
 (attendance)
 * https://github.com/fbelzunc[Felix Belzunce Arcos (fbelzunc)]
 (attendance)

--- a/content/events/fosdem/archive/2016.adoc
+++ b/content/events/fosdem/archive/2016.adoc
@@ -42,7 +42,7 @@ Who's coming?
 (attendance, organizing)
 * https://github.com/orrc[Christopher Orr (orrc)]
 (attendance)
-* https://wiki.jenkins.io/display/~fredg[ (fredg)]
+* https://wiki.jenkins.io/display/~fredg[(fredg)]
 (attendance)
 * https://github.com/aheritier[Arnaud Héritier (aheritier)]
 (attendance)
@@ -50,7 +50,7 @@ Who's coming?
 (attendance)
 * https://github.com/ydubreuil[Yoann Dubreuil (ydubreuil)]
 (attendance)
-* https://wiki.jenkins.io/display/~jgbiii[ (jgbiii)]
+* https://wiki.jenkins.io/display/~jgbiii[(jgbiii)]
 (attendance)
 * https://github.com/fbelzunc[Felix Belzunce Arcos (fbelzunc)]
 (attendance)

--- a/content/events/fosdem/archive/2016.adoc
+++ b/content/events/fosdem/archive/2016.adoc
@@ -16,9 +16,6 @@ NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent
 Jenkins was at http://fosdem.org/2016/[FOSDEM], in Brussels, on January 30-31st, 2016!
 We also had a http://www.meetup.com/jenkinsmeetup/events/227463345/[Jenkins 2.0 Contributor Summit] on February 1st.
 
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
-
 Join http://lists.jenkins-ci.org/mailman/listinfo/jenkins-fosdem[the
 mailing list] if you're interested in helping with coordination
 

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -34,18 +34,18 @@ d'Espagne) 
 
 Who's coming?
 
-* link:/blog/authors/rtyler/[ (rtyler)]
+* link:/blog/authors/rtyler/[(rtyler)]
 (attendance, organizing)
-* link:/blog/authors/daniel-beck/[ (danielbeck)]
+* link:/blog/authors/daniel-beck/[(danielbeck)]
 (attendance, organizing)
-* link:/blog/authors/kohsuke/[ (kohsuke)]
+* link:/blog/authors/kohsuke/[(kohsuke)]
 (attendance, organizing)
 * Alyssa Tong (not attending, organizing)
 * Victor Martinez (attendance)
-* link:/blog/authors/abayer[ (abayer)]
+* link:/blog/authors/abayer[(abayer)]
 (attendance, speaking)
-* link:/blog/authors/rsandell[ (rsandell)]
-* link:/blog/authors/aheritier[ (aheritier)]
+* link:/blog/authors/rsandell[(rsandell)]
+* link:/blog/authors/aheritier[(aheritier)]
 * link:/blog/authors/carlossg[
 (csanchez)] (attendance, speaking)
 

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -34,7 +34,7 @@ d'Espagne) 
 
 Who's coming?
 
-* https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+* link:/blog/authors/rtyler/[Unknown User (rtyler)]
 (attendance, organizing)
 * https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
 (attendance, organizing)

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -36,7 +36,7 @@ Who's coming?
 
 * link:/blog/authors/rtyler/[Unknown User (rtyler)]
 (attendance, organizing)
-* https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
+* link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
 (attendance, organizing)
 * link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
 (attendance, organizing)

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -46,7 +46,7 @@ Who's coming?
 (attendance, speaking)
 * link:/blog/authors/rsandell[Unknown User (rsandell)]
 * link:/blog/authors/aheritier[Unknown User (aheritier)]
-* https://wiki.jenkins.io/display/~csanchez[Unknown User
+* link:/blog/authors/carlossg[Unknown User
 (csanchez)] (attendance, speaking)
 
 [[FOSDEM2017-Jenkinsmerchandise]]

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -34,19 +34,19 @@ d'Espagne) 
 
 Who's coming?
 
-* link:/blog/authors/rtyler/[Unknown User (rtyler)]
+* link:/blog/authors/rtyler/[ (rtyler)]
 (attendance, organizing)
-* link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
+* link:/blog/authors/daniel-beck/[ (danielbeck)]
 (attendance, organizing)
-* link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
+* link:/blog/authors/kohsuke/[ (kohsuke)]
 (attendance, organizing)
 * Alyssa Tong (not attending, organizing)
 * Victor Martinez (attendance)
-* link:/blog/authors/abayer[Unknown User (abayer)]
+* link:/blog/authors/abayer[ (abayer)]
 (attendance, speaking)
-* link:/blog/authors/rsandell[Unknown User (rsandell)]
-* link:/blog/authors/aheritier[Unknown User (aheritier)]
-* link:/blog/authors/carlossg[Unknown User
+* link:/blog/authors/rsandell[ (rsandell)]
+* link:/blog/authors/aheritier[ (aheritier)]
+* link:/blog/authors/carlossg[
 (csanchez)] (attendance, speaking)
 
 [[FOSDEM2017-Jenkinsmerchandise]]

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -42,10 +42,10 @@ Who's coming?
 (attendance, organizing)
 * Alyssa Tong (not attending, organizing)
 * Victor Martinez (attendance)
-* https://wiki.jenkins.io/display/~abayer[Unknown User (abayer)]
+* link:/blog/authors/abayer[Unknown User (abayer)]
 (attendance, speaking)
-* https://wiki.jenkins.io/display/~rsandell[Unknown User (rsandell)]
-* https://wiki.jenkins.io/display/~aheritier[Unknown User (aheritier)]
+* link:/blog/authors/rsandell[Unknown User (rsandell)]
+* link:/blog/authors/aheritier[Unknown User (aheritier)]
 * https://wiki.jenkins.io/display/~csanchez[Unknown User
 (csanchez)] (attendance, speaking)
 

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -38,7 +38,7 @@ Who's coming?
 (attendance, organizing)
 * https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
 (attendance, organizing)
-* https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]
+* link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
 (attendance, organizing)
 * Alyssa Tong (not attending, organizing)
 * Victor Martinez (attendance)

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -45,7 +45,7 @@ Belgium +
 
 Who's attending:
 
-* @https://wiki.jenkins.io/display/~kohsuke[Unknown User
+* @link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)] (attendance, organizing)
 * link:/blog/authors/rtyler/[@R. Tyler Croy] (attendance,
 organizing)

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -49,14 +49,14 @@ Who's attending:
 (kohsuke)] (attendance, organizing)
 * link:/blog/authors/rtyler/[@R. Tyler Croy] (attendance,
 organizing)
-* https://wiki.jenkins.io/display/~atong[Unknown User (atong)]
+* link:/blog/authors/atong[Unknown User (atong)]
 (attendance, organizing)
-* https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)]
+* link:/blog/authors/markewaite[Unknown User (markewaite)]
 (attendance, organizing)
 * link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
-* https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
-* https://wiki.jenkins.io/display/~jglick[Unknown User (jglick)]
-* https://wiki.jenkins.io/display/~olblak[Unknown User
+* link:/blog/authors/batmat[Unknown User (batmat)]
+* link:/blog/authors/jglick[Unknown User (jglick)]
+* link:/blog/authors/olblak[Unknown User
 (olblak)] (attendance, organizing)
 
 [[FOSDEM2018-Jenkinsmerchandise]]

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -45,18 +45,18 @@ Belgium +
 
 Who's attending:
 
-* @link:/blog/authors/kohsuke/[Unknown User
+* @link:/blog/authors/kohsuke/[
 (kohsuke)] (attendance, organizing)
 * link:/blog/authors/rtyler/[@R. Tyler Croy] (attendance,
 organizing)
-* link:/blog/authors/atong[Unknown User (atong)]
+* link:/blog/authors/atong[ (atong)]
 (attendance, organizing)
-* link:/blog/authors/markewaite[Unknown User (markewaite)]
+* link:/blog/authors/markewaite[ (markewaite)]
 (attendance, organizing)
-* link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
-* link:/blog/authors/batmat[Unknown User (batmat)]
-* link:/blog/authors/jglick[Unknown User (jglick)]
-* link:/blog/authors/olblak[Unknown User
+* link:/blog/authors/daniel-beck/[ (danielbeck)]
+* link:/blog/authors/batmat[ (batmat)]
+* link:/blog/authors/jglick[ (jglick)]
+* link:/blog/authors/olblak[
 (olblak)] (attendance, organizing)
 
 [[FOSDEM2018-Jenkinsmerchandise]]

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -47,7 +47,7 @@ Who's attending:
 
 * @https://wiki.jenkins.io/display/~kohsuke[Unknown User
 (kohsuke)] (attendance, organizing)
-* https://wiki.jenkins.io/display/~rtyler[@R. Tyler Croy] (attendance,
+* link:/blog/authors/rtyler/[@R. Tyler Croy] (attendance,
 organizing)
 * https://wiki.jenkins.io/display/~atong[Unknown User (atong)]
 (attendance, organizing)

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -53,7 +53,7 @@ organizing)
 (attendance, organizing)
 * https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)]
 (attendance, organizing)
-* https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
+* link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
 * https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
 * https://wiki.jenkins.io/display/~jglick[Unknown User (jglick)]
 * https://wiki.jenkins.io/display/~olblak[Unknown User

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -49,13 +49,13 @@ Who's attending:
 (kohsuke)] (attendance, organizing)
 * link:/blog/authors/rtyler/[@R. Tyler Croy] (attendance,
 organizing)
-* link:/blog/authors/atong[ (atong)]
+* link:/blog/authors/atong[(atong)]
 (attendance, organizing)
-* link:/blog/authors/markewaite[ (markewaite)]
+* link:/blog/authors/markewaite[(markewaite)]
 (attendance, organizing)
-* link:/blog/authors/daniel-beck/[ (danielbeck)]
-* link:/blog/authors/batmat[ (batmat)]
-* link:/blog/authors/jglick[ (jglick)]
+* link:/blog/authors/daniel-beck/[(danielbeck)]
+* link:/blog/authors/batmat[(batmat)]
+* link:/blog/authors/jglick[(jglick)]
 * link:/blog/authors/olblak[
 (olblak)] (attendance, organizing)
 

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -52,11 +52,11 @@ summit and or hackathon]  +
 
 Who's attending:
 
-* @link:/blog/authors/kohsuke/[Unknown User
+* @link:/blog/authors/kohsuke/[
 (kohsuke)] (attendance, organizing)
-* link:/blog/authors/atong[Unknown User (atong)]
+* link:/blog/authors/atong[ (atong)]
 (attendance, organizing)
-* link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
-* link:/blog/authors/batmat[Unknown User (batmat)]
-* link:/blog/authors/olblak[Unknown User
+* link:/blog/authors/daniel-beck/[ (danielbeck)]
+* link:/blog/authors/batmat[ (batmat)]
+* link:/blog/authors/olblak[
 (olblak)] (attendance, organizing)

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -52,7 +52,7 @@ summit and or hackathon]  +
 
 Who's attending:
 
-* @https://wiki.jenkins.io/display/~kohsuke[Unknown User
+* @link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)] (attendance, organizing)
 * https://wiki.jenkins.io/display/~atong[Unknown User (atong)]
 (attendance, organizing)

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -54,9 +54,9 @@ Who's attending:
 
 * @link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)] (attendance, organizing)
-* https://wiki.jenkins.io/display/~atong[Unknown User (atong)]
+* link:/blog/authors/atong[Unknown User (atong)]
 (attendance, organizing)
 * link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
-* https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
-* https://wiki.jenkins.io/display/~olblak[Unknown User
+* link:/blog/authors/batmat[Unknown User (batmat)]
+* link:/blog/authors/olblak[Unknown User
 (olblak)] (attendance, organizing)

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -56,7 +56,7 @@ Who's attending:
 (kohsuke)] (attendance, organizing)
 * https://wiki.jenkins.io/display/~atong[Unknown User (atong)]
 (attendance, organizing)
-* https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
+* link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
 * https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
 * https://wiki.jenkins.io/display/~olblak[Unknown User
 (olblak)] (attendance, organizing)

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -54,9 +54,9 @@ Who's attending:
 
 * @link:/blog/authors/kohsuke/[
 (kohsuke)] (attendance, organizing)
-* link:/blog/authors/atong[ (atong)]
+* link:/blog/authors/atong[(atong)]
 (attendance, organizing)
-* link:/blog/authors/daniel-beck/[ (danielbeck)]
-* link:/blog/authors/batmat[ (batmat)]
+* link:/blog/authors/daniel-beck/[(danielbeck)]
+* link:/blog/authors/batmat[(batmat)]
 * link:/blog/authors/olblak[
 (olblak)] (attendance, organizing)

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -45,7 +45,7 @@ http://www.socallinuxexpo.org/scale10x/jenkins-ci[SCALE 10x] on January
 should we do (dev room talk? lightning talk? Jenkins stand?), and who
 will be going? (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
-* Jenkins CIA program https://wiki.jenkins.io/display/~kohsuke[Unknown
+* Jenkins CIA program link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)]
 * Context: people like http://t.co/CYzvqOUB[those Jenkins stickers].
 We'd like to use them well to spread words about Jenkins.
@@ -80,10 +80,10 @@ Jenkins infrastructure machines.
 * Appprove CloudBees request for the "Jenkins Enterprise from CloudBees"
 use request as per
 https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
-Document] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+Document] (link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 * LTS discussion. Branch is ready, I say time for RC
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 ** Augmenting LTS Test Matrix with written test plans
 (https://wiki.jenkins.io/display/~ryan[Unknown User (ryan)])
 ** Backport of JENKINS-10989 and SECURITY-17 as

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -72,7 +72,7 @@ or
 http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuchMethodError-org-codehaus-groovy-ast-ModuleNode-getStarIm-td3868116.html[here] or
 http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
 ** What can we do about it?
-* Add https://wiki.jenkins.io/display/~jieryn[(jieryn)] to
+* Add (jieryn) to
 the "users-core" puppet module, giving him administrator access on all
 Jenkins infrastructure machines.
 (link:/blog/authors/rtyler/[(rtyler)])
@@ -84,11 +84,10 @@ Document] (link:/blog/authors/kohsuke/[
 * LTS discussion. Branch is ready, I say time for RC
 (link:/blog/authors/kohsuke/[(kohsuke)])
 ** Augmenting LTS Test Matrix with written test plans
-(https://wiki.jenkins.io/display/~ryan[(ryan)])
+(ryan)
 ** Backport of JENKINS-10989 and SECURITY-17 as
 http://jenkins.361315.n4.nabble.com/LTS-1-424-1-RC-td4015360.html#a4015852[suggested
-by Romain] (https://wiki.jenkins.io/display/~vjuranek[
-(vjuranek)])
+by Romain] (vjuranek)
 ** Security advisory handling.
 
 MINUTES

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -17,7 +17,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Recap last meeting's action items
 * Infra update (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
-* Add https://wiki.jenkins.io/display/~aheritier[Unknown User
+* Add link:/blog/authors/aheritier[Unknown User
 (aheritier)] to the "users-core" puppet module, giving him administrator
 access on all Jenkins infrastructure machines.
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -15,12 +15,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 14th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Recap last meeting's action items
-* Infra update (link:/blog/authors/rtyler/[Unknown User
+* Infra update (link:/blog/authors/rtyler/[
 (rtyler)])
-* Add link:/blog/authors/aheritier[Unknown User
+* Add link:/blog/authors/aheritier[
 (aheritier)] to the "users-core" puppet module, giving him administrator
 access on all Jenkins infrastructure machines.
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-12-14-19.03.html[summary]
@@ -35,18 +35,17 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 30th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Recap last meeting action items
-* infra update (link:/blog/authors/rtyler/[Unknown User
+* infra update (link:/blog/authors/rtyler/[
 (rtyler)])
 * Discuss plans for exhibiting at
 http://www.socallinuxexpo.org/scale10x/jenkins-ci[SCALE 10x] on January
 20-22 in Los Angeles, CA.
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Discuss plans for http://www.fosdem.org/2012/[FOSDEM 2012]. What
 should we do (dev room talk? lightning talk? Jenkins stand?), and who
-will be going? (link:/blog/authors/rtyler/[Unknown User
+will be going? (link:/blog/authors/rtyler/[
 (rtyler)])
-* Jenkins CIA program link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)]
+* Jenkins CIA program link:/blog/authors/kohsuke/[ (kohsuke)]
 * Context: people like http://t.co/CYzvqOUB[those Jenkins stickers].
 We'd like to use them well to spread words about Jenkins.
 * LTS 1.424.1 release (vjuranek)
@@ -73,22 +72,22 @@ or
 http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuchMethodError-org-codehaus-groovy-ast-ModuleNode-getStarIm-td3868116.html[here] or
 http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
 ** What can we do about it?
-* Add https://wiki.jenkins.io/display/~jieryn[Unknown User (jieryn)] to
+* Add https://wiki.jenkins.io/display/~jieryn[ (jieryn)] to
 the "users-core" puppet module, giving him administrator access on all
 Jenkins infrastructure machines.
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Appprove CloudBees request for the "Jenkins Enterprise from CloudBees"
 use request as per
 https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
-Document] (link:/blog/authors/kohsuke/[Unknown User
+Document] (link:/blog/authors/kohsuke/[
 (kohsuke)])
 * LTS discussion. Branch is ready, I say time for RC
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 ** Augmenting LTS Test Matrix with written test plans
-(https://wiki.jenkins.io/display/~ryan[Unknown User (ryan)])
+(https://wiki.jenkins.io/display/~ryan[ (ryan)])
 ** Backport of JENKINS-10989 and SECURITY-17 as
 http://jenkins.361315.n4.nabble.com/LTS-1-424-1-RC-td4015360.html#a4015852[suggested
-by Romain] (https://wiki.jenkins.io/display/~vjuranek[Unknown User
+by Romain] (https://wiki.jenkins.io/display/~vjuranek[
 (vjuranek)])
 ** Security advisory handling.
 
@@ -112,7 +111,7 @@ http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuch
 http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
 ** What can we do about it?
 * Bringing old Jenkins plugins up to a common requiredCore (@jieryn)
-* Infra update (link:/blog/authors/rtyler/[Unknown User
+* Infra update (link:/blog/authors/rtyler/[
 (rtyler)])
 ** SPI donation status for cucumber
 
@@ -249,7 +248,7 @@ which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
 EMailer]' ?
 ** Maybe to get things going again, deprecate the built-in EMailer and
 deliver email-ext bundled?
-* Infra update from link:/blog/authors/rtyler/[Unknown User
+* Infra update from link:/blog/authors/rtyler/[
 (rtyler)] regarding new machines at the http://osuosl.org/[OSUOSL]
 * CLA discussion. We should start collecting CLA for core, and our
 current plan on the record was to reuse Apache CLA.

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -15,12 +15,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 14th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Recap last meeting's action items
-* Infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+* Infra update (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Add https://wiki.jenkins.io/display/~aheritier[Unknown User
 (aheritier)] to the "users-core" puppet module, giving him administrator
 access on all Jenkins infrastructure machines.
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-12-14-19.03.html[summary]
@@ -35,15 +35,15 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 30th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Recap last meeting action items
-* infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+* infra update (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Discuss plans for exhibiting at
 http://www.socallinuxexpo.org/scale10x/jenkins-ci[SCALE 10x] on January
 20-22 in Los Angeles, CA.
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Discuss plans for http://www.fosdem.org/2012/[FOSDEM 2012]. What
 should we do (dev room talk? lightning talk? Jenkins stand?), and who
-will be going? (https://wiki.jenkins.io/display/~rtyler[Unknown User
+will be going? (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Jenkins CIA program https://wiki.jenkins.io/display/~kohsuke[Unknown
 User (kohsuke)]
@@ -76,7 +76,7 @@ http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-huds
 * Add https://wiki.jenkins.io/display/~jieryn[Unknown User (jieryn)] to
 the "users-core" puppet module, giving him administrator access on all
 Jenkins infrastructure machines.
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Appprove CloudBees request for the "Jenkins Enterprise from CloudBees"
 use request as per
 https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
@@ -112,7 +112,7 @@ http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuch
 http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
 ** What can we do about it?
 * Bringing old Jenkins plugins up to a common requiredCore (@jieryn)
-* Infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+* Infra update (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 ** SPI donation status for cucumber
 
@@ -249,7 +249,7 @@ which should be 11am PDT, 2pm EDT, 8pm CET, 3am Tokyo.
 EMailer]' ?
 ** Maybe to get things going again, deprecate the built-in EMailer and
 deliver email-ext bundled?
-* Infra update from https://wiki.jenkins.io/display/~rtyler[Unknown User
+* Infra update from link:/blog/authors/rtyler/[Unknown User
 (rtyler)] regarding new machines at the http://osuosl.org/[OSUOSL]
 * CLA discussion. We should start collecting CLA for core, and our
 current plan on the record was to reuse Apache CLA.

--- a/content/project/governance-meeting/archives/2011.adoc
+++ b/content/project/governance-meeting/archives/2011.adoc
@@ -20,7 +20,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Add link:/blog/authors/aheritier[
 (aheritier)] to the "users-core" puppet module, giving him administrator
 access on all Jenkins infrastructure machines.
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2011/jenkins.2011-12-14-19.03.html[summary]
@@ -40,12 +40,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Discuss plans for exhibiting at
 http://www.socallinuxexpo.org/scale10x/jenkins-ci[SCALE 10x] on January
 20-22 in Los Angeles, CA.
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Discuss plans for http://www.fosdem.org/2012/[FOSDEM 2012]. What
 should we do (dev room talk? lightning talk? Jenkins stand?), and who
 will be going? (link:/blog/authors/rtyler/[
 (rtyler)])
-* Jenkins CIA program link:/blog/authors/kohsuke/[ (kohsuke)]
+* Jenkins CIA program link:/blog/authors/kohsuke/[(kohsuke)]
 * Context: people like http://t.co/CYzvqOUB[those Jenkins stickers].
 We'd like to use them well to spread words about Jenkins.
 * LTS 1.424.1 release (vjuranek)
@@ -72,19 +72,19 @@ or
 http://jenkins.361315.n4.nabble.com/Error-building-Jenkins-core-java-lang-NoSuchMethodError-org-codehaus-groovy-ast-ModuleNode-getStarIm-td3868116.html[here] or
 http://jenkins.361315.n4.nabble.com/Error-launching-JNLP-slave-when-running-hudson-dev-run-td3772780.html[here]
 ** What can we do about it?
-* Add https://wiki.jenkins.io/display/~jieryn[ (jieryn)] to
+* Add https://wiki.jenkins.io/display/~jieryn[(jieryn)] to
 the "users-core" puppet module, giving him administrator access on all
 Jenkins infrastructure machines.
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Appprove CloudBees request for the "Jenkins Enterprise from CloudBees"
 use request as per
 https://wiki.jenkins.io/display/JENKINS/Governance+Document[Governance
 Document] (link:/blog/authors/kohsuke/[
 (kohsuke)])
 * LTS discussion. Branch is ready, I say time for RC
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 ** Augmenting LTS Test Matrix with written test plans
-(https://wiki.jenkins.io/display/~ryan[ (ryan)])
+(https://wiki.jenkins.io/display/~ryan[(ryan)])
 ** Backport of JENKINS-10989 and SECURITY-17 as
 http://jenkins.361315.n4.nabble.com/LTS-1-424-1-RC-td4015360.html#a4015852[suggested
 by Romain] (https://wiki.jenkins.io/display/~vjuranek[

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -16,15 +16,15 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's items
 * Authorizing SSL certificate renewal
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Renewing jenkins-ci.org domain
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Website banner usage guideline for people in the events list.
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 ** like maybe giving automatic 1 week access to future events
 * Donation status and what can we do more?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
-* Adding https://wiki.jenkins.io/display/~larrys[Unknown User (larrys)]
+(link:/blog/authors/kohsuke/[ (kohsuke)])
+* Adding https://wiki.jenkins.io/display/~larrys[ (larrys)]
 to the admin to combat spam.
 
 MINUTES
@@ -41,13 +41,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's items
 * Balancing personal information of JUC attendees vs cost
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 ** https://docs.google.com/spreadsheet/ccc?key=0ApE2WVyiXL0hdGZSRTZVQmdTN2VnVWdJMWZCNEJqa1E[financial
 report of past JUCs]
 * Forming the Events subgroup in the community for the purpose of
 coordinating and running event
-(link:/blog/authors/lisawells[Unknown User
-(lisawells)]/link:/blog/authors/kohsuke/[Unknown User
+(link:/blog/authors/lisawells[
+(lisawells)]/link:/blog/authors/kohsuke/[
 (kohsuke)])
 ** Initial task – define model for user events so we can attract others
 to run them
@@ -57,7 +57,7 @@ community
 & Twitter
 ** let this group handle CIA program
 * Status of moving Jenkins to java 6 as minimal runtime
-(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[ (ndeloof)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-11-14-19.01.html[summary]
@@ -75,10 +75,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Take over http://www.meetup.com/jenkinsmeetup/["Jenkins users and
 developers" group] at meetup.com? (costs $144 per year)
 * Check on budget for buying stickers for next year's SCaLE11x and
-FOSDEM conferences (link:/blog/authors/rtyler/[Unknown User
+FOSDEM conferences (link:/blog/authors/rtyler/[
 (rtyler)])
 * Accepting donations in Europe
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 ** I spoke to the
 http://www.ffis.de/Verein/spi-en.html[Euro-friends-of-SPI] and it seems
 we could become affiliated. Would be nice to get working before FOSDEM
@@ -96,11 +96,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 17th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Recap last meeting's items
-* Picking next LTS (https://wiki.jenkins.io/display/~vjuranek[Unknown
-User (vjuranek)])
+* Picking next LTS (https://wiki.jenkins.io/display/~vjuranek[ (vjuranek)])
 * Advertising http://jenkins-ci.org/survey[survey] on
 http://jenkins-ci.org/ (for 2 more weeks until it closes)
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-17-18.02.html[summary]
@@ -140,7 +139,7 @@ Topic suggestions
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
 |who + |suggestion + |first thoughts +
-|link:/blog/authors/rtyler/[Unknown User (rtyler)]
+|link:/blog/authors/rtyler/[ (rtyler)]
 |Decommissioning "cabbage" and migrating some new services to OSUOSL VMs
 |
 
@@ -194,7 +193,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Discussion about future funding source/plan
 * Add more hackers to the SECURITY project to give more
 visibility/opportunity for security issues to be addressed
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Review survey questions for JUC San Francisco (Lisa Wells)
 
 MINUTES
@@ -212,14 +211,14 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Should the "Sponsor this issue" link be
 https://github.com/freedomsponsors/freedomsponsors-jira-plugin/issues/4[ommited
 for closed issues]?
-(https://wiki.jenkins.io/display/~tonylampada[Unknown User
+(https://wiki.jenkins.io/display/~tonylampada[
 (tonylampada)])
 * Discussion about the
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
-Election Process] (link:/blog/authors/kohsuke/[Unknown User
+Election Process] (link:/blog/authors/kohsuke/[
 (kohsuke)])
 * Help wanted: spams are on the rise
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * FOSDEM travel grant
 
 MINUTES
@@ -239,7 +238,7 @@ http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[action
 items]
 * Travel grant for FOSDEM?
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[context]
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-22-18.06.html[summary]
@@ -255,20 +254,20 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
 use of the name "Jenkins"]. Do we need to take any actions?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Demoing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - http://ambtest.freedomsponsors.org:8080/browse/TLM-1[live
 demo] /
 https://github.com/freedomsponsors/freedomsponsors-jira-plugin[installation
-instructions] (https://wiki.jenkins.io/display/~tonylampada[Unknown User
+instructions] (https://wiki.jenkins.io/display/~tonylampada[
 (tonylampada)])
 * Upcoming event planning and brainstorming
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/bokUEoheAAs%5B1-25%5D[link1]
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/eFawHz1JWYg%5B1-25%5D[link2]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)]).
+(link:/blog/authors/kohsuke/[ (kohsuke)]).
 * Documentation of jenkins-admin IRC-bot infra, so that community can
-manage restart. (link:/blog/authors/ndeloof[Unknown User
+manage restart. (link:/blog/authors/ndeloof[
 (ndeloof)])
 
 MINUTES
@@ -285,11 +284,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
 use of the name "Jenkins"]. Do we need to take any actions?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Installing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - when it's finished development.
-(https://wiki.jenkins.io/display/~tonylampada[Unknown User
+(https://wiki.jenkins.io/display/~tonylampada[
 (tonylampada)])
 
 MINUTES
@@ -309,7 +308,7 @@ http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-06-27-18.01.html[action
 items]
 * How much if any advertisement is acceptable on plugin pages (ex.
 https://wiki.jenkins.io/display/JENKINS/Warnings+Plugin[Warnings
-Plugin]) (link:/blog/authors/rtyler/[Unknown User
+Plugin]) (link:/blog/authors/rtyler/[
 (rtyler)])
 
 MINUTES
@@ -341,9 +340,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Selenium tests, switch to Cucumber/Capybara (vjuranek)
 * New home for wiki.jenkins-ci.org
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * maven.jenkins-ci.org to repo.jenkins-ci.org switch voer
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 [[GovernanceMeetingArchive2012-May30thMeeting]]
 == May 30th Meeting
@@ -353,12 +352,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Moving Subversion repository to GitHub
-link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
+link:/blog/authors/kohsuke/[ (kohsuke)]
 * Improving JonJ and IRC bot stability - JonJ gets stuck very often
 recently, IRC bot also seems to get stuck when forking repo (vjuranek,
 unfortunately cannot attend but can offer some help) 
 * Plugin JonJ on DEV@ or BuildHive
-https://wiki.jenkins.io/display/~jieryn[Unknown User (jieryn)]
+https://wiki.jenkins.io/display/~jieryn[ (jieryn)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-30-18.01.html[summary]
@@ -392,8 +391,8 @@ EDT, 14th Sat 5am CEST, 14th Sat 1pm Tokyo. +
 
 * Recap last meeting's action items
 * JUC Tokyo status updates
-(https://wiki.jenkins.io/display/~ikikko[Unknown User (ikikko)],
-link:/blog/authors/kohsuke/[Unknown User (kohsuke)], and
+(https://wiki.jenkins.io/display/~ikikko[ (ikikko)],
+link:/blog/authors/kohsuke/[ (kohsuke)], and
 others)
 * Anything we can do for bridging the Japanese community?
 
@@ -411,12 +410,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's action items
 * Move plugin CI jobs to jenkins.ci.cloudbees.com
-(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[ (ndeloof)])
 * Proposal : ask for FOSS JProfiler licenses ->
 http://www.ej-technologies.com/buy/jprofiler/openSource
-(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[ (ndeloof)])
 * Migrate plugins to get rid of glassfish repo
-(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[ (ndeloof)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-04-18.01.html[summary]
@@ -431,14 +430,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 21st 18:00 UTC], which should be 11am PDT, 2pm EDT, 7pm CET, 3am Tokyo.
 
 * Recap last meeting's action items
-* Please sign CLAs (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
+* Please sign CLAs (link:/blog/authors/kohsuke/[ (kohsuke)])
 * Officially launching
 https://wiki.jenkins.io/display/JENKINS/Jenkins+CIA+Program[Jenkins CIA
-Program] (link:/blog/authors/kohsuke/[Unknown User
+Program] (link:/blog/authors/kohsuke/[
 (kohsuke)])
 * "Jenkins@cloud for GitHub" and "Jenkins@cloud by CloudBees" name usage
-approval (link:/blog/authors/kohsuke/[Unknown User
+approval (link:/blog/authors/kohsuke/[
 (kohsuke)])
 
 MINUTES
@@ -456,15 +454,15 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Recap last meeting's action items
 * Review current status and plans for
 https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
-(link:/blog/authors/slide_o_mix[Unknown User
+(link:/blog/authors/slide_o_mix[
 (slide.o.mix@gmail.com)])
 * Last-minute discussion on Google SoC mentors
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Baseline for next major LTS release
 (https://wiki.jenkins.io/display/~vjuranek[vjuranek])
 * Cut-over from http://maven.jenkins-ci.org/ to
 http://repo.jenkins-ci.org/ : PoC demo
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-07-19.01.html[summary]
@@ -480,10 +478,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's action items
 * Proposal: Move away from Drupal to a Git repository powered by Jekyll
-for the community site (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
+for the community site (link:/blog/authors/rtyler/[ (rtyler)])
 * It's been a year, should we elect a new board, how/when/etc?
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * JUC promotion ideas
 
 MINUTES
@@ -536,7 +533,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Would it make sense to populate the *Affects Version/s* and *Fix
 Version/s* fields in the Jenkins JIRA (automatically)? (Might include
 talking about the long pending plan of separating core and plugins in
-JIRA) (https://wiki.jenkins.io/display/~fredg[Unknown User (fredg)])
+JIRA) (https://wiki.jenkins.io/display/~fredg[ (fredg)])
 * Funding for give-aways in events (stickers and T-shirts)
 * Start collecting CLAs
 

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -16,15 +16,15 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's items
 * Authorizing SSL certificate renewal
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Renewing jenkins-ci.org domain
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Website banner usage guideline for people in the events list.
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 ** like maybe giving automatic 1 week access to future events
 * Donation status and what can we do more?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
-* Adding https://wiki.jenkins.io/display/~larrys[ (larrys)]
+(link:/blog/authors/kohsuke/[(kohsuke)])
+* Adding https://wiki.jenkins.io/display/~larrys[(larrys)]
 to the admin to combat spam.
 
 MINUTES
@@ -41,7 +41,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's items
 * Balancing personal information of JUC attendees vs cost
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 ** https://docs.google.com/spreadsheet/ccc?key=0ApE2WVyiXL0hdGZSRTZVQmdTN2VnVWdJMWZCNEJqa1E[financial
 report of past JUCs]
 * Forming the Events subgroup in the community for the purpose of
@@ -57,7 +57,7 @@ community
 & Twitter
 ** let this group handle CIA program
 * Status of moving Jenkins to java 6 as minimal runtime
-(link:/blog/authors/ndeloof[ (ndeloof)])
+(link:/blog/authors/ndeloof[(ndeloof)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-11-14-19.01.html[summary]
@@ -78,7 +78,7 @@ developers" group] at meetup.com? (costs $144 per year)
 FOSDEM conferences (link:/blog/authors/rtyler/[
 (rtyler)])
 * Accepting donations in Europe
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 ** I spoke to the
 http://www.ffis.de/Verein/spi-en.html[Euro-friends-of-SPI] and it seems
 we could become affiliated. Would be nice to get working before FOSDEM
@@ -96,10 +96,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 17th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Recap last meeting's items
-* Picking next LTS (https://wiki.jenkins.io/display/~vjuranek[ (vjuranek)])
+* Picking next LTS (https://wiki.jenkins.io/display/~vjuranek[(vjuranek)])
 * Advertising http://jenkins-ci.org/survey[survey] on
 http://jenkins-ci.org/ (for 2 more weeks until it closes)
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-17-18.02.html[summary]
@@ -139,7 +139,7 @@ Topic suggestions
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
 |who + |suggestion + |first thoughts +
-|link:/blog/authors/rtyler/[ (rtyler)]
+|link:/blog/authors/rtyler/[(rtyler)]
 |Decommissioning "cabbage" and migrating some new services to OSUOSL VMs
 |
 
@@ -193,7 +193,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Discussion about future funding source/plan
 * Add more hackers to the SECURITY project to give more
 visibility/opportunity for security issues to be addressed
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Review survey questions for JUC San Francisco (Lisa Wells)
 
 MINUTES
@@ -218,7 +218,7 @@ https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
 Election Process] (link:/blog/authors/kohsuke/[
 (kohsuke)])
 * Help wanted: spams are on the rise
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * FOSDEM travel grant
 
 MINUTES
@@ -238,7 +238,7 @@ http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[action
 items]
 * Travel grant for FOSDEM?
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[context]
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-22-18.06.html[summary]
@@ -254,7 +254,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
 use of the name "Jenkins"]. Do we need to take any actions?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Demoing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - http://ambtest.freedomsponsors.org:8080/browse/TLM-1[live
@@ -265,7 +265,7 @@ instructions] (https://wiki.jenkins.io/display/~tonylampada[
 * Upcoming event planning and brainstorming
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/bokUEoheAAs%5B1-25%5D[link1]
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/eFawHz1JWYg%5B1-25%5D[link2]
-(link:/blog/authors/kohsuke/[ (kohsuke)]).
+(link:/blog/authors/kohsuke/[(kohsuke)]).
 * Documentation of jenkins-admin IRC-bot infra, so that community can
 manage restart. (link:/blog/authors/ndeloof[
 (ndeloof)])
@@ -284,7 +284,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
 use of the name "Jenkins"]. Do we need to take any actions?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Installing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - when it's finished development.
@@ -340,9 +340,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Selenium tests, switch to Cucumber/Capybara (vjuranek)
 * New home for wiki.jenkins-ci.org
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * maven.jenkins-ci.org to repo.jenkins-ci.org switch voer
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 [[GovernanceMeetingArchive2012-May30thMeeting]]
 == May 30th Meeting
@@ -352,12 +352,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Moving Subversion repository to GitHub
-link:/blog/authors/kohsuke/[ (kohsuke)]
+link:/blog/authors/kohsuke/[(kohsuke)]
 * Improving JonJ and IRC bot stability - JonJ gets stuck very often
 recently, IRC bot also seems to get stuck when forking repo (vjuranek,
 unfortunately cannot attend but can offer some help) 
 * Plugin JonJ on DEV@ or BuildHive
-https://wiki.jenkins.io/display/~jieryn[ (jieryn)]
+https://wiki.jenkins.io/display/~jieryn[(jieryn)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-30-18.01.html[summary]
@@ -391,8 +391,8 @@ EDT, 14th Sat 5am CEST, 14th Sat 1pm Tokyo. +
 
 * Recap last meeting's action items
 * JUC Tokyo status updates
-(https://wiki.jenkins.io/display/~ikikko[ (ikikko)],
-link:/blog/authors/kohsuke/[ (kohsuke)], and
+(https://wiki.jenkins.io/display/~ikikko[(ikikko)],
+link:/blog/authors/kohsuke/[(kohsuke)], and
 others)
 * Anything we can do for bridging the Japanese community?
 
@@ -410,12 +410,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's action items
 * Move plugin CI jobs to jenkins.ci.cloudbees.com
-(link:/blog/authors/ndeloof[ (ndeloof)])
+(link:/blog/authors/ndeloof[(ndeloof)])
 * Proposal : ask for FOSS JProfiler licenses ->
 http://www.ej-technologies.com/buy/jprofiler/openSource
-(link:/blog/authors/ndeloof[ (ndeloof)])
+(link:/blog/authors/ndeloof[(ndeloof)])
 * Migrate plugins to get rid of glassfish repo
-(link:/blog/authors/ndeloof[ (ndeloof)])
+(link:/blog/authors/ndeloof[(ndeloof)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-04-18.01.html[summary]
@@ -430,7 +430,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 21st 18:00 UTC], which should be 11am PDT, 2pm EDT, 7pm CET, 3am Tokyo.
 
 * Recap last meeting's action items
-* Please sign CLAs (link:/blog/authors/kohsuke/[ (kohsuke)])
+* Please sign CLAs (link:/blog/authors/kohsuke/[(kohsuke)])
 * Officially launching
 https://wiki.jenkins.io/display/JENKINS/Jenkins+CIA+Program[Jenkins CIA
 Program] (link:/blog/authors/kohsuke/[
@@ -457,12 +457,12 @@ https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
 (link:/blog/authors/slide_o_mix[
 (slide.o.mix@gmail.com)])
 * Last-minute discussion on Google SoC mentors
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Baseline for next major LTS release
 (https://wiki.jenkins.io/display/~vjuranek[vjuranek])
 * Cut-over from http://maven.jenkins-ci.org/ to
 http://repo.jenkins-ci.org/ : PoC demo
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-07-19.01.html[summary]
@@ -478,9 +478,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's action items
 * Proposal: Move away from Drupal to a Git repository powered by Jekyll
-for the community site (link:/blog/authors/rtyler/[ (rtyler)])
+for the community site (link:/blog/authors/rtyler/[(rtyler)])
 * It's been a year, should we elect a new board, how/when/etc?
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * JUC promotion ideas
 
 MINUTES
@@ -533,7 +533,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Would it make sense to populate the *Affects Version/s* and *Fix
 Version/s* fields in the Jenkins JIRA (automatically)? (Might include
 talking about the long pending plan of separating core and plugins in
-JIRA) (https://wiki.jenkins.io/display/~fredg[ (fredg)])
+JIRA) (https://wiki.jenkins.io/display/~fredg[(fredg)])
 * Funding for give-aways in events (stickers and T-shirts)
 * Start collecting CLAs
 

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -46,7 +46,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 report of past JUCs]
 * Forming the Events subgroup in the community for the purpose of
 coordinating and running event
-(https://wiki.jenkins.io/display/~lisawells[Unknown User
+(link:/blog/authors/lisawells[Unknown User
 (lisawells)]/link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 ** Initial task – define model for user events so we can attract others
@@ -57,7 +57,7 @@ community
 & Twitter
 ** let this group handle CIA program
 * Status of moving Jenkins to java 6 as minimal runtime
-(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-11-14-19.01.html[summary]
@@ -78,7 +78,7 @@ developers" group] at meetup.com? (costs $144 per year)
 FOSDEM conferences (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Accepting donations in Europe
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 ** I spoke to the
 http://www.ffis.de/Verein/spi-en.html[Euro-friends-of-SPI] and it seems
 we could become affiliated. Would be nice to get working before FOSDEM
@@ -268,7 +268,7 @@ https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/bokUEoheAAs%5B1
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/eFawHz1JWYg%5B1-25%5D[link2]
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)]).
 * Documentation of jenkins-admin IRC-bot infra, so that community can
-manage restart. (https://wiki.jenkins.io/display/~ndeloof[Unknown User
+manage restart. (link:/blog/authors/ndeloof[Unknown User
 (ndeloof)])
 
 MINUTES
@@ -411,12 +411,12 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's action items
 * Move plugin CI jobs to jenkins.ci.cloudbees.com
-(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
 * Proposal : ask for FOSS JProfiler licenses ->
 http://www.ej-technologies.com/buy/jprofiler/openSource
-(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
 * Migrate plugins to get rid of glassfish repo
-(https://wiki.jenkins.io/display/~ndeloof[Unknown User (ndeloof)])
+(link:/blog/authors/ndeloof[Unknown User (ndeloof)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-04-04-18.01.html[summary]

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -16,14 +16,14 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's items
 * Authorizing SSL certificate renewal
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Renewing jenkins-ci.org domain
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Website banner usage guideline for people in the events list.
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 ** like maybe giving automatic 1 week access to future events
 * Donation status and what can we do more?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Adding https://wiki.jenkins.io/display/~larrys[Unknown User (larrys)]
 to the admin to combat spam.
 
@@ -41,13 +41,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's items
 * Balancing personal information of JUC attendees vs cost
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 ** https://docs.google.com/spreadsheet/ccc?key=0ApE2WVyiXL0hdGZSRTZVQmdTN2VnVWdJMWZCNEJqa1E[financial
 report of past JUCs]
 * Forming the Events subgroup in the community for the purpose of
 coordinating and running event
 (https://wiki.jenkins.io/display/~lisawells[Unknown User
-(lisawells)]/https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(lisawells)]/link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 ** Initial task – define model for user events so we can attract others
 to run them
@@ -100,7 +100,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 User (vjuranek)])
 * Advertising http://jenkins-ci.org/survey[survey] on
 http://jenkins-ci.org/ (for 2 more weeks until it closes)
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-10-17-18.02.html[summary]
@@ -216,10 +216,10 @@ for closed issues]?
 (tonylampada)])
 * Discussion about the
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
-Election Process] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+Election Process] (link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 * Help wanted: spams are on the rise
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * FOSDEM travel grant
 
 MINUTES
@@ -255,7 +255,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
 use of the name "Jenkins"]. Do we need to take any actions?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Demoing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - http://ambtest.freedomsponsors.org:8080/browse/TLM-1[live
@@ -266,7 +266,7 @@ instructions] (https://wiki.jenkins.io/display/~tonylampada[Unknown User
 * Upcoming event planning and brainstorming
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/bokUEoheAAs%5B1-25%5D[link1]
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/eFawHz1JWYg%5B1-25%5D[link2]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]).
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)]).
 * Documentation of jenkins-admin IRC-bot infra, so that community can
 manage restart. (https://wiki.jenkins.io/display/~ndeloof[Unknown User
 (ndeloof)])
@@ -285,7 +285,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * http://itunes.apple.com/us/app/jenkins-ci-speak/id533789857?mt=12[Commercial
 use of the name "Jenkins"]. Do we need to take any actions?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Installing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - when it's finished development.
@@ -341,9 +341,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Selenium tests, switch to Cucumber/Capybara (vjuranek)
 * New home for wiki.jenkins-ci.org
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * maven.jenkins-ci.org to repo.jenkins-ci.org switch voer
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 [[GovernanceMeetingArchive2012-May30thMeeting]]
 == May 30th Meeting
@@ -353,7 +353,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Moving Subversion repository to GitHub
-https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]
+link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
 * Improving JonJ and IRC bot stability - JonJ gets stuck very often
 recently, IRC bot also seems to get stuck when forking repo (vjuranek,
 unfortunately cannot attend but can offer some help) 
@@ -393,7 +393,7 @@ EDT, 14th Sat 5am CEST, 14th Sat 1pm Tokyo. +
 * Recap last meeting's action items
 * JUC Tokyo status updates
 (https://wiki.jenkins.io/display/~ikikko[Unknown User (ikikko)],
-https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)], and
+link:/blog/authors/kohsuke/[Unknown User (kohsuke)], and
 others)
 * Anything we can do for bridging the Japanese community?
 
@@ -431,14 +431,14 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 21st 18:00 UTC], which should be 11am PDT, 2pm EDT, 7pm CET, 3am Tokyo.
 
 * Recap last meeting's action items
-* Please sign CLAs (https://wiki.jenkins.io/display/~kohsuke[Unknown
+* Please sign CLAs (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 * Officially launching
 https://wiki.jenkins.io/display/JENKINS/Jenkins+CIA+Program[Jenkins CIA
-Program] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+Program] (link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 * "Jenkins@cloud for GitHub" and "Jenkins@cloud by CloudBees" name usage
-approval (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+approval (link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 
 MINUTES
@@ -464,7 +464,7 @@ https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
 (https://wiki.jenkins.io/display/~vjuranek[vjuranek])
 * Cut-over from http://maven.jenkins-ci.org/ to
 http://repo.jenkins-ci.org/ : PoC demo
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-03-07-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -18,7 +18,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Authorizing SSL certificate renewal
 (https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
 * Renewing jenkins-ci.org domain
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Website banner usage guideline for people in the events list.
 (https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
 ** like maybe giving automatic 1 week access to future events
@@ -75,7 +75,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Take over http://www.meetup.com/jenkinsmeetup/["Jenkins users and
 developers" group] at meetup.com? (costs $144 per year)
 * Check on budget for buying stickers for next year's SCaLE11x and
-FOSDEM conferences (https://wiki.jenkins.io/display/~rtyler[Unknown User
+FOSDEM conferences (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Accepting donations in Europe
 (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
@@ -140,7 +140,7 @@ Topic suggestions
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
 |who + |suggestion + |first thoughts +
-|https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+|link:/blog/authors/rtyler/[Unknown User (rtyler)]
 |Decommissioning "cabbage" and migrating some new services to OSUOSL VMs
 |
 
@@ -194,7 +194,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Discussion about future funding source/plan
 * Add more hackers to the SECURITY project to give more
 visibility/opportunity for security issues to be addressed
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Review survey questions for JUC San Francisco (Lisa Wells)
 
 MINUTES
@@ -239,7 +239,7 @@ http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[action
 items]
 * Travel grant for FOSDEM?
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-08-18.01.html[context]
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-08-22-18.06.html[summary]
@@ -309,7 +309,7 @@ http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-06-27-18.01.html[action
 items]
 * How much if any advertisement is acceptable on plugin pages (ex.
 https://wiki.jenkins.io/display/JENKINS/Warnings+Plugin[Warnings
-Plugin]) (https://wiki.jenkins.io/display/~rtyler[Unknown User
+Plugin]) (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 
 MINUTES
@@ -459,7 +459,7 @@ https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
 (https://wiki.jenkins.io/display/~slide.o.mix@gmail.com[Unknown User
 (slide.o.mix@gmail.com)])
 * Last-minute discussion on Google SoC mentors
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Baseline for next major LTS release
 (https://wiki.jenkins.io/display/~vjuranek[vjuranek])
 * Cut-over from http://maven.jenkins-ci.org/ to
@@ -480,10 +480,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Recap last meeting's action items
 * Proposal: Move away from Drupal to a Git repository powered by Jekyll
-for the community site (https://wiki.jenkins.io/display/~rtyler[Unknown
+for the community site (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * It's been a year, should we elect a new board, how/when/etc?
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * JUC promotion ideas
 
 MINUTES

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -456,7 +456,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Recap last meeting's action items
 * Review current status and plans for
 https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
-(https://wiki.jenkins.io/display/~slide.o.mix@gmail.com[Unknown User
+(link:/blog/authors/slide_o_mix[Unknown User
 (slide.o.mix@gmail.com)])
 * Last-minute discussion on Google SoC mentors
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])

--- a/content/project/governance-meeting/archives/2012.adoc
+++ b/content/project/governance-meeting/archives/2012.adoc
@@ -24,7 +24,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 ** like maybe giving automatic 1 week access to future events
 * Donation status and what can we do more?
 (link:/blog/authors/kohsuke/[(kohsuke)])
-* Adding https://wiki.jenkins.io/display/~larrys[(larrys)]
+* Adding (larrys)
 to the admin to combat spam.
 
 MINUTES
@@ -96,7 +96,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 17th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Recap last meeting's items
-* Picking next LTS (https://wiki.jenkins.io/display/~vjuranek[(vjuranek)])
+* Picking next LTS (vjuranek)
 * Advertising http://jenkins-ci.org/survey[survey] on
 http://jenkins-ci.org/ (for 2 more weeks until it closes)
 (link:/blog/authors/kohsuke/[(kohsuke)])
@@ -211,8 +211,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Should the "Sponsor this issue" link be
 https://github.com/freedomsponsors/freedomsponsors-jira-plugin/issues/4[ommited
 for closed issues]?
-(https://wiki.jenkins.io/display/~tonylampada[
-(tonylampada)])
+(tonylampada)
 * Discussion about the
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
 Election Process] (link:/blog/authors/kohsuke/[
@@ -260,8 +259,7 @@ http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to
 JIRA plugin] - http://ambtest.freedomsponsors.org:8080/browse/TLM-1[live
 demo] /
 https://github.com/freedomsponsors/freedomsponsors-jira-plugin[installation
-instructions] (https://wiki.jenkins.io/display/~tonylampada[
-(tonylampada)])
+instructions] (tonylampada)
 * Upcoming event planning and brainstorming
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/bokUEoheAAs%5B1-25%5D[link1]
 https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/eFawHz1JWYg%5B1-25%5D[link2]
@@ -288,8 +286,7 @@ use of the name "Jenkins"]. Do we need to take any actions?
 * Installing the
 http://www.freedomsponsors.org/core/issue/12/jira-plugin-to-link-from-tickets-to-freedomsponsors[FreedomSponsors
 JIRA plugin] - when it's finished development.
-(https://wiki.jenkins.io/display/~tonylampada[
-(tonylampada)])
+(tonylampada)
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-07-25-18.05.html[summary]
@@ -324,7 +321,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 27th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Baseline for next major LTS release
-(https://wiki.jenkins.io/display/~vjuranek[vjuranek]) 
+(vjuranek) 
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-06-27-18.01.html[summary]
@@ -357,7 +354,7 @@ link:/blog/authors/kohsuke/[(kohsuke)]
 recently, IRC bot also seems to get stuck when forking repo (vjuranek,
 unfortunately cannot attend but can offer some help) 
 * Plugin JonJ on DEV@ or BuildHive
-https://wiki.jenkins.io/display/~jieryn[(jieryn)]
+(jieryn)
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2012/jenkins.2012-05-30-18.01.html[summary]
@@ -391,7 +388,7 @@ EDT, 14th Sat 5am CEST, 14th Sat 1pm Tokyo. +
 
 * Recap last meeting's action items
 * JUC Tokyo status updates
-(https://wiki.jenkins.io/display/~ikikko[(ikikko)],
+((ikikko),
 link:/blog/authors/kohsuke/[(kohsuke)], and
 others)
 * Anything we can do for bridging the Japanese community?
@@ -459,7 +456,7 @@ https://wiki.jenkins.io/display/JENKINS/The+new+EMailer[The new EMailer]
 * Last-minute discussion on Google SoC mentors
 (link:/blog/authors/rtyler/[(rtyler)])
 * Baseline for next major LTS release
-(https://wiki.jenkins.io/display/~vjuranek[vjuranek])
+(vjuranek)
 * Cut-over from http://maven.jenkins-ci.org/ to
 http://repo.jenkins-ci.org/ : PoC demo
 (link:/blog/authors/kohsuke/[(kohsuke)])
@@ -533,7 +530,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Would it make sense to populate the *Affects Version/s* and *Fix
 Version/s* fields in the Jenkins JIRA (automatically)? (Might include
 talking about the long pending plan of separating core and plugins in
-JIRA) (https://wiki.jenkins.io/display/~fredg[(fredg)])
+JIRA) (fredg)
 * Funding for give-aways in events (stickers and T-shirts)
 * Start collecting CLAs
 

--- a/content/project/governance-meeting/archives/2013.adoc
+++ b/content/project/governance-meeting/archives/2013.adoc
@@ -170,7 +170,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 26th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Highlighting LTS releases more
-(https://wiki.jenkins.io/display/~domi[(domi)])
+(domi)
 * Travel grant to JUC (link:/blog/authors/kohsuke/[(kohsuke)]) 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-26-18.01.html[summary]

--- a/content/project/governance-meeting/archives/2013.adoc
+++ b/content/project/governance-meeting/archives/2013.adoc
@@ -50,7 +50,7 @@ WHEN
 http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20131030T11&p1=224&ah=1&sort=1[Oct
 30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
-* LTS status (https://wiki.jenkins.io/display/~jglick[Unknown User
+* LTS status (link:/blog/authors/jglick[Unknown User
 (jglick)])
 * Name approval request for "Jenkins Multi-master by CloudBees"
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
@@ -331,7 +331,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * FOSDEM prep discussion?
 * Confirm European donation status (would be good to mention in all our
 talks/stands/flyers at FOSDEM)
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 * Authorize another sticker batch purchase of $500
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * SSL certificate renewal

--- a/content/project/governance-meeting/archives/2013.adoc
+++ b/content/project/governance-meeting/archives/2013.adoc
@@ -15,7 +15,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 11th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Advertisements on jenkins-ci.org?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * JUC 2014 brainstorming (Alyssa Tong)
 
 MINUTES
@@ -33,7 +33,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 13th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Name approval request take 2 "Jenkins Operations Center by CloudBees"
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * LTS status
 
 MINUTES
@@ -50,10 +50,10 @@ WHEN
 http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20131030T11&p1=224&ah=1&sort=1[Oct
 30th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
-* LTS status (link:/blog/authors/jglick[Unknown User
+* LTS status (link:/blog/authors/jglick[
 (jglick)])
 * Name approval request for "Jenkins Multi-master by CloudBees"
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Jenkins User Conference Recap (autojack)
 
 MINUTES
@@ -86,7 +86,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * JUC Palo Alto discussion and feedback (Alyssa)
 * Event coordination for winter — SCALE? FOSDEM?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-02-18.04.html[summary]
@@ -136,7 +136,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 24th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Next LTS plan and start lifting Java 6 dependency
-link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
+link:/blog/authors/kohsuke/[ (kohsuke)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-24-18.05.html[summary]
@@ -151,11 +151,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 10th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Improving out of the box experience: bundle more plugins
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Pull request greeting bot rollout
 (https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/5[example])
 (https://github.com/jenkinsci/nant-plugin/pull/2[why we need it])
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-10-18.00.html[summary]
@@ -170,10 +170,8 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 26th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Highlighting LTS releases more
-(https://wiki.jenkins.io/display/~domi[Unknown User (domi)])
-* Travel grant to JUC (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
-
+(https://wiki.jenkins.io/display/~domi[ (domi)])
+* Travel grant to JUC (link:/blog/authors/kohsuke/[ (kohsuke)]) 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-26-18.01.html[summary]
 and
@@ -331,11 +329,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * FOSDEM prep discussion?
 * Confirm European donation status (would be good to mention in all our
 talks/stands/flyers at FOSDEM)
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 * Authorize another sticker batch purchase of $500
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * SSL certificate renewal
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-01-23-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2013.adoc
+++ b/content/project/governance-meeting/archives/2013.adoc
@@ -15,7 +15,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 11th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Advertisements on jenkins-ci.org?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * JUC 2014 brainstorming (Alyssa Tong)
 
 MINUTES
@@ -33,7 +33,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 13th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Name approval request take 2 "Jenkins Operations Center by CloudBees"
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * LTS status
 
 MINUTES
@@ -53,7 +53,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * LTS status (https://wiki.jenkins.io/display/~jglick[Unknown User
 (jglick)])
 * Name approval request for "Jenkins Multi-master by CloudBees"
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Jenkins User Conference Recap (autojack)
 
 MINUTES
@@ -86,7 +86,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * JUC Palo Alto discussion and feedback (Alyssa)
 * Event coordination for winter — SCALE? FOSDEM?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-02-18.04.html[summary]
@@ -136,7 +136,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 24th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Next LTS plan and start lifting Java 6 dependency
-https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]
+link:/blog/authors/kohsuke/[Unknown User (kohsuke)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-24-18.05.html[summary]
@@ -151,11 +151,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 10th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Improving out of the box experience: bundle more plugins
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Pull request greeting bot rollout
 (https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/5[example])
 (https://github.com/jenkinsci/nant-plugin/pull/2[why we need it])
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-10-18.00.html[summary]
@@ -171,7 +171,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * Highlighting LTS releases more
 (https://wiki.jenkins.io/display/~domi[Unknown User (domi)])
-* Travel grant to JUC (https://wiki.jenkins.io/display/~kohsuke[Unknown
+* Travel grant to JUC (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 
 MINUTES
@@ -333,9 +333,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 talks/stands/flyers at FOSDEM)
 (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
 * Authorize another sticker batch purchase of $500
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * SSL certificate renewal
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-01-23-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2013.adoc
+++ b/content/project/governance-meeting/archives/2013.adoc
@@ -15,7 +15,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 11th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Advertisements on jenkins-ci.org?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * JUC 2014 brainstorming (Alyssa Tong)
 
 MINUTES
@@ -33,7 +33,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 13th 19:00 UTC], which should be 11am PST, 2pm EST, 8pm CET, 4am Tokyo.
 
 * Name approval request take 2 "Jenkins Operations Center by CloudBees"
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * LTS status
 
 MINUTES
@@ -53,7 +53,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * LTS status (link:/blog/authors/jglick[
 (jglick)])
 * Name approval request for "Jenkins Multi-master by CloudBees"
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Jenkins User Conference Recap (autojack)
 
 MINUTES
@@ -86,7 +86,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * JUC Palo Alto discussion and feedback (Alyssa)
 * Event coordination for winter — SCALE? FOSDEM?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-10-02-18.04.html[summary]
@@ -136,7 +136,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 24th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Next LTS plan and start lifting Java 6 dependency
-link:/blog/authors/kohsuke/[ (kohsuke)]
+link:/blog/authors/kohsuke/[(kohsuke)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-24-18.05.html[summary]
@@ -151,11 +151,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 10th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Improving out of the box experience: bundle more plugins
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Pull request greeting bot rollout
 (https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/5[example])
 (https://github.com/jenkinsci/nant-plugin/pull/2[why we need it])
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-07-10-18.00.html[summary]
@@ -170,8 +170,8 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 26th 18:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CEST, 3am Tokyo.
 
 * Highlighting LTS releases more
-(https://wiki.jenkins.io/display/~domi[ (domi)])
-* Travel grant to JUC (link:/blog/authors/kohsuke/[ (kohsuke)]) 
+(https://wiki.jenkins.io/display/~domi[(domi)])
+* Travel grant to JUC (link:/blog/authors/kohsuke/[(kohsuke)]) 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-06-26-18.01.html[summary]
 and
@@ -329,11 +329,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * FOSDEM prep discussion?
 * Confirm European donation status (would be good to mention in all our
 talks/stands/flyers at FOSDEM)
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 * Authorize another sticker batch purchase of $500
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * SSL certificate renewal
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2013/jenkins.2013-01-23-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -136,7 +136,7 @@ http://www.spi-inc.org/meetings/minutes/2014/2014-07-10/[$14K+ in the
 bank]. Can we spend some of it (proposal:$2K) to send spekaers to the
 upcoming JUC Tokyo?
 * Cease support for native Solaris packages
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Improvements to JENKINS project in JIRA
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User
 (danielbeck)]):
@@ -355,7 +355,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Review of the
 https://wiki.jenkins.io/display/JENKINS/2014+Jenkins+Infrastructure+Roadmap[2014
 Jenkins Infrastructure Roadmap]
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-19-18.01.html[summary]

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -29,7 +29,7 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 usage request from CloudBees]
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Can we improve the Jenkins release process?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * INFRA components
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
@@ -65,7 +65,7 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Decision on further component renames in Jira
 (link:https://groups.google.com/g/jenkinsci-dev/c/T_V9Z71rbPk[Thread: Further component renames/deletions in Jira])
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.log.html[raw]
@@ -95,7 +95,7 @@ commit for client but requires either force pushing or ours merging.
 `+stable-+`__x__ requires neither, though someone have to remember
 updating all automation.
 * Update on plugins not getting forked into jenkinsci, or not getting
-released from there (https://wiki.jenkins.io/display/~danielbeck[Unknown
+released from there (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 
 [[GovernanceMeetingArchive2014-Oct1meeting]]
@@ -109,7 +109,7 @@ Europe, 3am Tokyo.
 * Q4 patron ads on Jenkins Wiki
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Plugins not getting forked into jenkinsci, or not getting released
-from there (https://wiki.jenkins.io/display/~danielbeck[Unknown User
+from there (link:/blog/authors/daniel-beck/[Unknown User
 (danielbeck)])
 * GitHub private repositories for security work
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
@@ -138,7 +138,7 @@ upcoming JUC Tokyo?
 * Cease support for native Solaris packages
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Improvements to JENKINS project in JIRA
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(link:/blog/authors/daniel-beck/[Unknown User
 (danielbeck)]):
 ** Set the default priority to 'Minor'
 ** Remove the 'Patch' issue type
@@ -147,7 +147,7 @@ upcoming JUC Tokyo?
 Version' and 'Fix Version' fields, add specific instructions for some
 fields when creating an issue.
 * Can we improve the Jenkins release process?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.html[summary]
@@ -169,10 +169,10 @@ User (kohsuke)])
 * Decision on implementing
 https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[Browser
 Compatibility Matrix]
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/2014+JIRA+Components+Refactoring[2014
 JIRA Components Refactoring]
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** Decision on adding `+-plugin+` suffix and rename/merge of other
 components (table in _Modification of existing components_)
 

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -61,15 +61,11 @@ Europe, 4am Tokyo.
 It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 
-* https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
-usage request from CloudBees]
+* https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark usage request from CloudBees]
 (https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
 * Decision on further component renames in Jira
-(https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk[https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk|https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk])
-(https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk[https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk|https://groups.google.com/forum/#!topic/jenkinsci-dev/T_V9Z71rbPk])
+(link:https://groups.google.com/g/jenkinsci-dev/c/T_V9Z71rbPk[Thread: Further component renames/deletions in Jira])
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
-
-MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.log.html[raw]

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -16,14 +16,14 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 == Dec 10 meeting
 
 * 1.580.2 status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 
 [[GovernanceMeetingArchive2014-Nov26meeting]]
 == Nov 26 meeting
 
 * 1.580.2 RC status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
 usage request from CloudBees]
@@ -257,7 +257,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * 1.554.3 RC status check
-* JUC (https://wiki.jenkins.io/display/~lisawells[Unknown User
+* JUC (link:/blog/authors/lisawells[Unknown User
 (lisawells)])
 
 MINUTES
@@ -310,10 +310,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * JUC status update / travel grant?
-(https://wiki.jenkins.io/display/~lisawells[Unknown User
+(link:/blog/authors/lisawells[Unknown User
 (lisawells)]/Alyssa)
 ** how to reach German Jenkins community?
-* 1.554.1 RC status (https://wiki.jenkins.io/display/~jglick[Unknown
+* 1.554.1 RC status (link:/blog/authors/jglick[Unknown
 User (jglick)])
 
 MINUTES
@@ -393,7 +393,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * FOSDEM planning
 * LTS.next planning and its scheduled cadence
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * https://wiki.jenkins.io/pages/viewpage.action?pageId=71435396["Patron
 of Jenkins" proposal] (link:/blog/authors/kohsuke/[Unknown

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -334,7 +334,7 @@ User (kohsuke)])
 of Jenkins program] approval
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * JIRA Versions backend application
-(https://wiki.jenkins.io/display/~slide_o_mix[slide_o_mix])
+(link:/blog/authors/slide_o_mix[slide_o_mix])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-02-18.02.html[summary]

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -27,7 +27,7 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 (olivergondza)])
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
 usage request from CloudBees]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Can we improve the Jenkins release process?
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * INFRA components
@@ -45,7 +45,7 @@ contacts (or 1-person bottlenecks)
 (INFRA-147)
 * https://github.com/jenkinsci/patron/pull/2/files[Patron message
 changes from CloudBees]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 [[GovernanceMeetingArchive2014-Nov12meeting]]
 == Nov 12 meeting
@@ -62,7 +62,7 @@ It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark usage request from CloudBees]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Decision on further component renames in Jira
 (link:https://groups.google.com/g/jenkinsci-dev/c/T_V9Z71rbPk[Thread: Further component renames/deletions in Jira])
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
@@ -79,7 +79,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * LTS release status check
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 [[GovernanceMeetingArchive2014-Oct15meeting]]
 == Oct 15 meeting
@@ -107,13 +107,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * Q4 patron ads on Jenkins Wiki
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Plugins not getting forked into jenkinsci, or not getting released
 from there (https://wiki.jenkins.io/display/~danielbeck[Unknown User
 (danielbeck)])
 * GitHub private repositories for security work
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
-* New LTS base line (https://wiki.jenkins.io/display/~kohsuke[Unknown
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+* New LTS base line (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 
 MINUTES
@@ -130,7 +130,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * Travel grant for JUC Tokyo 2015
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)]). As
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)]). As
 of Jun 30th we have
 http://www.spi-inc.org/meetings/minutes/2014/2014-07-10/[$14K+ in the
 bank]. Can we spend some of it (proposal:$2K) to send spekaers to the
@@ -162,10 +162,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 3rd 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
 Europe, 3am Tokyo.
 
-* LTS status check (https://wiki.jenkins.io/display/~kohsuke[Unknown
+* LTS status check (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 * How do we run the "Ask the Experts" section in JUC?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Decision on implementing
 https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[Browser
 Compatibility Matrix]
@@ -274,9 +274,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * comission to build 3D model of Mr.Jenkins?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * 1.554.2 LTS release status check
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * JUC
 
 [[GovernanceMeetingArchive2014-May14thMeeting]]
@@ -298,7 +298,7 @@ Europe, 3am Tokyo.
 * 1.554.1 release status
 * Jenkins joining http://www.openinventionnetwork.com/[the software
 patent non-aggression community]?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Permanently switch to acceptance-tests for LTS testing. (ogondza)
 
 [[GovernanceMeetingArchive2014-Apr16thMeeting]]
@@ -328,11 +328,11 @@ WHEN
 http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140402T11&p1=224&ah=1&sort=1[Apr
 2nd 18:00 UTC], which should be 11am PDT, 2pm EDT, 9pm CEST, 4am Tokyo.
 
-* 1.554 go or no-go (https://wiki.jenkins.io/display/~kohsuke[Unknown
+* 1.554 go or no-go (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 * https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[Patron
 of Jenkins program] approval
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * JIRA Versions backend application
 (https://wiki.jenkins.io/display/~slide_o_mix[slide_o_mix])
 
@@ -351,7 +351,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 19th 19:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CET, 4am Tokyo.
 
 * Pick new LTS baseline
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Review of the
 https://wiki.jenkins.io/display/JENKINS/2014+Jenkins+Infrastructure+Roadmap[2014
 Jenkins Infrastructure Roadmap]
@@ -375,7 +375,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Moving Confluence to a new VM
 * Switching from masterless Puppet to a Puppet master.
 * Approval to order more stickers
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-05-19.00.html[summary]
@@ -396,7 +396,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * https://wiki.jenkins.io/pages/viewpage.action?pageId=71435396["Patron
-of Jenkins" proposal] (https://wiki.jenkins.io/display/~kohsuke[Unknown
+of Jenkins" proposal] (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 
 MINUTES

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -31,7 +31,7 @@ usage request from CloudBees]
 * Can we improve the Jenkins release process?
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * INFRA components
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Migration of repositories to https://github.com/jenkins-infra/
 (INFRA-169)

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -27,9 +27,9 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 (olivergondza)])
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
 usage request from CloudBees]
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Can we improve the Jenkins release process?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * INFRA components
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
@@ -45,7 +45,7 @@ contacts (or 1-person bottlenecks)
 (INFRA-147)
 * https://github.com/jenkinsci/patron/pull/2/files[Patron message
 changes from CloudBees]
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 [[GovernanceMeetingArchive2014-Nov12meeting]]
 == Nov 12 meeting
@@ -59,10 +59,10 @@ It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark usage request from CloudBees]
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Decision on further component renames in Jira
 (link:https://groups.google.com/g/jenkinsci-dev/c/T_V9Z71rbPk[Thread: Further component renames/deletions in Jira])
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.log.html[raw]
@@ -76,7 +76,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * LTS release status check
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 [[GovernanceMeetingArchive2014-Oct15meeting]]
 == Oct 15 meeting
@@ -103,13 +103,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * Q4 patron ads on Jenkins Wiki
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Plugins not getting forked into jenkinsci, or not getting released
 from there (link:/blog/authors/daniel-beck/[
 (danielbeck)])
 * GitHub private repositories for security work
-(link:/blog/authors/kohsuke/[ (kohsuke)])
-* New LTS base line (link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
+* New LTS base line (link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html[summary]
@@ -125,13 +125,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * Travel grant for JUC Tokyo 2015
-(link:/blog/authors/kohsuke/[ (kohsuke)]). As
+(link:/blog/authors/kohsuke/[(kohsuke)]). As
 of Jun 30th we have
 http://www.spi-inc.org/meetings/minutes/2014/2014-07-10/[$14K+ in the
 bank]. Can we spend some of it (proposal:$2K) to send spekaers to the
 upcoming JUC Tokyo?
 * Cease support for native Solaris packages
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Improvements to JENKINS project in JIRA
 (link:/blog/authors/daniel-beck/[
 (danielbeck)]):
@@ -142,7 +142,7 @@ upcoming JUC Tokyo?
 Version' and 'Fix Version' fields, add specific instructions for some
 fields when creating an issue.
 * Can we improve the Jenkins release process?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.html[summary]
@@ -157,16 +157,16 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 3rd 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
 Europe, 3am Tokyo.
 
-* LTS status check (link:/blog/authors/kohsuke/[ (kohsuke)])
+* LTS status check (link:/blog/authors/kohsuke/[(kohsuke)])
 * How do we run the "Ask the Experts" section in JUC?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Decision on implementing
 https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[Browser
 Compatibility Matrix]
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/2014+JIRA+Components+Refactoring[2014
 JIRA Components Refactoring]
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** Decision on adding `+-plugin+` suffix and rename/merge of other
 components (table in _Modification of existing components_)
 
@@ -268,9 +268,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * comission to build 3D model of Mr.Jenkins?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * 1.554.2 LTS release status check
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * JUC
 
 [[GovernanceMeetingArchive2014-May14thMeeting]]
@@ -292,7 +292,7 @@ Europe, 3am Tokyo.
 * 1.554.1 release status
 * Jenkins joining http://www.openinventionnetwork.com/[the software
 patent non-aggression community]?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Permanently switch to acceptance-tests for LTS testing. (ogondza)
 
 [[GovernanceMeetingArchive2014-Apr16thMeeting]]
@@ -307,7 +307,7 @@ Europe, 3am Tokyo.
 (link:/blog/authors/lisawells[
 (lisawells)]/Alyssa)
 ** how to reach German Jenkins community?
-* 1.554.1 RC status (link:/blog/authors/jglick[ (jglick)])
+* 1.554.1 RC status (link:/blog/authors/jglick[(jglick)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-16-18.00.html[summary]
@@ -321,10 +321,10 @@ WHEN
 http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140402T11&p1=224&ah=1&sort=1[Apr
 2nd 18:00 UTC], which should be 11am PDT, 2pm EDT, 9pm CEST, 4am Tokyo.
 
-* 1.554 go or no-go (link:/blog/authors/kohsuke/[ (kohsuke)])
+* 1.554 go or no-go (link:/blog/authors/kohsuke/[(kohsuke)])
 * https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[Patron
 of Jenkins program] approval
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * JIRA Versions backend application
 (link:/blog/authors/slide_o_mix[slide_o_mix])
 
@@ -343,11 +343,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 19th 19:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CET, 4am Tokyo.
 
 * Pick new LTS baseline
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Review of the
 https://wiki.jenkins.io/display/JENKINS/2014+Jenkins+Infrastructure+Roadmap[2014
 Jenkins Infrastructure Roadmap]
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-19-18.01.html[summary]
@@ -367,7 +367,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Moving Confluence to a new VM
 * Switching from masterless Puppet to a Puppet master.
 * Approval to order more stickers
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-05-19.00.html[summary]
@@ -388,7 +388,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 (link:/blog/authors/olivergondza[
 (olivergondza)])
 * https://wiki.jenkins.io/pages/viewpage.action?pageId=71435396["Patron
-of Jenkins" proposal] (link:/blog/authors/kohsuke/[ (kohsuke)])
+of Jenkins" proposal] (link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-01-22-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -16,22 +16,22 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 == Dec 10 meeting
 
 * 1.580.2 status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 
 [[GovernanceMeetingArchive2014-Nov26meeting]]
 == Nov 26 meeting
 
 * 1.580.2 RC status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark
 usage request from CloudBees]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Can we improve the Jenkins release process?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * INFRA components
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Migration of repositories to https://github.com/jenkins-infra/
 (INFRA-169)
@@ -45,7 +45,7 @@ contacts (or 1-person bottlenecks)
 (INFRA-147)
 * https://github.com/jenkinsci/patron/pull/2/files[Patron message
 changes from CloudBees]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 [[GovernanceMeetingArchive2014-Nov12meeting]]
 == Nov 12 meeting
@@ -62,10 +62,10 @@ It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 
 * https://groups.google.com/d/msg/jenkinsci-dev/rzNetnrhPRI/7rRfyshG9bEJ[Mark usage request from CloudBees]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Decision on further component renames in Jira
 (link:https://groups.google.com/g/jenkinsci-dev/c/T_V9Z71rbPk[Thread: Further component renames/deletions in Jira])
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-11-12-19.04.log.html[raw]
@@ -79,7 +79,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * LTS release status check
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 [[GovernanceMeetingArchive2014-Oct15meeting]]
 == Oct 15 meeting
@@ -95,8 +95,7 @@ commit for client but requires either force pushing or ours merging.
 `+stable-+`__x__ requires neither, though someone have to remember
 updating all automation.
 * Update on plugins not getting forked into jenkinsci, or not getting
-released from there (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
+released from there (link:/blog/authors/daniel-beck/[(danielbeck)])
 
 [[GovernanceMeetingArchive2014-Oct1meeting]]
 == Oct 1 meeting
@@ -107,14 +106,13 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * Q4 patron ads on Jenkins Wiki
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Plugins not getting forked into jenkinsci, or not getting released
-from there (link:/blog/authors/daniel-beck/[Unknown User
+from there (link:/blog/authors/daniel-beck/[
 (danielbeck)])
 * GitHub private repositories for security work
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
-* New LTS base line (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
+* New LTS base line (link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html[summary]
@@ -130,15 +128,15 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * Travel grant for JUC Tokyo 2015
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)]). As
+(link:/blog/authors/kohsuke/[ (kohsuke)]). As
 of Jun 30th we have
 http://www.spi-inc.org/meetings/minutes/2014/2014-07-10/[$14K+ in the
 bank]. Can we spend some of it (proposal:$2K) to send spekaers to the
 upcoming JUC Tokyo?
 * Cease support for native Solaris packages
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Improvements to JENKINS project in JIRA
-(link:/blog/authors/daniel-beck/[Unknown User
+(link:/blog/authors/daniel-beck/[
 (danielbeck)]):
 ** Set the default priority to 'Minor'
 ** Remove the 'Patch' issue type
@@ -147,7 +145,7 @@ upcoming JUC Tokyo?
 Version' and 'Fix Version' fields, add specific instructions for some
 fields when creating an issue.
 * Can we improve the Jenkins release process?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.html[summary]
@@ -162,17 +160,16 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 3rd 18:00 UTC], which should be 11am Pacific, 2pm Eastern, 8pm Central
 Europe, 3am Tokyo.
 
-* LTS status check (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
+* LTS status check (link:/blog/authors/kohsuke/[ (kohsuke)])
 * How do we run the "Ask the Experts" section in JUC?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Decision on implementing
 https://wiki.jenkins.io/display/JENKINS/Browser+Compatibility+Matrix[Browser
 Compatibility Matrix]
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/2014+JIRA+Components+Refactoring[2014
 JIRA Components Refactoring]
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** Decision on adding `+-plugin+` suffix and rename/merge of other
 components (table in _Modification of existing components_)
 
@@ -257,7 +254,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * 1.554.3 RC status check
-* JUC (link:/blog/authors/lisawells[Unknown User
+* JUC (link:/blog/authors/lisawells[
 (lisawells)])
 
 MINUTES
@@ -274,9 +271,9 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * comission to build 3D model of Mr.Jenkins?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * 1.554.2 LTS release status check
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * JUC
 
 [[GovernanceMeetingArchive2014-May14thMeeting]]
@@ -298,7 +295,7 @@ Europe, 3am Tokyo.
 * 1.554.1 release status
 * Jenkins joining http://www.openinventionnetwork.com/[the software
 patent non-aggression community]?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Permanently switch to acceptance-tests for LTS testing. (ogondza)
 
 [[GovernanceMeetingArchive2014-Apr16thMeeting]]
@@ -310,11 +307,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 Europe, 3am Tokyo.
 
 * JUC status update / travel grant?
-(link:/blog/authors/lisawells[Unknown User
+(link:/blog/authors/lisawells[
 (lisawells)]/Alyssa)
 ** how to reach German Jenkins community?
-* 1.554.1 RC status (link:/blog/authors/jglick[Unknown
-User (jglick)])
+* 1.554.1 RC status (link:/blog/authors/jglick[ (jglick)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-04-16-18.00.html[summary]
@@ -328,11 +324,10 @@ WHEN
 http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20140402T11&p1=224&ah=1&sort=1[Apr
 2nd 18:00 UTC], which should be 11am PDT, 2pm EDT, 9pm CEST, 4am Tokyo.
 
-* 1.554 go or no-go (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
+* 1.554 go or no-go (link:/blog/authors/kohsuke/[ (kohsuke)])
 * https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[Patron
 of Jenkins program] approval
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * JIRA Versions backend application
 (link:/blog/authors/slide_o_mix[slide_o_mix])
 
@@ -351,11 +346,11 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 19th 19:00 UTC], which should be 11am PDT, 2pm EDT, 8pm CET, 4am Tokyo.
 
 * Pick new LTS baseline
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Review of the
 https://wiki.jenkins.io/display/JENKINS/2014+Jenkins+Infrastructure+Roadmap[2014
 Jenkins Infrastructure Roadmap]
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-19-18.01.html[summary]
@@ -375,7 +370,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Moving Confluence to a new VM
 * Switching from masterless Puppet to a Puppet master.
 * Approval to order more stickers
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-03-05-19.00.html[summary]
@@ -393,11 +388,10 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 
 * FOSDEM planning
 * LTS.next planning and its scheduled cadence
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * https://wiki.jenkins.io/pages/viewpage.action?pageId=71435396["Patron
-of Jenkins" proposal] (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
+of Jenkins" proposal] (link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-01-22-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2014.adoc
+++ b/content/project/governance-meeting/archives/2014.adoc
@@ -55,9 +55,6 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 12th 11:00 Pacific], which should be 6pm UTC, 2pm Eastern, 8pm Central
 Europe, 4am Tokyo.
 
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
-
 It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -93,8 +93,6 @@ WHEN
 https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20151028T11&p1=224&ah=1&sort=1[Oct
 28 11:00 Pacific].
 
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
 
 *It is the end of daylight savings time season. The meeting will be held
 at 11 am Pacific time, adjust accordingly.*
@@ -154,9 +152,6 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-14-1
 
 [[GovernanceMeetingArchive2015-Sep30meeting]]
 == Sep 30 meeting
-
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
 
 *This is the first meeting to be held in #jenkins-meeting.*
 
@@ -519,8 +514,6 @@ WHEN
 https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20150401T11&p1=224&ah=1&sort=1[Apr
 1st 11:00 Pacific].
 
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
 
 It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -24,13 +24,13 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Next LTS baseline selection
 * (*hopefully*) Final review/adoption of
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
-Election Process] (link:/blog/authors/rtyler/[Unknown User
+Election Process] (link:/blog/authors/rtyler/[
 (rtyler)])
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * *NOT* tweet anymore plugins w/o a wiki page
-(link:/blog/authors/batmat[Unknown User (batmat)]) (for
+(link:/blog/authors/batmat[ (batmat)]) (for
 https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/qR8WqJZmNZs/1a9Zd3F0DAAJ[reference])
 
 MINUTES
@@ -48,7 +48,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS RC status check
 * Announce Security Officer
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-25-19.00.html[summary]
@@ -66,20 +66,20 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Review proposed www site change from Drupal to static site generation
 (current https://github.com/rtyler/jenkins.io[repo] and
 http://jenkins.lasagna.io/[generated version of site])
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * CERT membership requests from
 https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/UMBz91HMAgAJ[Ivan
 Meredith] and
 https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/v2sG6UvPAgAJ[Ben
-Walding] (link:/blog/authors/daniel-beck/[Unknown User
+Walding] (link:/blog/authors/daniel-beck/[
 (danielbeck)])
 * Review
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
 Election Process] and either move forward with the proposal or take
 feedback so we can have elections next year
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Jenkins 2.0 proposal recap
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary]
@@ -105,11 +105,11 @@ for reporting security issues]
 * LTS status check
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Revisiting+JUC+in+2016[Proposal
 - Revisiting JUC in 2016]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Sticker purchase approval
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Voting: Should we require squashing commits in the core?
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Related discussion:
 https://groups.google.com/forum/#\!searchin/jenkinsci-dev/squash/jenkinsci-dev/kqvuDqXwPZw/oF-KMdNbCwAJ
@@ -130,23 +130,22 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://wiki.jenkins.io/display/JENKINS/Approved+Trademark+Usage[Approved
 Trademark Usage] has been updated.
 * Quick announcement of `+#jenkins-community+`
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * LTS status check
 ** https://github.com/jenkinsci/jenkins/pull/1812/files#diff-600376dffeb79835ede4a0b285078036R850[Link
 to changelog-stable when building]?
 * New Website JIRA project to organize website efforts under
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Approval of new Q4 patron messages by CloudBees
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Project+sub-teams[Proposal
-- Project sub-teams] (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
+- Project sub-teams] (link:/blog/authors/rtyler/[ (rtyler)])
 * https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[Permission
 request] - Admin access to jenkinsci org
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * JIRA project for plugin hosting (and possibly similar) requests
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-14-18.00.html[summary]
@@ -171,19 +170,18 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://issues.jenkins.io/browse/JENKINS-29876[JENKINS-29876]
 * Q4
 https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[patron
-program] messages (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
+program] messages (link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** Same as for Q3, with same pre-approved message pending:
 https://github.com/jenkinsci/patron/pull/4
 * Time to think about Jenkins board elections?
-link:/blog/authors/orrc[Unknown User (orrc)]
+link:/blog/authors/orrc[ (orrc)]
 ** This was vaguely discussed in the 100k podcast in February, and soon
 2/3 of the board will be CloudBees employees
 ** The most recent proposal seems to be
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[proposal
 from April 2013]
 * Time to move to Java 8 and servlet 3.1?
-https://wiki.jenkins.io/display/~teilo[Unknown User (teilo)] for core?
+https://wiki.jenkins.io/display/~teilo[ (teilo)] for core?
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary]
@@ -199,9 +197,9 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS backporting status check
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Protect master branches of repositories
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA[https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA|https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA]
 
@@ -228,25 +226,24 @@ into prod
 https://wiki.jenkins.io/display/JENKINS/Infrastructure+Admins[Infrastructure
 Admins] (still missing Artifactory)
 * LTS RC status check
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * LTS baseline selection
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
 grant program] blessing
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Process for merging PRs with multiple commits
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
-but it was really https://wiki.jenkins.io/display/~integer[Unknown User
-(integer)] and https://wiki.jenkins.io/display/~tfennelly[Unknown User
+(link:/blog/authors/daniel-beck/[ (danielbeck)]
+but it was really https://wiki.jenkins.io/display/~integer[
+(integer)] and https://wiki.jenkins.io/display/~tfennelly[
 (tfennelly)] who brought it up)
 * Clarification what requires a CLA and what does not
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * CERT Team membership request for
-link:/blog/authors/oleg_nenashev/[Unknown User
-(oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[Unknown User
-(vlatombe)] and https://wiki.jenkins.io/display/~varmenise[Unknown User
-(varmenise)] (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)])
+link:/blog/authors/oleg_nenashev/[
+(oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[
+(vlatombe)] and https://wiki.jenkins.io/display/~varmenise[
+(varmenise)] (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-02-18.00.html[summary]
@@ -263,25 +260,25 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 ** https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
 grant program draft]
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * LTS RC status check / LTS baseline selection
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** What about
 https://issues.jenkins.io/browse/JENKINS-29936[JENKINS-29936]?
 * Revisiting bundled plugins
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 ** See
 https://groups.google.com/forum/#!topic/jenkinsci-dev/kRobm-cxFw8[mailing
 list post]
 * Allow file browsing in artifactory for ability view javadocs, add link
 in confluence macros live link, send request to jfrog support to get
 newer artifactory
-version.  (https://wiki.jenkins.io/display/~integer[Unknown User
+version.  (https://wiki.jenkins.io/display/~integer[
 (integer)])
 * Provide public list of JIRA/confluence/artifactory admins in wiki
-(https://wiki.jenkins.io/display/~integer[Unknown User (integer)])
+(https://wiki.jenkins.io/display/~integer[ (integer)])
 * https://github.com/jenkinsci/jenkins/pull/1774[HTMLUnit update]
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-19-18.03.html[summary]
@@ -297,13 +294,11 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * Jenkins certification
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Approval of new
 https://wiki.jenkins-ci.org/display/JENKINS/Patron+of+Jenkins+program[Patron
-program] messages (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
-* JUC travel grant (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
+program] messages (link:/blog/authors/daniel-beck/[ (danielbeck)])
+* JUC travel grant (link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** (http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.log.html[previous
 discussion])
 ** The Jenkins project currently has
@@ -322,7 +317,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 22th 11:00 Pacific].
 
 * LTS 1.609 RC status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 
 MINUTES
@@ -339,7 +334,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS 1.609.2 RC status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 
 MINUTES
@@ -357,22 +352,22 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * Can we start to look at fixing the
 https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA%20AND%20component%20%3D%20spof%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC[single
-points of failure]? (link:/blog/authors/orrc[Unknown User
+points of failure]? (link:/blog/authors/orrc[
 (orrc)])
 ** e.g. https://issues.jenkins.io/browse/INFRA-225[INFRA-225] was
 recently broken for a month; related
 https://issues.jenkins.io/browse/INFRA-75[INFRA-75] is one year old
 * Using labels for pull requests to core (instead of renaming to
 something like "[WIP] [JENKINS-12345] Foo").
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * "Action items are https://issues.jenkins.io/browse/MEETING[tracked
 in JIRA]" — can we agree to do this?
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 ** People miss meetings or forget action items, and there's usually no
 follow-up and the actions never get done
 * Time to move to Servlet 3.0 (3.1?) as
 http://jenkins-ci.org/content/good-bye-java6[announced]?
-(https://wiki.jenkins.io/display/~teilo[Unknown User (teilo)])
+(https://wiki.jenkins.io/display/~teilo[ (teilo)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-06-10-18.01.html[summary]
@@ -388,17 +383,17 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS RC status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * When to flip the switch on
 https://github.com/jenkinsci/backend-update-center2/pull/20[plugins
-without wiki pages]? (link:/blog/authors/orrc[Unknown User
+without wiki pages]? (link:/blog/authors/orrc[
 (orrc)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/dfvRxvCv7Mg/jIailHDwY2EJ[Mailing
 list thread]
 * Can we start to look at fixing the
 https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA%20AND%20component%20%3D%20spof%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC[single
-points of failure]? (link:/blog/authors/orrc[Unknown User
+points of failure]? (link:/blog/authors/orrc[
 (orrc)])
 ** e.g. https://issues.jenkins.io/browse/INFRA-225[INFRA-225] is
 currently (again) a visible problem; related
@@ -419,13 +414,12 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS RC status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
-* #jenkins-meeting (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
+* #jenkins-meeting (link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Should we only include plugins in the Update Centre if they have a
-wiki page? (link:/blog/authors/orrc[Unknown User (orrc)],
-https://wiki.jenkins.io/display/~evernat[Unknown User (evernat)])
+wiki page? (link:/blog/authors/orrc[ (orrc)],
+https://wiki.jenkins.io/display/~evernat[ (evernat)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion];
 https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/S_uQ_C_7NMQJ[more
@@ -442,13 +436,13 @@ repo, Java source excluded from release]: AntepediaReporter — orrc
 contacted them and they're considering open-sourcing)
 * Infra training/handover/expansion? (Was mentioned a while back and
 more recently, but can't find the link)
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 * Using a CDN with HTTPS / removing need for mirrorbrain?
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 * Further requirements for plugins published in the community update
-center (link:/blog/authors/daniel-beck/[Unknown User
+center (link:/blog/authors/daniel-beck/[
 (danielbeck)])
 ** To allow review, inspection and collaboration:
 *** Require a valid SCM URL for new plugin releases inside
@@ -475,24 +469,23 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Carryover from last meeting w.r.t. SECURITY bounties. Anything for
 historical submitters? Who has the action item?
 * Trademark usage approval for "CloudBees Jenkins Platform"
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * We only allow OSS plugins to be distributed via the update center, but
 what about closed source plugins which are documented on our wiki? (e.g.
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[CxSuite
 Jenkins Plugin])
 * Should we only include plugins in the Update Centre if they have a
-wiki page? (link:/blog/authors/orrc[Unknown User (orrc)])
+wiki page? (link:/blog/authors/orrc[ (orrc)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion]
-* #jenkins-meeting (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
-* LTS.next (link:/blog/authors/olivergondza[Unknown User
+* #jenkins-meeting (link:/blog/authors/daniel-beck/[ (danielbeck)])
+* LTS.next (link:/blog/authors/olivergondza[
 (olivergondza)])
 * Infra training? (Was mentioned a while back and more recently, but
-can't find the link) (link:/blog/authors/orrc[Unknown User
+can't find the link) (link:/blog/authors/orrc[
 (orrc)])
 * Using a CDN with HTTPS / removing need for mirrorbrain?
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 
@@ -510,7 +503,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * Migrate Jenkins-on-Jenkins jobs onto jenkins.ci.cloudbees.com
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Carryover from last meeting w.r.t. SECURITY bounties. Anything for
 historical submitters? Who has the action item?
 
@@ -536,41 +529,41 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * JUC 2015 - obtain approval for a Mobile Morning mini-track that focus
 on Jenkins mobile development (Alyssa)
 * Build/publisher steps & AbortException
-handling (https://wiki.jenkins.io/display/~integer[Unknown User
+handling (https://wiki.jenkins.io/display/~integer[
 (integer)])
 ** https://github.com/jenkinsci/jenkins/pull/1577
 * Defining guidelines on expected behavior and/or structure for plugins?
 If so, should we enforce them?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/OHjuxTD1W9k/d4dRBtR_vFQJ
 ** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html
 Item 3
 ** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-15-18.02.html
 Item 3
 * Would changing the meeting time to 10 AM PST/PDT allow overruns?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Who gets voice on IRC? "Committers"... to any plugin? To core?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * https://issues.jenkins.io/browse/JENKINS-27268[JENKINS-27268]
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Bug bounties/rewards for security issues?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Resurrecting the MEETING Jira project (maybe even have the bot create
 issues for action items automatically)
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * The important content of the Wiki is difficult to find (between
 outdated or even empty pages), and there's no real introduction to
 Jenkins – What can we do about it?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Proposal: move Jenkins
 https://github.com/cloudbees/jenkins-ci.org-docker[official image
 repo] to jenkinsci org so enhancement / version updates can be managed
-by the community (link:/blog/authors/ndeloof[Unknown User
+by the community (link:/blog/authors/ndeloof[
 (ndeloof)])
 * Disabling "Clone" feature in JIRA
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * The Chinese mirror is a mess
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** http://mirrors.jenkins-ci.org/status.html
 ** https://issues.jenkins.io/browse/INFRA-260
 
@@ -598,7 +591,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS RC status check
 * Recap last meeting's actions
 * Are there new "Patron of Jenkins" sponsors? No messages have been
-shown in 2015. (link:/blog/authors/orrc[Unknown User
+shown in 2015. (link:/blog/authors/orrc[
 (orrc)])
 ** Maybe there was supposed to be one in Q1?
 https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ[https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ|https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ]
@@ -608,12 +601,12 @@ program will be reviewed and changes might be made]" in March 2015
 * Workflow specific mailing lists
 (https://wiki.jenkins-ci.org/display/~dty[Dean Yu])
 * New release process? (i.e. release from master; no more RC branch)
-(discussed by link:/blog/authors/kohsuke/[Unknown User
-(kohsuke)], link:/blog/authors/jglick[Unknown User
-(jglick)] & link:/blog/authors/daniel-beck/[Unknown User
+(discussed by link:/blog/authors/kohsuke/[
+(kohsuke)], link:/blog/authors/jglick[
+(jglick)] & link:/blog/authors/daniel-beck/[
 (danielbeck)] in IRC)
 * Governance Document Updates
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 ** As per the Jenkins 100K podcast, we now have a trademark?
 ** More information about the board; there appears to be no information
 about _who_ that is, how to "contact the board", and if/when the board
@@ -625,7 +618,7 @@ wiki page, pull request wiki page
 years? e.g. at least simple text updates like "500+ repos" is now
 "1000+"...
 * Build/publisher steps & AbortException
-handling (https://wiki.jenkins.io/display/~integer[Unknown User
+handling (https://wiki.jenkins.io/display/~integer[
 (integer)])
 
 MINUTES
@@ -641,19 +634,18 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 18th 11:00 Pacific].
 
 * Approving another batch of stickers
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * https://groups.google.com/forum/?hl=en#!topic/jenkinsci-dev/oDXLTVcy56Y[IDEA
-licenses] (https://wiki.jenkins.io/display/~integer[Unknown User
+licenses] (https://wiki.jenkins.io/display/~integer[
 (integer)])
 * Should we have an "ops lead"? Adding more infra team members?
 Moderator teams?
 https://groups.google.com/forum/#!topic/jenkinsci-dev/046RwHh3Nko[mailing
-list discussion] (link:/blog/authors/orrc[Unknown User
+list discussion] (link:/blog/authors/orrc[
 (orrc)])
 * Who should we reach out for JUC speakers?
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
-* LTS status check (link:/blog/authors/kohsuke/[Unknown
-User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
+* LTS status check (link:/blog/authors/kohsuke/[ (kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[summary]
@@ -668,7 +660,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 4th 11:00 Pacific].
 
 * Jenkins 100K PR planning (hgilmore)
-* LTS RC status (link:/blog/authors/kohsuke/[Unknown User
+* LTS RC status (link:/blog/authors/kohsuke/[
 (kohsuke)]/https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[~ogondza])
 
 MINUTES
@@ -680,7 +672,7 @@ http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-04-19.01.log.html[ra
 == Jan 21 meeting
 
 * Releases of Windows libraries: winp and winsw
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** winp: https://github.com/kohsuke/winp/pull/12 - option to disable the
 DLL unpacking
@@ -691,7 +683,7 @@ correct properties handling, log rotation fix
 ** A decision on MVS version would be useful for both projects. Proposed
 version - *Visual Studio Community 2013* (free for FOSS projects)
 * Jenkins at 100K active users (Heidi Gilmore)
-* INFRA (https://wiki.jenkins.io/display/~integer[Unknown User
+* INFRA (https://wiki.jenkins.io/display/~integer[
 (integer)])
 
 MINUTES
@@ -702,8 +694,8 @@ http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-21-19.01.log.html[ra
 [[GovernanceMeetingArchive2015-Jan7meeting]]
 == Jan 7 meeting
 
-* JUC post-mortem (link:/blog/authors/atong[Unknown User
-(atong)]/link:/blog/authors/kohsuke/[Unknown User
+* JUC post-mortem (link:/blog/authors/atong[
+(atong)]/link:/blog/authors/kohsuke/[
 (kohsuke)])
 
 MINUTES

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -24,11 +24,11 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Next LTS baseline selection
 * (*hopefully*) Final review/adoption of
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
-Election Process] (https://wiki.jenkins.io/display/~rtyler[Unknown User
+Election Process] (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * *NOT* tweet anymore plugins w/o a wiki page
 (https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]) (for
 https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/qR8WqJZmNZs/1a9Zd3F0DAAJ[reference])
@@ -48,7 +48,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS RC status check
 * Announce Security Officer
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-25-19.00.html[summary]
@@ -66,7 +66,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Review proposed www site change from Drupal to static site generation
 (current https://github.com/rtyler/jenkins.io[repo] and
 http://jenkins.lasagna.io/[generated version of site])
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * CERT membership requests from
 https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/UMBz91HMAgAJ[Ivan
 Meredith] and
@@ -77,9 +77,9 @@ Walding] (https://wiki.jenkins.io/display/~danielbeck[Unknown User
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
 Election Process] and either move forward with the proposal or take
 feedback so we can have elections next year
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Jenkins 2.0 proposal recap
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary]
@@ -130,16 +130,16 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://wiki.jenkins.io/display/JENKINS/Approved+Trademark+Usage[Approved
 Trademark Usage] has been updated.
 * Quick announcement of `+#jenkins-community+`
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * LTS status check
 ** https://github.com/jenkinsci/jenkins/pull/1812/files#diff-600376dffeb79835ede4a0b285078036R850[Link
 to changelog-stable when building]?
 * New Website JIRA project to organize website efforts under
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Approval of new Q4 patron messages by CloudBees
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Project+sub-teams[Proposal
-- Project sub-teams] (https://wiki.jenkins.io/display/~rtyler[Unknown
+- Project sub-teams] (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[Permission
 request] - Admin access to jenkinsci org
@@ -510,7 +510,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * Migrate Jenkins-on-Jenkins jobs onto jenkins.ci.cloudbees.com
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Carryover from last meeting w.r.t. SECURITY bounties. Anything for
 historical submitters? Who has the action item?
 

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -109,7 +109,7 @@ for reporting security issues]
 * Sticker purchase approval
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Voting: Should we require squashing commits in the core?
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Related discussion:
 https://groups.google.com/forum/#\!searchin/jenkinsci-dev/squash/jenkinsci-dev/kqvuDqXwPZw/oF-KMdNbCwAJ
@@ -143,7 +143,7 @@ to changelog-stable when building]?
 User (rtyler)])
 * https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[Permission
 request] - Admin access to jenkinsci org
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * JIRA project for plugin hosting (and possibly similar) requests
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
@@ -242,10 +242,10 @@ but it was really https://wiki.jenkins.io/display/~integer[Unknown User
 * Clarification what requires a CLA and what does not
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * CERT Team membership request for
-https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[Unknown User
 (vlatombe)] and https://wiki.jenkins.io/display/~varmenise[Unknown User
-(varmenise)] (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+(varmenise)] (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 
 MINUTES
@@ -680,7 +680,7 @@ http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-04-19.01.log.html[ra
 == Jan 21 meeting
 
 * Releases of Windows libraries: winp and winsw
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** winp: https://github.com/kohsuke/winp/pull/12 - option to disable the
 DLL unpacking

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -71,7 +71,7 @@ http://jenkins.lasagna.io/[generated version of site])
 https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/UMBz91HMAgAJ[Ivan
 Meredith] and
 https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/v2sG6UvPAgAJ[Ben
-Walding] (https://wiki.jenkins.io/display/~danielbeck[Unknown User
+Walding] (link:/blog/authors/daniel-beck/[Unknown User
 (danielbeck)])
 * Review
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
@@ -137,7 +137,7 @@ to changelog-stable when building]?
 * New Website JIRA project to organize website efforts under
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Approval of new Q4 patron messages by CloudBees
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Project+sub-teams[Proposal
 - Project sub-teams] (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
@@ -146,7 +146,7 @@ request] - Admin access to jenkinsci org
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * JIRA project for plugin hosting (and possibly similar) requests
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-14-18.00.html[summary]
@@ -171,7 +171,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://issues.jenkins.io/browse/JENKINS-29876[JENKINS-29876]
 * Q4
 https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[patron
-program] messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
+program] messages (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 ** Same as for Q3, with same pre-approved message pending:
 https://github.com/jenkinsci/patron/pull/4
@@ -199,7 +199,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS backporting status check
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Protect master branches of repositories
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
@@ -228,19 +228,19 @@ into prod
 https://wiki.jenkins.io/display/JENKINS/Infrastructure+Admins[Infrastructure
 Admins] (still missing Artifactory)
 * LTS RC status check
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * LTS baseline selection
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
 grant program] blessing
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Process for merging PRs with multiple commits
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)]
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)]
 but it was really https://wiki.jenkins.io/display/~integer[Unknown User
 (integer)] and https://wiki.jenkins.io/display/~tfennelly[Unknown User
 (tfennelly)] who brought it up)
 * Clarification what requires a CLA and what does not
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * CERT Team membership request for
 link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[Unknown User
@@ -263,9 +263,9 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 ** https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
 grant program draft]
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * LTS RC status check / LTS baseline selection
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** What about
 https://issues.jenkins.io/browse/JENKINS-29936[JENKINS-29936]?
 * Revisiting bundled plugins
@@ -281,7 +281,7 @@ version.  (https://wiki.jenkins.io/display/~integer[Unknown User
 * Provide public list of JIRA/confluence/artifactory admins in wiki
 (https://wiki.jenkins.io/display/~integer[Unknown User (integer)])
 * https://github.com/jenkinsci/jenkins/pull/1774[HTMLUnit update]
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-19-18.03.html[summary]
@@ -300,9 +300,9 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Approval of new
 https://wiki.jenkins-ci.org/display/JENKINS/Patron+of+Jenkins+program[Patron
-program] messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
+program] messages (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
-* JUC travel grant (https://wiki.jenkins.io/display/~danielbeck[Unknown
+* JUC travel grant (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 ** (http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.log.html[previous
 discussion])
@@ -364,7 +364,7 @@ recently broken for a month; related
 https://issues.jenkins.io/browse/INFRA-75[INFRA-75] is one year old
 * Using labels for pull requests to core (instead of renaming to
 something like "[WIP] [JENKINS-12345] Foo").
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * "Action items are https://issues.jenkins.io/browse/MEETING[tracked
 in JIRA]" — can we agree to do this?
 (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
@@ -421,7 +421,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS RC status check
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
-* #jenkins-meeting (https://wiki.jenkins.io/display/~danielbeck[Unknown
+* #jenkins-meeting (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 * Should we only include plugins in the Update Centre if they have a
 wiki page? (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)],
@@ -448,7 +448,7 @@ more recently, but can't find the link)
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 * Further requirements for plugins published in the community update
-center (https://wiki.jenkins.io/display/~danielbeck[Unknown User
+center (link:/blog/authors/daniel-beck/[Unknown User
 (danielbeck)])
 ** To allow review, inspection and collaboration:
 *** Require a valid SCM URL for new plugin releases inside
@@ -484,7 +484,7 @@ Jenkins Plugin])
 wiki page? (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion]
-* #jenkins-meeting (https://wiki.jenkins.io/display/~danielbeck[Unknown
+* #jenkins-meeting (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 * LTS.next (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
@@ -541,36 +541,36 @@ handling (https://wiki.jenkins.io/display/~integer[Unknown User
 ** https://github.com/jenkinsci/jenkins/pull/1577
 * Defining guidelines on expected behavior and/or structure for plugins?
 If so, should we enforce them?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/OHjuxTD1W9k/d4dRBtR_vFQJ
 ** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html
 Item 3
 ** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-15-18.02.html
 Item 3
 * Would changing the meeting time to 10 AM PST/PDT allow overruns?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Who gets voice on IRC? "Committers"... to any plugin? To core?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * https://issues.jenkins.io/browse/JENKINS-27268[JENKINS-27268]
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Bug bounties/rewards for security issues?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Resurrecting the MEETING Jira project (maybe even have the bot create
 issues for action items automatically)
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * The important content of the Wiki is difficult to find (between
 outdated or even empty pages), and there's no real introduction to
 Jenkins – What can we do about it?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Proposal: move Jenkins
 https://github.com/cloudbees/jenkins-ci.org-docker[official image
 repo] to jenkinsci org so enhancement / version updates can be managed
 by the community (https://wiki.jenkins.io/display/~ndeloof[Unknown User
 (ndeloof)])
 * Disabling "Clone" feature in JIRA
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * The Chinese mirror is a mess
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** http://mirrors.jenkins-ci.org/status.html
 ** https://issues.jenkins.io/browse/INFRA-260
 
@@ -610,7 +610,7 @@ program will be reviewed and changes might be made]" in March 2015
 * New release process? (i.e. release from master; no more RC branch)
 (discussed by link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)], https://wiki.jenkins.io/display/~jglick[Unknown User
-(jglick)] & https://wiki.jenkins.io/display/~danielbeck[Unknown User
+(jglick)] & link:/blog/authors/daniel-beck/[Unknown User
 (danielbeck)] in IRC)
 * Governance Document Updates
 (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -105,9 +105,9 @@ for reporting security issues]
 * LTS status check
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Revisiting+JUC+in+2016[Proposal
 - Revisiting JUC in 2016]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Sticker purchase approval
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Voting: Should we require squashing commits in the core?
 (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
 (oleg_nenashev)])
@@ -269,7 +269,7 @@ grant program draft]
 ** What about
 https://issues.jenkins.io/browse/JENKINS-29936[JENKINS-29936]?
 * Revisiting bundled plugins
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 ** See
 https://groups.google.com/forum/#!topic/jenkinsci-dev/kRobm-cxFw8[mailing
 list post]
@@ -297,7 +297,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * Jenkins certification
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Approval of new
 https://wiki.jenkins-ci.org/display/JENKINS/Patron+of+Jenkins+program[Patron
 program] messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
@@ -475,7 +475,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Carryover from last meeting w.r.t. SECURITY bounties. Anything for
 historical submitters? Who has the action item?
 * Trademark usage approval for "CloudBees Jenkins Platform"
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * We only allow OSS plugins to be distributed via the update center, but
 what about closed source plugins which are documented on our wiki? (e.g.
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[CxSuite
@@ -608,7 +608,7 @@ program will be reviewed and changes might be made]" in March 2015
 * Workflow specific mailing lists
 (https://wiki.jenkins-ci.org/display/~dty[Dean Yu])
 * New release process? (i.e. release from master; no more RC branch)
-(discussed by https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(discussed by link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)], https://wiki.jenkins.io/display/~jglick[Unknown User
 (jglick)] & https://wiki.jenkins.io/display/~danielbeck[Unknown User
 (danielbeck)] in IRC)
@@ -641,7 +641,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 18th 11:00 Pacific].
 
 * Approving another batch of stickers
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * https://groups.google.com/forum/?hl=en#!topic/jenkinsci-dev/oDXLTVcy56Y[IDEA
 licenses] (https://wiki.jenkins.io/display/~integer[Unknown User
 (integer)])
@@ -651,8 +651,8 @@ https://groups.google.com/forum/#!topic/jenkinsci-dev/046RwHh3Nko[mailing
 list discussion] (https://wiki.jenkins.io/display/~orrc[Unknown User
 (orrc)])
 * Who should we reach out for JUC speakers?
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
-* LTS status check (https://wiki.jenkins.io/display/~kohsuke[Unknown
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+* LTS status check (link:/blog/authors/kohsuke/[Unknown
 User (kohsuke)])
 
 MINUTES
@@ -668,7 +668,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 4th 11:00 Pacific].
 
 * Jenkins 100K PR planning (hgilmore)
-* LTS RC status (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+* LTS RC status (link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)]/https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[~ogondza])
 
 MINUTES
@@ -703,7 +703,7 @@ http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-21-19.01.log.html[ra
 == Jan 7 meeting
 
 * JUC post-mortem (https://wiki.jenkins.io/display/~atong[Unknown User
-(atong)]/https://wiki.jenkins.io/display/~kohsuke[Unknown User
+(atong)]/link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 
 MINUTES

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -176,7 +176,7 @@ link:/blog/authors/orrc[(orrc)]
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[proposal
 from April 2013]
 * Time to move to Java 8 and servlet 3.1?
-https://wiki.jenkins.io/display/~teilo[(teilo)] for core?
+(teilo) for core?
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary]
@@ -229,16 +229,14 @@ grant program] blessing
 (link:/blog/authors/daniel-beck/[(danielbeck)])
 * Process for merging PRs with multiple commits
 (link:/blog/authors/daniel-beck/[(danielbeck)]
-but it was really https://wiki.jenkins.io/display/~integer[
-(integer)] and https://wiki.jenkins.io/display/~tfennelly[
-(tfennelly)] who brought it up)
+but it was really (integer) and (tfennelly) who brought it up)
 * Clarification what requires a CLA and what does not
 (link:/blog/authors/daniel-beck/[(danielbeck)])
 * CERT Team membership request for
 link:/blog/authors/oleg_nenashev/[
-(oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[
-(vlatombe)] and https://wiki.jenkins.io/display/~varmenise[
-(varmenise)] (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
+(oleg_nenashev)],
+(vlatombe) and
+(varmenise) (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-02-18.00.html[summary]
@@ -268,10 +266,9 @@ list post]
 * Allow file browsing in artifactory for ability view javadocs, add link
 in confluence macros live link, send request to jfrog support to get
 newer artifactory
-version.  (https://wiki.jenkins.io/display/~integer[
-(integer)])
+version. (integer)
 * Provide public list of JIRA/confluence/artifactory admins in wiki
-(https://wiki.jenkins.io/display/~integer[(integer)])
+(integer)]
 * https://github.com/jenkinsci/jenkins/pull/1774[HTMLUnit update]
 (link:/blog/authors/daniel-beck/[(danielbeck)])
 
@@ -362,7 +359,7 @@ in JIRA]" — can we agree to do this?
 follow-up and the actions never get done
 * Time to move to Servlet 3.0 (3.1?) as
 http://jenkins-ci.org/content/good-bye-java6[announced]?
-(https://wiki.jenkins.io/display/~teilo[(teilo)])
+(teilo)
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-06-10-18.01.html[summary]
@@ -414,7 +411,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * #jenkins-meeting (link:/blog/authors/daniel-beck/[(danielbeck)])
 * Should we only include plugins in the Update Centre if they have a
 wiki page? (link:/blog/authors/orrc[(orrc)],
-https://wiki.jenkins.io/display/~evernat[(evernat)])
+(evernat)
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion];
 https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/S_uQ_C_7NMQJ[more
@@ -522,8 +519,7 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * JUC 2015 - obtain approval for a Mobile Morning mini-track that focus
 on Jenkins mobile development (Alyssa)
 * Build/publisher steps & AbortException
-handling (https://wiki.jenkins.io/display/~integer[
-(integer)])
+handling (integer)
 ** https://github.com/jenkinsci/jenkins/pull/1577
 * Defining guidelines on expected behavior and/or structure for plugins?
 If so, should we enforce them?
@@ -611,8 +607,7 @@ wiki page, pull request wiki page
 years? e.g. at least simple text updates like "500+ repos" is now
 "1000+"...
 * Build/publisher steps & AbortException
-handling (https://wiki.jenkins.io/display/~integer[
-(integer)])
+handling (integer)
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-03-04-19.00.html[summary]
@@ -629,8 +624,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 * Approving another batch of stickers
 (link:/blog/authors/kohsuke/[(kohsuke)])
 * https://groups.google.com/forum/?hl=en#!topic/jenkinsci-dev/oDXLTVcy56Y[IDEA
-licenses] (https://wiki.jenkins.io/display/~integer[
-(integer)])
+licenses] (integer)
 * Should we have an "ops lead"? Adding more infra team members?
 Moderator teams?
 https://groups.google.com/forum/#!topic/jenkinsci-dev/046RwHh3Nko[mailing
@@ -676,8 +670,7 @@ correct properties handling, log rotation fix
 ** A decision on MVS version would be useful for both projects. Proposed
 version - *Visual Studio Community 2013* (free for FOSS projects)
 * Jenkins at 100K active users (Heidi Gilmore)
-* INFRA (https://wiki.jenkins.io/display/~integer[
-(integer)])
+* INFRA (integer)
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-21-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -28,9 +28,9 @@ Election Process] (link:/blog/authors/rtyler/[
 (rtyler)])
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * *NOT* tweet anymore plugins w/o a wiki page
-(link:/blog/authors/batmat[ (batmat)]) (for
+(link:/blog/authors/batmat[(batmat)]) (for
 https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/qR8WqJZmNZs/1a9Zd3F0DAAJ[reference])
 
 MINUTES
@@ -48,7 +48,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS RC status check
 * Announce Security Officer
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-25-19.00.html[summary]
@@ -66,7 +66,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Review proposed www site change from Drupal to static site generation
 (current https://github.com/rtyler/jenkins.io[repo] and
 http://jenkins.lasagna.io/[generated version of site])
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * CERT membership requests from
 https://groups.google.com/forum/#!msg/jenkinsci-dev/TachZG6zw44/UMBz91HMAgAJ[Ivan
 Meredith] and
@@ -77,9 +77,9 @@ Walding] (link:/blog/authors/daniel-beck/[
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[Board
 Election Process] and either move forward with the proposal or take
 feedback so we can have elections next year
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Jenkins 2.0 proposal recap
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary]
@@ -103,9 +103,9 @@ for reporting security issues]
 * LTS status check
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Revisiting+JUC+in+2016[Proposal
 - Revisiting JUC in 2016]
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Sticker purchase approval
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Voting: Should we require squashing commits in the core?
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
@@ -128,22 +128,22 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://wiki.jenkins.io/display/JENKINS/Approved+Trademark+Usage[Approved
 Trademark Usage] has been updated.
 * Quick announcement of `+#jenkins-community+`
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * LTS status check
 ** https://github.com/jenkinsci/jenkins/pull/1812/files#diff-600376dffeb79835ede4a0b285078036R850[Link
 to changelog-stable when building]?
 * New Website JIRA project to organize website efforts under
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Approval of new Q4 patron messages by CloudBees
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * https://wiki.jenkins.io/display/JENKINS/Proposal+-+Project+sub-teams[Proposal
-- Project sub-teams] (link:/blog/authors/rtyler/[ (rtyler)])
+- Project sub-teams] (link:/blog/authors/rtyler/[(rtyler)])
 * https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[Permission
 request] - Admin access to jenkinsci org
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * JIRA project for plugin hosting (and possibly similar) requests
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-10-14-18.00.html[summary]
@@ -165,18 +165,18 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://issues.jenkins.io/browse/JENKINS-29876[JENKINS-29876]
 * Q4
 https://wiki.jenkins.io/display/JENKINS/Patron+of+Jenkins+program[patron
-program] messages (link:/blog/authors/daniel-beck/[ (danielbeck)])
+program] messages (link:/blog/authors/daniel-beck/[(danielbeck)])
 ** Same as for Q3, with same pre-approved message pending:
 https://github.com/jenkinsci/patron/pull/4
 * Time to think about Jenkins board elections?
-link:/blog/authors/orrc[ (orrc)]
+link:/blog/authors/orrc[(orrc)]
 ** This was vaguely discussed in the 100k podcast in February, and soon
 2/3 of the board will be CloudBees employees
 ** The most recent proposal seems to be
 https://wiki.jenkins.io/display/JENKINS/Board+Election+Process[proposal
 from April 2013]
 * Time to move to Java 8 and servlet 3.1?
-https://wiki.jenkins.io/display/~teilo[ (teilo)] for core?
+https://wiki.jenkins.io/display/~teilo[(teilo)] for core?
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary]
@@ -192,7 +192,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS backporting status check
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Protect master branches of repositories
 (link:/blog/authors/olivergondza[
 (olivergondza)])
@@ -221,24 +221,24 @@ into prod
 https://wiki.jenkins.io/display/JENKINS/Infrastructure+Admins[Infrastructure
 Admins] (still missing Artifactory)
 * LTS RC status check
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * LTS baseline selection
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
 grant program] blessing
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Process for merging PRs with multiple commits
-(link:/blog/authors/daniel-beck/[ (danielbeck)]
+(link:/blog/authors/daniel-beck/[(danielbeck)]
 but it was really https://wiki.jenkins.io/display/~integer[
 (integer)] and https://wiki.jenkins.io/display/~tfennelly[
 (tfennelly)] who brought it up)
 * Clarification what requires a CLA and what does not
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * CERT Team membership request for
 link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)], https://wiki.jenkins.io/display/~vlatombe[
 (vlatombe)] and https://wiki.jenkins.io/display/~varmenise[
-(varmenise)] (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
+(varmenise)] (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-09-02-18.00.html[summary]
@@ -255,13 +255,13 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 ** https://wiki.jenkins-ci.org/display/JENKINS/Travel+Grant+Program[Travel
 grant program draft]
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * LTS RC status check / LTS baseline selection
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** What about
 https://issues.jenkins.io/browse/JENKINS-29936[JENKINS-29936]?
 * Revisiting bundled plugins
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 ** See
 https://groups.google.com/forum/#!topic/jenkinsci-dev/kRobm-cxFw8[mailing
 list post]
@@ -271,9 +271,9 @@ newer artifactory
 version.  (https://wiki.jenkins.io/display/~integer[
 (integer)])
 * Provide public list of JIRA/confluence/artifactory admins in wiki
-(https://wiki.jenkins.io/display/~integer[ (integer)])
+(https://wiki.jenkins.io/display/~integer[(integer)])
 * https://github.com/jenkinsci/jenkins/pull/1774[HTMLUnit update]
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-08-19-18.03.html[summary]
@@ -289,11 +289,11 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * Jenkins certification
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Approval of new
 https://wiki.jenkins-ci.org/display/JENKINS/Patron+of+Jenkins+program[Patron
-program] messages (link:/blog/authors/daniel-beck/[ (danielbeck)])
-* JUC travel grant (link:/blog/authors/daniel-beck/[ (danielbeck)])
+program] messages (link:/blog/authors/daniel-beck/[(danielbeck)])
+* JUC travel grant (link:/blog/authors/daniel-beck/[(danielbeck)])
 ** (http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-17-18.00.log.html[previous
 discussion])
 ** The Jenkins project currently has
@@ -354,15 +354,15 @@ recently broken for a month; related
 https://issues.jenkins.io/browse/INFRA-75[INFRA-75] is one year old
 * Using labels for pull requests to core (instead of renaming to
 something like "[WIP] [JENKINS-12345] Foo").
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * "Action items are https://issues.jenkins.io/browse/MEETING[tracked
 in JIRA]" — can we agree to do this?
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 ** People miss meetings or forget action items, and there's usually no
 follow-up and the actions never get done
 * Time to move to Servlet 3.0 (3.1?) as
 http://jenkins-ci.org/content/good-bye-java6[announced]?
-(https://wiki.jenkins.io/display/~teilo[ (teilo)])
+(https://wiki.jenkins.io/display/~teilo[(teilo)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-06-10-18.01.html[summary]
@@ -411,10 +411,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS RC status check
 (link:/blog/authors/olivergondza[
 (olivergondza)])
-* #jenkins-meeting (link:/blog/authors/daniel-beck/[ (danielbeck)])
+* #jenkins-meeting (link:/blog/authors/daniel-beck/[(danielbeck)])
 * Should we only include plugins in the Update Centre if they have a
-wiki page? (link:/blog/authors/orrc[ (orrc)],
-https://wiki.jenkins.io/display/~evernat[ (evernat)])
+wiki page? (link:/blog/authors/orrc[(orrc)],
+https://wiki.jenkins.io/display/~evernat[(evernat)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion];
 https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/S_uQ_C_7NMQJ[more
@@ -431,9 +431,9 @@ repo, Java source excluded from release]: AntepediaReporter — orrc
 contacted them and they're considering open-sourcing)
 * Infra training/handover/expansion? (Was mentioned a while back and
 more recently, but can't find the link)
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 * Using a CDN with HTTPS / removing need for mirrorbrain?
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 * Further requirements for plugins published in the community update
@@ -464,23 +464,23 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Carryover from last meeting w.r.t. SECURITY bounties. Anything for
 historical submitters? Who has the action item?
 * Trademark usage approval for "CloudBees Jenkins Platform"
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * We only allow OSS plugins to be distributed via the update center, but
 what about closed source plugins which are documented on our wiki? (e.g.
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[CxSuite
 Jenkins Plugin])
 * Should we only include plugins in the Update Centre if they have a
-wiki page? (link:/blog/authors/orrc[ (orrc)])
+wiki page? (link:/blog/authors/orrc[(orrc)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion]
-* #jenkins-meeting (link:/blog/authors/daniel-beck/[ (danielbeck)])
+* #jenkins-meeting (link:/blog/authors/daniel-beck/[(danielbeck)])
 * LTS.next (link:/blog/authors/olivergondza[
 (olivergondza)])
 * Infra training? (Was mentioned a while back and more recently, but
 can't find the link) (link:/blog/authors/orrc[
 (orrc)])
 * Using a CDN with HTTPS / removing need for mirrorbrain?
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 
@@ -498,7 +498,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * Migrate Jenkins-on-Jenkins jobs onto jenkins.ci.cloudbees.com
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Carryover from last meeting w.r.t. SECURITY bounties. Anything for
 historical submitters? Who has the action item?
 
@@ -527,36 +527,36 @@ handling (https://wiki.jenkins.io/display/~integer[
 ** https://github.com/jenkinsci/jenkins/pull/1577
 * Defining guidelines on expected behavior and/or structure for plugins?
 If so, should we enforce them?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/OHjuxTD1W9k/d4dRBtR_vFQJ
 ** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-01-18.01.html
 Item 3
 ** http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-10-15-18.02.html
 Item 3
 * Would changing the meeting time to 10 AM PST/PDT allow overruns?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Who gets voice on IRC? "Committers"... to any plugin? To core?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * https://issues.jenkins.io/browse/JENKINS-27268[JENKINS-27268]
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Bug bounties/rewards for security issues?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Resurrecting the MEETING Jira project (maybe even have the bot create
 issues for action items automatically)
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * The important content of the Wiki is difficult to find (between
 outdated or even empty pages), and there's no real introduction to
 Jenkins – What can we do about it?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Proposal: move Jenkins
 https://github.com/cloudbees/jenkins-ci.org-docker[official image
 repo] to jenkinsci org so enhancement / version updates can be managed
 by the community (link:/blog/authors/ndeloof[
 (ndeloof)])
 * Disabling "Clone" feature in JIRA
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * The Chinese mirror is a mess
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** http://mirrors.jenkins-ci.org/status.html
 ** https://issues.jenkins.io/browse/INFRA-260
 
@@ -599,7 +599,7 @@ program will be reviewed and changes might be made]" in March 2015
 (jglick)] & link:/blog/authors/daniel-beck/[
 (danielbeck)] in IRC)
 * Governance Document Updates
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 ** As per the Jenkins 100K podcast, we now have a trademark?
 ** More information about the board; there appears to be no information
 about _who_ that is, how to "contact the board", and if/when the board
@@ -627,7 +627,7 @@ http://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meet
 18th 11:00 Pacific].
 
 * Approving another batch of stickers
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * https://groups.google.com/forum/?hl=en#!topic/jenkinsci-dev/oDXLTVcy56Y[IDEA
 licenses] (https://wiki.jenkins.io/display/~integer[
 (integer)])
@@ -637,8 +637,8 @@ https://groups.google.com/forum/#!topic/jenkinsci-dev/046RwHh3Nko[mailing
 list discussion] (link:/blog/authors/orrc[
 (orrc)])
 * Who should we reach out for JUC speakers?
-(link:/blog/authors/kohsuke/[ (kohsuke)])
-* LTS status check (link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
+* LTS status check (link:/blog/authors/kohsuke/[(kohsuke)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2015.adoc
+++ b/content/project/governance-meeting/archives/2015.adoc
@@ -30,7 +30,7 @@ Election Process] (link:/blog/authors/rtyler/[Unknown User
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * *NOT* tweet anymore plugins w/o a wiki page
-(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]) (for
+(link:/blog/authors/batmat[Unknown User (batmat)]) (for
 https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/qR8WqJZmNZs/1a9Zd3F0DAAJ[reference])
 
 MINUTES
@@ -176,7 +176,7 @@ User (danielbeck)])
 ** Same as for Q3, with same pre-approved message pending:
 https://github.com/jenkinsci/patron/pull/4
 * Time to think about Jenkins board elections?
-https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)]
+link:/blog/authors/orrc[Unknown User (orrc)]
 ** This was vaguely discussed in the 100k podcast in February, and soon
 2/3 of the board will be CloudBees employees
 ** The most recent proposal seems to be
@@ -201,7 +201,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS backporting status check
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Protect master branches of repositories
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA[https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA|https://groups.google.com/forum/#!topic/jenkinsci-dev/0ciUju7raOA]
 
@@ -322,7 +322,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 22th 11:00 Pacific].
 
 * LTS 1.609 RC status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 
 MINUTES
@@ -339,7 +339,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS 1.609.2 RC status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 
 MINUTES
@@ -357,7 +357,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * Can we start to look at fixing the
 https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA%20AND%20component%20%3D%20spof%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC[single
-points of failure]? (https://wiki.jenkins.io/display/~orrc[Unknown User
+points of failure]? (link:/blog/authors/orrc[Unknown User
 (orrc)])
 ** e.g. https://issues.jenkins.io/browse/INFRA-225[INFRA-225] was
 recently broken for a month; related
@@ -367,7 +367,7 @@ something like "[WIP] [JENKINS-12345] Foo").
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * "Action items are https://issues.jenkins.io/browse/MEETING[tracked
 in JIRA]" — can we agree to do this?
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 ** People miss meetings or forget action items, and there's usually no
 follow-up and the actions never get done
 * Time to move to Servlet 3.0 (3.1?) as
@@ -388,17 +388,17 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS RC status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * When to flip the switch on
 https://github.com/jenkinsci/backend-update-center2/pull/20[plugins
-without wiki pages]? (https://wiki.jenkins.io/display/~orrc[Unknown User
+without wiki pages]? (link:/blog/authors/orrc[Unknown User
 (orrc)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/dfvRxvCv7Mg/jIailHDwY2EJ[Mailing
 list thread]
 * Can we start to look at fixing the
 https://issues.jenkins.io/issues/?jql=project%20%3D%20INFRA%20AND%20component%20%3D%20spof%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC[single
-points of failure]? (https://wiki.jenkins.io/display/~orrc[Unknown User
+points of failure]? (link:/blog/authors/orrc[Unknown User
 (orrc)])
 ** e.g. https://issues.jenkins.io/browse/INFRA-225[INFRA-225] is
 currently (again) a visible problem; related
@@ -419,12 +419,12 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS RC status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * #jenkins-meeting (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 * Should we only include plugins in the Update Centre if they have a
-wiki page? (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)],
+wiki page? (link:/blog/authors/orrc[Unknown User (orrc)],
 https://wiki.jenkins.io/display/~evernat[Unknown User (evernat)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion];
@@ -442,9 +442,9 @@ repo, Java source excluded from release]: AntepediaReporter — orrc
 contacted them and they're considering open-sourcing)
 * Infra training/handover/expansion? (Was mentioned a while back and
 more recently, but can't find the link)
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 * Using a CDN with HTTPS / removing need for mirrorbrain?
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 * Further requirements for plugins published in the community update
@@ -481,18 +481,18 @@ what about closed source plugins which are documented on our wiki? (e.g.
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2015#[CxSuite
 Jenkins Plugin])
 * Should we only include plugins in the Update Centre if they have a
-wiki page? (https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+wiki page? (link:/blog/authors/orrc[Unknown User (orrc)])
 ** https://groups.google.com/forum/#!msg/jenkinsci-dev/oEHEjKo08yA/_z2GEtcUfz0J[ML
 discussion]
 * #jenkins-meeting (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
-* LTS.next (https://wiki.jenkins.io/display/~olivergondza[Unknown User
+* LTS.next (link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Infra training? (Was mentioned a while back and more recently, but
-can't find the link) (https://wiki.jenkins.io/display/~orrc[Unknown User
+can't find the link) (link:/blog/authors/orrc[Unknown User
 (orrc)])
 * Using a CDN with HTTPS / removing need for mirrorbrain?
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 ** https://issues.jenkins.io/browse/INFRA-266?focusedCommentId=226524#comment-226524[Comments
 on INFRA-266]
 
@@ -565,7 +565,7 @@ Jenkins – What can we do about it?
 * Proposal: move Jenkins
 https://github.com/cloudbees/jenkins-ci.org-docker[official image
 repo] to jenkinsci org so enhancement / version updates can be managed
-by the community (https://wiki.jenkins.io/display/~ndeloof[Unknown User
+by the community (link:/blog/authors/ndeloof[Unknown User
 (ndeloof)])
 * Disabling "Clone" feature in JIRA
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
@@ -598,7 +598,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS RC status check
 * Recap last meeting's actions
 * Are there new "Patron of Jenkins" sponsors? No messages have been
-shown in 2015. (https://wiki.jenkins.io/display/~orrc[Unknown User
+shown in 2015. (link:/blog/authors/orrc[Unknown User
 (orrc)])
 ** Maybe there was supposed to be one in Q1?
 https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ[https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ|https://groups.google.com/forum/#!topic/jenkinsci-patrons/GQZwr5tQMyQ]
@@ -609,11 +609,11 @@ program will be reviewed and changes might be made]" in March 2015
 (https://wiki.jenkins-ci.org/display/~dty[Dean Yu])
 * New release process? (i.e. release from master; no more RC branch)
 (discussed by link:/blog/authors/kohsuke/[Unknown User
-(kohsuke)], https://wiki.jenkins.io/display/~jglick[Unknown User
+(kohsuke)], link:/blog/authors/jglick[Unknown User
 (jglick)] & link:/blog/authors/daniel-beck/[Unknown User
 (danielbeck)] in IRC)
 * Governance Document Updates
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 ** As per the Jenkins 100K podcast, we now have a trademark?
 ** More information about the board; there appears to be no information
 about _who_ that is, how to "contact the board", and if/when the board
@@ -648,7 +648,7 @@ licenses] (https://wiki.jenkins.io/display/~integer[Unknown User
 * Should we have an "ops lead"? Adding more infra team members?
 Moderator teams?
 https://groups.google.com/forum/#!topic/jenkinsci-dev/046RwHh3Nko[mailing
-list discussion] (https://wiki.jenkins.io/display/~orrc[Unknown User
+list discussion] (link:/blog/authors/orrc[Unknown User
 (orrc)])
 * Who should we reach out for JUC speakers?
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
@@ -702,7 +702,7 @@ http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-01-21-19.01.log.html[ra
 [[GovernanceMeetingArchive2015-Jan7meeting]]
 == Jan 7 meeting
 
-* JUC post-mortem (https://wiki.jenkins.io/display/~atong[Unknown User
+* JUC post-mortem (link:/blog/authors/atong[Unknown User
 (atong)]/link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -69,7 +69,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * LTS base line selection
 * Revival of the Klocwork plugin
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** The plugin is hosted outside jenkinsci org, but it seems to be
 abandoned by maintainers
@@ -78,11 +78,11 @@ https://groups.google.com/forum/#!search/klocwork/jenkinsci-dev/U7SFVsjsHHQ/cA8S
 ** We need to discuss if we can just proceed with plugin process and to
 grant the access to the requester
 * GSoC2017 sync-up
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Do we participate in it? If yes, should we schedule office hours?
 ** Who will be Jenkins org admins this time?
-https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] will need some help
 * Azure migration / Infrastructure update
 link:/blog/authors/rtyler/[Unknown User (rtyler)]
@@ -140,7 +140,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * Bumping Jenkins core to Remoting 3
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Remoting 3 offers a new JNLP4 protocol (Adds Java NIO compared to
 JNLP3 + stability fixes)
@@ -152,7 +152,7 @@ OSS and closed-source implementations, no real compatibility issues
 ** Question for voting: Do we want to go forward?
 * Out-of-order Jenkins Weekly release in order to get better soak
 testing for 2.19.3
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Question for voting: Do we want to release it if kohsuke is available?
 ** https://issues.jenkins.io/browse/JENKINS-38814[JENKINS-38814],
@@ -160,12 +160,12 @@ https://github.com/jenkinsci/jenkins/commit/a04e2f9836263f7ae5e68617f5bafde18e59
 * IntelliJ license handling
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * Moving Governance Meetings to UTC
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Plugin site deployment to Jenkins project infra
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * Allowing interface implementations as Extension points in Jenkins
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Background: https://github.com/jenkinsci/jenkins/pull/2566
 ** ** Question for voting: Do we want to allow such use-case?
@@ -235,7 +235,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -255,7 +255,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -275,7 +275,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Obtain permission to post Jenkins World banner
 on http://issues.jenkins.io/[issues.jenkins.io] and
@@ -299,7 +299,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -319,7 +319,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Officer updates
 ** Security status update
@@ -356,7 +356,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * Next LTS baseline selection
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Q3 patron messages
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
@@ -382,7 +382,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS status check
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -400,7 +400,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS status check
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Infrastructure status update
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
@@ -482,7 +482,7 @@ http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[action
 (https://wiki.jenkins.io/display/~integer[Unknown User (integer)])
 * https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
 Summer Of Code 2016] update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig[https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig|https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig]
 * Release officer announcement
@@ -547,11 +547,11 @@ User (danielbeck)])
 * Conversion of
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2016#[Office
 Hours] to Jenkins Online meetup
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY[https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY|https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY]
 * Planning of GSoC office hours
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Application draft:
 https://docs.google.com/document/d/1dv9UXyT_FPukJXrBYauIKvxrZeEU6BT7v90LSQX36MU/edit#
@@ -591,7 +591,7 @@ last thread about it]
 * (_time permitting_)
 https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
 Summer Of Code 2016] application progress -
-https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)]
 ** Mailing list:
 https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0[https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0|https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0]
@@ -624,7 +624,7 @@ World 2016 logo] (https://wiki.jenkins.io/display/~atong[Unknown User
 * Infrastructure status report -
 link:/blog/authors/rtyler/[Unknown User (rtyler)]
 * Should Jenkins be a mentor organisation for Google Summer of Code?
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Deadline is
 https://developers.google.com/open-source/gsoc/timeline[19th February]
@@ -658,14 +658,14 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * Approving Jenkins Press page and assigned contacts:
 https://jenkins-ci.org/press/&nbsp;
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Reworking / Shutting down the Jenkins CIA program
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY[https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY|https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY]
 * Follow-up to the unofficial Jenkins-related Twitter account
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://twitter.com/LearningJenkins
 ** Aim: agree if "Learning Jenkins" with the unofficial resource notice

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -47,7 +47,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 2017-01-04?
 ** Should we just skip two weeks around Christmas like we did last year,
 postpone .2 RC from Jan 4 to Jan 18?
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * JDK8 as baseline, with the
 https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
 proposed by Oliver] https://wiki.jenkins.io/display/~batmat[Unknown User
@@ -158,12 +158,12 @@ testing for 2.19.3
 ** https://issues.jenkins.io/browse/JENKINS-38814[JENKINS-38814],
 https://github.com/jenkinsci/jenkins/commit/a04e2f9836263f7ae5e68617f5bafde18e594446
 * IntelliJ license handling
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Moving Governance Meetings to UTC
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Plugin site deployment to Jenkins project infra
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Allowing interface implementations as Extension points in Jenkins
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
@@ -190,7 +190,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 https://groups.google.com/forum/#!topic/jenkinsci-users/hP8uwU0y8K4[name
 use for Jenkins-LSCI] (Life Science Continuous Integration)
 (https://wiki.jenkins.io/display/~ioannis[Unknown User (ioannis)])
-* Patron messages (https://wiki.jenkins.io/display/~danielbeck[Unknown
+* Patron messages (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 
 MINUTES
@@ -323,7 +323,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (oleg_nenashev)])
 * Officer updates
 ** Security status update
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** Events status update (https://wiki.jenkins.io/display/~atong[Unknown
 User (atong)])
 ** Release status update
@@ -338,7 +338,7 @@ http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
 context here] link:/blog/authors/rtyler/[Unknown User
 (rtyler)]
 * Approval of new Q3 patron messages
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-22-18.00.html[summary]
@@ -359,7 +359,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Q3 patron messages
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Licensing and unrestricted access of
 https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
 Statistics] (aka "census data")
@@ -405,7 +405,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Infrastructure status update
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Security status update
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Events status update (https://wiki.jenkins.io/display/~atong[Unknown
 User (atong)])
 
@@ -425,12 +425,12 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * 2.0 status check
 * Approval of Q2 patron messages
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** https://github.com/jenkinsci/patron/pull/11
 * CERT membership request process changes
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * Approval of CERT membership requests
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** Andres Rodriguez:
 https://groups.google.com/d/msg/jenkinsci-dev/WQO16ziPoCA/E9lmmKeiFAAJ
 ** Antonio Muñiz:
@@ -454,7 +454,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * 2.0 status check
 * CERT membership request by Yoann Dubreuil
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/M9GeJFo_qcg/4Wax34DrBAAJ
 * Jenkins 2.0 launch - go over activities of what has been planned for
 this release (R. Tyler
@@ -492,7 +492,7 @@ Summer Of Code 2016] update
 * Update to CD Summit & Jenkins Days wiki
 page (https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
 * Advance notice: Privacy affecting bug, 1.642.4 release
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-30-18.00.html[summary]
@@ -522,7 +522,7 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * Events status update (https://wiki.jenkins.io/display/~atong[Unknown
 User (atong)])
 * Security status update
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-16-18.00.html[summary]
@@ -540,7 +540,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * Board Election update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
-* 2.0 status check (https://wiki.jenkins.io/display/~danielbeck[Unknown
+* 2.0 status check (link:/blog/authors/daniel-beck/[Unknown
 User (danielbeck)])
 * Certification update from beta exams
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
@@ -692,7 +692,7 @@ https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://grou
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * Q1 Patron messages approval
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** PR: https://github.com/jenkinsci/patron/pull/8
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -186,7 +186,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Discuss
 https://groups.google.com/forum/#!topic/jenkinsci-users/hP8uwU0y8K4[name
 use for Jenkins-LSCI] (Life Science Continuous Integration)
-(https://wiki.jenkins.io/display/~ioannis[(ioannis)])
+(ioannis)
 * Patron messages (link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
@@ -472,7 +472,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Check status for
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[action
 3d] - JetBrains licenses
-(https://wiki.jenkins.io/display/~integer[(integer)])
+(integer)
 * https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
 Summer Of Code 2016] update
 (link:/blog/authors/oleg_nenashev/[
@@ -688,7 +688,7 @@ https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
 core/master (link:/blog/authors/abayer[
 (abayer)])
 * Spam problems on wiki and possible solutions
-(https://wiki.jenkins.io/display/~lshatzer[(lshatzer)])
+(lshatzer)
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -14,13 +14,13 @@ WHEN Dec 21 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* FOSDEM 2017 Plans (https://wiki.jenkins.io/display/~atong[Unknown User
+* FOSDEM 2017 Plans (link:/blog/authors/atong[Unknown User
 (atong)])
 ** https://wiki.jenkins-ci.org/display/JENKINS/FOSDEM+2017
 * Infra update
 * JDK8 baseline upgrade followup,
 https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
-proposed by Oliver] https://wiki.jenkins.io/display/~batmat[Unknown User
+proposed by Oliver] link:/blog/authors/batmat[Unknown User
 (batmat)] (will be absent
 image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/sad.svg[(sad)]
 )
@@ -41,7 +41,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 ** Is Kohsuke OK releasing 2.32.1 on 2016-12-21 or should we postpone to
 2017-01-04?
@@ -50,7 +50,7 @@ postpone .2 RC from Jan 4 to Jan 18?
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 * JDK8 as baseline, with the
 https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
-proposed by Oliver] https://wiki.jenkins.io/display/~batmat[Unknown User
+proposed by Oliver] link:/blog/authors/batmat[Unknown User
 (batmat)]
 * New Security Officer announcement
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
@@ -120,7 +120,7 @@ time.
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 
 MINUTES
@@ -137,7 +137,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Bumping Jenkins core to Remoting 3
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -147,7 +147,7 @@ JNLP3 + stability fixes)
 ** Remoting 3 is formally incompatible: Java 6 support drop from slaves,
 also JnlpServerHandshake rework:
 https://github.com/jenkinsci/jenkins/pull/2492
-** https://wiki.jenkins.io/display/~stephenc[~stephenc] checked known
+** link:/blog/authors/stephenc[~stephenc] checked known
 OSS and closed-source implementations, no real compatibility issues
 ** Question for voting: Do we want to go forward?
 * Out-of-order Jenkins Weekly release in order to get better soak
@@ -184,7 +184,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Discuss
 https://groups.google.com/forum/#!topic/jenkinsci-users/hP8uwU0y8K4[name
@@ -212,10 +212,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Pick new LTS version
-(﻿https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(﻿link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 
 MINUTES
@@ -232,7 +232,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -252,7 +252,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -272,14 +272,14 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Obtain permission to post Jenkins World banner
 on http://issues.jenkins.io/[issues.jenkins.io] and
-wiki.jenkins-ci.org (https://wiki.jenkins.io/display/~atong[Unknown User
+wiki.jenkins-ci.org (link:/blog/authors/atong[Unknown User
 (atong)])
 
 MINUTES
@@ -296,7 +296,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -316,7 +316,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -324,10 +324,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Officer updates
 ** Security status update
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
-** Events status update (https://wiki.jenkins.io/display/~atong[Unknown
+** Events status update (link:/blog/authors/atong[Unknown
 User (atong)])
 ** Release status update
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Infra update (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
@@ -406,7 +406,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Security status update
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
-* Events status update (https://wiki.jenkins.io/display/~atong[Unknown
+* Events status update (link:/blog/authors/atong[Unknown
 User (atong)])
 
 MINUTES
@@ -435,7 +435,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 https://groups.google.com/d/msg/jenkinsci-dev/WQO16ziPoCA/E9lmmKeiFAAJ
 ** Antonio Muñiz:
 https://groups.google.com/d/msg/jenkinsci-dev/5_k8Uj5rErA/vTOyPnsZBwAJ
-* GSoC status check (https://wiki.jenkins.io/display/~batmat[Unknown
+* GSoC status check (link:/blog/authors/batmat[Unknown
 User (batmat)])
 
 MINUTES
@@ -458,7 +458,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 ** https://groups.google.com/d/msg/jenkinsci-dev/M9GeJFo_qcg/4Wax34DrBAAJ
 * Jenkins 2.0 launch - go over activities of what has been planned for
 this release (R. Tyler
-Croy/https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+Croy/link:/blog/authors/atong[Unknown User (atong)])
 ** https://wiki.jenkins-ci.org/display/JENKINS/2.0+Launch+Marketing
 
 MINUTES
@@ -490,7 +490,7 @@ Summer Of Code 2016] update
 * Major infrastructure opportunity
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Update to CD Summit & Jenkins Days wiki
-page (https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+page (link:/blog/authors/atong[Unknown User (atong)])
 * Advance notice: Privacy affecting bug, 1.642.4 release
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
@@ -519,7 +519,7 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 (link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Infrastructure status update
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
-* Events status update (https://wiki.jenkins.io/display/~atong[Unknown
+* Events status update (link:/blog/authors/atong[Unknown
 User (atong)])
 * Security status update
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
@@ -571,7 +571,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * https://wiki.jenkins.io/display/JENKINS/Jenkins+Certification[Jenkins
 Certification] update and trademark approval request
@@ -584,7 +584,7 @@ image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea35
 ) Discussion: clarify that plugins available through the update center
 are required to have their source code canonical repository hosted under
 the Jenkinsci GitHub organization
-https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
+link:/blog/authors/batmat[Unknown User (batmat)]
 ** For context
 https://groups.google.com/forum/#!topic/jenkinsci-dev/IoRmYHNn3Q4[the
 last thread about it]
@@ -619,7 +619,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 https://wiki.jenkins.io/display/JENKINS/Governance+Document#GovernanceDocument-Trademark[trademark
 approval] for
 https://wiki.jenkins-ci.org/download/attachments/54722987/Jenkins-World-revised-logo.jpg?version=1&modificationDate=1453408974536[Jenkins
-World 2016 logo] (https://wiki.jenkins.io/display/~atong[Unknown User
+World 2016 logo] (link:/blog/authors/atong[Unknown User
 (atong)])
 * Infrastructure status report -
 link:/blog/authors/rtyler/[Unknown User (rtyler)]
@@ -631,11 +631,11 @@ https://developers.google.com/open-source/gsoc/timeline[19th February]
 ** Summary
 slides: https://speakerdeck.com/onenashev/jenkins-2-dot-0-google-code-of-summer-proposals
 * Do we have a timeline for the Governance Board elections?
-(https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[Unknown User (orrc)])
 * Discussion: clarify that plugins available through the update center
 are required to have their source code canonical repository hosted under
 the Jenkinsci GitHub organization
-https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
+link:/blog/authors/batmat[Unknown User (batmat)]
 ** As a first step, only discuss the matter (hopefully with the board).
 Only potentially on a future meeting may we want to settle on something
 and act upon it.
@@ -689,7 +689,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check - discuss baseline change:
 https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM
 (https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM)
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Q1 Patron messages approval
 (link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
@@ -698,7 +698,7 @@ https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://grou
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Discuss requiring pull requests for all non-release-process changes to
-core/master (https://wiki.jenkins.io/display/~abayer[Unknown User
+core/master (link:/blog/authors/abayer[Unknown User
 (abayer)])
 * Spam problems on wiki and possible solutions
 (https://wiki.jenkins.io/display/~lshatzer[Unknown User (lshatzer)])

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -14,13 +14,13 @@ WHEN Dec 21 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* FOSDEM 2017 Plans (link:/blog/authors/atong[Unknown User
+* FOSDEM 2017 Plans (link:/blog/authors/atong[
 (atong)])
 ** https://wiki.jenkins-ci.org/display/JENKINS/FOSDEM+2017
 * Infra update
 * JDK8 baseline upgrade followup,
 https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
-proposed by Oliver] link:/blog/authors/batmat[Unknown User
+proposed by Oliver] link:/blog/authors/batmat[
 (batmat)] (will be absent
 image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/sad.svg[(sad)]
 )
@@ -41,19 +41,19 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 ** Is Kohsuke OK releasing 2.32.1 on 2016-12-21 or should we postpone to
 2017-01-04?
 ** Should we just skip two weeks around Christmas like we did last year,
 postpone .2 RC from Jan 4 to Jan 18?
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * JDK8 as baseline, with the
 https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
-proposed by Oliver] link:/blog/authors/batmat[Unknown User
+proposed by Oliver] link:/blog/authors/batmat[
 (batmat)]
 * New Security Officer announcement
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-07-18.03.html[summary]
@@ -69,7 +69,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * LTS base line selection
 * Revival of the Klocwork plugin
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** The plugin is hosted outside jenkinsci org, but it seems to be
 abandoned by maintainers
@@ -78,14 +78,14 @@ https://groups.google.com/forum/#!search/klocwork/jenkinsci-dev/U7SFVsjsHHQ/cA8S
 ** We need to discuss if we can just proceed with plugin process and to
 grant the access to the requester
 * GSoC2017 sync-up
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Do we participate in it? If yes, should we schedule office hours?
 ** Who will be Jenkins org admins this time?
-link:/blog/authors/oleg_nenashev/[Unknown User
+link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] will need some help
 * Azure migration / Infrastructure update
-link:/blog/authors/rtyler/[Unknown User (rtyler)]
+link:/blog/authors/rtyler/[ (rtyler)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-23-18.00.html[summary]
@@ -120,7 +120,7 @@ time.
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 
 MINUTES
@@ -137,10 +137,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Bumping Jenkins core to Remoting 3
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Remoting 3 offers a new JNLP4 protocol (Adds Java NIO compared to
 JNLP3 + stability fixes)
@@ -152,20 +152,20 @@ OSS and closed-source implementations, no real compatibility issues
 ** Question for voting: Do we want to go forward?
 * Out-of-order Jenkins Weekly release in order to get better soak
 testing for 2.19.3
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Question for voting: Do we want to release it if kohsuke is available?
 ** https://issues.jenkins.io/browse/JENKINS-38814[JENKINS-38814],
 https://github.com/jenkinsci/jenkins/commit/a04e2f9836263f7ae5e68617f5bafde18e594446
 * IntelliJ license handling
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Moving Governance Meetings to UTC
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Plugin site deployment to Jenkins project infra
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Allowing interface implementations as Extension points in Jenkins
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Background: https://github.com/jenkinsci/jenkins/pull/2566
 ** ** Question for voting: Do we want to allow such use-case?
@@ -184,14 +184,13 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Discuss
 https://groups.google.com/forum/#!topic/jenkinsci-users/hP8uwU0y8K4[name
 use for Jenkins-LSCI] (Life Science Continuous Integration)
-(https://wiki.jenkins.io/display/~ioannis[Unknown User (ioannis)])
-* Patron messages (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
+(https://wiki.jenkins.io/display/~ioannis[ (ioannis)])
+* Patron messages (link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-09-28-18.00.html[summary]
@@ -212,10 +211,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Pick new LTS version
-(﻿link:/blog/authors/olivergondza[Unknown User
+(﻿link:/blog/authors/olivergondza[
 (olivergondza)])
 
 MINUTES
@@ -232,10 +231,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -252,10 +251,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -272,14 +271,14 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Obtain permission to post Jenkins World banner
 on http://issues.jenkins.io/[issues.jenkins.io] and
-wiki.jenkins-ci.org (link:/blog/authors/atong[Unknown User
+wiki.jenkins-ci.org (link:/blog/authors/atong[
 (atong)])
 
 MINUTES
@@ -296,10 +295,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -316,29 +315,28 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Officer updates
 ** Security status update
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
-** Events status update (link:/blog/authors/atong[Unknown
-User (atong)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
+** Events status update (link:/blog/authors/atong[ (atong)])
 ** Release status update
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
-* Infra update (link:/blog/authors/rtyler/[Unknown User
+* Infra update (link:/blog/authors/rtyler/[
 (rtyler)])
 * Licensing and unrestricted access of
 https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
 Statistics] (aka "census data")
 http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
-context here] link:/blog/authors/rtyler/[Unknown User
+context here] link:/blog/authors/rtyler/[
 (rtyler)]
 * Approval of new Q3 patron messages
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-22-18.00.html[summary]
@@ -356,15 +354,15 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * Next LTS baseline selection
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Q3 patron messages
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Licensing and unrestricted access of
 https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
 Statistics] (aka "census data")
 http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
-context here] link:/blog/authors/rtyler/[Unknown User
+context here] link:/blog/authors/rtyler/[
 (rtyler)]
 
 MINUTES
@@ -382,7 +380,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS status check
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -400,14 +398,13 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * LTS status check
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Infrastructure status update
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Security status update
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
-* Events status update (link:/blog/authors/atong[Unknown
-User (atong)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
+* Events status update (link:/blog/authors/atong[ (atong)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-05-11-18.00.html[summary]
@@ -425,18 +422,17 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * 2.0 status check
 * Approval of Q2 patron messages
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** https://github.com/jenkinsci/patron/pull/11
 * CERT membership request process changes
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Approval of CERT membership requests
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** Andres Rodriguez:
 https://groups.google.com/d/msg/jenkinsci-dev/WQO16ziPoCA/E9lmmKeiFAAJ
 ** Antonio Muñiz:
 https://groups.google.com/d/msg/jenkinsci-dev/5_k8Uj5rErA/vTOyPnsZBwAJ
-* GSoC status check (link:/blog/authors/batmat[Unknown
-User (batmat)])
+* GSoC status check (link:/blog/authors/batmat[ (batmat)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-04-27-18.01.html[summary]
@@ -454,11 +450,11 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * 2.0 status check
 * CERT membership request by Yoann Dubreuil
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/M9GeJFo_qcg/4Wax34DrBAAJ
 * Jenkins 2.0 launch - go over activities of what has been planned for
 this release (R. Tyler
-Croy/link:/blog/authors/atong[Unknown User (atong)])
+Croy/link:/blog/authors/atong[ (atong)])
 ** https://wiki.jenkins-ci.org/display/JENKINS/2.0+Launch+Marketing
 
 MINUTES
@@ -479,20 +475,20 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Check status for
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[action
 3d] - JetBrains licenses
-(https://wiki.jenkins.io/display/~integer[Unknown User (integer)])
+(https://wiki.jenkins.io/display/~integer[ (integer)])
 * https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
 Summer Of Code 2016] update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig[https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig|https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig]
 * Release officer announcement
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Major infrastructure opportunity
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Update to CD Summit & Jenkins Days wiki
-page (link:/blog/authors/atong[Unknown User (atong)])
+page (link:/blog/authors/atong[ (atong)])
 * Advance notice: Privacy affecting bug, 1.642.4 release
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-30-18.00.html[summary]
@@ -516,13 +512,12 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * LTS status check
 * Next LTS baseline selection
 * Seek trademark usage approval for "Jenkins Days"
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 * Infrastructure status update
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
-* Events status update (link:/blog/authors/atong[Unknown
-User (atong)])
+(link:/blog/authors/rtyler/[ (rtyler)])
+* Events status update (link:/blog/authors/atong[ (atong)])
 * Security status update
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-16-18.00.html[summary]
@@ -538,20 +533,18 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-* Board Election update (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
-* 2.0 status check (link:/blog/authors/daniel-beck/[Unknown
-User (danielbeck)])
+* Board Election update (link:/blog/authors/rtyler/[ (rtyler)])
+* 2.0 status check (link:/blog/authors/daniel-beck/[ (danielbeck)])
 * Certification update from beta exams
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Conversion of
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2016#[Office
 Hours] to Jenkins Online meetup
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY[https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY|https://groups.google.com/forum/#!topic/jenkinsci-dev/LMTCNDv-jgY]
 * Planning of GSoC office hours
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Application draft:
 https://docs.google.com/document/d/1dv9UXyT_FPukJXrBYauIKvxrZeEU6BT7v90LSQX36MU/edit#
@@ -571,27 +564,27 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * https://wiki.jenkins.io/display/JENKINS/Jenkins+Certification[Jenkins
 Certification] update and trademark approval request
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * New team lead positions: *Events* and *Release* (see
 https://wiki.jenkins.io/display/JENKINS/Team+Leads[Team Leads])
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * (2nd run
 image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/smile.svg[(smile)]
 ) Discussion: clarify that plugins available through the update center
 are required to have their source code canonical repository hosted under
 the Jenkinsci GitHub organization
-link:/blog/authors/batmat[Unknown User (batmat)]
+link:/blog/authors/batmat[ (batmat)]
 ** For context
 https://groups.google.com/forum/#!topic/jenkinsci-dev/IoRmYHNn3Q4[the
 last thread about it]
 * (_time permitting_)
 https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
 Summer Of Code 2016] application progress -
-link:/blog/authors/oleg_nenashev/[Unknown User
+link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)]
 ** Mailing list:
 https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0[https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0|https://groups.google.com/forum/#!topic/jenkinsci-dev/vTxsCLk1XS0]
@@ -619,23 +612,23 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 https://wiki.jenkins.io/display/JENKINS/Governance+Document#GovernanceDocument-Trademark[trademark
 approval] for
 https://wiki.jenkins-ci.org/download/attachments/54722987/Jenkins-World-revised-logo.jpg?version=1&modificationDate=1453408974536[Jenkins
-World 2016 logo] (link:/blog/authors/atong[Unknown User
+World 2016 logo] (link:/blog/authors/atong[
 (atong)])
 * Infrastructure status report -
-link:/blog/authors/rtyler/[Unknown User (rtyler)]
+link:/blog/authors/rtyler/[ (rtyler)]
 * Should Jenkins be a mentor organisation for Google Summer of Code?
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Deadline is
 https://developers.google.com/open-source/gsoc/timeline[19th February]
 ** Summary
 slides: https://speakerdeck.com/onenashev/jenkins-2-dot-0-google-code-of-summer-proposals
 * Do we have a timeline for the Governance Board elections?
-(link:/blog/authors/orrc[Unknown User (orrc)])
+(link:/blog/authors/orrc[ (orrc)])
 * Discussion: clarify that plugins available through the update center
 are required to have their source code canonical repository hosted under
 the Jenkinsci GitHub organization
-link:/blog/authors/batmat[Unknown User (batmat)]
+link:/blog/authors/batmat[ (batmat)]
 ** As a first step, only discuss the matter (hopefully with the board).
 Only potentially on a future meeting may we want to settle on something
 and act upon it.
@@ -658,14 +651,14 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Recap last meeting's actions
 * Approving Jenkins Press page and assigned contacts:
 https://jenkins-ci.org/press/&nbsp;
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Reworking / Shutting down the Jenkins CIA program
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY[https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY|https://groups.google.com/forum/#!topic/jenkinsci-dev/ktTrIZQlNTY]
 * Follow-up to the unofficial Jenkins-related Twitter account
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://twitter.com/LearningJenkins
 ** Aim: agree if "Learning Jenkins" with the unofficial resource notice
@@ -689,19 +682,19 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check - discuss baseline change:
 https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM
 (https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM)
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Q1 Patron messages approval
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** PR: https://github.com/jenkinsci/patron/pull/8
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Discuss requiring pull requests for all non-release-process changes to
-core/master (link:/blog/authors/abayer[Unknown User
+core/master (link:/blog/authors/abayer[
 (abayer)])
 * Spam problems on wiki and possible solutions
-(https://wiki.jenkins.io/display/~lshatzer[Unknown User (lshatzer)])
+(https://wiki.jenkins.io/display/~lshatzer[ (lshatzer)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -47,13 +47,13 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 2017-01-04?
 ** Should we just skip two weeks around Christmas like we did last year,
 postpone .2 RC from Jan 4 to Jan 18?
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * JDK8 as baseline, with the
 https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
 proposed by Oliver] link:/blog/authors/batmat[
 (batmat)]
 * New Security Officer announcement
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-07-18.03.html[summary]
@@ -85,7 +85,7 @@ grant the access to the requester
 link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] will need some help
 * Azure migration / Infrastructure update
-link:/blog/authors/rtyler/[ (rtyler)]
+link:/blog/authors/rtyler/[(rtyler)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-23-18.00.html[summary]
@@ -155,12 +155,12 @@ testing for 2.19.3
 ** https://issues.jenkins.io/browse/JENKINS-38814[JENKINS-38814],
 https://github.com/jenkinsci/jenkins/commit/a04e2f9836263f7ae5e68617f5bafde18e594446
 * IntelliJ license handling
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Moving Governance Meetings to UTC
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Plugin site deployment to Jenkins project infra
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Allowing interface implementations as Extension points in Jenkins
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
@@ -186,8 +186,8 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Discuss
 https://groups.google.com/forum/#!topic/jenkinsci-users/hP8uwU0y8K4[name
 use for Jenkins-LSCI] (Life Science Continuous Integration)
-(https://wiki.jenkins.io/display/~ioannis[ (ioannis)])
-* Patron messages (link:/blog/authors/daniel-beck/[ (danielbeck)])
+(https://wiki.jenkins.io/display/~ioannis[(ioannis)])
+* Patron messages (link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-09-28-18.00.html[summary]
@@ -319,8 +319,8 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (oleg_nenashev)])
 * Officer updates
 ** Security status update
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
-** Events status update (link:/blog/authors/atong[ (atong)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
+** Events status update (link:/blog/authors/atong[(atong)])
 ** Release status update
 (link:/blog/authors/olivergondza[
 (olivergondza)])
@@ -333,7 +333,7 @@ http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
 context here] link:/blog/authors/rtyler/[
 (rtyler)]
 * Approval of new Q3 patron messages
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-06-22-18.00.html[summary]
@@ -354,7 +354,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Q3 patron messages
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Licensing and unrestricted access of
 https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
 Statistics] (aka "census data")
@@ -398,10 +398,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Infrastructure status update
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Security status update
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
-* Events status update (link:/blog/authors/atong[ (atong)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
+* Events status update (link:/blog/authors/atong[(atong)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-05-11-18.00.html[summary]
@@ -419,17 +419,17 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * 2.0 status check
 * Approval of Q2 patron messages
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** https://github.com/jenkinsci/patron/pull/11
 * CERT membership request process changes
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 * Approval of CERT membership requests
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** Andres Rodriguez:
 https://groups.google.com/d/msg/jenkinsci-dev/WQO16ziPoCA/E9lmmKeiFAAJ
 ** Antonio Muñiz:
 https://groups.google.com/d/msg/jenkinsci-dev/5_k8Uj5rErA/vTOyPnsZBwAJ
-* GSoC status check (link:/blog/authors/batmat[ (batmat)])
+* GSoC status check (link:/blog/authors/batmat[(batmat)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-04-27-18.01.html[summary]
@@ -447,11 +447,11 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * LTS status check
 * 2.0 status check
 * CERT membership request by Yoann Dubreuil
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/M9GeJFo_qcg/4Wax34DrBAAJ
 * Jenkins 2.0 launch - go over activities of what has been planned for
 this release (R. Tyler
-Croy/link:/blog/authors/atong[ (atong)])
+Croy/link:/blog/authors/atong[(atong)])
 ** https://wiki.jenkins-ci.org/display/JENKINS/2.0+Launch+Marketing
 
 MINUTES
@@ -472,20 +472,20 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 * Check status for
 http://meetings.jenkins-ci.org/jenkins/2015/jenkins.2015-02-18-19.01.html[action
 3d] - JetBrains licenses
-(https://wiki.jenkins.io/display/~integer[ (integer)])
+(https://wiki.jenkins.io/display/~integer[(integer)])
 * https://wiki.jenkins.io/display/JENKINS/Google+Summer+Of+Code+2016[Google
 Summer Of Code 2016] update
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig[https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig|https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig]
 * Release officer announcement
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Major infrastructure opportunity
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Update to CD Summit & Jenkins Days wiki
-page (link:/blog/authors/atong[ (atong)])
+page (link:/blog/authors/atong[(atong)])
 * Advance notice: Privacy affecting bug, 1.642.4 release
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-30-18.00.html[summary]
@@ -506,12 +506,12 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * LTS status check
 * Next LTS baseline selection
 * Seek trademark usage approval for "Jenkins Days"
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 * Infrastructure status update
-(link:/blog/authors/rtyler/[ (rtyler)])
-* Events status update (link:/blog/authors/atong[ (atong)])
+(link:/blog/authors/rtyler/[(rtyler)])
+* Events status update (link:/blog/authors/atong[(atong)])
 * Security status update
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-16-18.00.html[summary]
@@ -527,10 +527,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-* Board Election update (link:/blog/authors/rtyler/[ (rtyler)])
-* 2.0 status check (link:/blog/authors/daniel-beck/[ (danielbeck)])
+* Board Election update (link:/blog/authors/rtyler/[(rtyler)])
+* 2.0 status check (link:/blog/authors/daniel-beck/[(danielbeck)])
 * Certification update from beta exams
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Conversion of
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2016#[Office
 Hours] to Jenkins Online meetup
@@ -562,16 +562,16 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (olivergondza)])
 * https://wiki.jenkins.io/display/JENKINS/Jenkins+Certification[Jenkins
 Certification] update and trademark approval request
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * New team lead positions: *Events* and *Release* (see
 https://wiki.jenkins.io/display/JENKINS/Team+Leads[Team Leads])
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * (2nd run
 image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/smile.svg[(smile)]
 ) Discussion: clarify that plugins available through the update center
 are required to have their source code canonical repository hosted under
 the Jenkinsci GitHub organization
-link:/blog/authors/batmat[ (batmat)]
+link:/blog/authors/batmat[(batmat)]
 ** For context
 https://groups.google.com/forum/#!topic/jenkinsci-dev/IoRmYHNn3Q4[the
 last thread about it]
@@ -609,7 +609,7 @@ https://wiki.jenkins-ci.org/download/attachments/54722987/Jenkins-World-revised-
 World 2016 logo] (link:/blog/authors/atong[
 (atong)])
 * Infrastructure status report -
-link:/blog/authors/rtyler/[ (rtyler)]
+link:/blog/authors/rtyler/[(rtyler)]
 * Should Jenkins be a mentor organisation for Google Summer of Code?
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
@@ -618,11 +618,11 @@ https://developers.google.com/open-source/gsoc/timeline[19th February]
 ** Summary
 slides: https://speakerdeck.com/onenashev/jenkins-2-dot-0-google-code-of-summer-proposals
 * Do we have a timeline for the Governance Board elections?
-(link:/blog/authors/orrc[ (orrc)])
+(link:/blog/authors/orrc[(orrc)])
 * Discussion: clarify that plugins available through the update center
 are required to have their source code canonical repository hosted under
 the Jenkinsci GitHub organization
-link:/blog/authors/batmat[ (batmat)]
+link:/blog/authors/batmat[(batmat)]
 ** As a first step, only discuss the matter (hopefully with the board).
 Only potentially on a future meeting may we want to settle on something
 and act upon it.
@@ -679,16 +679,16 @@ https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://grou
 (link:/blog/authors/olivergondza[
 (olivergondza)])
 * Q1 Patron messages approval
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** PR: https://github.com/jenkinsci/patron/pull/8
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Discuss requiring pull requests for all non-release-process changes to
 core/master (link:/blog/authors/abayer[
 (abayer)])
 * Spam problems on wiki and possible solutions
-(https://wiki.jenkins.io/display/~lshatzer[ (lshatzer)])
+(https://wiki.jenkins.io/display/~lshatzer[(lshatzer)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-01-06-19.01.html[summary]

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -53,7 +53,7 @@ https://groups.google.com/d/msg/jenkinsci-dev/fo5nKLhZK5U/IRJdMeS6CgAJ[timeline
 proposed by Oliver] https://wiki.jenkins.io/display/~batmat[Unknown User
 (batmat)]
 * New Security Officer announcement
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-12-07-18.03.html[summary]
@@ -85,7 +85,7 @@ grant the access to the requester
 https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
 (oleg_nenashev)] will need some help
 * Azure migration / Infrastructure update
-https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+link:/blog/authors/rtyler/[Unknown User (rtyler)]
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-11-23-18.00.html[summary]
@@ -329,13 +329,13 @@ User (atong)])
 ** Release status update
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
-* Infra update (https://wiki.jenkins.io/display/~rtyler[Unknown User
+* Infra update (link:/blog/authors/rtyler/[Unknown User
 (rtyler)])
 * Licensing and unrestricted access of
 https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
 Statistics] (aka "census data")
 http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
-context here] https://wiki.jenkins.io/display/~rtyler[Unknown User
+context here] link:/blog/authors/rtyler/[Unknown User
 (rtyler)]
 * Approval of new Q3 patron messages
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
@@ -364,7 +364,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 https://wiki.jenkins.io/display/JENKINS/Usage+Statistics[Usage
 Statistics] (aka "census data")
 http://lists.jenkins-ci.org/pipermail/jenkins-infra/2016-June/000742.html[more
-context here] https://wiki.jenkins.io/display/~rtyler[Unknown User
+context here] link:/blog/authors/rtyler/[Unknown User
 (rtyler)]
 
 MINUTES
@@ -403,7 +403,7 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
 (oleg_nenashev)])
 * Infrastructure status update
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Security status update
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
 * Events status update (https://wiki.jenkins.io/display/~atong[Unknown
@@ -486,9 +486,9 @@ Summer Of Code 2016] update
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig[https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig|https://groups.google.com/forum/#!topic/jenkinsci-dev/bmLARYolMig]
 * Release officer announcement
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Major infrastructure opportunity
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Update to CD Summit & Jenkins Days wiki
 page (https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
 * Advance notice: Privacy affecting bug, 1.642.4 release
@@ -518,7 +518,7 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * Seek trademark usage approval for "Jenkins Days"
 (https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
 * Infrastructure status update
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Events status update (https://wiki.jenkins.io/display/~atong[Unknown
 User (atong)])
 * Security status update
@@ -538,12 +538,12 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 
 * Recap last meeting's actions
 * LTS status check
-* Board Election update (https://wiki.jenkins.io/display/~rtyler[Unknown
+* Board Election update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * 2.0 status check (https://wiki.jenkins.io/display/~danielbeck[Unknown
 User (danielbeck)])
 * Certification update from beta exams
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Conversion of
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+Archive+2016#[Office
 Hours] to Jenkins Online meetup
@@ -575,10 +575,10 @@ https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Mee
 (olivergondza)])
 * https://wiki.jenkins.io/display/JENKINS/Jenkins+Certification[Jenkins
 Certification] update and trademark approval request
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * New team lead positions: *Events* and *Release* (see
 https://wiki.jenkins.io/display/JENKINS/Team+Leads[Team Leads])
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * (2nd run
 image:https://wiki.jenkins.io/s/en_GB/8100/5084f018d64a97dc638ca9a178856f851ea353ff/_/images/icons/emoticons/smile.svg[(smile)]
 ) Discussion: clarify that plugins available through the update center
@@ -622,7 +622,7 @@ https://wiki.jenkins-ci.org/download/attachments/54722987/Jenkins-World-revised-
 World 2016 logo] (https://wiki.jenkins.io/display/~atong[Unknown User
 (atong)])
 * Infrastructure status report -
-https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)]
+link:/blog/authors/rtyler/[Unknown User (rtyler)]
 * Should Jenkins be a mentor organisation for Google Summer of Code?
 (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
 (oleg_nenashev)])
@@ -696,7 +696,7 @@ https://groups.google.com/forum/#\!topic/jenkinsci-dev/K06ny0sozWM\|https://grou
 ** PR: https://github.com/jenkinsci/patron/pull/8
 * Review/adopt a
 https://wiki.jenkins.io/display/JENKINS/Code+of+Conduct[Code of Conduct]
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Discuss requiring pull requests for all non-release-process changes to
 core/master (https://wiki.jenkins.io/display/~abayer[Unknown User
 (abayer)])

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -516,7 +516,7 @@ https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!
 * LTS status check
 * Next LTS baseline selection
 * Seek trademark usage approval for "Jenkins Days"
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 * Infrastructure status update
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Events status update (https://wiki.jenkins.io/display/~atong[Unknown

--- a/content/project/governance-meeting/archives/2016.adoc
+++ b/content/project/governance-meeting/archives/2016.adoc
@@ -111,9 +111,6 @@ WHEN
 https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20161026T18&p1=1440&ah=1[October
 26 18:00 UTC].
 
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
-
 We decided to switch to a fixed UTC-based time for the project meeting.
 It's now always at 18:00 UTC. This is the first meeting at this new
 time.
@@ -501,9 +498,6 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2016/jenkins-meeting.2016-03-30-1
 WHEN
 https://www.timeanddate.com/worldclock/fixedtime.html?msg=Jenkins+Governance+Meeting&iso=20160316T11&p1=224&ah=1&sort=1[Mar
 16 11:00 Pacific].
-
-[.aui-icon .aui-icon-small .aui-iconfont-warning .confluence-information-macro-icon]#
-#
 
 It's DST change season: Make sure you're not
 https://en.wikipedia.org/wiki/Off-by-one_error[off by one] (hour)!

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -71,7 +71,7 @@ WHEN November 8th 18:00 UTC
 * LTS baseline selection
 * Jenkins Enhancement Proposals
 (https://github.com/jenkinsci/jep/tree/jep-1/jep/1[JEP-1])
-( https://wiki.jenkins.io/display/~rtyler[Unknown User
+( link:/blog/authors/rtyler/[Unknown User
 (rtyler)] and https://wiki.jenkins.io/display/~bitwiseman[Unknown User
 (bitwiseman)] )
 
@@ -202,12 +202,12 @@ WHEN August 2nd 18:00 UTC
 (olivergondza)] )
 * Jenkins World organization update (https://github.com/alyssat[Alyssa
 Tong])
-* Infra status update (https://wiki.jenkins.io/display/~rtyler[Unknown
+* Infra status update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * https://groups.google.com/d/msg/jenkinsci-dev/PoxnVCKa9NM/2F2iLlDuBwAJ[Jenkins
 mark usage request from CloudBees]
 (https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)] but
- https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)] will
+ link:/blog/authors/rtyler/[Unknown User (rtyler)] will
 proxy)
 * Deprecate Remoting CLI1/JNLP1/JNLP2/JNLP3 protocol - sign-off
 https://issues.jenkins.io/browse/JENKINS-45841[JENKINS-45841]
@@ -311,7 +311,7 @@ WHEN May 24th 18:00 UTC
 (olivergondza)] )
 ** Next LTS baseline selection ([~olivergondza])
 * Purchasing a SendGrid account to send project emails from Azure-based
-applications - https://wiki.jenkins.io/display/~rtyler[Unknown User
+applications - link:/blog/authors/rtyler/[Unknown User
 (rtyler)], https://wiki.jenkins.io/display/~olblak[Unknown User
 (olblak)]
 * Adding https://wiki.jenkins.io/display/~olblak[Unknown User
@@ -336,7 +336,7 @@ WHEN: May 10th 18:00 UTC
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
 * Infrastructure update (JIRA, Confluence, accounts, etc) (
-https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)],
+link:/blog/authors/rtyler/[Unknown User (rtyler)],
 https://wiki.jenkins.io/display/~olblak[Unknown User (olblak)])
 
  
@@ -376,7 +376,7 @@ WHEN: April 12th 18:00 UTC
 * LTS status check
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
-* Google Groups issues (https://wiki.jenkins.io/display/~rtyler[Unknown
+* Google Groups issues (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 
  
@@ -467,7 +467,7 @@ WHEN: Feb 15 18:00 UTC
 (olivergondza)])
 * GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
 User (oleg_nenashev)])
-* Infrastructure update (https://wiki.jenkins.io/display/~rtyler[Unknown
+* Infrastructure update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * Should we host plugins with closed-source dependencies?
 (https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)],
@@ -501,11 +501,11 @@ WHEN: Feb 01 18:00 UTC
 update]
 ** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
 draf]
-* Infrastructure update (https://wiki.jenkins.io/display/~rtyler[Unknown
+* Infrastructure update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * https://groups.google.com/forum/#!topic/jenkinsci-dev/1jZmjgSDcqM[Trademark
 usage approval] for upcoming "CloudBees Jenkins" product names
-(https://wiki.jenkins.io/display/~rtyler[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Request for 50 private repos in the jenkinsci-cert GitHub org (1200
 USD/year, up from 20 repos for 600 USD/year)
 (https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -167,7 +167,7 @@ WHEN August 16th 18:00 UTC
 ( link:/blog/authors/olivergondza[
 (olivergondza)] will not make it to the meeting)*
 * next LTS baseline selection
-(link:/blog/authors/jglick[ (jglick)])
+(link:/blog/authors/jglick[(jglick)])
 * Vote on proposal:[.F0XO1GC-mb-Y]# Add optional "Released as" and
 "Stage Release" states to JIRA#
 (link:/blog/authors/oleg_nenashev/[
@@ -197,11 +197,11 @@ WHEN August 2nd 18:00 UTC
 (olivergondza)] )
 * Jenkins World organization update (https://github.com/alyssat[Alyssa
 Tong])
-* Infra status update (link:/blog/authors/rtyler/[ (rtyler)])
+* Infra status update (link:/blog/authors/rtyler/[(rtyler)])
 * https://groups.google.com/d/msg/jenkinsci-dev/PoxnVCKa9NM/2F2iLlDuBwAJ[Jenkins
 mark usage request from CloudBees]
-(link:/blog/authors/kohsuke/[ (kohsuke)] but
- link:/blog/authors/rtyler/[ (rtyler)] will
+(link:/blog/authors/kohsuke/[(kohsuke)] but
+ link:/blog/authors/rtyler/[(rtyler)] will
 proxy)
 * Deprecate Remoting CLI1/JNLP1/JNLP2/JNLP3 protocol - sign-off
 https://issues.jenkins.io/browse/JENKINS-45841[JENKINS-45841]
@@ -330,8 +330,8 @@ WHEN: May 10th 18:00 UTC
 (link:/blog/authors/olivergondza[
 (olivergondza)])
 * Infrastructure update (JIRA, Confluence, accounts, etc) (
-link:/blog/authors/rtyler/[ (rtyler)],
-link:/blog/authors/olblak[ (olblak)])
+link:/blog/authors/rtyler/[(rtyler)],
+link:/blog/authors/olblak[(olblak)])
 
  
 
@@ -370,7 +370,7 @@ WHEN: April 12th 18:00 UTC
 * LTS status check
 (link:/blog/authors/olivergondza[
 (olivergondza)])
-* Google Groups issues (link:/blog/authors/rtyler/[ (rtyler)])
+* Google Groups issues (link:/blog/authors/rtyler/[(rtyler)])
 
  
 
@@ -391,7 +391,7 @@ WHEN: March 29 18:00 UTC
 * Sublicense request, on behalf of JFrog, "Jenkins Community Day" event
 in Paris (Alyssa Tong)
 * Java 8 baseline bump heads up
-(link:/blog/authors/batmat[ (batmat)])
+(link:/blog/authors/batmat[(batmat)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-29-18.02.html[summary]
@@ -433,7 +433,7 @@ WHEN: March 1 18:00 UTC
 (olivergondza)])
 ** https://jenkins.io/changelog/
 * The future of the patron program
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 ** It doesn't make sense in its current form with the wiki slowly
 getting replaced
 ** Do we want to just end it (for now), or implement e.g. on the site,
@@ -458,12 +458,12 @@ WHEN: Feb 15 18:00 UTC
 * LTS Status check
 (link:/blog/authors/olivergondza[
 (olivergondza)])
-* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
-* Infrastructure update (link:/blog/authors/rtyler/[ (rtyler)])
+* GSoC update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
+* Infrastructure update (link:/blog/authors/rtyler/[(rtyler)])
 * Should we host plugins with closed-source dependencies?
-(link:/blog/authors/batmat[ (batmat)],
-link:/blog/authors/orrc[ (orrc)])
-** link:/blog/authors/batmat[ (batmat)]
+(link:/blog/authors/batmat[(batmat)],
+link:/blog/authors/orrc[(orrc)])
+** link:/blog/authors/batmat[(batmat)]
 brought up the point after
 https://issues.jenkins.io/browse/HOSTING-271[HOSTING-271]
 ** Closed-source plugins are explicitly banned in the
@@ -492,13 +492,13 @@ WHEN: Feb 01 18:00 UTC
 update]
 ** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
 draf]
-* Infrastructure update (link:/blog/authors/rtyler/[ (rtyler)])
+* Infrastructure update (link:/blog/authors/rtyler/[(rtyler)])
 * https://groups.google.com/forum/#!topic/jenkinsci-dev/1jZmjgSDcqM[Trademark
 usage approval] for upcoming "CloudBees Jenkins" product names
-(link:/blog/authors/rtyler/[ (rtyler)])
+(link:/blog/authors/rtyler/[(rtyler)])
 * Request for 50 private repos in the jenkinsci-cert GitHub org (1200
 USD/year, up from 20 repos for 600 USD/year)
-(link:/blog/authors/daniel-beck/[ (danielbeck)])
+(link:/blog/authors/daniel-beck/[(danielbeck)])
 
 Part 1:
 
@@ -531,7 +531,7 @@ draf]
 (link:/blog/authors/slide_o_mix[
 (slide_o_mix)])
 * JDK8 baseline upgrade news
-(link:/blog/authors/batmat[ (batmat)])
+(link:/blog/authors/batmat[(batmat)])
 ** Jenkins https://github.com/jenkinsci/jenkins/pull/2698[core now
 builds on Windows] and is green \o/ (err, blue)
 ** https://github.com/jenkins-infra/jenkins.io/pull/545[PR] for the

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -538,7 +538,7 @@ update]
 ** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
 draf]
 * Bug Triage Team Idea
-(https://wiki.jenkins.io/display/~slide_o_mix[Unknown User
+(link:/blog/authors/slide_o_mix[Unknown User
 (slide_o_mix)])
 * JDK8 baseline upgrade news
 (link:/blog/authors/batmat[Unknown User (batmat)])

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -56,9 +56,6 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-11-22-1
 [[GovernanceMeetingArchive2017-November8thmeeting]]
 == November 8th meeting
 
-[.aui-icon .aui-icon-small .aui-iconfont-error .confluence-information-macro-icon]#
-#
-
 Note that the meeting time is in UTC, due to daylight savings time the
 start time for you may have changed recently.
 
@@ -175,11 +172,9 @@ WHEN August 16th 18:00 UTC
 "Stage Release" states to JIRA#
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
-** JIRA ticket: [.jira-issue .conf-macro .output-block]#
-https://issues.jenkins.io/browse/INFRA-1301[[.aui-icon .aui-icon-wait .issue-placeholder]##
-##INFRA-1301] - [.summary]#Getting issue details...#
-[.aui-lozenge .aui-lozenge-subtle .aui-lozenge-default .issue-placeholder]#STATUS#
-#
+** JIRA ticket:
+https://issues.jenkins.io/browse/INFRA-1301[INFRA-1301]
+
 ** https://groups.google.com/forum/#%21topic/jenkinsci-dev/wzc4VLplHvs[https://groups.google.com/forum/#!topic/jenkinsci-dev/wzc4VLplHvs]
 ** Proposal Text with
 Edits: https://docs.google.com/document/d/1EIRuCMOjmPgpxybkWRPHfx1f1yglcuYlqPWN8K1Ni28/edit?usp=sharing

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -206,7 +206,7 @@ Tong])
 User (rtyler)])
 * https://groups.google.com/d/msg/jenkinsci-dev/PoxnVCKa9NM/2F2iLlDuBwAJ[Jenkins
 mark usage request from CloudBees]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)] but
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)] but
  link:/blog/authors/rtyler/[Unknown User (rtyler)] will
 proxy)
 * Deprecate Remoting CLI1/JNLP1/JNLP2/JNLP3 protocol - sign-off

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -40,10 +40,10 @@ WHEN: November 22nd 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)])
 * Planned release schedule for holiday season (topic for discussion
-proposed by https://wiki.jenkins.io/display/~andresrc[Unknown User
+proposed by https://wiki.jenkins.io/display/~andresrc[
 (andresrc)])
 
  
@@ -66,13 +66,13 @@ WHEN November 8th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)])
 * LTS baseline selection
 * Jenkins Enhancement Proposals
 (https://github.com/jenkinsci/jep/tree/jep-1/jep/1[JEP-1])
-( link:/blog/authors/rtyler/[Unknown User
-(rtyler)] and link:/blog/authors/lnewman[Unknown User
+( link:/blog/authors/rtyler/[
+(rtyler)] and link:/blog/authors/lnewman[
 (bitwiseman)] )
 
  
@@ -91,7 +91,7 @@ WHEN October 25th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)])
 * Q4 patron messages (Daniel) +
 
@@ -112,7 +112,7 @@ WHEN October 11th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)])
 
 MINUTES
@@ -127,7 +127,7 @@ WHEN September 27th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)])
 * Huayou Tech request for mark usage for events "Jenkins User Conference
 China" (Forest Jing)
@@ -144,7 +144,7 @@ WHEN September 13th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)])
 * CloudBees request for mark usage for events  “Jenkins Days by
 CloudBees” (https://github.com/alyssat[Alyssa Tong])
@@ -167,13 +167,13 @@ WHEN August 16th 18:00 UTC
 
 * Recap last meeting's actions
 * [line-through]*LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] will not make it to the meeting)*
 * next LTS baseline selection
-(link:/blog/authors/jglick[Unknown User (jglick)])
+(link:/blog/authors/jglick[ (jglick)])
 * Vote on proposal:[.F0XO1GC-mb-Y]# Add optional "Released as" and
 "Stage Release" states to JIRA#
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** JIRA ticket: [.jira-issue .conf-macro .output-block]#
 https://issues.jenkins.io/browse/INFRA-1301[[.aui-icon .aui-icon-wait .issue-placeholder]##
@@ -198,20 +198,19 @@ WHEN August 2nd 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] )
 * Jenkins World organization update (https://github.com/alyssat[Alyssa
 Tong])
-* Infra status update (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
+* Infra status update (link:/blog/authors/rtyler/[ (rtyler)])
 * https://groups.google.com/d/msg/jenkinsci-dev/PoxnVCKa9NM/2F2iLlDuBwAJ[Jenkins
 mark usage request from CloudBees]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)] but
- link:/blog/authors/rtyler/[Unknown User (rtyler)] will
+(link:/blog/authors/kohsuke/[ (kohsuke)] but
+ link:/blog/authors/rtyler/[ (rtyler)] will
 proxy)
 * Deprecate Remoting CLI1/JNLP1/JNLP2/JNLP3 protocol - sign-off
 https://issues.jenkins.io/browse/JENKINS-45841[JENKINS-45841]
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)]) +
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/sN2wHHFOJPg[Discussion
 in the Mailing List] (see compatibility notes and the rollout plan)
@@ -233,7 +232,7 @@ WHEN July 19th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] )
 * https://github.com/docker-library/docs/pull/948[Deprecate] "jenkins"
 official docker image (that we don't control) and "jenkinsci/*" and
@@ -256,7 +255,7 @@ WHEN July 5th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] )
 
  
@@ -273,7 +272,7 @@ WHEN June 21st 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] )
 
  
@@ -290,7 +289,7 @@ WHEN June 7th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] )
 
  
@@ -307,14 +306,14 @@ WHEN May 24th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( link:/blog/authors/olivergondza[Unknown User
+( link:/blog/authors/olivergondza[
 (olivergondza)] )
 ** Next LTS baseline selection ([~olivergondza])
 * Purchasing a SendGrid account to send project emails from Azure-based
-applications - link:/blog/authors/rtyler/[Unknown User
-(rtyler)], link:/blog/authors/olblak[Unknown User
+applications - link:/blog/authors/rtyler/[
+(rtyler)], link:/blog/authors/olblak[
 (olblak)]
-* Adding link:/blog/authors/olblak[Unknown User
+* Adding link:/blog/authors/olblak[
 (olblak)] as an admin in LDAP and provide access to jenkins-keys
 (provides puppet dashboard, account admin access, ability to encrypt
 secrets, etc)
@@ -333,11 +332,11 @@ WHEN: May 10th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Infrastructure update (JIRA, Confluence, accounts, etc) (
-link:/blog/authors/rtyler/[Unknown User (rtyler)],
-link:/blog/authors/olblak[Unknown User (olblak)])
+link:/blog/authors/rtyler/[ (rtyler)],
+link:/blog/authors/olblak[ (olblak)])
 
  
 
@@ -353,7 +352,7 @@ WHEN: April 12th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Jenkins Ambassador program heads up (https://github.com/alyssat[Alyssa
 Tong])
@@ -374,10 +373,9 @@ WHEN: April 12th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
-* Google Groups issues (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
+* Google Groups issues (link:/blog/authors/rtyler/[ (rtyler)])
 
  
 
@@ -393,12 +391,12 @@ WHEN: March 29 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Sublicense request, on behalf of JFrog, "Jenkins Community Day" event
 in Paris (Alyssa Tong)
 * Java 8 baseline bump heads up
-(link:/blog/authors/batmat[Unknown User (batmat)])
+(link:/blog/authors/batmat[ (batmat)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-29-18.02.html[summary]
@@ -412,7 +410,7 @@ WHEN: March 15 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * The "Day of Jenkins" events (in
 http://www.code-conf.com/doj/doj-gbg/[GOT] and
@@ -433,14 +431,14 @@ WHEN: March 1 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 * Pick new LTS line
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
 ** https://jenkins.io/changelog/
 * The future of the patron program
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 ** It doesn't make sense in its current form with the wiki slowly
 getting replaced
 ** Do we want to just end it (for now), or implement e.g. on the site,
@@ -448,7 +446,7 @@ on JIRA, …?
 * Obtain clearance on trademark usage "CloudBees Jenkins X" (Alyssa
 Tong)
 * GSoC 2017 update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -463,16 +461,14 @@ WHEN: Feb 15 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)])
-* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)])
-* Infrastructure update (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
+* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
+* Infrastructure update (link:/blog/authors/rtyler/[ (rtyler)])
 * Should we host plugins with closed-source dependencies?
-(link:/blog/authors/batmat[Unknown User (batmat)],
-link:/blog/authors/orrc[Unknown User (orrc)])
-** link:/blog/authors/batmat[Unknown User (batmat)]
+(link:/blog/authors/batmat[ (batmat)],
+link:/blog/authors/orrc[ (orrc)])
+** link:/blog/authors/batmat[ (batmat)]
 brought up the point after
 https://issues.jenkins.io/browse/HOSTING-271[HOSTING-271]
 ** Closed-source plugins are explicitly banned in the
@@ -501,14 +497,13 @@ WHEN: Feb 01 18:00 UTC
 update]
 ** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
 draf]
-* Infrastructure update (link:/blog/authors/rtyler/[Unknown
-User (rtyler)])
+* Infrastructure update (link:/blog/authors/rtyler/[ (rtyler)])
 * https://groups.google.com/forum/#!topic/jenkinsci-dev/1jZmjgSDcqM[Trademark
 usage approval] for upcoming "CloudBees Jenkins" product names
-(link:/blog/authors/rtyler/[Unknown User (rtyler)])
+(link:/blog/authors/rtyler/[ (rtyler)])
 * Request for 50 private repos in the jenkinsci-cert GitHub org (1200
 USD/year, up from 20 repos for 600 USD/year)
-(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[ (danielbeck)])
 
 Part 1:
 
@@ -538,10 +533,10 @@ update]
 ** https://docs.google.com/document/d/13mkt5DBjVAnr7dSiJ0oO4R5-nn80kGQ5OFhBoUzInIU/edit#heading=h.w10hxu7oxi77[Application
 draf]
 * Bug Triage Team Idea
-(link:/blog/authors/slide_o_mix[Unknown User
+(link:/blog/authors/slide_o_mix[
 (slide_o_mix)])
 * JDK8 baseline upgrade news
-(link:/blog/authors/batmat[Unknown User (batmat)])
+(link:/blog/authors/batmat[ (batmat)])
 ** Jenkins https://github.com/jenkinsci/jenkins/pull/2698[core now
 builds on Windows] and is green \o/ (err, blue)
 ** https://github.com/jenkins-infra/jenkins.io/pull/545[PR] for the

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -40,7 +40,7 @@ WHEN: November 22nd 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Planned release schedule for holiday season (topic for discussion
 proposed by https://wiki.jenkins.io/display/~andresrc[Unknown User
@@ -66,7 +66,7 @@ WHEN November 8th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * LTS baseline selection
 * Jenkins Enhancement Proposals
@@ -91,7 +91,7 @@ WHEN October 25th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Q4 patron messages (Daniel) +
 
@@ -112,7 +112,7 @@ WHEN October 11th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 
 MINUTES
@@ -127,7 +127,7 @@ WHEN September 27th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Huayou Tech request for mark usage for events "Jenkins User Conference
 China" (Forest Jing)
@@ -144,7 +144,7 @@ WHEN September 13th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * CloudBees request for mark usage for events  “Jenkins Days by
 CloudBees” (https://github.com/alyssat[Alyssa Tong])
@@ -167,10 +167,10 @@ WHEN August 16th 18:00 UTC
 
 * Recap last meeting's actions
 * [line-through]*LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] will not make it to the meeting)*
 * next LTS baseline selection
-(https://wiki.jenkins.io/display/~jglick[Unknown User (jglick)])
+(link:/blog/authors/jglick[Unknown User (jglick)])
 * Vote on proposal:[.F0XO1GC-mb-Y]# Add optional "Released as" and
 "Stage Release" states to JIRA#
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -198,7 +198,7 @@ WHEN August 2nd 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] )
 * Jenkins World organization update (https://github.com/alyssat[Alyssa
 Tong])
@@ -233,7 +233,7 @@ WHEN July 19th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] )
 * https://github.com/docker-library/docs/pull/948[Deprecate] "jenkins"
 official docker image (that we don't control) and "jenkinsci/*" and
@@ -256,7 +256,7 @@ WHEN July 5th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] )
 
  
@@ -273,7 +273,7 @@ WHEN June 21st 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] )
 
  
@@ -290,7 +290,7 @@ WHEN June 7th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] )
 
  
@@ -307,14 +307,14 @@ WHEN May 24th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-( https://wiki.jenkins.io/display/~olivergondza[Unknown User
+( link:/blog/authors/olivergondza[Unknown User
 (olivergondza)] )
 ** Next LTS baseline selection ([~olivergondza])
 * Purchasing a SendGrid account to send project emails from Azure-based
 applications - link:/blog/authors/rtyler/[Unknown User
-(rtyler)], https://wiki.jenkins.io/display/~olblak[Unknown User
+(rtyler)], link:/blog/authors/olblak[Unknown User
 (olblak)]
-* Adding https://wiki.jenkins.io/display/~olblak[Unknown User
+* Adding link:/blog/authors/olblak[Unknown User
 (olblak)] as an admin in LDAP and provide access to jenkins-keys
 (provides puppet dashboard, account admin access, ability to encrypt
 secrets, etc)
@@ -333,11 +333,11 @@ WHEN: May 10th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Infrastructure update (JIRA, Confluence, accounts, etc) (
 link:/blog/authors/rtyler/[Unknown User (rtyler)],
-https://wiki.jenkins.io/display/~olblak[Unknown User (olblak)])
+link:/blog/authors/olblak[Unknown User (olblak)])
 
  
 
@@ -353,7 +353,7 @@ WHEN: April 12th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Jenkins Ambassador program heads up (https://github.com/alyssat[Alyssa
 Tong])
@@ -374,7 +374,7 @@ WHEN: April 12th 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Google Groups issues (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
@@ -393,12 +393,12 @@ WHEN: March 29 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Sublicense request, on behalf of JFrog, "Jenkins Community Day" event
 in Paris (Alyssa Tong)
 * Java 8 baseline bump heads up
-(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)])
+(link:/blog/authors/batmat[Unknown User (batmat)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2017/jenkins-meeting.2017-03-29-18.02.html[summary]
@@ -412,7 +412,7 @@ WHEN: March 15 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * The "Day of Jenkins" events (in
 http://www.code-conf.com/doj/doj-gbg/[GOT] and
@@ -433,10 +433,10 @@ WHEN: March 1 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * Pick new LTS line
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 ** https://jenkins.io/changelog/
 * The future of the patron program
@@ -463,16 +463,16 @@ WHEN: Feb 15 18:00 UTC
 
 * Recap last meeting's actions
 * LTS Status check
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)])
 * GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 * Infrastructure update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])
 * Should we host plugins with closed-source dependencies?
-(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)],
-https://wiki.jenkins.io/display/~orrc[Unknown User (orrc)])
-** https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)]
+(link:/blog/authors/batmat[Unknown User (batmat)],
+link:/blog/authors/orrc[Unknown User (orrc)])
+** link:/blog/authors/batmat[Unknown User (batmat)]
 brought up the point after
 https://issues.jenkins.io/browse/HOSTING-271[HOSTING-271]
 ** Closed-source plugins are explicitly banned in the
@@ -541,7 +541,7 @@ draf]
 (https://wiki.jenkins.io/display/~slide_o_mix[Unknown User
 (slide_o_mix)])
 * JDK8 baseline upgrade news
-(https://wiki.jenkins.io/display/~batmat[Unknown User (batmat)])
+(link:/blog/authors/batmat[Unknown User (batmat)])
 ** Jenkins https://github.com/jenkinsci/jenkins/pull/2698[core now
 builds on Windows] and is green \o/ (err, blue)
 ** https://github.com/jenkins-infra/jenkins.io/pull/545[PR] for the

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -72,7 +72,7 @@ WHEN November 8th 18:00 UTC
 * Jenkins Enhancement Proposals
 (https://github.com/jenkinsci/jep/tree/jep-1/jep/1[JEP-1])
 ( link:/blog/authors/rtyler/[Unknown User
-(rtyler)] and https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(rtyler)] and link:/blog/authors/lnewman[Unknown User
 (bitwiseman)] )
 
  

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -440,7 +440,7 @@ WHEN: March 1 18:00 UTC
 (olivergondza)])
 ** https://jenkins.io/changelog/
 * The future of the patron program
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 ** It doesn't make sense in its current form with the wiki slowly
 getting replaced
 ** Do we want to just end it (for now), or implement e.g. on the site,
@@ -508,7 +508,7 @@ usage approval] for upcoming "CloudBees Jenkins" product names
 (link:/blog/authors/rtyler/[Unknown User (rtyler)])
 * Request for 50 private repos in the jenkinsci-cert GitHub org (1200
 USD/year, up from 20 repos for 600 USD/year)
-(https://wiki.jenkins.io/display/~danielbeck[Unknown User (danielbeck)])
+(link:/blog/authors/daniel-beck/[Unknown User (danielbeck)])
 
 Part 1:
 

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -43,8 +43,7 @@ WHEN: November 22nd 18:00 UTC
 ( link:/blog/authors/olivergondza[
 (olivergondza)])
 * Planned release schedule for holiday season (topic for discussion
-proposed by https://wiki.jenkins.io/display/~andresrc[
-(andresrc)])
+proposed by (andresrc)
 
  
 

--- a/content/project/governance-meeting/archives/2017.adoc
+++ b/content/project/governance-meeting/archives/2017.adoc
@@ -173,7 +173,7 @@ WHEN August 16th 18:00 UTC
 (https://wiki.jenkins.io/display/~jglick[Unknown User (jglick)])
 * Vote on proposal:[.F0XO1GC-mb-Y]# Add optional "Released as" and
 "Stage Release" states to JIRA#
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** JIRA ticket: [.jira-issue .conf-macro .output-block]#
 https://issues.jenkins.io/browse/INFRA-1301[[.aui-icon .aui-icon-wait .issue-placeholder]##
@@ -211,7 +211,7 @@ mark usage request from CloudBees]
 proxy)
 * Deprecate Remoting CLI1/JNLP1/JNLP2/JNLP3 protocol - sign-off
 https://issues.jenkins.io/browse/JENKINS-45841[JENKINS-45841]
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)]) +
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/sN2wHHFOJPg[Discussion
 in the Mailing List] (see compatibility notes and the rollout plan)
@@ -448,7 +448,7 @@ on JIRA, …?
 * Obtain clearance on trademark usage "CloudBees Jenkins X" (Alyssa
 Tong)
 * GSoC 2017 update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -465,7 +465,7 @@ WHEN: Feb 15 18:00 UTC
 * LTS Status check
 (https://wiki.jenkins.io/display/~olivergondza[Unknown User
 (olivergondza)])
-* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 * Infrastructure update (link:/blog/authors/rtyler/[Unknown
 User (rtyler)])

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -47,7 +47,7 @@ WHEN December 5, 18:00 UTC
 sublicensing request
 "]https://groups.google.com/d/msg/jenkinsci-dev/5uFXdnr6-k0/tHjewODYBgAJ[CloudBees
 Jenkins X
-Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (https://wiki.jenkins.io/display/~tmiranda[Unknown
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
 * Java 11 preview availability - status update
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -73,7 +73,7 @@ User (oleg_nenashev)])
 * Platform SIG update
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
-*  Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+*  Outreachy update (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
 
 
@@ -95,7 +95,7 @@ WHEN November 7, 18:00 UTC
 request(https://wiki.jenkins.io/display/~surenpi[Unknown User
 (surenpi)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/UveOvVO-gwQhttps://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion[/discussion]
-*  Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+*  Outreachy update (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
 
 
@@ -113,7 +113,7 @@ WHEN: October 10, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Participating in
-Outreachy (https://wiki.jenkins.io/display/~tmiranda[Unknown User
+Outreachy (link:/blog/authors/tracymiranda[Unknown User
 (tmiranda)])
 ** https://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion
 * Trademark sublicensing request
@@ -201,7 +201,7 @@ WHEN: August 1st, 18:00 UTC
 * LTS status check
 * GSoC status check
 * Travel grant request to DevOps World - Jenkins World SF
-(https://wiki.jenkins.io/display/~mandyhubbard[Unknown User
+(link:/blog/authors/devmandy[Unknown User
 (mandyhubbard)])
 ** https://docs.google.com/document/d/1xbK9hbEMzg2oXNdxPDA6K-u3IWzbyVs2atqmzHu6VDE/edit?usp=sharing
 
@@ -225,7 +225,7 @@ WHEN: July 18th, 18:00 UTC
 (olivergondza)]) +
 ** https://groups.google.com/d/topic/jenkinsci-dev/6f_wKvfpESk/discussion
 * Growing community via a stronger Twitter presence
-(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)]) +
+(link:/blog/authors/tracymiranda[Unknown User (tmiranda)]) +
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/gqR_ee5grtM +
 * Jenkins Ambassader
 applicants (link:/blog/authors/lnewman[Unknown User
@@ -294,7 +294,7 @@ WHEN: June 6th, 18:00 UTC
 sublicensing request
 "]https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/jenkinsci-dev/dvnua3N32C0[CloudBees
 Jenkins
-Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (https://wiki.jenkins.io/display/~tmiranda[Unknown
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
 * https://github.com/jenkinsci/jep/edit/master/jep/5/README.adoc[Jenkins
 Ambassador program update]

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -88,8 +88,7 @@ WHEN November 7, 18:00 UTC
 * LTS status check
 * LTS next baseline selection
 * Trademark sublicensing
-request(https://wiki.jenkins.io/display/~surenpi[
-(surenpi)])
+request (surenpi)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/UveOvVO-gwQhttps://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion[/discussion]
 *  Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 
@@ -261,8 +260,7 @@ WHEN: June 20th, 18:00 UTC
 * https://groups.google.com/forum/#!topic/jenkinsci-dev/bmd6ooZZ7wI[Trademark
 Sublicensing Request]:
 https://www.code-conf.com/2018/day-of-jenkins-as-code/[Day of
-Jenkins [as code]] (https://wiki.jenkins.io/display/~ewel[
-(ewel)] & Jasmine Crozier)
+Jenkins [as code]](ewel) & Jasmine Crozier)
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
@@ -356,7 +354,7 @@ WHEN: April 25th, 18:00 UTC
 * LTS status check
 * JEP-200 status update (link:/blog/authors/jglick[(jglick)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/AUdrTLmezgU
-* GSoC status update (https://wiki.jenkins.io/display/~deepchip[(deepchip)])
+* GSoC status update (deepchip)
 ** Announcement:
 https://groups.google.com/forum/#!topic/jenkinsci-dev/92wY9hBW1Vo
 

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -165,7 +165,7 @@ WHEN August 29, 18:00 UTC
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Jenkins Ambassador applicants: Request to approve 2 new applicants
-(https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+(link:/blog/authors/atong[Unknown User (atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
 
 MINUTES
@@ -221,7 +221,7 @@ WHEN: July 18th, 18:00 UTC
 ** http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-20-18.10.html
 * LTS status check
 * Vote for mass adding Jenkinsfiles
-(https://wiki.jenkins.io/display/~olivergondza[Unknown User
+(link:/blog/authors/olivergondza[Unknown User
 (olivergondza)]) +
 ** https://groups.google.com/d/topic/jenkinsci-dev/6f_wKvfpESk/discussion
 * Growing community via a stronger Twitter presence
@@ -229,7 +229,7 @@ WHEN: July 18th, 18:00 UTC
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/gqR_ee5grtM +
 * Jenkins Ambassader
 applicants (https://wiki.jenkins.io/display/~bitwiseman[Unknown User
-(bitwiseman)] & https://wiki.jenkins.io/display/~atong[Unknown User
+(bitwiseman)] & link:/blog/authors/atong[Unknown User
 (atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
 * GSoC status update and travel grants budget request
@@ -299,7 +299,7 @@ User (tmiranda)])
 * https://github.com/jenkinsci/jep/edit/master/jep/5/README.adoc[Jenkins
 Ambassador program update]
 (https://wiki.jenkins.io/display/~bitwiseman[Unknown User (bitwiseman)]
-& https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
+& link:/blog/authors/atong[Unknown User (atong)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/12D2tWxO6mM
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[Unknown User
@@ -360,7 +360,7 @@ WHEN: April 25th, 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* JEP-200 status update (https://wiki.jenkins.io/display/~jglick[Unknown
+* JEP-200 status update (link:/blog/authors/jglick[Unknown
 User (jglick)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/AUdrTLmezgU
 * GSoC status update (https://wiki.jenkins.io/display/~deepchip[Unknown

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -16,11 +16,10 @@ WHEN December 19, 18:00 UTC
 * LTS status check
 * https://groups.google.com/d/msg/jenkinsci-dev/MGZDWfhFaZI/Q6HdjOcHCQAJ[Trademark
 sublicensing request "CloudBees Jenkins X
-Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((link:/blog/authors/lnewman[Unknown
-User (bitwiseman)] )
+Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((link:/blog/authors/lnewman[ (bitwiseman)] )
 * https://groups.google.com/d/msg/jenkinsci-dev/jv8oFl9PMM4/HvGw7ksICQAJ[Trademark
 sublicensing requests]
-(link:/blog/authors/lnewman[Unknown User
+(link:/blog/authors/lnewman[
 (bitwiseman)] ) +
 ** Jenkins CI/CD Workshop by CloudBees
 ** Jenkins Jumpstart by CloudBees +
@@ -47,13 +46,12 @@ WHEN December 5, 18:00 UTC
 sublicensing request
 "]https://groups.google.com/d/msg/jenkinsci-dev/5uFXdnr6-k0/tHjewODYBgAJ[CloudBees
 Jenkins X
-Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[ (tmiranda)])
 * Java 11 preview availability - status update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 * GSoC status Update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -68,13 +66,11 @@ WHEN November 21, 18:00 UTC
 
 * Recap last meeting actions
 * LTS status check
-* GSoC Update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)])
+* GSoC Update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
 * Platform SIG update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
-*  Outreachy update (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
+*  Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
 
 
 
@@ -92,11 +88,10 @@ WHEN November 7, 18:00 UTC
 * LTS status check
 * LTS next baseline selection
 * Trademark sublicensing
-request(https://wiki.jenkins.io/display/~surenpi[Unknown User
+request(https://wiki.jenkins.io/display/~surenpi[
 (surenpi)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/UveOvVO-gwQhttps://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion[/discussion]
-*  Outreachy update (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
+*  Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
 
 
 
@@ -113,11 +108,11 @@ WHEN: October 10, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Participating in
-Outreachy (link:/blog/authors/tracymiranda[Unknown User
+Outreachy (link:/blog/authors/tracymiranda[
 (tmiranda)])
 ** https://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion
 * Trademark sublicensing request
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)] )
+(link:/blog/authors/kohsuke/[ (kohsuke)] )
 ** https://groups.google.com/d/topic/jenkinsci-dev/VysVavIJCnc/discussion
 
 
@@ -156,16 +151,16 @@ WHEN August 29, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * GSoC Summer of Code: Results
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Cloud Native SIG update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Platform SIG update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Jenkins Ambassador applicants: Request to approve 2 new applicants
-(link:/blog/authors/atong[Unknown User (atong)])
+(link:/blog/authors/atong[ (atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
 
 MINUTES
@@ -201,7 +196,7 @@ WHEN: August 1st, 18:00 UTC
 * LTS status check
 * GSoC status check
 * Travel grant request to DevOps World - Jenkins World SF
-(link:/blog/authors/devmandy[Unknown User
+(link:/blog/authors/devmandy[
 (mandyhubbard)])
 ** https://docs.google.com/document/d/1xbK9hbEMzg2oXNdxPDA6K-u3IWzbyVs2atqmzHu6VDE/edit?usp=sharing
 
@@ -221,19 +216,19 @@ WHEN: July 18th, 18:00 UTC
 ** http://meetings.jenkins-ci.org/jenkins-meeting/2018/jenkins-meeting.2018-06-20-18.10.html
 * LTS status check
 * Vote for mass adding Jenkinsfiles
-(link:/blog/authors/olivergondza[Unknown User
+(link:/blog/authors/olivergondza[
 (olivergondza)]) +
 ** https://groups.google.com/d/topic/jenkinsci-dev/6f_wKvfpESk/discussion
 * Growing community via a stronger Twitter presence
-(link:/blog/authors/tracymiranda[Unknown User (tmiranda)]) +
+(link:/blog/authors/tracymiranda[ (tmiranda)]) +
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/gqR_ee5grtM +
 * Jenkins Ambassader
-applicants (link:/blog/authors/lnewman[Unknown User
-(bitwiseman)] & link:/blog/authors/atong[Unknown User
+applicants (link:/blog/authors/lnewman[
+(bitwiseman)] & link:/blog/authors/atong[
 (atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
 * GSoC status update and travel grants budget request
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/zS1jzYRoF08
 
@@ -266,13 +261,13 @@ WHEN: June 20th, 18:00 UTC
 * https://groups.google.com/forum/#!topic/jenkinsci-dev/bmd6ooZZ7wI[Trademark
 Sublicensing Request]:
 https://www.code-conf.com/2018/day-of-jenkins-as-code/[Day of
-Jenkins [as code]] (https://wiki.jenkins.io/display/~ewel[Unknown User
+Jenkins [as code]] (https://wiki.jenkins.io/display/~ewel[
 (ewel)] & Jasmine Crozier)
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Update: Jenkins & Java 10 Online
-Hackathon (link:/blog/authors/oleg_nenashev/[Unknown User
+Hackathon (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)]) +
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I
 
@@ -294,18 +289,17 @@ WHEN: June 6th, 18:00 UTC
 sublicensing request
 "]https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/jenkinsci-dev/dvnua3N32C0[CloudBees
 Jenkins
-Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[ (tmiranda)])
 * https://github.com/jenkinsci/jep/edit/master/jep/5/README.adoc[Jenkins
 Ambassador program update]
-(link:/blog/authors/lnewman[Unknown User (bitwiseman)]
-& link:/blog/authors/atong[Unknown User (atong)])
+(link:/blog/authors/lnewman[ (bitwiseman)]
+& link:/blog/authors/atong[ (atong)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/12D2tWxO6mM
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Update: Jenkins & Java 10 Online
-Hackathon (link:/blog/authors/oleg_nenashev/[Unknown User
+Hackathon (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I
 
@@ -343,7 +337,7 @@ WHEN: May 9th, 18:00 UTC
 * LTS status check
 * LTS next baseline selection
 * GSoC status check
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -360,11 +354,9 @@ WHEN: April 25th, 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* JEP-200 status update (link:/blog/authors/jglick[Unknown
-User (jglick)])
+* JEP-200 status update (link:/blog/authors/jglick[ (jglick)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/AUdrTLmezgU
-* GSoC status update (https://wiki.jenkins.io/display/~deepchip[Unknown
-User (deepchip)])
+* GSoC status update (https://wiki.jenkins.io/display/~deepchip[ (deepchip)])
 ** Announcement:
 https://groups.google.com/forum/#!topic/jenkinsci-dev/92wY9hBW1Vo
 
@@ -385,7 +377,7 @@ WHEN: April 11th, 18:00 UTC
 * GSoC status check
 * https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ[Trademark
 sublicensing request "DevOps World - Jenkins
-World"] (link:/blog/authors/kohsuke/[Unknown User
+World"] (link:/blog/authors/kohsuke/[
 (kohsuke)])
 * SPI financial request for review
 
@@ -405,10 +397,8 @@ WHEN: March 28th, 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* JEP-200 update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)])
-* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)])
+* JEP-200 update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
+* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
 
 
 
@@ -428,7 +418,7 @@ WHEN: March 14th, 18:00 UTC
 * LTS status check
 * https://groups.google.com/d/msg/jenkinsci-dev/7m9bz6KkVv4/gd8qhk6cAQAJ[Trademark
 sublicensing request "CloudBees Jenkins Metrics"]
-(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[ (kohsuke)])
 
 
 
@@ -461,7 +451,7 @@ WHEN: February 14th, 18:00 UTC
 * LTS status check
 * LTS baseline selection
 * Quick GSoC update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 
 MINUTES
@@ -487,7 +477,7 @@ WHEN: January 17th 18:00 UTC
 * Recap last meeting's actions
 * LTS status check
 * JEP-200 status update / Q&A
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/EALjDtS4riU
 ** https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins
@@ -495,7 +485,7 @@ affected by fix for JEP-200]
 ** Agenda: Answer any questions, agree on the out-of-order weekly
 release if needed
 * GSoC 2018: Discussion - Do we want to kick-it off?
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!searchin/jenkinsci-dev/Gsoc%7Csort:date/jenkinsci-dev/We-14-z_YXU/NgmQbPeFCwAJ
 ** Current project

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -117,7 +117,7 @@ Outreachy (https://wiki.jenkins.io/display/~tmiranda[Unknown User
 (tmiranda)])
 ** https://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion
 * Trademark sublicensing request
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)] )
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)] )
 ** https://groups.google.com/d/topic/jenkinsci-dev/VysVavIJCnc/discussion
 
 
@@ -385,7 +385,7 @@ WHEN: April 11th, 18:00 UTC
 * GSoC status check
 * https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ[Trademark
 sublicensing request "DevOps World - Jenkins
-World"] (https://wiki.jenkins.io/display/~kohsuke[Unknown User
+World"] (link:/blog/authors/kohsuke/[Unknown User
 (kohsuke)])
 * SPI financial request for review
 
@@ -428,7 +428,7 @@ WHEN: March 14th, 18:00 UTC
 * LTS status check
 * https://groups.google.com/d/msg/jenkinsci-dev/7m9bz6KkVv4/gd8qhk6cAQAJ[Trademark
 sublicensing request "CloudBees Jenkins Metrics"]
-(https://wiki.jenkins.io/display/~kohsuke[Unknown User (kohsuke)])
+(link:/blog/authors/kohsuke/[Unknown User (kohsuke)])
 
 
 

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -16,7 +16,7 @@ WHEN December 19, 18:00 UTC
 * LTS status check
 * https://groups.google.com/d/msg/jenkinsci-dev/MGZDWfhFaZI/Q6HdjOcHCQAJ[Trademark
 sublicensing request "CloudBees Jenkins X
-Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((link:/blog/authors/lnewman[ (bitwiseman)] )
+Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((link:/blog/authors/lnewman[(bitwiseman)] )
 * https://groups.google.com/d/msg/jenkinsci-dev/jv8oFl9PMM4/HvGw7ksICQAJ[Trademark
 sublicensing requests]
 (link:/blog/authors/lnewman[
@@ -46,7 +46,7 @@ WHEN December 5, 18:00 UTC
 sublicensing request
 "]https://groups.google.com/d/msg/jenkinsci-dev/5uFXdnr6-k0/tHjewODYBgAJ[CloudBees
 Jenkins X
-Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[ (tmiranda)])
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[(tmiranda)])
 * Java 11 preview availability - status update
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
@@ -66,11 +66,11 @@ WHEN November 21, 18:00 UTC
 
 * Recap last meeting actions
 * LTS status check
-* GSoC Update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
+* GSoC Update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
 * Platform SIG update
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
-*  Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
+*  Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 
 
@@ -91,7 +91,7 @@ WHEN November 7, 18:00 UTC
 request(https://wiki.jenkins.io/display/~surenpi[
 (surenpi)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/UveOvVO-gwQhttps://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion[/discussion]
-*  Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
+*  Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 
 
@@ -112,7 +112,7 @@ Outreachy (link:/blog/authors/tracymiranda[
 (tmiranda)])
 ** https://groups.google.com/d/topic/jenkinsci-dev/WdcOrRog2IQ/discussion
 * Trademark sublicensing request
-(link:/blog/authors/kohsuke/[ (kohsuke)] )
+(link:/blog/authors/kohsuke/[(kohsuke)] )
 ** https://groups.google.com/d/topic/jenkinsci-dev/VysVavIJCnc/discussion
 
 
@@ -160,7 +160,7 @@ WHEN August 29, 18:00 UTC
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Jenkins Ambassador applicants: Request to approve 2 new applicants
-(link:/blog/authors/atong[ (atong)])
+(link:/blog/authors/atong[(atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
 
 MINUTES
@@ -220,7 +220,7 @@ WHEN: July 18th, 18:00 UTC
 (olivergondza)]) +
 ** https://groups.google.com/d/topic/jenkinsci-dev/6f_wKvfpESk/discussion
 * Growing community via a stronger Twitter presence
-(link:/blog/authors/tracymiranda[ (tmiranda)]) +
+(link:/blog/authors/tracymiranda[(tmiranda)]) +
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/gqR_ee5grtM +
 * Jenkins Ambassader
 applicants (link:/blog/authors/lnewman[
@@ -289,11 +289,11 @@ WHEN: June 6th, 18:00 UTC
 sublicensing request
 "]https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/jenkinsci-dev/dvnua3N32C0[CloudBees
 Jenkins
-Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[ (tmiranda)])
+Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (link:/blog/authors/tracymiranda[(tmiranda)])
 * https://github.com/jenkinsci/jep/edit/master/jep/5/README.adoc[Jenkins
 Ambassador program update]
-(link:/blog/authors/lnewman[ (bitwiseman)]
-& link:/blog/authors/atong[ (atong)])
+(link:/blog/authors/lnewman[(bitwiseman)]
+& link:/blog/authors/atong[(atong)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/12D2tWxO6mM
 * GSoC status check
 (link:/blog/authors/oleg_nenashev/[
@@ -354,9 +354,9 @@ WHEN: April 25th, 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* JEP-200 status update (link:/blog/authors/jglick[ (jglick)])
+* JEP-200 status update (link:/blog/authors/jglick[(jglick)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/AUdrTLmezgU
-* GSoC status update (https://wiki.jenkins.io/display/~deepchip[ (deepchip)])
+* GSoC status update (https://wiki.jenkins.io/display/~deepchip[(deepchip)])
 ** Announcement:
 https://groups.google.com/forum/#!topic/jenkinsci-dev/92wY9hBW1Vo
 
@@ -397,8 +397,8 @@ WHEN: March 28th, 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* JEP-200 update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
-* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
+* JEP-200 update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
+* GSoC update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
 
 
 
@@ -418,7 +418,7 @@ WHEN: March 14th, 18:00 UTC
 * LTS status check
 * https://groups.google.com/d/msg/jenkinsci-dev/7m9bz6KkVv4/gd8qhk6cAQAJ[Trademark
 sublicensing request "CloudBees Jenkins Metrics"]
-(link:/blog/authors/kohsuke/[ (kohsuke)])
+(link:/blog/authors/kohsuke/[(kohsuke)])
 
 
 

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -50,10 +50,10 @@ Jenkins X
 Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] (https://wiki.jenkins.io/display/~tmiranda[Unknown
 User (tmiranda)])
 * Java 11 preview availability - status update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 * GSoC status Update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -68,10 +68,10 @@ WHEN November 21, 18:00 UTC
 
 * Recap last meeting actions
 * LTS status check
-* GSoC Update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC Update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 * Platform SIG update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 *  Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
 User (tmiranda)])
@@ -156,13 +156,13 @@ WHEN August 29, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * GSoC Summer of Code: Results
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Cloud Native SIG update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Platform SIG update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Jenkins Ambassador applicants: Request to approve 2 new applicants
 (https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
@@ -233,7 +233,7 @@ applicants (https://wiki.jenkins.io/display/~bitwiseman[Unknown User
 (atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
 * GSoC status update and travel grants budget request
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/zS1jzYRoF08
 
@@ -269,10 +269,10 @@ https://www.code-conf.com/2018/day-of-jenkins-as-code/[Day of
 Jenkins [as code]] (https://wiki.jenkins.io/display/~ewel[Unknown User
 (ewel)] & Jasmine Crozier)
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Update: Jenkins & Java 10 Online
-Hackathon (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+Hackathon (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)]) +
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I
 
@@ -302,10 +302,10 @@ Ambassador program update]
 & https://wiki.jenkins.io/display/~atong[Unknown User (atong)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/12D2tWxO6mM
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Update: Jenkins & Java 10 Online
-Hackathon (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+Hackathon (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/FdCvQlscl_I
 
@@ -343,7 +343,7 @@ WHEN: May 9th, 18:00 UTC
 * LTS status check
 * LTS next baseline selection
 * GSoC status check
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -405,9 +405,9 @@ WHEN: March 28th, 18:00 UTC
 
 * Recap last meeting's actions
 * LTS status check
-* JEP-200 update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* JEP-200 update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
-* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 
 
@@ -461,7 +461,7 @@ WHEN: February 14th, 18:00 UTC
 * LTS status check
 * LTS baseline selection
 * Quick GSoC update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 
 MINUTES
@@ -487,7 +487,7 @@ WHEN: January 17th 18:00 UTC
 * Recap last meeting's actions
 * LTS status check
 * JEP-200 status update / Q&A
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/EALjDtS4riU
 ** https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200[Plugins
@@ -495,7 +495,7 @@ affected by fix for JEP-200]
 ** Agenda: Answer any questions, agree on the out-of-order weekly
 release if needed
 * GSoC 2018: Discussion - Do we want to kick-it off?
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!searchin/jenkinsci-dev/Gsoc%7Csort:date/jenkinsci-dev/We-14-z_YXU/NgmQbPeFCwAJ
 ** Current project

--- a/content/project/governance-meeting/archives/2018.adoc
+++ b/content/project/governance-meeting/archives/2018.adoc
@@ -16,11 +16,11 @@ WHEN December 19, 18:00 UTC
 * LTS status check
 * https://groups.google.com/d/msg/jenkinsci-dev/MGZDWfhFaZI/Q6HdjOcHCQAJ[Trademark
 sublicensing request "CloudBees Jenkins X
-Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((https://wiki.jenkins.io/display/~bitwiseman[Unknown
+Distribution]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["] ((link:/blog/authors/lnewman[Unknown
 User (bitwiseman)] )
 * https://groups.google.com/d/msg/jenkinsci-dev/jv8oFl9PMM4/HvGw7ksICQAJ[Trademark
 sublicensing requests]
-(https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(link:/blog/authors/lnewman[Unknown User
 (bitwiseman)] ) +
 ** Jenkins CI/CD Workshop by CloudBees
 ** Jenkins Jumpstart by CloudBees +
@@ -228,7 +228,7 @@ WHEN: July 18th, 18:00 UTC
 (https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)]) +
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/gqR_ee5grtM +
 * Jenkins Ambassader
-applicants (https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+applicants (link:/blog/authors/lnewman[Unknown User
 (bitwiseman)] & link:/blog/authors/atong[Unknown User
 (atong)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Tp0Q1QAHP2k
@@ -298,7 +298,7 @@ Support]https://groups.google.com/d/msg/jenkinsci-dev/d1rrCcY-VyM/Pu4RdH2LBwAJ["
 User (tmiranda)])
 * https://github.com/jenkinsci/jep/edit/master/jep/5/README.adoc[Jenkins
 Ambassador program update]
-(https://wiki.jenkins.io/display/~bitwiseman[Unknown User (bitwiseman)]
+(link:/blog/authors/lnewman[Unknown User (bitwiseman)]
 & link:/blog/authors/atong[Unknown User (atong)])
 ** Thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/12D2tWxO6mM
 * GSoC status check

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -109,7 +109,7 @@ thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 ** Dev List
 thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/ZyLV-FTPbcM
 * SIG status reports
-( https://wiki.jenkins.io/display/~markewaite[Unknown User
+( link:/blog/authors/markewaite[Unknown User
 (markewaite)])
 ** Process change - use e-mail or blog posts for
 https://github.com/jenkinsci/jep/tree/master/jep/4#specification[JEP-4
@@ -137,7 +137,7 @@ User (oleg_nenashev)] )
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQwQiI
-* Docs SIG update ( https://wiki.jenkins.io/display/~markewaite[Unknown
+* Docs SIG update ( link:/blog/authors/markewaite[Unknown
 User (markewaite)])
 
 [[GovernanceMeetingAgenda-May22]]
@@ -145,7 +145,7 @@ User (markewaite)])
 
 * Recap last meeting actions
 * LTS status check
-* Docs SIG update (https://wiki.jenkins.io/display/~markewaite[Unknown
+* Docs SIG update (link:/blog/authors/markewaite[Unknown
 User (markewaite)])
 
 [[GovernanceMeetingAgenda-May8]]
@@ -175,7 +175,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-1
 * LTS status check
 * Google Summer of Code update (as needed)
 * Google Season of Docs update
-(https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)]
+(link:/blog/authors/markewaite[Unknown User (markewaite)]
 )
 * Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
 User (tmiranda)])
@@ -252,7 +252,7 @@ WHEN January 16, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Platform SIG status report - Java 11 and more
-(https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)])
+(link:/blog/authors/markewaite[Unknown User (markewaite)])
 * GSoC status report
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
@@ -283,7 +283,7 @@ WHEN January 2, 18:00 UTC
 * LTS status check
 * Jenkins GSoC: 500USD budget approval for swag
 (link:/blog/authors/oleg_nenashev/[Unknown User
-(oleg_nenashev)] or https://wiki.jenkins.io/display/~lloydchang[Unknown
+(oleg_nenashev)] or link:/blog/authors/lloydchang[Unknown
 User (lloydchang)] or [.fabric]#@deepchip#)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw 
 

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -42,7 +42,7 @@ Advisor by CloudBees" instead of "CloudBees Jenkins Advisor".
 * Last meeting actions
 * LTS status check
 * Jenkins Board & Officer Elections 2019
-(link:/blog/authors/tracymiranda[ (tmiranda)])
+(link:/blog/authors/tracymiranda[(tmiranda)])
 ** Dev list
 thread: https://groups.google.com/d/msg/jenkinsci-dev/vKi9JpxTQxY/pBidPImHAQAJ
 ** Links:
@@ -84,15 +84,15 @@ the
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 * LTS status check
-* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
+* GSoC update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
 ** Part 1 demos: https://www.youtube.com/watch?v=tnoObQqGhyM
 ** Part 2 demos:  https://www.youtube.com/watch?v=HlENuZZq7zc
-* GSoC budgeting (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
+* GSoC budgeting (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
 ** Blanket approval for using GSoC budget for GSoC in 2019
 *** https://groups.google.com/forum/#!topic/jenkinsci-dev/MaFMYoo8Nxg
 *** https://github.com/jenkinsci/jep/tree/master/jep/8
 ** If not approved, Budget approvals for GSoC: Swag and Travel grants
-(link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[ (markyjackson5)] https://wiki.jenkins.io/display/~deepchip[ (deepchip)] )
+(link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[(markyjackson5)] https://wiki.jenkins.io/display/~deepchip[(deepchip)] )
 *** Earmarking swag, swag shipping budget and community/contributors
 poster
 requests: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
@@ -122,7 +122,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 
 * Recap last meeting actions
 * LTS status check
-* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
+* GSoC update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
 * Platform SIG and Java 11 support status update
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
@@ -131,14 +131,14 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQwQiI
-* Docs SIG update ( link:/blog/authors/markewaite[ (markewaite)])
+* Docs SIG update ( link:/blog/authors/markewaite[(markewaite)])
 
 [[GovernanceMeetingAgenda-May22]]
 === May 22
 
 * Recap last meeting actions
 * LTS status check
-* Docs SIG update (link:/blog/authors/markewaite[ (markewaite)])
+* Docs SIG update (link:/blog/authors/markewaite[(markewaite)])
 
 [[GovernanceMeetingAgenda-May8]]
 === May 8
@@ -146,8 +146,8 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 * Recap last meeting actions
 * LTS status check
 * LTS baseline selection
-* GSoC Update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
-* Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
+* GSoC Update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
+* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 * CDF update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
@@ -164,9 +164,9 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-1
 * LTS status check
 * Google Summer of Code update (as needed)
 * Google Season of Docs update
-(link:/blog/authors/markewaite[ (markewaite)]
+(link:/blog/authors/markewaite[(markewaite)]
 )
-* Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
+* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-18.00.html[summary]
@@ -180,7 +180,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-1
 
 * Recap last meeting actions
 * LTS status check
-* Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
+* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-10-18.00.html[summary]
@@ -215,9 +215,9 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-1
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Outreachy update & next application period
-(link:/blog/authors/tracymiranda[ (tmiranda)])
+(link:/blog/authors/tracymiranda[(tmiranda)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/yaPrguId_sY/lSs7mHaxAAAJ
-* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
+* GSoC update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
 
 Meeting bot was unavailable during the meeting, so minutes are here:
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+2019-02-13+Notes+and+Log[Governance
@@ -238,13 +238,13 @@ WHEN January 16, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Platform SIG status report - Java 11 and more
-(link:/blog/authors/markewaite[ (markewaite)])
+(link:/blog/authors/markewaite[(markewaite)])
 * GSoC status report
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Status report: Advocacy and Outreach SIG
 (link:/blog/authors/lnewman[
-(bitwiseman)] or link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
+(bitwiseman)] or link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/84vjWz_Ho1k
 * Update: Hardware&EDA and Embedded SIGs
 (link:/blog/authors/oleg_nenashev/[
@@ -252,7 +252,7 @@ WHEN January 16, 18:00 UTC
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/a69DXm6qQms
 * Request for https://github.com/LinuxSuRen[Rick] to be listed as
 Jenkins press contact for China
-(link:/blog/authors/tracymiranda[ (tmiranda)]) 
+(link:/blog/authors/tracymiranda[(tmiranda)]) 
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-16-18.00.html[summary]
@@ -268,7 +268,7 @@ WHEN January 2, 18:00 UTC
 * LTS status check
 * Jenkins GSoC: 500USD budget approval for swag
 (link:/blog/authors/oleg_nenashev/[
-(oleg_nenashev)] or link:/blog/authors/lloydchang[ (lloydchang)] or [.fabric]#@deepchip#)
+(oleg_nenashev)] or link:/blog/authors/lloydchang[(lloydchang)] or [.fabric]#@deepchip#)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw 
 
 MINUTES

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -85,32 +85,32 @@ the
 (oleg_nenashev)] )
 * LTS status check
 * GSoC update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
-** Part 1 demos: https://www.youtube.com/watch?v=tnoObQqGhyM
-** Part 2 demos:  https://www.youtube.com/watch?v=HlENuZZq7zc
+** Part 1 demos: https://www.youtube.com/watch?v=tnoObQqGhyM
+** Part 2 demos:  https://www.youtube.com/watch?v=HlENuZZq7zc
 * GSoC budgeting (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
 ** Blanket approval for using GSoC budget for GSoC in 2019
 *** https://groups.google.com/forum/#!topic/jenkinsci-dev/MaFMYoo8Nxg
 *** https://github.com/jenkinsci/jep/tree/master/jep/8
 ** If not approved, Budget approvals for GSoC: Swag and Travel grants
-(link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[(markyjackson5)] https://wiki.jenkins.io/display/~deepchip[(deepchip)] )
+(link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[(markyjackson5)] (deepchip)
 *** Earmarking swag, swag shipping budget and community/contributors
 poster
-requests: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
+requests: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 *** Dev list
-thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
+thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 * Budget approvals for the Community Bridge dry-run
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** Dev List
-thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/ZyLV-FTPbcM
+thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/ZyLV-FTPbcM
 * SIG status reports
-( link:/blog/authors/markewaite[
+( link:/blog/authors/markewaite[
 (markewaite)])
 ** Process change - use e-mail or blog posts for
 https://github.com/jenkinsci/jep/tree/master/jep/4#specification[JEP-4
 status reports]
 ** Platform SIG status
-** Docs SIG status 
+** Docs SIG status
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-18.01.html[summary]
@@ -131,7 +131,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQwQiI
-* Docs SIG update ( link:/blog/authors/markewaite[(markewaite)])
+* Docs SIG update ( link:/blog/authors/markewaite[(markewaite)])
 
 [[GovernanceMeetingAgenda-May22]]
 === May 22
@@ -147,15 +147,13 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 * LTS status check
 * LTS baseline selection
 * GSoC Update (link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] )
-* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
-* CDF update (link:/blog/authors/tracymiranda[(tmiranda)])
+* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
+* CDF update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-18.00.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-18.00.log.html[raw]
-
-
 
 [[GovernanceMeetingAgenda-April24]]
 === April 24
@@ -166,14 +164,12 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-1
 * Google Season of Docs update
 (link:/blog/authors/markewaite[(markewaite)]
 )
-* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
+* Outreachy update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-18.00.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-18.00.log.html[raw]
-
-
 
 [[GovernanceMeetingAgenda-April10]]
 === April 10
@@ -187,24 +183,17 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-10-1
 and
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-10-18.00.log.html[raw]
 
-
-
 [[GovernanceMeetingAgenda-Mar27]]
 === Mar 27
-
-
 
 * Recap last meeting actions
 * LTS status checks
 * Google Season of Docs discussion +
 
-
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-18.24.html[summary]
 and
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-18.24.log.html[raw]
-
-
 
 [[GovernanceMeetingAgenda-Feb13]]
 === Feb 13
@@ -244,15 +233,15 @@ WHEN January 16, 18:00 UTC
 (oleg_nenashev)])
 * Status report: Advocacy and Outreach SIG
 (link:/blog/authors/lnewman[
-(bitwiseman)] or link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
+(bitwiseman)] or link:/blog/authors/oleg_nenashev/[(oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/84vjWz_Ho1k
 * Update: Hardware&EDA and Embedded SIGs
 (link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/a69DXm6qQms
-* Request for https://github.com/LinuxSuRen[Rick] to be listed as
+* Request for https://github.com/LinuxSuRen[Rick] to be listed as
 Jenkins press contact for China
-(link:/blog/authors/tracymiranda[(tmiranda)]) 
+(link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-16-18.00.html[summary]
@@ -268,8 +257,8 @@ WHEN January 2, 18:00 UTC
 * LTS status check
 * Jenkins GSoC: 500USD budget approval for swag
 (link:/blog/authors/oleg_nenashev/[
-(oleg_nenashev)] or link:/blog/authors/lloydchang[(lloydchang)] or [.fabric]#@deepchip#)
-** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw 
+(oleg_nenashev)] or link:/blog/authors/lloydchang[(lloydchang)] or [.fabric]#@deepchip#)
+** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-02-18.06.html[summary]

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -15,16 +15,16 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 * Trademark usage request: Jenkins Master Class (Parker Ennis)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Cq_NQwyLD5s
 * Budget request: Hacktoberfest swag
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/k5KICbRDoz4
 * Approving Browser Support Policy update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/TV_pLEah9B4
 ** https://github.com/jenkins-infra/jenkins.io/pull/2659
 * Approving the OS X packaging deprecation
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/xc-lDVsr0bQ
 
@@ -81,20 +81,20 @@ the
 === July 31
 
 * Weekly Release delay
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 * LTS status check
-* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
 ** Part 1 demos: https://www.youtube.com/watch?v=tnoObQqGhyM
 ** Part 2 demos:  https://www.youtube.com/watch?v=HlENuZZq7zc
-* GSoC budgeting (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC budgeting (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
 ** Blanket approval for using GSoC budget for GSoC in 2019
 *** https://groups.google.com/forum/#!topic/jenkinsci-dev/MaFMYoo8Nxg
 *** https://github.com/jenkinsci/jep/tree/master/jep/8
 ** If not approved, Budget approvals for GSoC: Swag and Travel grants
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] https://wiki.jenkins.io/display/~markyjackson5[Unknown
 User (markyjackson5)] https://wiki.jenkins.io/display/~deepchip[Unknown
 User (deepchip)] )
@@ -104,7 +104,7 @@ requests: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 *** Dev list
 thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 * Budget approvals for the Community Bridge dry-run
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 ** Dev List
 thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/ZyLV-FTPbcM
@@ -127,14 +127,14 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 
 * Recap last meeting actions
 * LTS status check
-* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
 * Platform SIG and Java 11 support status update
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 ** https://github.com/jenkinsci/jep/tree/master/jep/211
 * Introducing global configurations in jenkinsci GitHub org
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQwQiI
 * Docs SIG update ( https://wiki.jenkins.io/display/~markewaite[Unknown
@@ -154,7 +154,7 @@ User (markewaite)])
 * Recap last meeting actions
 * LTS status check
 * LTS baseline selection
-* GSoC Update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC Update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
 * Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
 User (tmiranda)])
@@ -225,12 +225,12 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-1
 * Recap last meeting actions
 * LTS status check and baseline selection
 * Java 11 Support Update && GA support in the new LTS baseline
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Outreachy update & next application period
 (https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/yaPrguId_sY/lSs7mHaxAAAJ
-* GSoC update (https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
 
 Meeting bot was unavailable during the meeting, so minutes are here:
@@ -254,15 +254,15 @@ WHEN January 16, 18:00 UTC
 * Platform SIG status report - Java 11 and more
 (https://wiki.jenkins.io/display/~markewaite[Unknown User (markewaite)])
 * GSoC status report
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Status report: Advocacy and Outreach SIG
 (https://wiki.jenkins.io/display/~bitwiseman[Unknown User
-(bitwiseman)] or https://wiki.jenkins.io/display/~oleg_nenashev[Unknown
+(bitwiseman)] or link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/84vjWz_Ho1k
 * Update: Hardware&EDA and Embedded SIGs
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/a69DXm6qQms
 * Request for https://github.com/LinuxSuRen[Rick] to be listed as
@@ -282,7 +282,7 @@ WHEN January 2, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Jenkins GSoC: 500USD budget approval for swag
-(https://wiki.jenkins.io/display/~oleg_nenashev[Unknown User
+(link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)] or https://wiki.jenkins.io/display/~lloydchang[Unknown
 User (lloydchang)] or [.fabric]#@deepchip#)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw 

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -42,7 +42,7 @@ Advisor by CloudBees" instead of "CloudBees Jenkins Advisor".
 * Last meeting actions
 * LTS status check
 * Jenkins Board & Officer Elections 2019
-(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)])
+(link:/blog/authors/tracymiranda[Unknown User (tmiranda)])
 ** Dev list
 thread: https://groups.google.com/d/msg/jenkinsci-dev/vKi9JpxTQxY/pBidPImHAQAJ
 ** Links:
@@ -95,7 +95,7 @@ User (oleg_nenashev)] )
 *** https://github.com/jenkinsci/jep/tree/master/jep/8
 ** If not approved, Budget approvals for GSoC: Swag and Travel grants
 (link:/blog/authors/oleg_nenashev/[Unknown User
-(oleg_nenashev)] https://wiki.jenkins.io/display/~markyjackson5[Unknown
+(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[Unknown
 User (markyjackson5)] https://wiki.jenkins.io/display/~deepchip[Unknown
 User (deepchip)] )
 *** Earmarking swag, swag shipping budget and community/contributors
@@ -156,9 +156,9 @@ User (markewaite)])
 * LTS baseline selection
 * GSoC Update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
-* Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+* Outreachy update (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
-* CDF update (https://wiki.jenkins.io/display/~tmiranda[Unknown User
+* CDF update (link:/blog/authors/tracymiranda[Unknown User
 (tmiranda)])
 
 MINUTES
@@ -177,7 +177,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-1
 * Google Season of Docs update
 (link:/blog/authors/markewaite[Unknown User (markewaite)]
 )
-* Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+* Outreachy update (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
 
 MINUTES
@@ -192,7 +192,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-1
 
 * Recap last meeting actions
 * LTS status check
-* Outreachy update (https://wiki.jenkins.io/display/~tmiranda[Unknown
+* Outreachy update (link:/blog/authors/tracymiranda[Unknown
 User (tmiranda)])
 
 MINUTES
@@ -228,7 +228,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-1
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Outreachy update & next application period
-(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)])
+(link:/blog/authors/tracymiranda[Unknown User (tmiranda)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/yaPrguId_sY/lSs7mHaxAAAJ
 * GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)] )
@@ -267,7 +267,7 @@ User (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/a69DXm6qQms
 * Request for https://github.com/LinuxSuRen[Rick] to be listed as
 Jenkins press contact for China
-(https://wiki.jenkins.io/display/~tmiranda[Unknown User (tmiranda)]) 
+(link:/blog/authors/tracymiranda[Unknown User (tmiranda)]) 
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-16-18.00.html[summary]

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -15,16 +15,16 @@ For current information, see the link:/project/governance-meeting[Governance Mee
 * Trademark usage request: Jenkins Master Class (Parker Ennis)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/Cq_NQwyLD5s
 * Budget request: Hacktoberfest swag
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/k5KICbRDoz4
 * Approving Browser Support Policy update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/TV_pLEah9B4
 ** https://github.com/jenkins-infra/jenkins.io/pull/2659
 * Approving the OS X packaging deprecation
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/xc-lDVsr0bQ
 
@@ -42,7 +42,7 @@ Advisor by CloudBees" instead of "CloudBees Jenkins Advisor".
 * Last meeting actions
 * LTS status check
 * Jenkins Board & Officer Elections 2019
-(link:/blog/authors/tracymiranda[Unknown User (tmiranda)])
+(link:/blog/authors/tracymiranda[ (tmiranda)])
 ** Dev list
 thread: https://groups.google.com/d/msg/jenkinsci-dev/vKi9JpxTQxY/pBidPImHAQAJ
 ** Links:
@@ -81,35 +81,30 @@ the
 === July 31
 
 * Weekly Release delay
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 * LTS status check
-* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)] )
+* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
 ** Part 1 demos: https://www.youtube.com/watch?v=tnoObQqGhyM
 ** Part 2 demos:  https://www.youtube.com/watch?v=HlENuZZq7zc
-* GSoC budgeting (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)] )
+* GSoC budgeting (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
 ** Blanket approval for using GSoC budget for GSoC in 2019
 *** https://groups.google.com/forum/#!topic/jenkinsci-dev/MaFMYoo8Nxg
 *** https://github.com/jenkinsci/jep/tree/master/jep/8
 ** If not approved, Budget approvals for GSoC: Swag and Travel grants
-(link:/blog/authors/oleg_nenashev/[Unknown User
-(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[Unknown
-User (markyjackson5)] https://wiki.jenkins.io/display/~deepchip[Unknown
-User (deepchip)] )
+(link:/blog/authors/oleg_nenashev/[(oleg_nenashev)] link:/blog/authors/markyjackson-taulia[ (markyjackson5)] https://wiki.jenkins.io/display/~deepchip[ (deepchip)] )
 *** Earmarking swag, swag shipping budget and community/contributors
 poster
 requests: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 *** Dev list
 thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/4OUrH562INQ
 * Budget approvals for the Community Bridge dry-run
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** Dev List
 thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/ZyLV-FTPbcM
 * SIG status reports
-( link:/blog/authors/markewaite[Unknown User
+( link:/blog/authors/markewaite[
 (markewaite)])
 ** Process change - use e-mail or blog posts for
 https://github.com/jenkinsci/jep/tree/master/jep/4#specification[JEP-4
@@ -127,26 +122,23 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-07-31-1
 
 * Recap last meeting actions
 * LTS status check
-* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)] )
+* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
 * Platform SIG and Java 11 support status update
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** https://github.com/jenkinsci/jep/tree/master/jep/211
 * Introducing global configurations in jenkinsci GitHub org
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)] )
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/dOs8YRQwQiI
-* Docs SIG update ( link:/blog/authors/markewaite[Unknown
-User (markewaite)])
+* Docs SIG update ( link:/blog/authors/markewaite[ (markewaite)])
 
 [[GovernanceMeetingAgenda-May22]]
 === May 22
 
 * Recap last meeting actions
 * LTS status check
-* Docs SIG update (link:/blog/authors/markewaite[Unknown
-User (markewaite)])
+* Docs SIG update (link:/blog/authors/markewaite[ (markewaite)])
 
 [[GovernanceMeetingAgenda-May8]]
 === May 8
@@ -154,12 +146,9 @@ User (markewaite)])
 * Recap last meeting actions
 * LTS status check
 * LTS baseline selection
-* GSoC Update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)] )
-* Outreachy update (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
-* CDF update (link:/blog/authors/tracymiranda[Unknown User
-(tmiranda)])
+* GSoC Update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
+* Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
+* CDF update (link:/blog/authors/tracymiranda[(tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-18.00.html[summary]
@@ -175,10 +164,9 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-05-08-1
 * LTS status check
 * Google Summer of Code update (as needed)
 * Google Season of Docs update
-(link:/blog/authors/markewaite[Unknown User (markewaite)]
+(link:/blog/authors/markewaite[ (markewaite)]
 )
-* Outreachy update (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
+* Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-18.00.html[summary]
@@ -192,8 +180,7 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-24-1
 
 * Recap last meeting actions
 * LTS status check
-* Outreachy update (link:/blog/authors/tracymiranda[Unknown
-User (tmiranda)])
+* Outreachy update (link:/blog/authors/tracymiranda[ (tmiranda)])
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-04-10-18.00.html[summary]
@@ -225,13 +212,12 @@ http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-03-27-1
 * Recap last meeting actions
 * LTS status check and baseline selection
 * Java 11 Support Update && GA support in the new LTS baseline
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Outreachy update & next application period
-(link:/blog/authors/tracymiranda[Unknown User (tmiranda)])
+(link:/blog/authors/tracymiranda[ (tmiranda)])
 ** https://groups.google.com/d/msg/jenkinsci-dev/yaPrguId_sY/lSs7mHaxAAAJ
-* GSoC update (link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)] )
+* GSoC update (link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)] )
 
 Meeting bot was unavailable during the meeting, so minutes are here:
 https://wiki.jenkins.io/display/JENKINS/Governance+Meeting+2019-02-13+Notes+and+Log[Governance
@@ -252,22 +238,21 @@ WHEN January 16, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Platform SIG status report - Java 11 and more
-(link:/blog/authors/markewaite[Unknown User (markewaite)])
+(link:/blog/authors/markewaite[ (markewaite)])
 * GSoC status report
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 * Status report: Advocacy and Outreach SIG
-(link:/blog/authors/lnewman[Unknown User
-(bitwiseman)] or link:/blog/authors/oleg_nenashev/[Unknown
-User (oleg_nenashev)])
+(link:/blog/authors/lnewman[
+(bitwiseman)] or link:/blog/authors/oleg_nenashev/[ (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/84vjWz_Ho1k
 * Update: Hardware&EDA and Embedded SIGs
-(link:/blog/authors/oleg_nenashev/[Unknown User
+(link:/blog/authors/oleg_nenashev/[
 (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/a69DXm6qQms
 * Request for https://github.com/LinuxSuRen[Rick] to be listed as
 Jenkins press contact for China
-(link:/blog/authors/tracymiranda[Unknown User (tmiranda)]) 
+(link:/blog/authors/tracymiranda[ (tmiranda)]) 
 
 MINUTES
 http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-01-16-18.00.html[summary]
@@ -282,9 +267,8 @@ WHEN January 2, 18:00 UTC
 * Recap last meeting actions
 * LTS status check
 * Jenkins GSoC: 500USD budget approval for swag
-(link:/blog/authors/oleg_nenashev/[Unknown User
-(oleg_nenashev)] or link:/blog/authors/lloydchang[Unknown
-User (lloydchang)] or [.fabric]#@deepchip#)
+(link:/blog/authors/oleg_nenashev/[
+(oleg_nenashev)] or link:/blog/authors/lloydchang[ (lloydchang)] or [.fabric]#@deepchip#)
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/p_hRMKfQuJw 
 
 MINUTES

--- a/content/project/governance-meeting/archives/2019.adoc
+++ b/content/project/governance-meeting/archives/2019.adoc
@@ -257,7 +257,7 @@ WHEN January 16, 18:00 UTC
 (link:/blog/authors/oleg_nenashev/[Unknown User
 (oleg_nenashev)])
 * Status report: Advocacy and Outreach SIG
-(https://wiki.jenkins.io/display/~bitwiseman[Unknown User
+(link:/blog/authors/lnewman[Unknown User
 (bitwiseman)] or link:/blog/authors/oleg_nenashev/[Unknown
 User (oleg_nenashev)])
 ** https://groups.google.com/forum/#!topic/jenkinsci-dev/84vjWz_Ho1k


### PR DESCRIPTION
## Fix some broken wiki references

* Fix dev list URL reference
* Update link to rtyler bio
* Update link to kohsuke bio
* Update link to oleg_nenashev bio
* Update link to daniel-beck bio
* Use blog author links instead of broken wiki author links
* Use Liam Newman author page
* Update more blog authors
* Remove unhelpful 'Unknwon User' text
* Remove some confluence remnants
* Remove the easy cases of '[ (username)]'
* Remove user references to wiki
