### PR TITLE
Fix updates versions list appearance

### DIFF
--- a/content/_layouts/developerguide.html.haml
+++ b/content/_layouts/developerguide.html.haml
@@ -2,6 +2,14 @@
 layout: developerbook
 ---
 
+:css
+  .docs__version {
+    background: hsl(0deg, 0%, 93%);
+    font-size: 13px;
+    font-weight: 600;
+    padding: 1.75ch 2ch;
+  }
+
 %p
   %a{:href => expand_link('doc/developer/guides')}
     View the index of available developer guides

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1761,10 +1761,3 @@ i.icon-report::before {
   vertical-align: top;
   margin-right: 5px;
 }
-
-.docs__version {
-  background: hsl(0deg, 0%, 93%);
-  font-size: 13px;
-  font-weight: 600;
-  padding: 1.75ch 2ch;
-}

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1762,7 +1762,7 @@ i.icon-report::before {
   margin-right: 5px;
 }
 
-.version {
+.docs__version {
   background: hsl(0deg, 0%, 93%);
   font-size: 13px;
   font-weight: 600;

--- a/content/doc/developer/views/symbols.adoc
+++ b/content/doc/developer/views/symbols.adoc
@@ -3,7 +3,7 @@ title: Symbols
 layout: developerguide
 ---
 
-[.version]#Available since Jenkins 2.235.#
+[.docs__version]#Available since Jenkins 2.235.#
 
 
 image::/images/developer/views/symbols.svg[Selection of Symbols]
@@ -57,7 +57,7 @@ l.icon(src: 'symbol-search', alt: 'Search', class: 'custom-class')
 
 === Custom Symbols
 
-pass:[<span class="version">Coming soon</span>]
+[.docs__version]#Coming soon#
 
 As a plugin developer, you'll soon be able to add your own symbols for use in your plugin for when
 there isn't an appropriate existing symbol to use.


### PR DESCRIPTION
Accidentally broken due to a global class addition in #4900.

This PR pulls out that CSS and moves it to the `developersguide.html.haml` file with a less generic name.