### PR TITLE
Add overview of pages in Managing Jenkins chapter

### DIFF
--- a/content/doc/book/managing/_chapter.yml
+++ b/content/doc/book/managing/_chapter.yml
@@ -2,10 +2,12 @@
 sections:
   - system-configuration
   - casc
-  - system-properties
-  - change-system-timezone
   - tools
   - plugins
+  - about-jenkins
+  - system-info
+  - system-properties
+  - change-system-timezone
   - cli
   - script-console
   - groovy-hook-scripts

--- a/content/doc/book/managing/about-jenkins.adoc
+++ b/content/doc/book/managing/about-jenkins.adoc
@@ -1,0 +1,30 @@
+---
+layout: section
+wip: true
+---
+ifdef::backend-html5[]
+:notitle:
+:description:
+:author:
+:email: jenkinsci-docs@googlegroups.com
+:sectanchors:
+:toc:
+:hide-uri-scheme:
+endif::[]
+
+= About Jenkins
+
+The*Manage Jenkins >> About Jenkins* page shows
+the current release of Jenkins on your system
+plus information about licenses for all components.
+The top of the display shows the release and version of Jenkins that is running.
+
+The following information about your Jenkins cluster is also provided:
+
+* List of all third-party libraries used for this release of Jenkins,
+with links to licensing details about each library.
+* List of static resources that are installed.
+* List of installed plugins, each of which includes a link to the page
+that shows all third-party dependencies for each plugin
+with a link to licensing details about each library.
+

--- a/content/doc/book/managing/about-jenkins.adoc
+++ b/content/doc/book/managing/about-jenkins.adoc
@@ -1,6 +1,5 @@
 ---
 layout: section
-wip: true
 ---
 ifdef::backend-html5[]
 :notitle:

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -13,15 +13,145 @@ endif::[]
 
 = Managing Jenkins
 
-This chapter cover how to manage and configure Jenkins controllers and nodes.
+Most standard administrative tasks can be performed from the screens
+in the *Manage Jenkins* section of the dashboard.
+In this chapter, we look at these screens and explain how to use them.
 
-This chapter is intended for Jenkins administrators. More experienced users may find
-this information useful, but only to the extent that they will understand what is and is not possible
-for administrators to do.  Individual sections may assume knowledge of information
-from previous sections, but such assumptions will be explicitly called out and cross-referenced.
-
-If you are a system administrator and want learn how to back-up, restore, maintain as Jenkins servers and nodes, see
+Additional system administration topics are provided in
 <<system-administration#,Jenkins System Administration>>.
 
