### PR TITLE
refresh the documentation of the plugin adoption process

### DIFF
--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -53,8 +53,8 @@ The typical way to do that is to ping in GitHub and to add her/his/their email a
 We typically wait for about 2 weeks in normal work periods before proceeding, so please be patient.
 Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be faster.
 
-Once the situation clarified, proceed as for a "adoptable" plugins (see above). 
-On the notification email, add information about the steps taken to contact the exisiting maintainers.
+Once the situation is clarified, proceed as for a "adoptable" plugins (see above). 
+On the notification email, add information about the steps taken to contact the existing maintainers.
 
 
 == FAQ

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -22,7 +22,7 @@ This page addresses cases when there is no active maintainer of a plugin:
 
 The procedure is two-fold: 
 
-==== Announce your adoption intention by mail 
+**Announce your adoption intention by mail** 
 
 Send the notification email to the https://groups.google.com/g/jenkinsci-dev[Jenkins Developers mailing list].
 Be sure to provide the following information: 
@@ -34,7 +34,7 @@ Be sure to provide the following information:
 * Your Jenkins infrastructure account id. link:https://accounts.jenkins.io/[Create your account] if you don't have one.
 * The link to the "Repository Permission Updater" PR described below
 
-==== Submit a PR on the "Repository Permission Updater" repository
+**Submit a PR on the "Repository Permission Updater" repository**
 
 File a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
 You need to update the plugin's definition yaml file located in the `permission` directory.

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -36,17 +36,17 @@ Be sure to provide the following information:
 
 **Submit a PR on the "Repository Permission Updater" repository**
 
-File a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
+File a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy releases for your plugin.
 You need to update the plugin's definition yaml file located in the `permission` directory.
 Add your Jenkins infrastructure account under the `developer` section.
 Refer to the link:https://github.com/jenkins-infra/repository-permissions-updater/blob/master/README.md[Readme] for detailed guidance.
 
-It is a good practice to ping the current registered developers on the PR (just in case they miss the notification on the Jenkins Dev List).
+Ping the current registered developers on the PR to inform them of your initiative (just in case they miss the notification on the Jenkins Dev List).
 
 Once you got access to the plugin's Github repository, don't forget to remove the "adopt-this-plugin" topic.
 This can be done by clicking on the gear wheel near the "About".
 
-== Abandonned plugins
+== Abandoned plugins
 
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.
 The typical way to do that is to ping in GitHub and to add her/his/their email addresses in CC (hint: Git commits should have this information).

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -20,23 +20,44 @@ This page addresses cases when there is no active maintainer of a plugin:
 
 == Requesting commit access
 
-Email the http://jenkins-ci.org/content/mailing-lists[Jenkins Developers mailing list] and request to be made a maintainer 
-(which usually means commit access to the plugin repository and being made default assignee for newly reported issues in JIRA).
-Please provide the following things in the request:
+=== Plugins marked for adoption
+
+The procedure is two-fold: 
+
+==== announce your adoption intention by mail 
+
+Send the notification email to the http://jenkins-ci.org/content/mailing-lists[Jenkins Developers mailing list].
+Be sure to provide the following information: 
 
 * Link to a plugin you want to adopt
