### PR TITLE
Documentation on installing Jenkins with Jenkins Operator

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -55,16 +55,6 @@ NOTE: It’s worth noting that, in the above spec, hostPath uses the /data/jenki
 This approach is only suited for development and testing purposes.
 For production, you should provide a network resource like a Google Compute Engine persistent disk, or an Amazon Elastic Block Store volume.
 
-[NOTE]
-====
-Minikube configured for hostPath sets the permissions on /data to the root account only. Once the volume is created you will need to manually change the permissions to allow the jenkins account to write its data.
-[source,bash]
-----
-minikube ssh
-sudo chown -R 1000:1000 /data/jenkins-volume
-----
-====
-
 === Create a service account
 
 In Kubernetes, service accounts are used to provide an identity for pods.

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -55,6 +55,16 @@ NOTE: It’s worth noting that, in the above spec, hostPath uses the /data/jenki
 This approach is only suited for development and testing purposes.
 For production, you should provide a network resource like a Google Compute Engine persistent disk, or an Amazon Elastic Block Store volume.
 
+[NOTE]
+====
+Minikube configured for hostPath sets the permissions on /data to the root account only. Once the volume is created you will need to manually change the permissions to allow the jenkins account to write its data.
+[source,bash]
+----
+minikube ssh
+sudo chown -R 1000:1000 /data/jenkins-volume
+----
+====
+
 === Create a service account
 
 In Kubernetes, service accounts are used to provide an identity for pods.
@@ -86,7 +96,7 @@ A RoleBinding may reference any Role in the same namespace.
 Alternatively, a RoleBinding can reference a ClusterRole and bind that ClusterRole to the namespace of the RoleBinding.
 To bind a ClusterRole to all the namespaces in our cluster, we use a ClusterRoleBinding.
 
-. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-sa.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkins-sa.yaml] into a YAML formatted file called 
+. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-sa.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkins-sa.yaml] into a YAML formatted file called
 `jenkins-sa.yaml`.
 +
 . Run the following command to apply the spec:
@@ -412,189 +422,11 @@ You have successfully installed Jenkins on your Kubernetes cluster and can use i
 
 The link:https://jenkinsci.github.io/kubernetes-operator/docs/[Jenkins Operator] is a Kubernetes native Operator which manages operations
 for Jenkins on Kubernetes.
-It was built with immutability and declarative configuration as code in mind.
-The Jenkins Operator is easy to install with just a few manifest and allows
-users to configure and manage Jenkins on Kubernetes.
 
-=== Prerequisites
+It was built with immutability and declarative configuration as code in mind, to automate many of the manual tasks required
+to deploy and run Jenkins on Kubernetes.
 
-Jenkins Operator::
-If you don't have Jenkins Operator installed and configured locally,
-see the sections below to <<Install Jenkins Operator>>.
+Jenkins Operator is easy to install with applying just a few yaml manifests or with the use of Helm.
 
