### PR TITLE
GSoC2022 application document

### DIFF
--- a/content/projects/gsoc/2022/application.adoc
+++ b/content/projects/gsoc/2022/application.adoc
@@ -1,0 +1,260 @@
+---
+layout: project
+title: "Jenkins GSoC Application 2022"
+description: "This page is Jenkins application form for Google Summer of Code"
+tags:
+- gsoc
+project: gsoc
+opengraph:
+    image: /images/gsoc/opengraph.png
+---
+
+//https://docs.google.com/document/d/1gVO2XT_7m8kf5aJJS00G05f5zBBf1eaFZPcoWl8W0m0/edit#heading=h.pj9miykzw86z
+
+{nbsp} +
+{nbsp} +
+
+
+**Organization Name**
+
+Jenkins
+
+{nbsp} +
+{nbsp} +
+ 
+
+**Is this organization an established Open Source project or organization that releases code under an OSI approved license ? An OSI License is required for program participation.**
+
+Yes
+
+{nbsp} +
+{nbsp} +
+
+
+**Has your organization participated in Google Summer of Code before?**
+
+Yes
+
+{nbsp} +
+{nbsp} +
+
+
+**Please select all years in which your organization participated prior to 2022.**
+
+2021, 2020, 2019, 2018, 2016
+
+{nbsp} +
+{nbsp} +
+
+
+**Agreements and Rules**
+
+_link:https://summerofcode.withgoogle.com/terms/org[Click the link] to review the organization agreement to continue._
+
+>> Accept
+
+{nbsp} +
+{nbsp} +
+
+
+=== Organization Profile
+
+* **Website url:** https://jenkins.io/
+* **Organization logo**
+
+<logo comes here>
+
+* **Tagline:** Open-source automation server for building great things at any scale
+
+* **Primary Open Source License:** MIT License is used for most of the components.
+
+* **What year was your project started:** 2006
+
+* **Link to your source code location:** 
+** https://github.com/jenkinsci/, 
+** https://github.com/jenkins-zh/,
+** https://github.com/jenkins-infra/ 
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== Organization Categories 
+_Select which categories fit your organization best. You may select up to 2 categories. This helps GSoC contributors filter the large list of organizations by their interests._
+_Select at least 1_
+
+* Data (databases, analytics, visualization, AI/ML, etc) 
+* **Development tools** (version control systems, CICD tools, text editors, issue managers, q/a tools, etc) 
+* End user applications 
+* **Infrastructure and cloud** (hardware, software defined infrastructure, cloud native tooling, orchestration and automation, etc) 
+* Media (graphics, video, audio, VR, streaming, gaming, content management, etc) 
+* Operating systems 
+* **Programming languages** (libraries, package managers, testing tools, etc) 
+* Science and medicine (healthcare, biotech, life sciences, academic research, etc) 
+* Security (tools and frameworks) 
+* Social and communications (Blog, chat, forums, wikis, etc) 
+* Web (tools and frameworks) 
+* Other
+
+=== Organization Technologies 
+_Enter up to 5 keywords for the primary specific technologies your organization uses._ 
+
+* java
+* javascript
+* docker
+* kubernetes
+* go
+
+=== Organization Topics 
+_Enter keywords for general topics that describe your organization. Examples: Robotics, Cloud,_ 
+
+* continuous integration
+* continuous delivery
+* developer tools
+* devops
+* automation
+
+
+{nbsp} +
+{nbsp} +
+ 
+
+=== Organization Description 
+_Describe what it is your organization does. This information will also be included in the archive once the program has ended._
+
+{nbsp} +
+
+
+**Short description**
+
+Jenkins is a popular open source automation server which is used for building, testing, CI/CD, deployment and many other use-cases. Our motto is "Build great things at any scale".
+
+{nbsp} + 
+
+**Long description (Markdown)**
+
+link:https://jenkins.io/[Jenkins], originally founded in 2006 as "Hudson", is one of the leading automation servers. 
+Jenkins' motto is "Build great things at any scale". 
+Using an extensible, plugin-based architecture developers have created hundreds of plugins to adapt Jenkins to a multitude of build, test, and deployment automation workloads. 
+Jenkins is open-source, link:https://www.opensource.org/licenses/mit-license.php[MIT License] is used for most of the components.
+
+This year we invite potential GSoC contributors to join the Jenkins community and to work together to improve Jenkins. 
+We have many strategic project ideas which are important to hundreds of thousands of Jenkins users.
+
+The project has over 600 active contributors working on Jenkins core, plugins, website, project infrastructure, localization activities, etc. 
+In total we have more than 2,000 components including plugins, libraries, and various utilities. 
+The main languages in the project are Java, Groovy and JavaScript, but we also have components written in other languages (Go, C/C++, C#, etc.). 
+Jenkins project includes multiple sub-projects (including link:/projects/jcasc/[Configuration-as-Code], link:/projects/infrastructure/[Infrastructure] and link:/projects/remoting/[Remoting]) and link:/sigs/[special interest groups]. 
+These entities participate in GSoC as a part of the Jenkins project. 
+
+The Jenkins project is a part of link:https://cd.foundation/[Continuous Delivery Foundation (CDF)]. 
+
+{nbsp} +
+{nbsp} +
+ 
+
+=== Contributor Guidance 
+
+_Provide your potential contributors with a page containing tips on how to write a successful proposal for your organization. Let them know what you want included, how you want it structured, and how to best get in touch. link:https://developers.google.com/open-source/gsoc/help/contributor-guidance[Examples]._
+
+Welcome and thank you for your interest! 
+To apply to the organization, please follow the link:https:/projects/gsoc/students/#student-application-process[guidelines on our website].
+
+Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/students/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
+If you have any questions about the application process, please feel free to contact us via link:https://community.jenkins.io/tag/gsoc[Jenkins GSoC Discourse] or in the link:https://gitter.im/jenkinsci/gsoc-sig[jenkinsci/gsoc-sig Gitter] chat. We also have weekly meetings which are open to everyone.
+
+
+{nbsp} +
+{nbsp} + 
+
+=== Communication Methods 
+
+_How do you want potential contributors to interact with your organization? Select methods that your community uses daily as you will receive many inquiries if your org is selected._
+
+Jenkins GSoC communication channels: link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse], link:https://gitter.im/jenkinsci/gsoc-sig[Gitter]
+
+
+{nbsp} +
+{nbsp} +
+
+
+== Organization Questionnaire
+
+=== Why does your organization want to participate in GSoC?
+
+In our community we are interested to have more contributors in both the Jenkins core and 1,800+ existing plugins. GSoC is an opportunity to find new contributors interested in software development automation (continuous integration and continuous delivery). 
+It also helps to get existing contributors more involved in community work. We have previously participated in GSoC 2016-2021.  
+We gained valuable experience, especially regarding the student selection process. 
+We received significant contributions and are still using those contributions in the project.  
+We are confident that we can host a successful Google Summer of Code 2022 in the Jenkins project.
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== What would your organization consider to be a successful GSoC program?
+
+A successful Jenkins GSoC program consists of:
+
+* A positive and enjoyable experience for both GSoC contributors and mentors, where the project’s goals provide a sense of challenge and rewarding learning experience. 
+* Contributor’s code contributions play a part in the betterment of Jenkins resulting in benefit for Jenkins users    
+* GSoC contributors are inspired to contribute to Jenkins after the program and return as a GSoC mentor in the future.
+
+{nbsp} +
+{nbsp} +
+
+=== How will you keep mentors engaged with their GSoC contributors?
+
+* We have explicit expectations from mentors, they are documented in our link:/projects/gsoc/mentors[mentor guidelines]. 
+  All mentors commit to these expectations during the project selection.
+* Each GSoC contributor will have at least 2 mentors AND an org admin advisor assigned to the project.
+* Mentors are expected to be accomplished Jenkins contributors, who are passionate about community/mentorship work.
+* Mentors are highly interested in the project they are mentoring
+* Mentors are directly involved in the GSoC contributor selection and interview processes so they will establish early connections with GSoC contributors
+* Org admins will be monitoring mentor/GSoC contributor interaction starting from the application phase and intervene if needed
+* There will be regular sync-ups between org admins and mentors
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== How will you keep your GSoC contributors on schedule to complete their projects?
+
+* During the Application phase and Community Bonding phase mentors will share their expertise to define realistic project plans.
+* The GSoC contributor project milestones will be discussed and confirmed between mentors and GSoC contributors. Milestones will be aligned with GSoC contributor evaluations and will have clear expectations defined.
+* Mentors will set up regular meetings with their GSoC contributor (at least weekly) in order to sync-up on projects. 
+* Retrospectives with GSoC contributors will be held after each evaluation.
+* Mentors should be available for questions. They should also provide periodic feedback on the progress and on the performance of particular GSoC contributors (1x1).
+* Weekly public GSoC office-hours allow GSoC contributors, mentors, and organization administrators to meet, plan, and review. (or two meetings if time-zones require it) and private ones between mentors and org admins to sync-up
+* We will encourage frequent push to branches so that the GSoC contributors show progress and keep changes atomic.
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== How will you get your GSoC contributors involved in your community during GSoC?
+
+* GSoC contributors will cooperate with the Jenkins community during the project. Community Bonding will be a critical phase for us.
+* Projects will handled under an umbrella of SIGs or sub-projects so that non-mentor stakeholders and early adopters are included in the projects
+* GSoC contributors will be participating in sub-project/SIG meetings and presenting their work on a regular basis
+* Org Admins will provide an introductory training (community overview, code-of-conduct, etc.), then mentors will help GSoC contributors establish contacts with experts from the community
+* We expect GSoC contributors to be around in public chats and other communication channels during the “working days”
+* GSoC contributors will be involved in all standard processes in our community (pull requests, code reviews, chats and mailing lists, test automation, documentation, online meetups, etc.).
+* GSoC contributors will be encouraged to give updates to the wider community via the Jenkins blog and Jenkins online meetups
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== Is your organization part of any government?
+
+No
+
+
+{nbsp} +
+{nbsp} +

