### PR TITLE
Add spell checker to Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,3 +11,4 @@ ports:
 vscode:
   extensions:
     - asciidoctor.asciidoctor-vscode
+    - streetsidesoftware.code-spell-checker


### PR DESCRIPTION
The Gitpod configuration is adapted to automatically install the Streetside Software code spell checker extension.