### PR TITLE
Go back to single preview env

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -7,7 +7,7 @@ def recordDeployment(owner, repo, ref, status, environmentURL, environment = "pr
         "required_contexts": [],
         "auto_merge": false,
         "auto_inactive": false,
-        "transient_environment": false,
+        "transient_environment": environment != "production",
     ])
     def id = readJSON(text: sh(script: "gh api repos/${owner}/${repo}/deployments  -X POST --input - << EOF\n${json}\nEOF", returnStdout: true).trim()).id
     if (id == ''){
@@ -19,7 +19,6 @@ def recordDeployment(owner, repo, ref, status, environmentURL, environment = "pr
         "description": description,
         "log_url": "${BUILD_URL}console",
         "environment_url": environmentURL,
-        "log_url": "${BUILD_URL}console",
     ])
     sh("gh api repos/${owner}/${repo}/deployments/${id}/statuses  -X POST --input - << EOF\n${json}\nEOF")
   }
@@ -113,10 +112,10 @@ spec:
       }
       post {
         success {
-          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app", "preview-${CHANGE_ID}")
+          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app")
         }
         failure {
-          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app", "preview-${CHANGE_ID}")
+          recordDeployment('jenkins-infra', 'jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-io-site-pr.netlify.app")
         }
       }
       steps {


### PR DESCRIPTION
production replaces previous url, everything else is transient. Not that we're deploying via these scripts (yet).

Sorry @MarkEWaite for flip flopping