### PR TITLE
Add GSoC 2022 Screenshot Automation project idea

### DIFF
--- a/content/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions.adoc
+++ b/content/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions.adoc
@@ -5,7 +5,7 @@ goal: "Implement a (near) feature-complete version of Jenkinsfile Runner Action 
 category: Tools
 year: 2022
 status: published
-sig: docs
+sig: platform
 skills:
 - Java
 - Jenkinsfile Runner
@@ -21,7 +21,7 @@ In light of the latest development of the link:https://github.com/jenkinsci/jenk
 Ideally, the GSoC contributor to work on the project should have some basic Java programming skills, as well as some experience and understanding of the configuration of Jenkins/Jenkinsfile Runner or Docker.
 The project is suitable to be tackled independently over a summer, or to extend to a slightly longer version based on pace of completion and need.
 
-=== Project Details
+=== Project details
 This project would be a great opportunity for GSoC contributors who are interested in knowing more about DevOps processes, or at least to have a glimpse at what could potentially be involved.
 This project is chiefly based on two existing projects available on GitHub, namely the link:https://github.com/jenkinsci/jenkinsfile-runner/[Jenkinsfile Runner project] and the link:https://github.com/jenkinsci/jenkinsfile-runner-github-actions/[GitHub Actions POC for Jenkins Single-shot Master project], so the GSoC contributor will be able to build on these and not having to entirely start from scratch from first principles.
 It is expected that the GSoC contributor may need to contribute pull requests to the Jenkinsfile Runner project in order to facilitate the completion of this goal.

--- a/content/projects/gsoc/2022/project-ideas/screenshot-automation.adoc
+++ b/content/projects/gsoc/2022/project-ideas/screenshot-automation.adoc
@@ -4,22 +4,26 @@ title: "Screenshot Automation for Jenkins Docs"
 goal: "To automate screenshot capture process for Jenkins docs"
 category: Dev Tools
 year: 2022
-status: discussion
+status: draft
 sig: docs
 skills:
 - Web Browser Automation
 - Image Comparison
 mentors:
-- "mentorname"
+- "markewaite"
+links:
+  emailThread: https://community.jenkins.io/t/she-code-africa-contributhon-2022/253/3
 ---
 
 === Background
+
 * Browser automation is a known thing and is an interesting idea to explore for the Jenkins project
 * Basic idea is to convert the steps from a human-readable format to a set of computer operations
 * This idea is relatively light-weight and is expected to require no more than a few months' time to complete
 * Could be in almost any language, it is a separate dev tool
 
 === Project details
+
 * May be extended to render a series of screenshots assembled as gif or mp4
 * How would we define the steps needed?
     - A YAML format to describe the steps
@@ -29,15 +33,18 @@ mentors:
     - Reducing image size is a more complicated procedure, but feasible
 
 === Links
+
 * https://www.selenium.dev/documentation/
 * https://github.com/teamcapybara/capybara/
 * https://developers.google.com/web/tools/puppeteer
 * https://www.cypress.io/
 
 === Newbie-friendly issues
+
 Any relevant issue to acquire the GSoC contributor with the way documentation is handled in the Jenkins ecosystem, especially the ones in link:https://github.com/jenkins-infra/jenkins.io/issues/[the jenkins.io repo].
 
 === Tools available in this space
+
 * Selenium (for web browser automation)
 * Capybara (for web browser automation)
 * Puppeteer (for webdriver web browser automation)
@@ -45,5 +52,21 @@ Any relevant issue to acquire the GSoC contributor with the way documentation is
 * Zika (for image comparison)
 
 === Skills to improve/study
+
 * Web browser automation
 * Automatic image comparison
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+=== Project Size
+
+175 hours
+
+=== Expected outcomes
+
+New tool to maintain documentation screenshots
+
+Documentation screenshots will be updated automatically based on steps defined as code.
+The steps will be a small domain-specific language that describe common Jenkins UI operations in a way that documentation writers understand.

--- a/content/projects/gsoc/2022/project-ideas/screenshot-automation.adoc
+++ b/content/projects/gsoc/2022/project-ideas/screenshot-automation.adoc
@@ -1,0 +1,49 @@
+---
+layout: gsocprojectidea
+title: "Screenshot Automation for Jenkins Docs"
+goal: "To automate screenshot capture process for Jenkins docs"
+category: Dev Tools
+year: 2022
+status: discussion
+sig: docs
+skills:
+- Web Browser Automation
+- Image Comparison
+mentors:
+- "mentorname"
+---
+
+=== Background
+* Browser automation is a known thing and is an interesting idea to explore for the Jenkins project
+* Basic idea is to convert the steps from a human-readable format to a set of computer operations
+* This idea is relatively light-weight and is expected to require no more than a few months' time to complete
+* Could be in almost any language, it is a separate dev tool
+
+=== Project details
+* May be extended to render a series of screenshots assembled as gif or mp4
+* How would we define the steps needed?
+    - A YAML format to describe the steps
+    - Capybara in Ruby expresses UI automation in English phrasing
+* How to reduce images to the relevant portion could also be considered
+    - Focusing on an element is a known Javascript technique
+    - Reducing image size is a more complicated procedure, but feasible
+
+=== Links
+* https://www.selenium.dev/documentation/
+* https://github.com/teamcapybara/capybara/
+* https://developers.google.com/web/tools/puppeteer
+* https://www.cypress.io/
+
+=== Newbie-friendly issues
+Any relevant issue to acquire the GSoC contributor with the way documentation is handled in the Jenkins ecosystem, especially the ones in link:https://github.com/jenkins-infra/jenkins.io/issues/[the jenkins.io repo].
+
+=== Tools available in this space
+* Selenium (for web browser automation)
+* Capybara (for web browser automation)
+* Puppeteer (for webdriver web browser automation)
+* Cypress (for webdriver web browser automation)
+* Zika (for image comparison)
+
+=== Skills to improve/study
+* Web browser automation
+* Automatic image comparison


### PR DESCRIPTION
As discussed during the Jenkins GSoC Office Hour on February 24th, 2022 at 2PM UTC, it was brought to our attention that a Jenkins Docs Screenshot Automation project idea has been discussed previously in the Jenkins Docs Office Hour on February 11th, 2022. We intend to formalise the discussion into a proper project idea for GSoC 2022, hence the follow-up with this write-up. No mentor has committed to this project yet thus detail has been intentionally left out for now. At least one GSoC contributor has expressed interest in pursuing this idea as of the time of this PR's submission. 