### PR TITLE
Remove markdown from weekly changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -13626,12 +13626,28 @@
         pr_title: "[JENKINS-65237] Bump Groovy from 2.4.12 to 2.4.21"
         references:
           - pull: 5939
-          - url: http://groovy-lang.org/changelogs/changelog-2.4.12.html
-            title: Groovy 2.4.12 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.13.html
+            title: Groovy 2.4.13 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.14.html
+            title: Groovy 2.4.14 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.15.html
+            title: Groovy 2.4.15 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.16.html
+            title: Groovy 2.4.16 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.17.html
+            title: Groovy 2.4.17 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.18.html
+            title: Groovy 2.4.18 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.19.html
+            title: Groovy 2.4.19 changelog
+          - url: http://groovy-lang.org/changelogs/changelog-2.4.20.html
+            title: Groovy 2.4.20 changelog
           - url: http://groovy-lang.org/changelogs/changelog-2.4.21.html
             title: Groovy 2.4.21 changelog
+          - url: https://groovy-lang.org/
+            title: Groovy language site
         message: |-
-          Upgrade [Groovy](https://groovy-lang.org/) from 2.4.12 to 2.4.21.
+          Upgrade Groovy from 2.4.12 to 2.4.21.
       - type: major bug
         category: regression
         pull: 6059


### PR DESCRIPTION
## Remove markdown from weekly changelog

Also update the Groovy upgrade changelog to include links to all the relevant Groovy release changelogs.
