### PR TITLE
Update Docs office hours participants and details

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -14,15 +14,14 @@ leads:
 - "markewaite"
 participants:
 - "oleg_nenashev"
-- "tracymiranda"
+- "dheerajodha"
 - "kwhetstone"
 - "stackscribe"
-- "vsilverman"
-- "linuxsuren"
+- "zaycodes"
 links:
   gitter: "jenkinsci/docs"
   googlegroup: "jenkinsci-docs"
-  meetings: "https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit#"
+  meetings: "https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit"
 overview: >
   This special interest group improves Jenkins use and adoption through documentation.
   The SIG encourages, creates, and reviews documentation contributions and improves documentation with contributors and external communities.
@@ -80,6 +79,8 @@ on platform topics.
 
 == Topics
 
+* Reviewing link:/changelog/[weekly changelogs]
+* Creating and reviewing link:/changelog-stable/[LTS changelogs] and link:/doc/upgrade-guide/[LTS upgrade guides]
 * Creating new documentation
 * Improving existing documentation
 * Reviewing documentation contributions
@@ -89,14 +90,14 @@ on platform topics.
 == Contributing
 
 See link:/participate/document[this page] for information about contributing to Jenkins documentation.
-It contains links for newcomer and seasoned contributors.
+It contains links for newcomers and seasoned contributors.
 If you have any questions or ideas, please feel free to reach out to us using the channels listed on the right panel.
 
 [[ongoing-projects]]
 == Projects
 
 This section lists some of the projects working under the direction of this SIG.
-See the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
+See the link:https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
 === Google Season of Docs
 
@@ -196,9 +197,9 @@ Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gi
 
 === Meeting Agendas
 
-Meeting agendas and meeting notes for the SIG are posted in link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c[this Google Document].
-Anyone is welcome to add a topic for an upcoming meeting by suggesting a change in the link:https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c[agenda].
+Meeting agendas and meeting notes for the SIG are posted in link:https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit[this Google Document].
+Anyone is welcome to add a topic for an upcoming meeting by suggesting a change in the link:https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit[agenda].
 
 ++++
-<iframe src="https://docs.google.com/document/d/1uNNo0QJKPHnNp8PGr_jLI8p3K_94ZYD-M0evZOEZ93c?embedded=true" width="100%" height="600px"></iframe>
+<iframe src="https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo?embedded=true" width="100%" height="600px"></iframe>
 ++++


### PR DESCRIPTION
## Update Docs participants, topics, and meeting notes

Link to the current office hours notes for both the office hours and the SIG meetings, since they are the same meeting.

Add changelog and upgrade guide reviews as common topics.