-=== Install Jenkins Operator
-
-Requirements::
-
-To run Jenkins Operator, you will need:
-
-. Access to a Kubernetes cluster. If you don't have a running Kubernetes cluster,
-see the link:/doc/book/installing/kubernetes/#create-a-kubernetes-cluster-with-minikube[Create a Kubernetes cluster with minikube] section above.
-
-. kubectl version 1.11+
-
-=== Configure Custom Resource Definition
-
-The Custom Resource Definition (CRD) API has been introduced to Kubernetes in v1.7
-and it enables users to add custom APIs to their Kubernetes cluster which can be
-used like any other native Kubernetes objects.
-Defining a CRD object creates a new custom resource with a name and schema that you specify. The Kubernetes API serves and handles the storage of your custom resource.
-
-Install Jenkins Custom Resource Definition::
-
-[NOTE]
-====
-Kindly note that links to sample yaml files such as the one below are subject to change based on maintenance and will be best to verify from the official documentation link:https://jenkinsci.github.io/kubernetes-operator/docs/installation/[here] before use.
-====
-
-[source,bash]
-----
-$ CRD_FILE=kubernetes-operator/master/deploy/crds/jenkins_v1alpha2_jenkins_crd.yaml
-$ kubectl apply -f https://raw.githubusercontent.com/jenkinsci/$CRD_FILE
-----
-
-=== Deploy Jenkins Operator
-There are two ways to deploy the Jenkins Operator.
-
-Using YAML’s::
-
-Apply Service Account and RBAC roles:
-
-[source,bash]
-----
-$ DEPLOY_FILE=kubernetes-operator/master/deploy/all-in-one-v1alpha2.yaml
-$ kubectl apply -f https://raw.githubusercontent.com/jenkinsci/$DEPLOY_FILE
-----
-Watch Jenkins Operator instance being created:
-
-[source,bash]
-----
-$ kubectl get pods
-----
-Now Jenkins Operator should be up and running in the default namespace.
-
-Using Helm Chart::
-
-There is an option to use Helm to install the operator.
-It requires the Helm 3+ for deployment.
-If you don't have Helm command line interface installed and configured locally,
-see the sections above to <<Install Helm>>
-
-Create a namespace for the operator::
-See the link:/doc/book/installing/kubernetes/#create-a-namespace[Create a namespace] section above.
-
-Configure Helm::
-Once Helm is installed and set up properly, add the Jenkins-Operator repo as follows:
-
-[source,bash]
-----
-$ CHART_FILE=kubernetes-operator/master/chart
-$ helm repo add jenkins https://raw.githubusercontent.com/jenkinsci/$CHART_FILE
-----
-
-Install Jenkins Operator::
-
-[source,bash]
-----
-$ helm install <name> jenkins/jenkins-operator -n jenkins
-----
-
-To add custom labels and annotations, you can use `values.yaml` file as explained in the link:/doc/book/installing/kubernetes/#install-jenkins[Install Jenkins] section above or pass them into helm install command, e.g.:
-
-[source,bash]
-----
-$ LABEL="jenkins.labels.LabelKey=LabelValue"
-$ ANNOTATION="jenkins.annotations.AnnotationKey=AnnotationValue"
-$ NAME=my-jenkins-operator-install
-$ helm install $NAME jenkins/jenkins-operator -n jenkins --set $LABEL,$ANNOTATION
-----
-
-=== Deploy Jenkins
-Once Jenkins Operator is up and running let’s deploy the actual Jenkins instance.
-Create a manifest e.g. jenkins_instance.yaml with the following data and save it locally.
-
-[source,yaml]
-----
-apiVersion: jenkins.io/v1alpha2
-kind: Jenkins
-metadata:
-  name: example
-spec:
-  master:
-    containers:
-    - name: jenkins-master
-      image: jenkins/jenkins:lts-jdk11
-      imagePullPolicy: Always
-      livenessProbe:
-        failureThreshold: 12
-        httpGet:
-          path: /login
-          port: http
-          scheme: HTTP
-        initialDelaySeconds: 80
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 5
-      readinessProbe:
-        failureThreshold: 3
-        httpGet:
-          path: /login
-          port: http
-          scheme: HTTP
-        initialDelaySeconds: 30
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 1
-      resources:
-        limits:
-          cpu: 1500m
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 500Mi
-  seedJobs:
-  - id: jenkins-operator
-    targets: "cicd/jobs/*.jenkins"
-    description: "Jenkins Operator repository"
-    repositoryBranch: master
-    repositoryUrl: https://github.com/jenkinsci/kubernetes-operator.git
-----
-
-=== Deploy Jenkins to Kubernetes:
-
-[source,bash]
-----
-$ kubectl create -f jenkins_instance.yaml -n jenkins
-----
-
-Watch the Jenkins instance being created:
-
-[source,bash]
-----
-$ kubectl get pods -n jenkins
-----
-
-Get Jenkins credentials::
-
-[source,bash]
-----
-$ SECRET_NAME=jenkins-operator-credentials-<cr_name>
-$ kubectl -n jenkins get secret $SECRET_NAME -o 'jsonpath={.data.user}' | base64 -d
-$ kubectl -n jenkins get secret $SECRET_NAME -o 'jsonpath={.data.password}' | base64 -d
-----
-
-Connect to Jenkins (minikube)::
-
-[source,bash]
-----
-$ minikube service jenkins-operator-http-<cr_name> --url -n jenkins
-----
-
-Connect to Jenkins (actual Kubernetes cluster)::
-
-[source,bash]
-----
-$ kubectl port-forward jenkins-<cr_name> 8080:8080
-----
-
-Then open a browser with the address http://localhost:8080 to view your Jenkins Dashboard.
+For instructions on installing Jenkins Operator on your Kubernetes cluster and deploying and configuring Jenkins there,
+see link:https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/[official documentation of Jenkins Operator].

--- a/content/doc/book/installing/_setup-wizard.adoc
+++ b/content/doc/book/installing/_setup-wizard.adoc
@@ -14,7 +14,7 @@ _run-jenkins-in-docker.adoc).
 == Post-installation setup wizard
 
 After downloading, installing and running Jenkins using one of the procedures
-above, the post-installation setup wizard begins.
+above (except for installation with Jenkins Operator), the post-installation setup wizard begins.
 
 This setup wizard takes you through a few quick "one-off" steps to unlock
 Jenkins, customize it with plugins and create the first administrator user


### PR DESCRIPTION
* modified /doc/book/installing/kubernetes/#install-jenkins-with-jenkins-operator - deleted instructions on installing Jenkins with Jenkins Operator and instead added link those instructions in Jenkins Operator project's docs - to avoid having to document installation process on 2 separate repos and confusing users with outdated documentation
* modified doc/book/installing/kubernetes/#setup-wizard to state that it doesn't apply to installation with Jenkins Operator