### PR TITLE
Clarification of responsabilities

### DIFF
--- a/content/project/team-leads.adoc
+++ b/content/project/team-leads.adoc
@@ -55,6 +55,7 @@ Oversees the Jenkins project infrastructure. This is an **elected role**.
 
 * Direct triage of INFRA issues
 * Direct maintenance of Jenkins project infrastructure ('INFRA' issues)
+* Ensure the security of Jenkins project infrastructure
 * Encourage contributors to INFRA project
 * Communicate maintenance windows and manage execution of those windows
 * Coordinate Jenkins Infrastructure initiatives and define priorities, get key initiatives reflected on the link:/project/roadmap/[public Jenkins roadmap]


### PR DESCRIPTION
Clarification of responsabilities between Security officer and Infra officer concerning the security of the infrastructure. As it could generate confusion as it's related to both security and infra, we agreed that it's better that it belongs to the Infra officer. Otherwise, the security officer would need to be aware of any changes in the infra, which is counter productive and overlapping with the infra officer role.

Discussed with @dduportal before, but still expecting his review/approval :-)

(great to have the board review being automated, nice!)