--- a/content/projects/gsoc/2022/application.adoc
+++ b/content/projects/gsoc/2022/application.adoc
@@ -87,7 +87,7 @@ _Select at least 1_
 * Data (databases, analytics, visualization, AI/ML, etc) 
 * **Development tools** (version control systems, CICD tools, text editors, issue managers, q/a tools, etc) 
 * End user applications 
-* **Infrastructure and cloud** (hardware, software defined infrastructure, cloud native tooling, orchestration and automation, etc) 
+* Infrastructure and cloud (hardware, software defined infrastructure, cloud native tooling, orchestration and automation, etc) 
 * Media (graphics, video, audio, VR, streaming, gaming, content management, etc) 
 * Operating systems 
 * **Programming languages** (libraries, package managers, testing tools, etc) 

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -30,6 +30,8 @@ in completing their projects.
 We plan to participate in Google Summer of Code 2022.
 See the link:./2022/project-ideas[current project ideas].
 
+The draft of the Jenkins GSoC application for 2022 can be seen link:./2022/application[here].
+
 // * To Be Defined
 // * link:/projects/gsoc/2021/projects/cloudevents-plugin[CloudEvents Plugin for Jenkins] by Shruti Chaturvedi
 // * link:/projects/gsoc/2021/projects/conventional-commits-plugin[Conventional Commits Plugin for Jenkins] by Aditya Srivastava


### PR DESCRIPTION
Jenkins GSoC 2022 Application form

Modified pages can be previewed at:

- (main GSoC page): https://deploy-preview-4913--jenkins-io-site-pr.netlify.app/projects/gsoc/
- (application): https://deploy-preview-4913--jenkins-io-site-pr.netlify.app/projects/gsoc/2022/application/