### PR TITLE
Update NodeJS tutorial

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -37,8 +37,8 @@ docker run \
   --env DOCKER_TLS_CERTDIR=/certs \# <7>
   --volume jenkins-docker-certs:/certs/client \# <8>
   --volume jenkins-data:/var/jenkins_home \# <9>
-  --publish 3000:3000 \# <10>
-  --publish 2376:2376 \# <11>
+  --publish 2376:2376 \# <10>
+  --publish 3000:3000 \# <11>
   docker:dind \# <12>
   --storage-driver overlay2 # <13>
 ----
@@ -64,10 +64,10 @@ a Docker volume named `jenkins-docker-certs` as created above.
 volume named `jenkins-data`. This will allow for other Docker
 containers controlled by this Docker container's Docker daemon to mount data
 from Jenkins.
-<10> Exposes the Docker daemon port, used by some of tutorials.
-<11> ( _Optional_ ) Exposes the Docker daemon port on the host machine. This is
+<10> ( _Optional_ ) Exposes the Docker daemon port on the host machine. This is
 useful for executing `docker` commands on the host machine to control this
 inner Docker daemon.
+<11> Exposes port 3000 from the docker in docker container, used by some of the tutorials.
 <12> The `docker:dind` image itself. This image can be downloaded before running
 by using the command: `docker image pull docker:dind`.
 <13> The storage driver for the Docker volume. See

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -105,21 +105,21 @@ RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
-.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-docker build -t myjenkins-blueocean:1.1 .
+docker build -t myjenkins-blueocean:{jenkins-stable}-1 .
 ----
 Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
 
-. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the
+. Run your own `myjenkins-blueocean:{jenkins-stable}-1` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
 docker run \
   --name jenkins-blueocean \# <1>
@@ -134,7 +134,7 @@ docker run \
   --volume jenkins-data:/var/jenkins_home \# <8>
   --volume jenkins-docker-certs:/certs/client:ro \# <9>
   --volume "$HOME":/home \# <10>
-  myjenkins-blueocean:1.1 # <11>
+  myjenkins-blueocean:{jenkins-stable}-1 # <11>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name for this instance of
 the Docker image.
@@ -185,13 +185,13 @@ to connect to the Docker daemon available in the path specified by the
 `DOCKER_CERT_PATH` environment variable.
 <10> Maps the `$HOME` directory on the host (i.e. your local) machine (usually
 the `/Users/<your-username>` directory) to the `/home` directory in the
-container.
+container. Used to access local changes to the tutorial repository.
 <11> The name of the Docker image, which you built in the previous step.
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
 docker run --name jenkins-blueocean --rm --detach \
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 \
@@ -200,7 +200,7 @@ docker run --name jenkins-blueocean --rm --detach \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
   --volume "$HOME":/home \
-  myjenkins-blueocean:1.1
+  myjenkins-blueocean:{jenkins-stable}-1
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
@@ -249,20 +249,20 @@ RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
-.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-docker build -t myjenkins-blueocean:1.1 .
+docker build -t myjenkins-blueocean:{jenkins-stable}-1 .
 ----
 Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
 
-. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
+. Run your own `myjenkins-blueocean:{jenkins-stable}-1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
-[source]
+[source,subs="attributes+"]
 ----
 docker run --name jenkins-blueocean --rm --detach ^
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
@@ -270,7 +270,7 @@ docker run --name jenkins-blueocean --rm --detach ^
   --volume jenkins-data:/var/jenkins_home ^
   --volume jenkins-docker-certs:/certs/client:ro ^
   --volume "%HOMEDRIVE%%HOMEPATH%":/home ^
-  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
+  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:{jenkins-stable}-1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.
 

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +
@@ -245,7 +245,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -84,7 +84,8 @@ docker run --name jenkins-docker --rm --detach \
   --env DOCKER_TLS_CERTDIR=/certs \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
-  --publish 2376:2376 docker:dind --storage-driver overlay2
+  --publish 3000:3000 --publish 2376:2376 \
+  docker:dind --storage-driver overlay2
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
 .. Create Dockerfile with the following content:
@@ -227,6 +228,7 @@ docker run --name jenkins-docker --rm --detach ^
   --env DOCKER_TLS_CERTDIR=/certs ^
   --volume jenkins-docker-certs:/certs/client ^
   --volume jenkins-data:/var/jenkins_home ^
+  --publish 3000:3000 --publish 2376:2376 ^
   docker:dind
 ----
 . Customise official Jenkins Docker image, by executing below two steps:

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -84,7 +84,8 @@ docker run --name jenkins-docker --rm --detach \
   --env DOCKER_TLS_CERTDIR=/certs \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
-  --publish 2376:2376 docker:dind --storage-driver overlay2
+  --publish 2376:2376 \
+  docker:dind --storage-driver overlay2
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
 .. Create Dockerfile with the following content:
@@ -250,7 +251,6 @@ docker build -t myjenkins-blueocean:1.1 .
 ----
 Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
-
 
 . Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -218,11 +218,11 @@ docker network create jenkins
 +
 [source]
 ----
-docker run --name jenkins-docker --rm --detach `
-  --privileged --network jenkins --network-alias docker `
-  --env DOCKER_TLS_CERTDIR=/certs `
-  --volume jenkins-docker-certs:/certs/client `
-  --volume jenkins-data:/var/jenkins_home `
+docker run --name jenkins-docker --rm --detach ^
+  --privileged --network jenkins --network-alias docker ^
+  --env DOCKER_TLS_CERTDIR=/certs ^
+  --volume jenkins-docker-certs:/certs/client ^
+  --volume jenkins-data:/var/jenkins_home ^
   docker:dind
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
@@ -258,11 +258,11 @@ if this hasn't been done before.
 +
 [source]
 ----
