### PR TITLE
fix: mention of jenkins-infra/helpdesk for Infrastructure project issues

### DIFF
--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -89,7 +89,7 @@ https://issues.jenkins.io/secure/Dashboard.jspa[the JIRA home page].
 * For *Project* select:
 ** _Jenkins_ for general issues with Jenkins,
 ** _Security Issues_ if you want to report a security issue privately
-* For _Infrastructure_, if you're reporting a bug with the Jenkins web site, wiki, or any other services run by the Jenkins project, link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
+* For _Infrastructure_, if you're reporting a bug with the Jenkins web site or any other services run by the Jenkins project, link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
 * Enter a short but meaningful description of your problem as *Summary*.
 * For *Priority*, see
 https://issues.jenkins.io/secure/ShowConstantsHelp.jspa?decorator=popup#PriorityLevels[here]

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -89,7 +89,7 @@ https://issues.jenkins.io/secure/Dashboard.jspa[the JIRA home page].
 * For *Project* select:
 ** _Jenkins_ for general issues with Jenkins,
 ** _Security Issues_ if you want to report a security issue privately
-* For _Infrastructure_, if you're reporting a bug with a Jenkins service run by the Jenkins project, link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
+* For _Infrastructure_, if you're reporting a bug with https://www.jenkins.io/projects/infrastructure/[a Jenkins service run by the Jenkins project], link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
 * Enter a short but meaningful description of your problem as *Summary*.
 * For *Priority*, see
 https://issues.jenkins.io/secure/ShowConstantsHelp.jspa?decorator=popup#PriorityLevels[here]

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -89,7 +89,7 @@ https://issues.jenkins.io/secure/Dashboard.jspa[the JIRA home page].
 * For *Project* select:
 ** _Jenkins_ for general issues with Jenkins,
 ** _Security Issues_ if you want to report a security issue privately
-* For _Infrastructure_, if you're reporting a bug with https://www.jenkins.io/projects/infrastructure/[a Jenkins service run by the Jenkins project], link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
+* For _Infrastructure_, if you're reporting a bug with https://www.jenkins.io/projects/infrastructure/[a Jenkins service run by the Jenkins project], open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
 * Enter a short but meaningful description of your problem as *Summary*.
 * For *Priority*, see
 https://issues.jenkins.io/secure/ShowConstantsHelp.jspa?decorator=popup#PriorityLevels[here]

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -88,10 +88,8 @@ https://issues.jenkins.io/secure/Dashboard.jspa[the JIRA home page].
 
 * For *Project* select:
 ** _Jenkins_ for general issues with Jenkins,
-** _Security Issues_ if you want to report a security issue privately,
-or
-** _Infrastructure_ if you're reporting a bug with the Jenkins web site,
-wiki, or any other services run by the Jenkins project.
+** _Security Issues_ if you want to report a security issue privately
+* For _Infrastructure_, if you're reporting a bug with the Jenkins web site, wiki, or any other services run by the Jenkins project, link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
 * Enter a short but meaningful description of your problem as *Summary*.
 * For *Priority*, see
 https://issues.jenkins.io/secure/ShowConstantsHelp.jspa?decorator=popup#PriorityLevels[here]

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -89,7 +89,7 @@ https://issues.jenkins.io/secure/Dashboard.jspa[the JIRA home page].
 * For *Project* select:
 ** _Jenkins_ for general issues with Jenkins,
 ** _Security Issues_ if you want to report a security issue privately
-* For _Infrastructure_, if you're reporting a bug with the Jenkins web site or any other services run by the Jenkins project, link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
+* For _Infrastructure_, if you're reporting a bug with a Jenkins service run by the Jenkins project, link: open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
 * Enter a short but meaningful description of your problem as *Summary*.
 * For *Priority*, see
 https://issues.jenkins.io/secure/ShowConstantsHelp.jspa?decorator=popup#PriorityLevels[here]


### PR DESCRIPTION
Since all INFRA issues have been migrated from Jira to Github, mention the new helpdesk url to open an issue related to infrastructure. (See https://github.com/jenkins-infra/helpdesk/issues/9)

Part of https://github.com/jenkins-infra/helpdesk/issues/2730