### PR TITLE
Fix changelog 2.333 formatting

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -14081,7 +14081,8 @@
         issue: 56911
         authors:
           - basil
-        pr_title: "[JENKINS-56911] Debian package postinst script does not support group names with spaces"
+        pr_title: "[JENKINS-56911] Debian package postinst script does not support\
+          \ group names with spaces"
         references:
           - issue: 56911
           - url: https://github.com/jenkinsci/packaging/pull/268


### PR DESCRIPTION
## Fix 2.333 weekly changelog formatting

Interactive editing did not apply the same formatting rules as the automated formatter applies.