-For an overview of content in the Jenkins User Handbook, see
-<<getting-started#,User Handbook overview>>.
+The top of the *Manage Jenkins* screen may contain "Monitors"
+that alert you when a new version
+of the Jenkins software or a security update is available.
+Each monitor includes links to the _changelog_ that describes the new update
+as well as instructions to download and install the update.
+
+The tiles displayed on the *Manage Jenkins* page are grouped logically.
+Here we discuss the pages that are part of the standard installation.
+Some plugins may add pages to this screen.
+
+Inline help is available on most *Manage Jenkins* pages:
+
+* To access the help, select the `?` icon to the right of each field.
+* Click the `?` icon again to hide the help text.
+
+Inline help is available on most *Manage Jenkins* pages:
+
+* To access the help, select the `?` icon to the right of each field.
+* Click the `?` icon again to hide the help text.
+
+[NOTE]
+====
+The *Manage Jenkins* screens were modernized in 2020
+to provide a more attractive user interface for all users
+and a much better experience for users on narrow devices such as tablets and phones.
+The main changes made were:
+
+* Configuration screens used to use HTML `table` tags but now use HTML `div` tags.
+* Older versions presented a long list of tasks in somewhat random order
+rather than the logical groupings that are now used.
+* Some configuration fields were moved or added.
+
+For more information about these and other changes that have been implemented, see:
+
+* link:https://www.jenkins.io/changelog-stable/[LTS Changelog]
+* link:https://www.jenkins.io/blog/2020/11/10/major-changes-in-weekly-releases/[Jenkins 2.264+: Major changes in the weekly release line]
+* link:https://www.jenkins.io/doc/upgrade-guide/[Jenkins LTS Upgrade Guide]
+====
+
+== System Configuration section
+
+Screens for configuring resources for your Jenkins instance.
+
+link:system-configuration[Configure System]::
+Configure global settings and paths for the Jenkins instance
+
+link:tools.adoc[Global Tool Configuration]::
+Configure tools, their locations, and automatic installers
+
+link:plugins.adoc[Manage Plugins]::
+Add, update, remove, disable/enable plugins
+that extend the functionality of Jenkins.
+
+link:nodes.adoc[Manage Nodes and Clouds]::
+Add, remove, control, and monitor the nodes used for the agents on which build jobs run.
+
+link:casc.adoc[Configuration as Code]::
+Configure your Jenkins instance using a human-readable YAML file.
+This is an optional feature that appears here
+only when the plugin is installed on your controller.
+
+== Security section
+
+Screens for configuring security features for your Jenkins instance.
+See link:/doc/book/security/[Securing Jenkins] for general information
+about managing Jenkins security.
+
+link:system-configuration.adoc[Configure Global Security]::
+Set configuration parameters that secure your Jenkins instance.
+
+*Manage Credentials*::
+Configure the credentials that provide secure access
+to third-party sites and applications that interact with Jenkins.
+
+*Configure Credential Providers*::
+Configure credential providers and types
+
+link:users.adoc[Manage Users]::
+Manage users defined in the Jenkins user database.
+This is not used if you use a different security realm such as LDAP or AD.
+
+== Status Information section
+
+link:system-info.adoc[System Information]::
+Displays information about the Jenkins environment.
+
+*System Log*::
+Jenkins log that contains all `java.uil.logging` output related to Jenkins.
+
+*Load Statistics*::
+Displays information about resource utilization on you Jenkins instance.
+
+*Disk usage*::
+Simple disk usage estimation
+
+link:about-jenkins.adoc[About Jenkins]::
+Provides version and license information for your Jenkins instance.
+
+== Troubleshooting section
+
+*Manage Old Data*::
+Remove configuraion information related to plugins that have been removed from the instance.
+
+== Tools and Actions section
+
+Screens for common management tasks
+and management tools that enable you to do administrative tasks without using the UI.
+
+*Reload Configuration from Disk*::
+Discard all data that is loaded in memory and reload everything from the file system.
+This is useful when you modify configuration files directly on disk.
+
+link:cli-adoc[Jenkins CLI]::
+How to use the Jenkins CLI from a shell or script.
+
+*Script Console*::
+Execute an Apache Groovy script for administration, troubleshooting, and diagnostics.
+
+*Prepare for Shutdown*::
+Prevents new builds from starting so that the system can be shut down safely.
+
+== Uncategorized section
+
+Screens for monitoring the Jenkins controller and agents
+and for launching build agents as Docker containers.
+
+*Monitoring of Jenkins controller*::
+Monitors memory, cpu, http requests and more on the Jenkins controller.
+
+*Monitoring of Jenkins agents*::
+Monitors builds, the build queue, and Jenkins agents.
+
+*Docker*::
+Plugin for launching build agents as Docker containers.
+

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -17,18 +17,15 @@ Most standard administrative tasks can be performed from the screens
 in the *Manage Jenkins* section of the dashboard.
 In this chapter, we look at these screens and explain how to use them.
 
-Additional system administration topics are provided in
-<<system-administration#,Jenkins System Administration>>.
+The tiles displayed on the *Manage Jenkins* page are grouped logically.
+Here we discuss the pages that are part of the standard installation.
+Some plugins may add pages to this screen.
 
 The top of the *Manage Jenkins* screen may contain "Monitors"
 that alert you when a new version
 of the Jenkins software or a security update is available.
 Each monitor includes links to the _changelog_ that describes the new update
 as well as instructions to download and install the update.
