### PR TITLE
Update Log4j blog post to also cover the GH issues

### DIFF
--- a/content/blog/2021/12/2021-12-10-log4j2-rce-CVE-2021-44228.adoc
+++ b/content/blog/2021/12/2021-12-10-log4j2-rce-CVE-2021-44228.adoc
@@ -38,7 +38,7 @@ Otherwise, the script output will print one location where Log4j is found, which
 That plugin should be disabled or uninstalled, followed by a Jenkins restart and another script execution until the "No such property" error appears.
 
 Affected plugins and their mitigation status are listed in the Jenkins issue tracker.
-See link:https://issues.jenkins.io/issues/?jql=labels%20%3D%20CVE-2021-44228[this Jira query] for components known to be affected.
+See link:https://issues.jenkins.io/browse/JENKINS-67353[this Jira Epic] for components known to be affected.
 
 ## Log4j in web application containers
 


### PR DESCRIPTION
Currently the Jira query just list a subset of the plugins, the ones that manage their task in Jira. But half of the affected components are using GitHub.

Using https://issues.jenkins.io/browse/JENKINS-67353 instead of https://issues.jenkins.io/issues/?jql=labels%20%3D%20CVE-2021-44228