### PR TITLE
Update tool versions

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -115,7 +115,7 @@ node {
 
 // Declarative //
 pipeline {
-    agent docker: 'node:16.13.1-alpine'
+    agent { docker { image 'node:16.13.1-alpine' } }
     stages {
 	stage('Build') {
 	    sh 'npm install'

--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -116,7 +116,7 @@ node {
 
 // Declarative //
 pipeline {
-    agent docker: 'node:14-alpine'
+    agent docker: 'node:16.13.1-alpine'
     stages {
 	stage('Build') {
 	    sh 'npm install'

--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -108,7 +108,6 @@ Script* syntax. For example:
 // Script //
 node {
     stage('Build') {
-      checkout scm
       // Install dependencies
       sh 'npm install'
     }

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.1 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +
@@ -245,7 +245,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.1 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.1 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +
@@ -240,7 +240,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.1 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -45,7 +45,7 @@ can be used with ease by making only minor edits to a `Jenkinsfile`.
 // Declarative //
 pipeline {
     agent {
-        docker { image 'node:14-alpine' }
+        docker { image 'node:16.13.1-alpine' }
     }
     stages {
         stage('Test') {
@@ -58,7 +58,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('node:14-alpine').inside {
+    docker.image('node:16.13.1-alpine').inside {
         stage('Test') {
             sh 'node --version'
         }
@@ -197,7 +197,7 @@ pipeline {
         }
         stage('Front-end') {
             agent {
-                docker { image 'node:14-alpine' }
+                docker { image 'node:16.13.1-alpine' }
             }
             steps {
                 sh 'node --version'
@@ -216,7 +216,7 @@ node {
     }
 
     stage('Front-end') {
-        docker.image('node:14-alpine').inside {
+        docker.image('node:16.13.1-alpine').inside {
             sh 'node --version'
         }
     }
@@ -238,7 +238,7 @@ Re-using an example from above, with a more custom `Dockerfile`:
 .Dockerfile
 [source]
 ----
-FROM node:14-alpine
+FROM node:16.13.1-alpine
 
 RUN apk add -U subversion
 ----

--- a/content/doc/pipeline/tour/agents.adoc
+++ b/content/doc/pipeline/tour/agents.adoc
@@ -49,7 +49,7 @@ link:/doc/book/pipeline/syntax#agent[syntax reference].
 // Declarative //
 pipeline {
     agent {
-        docker { image 'node:14-alpine' }
+        docker { image 'node:16.13.1-alpine' }
     }
     stages {
         stage('Test') {
@@ -62,7 +62,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('node:14-alpine').inside {
+    docker.image('node:16.13.1-alpine').inside {
         stage('Test') {
             sh 'node --version'
         }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -107,7 +107,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'ruby' } }
+    agent { docker { image 'ruby:3.0.3-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -121,7 +121,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('ruby').inside {
+        docker.image('ruby:3.0.3-alpine').inside {
             sh 'ruby --version'
         }
     }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -80,7 +80,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'node:14-alpine' } }
+    agent { docker { image 'node:16.13.1-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -94,7 +94,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('node:14-alpine').inside {
+        docker.image('node:16.13.1-alpine').inside {
             sh 'npm --version'
         }
     }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -53,7 +53,7 @@ various languages.
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'maven:3.3.3' } }
+    agent { docker { image 'maven:3.8.4-openjdk-11-slim' } }
     stages {
         stage('build') {
             steps {
@@ -67,7 +67,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('maven:3.3.3').inside {
+        docker.image('maven:3.8.4-openjdk-11-slim').inside {
             sh 'mvn --version'
         }
     }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -188,7 +188,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'golang' } }
+    agent { docker { image 'golang:1.17.5-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -202,7 +202,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('golang').inside {
+        docker.image('golang:1.17.5-alpine').inside {
             sh 'go version'
         }
     }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -161,7 +161,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'php' } }
+    agent { docker { image 'php:8.1.0-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -175,7 +175,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('php').inside {
+        docker.image('php:8.1.0-alpine').inside {
             sh 'php --version'
         }
     }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -65,7 +65,6 @@ pipeline {
 // Scripted //
 /* Requires the Docker Pipeline plugin */
 node('docker') {
-    checkout scm
     stage('Build') {
         docker.image('maven:3.8.4-openjdk-11-slim').inside {
             sh 'mvn --version'
@@ -92,7 +91,6 @@ pipeline {
 // Scripted //
 /* Requires the Docker Pipeline plugin */
 node('docker') {
-    checkout scm
     stage('Build') {
         docker.image('node:16.13.1-alpine').inside {
             sh 'npm --version'
@@ -119,7 +117,6 @@ pipeline {
 // Scripted //
 /* Requires the Docker Pipeline plugin */
 node('docker') {
-    checkout scm
     stage('Build') {
         docker.image('ruby:3.0.3-alpine').inside {
             sh 'ruby --version'
@@ -146,7 +143,6 @@ pipeline {
 // Scripted //
 /* Requires the Docker Pipeline plugin */
 node('docker') {
-    checkout scm
     stage('Build') {
         docker.image('python:3.10.1-alpine').inside {
             sh 'python --version'
@@ -173,7 +169,6 @@ pipeline {
 // Scripted //
 /* Requires the Docker Pipeline plugin */
 node('docker') {
-    checkout scm
     stage('Build') {
         docker.image('php:8.1.0-alpine').inside {
             sh 'php --version'
@@ -200,7 +195,6 @@ pipeline {
 // Scripted //
 /* Requires the Docker Pipeline plugin */
 node('docker') {
-    checkout scm
     stage('Build') {
         docker.image('golang:1.17.5-alpine').inside {
             sh 'go version'

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -83,7 +83,7 @@ pipeline {
     stages {
         stage('build') {
             steps {
-                sh 'npm --version'
+                sh 'node --version'
             }
         }
     }
@@ -93,7 +93,7 @@ pipeline {
 node('docker') {
     stage('Build') {
         docker.image('node:16.13.1-alpine').inside {
-            sh 'npm --version'
+            sh 'node --version'
         }
     }
 }

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -134,7 +134,7 @@ node('docker') {
 ----
 // Declarative //
 pipeline {
-    agent { docker { image 'python:3.5.1' } }
+    agent { docker { image 'python:3.10.1-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -148,7 +148,7 @@ pipeline {
 node('docker') {
     checkout scm
     stage('Build') {
-        docker.image('python:3.5.1').inside {
+        docker.image('python:3.10.1-alpine').inside {
             sh 'python --version'
         }
     }


### PR DESCRIPTION
## Update tool versions in tutorials

Use the most recent version of Blue Ocean in the tutorial.

Use specific versions of the tools to show the good practice of exact definition of tool version.  Reduce download size by using the Alpine Linux version of tools when available.

Apache Maven is specifically configured to use JDK 11 because that is our primary supported platform.  It is configured to use Debian slim rather than Alpine because the Maven docker images do not include an Alpine image.

* Use Blue Ocean 1.25.2
* Use Apache Maven 3.8.4, not 3.3.3
* Use Ruby 3.0.3 alpine
* Use NodeJS 16.13.1 alpine
* Use Python 3.10.1 alpine
* Use PHP 8.1.0 alpine
* Use golang 1.17.5 alpine

@lemeurherve and @smerle33 this is a small but useful step towards improving the guided tour.  It doesn't fix the clarity and completeness issues but does begin the process of updating it.