-
-The tiles displayed on the *Manage Jenkins* page are grouped logically.
-Here we discuss the pages that are part of the standard installation.
-Some plugins may add pages to this screen.
 
 Inline help is available on most *Manage Jenkins* pages:
 
@@ -47,9 +44,10 @@ to provide a more attractive user interface for all users
 and a much better experience for users on narrow devices such as tablets and phones.
 The main changes made were:
 
-* Configuration screens used to use HTML `table` tags but now use HTML `div` tags.
-* Older versions presented a long list of tasks in somewhat random order
-rather than the logical groupings that are now used.
+* Configuration screens now use HTML `div` tags
+rather than the HTML `table` tags that were used in older releases.
+* The screens linked from this page are grouped somewhat logically,
+whereas older versions presented a long list of tasks in somewhat random order.
 * Some configuration fields were moved or added.
 
 For more information about these and other changes that have been implemented, see:
@@ -59,7 +57,10 @@ For more information about these and other changes that have been implemented, s
 * link:https://www.jenkins.io/doc/upgrade-guide/[Jenkins LTS Upgrade Guide]
 ====
 
-== System Configuration section
+Other system administration topics are discssed in
+<<system-administration#,Jenkins System Administration>>.
+
+== System Configuration group
 
 Screens for configuring resources for your Jenkins instance.
 
@@ -77,11 +78,11 @@ link:nodes.adoc[Manage Nodes and Clouds]::
 Add, remove, control, and monitor the nodes used for the agents on which build jobs run.
 
 link:casc.adoc[Configuration as Code]::
-Configure your Jenkins instance using a human-readable YAML file.
-This is an optional feature that appears here
+Configure your Jenkins instance using a human-readable YAML file rather than the UI.
+This is an optional feature that appears in this group
 only when the plugin is installed on your controller.
 
-== Security section
+== Security group
 
 Screens for configuring security features for your Jenkins instance.
 See link:/doc/book/security/[Securing Jenkins] for general information
@@ -90,7 +91,7 @@ about managing Jenkins security.
 link:system-configuration.adoc[Configure Global Security]::
 Set configuration parameters that secure your Jenkins instance.
 
-*Manage Credentials*::
+link:/doc/book/using/using-credentials/#adding-new-global-credentials[Manage Credentials]::
 Configure the credentials that provide secure access
 to third-party sites and applications that interact with Jenkins.
 
@@ -101,12 +102,12 @@ link:users.adoc[Manage Users]::
 Manage users defined in the Jenkins user database.
 This is not used if you use a different security realm such as LDAP or AD.
 
-== Status Information section
+== Status Information group
 
 link:system-info.adoc[System Information]::
 Displays information about the Jenkins environment.
 
-*System Log*::
+link:/doc/book/system-administration/viewing-logs/[System Log]::
 Jenkins log that contains all `java.uil.logging` output related to Jenkins.
 
 *Load Statistics*::
@@ -118,12 +119,12 @@ Simple disk usage estimation
 link:about-jenkins.adoc[About Jenkins]::
 Provides version and license information for your Jenkins instance.
 
-== Troubleshooting section
+== Troubleshooting group
 
 *Manage Old Data*::
 Remove configuraion information related to plugins that have been removed from the instance.
 
-== Tools and Actions section
+== Tools and Actions group
 
 Screens for common management tasks
 and management tools that enable you to do administrative tasks without using the UI.
@@ -135,13 +136,13 @@ This is useful when you modify configuration files directly on disk.
 link:cli-adoc[Jenkins CLI]::
 How to use the Jenkins CLI from a shell or script.
 
