### PR TITLE
[doc] add a full content of logging.properties

### DIFF
--- a/content/doc/book/system-administration/viewing-logs.adoc
+++ b/content/doc/book/system-administration/viewing-logs.adoc
@@ -88,8 +88,8 @@ which causes custom logs to be written to disk automatically.
 2. Define the logging levels and a `ConsoleHandler`
 3. Pass this file to the JVM by adding the system property `-Djava.util.logging.config.file=<pathTo>/logging.properties`.
 
-See below an example of *logging.properties* content.
-Note that for a normal production environement the default level is INFO, it is not advised to have debug log in production.
+An example *logging.properties* is included below.
+Note that for a normal production environment the default level is INFO, it is not advised to have debug log in production.
 
 [source]
 ----

--- a/content/doc/book/system-administration/viewing-logs.adoc
+++ b/content/doc/book/system-administration/viewing-logs.adoc
@@ -84,14 +84,26 @@ which causes custom logs to be written to disk automatically.
 
 == Debug logging in Jenkins
 
-Create a file `logging.properties` in which you define the logging
-levels and a `ConsoleHandler` Then pass this file to the JVM by adding
-the system property `-Djava.util.logging.config.file=<pathTo>/logging.properties`.
-In the logging.properties file please add the below line:
+1. Create a file `logging.properties`
+2. Define the logging levels and a `ConsoleHandler`
+3. Pass this file to the JVM by adding the system property `-Djava.util.logging.config.file=<pathTo>/logging.properties`.
 
-*logging.properties*
+See below an example of *logging.properties* content.
+Note that for a normal production environement the default level is INFO, it is not advised to have debug log in production.
 
 [source]
 ----
-.level=TRACE
+handlers = java.util.logging.ConsoleHandler
+
+# see https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/SimpleFormatter.html
+java.util.logging.SimpleFormatter.format = [%1$tF %1$tT][%4$-6s][%2$s] %5$s %6$s %n
+
+# Keep this level to ALL or FINEST or it will be filtered before applying other levels
+java.util.logging.ConsoleHandler.level = ALL
+
+# Default level
+.level= INFO
+
+# High verbosity for a dedicated package com.myplugin.*
+com.myplugin.level = ALL
 ----


### PR DESCRIPTION
It's not that easy to fill the logging property file when you are not used to this logging system (but more used to log4J or Slf4J or logback).

So I propose to give a full working example (tested locally)