### PR TITLE
Move Docs office hours to Friday

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -184,7 +184,7 @@ This project is tracked in the jira:WEBSITE-742[] EPIC.
 
 == Office Hours
 
-Documentation office hours are held each Tuesday at *02:00 UTC* (Asia and US West) and each Thursday at *16:00 UTC* (Europe and US East).
+Documentation office hours are held each Thursday at *16:00 UTC* (Europe and US East) and each Friday at *02:00 UTC* (Asia and US West).
 Office hours are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
 


### PR DESCRIPTION
## Move Docs office hours to coordinate with GSoC office hours

Last meeting of Docs office hours (US West and Asia) agreed that it would be OK to move the meeting to the same time, but 3 days later in the week.  That alllows the meeting to immediately precede Google Summer of Code office hours (Asia)
