### PR TITLE
Drop IE 11 support in browser policy, promote edge to L1

### DIFF
--- a/content/doc/administration/requirements/web-browsers.adoc
+++ b/content/doc/administration/requirements/web-browsers.adoc
@@ -39,14 +39,9 @@ Latest https://www.mozilla.org/en-US/firefox/organizations/[ESR] release
 |Version N-1, latest patch
 |Other versions 
 
-|Microsoft Internet Explorer
-|Version 11, latest patch
-|Version 11, previous patches
-|Other versions
-
 |Microsoft Edge
-|-
-|Latest release/patch
+|Latest regular release/patch
+|Version N-1, latest patch
 |Other versions
 
 |Apple Safari
@@ -59,5 +54,6 @@ Support for mobile browsers (e.g. iOS Safari) has not yet been determined.
 
 == Change history
 
+* 2022-02-01 - Remove support for Internet Explorer, Add Edge (link:https://groups.google.com/g/jenkinsci-dev/c/piANoeohdik[discussion in the developer mailing list])
 * 2019-11-19 - Policy update (link:https://groups.google.com/forum/#!topic/jenkinsci-dev/TV_pLEah9B4[discussion in the developer mailing list])
 * 2014-09-03 - Original policy for Jenkins 1.579 (http://meetings.jenkins-ci.org/jenkins/2014/jenkins.2014-09-03-18.01.html[governance meeting notes])


### PR DESCRIPTION
see https://groups.google.com/g/jenkinsci-dev/c/piANoeohdik

Will leave in draft for a week or two, but suggested time for merge is after new LTS baseline (week of 24th January).