### PR TITLE
Fix typos in GSoC 2022 docs

### DIFF
--- a/content/projects/gsoc/2022/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2022/project-ideas/automatic-spec-generator-for-jenkins-rest-api.adoc
@@ -45,7 +45,7 @@ It might be helpful to automatically generate some code for the REST API when th
 Any methodology created to handle the REST API should be built into the skeleton generator.
 
 The jenkins core REST API and the plugins own REST API need to be versioned separately.
-It is suggested to first focus first on generating the specification, then later look at the versioning of the REST API.
+It is suggested to focus first on generating the specification, then later look at the versioning of the REST API.
 Nested objects make versioning challenging.
 
 Jenkins users should be easily able to see the REST APIs available for their installed Jenkins.

--- a/content/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions.adoc
+++ b/content/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions.adoc
@@ -2,7 +2,7 @@
 layout: gsocprojectidea
 title: "Jenkinsfile Runner Action for GitHub Actions"
 goal: "Implement a (near) feature-complete version of Jenkinsfile Runner Action for GitHub Actions"
-category: Tool
+category: Tools
 year: 2022
 status: published
 sig: docs


### PR DESCRIPTION
Have been checking the latest batch of GSoC 2022 docs for typos. Found two and fixed both. These are minor but thought it be better handled earlier for better presentation and consistency. 