### PR TITLE
Add documentation for JEP-235

### DIFF
--- a/content/doc/book/security/controller-isolation.adoc
+++ b/content/doc/book/security/controller-isolation.adoc
@@ -62,11 +62,14 @@ This allows an agent to ask the controller process for information available to 
 
 So while not building on the built-in node is a good general practice to protect from bugs and less sophisticated attackers, an agent process taken over by a malicious user would still be able to obtain data or execute commands on the Jenkins controller.
 To prevent this, the Agent &rarr; Controller Access Control system prevents agent processes from being able to send malicious commands to the Jenkins controller.
-It is enabled by default, but can be disabled in the web UI by un-checking the box on the _Manage Jenkins » Configure Global Security_ page.
+
+// TODO Also mention first LTS once it's known
+This system is always enabled since Jenkins 2.326 (see link:jep-235[Agent &rarr; Controller Security Changes in 2.326]).
+In Jenkins 2.325 and earlier, it is enabled by default, but can be disabled in the web UI by un-checking the box on the _Manage Jenkins » Configure Global Security_ page.
 
 IMPORTANT: It is strongly recommended not to disable the Agent &rarr; Controller Access Control system.
 
 image::security/configure-global-security-agent-controller-toggle.png["Configure Global Security - Enable Agent => Controller Access Control", role=center]
 
-As an alternative to disabling Agent &rarr; Controller Access Control, administrators can selectively allow greater access.
+As an alternative to disabling Agent &rarr; Controller Access Control, administrators can selectively allow greater access in Jenkins 2.325 and earlier.
 See link:/doc/book/security/controller-isolation/agent-to-controller/[the documentation] for details.

--- a/content/doc/book/security/controller-isolation.adoc
+++ b/content/doc/book/security/controller-isolation.adoc
@@ -67,9 +67,9 @@ To prevent this, the Agent &rarr; Controller Access Control system prevents agen
 This system is always enabled since Jenkins 2.326 (see link:jep-235[Agent &rarr; Controller Security Changes in 2.326]).
 In Jenkins 2.325 and earlier, it is enabled by default, but can be disabled in the web UI by un-checking the box on the _Manage Jenkins » Configure Global Security_ page.
 
-IMPORTANT: It is strongly recommended not to disable the Agent &rarr; Controller Access Control system.
+IMPORTANT: It is strongly recommended that you not disable the Agent &rarr; Controller Access Control system.
 
 image::security/configure-global-security-agent-controller-toggle.png["Configure Global Security - Enable Agent => Controller Access Control", role=center]
 
-As an alternative to disabling Agent &rarr; Controller Access Control, administrators can selectively allow greater access in Jenkins 2.325 and earlier.
+As an alternative to disabling Agent &rarr; Controller Access Control, in Jenkins 2.325 and earlier, administrators can selectively allow greater access.
 See link:/doc/book/security/controller-isolation/agent-to-controller/[the documentation] for details.

--- a/content/doc/book/security/controller-isolation/agent-to-controller.adoc
+++ b/content/doc/book/security/controller-isolation/agent-to-controller.adoc
@@ -14,11 +14,11 @@ This section describes how to customize the rules restricting agents' access to 
 
 // TODO Also mention first LTS once it's known
 NOTE: In Jenkins 2.326, the ability to disable or customize the agent-to-controller security system has been removed without replacement.
-This documentation only applies to older releases of Jenkins.
+This documentation applies only to older releases of Jenkins.
 For documentation specific to the change in Jenkins 2.326, see link:../jep-235[Agent &rarr; Controller Security Changes in 2.326].
 
-For advanced users who may wish to allow certain access patterns from the agents to the Jenkins controller, Jenkins allows administrators to create specific exemptions from the built-in access control rules.
-This should only be necessary when trying to run plugins that haven't been adapted yet to be compatible.
+Sophisticated administrators can use the built-in access control rules to create specific exemptions for certain access patterns from the agents to the Jenkins controller.
+This should only be necessary when trying to run plugins that have not yet been adapted to be compatible.
 
 NOTE: For an introduction about the Agent &rarr; Controller Security system, see link:/doc/book/security/controller-isolation/#agent-controller-access-control[Isolating the Controller from Builds].
 

--- a/content/doc/book/security/controller-isolation/agent-to-controller.adoc
+++ b/content/doc/book/security/controller-isolation/agent-to-controller.adoc
@@ -10,7 +10,12 @@ ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
 
