### PR TITLE
fix(docker): catch invalid host names in the default vhost

### DIFF
--- a/docker/default.conf
+++ b/docker/default.conf
@@ -5,7 +5,7 @@ map $http_accept_language $lang {
 
 server {
   listen       80;
-  server_name  localhost;
+  server_name _ localhost;
 
   root   /usr/share/nginx/html;
 


### PR DESCRIPTION
Adding "_" to catch all requests invalid hosts

See http://nginx.org/en/docs/http/server_names.html (search for "strange" in this page)