### PR TITLE
Note concrete change for JCasC

### DIFF
--- a/content/doc/book/security/controller-isolation/jep-235.adoc
+++ b/content/doc/book/security/controller-isolation/jep-235.adoc
@@ -32,4 +32,13 @@ As part of the change in 2.326, almost all code related to the agent-to-controll
 A notable exception is `jenkins.security.s2m.AdminWhitelistRule` as that is used by https://plugins.jenkins.io/configuration-as-code/[Configuration as Code Plugin] and is also expected to be in frequent use in link:/doc/book/managing/groovy-hook-scripts/[Groovy init scripts].
 It is now a stub retaining the basic API -- `#getMasterKillSwitch` and `#setMasterKillSwitch(boolean)`, but both methods only generate log messages informing users about their obsolescence.
 Invocations of these methods can be safely removed when running Jenkins 2.326 or newer.
+Users of Configuration as Code may remove the `remotingSecurity` section from
+
+[source,yaml]
+----
+jenkins:
+  remotingSecurity:
+    enabled: true
+----
+
 // TODO Also mention first LTS here.


### PR DESCRIPTION
https://github.com/jenkinsci/configuration-as-code-plugin/pull/90 created a custom configurator so neither the current stack trace nor the current help page gives you any clue as to what you actually need to it. @jetersen @daniel-beck 