-*Script Console*::
+link:/doc/book/managing/script-console/[Script Console]::
 Execute an Apache Groovy script for administration, troubleshooting, and diagnostics.
 
 *Prepare for Shutdown*::
 Prevents new builds from starting so that the system can be shut down safely.
 
-== Uncategorized section
+== Uncategorized group
 
 Screens for monitoring the Jenkins controller and agents
 and for launching build agents as Docker containers.

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -19,18 +19,12 @@ In this chapter, we look at these screens and explain how to use them.
 
 The tiles displayed on the *Manage Jenkins* page are grouped logically.
 Here we discuss the pages that are part of the standard installation.
-Some plugins may add pages to this screen.
+Plugins may add pages to this screen.
 
 The top of the *Manage Jenkins* screen may contain "Monitors"
 that alert you when a new version
 of the Jenkins software or a security update is available.
-Each monitor includes links to the _changelog_ that describes the new update
-as well as instructions to download and install the update.
-
-Inline help is available on most *Manage Jenkins* pages:
-
-* To access the help, select the `?` icon to the right of each field.
-* Click the `?` icon again to hide the help text.
+Each monitor includes a description of the issue it is reporting and links to additional information about the issue
 
 Inline help is available on most *Manage Jenkins* pages:
 
@@ -52,9 +46,9 @@ whereas older versions presented a long list of tasks in somewhat random order.
 
 For more information about these and other changes that have been implemented, see:
 
-* link:https://www.jenkins.io/changelog-stable/[LTS Changelog]
-* link:https://www.jenkins.io/blog/2020/11/10/major-changes-in-weekly-releases/[Jenkins 2.264+: Major changes in the weekly release line]
-* link:https://www.jenkins.io/doc/upgrade-guide/[Jenkins LTS Upgrade Guide]
+* link:/changelog-stable/#v2.277.1[2.277.1 LTS Changelog]
+* link:/blog/2020/11/10/major-changes-in-weekly-releases/[Jenkins 2.264+: Major changes in the weekly release line]
+* link:/doc/upgrade-guide/[Jenkins LTS Upgrade Guide]
 ====
 
 Other system administration topics are discssed in
@@ -113,9 +107,6 @@ Jenkins log that contains all `java.uil.logging` output related to Jenkins.
 *Load Statistics*::
 Displays information about resource utilization on you Jenkins instance.
 
-*Disk usage*::
-Simple disk usage estimation
-
 link:about-jenkins.adoc[About Jenkins]::
 Provides version and license information for your Jenkins instance.
 
@@ -133,26 +124,16 @@ and management tools that enable you to do administrative tasks without using th
 Discard all data that is loaded in memory and reload everything from the file system.
 This is useful when you modify configuration files directly on disk.
 
-link:cli-adoc[Jenkins CLI]::
+link:cli[Jenkins CLI]::
 How to use the Jenkins CLI from a shell or script.
 
 link:/doc/book/managing/script-console/[Script Console]::
 Execute an Apache Groovy script for administration, troubleshooting, and diagnostics.
 
-*Prepare for Shutdown*::
+Prepare for Shutdown::
 Prevents new builds from starting so that the system can be shut down safely.
 
 == Uncategorized group
 
-Screens for monitoring the Jenkins controller and agents
-and for launching build agents as Docker containers.
-
-*Monitoring of Jenkins controller*::
-Monitors memory, cpu, http requests and more on the Jenkins controller.
-
-*Monitoring of Jenkins agents*::
-Monitors builds, the build queue, and Jenkins agents.
-
-*Docker*::
-Plugin for launching build agents as Docker containers.
+Screens for plugins that have not yet declared the category of their page.
 

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -29,10 +29,10 @@ To protect Jenkins from execution of malicious scripts,
 these plugins execute user-provided scripts in a <<groovy-sandbox>>
 that limits the internal APIs that are accessible.
 This protection is provided by the plugin:script-security[Script Security plugin].
-As soon as an unsafe method is used in any of the scripts,
+As soon as an unsafe method is used in any of the scripts, the administrator can use
 the "In-process Script Approval" action appears in *Manage Jenkins*
