### PR TITLE
add note about jenkinsci membership in plugin adoption explanation

### DIFF
--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -53,7 +53,7 @@ Note that the invitation is valid for 7 days only.
 
 If you need a new invitation because you missed it, 
 replying on the RPU pull request is the easiest way. 
-You can also create an INFRA helpdesk ticket or email the jenkinsci-dev mailing list.
+You can also create an link:https://github.com/jenkins-infra/helpdesk/issues/new/choose[INFRA helpdesk ticket] or email the link:https://github.com/jenkins-infra/helpdesk/issues/new/choose[jenkinsci-dev mailing list].
 
 == Abandoned plugins
 

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -51,6 +51,10 @@ If this is not the case yet, you will receive an invitation sent to your GitHub 
 You can also accept it at https://github.com/jenkinsci if you can't find the invite. 
 Note that the invitation is valid for 7 days only.
 
+If you need a new invitation because you missed it, 
+replying on the RPU pull request is the easiest way. 
+You can also create an INFRA helpdesk ticket or email the jenkinsci-dev mailing list.
+
 == Abandoned plugins
 
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -53,7 +53,7 @@ Note that the invitation is valid for 7 days only.
 
 If you need a new invitation because you missed it, 
 replying on the RPU pull request is the easiest way. 
-You can also create an link:https://github.com/jenkins-infra/helpdesk/issues/new/choose[INFRA helpdesk ticket] or email the link:https://github.com/jenkins-infra/helpdesk/issues/new/choose[jenkinsci-dev mailing list].
+You can also create an link:https://github.com/jenkins-infra/helpdesk/issues/new/choose[INFRA helpdesk ticket] or email the link:https://groups.google.com/g/jenkinsci-dev[jenkinsci-dev mailing list].
 
 == Abandoned plugins
 
@@ -98,7 +98,7 @@ https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+inco
 === How can I mark a plugin for adoption?
 
 Before marking a plugin for adoption,
-we recommend to announce the incoming change in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Jenkins Developer Mailing list] or in other appropriate channels.
+we recommend to announce the incoming change in the link:https://groups.google.com/g/jenkinsci-dev[Jenkins Developer Mailing list] or in other appropriate channels.
 It may help you to find new maintainers and, ideally, to establish a transition and knowledge transfer process.
 
 . Add the `+adopt-this-plugin+` label to the plugin. It can be done in 2 ways:

--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -46,6 +46,11 @@ Ping the current registered developers on the PR to inform them of your initiati
 Once you have access to the plugin's Github repository, be sure to remove the `+adopt-this-plugin+` label.
 This can be done by clicking on the gear wheel near the "About".
 
+**Note**: Membership of the `jenkinsci` github organization is required.
+If this is not the case yet, you will receive an invitation sent to your GitHub email account. 
+You can also accept it at https://github.com/jenkinsci if you can't find the invite. 
+Note that the invitation is valid for 7 days only.
+
 == Abandoned plugins
 
 For abandoned plugins, you are expected to try and reach out to existing maintainer(s) using a best effort.


### PR DESCRIPTION
For plugin adoption, it is required to be member of the jenkinsci
Github org. This requirement is clarified in this contribution.