### PR TITLE
Fix broken link to donate page

### DIFF
--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -233,7 +233,7 @@ description: >
     .content
       %h3 DONATE
       %p.p1 If you have no time but want to help, we accept money to facilitate project goals.
-      %a.btn.btn-donate.bl{ :href => "/donate"} Read More
+      %a.btn.btn-donate.bl{ :href => "/donate/"} Read More
 
 %p.channels-help
   %b


### PR DESCRIPTION
# Fix link from overview page to donate page

When I click the "DONATE" button on the [community overview page](https://www.jenkins.io/projects/), it redirects to https://wiki.jenkins-ci.org/display/JENKINS/Donation even though we haave a much better donate page at https://www.jenkins.io/donate/

