### PR TITLE
Update GSoC links

### DIFF
--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -28,7 +28,7 @@ in completing their projects.
 == GSoC 2022
 
 We plan to participate in Google Summer of Code 2022.
-See the link:./2022/project-ideas[current project ideas].
+See the *link:./2022/project-ideas[current project ideas]*.
 
 The draft of the Jenkins GSoC application for 2022 can be seen link:./2022/application[here].
 
@@ -49,10 +49,9 @@ please report any issues you discover.
 
 * link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
 * Online Meetup: Introduction to Jenkins in GSoC
-(To be planned. Links to 2020 edition: link:http://bit.ly/jenkins-gsoc2020-intro[slides],
-link:https://youtu.be/qokQu7QbbZA[video])
-// TODO: to be updated as soon as available
-// * link:https://summerofcode.withgoogle.com/organizations/4945163270488064/[Jenkins organization page on the GSoC website] 
+(link:https://bit.ly/3pbJFuC/[slides],
+link:https://youtu.be/GDRTgEvIVBc[video])
+* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins organization page on the GSoC website] 
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
 
 == Mentors
@@ -134,7 +133,7 @@ See the project pages for the schedule.
 == References, 2022
 
 * link:./2022/project-ideas[GSoC 2022 project ideas]
-// * link:https://summerofcode.withgoogle.com/organizations/5542063241691136/[Jenkins page on the GSoC website]
+* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins page on the GSoC website]
  * link:/blog/2022/01/07/gsoc-2022/[GSoC 2022 announcement]
 
 == References

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -49,7 +49,7 @@ please report any issues you discover.
 
 * link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
 * Online Meetup: Introduction to Jenkins in GSoC
-(link:https://bit.ly/3pbJFuC/[slides],
+(link:https://bit.ly/3pbJFuC[slides],
 link:https://youtu.be/GDRTgEvIVBc[video])
 * link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins organization page on the GSoC website] 
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]


### PR DESCRIPTION
* link to the GSoC 2022 JOM video and slides
* link to the Google official page for Jenkins
* Setting the project list in bold

preview available at https://deploy-preview-4980--jenkins-io-site-pr.netlify.app/projects/gsoc/