### PR TITLE
Add GSoC 2022 project idea for Jenkinsfile Runner Action

### DIFF
--- a/content/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions.adoc
+++ b/content/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions.adoc
@@ -1,0 +1,67 @@
+---
+layout: gsocprojectidea
+title: "Jenkinsfile Runner Action for GitHub Actions"
+goal: "Implement a (near) feature-complete version of Jenkinsfile Runner Action for GitHub Actions"
+category: Tool
+year: 2022
+status: published
+sig: docs
+skills:
+- Java
+- Jenkinsfile Runner
+- Docker
+- GitHub Actions
+mentors:
+- "krisstern"
+- "oleg_nenashev"
+---
+
+=== Background
+In light of the latest development of the link:https://github.com/jenkinsci/jenkinsfile-runner/[Jenkinsfile Runner project], and to follow up on an old Proof-of-Concept (PoC) project preceding it called link:https://github.com/jenkinsci/jenkinsfile-runner-github-actions/[GitHub Actions POC for Jenkins Single-shot master] based on the idea of creating Jenkinsfile Runner action for GitHub Actions, we would like to further develop the latter into a full-fledged feature-complete version combining the strengths of both work into a new Jenkinsfile Runner Action for GitHub Action project.
+Ideally, the GSoC contributor to work on the project should have some basic Java programming skills, as well as some experience and understanding of the configuration of Jenkins/Jenkinsfile Runner or Docker.
+The project is suitable to be tackled independently over a summer, or to extend to a slightly longer version based on pace of completion and need.
+
+=== Project Details
+This project would be a great opportunity for GSoC contributors who are interested in knowing more about DevOps processes, or at least to have a glimpse at what could potentially be involved.
+This project is chiefly based on two existing projects available on GitHub, namely the link:https://github.com/jenkinsci/jenkinsfile-runner/[Jenkinsfile Runner project] and the link:https://github.com/jenkinsci/jenkinsfile-runner-github-actions/[GitHub Actions POC for Jenkins Single-shot Master project], so the GSoC contributor will be able to build on these and not having to entirely start from scratch from first principles.
+It is expected that the GSoC contributor may need to contribute pull requests to the Jenkinsfile Runner project in order to facilitate the completion of this goal.
+
+The former GitHub Actions PoC can be used as a study to gain insights on the overall idea; however, the outcome of this project will be based very loosely on it as the tooling with the Jenskinsfile Runner project will be used as a basis instead.
+
+The three potential use cases of Jenkinsfile are but not limited to:
+
+* Using Jenkins in a Function-as-a-Service (FaaS) context.
+* Assisting in the editing and testing of Jenkins Pipeline definitions and libraries locally.
+* Integration testing of Pipelines.
+
+We will focus on a containerized pipeline execution which is the last of the three main Jenkinsfile Runner use-cases.
+The Jenkinsfile Runner project provides official Docker images which can be used and extended for custom use-cases, as in our case.
+The existing Jenkinsfile Runner repository provides the Vanilla distribution of Docker.
+
+Additional Docker images are available for common use-cases in link:https://github.com/jenkinsci/jenkinsfile-runner-image-packs/[this repository]; e.g., for building Java projects with either Maven or Gradle.
+Each Docker image includes a set of Jenkins plugins, configurations, as well as Pipeline libraries which are commonly used in the desired technology stack.
+These image packs can be pulled from link:https://hub.docker.com/r/jenkins/jenkinsfile-runner/[DockerHub].
+
+Finally, the end goal would be to enable running of link:https://github.com/features/actions/[GitHub Actions] using the above.
+This will neatly tie up all the loose ends once a basic version is implemented.
+Throughout the entire GSoC project, the GSoC contributor is expected to employ test-driven development (TDD) and to supply supporting documentation for both the user and fellow developers.
+
+It is hoped that through successful completion of this project, the GSoC contributor will be able to gain good software development skills, knowledge, and most importantly habits such as relying on official documentation for the different tools used, writing good documentation for self and others, as well as seeking help from mentors and the Jenkins community at large when needed.
+
+=== Links
+Some useful links serving as the background are as follows:
+
+* link:https://github.com/jenkinsci/jenkinsfile-runner/[Jenkinsfile Runner official repository] as the point of origin of this project idea
+* link:https://github.com/jenkinsci/jenkinsfile-runner/blob/master/CONTRIBUTING.adoc/[The official CONTRIBUTING document] introducing the steps to start using Jenkinsfile Runner in a very detailed manner
+* link:https://github.com/jenkinsci/jenkinsfile-runner-image-packs/[The official Jenkinsfile Runner Image Packs repository]
+* link:https://hub.docker.com/r/jenkins/jenkinsfile-runner/[The DockerHub page for Jenkinsfile Runner] with instructions on how to pull the Jenkinsfile Runner Image Packs from Docker
+* link:https://docs.github.com/en/actions/[GitHub Action official documenation]
+
+=== Newbie-friendly issues
+The "good first issues" at link:https://github.com/jenkinsci/jenkinsfile-runner/contribute/[the tracker at the official Jenkinsfile Runner repository] would be a good place to start.
+
+=== Skills to improve/study
+* Java
+* To run Jenkinsfile Runner (an incubating project) to create an action inside Docker
+* Docker configuration
+* GitHub Actions configuration


### PR DESCRIPTION
@alyssat and @MarkEWaite 

## Description
**To follow up on our previous communication**: This is to add the Jenkinsfile Runner Action for GitHub Actions project originally proposed and will be co-led by @oleg-nenashev. I have tried my best to come up with a draft with as much essential detail as possible. Hopefully both of you and Oleg will get the chance to take a look and provide any comments or feedback before this can be approved and merged to the repo after some modifications. I expect since I am new to / not known on Jenkins.io so my tag as a co-mentor may not get properly rendered. 