### PR TITLE
Switch hosting project to GitHub issues

### DIFF
--- a/content/doc/developer/publishing/requesting-hosting.adoc
+++ b/content/doc/developer/publishing/requesting-hosting.adoc
@@ -20,19 +20,19 @@ Complete the following steps before requesting plugin hosting with the Jenkins p
 . Have a public repository containing the plugin source code on GitHub.
 
 
-== Open HOSTING request
+== Open Hosting request
 
 [NOTE]
 Our automated process makes it much easier to fork + delete (see below), rather than transfer repository ownership.
 If your repository already has a significant number of forks, issues, pull requests, or other auxiliary data, we can manually transfer it -- just request so in the hosting request, and provide an explanation.
 
-Log in to link:https://issues.jenkins.io/[JIRA] and create a new issue link:https://issues.jenkins.io/browse/HOSTING[in the HOSTING] project.
+Log in to link:https://github.com/[GitHub] and create a new issue link:https://github.com/jenkins-infra/repository-permissions-updater/issues/new?assignees=&labels=hosting-request&template=1-hosting-request.yml[in the repository-permissions-updater] repository.
 Make sure to fill out all fields as described.
 
 A Jenkins project member will review your request within a few days.
 If any changes are requested, please implement them.
 
-Once all requirements have been satisfied, your repository will be forked into the `jenkinsci` organization and you will be invited to join it, and a JIRA component in the JENKINS project will be created for you.
+Once all requirements have been satisfied, your repository will be forked into the `jenkinsci` organization and you will be invited to join it.
 
 At this point, you're asked to delete your repository we forked from.
 You can recreate it afterwards by forking from `jenkinsci` again.
@@ -52,7 +52,7 @@ See link:../continuous-integration[the documentation for CI builds] for details 
 
 == Request Upload Permissions
 
-After your plugin source code has been forked into the `jenkinsci` organization, you will need to file a request for upload permissions.
+After your plugin source code has been forked into the `jenkinsci` organization, a pull request will be created for you that adds release permissions, if this doesn't happen you may need to create the request yourself.
 link:https://github.com/jenkins-infra/repository-permissions-updater/[Follow the instructions in the README of this repository] to do that.
 
 Once you've completed this step and your request has been merged, you will be able to link:../releasing/[release your plugin].

--- a/content/project/teams/hosting.adoc
+++ b/content/project/teams/hosting.adoc
@@ -15,7 +15,7 @@ There are multiple contributors involved in this activity on a regular basis.
 
 == Team Responsibilities
 
-* Triage and processing of new plugin link:https://issues.jenkins.io/projects/HOSTING[HOSTING] requests in Jenkins Jira.
+* Triage and processing of new plugin link:https://github.com/jenkins-infra/repository-permissions-updater/issues?q=is%3Aissue+is%3Aopen++label%3Ahosting-request+[Hosting] requests.
   There is some automation around this process, but human reviews are needed too...
 ** Ensure that link:/doc/developer/publishing/preparation[plugin publishing requirements] are followed:
 naming conventions and `artifactId`s, `groupId`s, documentation, duplication of existing plugins, license compliance, etc.]
@@ -44,7 +44,6 @@ We invite any interested Jenkins contributor to join the team.
 How to start contributing?
 
 . Subscribe to the link:/mailing-lists/#jenkinsci-dev-googlegroups-com[Jenkins Developer Mailing list]
-. Subscribe to the link:https://issues.jenkins.io/projects/HOSTING[HOSTING project] in Jenkins Jira
 . Subscribe to the link:https://github.com/jenkins-infra/repository-permissions-updater/[Repository Permission Updater] repository
 . Subscribe to the link:https://github.com/jenkins-infra/update-center2[Jenkins Update Center] repository.
 

--- a/content/projects/infrastructure/ircbot.adoc
+++ b/content/projects/infrastructure/ircbot.adoc
@@ -219,29 +219,3 @@ The command removes the specified component. All its issues will be moved to COM
 jenkins-admin: Remove component COMPONENT1 and move its issues to COMPONENT2
 jenkins-admin: Delete component COMPONENT1 and move its issues to COMPONENT2
 ----
-
-=== Hosting Requests
-
-The IRC Bot provides hosting management commands which are used by the link:/project/teams/hosting/[Jenkins Hosting Team] to process the 
-hosting requests for new Jenkins plugins, libraries and other components.
-
-*Verify the plugin/library hosting request from Jira*
-
-This command will launch the automatic hosting request checker.
-It will verify the hosting ticket in Jira and check the links supplied in the `HOSTING` tickets.
-Then it will also verify the Maven and Gradle settings and existence of the expected files in the repository.
-Other verification steps (e.g. security audit) should be done manually by contributors.
-
-[source]
-----
-jenkins-admin: check hosting-XXXX
-----
-
-*Approve and initiate a plugin/library request from Jira*
-
-This command will fork the repository on GitHub, add all listed users as committers and create a JIRA component with the issue submitter as the default assignee. (hosting-XXXX is the JIRA item that was submitted for hosting)
-
-[source]
-----
-jenkins-admin: host hosting-XXXX
-----


### PR DESCRIPTION
Requires https://github.com/jenkins-infra/repository-permissions-updater/pull/2287

and enabling issues on https://github.com/jenkins-infra/repository-permissions-updater/