### PR TITLE
add required configuration to enable gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,13 @@
+tasks:
+  - init: make prepare # runs during prebuild
+    command: make run
+  - openMode: tab-before
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 4242
+    # onOpen: open-browser
+
+vscode:
+  extensions:
+    - asciidoctor.asciidoctor-vscode


### PR DESCRIPTION
Gitpod simplifies the development and preview environment setup by providing a standardised cloud based  setup.