### PR TITLE
Add nginx config block to deny access to files in root

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-nginx.adoc
@@ -52,6 +52,11 @@ server {
   # pass through headers from Jenkins that Nginx considers invalid
   ignore_invalid_headers off;
 
+  # deny access to config files
+  location ~ ^/[^/]*\.[^/]+$ {
+    deny all;
+  }
+
   location ~ "^/static/[0-9a-fA-F]{8}\/(.*)$" {
     # rewrite all static files into requests to the root
     # E.g /static/12345678/css/something.css will become /css/something.css
@@ -62,7 +67,7 @@ server {
     # have nginx handle all the static requests to userContent folder
     # note : This is the $JENKINS_HOME dir
     root /var/lib/jenkins/;
-    if (!-f $request_filename){
+    if (!-f $request_filename) {
       # this file does not exist, might be a directory or a /**view** url
       rewrite (.*) /$1 last;
       break;


### PR DESCRIPTION
The previous config allowed anyone access to files in the Jenkins root dir, many of them containing secret tokens & other sensitive info. I think that the official docs should provide good defaults.

I'm not an nginx expert, and while this has worked fine in my environment, this config may break some plugins that rely on serving files from the root dir over HTTP, but I thought it better to provide a fairly restrictive default rather than rely on a blacklist of files (since the directory is a bit of a Wild West, with different Jenkins core features and plugins storing files in it).