-docker run --name jenkins-blueocean --rm --detach `
-  --network jenkins --env DOCKER_HOST=tcp://docker:2376 `
-  --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 `
-  --volume jenkins-data:/var/jenkins_home `
-  --volume jenkins-docker-certs:/certs/client:ro `
+docker run --name jenkins-blueocean --rm --detach ^
+  --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
+  --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
+  --volume jenkins-data:/var/jenkins_home ^
+  --volume jenkins-docker-certs:/certs/client:ro ^
   --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -105,21 +105,21 @@ RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
-.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-docker build -t myjenkins-blueocean:1.1 .
+docker build -t myjenkins-blueocean:{jenkins-stable}-1 .
 ----
 Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
 
-. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the
+. Run your own `myjenkins-blueocean:{jenkins-stable}-1` image as a container in Docker using the
   following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
 docker run \
   --name jenkins-blueocean \# <1>
@@ -133,7 +133,7 @@ docker run \
   --publish 50000:50000 \# <7>
   --volume jenkins-data:/var/jenkins_home \# <8>
   --volume jenkins-docker-certs:/certs/client:ro \# <9>
-  myjenkins-blueocean:1.1 # <10>
+  myjenkins-blueocean:{jenkins-stable}-1 # <10>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name for this instance of
 the Docker image.
@@ -187,7 +187,7 @@ to connect to the Docker daemon available in the path specified by the
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
 docker run --name jenkins-blueocean --rm --detach \
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 \
@@ -195,7 +195,7 @@ docker run --name jenkins-blueocean --rm --detach \
   --publish 8080:8080 --publish 50000:50000 \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
-  myjenkins-blueocean:1.1
+  myjenkins-blueocean:{jenkins-stable}-1
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
 
@@ -223,6 +223,7 @@ docker run --name jenkins-docker --rm --detach ^
   --env DOCKER_TLS_CERTDIR=/certs ^
   --volume jenkins-docker-certs:/certs/client ^
   --volume jenkins-data:/var/jenkins_home ^
+  --publish 2376:2376 ^
   docker:dind
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
@@ -243,27 +244,27 @@ RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
-.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
+.. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-docker build -t myjenkins-blueocean:1.1 .
+docker build -t myjenkins-blueocean:{jenkins-stable}-1 .
 ----
 Keep in mind that the process described above will automatically download the official Jenkins Docker image
 if this hasn't been done before.
 
-. Run your own `myjenkins-blueocean:1.1` image as a container in Docker using the following
+. Run your own `myjenkins-blueocean:{jenkins-stable}-1` image as a container in Docker using the following
   link:https://docs.docker.com/engine/reference/run/[`docker run`]
   command:
 +
-[source]
+[source,subs="attributes+"]
 ----
 docker run --name jenkins-blueocean --rm --detach ^
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
   --volume jenkins-data:/var/jenkins_home ^
   --volume jenkins-docker-certs:/certs/client:ro ^
-  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:1.1
+  --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:{jenkins-stable}-1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.
 

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +
@@ -240,7 +240,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.26"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.2 docker-workflow:1.27"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:1.1":
 +

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -227,16 +227,7 @@ Ocean interface",width=100%]
 === Add a test stage to your Pipeline
 
 . Go back to your text editor/IDE and ensure your `Jenkinsfile` is open.
-. Copy and paste the following Declarative Pipeline syntax immediately under the
-  `agent` section of your `Jenkinsfile`:
-+
-[source,groovy]
-----
-    environment {
-        CI = 'true'
-    }
-----
-as well as the following immediately under the `Build` stage:
+. Copy and paste the following Declarative Pipeline syntax immediately under the `Build` stage:
 +
 [source,groovy]
 ----
@@ -257,44 +248,23 @@ pipeline {
             args '-p 3000:3000'
         }
     }
-    environment {
-        CI = 'true' // <1>
-    }
     stages {
         stage('Build') {
             steps {
                 sh 'npm install'
             }
         }
-        stage('Test') { // <2>
+        stage('Test') { // <1>
             steps {
-                sh './jenkins/scripts/test.sh' // <3>
+                sh './jenkins/scripts/test.sh' // <2>
             }
         }
     }
 }
 ----
-<1> The link:/doc/book/pipeline/syntax#environment[`environment`] directive sets
-the environment variable `CI` with a boolean value of `true`, which is available
-to all steps in this Pipeline. When the `npm test` command in `test.sh` (which
-is run during the `Test` stage defined further down the Pipeline) detects the
-environment variable `CI` with a value of `true`, then this command is run in
-"non-watch" (i.e. non-interactive) mode. In "watch" mode, `npm test` expects
-user input, which can pause running builds of CI/CD applications indefinitely.
-As an alternative to specifying the `environment` directive in a Jenkins
-Pipeline, you could also specify this environment variable in the `package.json`
-file (to pass on to the `npm test` command) by:
-.. Uncommenting the `npm install --save-dev cross-env` command in
-   `jenkins/scripts/test.sh` (to install the `cross-env` dependency during the
-   `Test` stage). Read more about this in the `test.sh` file itself.
-.. Updating the following line in the `package.json` file (at the root of the
-   `simple-node-js-react-npm-app` repository) from:
-   * `"test": "react-scripts test --env=jsdom",` +
-     to
-   * `"test": "cross-env CI=true react-scripts test --env=jsdom",`
-<2> Defines a link:/doc/book/pipeline/syntax/#stage[`stage`] (directive) called
+<1> Defines a link:/doc/book/pipeline/syntax/#stage[`stage`] (directive) called
 `Test` that appears on the Jenkins UI.
-<3> This
+<2> This
 link:/doc/pipeline/steps/workflow-durable-task-step/#code-sh-code-shell-script[`sh`]
 step (of the link:/doc/book/pipeline/syntax/#steps[`steps`] section) runs the
 shell script `test.sh` located in the `jenkins/scripts` directory from the root
@@ -357,9 +327,6 @@ pipeline {
             args '-p 3000:3000'
         }
     }
-    environment { // <1>
-        CI = 'true'
-    }
     stages {
         stage('Build') {
             steps {
@@ -371,33 +338,29 @@ pipeline {
                 sh './jenkins/scripts/test.sh'
             }
         }
-        stage('Deliver') { // <2>
+        stage('Deliver') { // <1>
             steps {
-                sh './jenkins/scripts/deliver.sh' // <3>
-                input message: 'Finished using the web site? (Click "Proceed" to continue)' // <4>
-                sh './jenkins/scripts/kill.sh' // <5>
+                sh './jenkins/scripts/deliver.sh' // <2>
+                input message: 'Finished using the web site? (Click "Proceed" to continue)' // <3>
+                sh './jenkins/scripts/kill.sh' // <4>
             }
         }
     }
 }
 ----
-<1> This link:/doc/book/pipeline/syntax#environment[`environment`] directive
-might not be present in your Pipeline if you chose to specify the `CI`
-environment variable in the `package.json` file
-<<add-a-test-stage-to-your-pipeline,above>>.
-<2> Defines a new stage called `Deliver` that appears on the Jenkins UI.
-<3> This
+<1> Defines a new stage called `Deliver` that appears on the Jenkins UI.
+<2> This
 link:/doc/pipeline/steps/workflow-durable-task-step/#code-sh-code-shell-script[`sh`]
 step (of the link:/doc/book/pipeline/syntax/#steps[`steps`] section) runs the
 shell script `deliver.sh` located in the `jenkins/scripts` directory from the
 root of the `simple-node-js-react-npm-app` repository. Explanations about what
 this script does are covered in the `deliver.sh` file itself.
-<4> This
+<3> This
 link:/doc/pipeline/steps/pipeline-input-step/#code-input-code-wait-for-interactive-input[`input`]
 step (provided by the link:/doc/pipeline/steps/pipeline-input-step[Pipeline:
 Input Step] plugin) pauses the running build and prompts the user (with a custom
 message) to proceed or abort.
-<5> This
+<4> This
 link:/doc/pipeline/steps/workflow-durable-task-step/#code-sh-code-shell-script[`sh`]
 step runs the shell script `kill.sh`, also located in the `jenkins/scripts`
 directory. Explanations about what this script does are covered in the `kill.sh`

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -145,7 +145,7 @@ process.
 pipeline {
     agent {
         docker {
-            image 'node:lts-buster-slim' // <1>
+            image 'node:lts-bullseye-slim' // <1>
             args '-p 3000:3000' // <2>
         }
     }
@@ -160,7 +160,7 @@ pipeline {
 ----
 <1> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/node/[`node:lts-buster-slim` Docker image] (if it's not
+https://hub.docker.com/_/node/[`node:lts-bullseye-slim` Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Node containers running locally in Docker.
@@ -253,7 +253,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'node:lts-buster-slim'
+            image 'node:lts-bullseye-slim'
             args '-p 3000:3000'
         }
     }


### PR DESCRIPTION
## Update NodeJS tutorial

Fix #4825 - React app does not open based on Windows tutorial steps.

- Use Debian bullseye, not buster in React tutorial - use Debian stable, not oldstable
- Use docker-workflow:1.27 in tutorial, not 1.26 - use latest release
- Publish port 3000 on Windows and Linux tutorial
    - Fix #4825 
- Reduce differences between tutorial and installing
- Use bat line continuation, not powershell - more widely used
- Use Jenkins version in sample docker image tag - healthier pattern to use a tag related to image content
- Remove CI environment variable - included in Jenkins LTS since 2.289.1
