### PR TITLE
Have one github preview environment per PR

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -113,10 +113,10 @@ spec:
       }
       post {
         success {
-          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app")
+          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app", "preview-${CHANGE_ID}")
         }
         failure {
-          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app")
+          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app", "preview-${CHANGE_ID}")
         }
       }
       steps {


### PR DESCRIPTION
Right now when one PR deploys, the previous deploy gets marked as inactive since they are the same env. So make env separate for each PR.