+* The status of the plugin ("for adoption" or "abandonned")
 * Link(s) to pull requests you want to deliver, if applicable
 * Your GitHub username/id (e.g. oleg-nenashev for https://github.com/oleg-nenashev/)
 * Your Jenkins infrastructure account id. link:https://accounts.jenkins.io/[Create your account] if you don't have one.
+* The link to the "Repository Permission Updater" PR described below
+
+==== submit a PR on the "Repository Permission Updater" (RPU) repository
+
+File a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
+You need to update the plugin's definition yaml file located in the `permission` directory.
+Add your Jenkins infrastructure account under the `developer` section.
+Refer to the link:https://github.com/jenkins-infra/repository-permissions-updater/blob/master/README.md[Readme] for detailed guidance.
+
+It is a good practice to ping the current registered developers on the PR (just in case they miss the notification pn the Jenkins Dev List).
+
+Once you got access to the plugin's Github repository, don't forget to remove the "adopt-this-plugin" topic.
+This can be done by clicking on the gear wheel near the about.
+
+=== Abandonned plugins
 
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.
 The typical way to do that is to ping in GitHub and to add her/his/their email addresses in CC (hint: Git commits should have this information).
 We typically wait for about 2 weeks in normal work periods before proceeding, so please be patient.
 Hence, if you can prove the existing maintainer already agrees and you explicitly asked about taking over (e.g. in a PR discussion), the process can be faster.
 
-Once granted access, you can file a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
-You're generally expected to start slowly, by filing PRs, and not commit directly.
-Even more for plugins with a big number of installations for obvious reasons.
+Once the situation clarified, proceed as for a "adoptable" plugins (see above). 
+On the notification email, add information about the steps taken to contact the exisiting maintainers.
+
 
 == FAQ
 

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -18,9 +18,7 @@ This page addresses cases when there is no active maintainer of a plugin:
   In such case we can transfer ownership for plugins being hosted within the `jenkinsci` GitHub organization.
   Such transfer may take a while.
 
-== Requesting commit access
-
-=== Plugins marked for adoption
+== Plugins marked for adoption
 
 The procedure is two-fold: 
 
@@ -48,7 +46,7 @@ It is a good practice to ping the current registered developers on the PR (just 
 Once you got access to the plugin's Github repository, don't forget to remove the "adopt-this-plugin" topic.
 This can be done by clicking on the gear wheel near the "About".
 
-=== Abandonned plugins
+== Abandonned plugins
 
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.
 The typical way to do that is to ping in GitHub and to add her/his/their email addresses in CC (hint: Git commits should have this information).

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -43,7 +43,7 @@ Refer to the link:https://github.com/jenkins-infra/repository-permissions-update
 
 Ping the current registered developers on the PR to inform them of your initiative (just in case they miss the notification on the Jenkins Dev List).
 
-Once you have access to the plugin's Github repository, be sure to remove the "adopt-this-plugin" topic.
+Once you have access to the plugin's Github repository, be sure to remove the `+adopt-this-plugin+` label.
 This can be done by clicking on the gear wheel near the "About".
 
 == Abandoned plugins

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -43,7 +43,7 @@ Refer to the link:https://github.com/jenkins-infra/repository-permissions-update
 
 Ping the current registered developers on the PR to inform them of your initiative (just in case they miss the notification on the Jenkins Dev List).
 
-Once you got access to the plugin's Github repository, don't forget to remove the "adopt-this-plugin" topic.
+Once you have access to the plugin's Github repository, be sure to remove the "adopt-this-plugin" topic.
 This can be done by clicking on the gear wheel near the "About".
 
 == Abandoned plugins

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -24,29 +24,29 @@ This page addresses cases when there is no active maintainer of a plugin:
 
 The procedure is two-fold: 
 
-==== announce your adoption intention by mail 
+==== Announce your adoption intention by mail 
 
-Send the notification email to the http://jenkins-ci.org/content/mailing-lists[Jenkins Developers mailing list].
+Send the notification email to the https://groups.google.com/g/jenkinsci-dev[Jenkins Developers mailing list].
 Be sure to provide the following information: 
 
 * Link to a plugin you want to adopt
-* The status of the plugin ("for adoption" or "abandonned")
+* The status of the plugin ("for adoption" or "abandoned")
 * Link(s) to pull requests you want to deliver, if applicable
 * Your GitHub username/id (e.g. oleg-nenashev for https://github.com/oleg-nenashev/)
 * Your Jenkins infrastructure account id. link:https://accounts.jenkins.io/[Create your account] if you don't have one.
 * The link to the "Repository Permission Updater" PR described below
 
-==== submit a PR on the "Repository Permission Updater" (RPU) repository
+==== Submit a PR on the "Repository Permission Updater" repository
 
 File a pull request against link:https://github.com/jenkins-infra/repository-permissions-updater[Repository Permission updater] to be able to deploy snapshots and releases for your plugin.
 You need to update the plugin's definition yaml file located in the `permission` directory.
 Add your Jenkins infrastructure account under the `developer` section.
 Refer to the link:https://github.com/jenkins-infra/repository-permissions-updater/blob/master/README.md[Readme] for detailed guidance.
 
-It is a good practice to ping the current registered developers on the PR (just in case they miss the notification pn the Jenkins Dev List).
+It is a good practice to ping the current registered developers on the PR (just in case they miss the notification on the Jenkins Dev List).
 
 Once you got access to the plugin's Github repository, don't forget to remove the "adopt-this-plugin" topic.
-This can be done by clicking on the gear wheel near the about.
+This can be done by clicking on the gear wheel near the "About".
 
 === Abandonned plugins
 


### PR DESCRIPTION
The existing documentation became a little dated and did not reflect the current practice. This is a proposal for a documentation update (unless the current adoption practice should be ironed out).