### PR TITLE
Remove css from 2014 that makes the box for headers with IDs just HUGE

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1,22 +1,3 @@
-/* https://github.com/twbs/bootstrap/issues/1768#issuecomment-46519033 */
-h1[id]:before,
-h2[id]:before,
-h3[id]:before,
-h4[id]:before,
-h5[id]:before,
-h6[id]:before,
-dt[id]:before,
-.artifact-list li:before {
-  display: block;
-  content: " ";
-
-  /* the top header wraps when the page isn't wide enough, but most of
-     the time the height of a single row of links should be correct */
-  margin-top: -55px;
-  height: 55px;
-  visibility: hidden;
-}
-
 /* hide anchors unless they're hovered to offset the weird margin/padding
    needed for anchored links to not hide the target behind the navigation bar */
 *:hover > .anchorjs-link {


### PR DESCRIPTION
```
hervelemeur: I don't understand why the links in the docker plugin main page aren't working (like the one pointing to the plugin doc): https://plugins.jenkins.io/docker-workflow/
timja: the h2 has a position relative style on it which expands over the text copy preventing you interacting with the text
```

this lead me to finding the h1[id]:before statements that were doing
massive padding

I can't find any pages that are not rendered correctly: https://jenkins-io-halkeye.netlify.app/blog/2021/12/08/containers-as-build-agents/#using-containers-as-build-agents-for-greater-pipeline-flexibility

cc @lemeurherve @timja @MarkEWaite 