### PR TITLE
update Advocacy SIG members

### DIFF
--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -12,18 +12,12 @@ tags:
   - community
   - outreach
   - events
+
 leads:
-- "oleg_nenashev"
-- "lnewman"
-- "markyjackson-taulia"
-participants:
-- "tracymiranda"
-- "jvz"
-- "linuxsuren"
-- "ewelinawilkosz"
-- "ndeloof"
+- "alyssat"
 - "markewaite"
-- "mattzand"
+participants:
+- "jmMeessen"
 
 
 links:


### PR DESCRIPTION
Removed people from the list not attending meetings or contributing anymore while reviewing the page for accuracy.