### PR TITLE
Update 2.333 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -13972,14 +13972,6 @@
   - version: '2.333'
     date: 2022-01-31
     changes:
-      - type: TODO
-        category: developer
-        pull: 6231
-        authors:
-          - dependabot[bot]
-        pr_title: Bump XStream from 1.4.18 to 1.4.19
-        message: |-
-          Jenkins has upgraded the [XStream](https://x-stream.github.io/) library from 1.4.18 (released on August 22, 2021) to 1.4.19 (released on January 29, 2022). This maintenance release of XStream addresses the security vulnerability [CVE-2021-43859](https://x-stream.github.io/CVE-2021-43859.html), when unmarshalling highly recursive collections or maps causing a Denial of Service.
       - type: rfe
         category: rfe
         pull: 6228
@@ -13997,9 +13989,28 @@
           - Wadeck
           - daniel-beck
         pr_title: "[JENKINS-67674] Update bundled dependencies after the advisory"
+        references:
+          - pull: 6180
+          - issue: 67674
+          - url: https://www.jenkins.io/security/advisory/2022-01-12/
+            title: 2022-01-12 security advisory
         message: |-
-          Update the bundled Mailer Plugin from 1.32.1 to 408.vd726a_1130320 based on [security advisory](https://www.jenkins.io/security/advisory/2022-01-12/).
-           Update the bundled Matrix Project Plugin from 1.18 to 1.20 based on [security advisory](https://www.jenkins.io/security/advisory/2022-01-12/).
+          Update the bundled Mailer Plugin from 1.32.1 to 408.vd726a_1130320.
+      - type: rfe
+        category: rfe
+        pull: 6180
+        issue: 67674
+        authors:
+          - Wadeck
+          - daniel-beck
+        pr_title: "[JENKINS-67674] Update bundled dependencies after the advisory"
+        references:
+          - pull: 6180
+          - issue: 67674
+          - url: https://www.jenkins.io/security/advisory/2022-01-12/
+            title: 2022-01-12 security advisory
+        message: |-
+          Update the bundled Matrix Project Plugin from 1.18 to 1.20.
       - type: rfe
         category: rfe
         pull: 5778
@@ -14028,8 +14039,6 @@
         pr_title: JENKINS-67635 consider agent label expressions when applying trimLabels
         message: |-
           Launch only one agent to satisfy cloud agent requests that use label expressions.
-
-          tests: did not find existing testing to expand :/
       - type: bug
         category: bug
         pull: 6230
@@ -14067,6 +14076,21 @@
         pr_title: "[JENKINS-67662] Do not show wrong feature name in tooltips"
         message: |-
           Show correct feature name in tooltips of help links (regression in 2.179).
+      - type: rfe
+        category: developer
+        pull: 6231
+        authors:
+          - dependabot[bot]
+        pr_title: Bump XStream from 1.4.18 to 1.4.19
+        references:
+          - pull: 6231
+          - url: https://x-stream.github.io/changes.html#1.4.19
+            title: XStream 1.4.19 changelog
+          - url: https://x-stream.github.io/CVE-2021-43859.html
+            title: XStream CVE-2021-43859
+        message: |-
+          Upgrade the XStream library from 1.4.18 to 1.4.19.
+          Addresses the CVE-2021-43859 security vulnerability when unmarshalling highly recursive collections or maps causing a Denial of Service.
 
   # pull: 6191 (PR title: Prevent one redirect in `AsynchPeople`)
   # pull: 6204 (PR title: Add test to confirm bundled plugins don't have active warnings)


### PR DESCRIPTION
## Update 2.333 changelog

Docs office hours noted that the developer section needs to move to the end and that the reference links need to be added as references rather than inlined as markdown links.

![Screenshot 2022-02-01 072512](https://user-images.githubusercontent.com/156685/151986750-486c0910-c4b1-4afd-85bf-f29a2d130786.png)
