### PR TITLE
Direct `systemd` users to appropriate log location

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -80,7 +80,7 @@ The weekly package installation will:
 
 * Setup Jenkins as a daemon launched on start. Run `systemctl cat jenkins` for more details.
 * Create a '`jenkins`' user to run this service.
-* Direct console log output to the file `/var/log/jenkins/jenkins.log`. Check this file if you are troubleshooting Jenkins.
+* Direct console log output to `systemd-journald`. Run `journalctl -u jenkins.service` if you are troubleshooting Jenkins.
 * Populate `/lib/systemd/system/jenkins.service` with configuration parameters for the launch, e.g `JENKINS_HOME`
 * Set Jenkins to listen on port 8080. Access this port with your browser to start configuration.
 


### PR DESCRIPTION
Amends #4875.