### PR TITLE
Simplify JRE requirements description for better readability.

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -11,7 +11,7 @@ Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading
 
 Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
 
-Early adopters may alternatively use the Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
+Early adopters may use Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
 
 All other Java versions are not supported.
 

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -7,7 +7,7 @@ There are separate run and job execution requirements for Jenkins installations.
 
 ## Running Jenkins
 
-Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading an existing Jenkins setup from Java 8 to Java 11? See the  link:/doc/administration/requirements/upgrade-java-guidelines[upgrade guidelines].
+Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading an existing Jenkins setup from Java 8 to Java 11? See the link:/doc/administration/requirements/upgrade-java-guidelines[upgrade guidelines].
 
 Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
 

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -13,7 +13,7 @@ Java 11 Docker installation instructions are included in link:/doc/book/installi
 
 Early adopters may alternatively use the Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
 
-All other JRE versions are not supported.
+All other Java versions are not supported.
 
 These requirements apply to all components of the Jenkins system, including Jenkins controller,
 all types of agents, CLI clients, and other components.

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -7,16 +7,13 @@ There are separate run and job execution requirements for Jenkins installations.
 
 ## Running Jenkins
 
-Modern Jenkins versions have the following Java requirements:
+Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading an existing Jenkins setup from Java 8 to Java 11? See the  link:/doc/administration/requirements/upgrade-java-guidelines[upgrade guidelines].
 
-* Java 8 runtime environments are supported in both 32-bit and 64-bit versions
-* Java 11 runtime environments are supported
-** Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
-** See the link:/doc/administration/requirements/upgrade-java-guidelines[Java 8 to Java 11 upgrade guidelines] for additional upgrade instructions
-* Java 7 and prior are not supported
-* Java 9 and 10 are not supported
-* Java 12, 13, 14, 15, and 16 are not supported
-* Java 17 is available for early adopters when using the Docker images (`jenkins/jenkins:jdk17-preview`)
+Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
+
+Early adopters may alternatively use the Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
+
+All other JRE versions are not supported.
 
 These requirements apply to all components of the Jenkins system, including Jenkins controller,
 all types of agents, CLI clients, and other components.


### PR DESCRIPTION
Just a minor documentation improvement, simplifying the description of the required JREs.

Somewhat related to #3474. Mentioning it here in case someone started working on that one.
