### PR TITLE
Make single discourse link

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -24,6 +24,7 @@
     %meta{:charset => "utf-8"}/
     %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}/
     %meta{:content => "ie=edge", "http-equiv" => "x-ua-compatible"}/
+    %link{:rel => "canonical", :href => absolute_link(page.output_path)}/
 
     / Favicons
     %link{:rel => "shortcut icon", :href => "/favicon.ico", :type => "image/x-icon"}/

--- a/content/_partials/discuss.html.haml
+++ b/content/_partials/discuss.html.haml
@@ -9,7 +9,7 @@
     Discuss
   %div{:id => 'discourse-comments'}
     :javascript
-        window.DiscourseEmbed = #{embedOptions.to_json}; #{"window.DiscourseEmbed.discourseEmbedUrl = [location.protocol, '//', location.host, location.pathname].join('');" if page.links.discourse == true}
+        window.DiscourseEmbed = #{embedOptions.to_json}; #{"window.DiscourseEmbed.discourseEmbedUrl = document.head.querySelector('link[rel=\"canonical\"]').href;" if page.links.discourse == true}
         (function() {
             var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
             d.src = window.DiscourseEmbed.discourseUrl + 'javascripts/embed.js';


### PR DESCRIPTION
Noticed on forums that year/month/day//post and year/month/day/post were
both created

This adds canonical link (helps with seo, and probably should always be
    jenkins/path so if we start deploying forks, it doesnt break hurt us
    in search engines. But leave it for now)
Tell disourse to use the canonical url not just the current url