### PR TITLE
Propose developer guide for icon removal from core

### DIFF
--- a/content/doc/developer/views/_chapter.yml
+++ b/content/doc/developer/views/_chapter.yml
@@ -4,3 +4,4 @@ sections:
 guides:
 - table-to-div-migration
 - exposing-bundled-resources
+- icon-path-to-icon-class-migration

--- a/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
+++ b/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
@@ -49,4 +49,5 @@ More information about Jelly tags provided by core to display icons can be found
 
 == I still need more help?
 
-Contact the link:/sigs/ux[UX sig] on link:https://gitter.im/jenkinsci/ux-sig[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-ux[mailing list].
+Contact the link:/sigs/ux[UX sig] on link:https://gitter.im/jenkinsci/ux-sig[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[mailing list].
+

--- a/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
+++ b/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
@@ -45,7 +45,8 @@ Groovy example:
 l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
 ----
 
-More information about Jelly tags provided by core to display icons can be found link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html#layout[here].
+More information about Jelly tags provided by core to display icons can be found in it's link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html#layout:icon[jelly documentation].
+
 
 == I still need more help?
 

--- a/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
+++ b/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
@@ -1,0 +1,52 @@
+---
+title: Icon path to icon class migration
+layout: developerguide
+---
+
+Jenkins core has removed `GIF` and `PNG` icons as of Jenkins v2.333, in favor of the previously added SVG icons.
+
+Plugins, that don't interact with icons at all, are unaffected by this change.
+
+== Examples of area which require changes
+
+* If a plugin reads icons from its icon path, it typically does the following in jelly:
+
+[source, xml]
+----
+<img src="${imagesURL}/16x16/fingerprint.png" alt="" height="16" width="16" />
+<!-- or -->
+<l:task icon="images/24x24/document.png" href="" title="${%Modules}" />
+----
+
+* or in groovy:
+
+[source, groovy]
+----
+img(width:"16", height:"16", src:"${imagesURL}/16x16/next.gif")
+----
+
+* A plugin can do that in Java too, but that is, by far, less common.
+
+== Maintaining support for legacy icons and modern icons
+
+Jelly offers a couple of properties to access an icon class instead of an icon path. Jenkins core will display a GIF, a PNG or an SVG, based on the Jenkins version used. The properties `<l:icon class>` and `<l:task icon>` are used based on the location the icon is displayed in.
+
+Jelly example:
+[source, xml]
+----
+<l:task icon="icon-gear2 icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+<!-- or -->
+<l:icon class="icon-gear2 icon-md" />
+----
+
+Groovy example:
+[source, groovy]
+----
+l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
+----
+
+More information about Jelly tags provided by core to display icons can be found link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html#layout[here].
+
+== I still need more help?
+
+Contact the link:/sigs/ux[UX sig] on link:https://gitter.im/jenkinsci/ux-sig[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-ux[mailing list].


### PR DESCRIPTION
This guide complements https://github.com/jenkinsci/jenkins/pull/5778 and should help plugin developers to update their plugins, if they are working with icons, according to the latest changes in core.