### PR TITLE
Modern fix for #4758

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1,3 +1,8 @@
+/* Make all anchors on the page slightly lower so they don't get clipped by the header */
+*[id] {
+  scroll-margin-top: 55px;
+}
+
 /* hide anchors unless they're hovered to offset the weird margin/padding
    needed for anchored links to not hide the target behind the navigation bar */
 *:hover > .anchorjs-link {


### PR DESCRIPTION
Previously removed because headers were made huge, so some other css was
conflicting. The plugins site's hover link only worked after the header,
  and was making some links hard to click, and lots of other tiny
  things.

The fix in #4758 fixed the issue, but direct linking to anchors will
  now be under the header. This css will still fix the under the header
  issue in modern browsers, without making the h1 like 200px tall.

Test: http://odin:5000/blog/2021/12/08/containers-as-build-agents/#thanks-to-our-sponsor