### PR TITLE
Use systemd for LTS

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -213,10 +213,6 @@ You need to choose either the Jenkins Long Term Support release or the Jenkins w
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
 It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
 
-The Linux installer for the long term support release depends on the `daemonize` program.
-The `daemonize` program is available from the link:https://docs.fedoraproject.org/en-US/epel/["Extra Packages for Enterprise Linux (EPEL)"].
-Follow the link:https://docs.fedoraproject.org/en-US/epel/#_quickstart[EPEL installation instructions] for your Linux distribution before installing the Jenkins LTS.
-
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -42,21 +42,6 @@ sudo apt-get update
 sudo apt-get install jenkins
 ----
 
-The LTS package installation will:
-
-* Setup Jenkins as a daemon launched on start. See `/etc/init.d/jenkins` for more details.
-* Create a '`jenkins`' user to run this service.
-* Direct console log output to the file `/var/log/jenkins/jenkins.log`. Check this file if you are troubleshooting Jenkins.
-* Populate `/etc/default/jenkins` with configuration parameters for the launch, e.g `JENKINS_HOME`
-* Set Jenkins to listen on port 8080. Access this port with your browser to start configuration.
-
-[NOTE]
-====
-If your `/etc/init.d/jenkins` file fails to start Jenkins, edit the `/etc/default/jenkins` to replace the line
-`HTTP_PORT=8080` with `HTTP_PORT=8081`
-Here, "8081" was chosen but you can put another port available.
-====
-
 === Weekly release
 
 A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
@@ -73,10 +58,10 @@ sudo apt-get update
 sudo apt-get install jenkins
 ----
 
-Beginning with Jenkins 2.335, the weekly package is configured with `systemd` rather than the older System V `init`.
+Beginning with Jenkins 2.335 and Jenkins 2.332.1, the package is configured with `systemd` rather than the older System V `init`.
 See the link:https://www.digitalocean.com/community/tutorials/how-to-use-systemctl-to-manage-systemd-services-and-units[DigitalOcean community `systemd` tutorial] to better understand the benefits of `systemd` and the `systemctl` command.
 
-The weekly package installation will:
+The package installation will:
 
 * Setup Jenkins as a daemon launched on start. Run `systemctl cat jenkins` for more details.
 * Create a '`jenkins`' user to run this service.

--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -170,8 +170,8 @@ image::tutorials/AWS/ec2_view_created_instance.png[]
 In this step you will deploy Jenkins on your EC2 instance by completing the
 following tasks:
 
-* <<Connect to Your Linux Instance>>
-* <<Download and Install Jenkins>>
+* <<Connect to your Linux instance>>
+* <<Download and install Jenkins>>
 * <<Configure Jenkins>>
 
 === Connect to your Linux instance


### PR DESCRIPTION
## Use `systemd` for LTS installation

Describe LTS installation with `systemd` instead of System V `init`.

* Fix broken links in AWS install doc
* Debian LTS installer now uses systemd
* Remove reference to daemonize program