-to allow Administrators to make a decision about which unsafe methods,
-if any, should be allowed in the Jenkins environment.
+to allow the unsafe method.
+Unsafe methods should not be enabled without careful consideration of the impact.
 
 image::managing/manage-inprocess-script-approval.png["Entering the In-process Script Approval configuration", role=center]
 

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -25,11 +25,14 @@ Groovy scripts _in_ Jenkins. These scripting capabilities are provided by:
   script" step.
 * The plugin:job-dsl[JobDSL plugin] as of version 1.60 and later.
 
-To protect Jenkins from execution of malicious scripts, these plugins execute
-user-provided scripts in a <<groovy-sandbox>> that limits what internal APIs
-are accessible. This protection is provided by the plugin:script-security[Script Security plugin]. As soon as unsafe method is used in any of the scripts, the "In-process Script Approval"
-action should appear in "Manage Jenkins" to allow Administrators to make a decision about
-which unsafe methods, if any, should be allowed in the Jenkins environment.
+To protect Jenkins from execution of malicious scripts,
+these plugins execute user-provided scripts in a <<groovy-sandbox>>
+that limits the internal APIs that are accessible.
+This protection is provided by the plugin:script-security[Script Security plugin].
+As soon as an unsafe method is used in any of the scripts,
+the "In-process Script Approval" action appears in *Manage Jenkins*
+to allow Administrators to make a decision about which unsafe methods,
+if any, should be allowed in the Jenkins environment.
 
 image::managing/manage-inprocess-script-approval.png["Entering the In-process Script Approval configuration", role=center]
 

--- a/content/doc/book/managing/system-info.adoc
+++ b/content/doc/book/managing/system-info.adoc
@@ -1,0 +1,29 @@
+---
+layout: section
+wip: true
+---
+ifdef::backend-html5[]
+:notitle:
+:description:
+:author:
+:email: jenkinsci-docs@googlegroups.com
+:sectanchors:
+:toc:
+:hide-uri-scheme:
+endif::[]
+
+= System Information
+
+The *Manage Jenkins >> System Information* page provides detailed information
+about what is available on this Jenkins instance:
+
+* *System Properties* that can be used as arguments
+to the command line used to start Jenkins.
+* *Environment Variables* recognized on this system,  with current values.
+This includes the environment variables defined by Jenkins
+and available on all systems
+as well as environment variables associated with plugins installed on this instance.
+* List of Plugins installed on the system.
+* *Memory Usage* gives a graph that shows the current memory usage for this instance.
+
+

--- a/content/doc/book/managing/system-info.adoc
+++ b/content/doc/book/managing/system-info.adoc
@@ -1,6 +1,5 @@
 ---
 layout: section
-wip: true
 ---
 ifdef::backend-html5[]
 :notitle:

--- a/content/doc/book/managing/users.adoc
+++ b/content/doc/book/managing/users.adoc
@@ -12,5 +12,5 @@ ifdef::backend-html5[]
 :hide-uri-scheme:
 endif::[]
 
-= Managing Users
+= Manage Users
 


### PR DESCRIPTION
The original concept was to list the items from the "Manage Jenkins" screen in the index.adoc file, in order, with links to the sections that discuss each.  We may need to refine that concept.  For now, I started that and linked to relevant files, wherever they are.  I did not move any files.

At issue is what belongs in "Managing Jenkins" versus "System Administration".  We posited having "Manage Jenkins" be for the "basic" information that is on the "Manage Jenkins" screen and then have "System Administration" go into more advanced topics but a couple of the items on "Manage Jenkins" are kind of advanced.

If anyone has any opinions, I would love to hear them.  Meanwhile, I think that this piece is better than the stub file we did have.

I added a couple files for topics that were completely missing.  I did not touch existing files for other topics although some of them do need revision, but I'll do those in separate PRs.