### PR TITLE
Remove incorrect // in mailto links

### DIFF
--- a/content/blog/2019/12/2019-12-16-board-election-results.adoc
+++ b/content/blog/2019/12/2019-12-16-board-election-results.adoc
@@ -110,7 +110,7 @@ Please use the following channels for feedback and suggestions:
   Everyone can suggest changes in this document, and we will integrate them.
 * For ideas about the project improvements and next steps for the board,
   please use the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Jenkins Developers] mailing list.
-* For private feedback, please send an email to the link:mailto://jenkinsci-board@googlegroups.com[Jenkins Board] or to link:mailto://tmiranda@cloudbees.com[Tracy Miranda].
+* For private feedback, please send an email to the link:mailto:jenkinsci-board@googlegroups.com[Jenkins Board] or to link:mailto:tmiranda@cloudbees.com[Tracy Miranda].
 
 === References
 

--- a/content/blog/2020/12/2020-12-03-election-results.adoc
+++ b/content/blog/2020/12/2020-12-03-election-results.adoc
@@ -180,7 +180,7 @@ Everyone can suggest changes in this document, and we will integrate them.
 There will be also a public retrospective review at the next link:/sigs/advocacy-and-outreach/[Advocacy and Outreach SIG] meeting on Dec 17.
 
 If you have any private feedback you would like to share,
-please send an email to the link:mailto://jenkinsci-board@googlegroups.com[Jenkins Board].
+please send an email to the link:mailto:jenkinsci-board@googlegroups.com[Jenkins Board].
 If you would like to raise any issues about the election process,
 please contact one of the elected Governance Board members.
 

--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -32,7 +32,7 @@ As per the Jenkins project
   governance document
 the project has a board consisting of five members.
 The board can be contacted confidentially by emailing to 
-%a{:href => "mailto://jenkinsci-board@googlegroups.com"}
+%a{:href => "mailto:jenkinsci-board@googlegroups.com"}
   jenkinsci-board@googlegroups.com
 
 %h2


### PR DESCRIPTION
In this current state, someone clicking on the link will create an email to "//jenkinsci-board@googlegroups.com" instead of the intended "jenkinsci-board@googlegroups.com"