### PR TITLE
Adapt Linux install docs to current status

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -108,7 +108,7 @@ Update the Debian apt repositories, install OpenJDK 11, and check the installati
 [source,bash]
 ----
 $ sudo apt update
-$ sudo apt install fontconfig openjdk-11-jre
+$ sudo apt install openjdk-11-jre
 $ java -version
 openjdk version "11.0.12" 2021-07-20
 OpenJDK Runtime Environment (build 11.0.12+7-post-Debian-2)
@@ -139,8 +139,9 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install fontconfig java-11-openjdk
+sudo dnf install java-11-openjdk
 sudo dnf install jenkins
+sudo systemctl daemon-reload
 ----
 
 === Weekly release
@@ -155,7 +156,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install fontconfig java-11-openjdk
+sudo dnf install java-11-openjdk
 sudo dnf install jenkins
 ----
 
@@ -227,6 +228,10 @@ You need to choose either the Jenkins Long Term Support release or the Jenkins w
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
 It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
 
+The Linux installer for the long term support release depends on the `daemonize` program.
+The `daemonize` program is available from the link:https://docs.fedoraproject.org/en-US/epel/["Extra Packages for Enterprise Linux (EPEL)"].
+Follow the link:https://docs.fedoraproject.org/en-US/epel/#_quickstart[EPEL installation instructions] for your Linux distribution before installing the Jenkins LTS.
+
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
@@ -234,8 +239,9 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install fontconfig java-11-openjdk
+sudo yum install java-11-openjdk
 sudo yum install jenkins
+sudo systemctl daemon-reload
 ----
 
 === Weekly release
@@ -250,7 +256,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install fontconfig java-11-openjdk
+sudo yum install java-11-openjdk
 sudo yum install jenkins
 ----
 


### PR DESCRIPTION
## Adapt Linux install instructions to current status

The fontconfig package is already a dependency of the operating system Java installer.  It is only needed when using a JDK that is not provided as an operating system packages (like Eclipse Adoptium).

LTS 2.319.3 requires the `daemonize` package on Red Hat and its derivatives, but is provided by EPEL.  EPEL instructions are different depending on the operating system version.  Stop trying to describe EPEL installation, point the reader to the EPEL installation instructions.
