### PR TITLE
Add reference to nvim-jenkinsfile-linter plugin

### DIFF
--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -217,6 +217,12 @@ The extension adds four settings entries to VS Code which select the Jenkins ser
 * `jenkins.pipeline.linter.connector.pass` allows you to specify your Jenkins password.
 * `jenkins.pipeline.linter.connector.crumbUrl` has to be specified if your Jenkins Server has CRSF protection enabled. Typically this points to __http://<your_jenkins_server:port>/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)__.
 
+=== Neovim nvim-jenkinsfile-linter plugin
+
+The link:https://github.com/ckipp01/nvim-jenkinsfile-linter[nvim-jenkinsfile-linter]
+Neovim plugins allows you to validate a Jenkinsfile by using the Pipeline Linter API
+of your Jenkins instance and report any existing diagnostics in your editor.
+
 === Atom linter-jenkins package
 
 The link:https://atom.io/packages/linter-jenkins[linter-jenkins] Atom package allows 

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -220,7 +220,7 @@ The extension adds four settings entries to VS Code which select the Jenkins ser
 === Neovim nvim-jenkinsfile-linter plugin
 
 The link:https://github.com/ckipp01/nvim-jenkinsfile-linter[nvim-jenkinsfile-linter]
-Neovim plugins allows you to validate a Jenkinsfile by using the Pipeline Linter API
+Neovim plugin allows you to validate a Jenkinsfile by using the Pipeline Linter API
 of your Jenkins instance and report any existing diagnostics in your editor.
 
 === Atom linter-jenkins package


### PR DESCRIPTION
I recently created https://github.com/ckipp01/nvim-jenkinsfile-linter in order to get the same support for linting Jenkinsfiles like the other editors listed here. This pr just adds a link to it letting people know there is Neovim support.