-This section describes how to customize the rules restricting agents' access to the Jenkins controller.
+This section describes how to customize the rules restricting agents' access to the Jenkins controller in Jenkins 2.325 and earlier.
+
+// TODO Also mention first LTS once it's known
+NOTE: In Jenkins 2.326, the ability to disable or customize the agent-to-controller security system has been removed without replacement.
+This documentation only applies to older releases of Jenkins.
+For documentation specific to the change in Jenkins 2.326, see link:../jep-235[Agent &rarr; Controller Security Changes in 2.326].
 
 For advanced users who may wish to allow certain access patterns from the agents to the Jenkins controller, Jenkins allows administrators to create specific exemptions from the built-in access control rules.
 This should only be necessary when trying to run plugins that haven't been adapted yet to be compatible.

--- a/content/doc/book/security/controller-isolation/jep-235.adoc
+++ b/content/doc/book/security/controller-isolation/jep-235.adoc
@@ -21,7 +21,7 @@ For the following plugins, updates are available as of December 29, 2021:
 * https://plugins.jenkins.io/xunit/[XUnit Plugin] needs to be updated to 2.0.3 or newer
 // XUnit is speculative, see JEP
 
-Other plugins have not been adapted yet.
+Other plugins have not yet been adapted.
 Their compatibility fixes are tracked in the Jira epic https://issues.jenkins.io/browse/JENKINS-67173[JENKINS-67173].
 
 

--- a/content/doc/book/security/controller-isolation/jep-235.adoc
+++ b/content/doc/book/security/controller-isolation/jep-235.adoc
@@ -1,0 +1,35 @@
+---
+title: Agent &rarr; Controller Security Changes in 2.326
+# TODO Mention the first LTS release with this change as well
+layout: documentation
+---
+
+Jenkins 2.326 removes the ability to disable or customize the agent-to-controller security system.
+This change is specified in https://github.com/jenkinsci/jep/tree/master/jep/235[JEP-235].
+
+== Plugin Compatibility
+
+Several plugins are known to be affected by this change.
+For the following plugins, updates are available as of December 29, 2021:
+// DATE SENSITIVE
+
+* https://plugins.jenkins.io/cobertura/[Cobertura Plugin Plugin] needs to be updated to 1.17 or newer.
+* https://plugins.jenkins.io/code-coverage-api/[Code Coverage API Plugin] needs to be updated to 2.0.4 or newer
+* https://plugins.jenkins.io/log-parser/[Log Parser Plugin] needs to be updated to 2.2 or newer
+* https://plugins.jenkins.io/maven-plugin/[Maven Integration Plugin] needs to be updated to 3.15.1 or newer
+* https://plugins.jenkins.io/warnings-ng/[Warnings Next Generation Plugin] needs to be updated to 5.2.0 or newer
+* https://plugins.jenkins.io/xunit/[XUnit Plugin] needs to be updated to 2.0.3 or newer
+// XUnit is speculative, see JEP
+
+Other plugins have not been adapted yet.
+Their compatibility fixes are tracked in the Jira epic https://issues.jenkins.io/browse/JENKINS-67173[JENKINS-67173].
+
+
+== API Compatibility
+
+As part of the change in 2.326, almost all code related to the agent-to-controller security system's configuration has been removed.
+
+A notable exception is `jenkins.security.s2m.AdminWhitelistRule` as that is used by https://plugins.jenkins.io/configuration-as-code/[Configuration as Code Plugin] and is also expected to be in frequent use in link:/doc/book/managing/groovy-hook-scripts/[Groovy init scripts].
+It is now a stub retaining the basic API -- `#getMasterKillSwitch` and `#setMasterKillSwitch(boolean)`, but both methods only generate log messages informing users about their obsolescence.
+Invocations of these methods can be safely removed when running Jenkins 2.326 or newer.
+// TODO Also mention first LTS here.

--- a/content/redirect/AdminWhitelistRule.adoc
+++ b/content/redirect/AdminWhitelistRule.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /doc/book/security/controller-isolation/jep-235/#api-compatibility
+---


### PR DESCRIPTION
Documentation for jenkinsci/jenkins#5885 and https://github.com/jenkinsci/jep/tree/master/jep/235

The new page's URL is a bit weird, but making it related to JEP-235 seems preferable to make it related to the weekly version number -- and I couldn't think of a better URL.