### PR TITLE
JEP-221 is now current as JEP-229

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -621,7 +621,7 @@ categories:
     - name: "JEP-229: Continuous Delivery of Jenkins Plugins"
       description: >
         Introduce a new system which would enable Jenkins plugin maintainers to add Continuous Delivery (CD) to their projects.
-      status: current
+      status: preview
       link: https://github.com/jenkinsci/jep/blob/master/jep/229
       labels:
       - tools

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -618,11 +618,11 @@ categories:
       link: https://github.com/jenkinsci/jep/blob/master/jep/217
       labels:
       - infrastructure
-    - name: "JEP-221: Continuous Delivery of Jenkins Plugins"
+    - name: "JEP-229: Continuous Delivery of Jenkins Plugins"
       description: >
         Introduce a new system which would enable Jenkins plugin maintainers to add Continuous Delivery (CD) to their projects.
-      status: future
-      link: https://github.com/jenkinsci/jep/blob/master/jep/221
+      status: current
+      link: https://github.com/jenkinsci/jep/blob/master/jep/229
       labels:
       - tools
       - infrastructure


### PR DESCRIPTION
## JEP-221 is now JEP-229 and is in progress

Over 100 plugins are using the JEP-229 continuous delivery technique.  I think that is enough to call it a "current" project on the roadmap.
