### PR TITLE
Promote two projects ideas to draft

### DIFF
--- a/content/projects/gsoc/2022/project-ideas/JCasC-drift-detector.adoc
+++ b/content/projects/gsoc/2022/project-ideas/JCasC-drift-detector.adoc
@@ -4,7 +4,7 @@ title: "Jenkins Configuration as Code (JCasC) drift detector"
 goal: "Report differences between a Jenkins active configuration and a given JCasC definition"
 category: Tools
 year: 2022
-status: discussion
+status: draft
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2022/project-ideas/automating-plugin-buildmetadata-updates.adoc
+++ b/content/projects/gsoc/2022/project-ideas/automating-plugin-buildmetadata-updates.adoc
@@ -4,7 +4,7 @@ title: "Automating plugin build metadata updates"
 goal: "Apply generic transformations across the Jenkins ecosystem"
 category: Tools
 year: 2022
-status: discussion
+status: draft
 sig: platform
 skills:
 - Java


### PR DESCRIPTION
## Promote two project ideas to draft

They have a description, mentors identified, and general concepts.

They were described in the Jenkins Online Meetup as well.
