### PR TITLE
Document agent-to-controller security bypass

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1774,6 +1774,16 @@ properties:
     How long a resource URL served from the resource root URL will be valid for before users are required to reauthenticate to access it.
     See inline documentation in Jenkins for details.
 
+- name: jenkins.security.s2m.CallableDirectionChecker.allow
+  tags:
+  - security
+  - escape hatch
+  def: |
+    `false`
+  since: 1.587 and 1.580.1
+  description: |
+    This flag can be set to `true` to disable the agent-to-controller security system entirely.
+    Since Jenkins 2.326, this is the only way to do that, as the UI option has been removed.
 
 - name: jenkins.security.s2m.CallableDirectionChecker.allowAnyRole
   tags:


### PR DESCRIPTION
Looks like I missed this one when setting up the initial list.