### PR TITLE
Adding dev doc for managing HTTP/Json API

### DIFF
--- a/content/doc/developer/handling-requests/_chapter.yml
+++ b/content/doc/developer/handling-requests/_chapter.yml
@@ -3,4 +3,5 @@ sections:
 - routing
 - actions
 - responses
+- json
 - deprecated-reflective-access

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -11,14 +11,15 @@ references:
   title: Testing Jenkins
 ---
 
-== Expose HTTP API with json content with Jenkins
+This page explains how to expose Json objects over HTTP API in your Jenkins plugins, using `GET` and `POST` verbs.
+This page also shows how to test it with JenkinsRules from link:https://github.com/jenkinsci/jenkins-test-harness[jenkins-test-harness].
 
-It's a common requirement for automation to expose Json object over HTTP API in server. This page show how a plugin can create a Jenkins Extension to expose HTTP API for GET and POST request, and how to test it with JenkinsRules (from acceptance-test-harness).
+== Pre-requisite : a POJO (Plain Old Java Object)
 
-=== Pre-requisite : a POJO (Plain Old Java Object)
+This object represent the structured data that is exchanged between the HTTP server (Jenkins) and the client (Curl for example).
+We are using a very simple java Object for example purpose, but in production code you will have more complex objects to manipulate. 
 
-For this example we are using a very simple Object.
-Note that if you use Stapler for marshalling and unmarshalling JSON, you need an empty constructor.
+Note that if you use Stapler (JSONObject) for marshalling and unmarshalling JSON, you need an empty constructor.
 
 [source,java]
 ----
@@ -42,7 +43,9 @@ public static class MyJsonObject {
 }
 ----
 
-=== Handling GET with Jenkins
+== Handling GET with Jenkins
+
+This part shows how to expose an HTTP GET that return a structured json response.
 
 [source,java]
 ----
