### PR TITLE
Add redirect URL for jenkinsci/jenkins#5890

### DIFF
--- a/content/redirect/permitted-agent-to-controller-file-access.adoc
+++ b/content/redirect/permitted-agent-to-controller-file-access.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://github.com/jenkinsci/jep/pull/381 # TODO Use better URL once we have it, or create a new page about this.
+---


### PR DESCRIPTION
When https://github.com/jenkinsci/jenkins/pull/5890 emits a warning, users are directed here.

On hold: To be merged once the core PR is merged.