### PR TITLE
update GSoC SIG page

### DIFF
--- a/content/sigs/gsoc/index.adoc
+++ b/content/sigs/gsoc/index.adoc
@@ -18,8 +18,6 @@ participants:
 links:
   gitter: "jenkinsci/gsoc-sig"
   googlegroup: "jenkinsci-gsoc-all-public"
-meetings:
-  text: Every Wednesday
 overview: >
   This special interest group organizes Google Summer of Code in the Jenkins organization.
   Scope of work includes coordinating GSoC and working with potentials mentors and students
@@ -28,7 +26,7 @@ overview: >
 
 This SIG focuses on link:https://summerofcode.withgoogle.com/[Google Summer of Code] and
 other similar event.
-The group drives the link:/projects/gsoc[GSoC subproject] in the Jenkins organization.
+The group drives the link:/projects/gsoc[GSoC sub-project] in the Jenkins organization.
 The scope of work includes organizing the events and working with potentials mentors and students in order
 to organize GSoC teams.
 
@@ -36,8 +34,8 @@ You can find more info about GSoC in Jenkins link:/projects/gsoc[here].
 
 === Meetings
 
-// * Every Wednesday, please see link:/events/[Jenkins event calendar] to add the event to your calendar
+* GSoC SIG topics are discussed during the Advocacy & Outreach topics. See its link:/sigs/advocacy-and-outreach[information page] for further details. 
 // * link:https://docs.google.com/document/d/1H0gJt1zdr37YDpuSLXSeFqYco_a_CIrAuZ1f0Oyl4XE/edit#heading=h.szu3oyozkdfv[Meeting minutes]
-* See the link:/projects/gsoc[GSoC subproject] for the list of public events
-  within Google Summer of Code timeframe
+* See the link:/projects/gsoc[GSoC sub-project] for the list of public events
+  within Google Summer of Code time frame
 * Other meetings will be announced in GSoC mailing lists


### PR DESCRIPTION
Remove references to a weekly specific meeting and point to the "Advocacy & Outreach" meeting.