@@ -182,7 +185,10 @@ public class JsonAPITest {
 
 ----
 
-=== Handling POST with Jenkins
+== Handling POST with Jenkins
+
+This section shows how to expose an HTTP endpoint that takes a structured json Object as input, and do a response with a json structured Object.
+For this exmaple the same Object is used as input and output, but you can also use different json structure for the response.
 
 Starting from the class `JsonAPI` provided for GET example, add:
 
@@ -190,19 +196,18 @@ Starting from the class `JsonAPI` provided for GET example, add:
 ----
 @POST
 @WebMethod(name = "")
-public JsonHttpResponse create(@JsonBody JSONObject body) {
-    MyJsonObject parsedBody = (MyJsonObject) body.toBean(MyJsonObject.class);
+public JsonHttpResponse create(@JsonBody MyJsonObject body) {
     //Do any logic required for creation
-    //For the example purpose we just unmarshall and recreate json
-    JSONObject response = JSONObject.fromObject(parsedBody);
+    //For the example purpose we just recreate json from the same object.
+    JSONObject response = JSONObject.fromObject(body);
     return new JsonHttpResponse(response, 200);
 }
-
 ----
 
 === Testing with CURL
 
-A `mvn hpi:run` in the plugin should be enough to run it locally.  Assuming that Jenkins is up at http://localhost:8080/jenkins/ , you should have at this point:
+A `mvn hpi:run` in the plugin should be enough to run it locally.
+Assuming that Jenkins is up at http://localhost:8080/jenkins/ , you should have at this point:
 
 Write a file `my.json` containing the JSON body:
 [source,bash]
@@ -253,3 +258,14 @@ public void testPostJSON() throws Exception {
     assertEquals(response.getStatusCode(), 200);
 }
 ----
+
+== Some additional informations
+
+For people that are familiar with REST/json concept you may want to use other HTTP verbs, it should work, but since generally in Jenkins onlly `GET` and `POST are used this page only shows example for this 2 verbs.
+
+You may also want to use several HTTP status code, following HTTP convention like `201` for created, it will also work, and the example above are returning explicit `200` status to show how to manage the HTTP status that is return.
+Some status are managed by Jenkins Core and may be return automatically, like `403` when the user in the request does not have the required permission or is anonymous, or `404` when the HTTP API is not found.
+
+If you are not familiar with Jenkins architecture, you can have a look to link:../../architecture/model[High level view of Jenkins application] and at link:../../architecture[Architecture]
+
+For more advanced reading on the HTTP layer of Jenkins, it's managed by link:https://github.com/jenkinsci/stapler[Stapler].

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -54,11 +54,10 @@ import org.kohsuke.stapler.json.JsonBody;
 import org.kohsuke.stapler.json.JsonHttpResponse;
 import org.kohsuke.stapler.verb.GET;
 import org.kohsuke.stapler.verb.POST;
-import org.kohsuke.stapler.verb.PUT;
 
 
 @Extension /* (2) */
-public static class JsonAPIForTests implements RootAction /* (3) */ {
+public static class JsonAPI implements RootAction /* (3) */ {
 
     @CheckForNull
     @Override
@@ -95,8 +94,7 @@ public static class JsonAPIForTests implements RootAction /* (3) */ {
     @GET
     @WebMethod(name = "get-error500")
     public JsonHttpResponse getError500() { /* (10) */
-        JsonHttpResponse error500 = new JsonHttpResponse(
-                JSONObject.fromObject(new MyJsonObject("You got an error 500")), 500);
+        JsonHttpResponse error500 = new JsonHttpResponse(JSONObject.fromObject(new MyJsonObject("You got an error 500")), 500);
         throw error500;
     }
 }
@@ -120,13 +118,13 @@ A `mvn hpi:run` in the plugin should be enough to run it locally; assuming that 
 ```shell
 curl -XGET -w "\n STATUS:%{http_code}" http://localhost:8080/jenkins/custom-api/get-example-param?paramValue=hello
 {"message":"I am Jenkins hello"}
- STATUS:200%   
+ STATUS:200
 ```
 
 ### Exemple of test with JenkinsRule
 
 ```java
-public class JenkinsRuleTest {
+public class JsonAPITest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -162,5 +160,56 @@ public class JenkinsRuleTest {
         response = j.getJSON("custom-api/get-example-param?paramValue=hello", webClientAcceptException.withBasicApiToken(admin));
         assertEquals(response.getStatusCode(), 200);
     }
+
+```
+
+### Handling POST with Jenkins
+
+Starting from the class `JsonAPI` provided for GET example, add:
+
+```java
+@POST
+@WebMethod(name = "")
+public JsonHttpResponse create(@JsonBody JSONObject body) {
+    MyJsonObject parsedBody = (MyJsonObject) body.toBean(MyJsonObject.class);
+    //Do any logic required for creation
+    //For the example purpose we just unmarshall and recreate json
+    JSONObject response = JSONObject.fromObject(parsedBody);
+    return new JsonHttpResponse(response, 200);
+}
+
+```
+
+### Testing with CURL
+
+A `mvn hpi:run` in the plugin should be enough to run it locally; assuming that jenkins is up at http://localhost:8080/jenkins/ you should have at this point:
+
+Get the crumb.... TBD
+
+Write a file `my.json` containing the json body:
+```
+{"message":"A nice message to send"}
+```
+
+And then send the POST request:
+```shell
+curl -XPOST -H "Content-Type: application/json" -H "Jenkins-Crumb: test" http://localhost:40393/jenkins/testing-cli/postSomething --data "@/my.json"
+{"message":"A nice message to send"}
+ STATUS:200
+```
+
+### Exemple of test with JenkinsRule
+
+Starting from the class `JsonAPITest` provided for GET example, add:
+
+```java
+@Test
+public void testPostJSON() throws Exception {
+
+    MyJsonObject objectToSend = new MyJsonObject("Jenkins is the way !");
+    JenkinsRule.JSONWebResponse response = j.postJSON("testing-cli/postSomething", jsonBody);
+    assertTrue(response.getContentAsString().contains("Jenkins is the way !")); //because API is returning the same object.
+    assertEquals(response.getStatusCode(), 200);
+}
 
 ```

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -20,7 +20,7 @@ It's a common requirement for automation to expose Json object over HTTP API in 
 For this example we are using a very simple Object.
 Note that if you use Stapler for marshalling and unmarshalling JSON, you need an empty constructor.
 
-[source,bash]
+[source,java]
 ----
 public static class MyJsonObject {
     private String message;
@@ -204,20 +204,31 @@ public JsonHttpResponse create(@JsonBody JSONObject body) {
 
 A `mvn hpi:run` in the plugin should be enough to run it locally.  Assuming that Jenkins is up at http://localhost:8080/jenkins/ , you should have at this point:
 
-Get the crumb.... TBD
-
 Write a file `my.json` containing the JSON body:
 [source,bash]
 ----
 {"message":"A nice message to send"}
 ----
 
+Then if you need a user and a token:
+
+* go on Jenkins UI
+* login as a user, for example 'myuser'
+* on the top right click on user name
+* go on configure (for this user)
+* in the section "API Token" create a new token.
+
+For additional documentation on token, please visit:
+
+* link:../../../book/system-administration/authenticating-scripted-clients[Authenticating scripted clients]
+* link:../../../book/security/csrf-protection[CSRF Protection]
+
 And then send the POST request:
 [source,bash]
 ----
 curl -XPOST \
     -H "Content-Type: application/json" \
-    -H "Jenkins-Crumb: test" \
+    --user myuser:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
     http://localhost:40393/jenkins/testing-cli/postSomething \
     --data "@/my.json" \
 

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -198,7 +198,7 @@ public JsonHttpResponse create(@JsonBody JSONObject body) {
 
 ----
 
-### Testing with CURL
+=== Testing with CURL
 
 A `mvn hpi:run` in the plugin should be enough to run it locally.  Assuming that Jenkins is up at http://localhost:8080/jenkins/ , you should have at this point:
 

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -87,16 +87,21 @@ public static class JsonAPI implements RootAction /* (3) */ {
 
     @GET
     @WebMethod(name = "get-example-param")
-    public JsonHttpResponse getWithParameters(@QueryParameter(required = true) String paramValue /* (9) */) {
+    public JsonHttpResponse getWithParameters(
+        @QueryParameter(required = true) String paramValue /* (9) */) {
+
         assertNotNull(paramValue);
-        JSONObject response = JSONObject.fromObject(new MyJsonObject("I am Jenkins " + paramValue));
+        MyJsonObject myJsonObject = new MyJsonObject("I am Jenkins " + paramValue);
+        JSONObject response = JSONObject.fromObject(myJsonObject);
         return new JsonHttpResponse(response, 200);
     }
 
     @GET
     @WebMethod(name = "get-error500")
     public JsonHttpResponse getError500() { /* (10) */
-        JsonHttpResponse error500 = new JsonHttpResponse(JSONObject.fromObject(new MyJsonObject("You got an error 500")), 500);
+        MyJsonObject myJsonObject = new MyJsonObject("You got an error 500");
+        JSONObject jsonResponse = JSONObject.fromObject(myJsonObject);
+        JsonHttpResponse error500 = new JsonHttpResponse(jsonResponse, 500);
         throw error500;
     }
 }
@@ -134,11 +139,13 @@ public class JsonAPITest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    private static String GET_API_URL = "custom-api/get-example-param?paramValue=hello";
+
     @Test
     public void testGetJSON() throws Exception {
 
         // Testing a simple GET that should answer 200 OK and a json
-        JenkinsRule.JSONWebResponse response = j.getJSON("custom-api/get-example-param?paramValue=hello");
+        JenkinsRule.JSONWebResponse response = j.getJSON(GET_API_URL);
         assertTrue(response.getContentAsString().contains("I am JenkinsRule hello"));
         assertEquals(response.getStatusCode(), 200);
     }
@@ -154,15 +161,17 @@ public class JsonAPITest {
         j.jenkins.setAuthorizationStrategy(auth);
 
         //We need to setup the webclient
+        //By default if the status code is not ok, WebClient throw an exception
+        //Since we want to assert the error status code, we need to set to false.
         JenkinsRule.WebClient webClient = j.createWebClient();
-        webClient.setThrowExceptionOnFailingStatusCode(false); //we need this to assert status code, by default it's throwing an exception.
+        webClient.setThrowExceptionOnFailingStatusCode(false);
 
         // - simple call without authentication should be forbidden
-        response = j.getJSON("custom-api/get-example-param?paramValue=hello", webClientAcceptException);
+        response = j.getJSON(GET_API_URL, webClient);
         assertEquals(response.getStatusCode(), 403);
 
         // - same call but authenticated using withBasicApiToken() should be fine
-        response = j.getJSON("custom-api/get-example-param?paramValue=hello", webClientAcceptException.withBasicApiToken(admin));
+        response = j.getJSON(GET_API_URL, webClient.withBasicApiToken(admin));
         assertEquals(response.getStatusCode(), 200);
     }
 
@@ -217,8 +226,9 @@ public void testPostJSON() throws Exception {
 
     MyJsonObject objectToSend = new MyJsonObject("Jenkins is the way !");
     JenkinsRule.JSONWebResponse response = j.postJSON("testing-cli/postSomething", jsonBody);
-    assertTrue(response.getContentAsString().contains("Jenkins is the way !")); //because API is returning the same object.
+
+    //because API is returning the same object, we assert the input message.
+    assertTrue(response.getContentAsString().contains("Jenkins is the way !")); 
     assertEquals(response.getStatusCode(), 200);
 }
-
 ----

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -1,6 +1,6 @@
 ---
-title: Working with json
-summary: How to handle Json HTTP request with Jenkins
+title: Working with JSON
+summary: How to handle JSON HTTP request with Jenkins
 layout: developersection
 references:
 - url: https://github.com/stapler/stapler/blob/master/docs/reference.adoc
@@ -11,14 +11,15 @@ references:
   title: Testing Jenkins
 ---
 
-## Handle request in Jenkins
+== Handle request in Jenkins
 
-### Pre-requisite : a POJO (Plain Old Java Object)
+=== Pre-requisite : a POJO (Plain Old Java Object)
 
-For the exemple we are using a very simple Object.
-Note that if you use Stapler for marshalling and unmarshalling Json, you will need an empty constructor.
+For this example we are using a very simple Object.
+Note that if you use Stapler for marshalling and unmarshalling JSON, you need an empty constructor.
 
-```
+[source,bash]
+----
 public static class MyJsonObject {
     private String message;
 
@@ -37,11 +38,12 @@ public static class MyJsonObject {
         return message;
     }
 }
-```
+----
 
-### Handling GET with Jenkins
+=== Handling GET with Jenkins
 
-```java
+[source,java]
+----
 /* (1) */
 import hudson.model.RootAction;
 import net.sf.json.JSONObject;
@@ -98,32 +100,35 @@ public static class JsonAPI implements RootAction /* (3) */ {
         throw error500;
     }
 }
-```
+----
+
 1. Non exhaustive list of imports to use.
-2. Need to be an extension to be discovered as a service by Jenkins.
-3. This class is an extension of RootAction, it's a way to expose HTTP paths. It's more frequently use to expose Web UI, but it can be use also without HTML rendering.
-4. Since there is no HTML/Jelly rendering, no icon are needed.
-5. Since there is no HTML/Jelly rendering, no display name are needed.
-6. `getUrlName()` is the root of the Json API, all WebMethod in the class will be prefixed by this.
-7. `@GET` indicates the HTTP method that is expected, and `@WebMethod` that it's accepting an HTTP request. By default the java name of the WebMethod is used, but it can be specified by using `name =`
-8. `JsonHttpResponse` is a sub class of `HttpResponse` that indicates that the response content will be Json
-9. It's possible to indicate an HTTP status to set in the response.
-10. This method `get-error500` is added in the exemple to show how to do a error response as Json.
+2. Must be an extension to be discovered as a service by Jenkins.
+3. This class is an extension of RootAction.  It is a way to expose HTTP paths that is more frequently used to expose the Web UI, but it can also be used without HTML rendering.
+4. Since there is no HTML/Jelly rendering, no icons are needed.
+5. Since there is no HTML/Jelly rendering, no display name is needed.
+6. `getUrlName()` is the root of the JSON API.  Each WebMethod in the class is prefixed by this.
+7. `@GET` indicates the HTTP method that is expected, and `@WebMethod` indicates that it is accepting an HTTP request. By default, the JAVA name of the WebMethod is used, but a different name can be specified by using `name =`
+8. `JsonHttpResponse` is a sub class of `HttpResponse` that indicates that the response content will be JSON
+9. An HTTP status can be set in the response.
+10. The method `get-error500` is added in the example to show how to set a error response as JSON.
 
 
-### Testing with CURL
+=== Testing with CURL
 
-A `mvn hpi:run` in the plugin should be enough to run it locally; assuming that jenkins is up at http://localhost:8080/jenkins/ you should have at this point:
+A `mvn hpi:run` in the plugin should be enough to run it locally.  Assuming that Jenkins is up at http://localhost:8080/jenkins/ , you should have at this point:
 
-```shell
+[source,bash]
+----
 curl -XGET -w "\n STATUS:%{http_code}" http://localhost:8080/jenkins/custom-api/get-example-param?paramValue=hello
 {"message":"I am Jenkins hello"}
  STATUS:200
-```
+----
 
-### Exemple of test with JenkinsRule
+=== Example of test with JenkinsRule
 
-```java
+[source,java]
+----
 public class JsonAPITest {
 
     @Rule
@@ -161,13 +166,14 @@ public class JsonAPITest {
         assertEquals(response.getStatusCode(), 200);
     }
 
-```
+----
 
-### Handling POST with Jenkins
+=== Handling POST with Jenkins
 
 Starting from the class `JsonAPI` provided for GET example, add:
 
-```java
+[source,java]
+----
 @POST
 @WebMethod(name = "")
 public JsonHttpResponse create(@JsonBody JSONObject body) {
@@ -178,31 +184,34 @@ public JsonHttpResponse create(@JsonBody JSONObject body) {
     return new JsonHttpResponse(response, 200);
 }
 
-```
+----
 
 ### Testing with CURL
 
-A `mvn hpi:run` in the plugin should be enough to run it locally; assuming that jenkins is up at http://localhost:8080/jenkins/ you should have at this point:
+A `mvn hpi:run` in the plugin should be enough to run it locally.  Assuming that Jenkins is up at http://localhost:8080/jenkins/ , you should have at this point:
 
 Get the crumb.... TBD
 
-Write a file `my.json` containing the json body:
-```
+Write a file `my.json` containing the JSON body:
+[source,bash]
+----
 {"message":"A nice message to send"}
-```
+----
 
 And then send the POST request:
-```shell
+[source,bash]
+----
 curl -XPOST -H "Content-Type: application/json" -H "Jenkins-Crumb: test" http://localhost:40393/jenkins/testing-cli/postSomething --data "@/my.json"
 {"message":"A nice message to send"}
  STATUS:200
-```
+----
 
-### Exemple of test with JenkinsRule
+=== Example of test with JenkinsRule
 
-Starting from the class `JsonAPITest` provided for GET example, add:
+Starting from the class `JsonAPITest` provided for the GET example, add:
 
-```java
+[source,java]
+----
 @Test
 public void testPostJSON() throws Exception {
 
@@ -212,4 +221,4 @@ public void testPostJSON() throws Exception {
     assertEquals(response.getStatusCode(), 200);
 }
 
-```
+----

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -125,7 +125,10 @@ A `mvn hpi:run` in the plugin should be enough to run it locally.  Assuming that
 
 [source,bash]
 ----
-curl -XGET -w "\n STATUS:%{http_code}" http://localhost:8080/jenkins/custom-api/get-example-param?paramValue=hello
+curl -XGET \
+    -w "\n STATUS:%{http_code}"  \
+    http://localhost:8080/jenkins/custom-api/get-example-param?paramValue=hello
+
 {"message":"I am Jenkins hello"}
  STATUS:200
 ----
@@ -210,7 +213,12 @@ Write a file `my.json` containing the JSON body:
 And then send the POST request:
 [source,bash]
 ----
-curl -XPOST -H "Content-Type: application/json" -H "Jenkins-Crumb: test" http://localhost:40393/jenkins/testing-cli/postSomething --data "@/my.json"
+curl -XPOST \
+    -H "Content-Type: application/json" \
+    -H "Jenkins-Crumb: test" \
+    http://localhost:40393/jenkins/testing-cli/postSomething \
+    --data "@/my.json" \
+
 {"message":"A nice message to send"}
  STATUS:200
 ----

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -1,5 +1,5 @@
 ---
-title: Expose HTTP API with json content with Jenkins
+title: Expose HTTP API with JSON content with Jenkins
 summary: How to write GET and POST HTTP API with Jenkins, and how to test it.
 layout: developersection
 references:
@@ -16,7 +16,7 @@ This page also shows how to test it with JenkinsRules from link:https://github.c
 
 == Pre-requisite : a POJO (Plain Old Java Object)
 
-This object represent the structured data that is exchanged between the HTTP server (Jenkins) and the client (Curl for example).
+This object represent the structured data that is exchanged between the HTTP server (Jenkins) and the client (curl for example).
 We are using a very simple java Object for example purpose, but in production code you will have more complex objects to manipulate. 
 
 Note that if you use Stapler (JSONObject) for marshalling and unmarshalling JSON, you need an empty constructor.
@@ -45,7 +45,7 @@ public static class MyJsonObject {
 
 == Handling GET with Jenkins
 
-This part shows how to expose an HTTP GET that return a structured json response.
+This part shows how to expose an HTTP GET that return a structured JSON response.
 
 [source,java]
 ----
@@ -152,7 +152,7 @@ public class JsonAPITest {
     @Test
     public void testGetJSON() throws Exception {
 
-        // Testing a simple GET that should answer 200 OK and a json
+        // Testing a simple GET that should answer 200 OK and a JSON
         JenkinsRule.JSONWebResponse response = j.getJSON(GET_API_URL);
         assertTrue(response.getContentAsString().contains("I am JenkinsRule hello"));
         assertEquals(response.getStatusCode(), 200);
@@ -187,8 +187,8 @@ public class JsonAPITest {
 
 == Handling POST with Jenkins
 
-This section shows how to expose an HTTP endpoint that takes a structured json Object as input, and do a response with a json structured Object.
-For this exmaple the same Object is used as input and output, but you can also use different json structure for the response.
+This section shows how to expose an HTTP endpoint that takes a structured JSON Object as input, and do a response with a JSON structured Object.
+For this exmaple the same Object is used as input and output, but you can also use different JSON structure for the response.
 
 Starting from the class `JsonAPI` provided for GET example, add:
 
@@ -198,8 +198,9 @@ Starting from the class `JsonAPI` provided for GET example, add:
 @WebMethod(name = "")
 public JsonHttpResponse create(@JsonBody MyJsonObject body) {
     //Do any logic required for creation
-    //For the example purpose we just recreate json from the same object.
-    JSONObject response = JSONObject.fromObject(body);
+    //For the example purpose we just uppercase the message parsed from the request.
+    JSONObject response = new JSONObject();
+    response.put("message", body.message.toUpperCase());
     return new JsonHttpResponse(response, 200);
 }
 ----
@@ -261,7 +262,7 @@ public void testPostJSON() throws Exception {
 
 == Some additional informations
 
-For people that are familiar with REST/json concept you may want to use other HTTP verbs, it should work, but since generally in Jenkins onlly `GET` and `POST are used this page only shows example for this 2 verbs.
+For people that are familiar with REST/JSON concept you may want to use other HTTP verbs, it should work, but since generally in Jenkins only `GET` and `POST are used this page only shows example for this 2 verbs.
 
 You may also want to use several HTTP status code, following HTTP convention like `201` for created, it will also work, and the example above are returning explicit `200` status to show how to manage the HTTP status that is return.
 Some status are managed by Jenkins Core and may be return automatically, like `403` when the user in the request does not have the required permission or is anonymous, or `404` when the HTTP API is not found.

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -1,6 +1,6 @@
 ---
-title: Working with JSON
-summary: How to handle JSON HTTP request with Jenkins
+title: Expose HTTP API with json content with Jenkins
+summary: How to write GET and POST HTTP API with Jenkins, and how to test it.
 layout: developersection
 references:
 - url: https://github.com/stapler/stapler/blob/master/docs/reference.adoc
@@ -11,7 +11,9 @@ references:
   title: Testing Jenkins
 ---
 
-== Handle request in Jenkins
+== Expose HTTP API with json content with Jenkins
+
+It's a common requirement for automation to expose Json object over HTTP API in server. This page show how a plugin can create a Jenkins Extension to expose HTTP API for GET and POST request, and how to test it with JenkinsRules (from acceptance-test-harness).
 
 === Pre-requisite : a POJO (Plain Old Java Object)
 

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -1,0 +1,166 @@
+---
+title: Working with json
+summary: How to handle Json HTTP request with Jenkins
+layout: developersection
+references:
+- url: https://github.com/stapler/stapler/blob/master/docs/reference.adoc
+  title: Stapler URL Binding Reference
+- url: ../routing
+  title: How requests in Jenkins are routed
+- url: ../../testing
+  title: Testing Jenkins
+---
+
+## Handle request in Jenkins
+
+### Pre-requisite : a POJO (Plain Old Java Object)
+
+For the exemple we are using a very simple Object.
+Note that if you use Stapler for marshalling and unmarshalling Json, you will need an empty constructor.
+
+```
+public static class MyJsonObject {
+    private String message;
+
+    //empty constructor required for JSON parsing.
+    public MyJsonObject() {}
+
+    public MyJsonObject(String message) {
+        this.message = message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}
+```
+
+### Handling GET with Jenkins
+
+```java
+/* (1) */
+import hudson.model.RootAction;
+import net.sf.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.json.JsonBody;
+import org.kohsuke.stapler.json.JsonHttpResponse;
+import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
+import org.kohsuke.stapler.verb.PUT;
+
+
+@Extension /* (2) */
+public static class JsonAPIForTests implements RootAction /* (3) */ {
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null; /* (4) */
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return null; /* (5) */
+    }
+
+    @Override
+    public String getUrlName() {
+        return "custom-api"; /* (6) */
+    }
+
+    @GET
+    @WebMethod(name = "get-example")/* (7) */
+    public /* (8) */ JsonHttpResponse getExample() {
+        JSONObject response = JSONObject.fromObject(new MyJsonObject("I am Jenkins"));
+        return new JsonHttpResponse(response, 200); /* (9) */
+    }
+
+    @GET
+    @WebMethod(name = "get-example-param")
+    public JsonHttpResponse getWithParameters(@QueryParameter(required = true) String paramValue /* (9) */) {
+        assertNotNull(paramValue);
+        JSONObject response = JSONObject.fromObject(new MyJsonObject("I am Jenkins " + paramValue));
+        return new JsonHttpResponse(response, 200);
+    }
+
+    @GET
+    @WebMethod(name = "get-error500")
+    public JsonHttpResponse getError500() { /* (10) */
+        JsonHttpResponse error500 = new JsonHttpResponse(
+                JSONObject.fromObject(new MyJsonObject("You got an error 500")), 500);
+        throw error500;
+    }
+}
+```
+1. Non exhaustive list of imports to use.
+2. Need to be an extension to be discovered as a service by Jenkins.
+3. This class is an extension of RootAction, it's a way to expose HTTP paths. It's more frequently use to expose Web UI, but it can be use also without HTML rendering.
+4. Since there is no HTML/Jelly rendering, no icon are needed.
+5. Since there is no HTML/Jelly rendering, no display name are needed.
+6. `getUrlName()` is the root of the Json API, all WebMethod in the class will be prefixed by this.
+7. `@GET` indicates the HTTP method that is expected, and `@WebMethod` that it's accepting an HTTP request. By default the java name of the WebMethod is used, but it can be specified by using `name =`
+8. `JsonHttpResponse` is a sub class of `HttpResponse` that indicates that the response content will be Json
+9. It's possible to indicate an HTTP status to set in the response.
+10. This method `get-error500` is added in the exemple to show how to do a error response as Json.
+
+
+### Testing with CURL
+
+A `mvn hpi:run` in the plugin should be enough to run it locally; assuming that jenkins is up at http://localhost:8080/jenkins/ you should have at this point:
+
+```shell
+curl -XGET -w "\n STATUS:%{http_code}" http://localhost:8080/jenkins/custom-api/get-example-param?paramValue=hello
+{"message":"I am Jenkins hello"}
+ STATUS:200%   
+```
+
+### Exemple of test with JenkinsRule
+
+```java
+public class JenkinsRuleTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testGetJSON() throws Exception {
+
+        // Testing a simple GET that should answer 200 OK and a json
+        JenkinsRule.JSONWebResponse response = j.getJSON("custom-api/get-example-param?paramValue=hello");
+        assertTrue(response.getContentAsString().contains("I am JenkinsRule hello"));
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testAdvancedGetJSON() throws Exception {
+        //Testing a GET that requires the user to be authenticated
+        User admin = User.getById("admin", true);
+        MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().to(admin);
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(auth);
+
+        //We need to setup the webclient
+        JenkinsRule.WebClient webClient = j.createWebClient();
+        webClient.setThrowExceptionOnFailingStatusCode(false); //we need this to assert status code, by default it's throwing an exception.
+
+        // - simple call without authentication should be forbidden
+        response = j.getJSON("custom-api/get-example-param?paramValue=hello", webClientAcceptException);
+        assertEquals(response.getStatusCode(), 403);
+
+        // - same call but authenticated using withBasicApiToken() should be fine
+        response = j.getJSON("custom-api/get-example-param?paramValue=hello", webClientAcceptException.withBasicApiToken(admin));
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+```


### PR DESCRIPTION
Starting something about HTTP/Json, feel free to tell me if this doc exist somewhere else.

Done in regard of https://github.com/jenkinsci/jenkins-test-harness/pull/378, so the PR on jenkins-test-harness must but merged first for the doc to be accurate.

Also I haven't time to run it locally to verify the format, I will do it (my Internet connection is very bad).