### PR TITLE
Use cdCon 2022 image, not cdCon 2021

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -6,7 +6,7 @@
     Become part of the conversation that drives continuous delivery by meeting peers, 
     sharing ideas and talking to industry leaders on all things software delivery and DevOps.
   :image:
-    :src: images/conferences/cdCon2021.jpg
+    :src: https://events.linuxfoundation.org/wp-content/uploads/2021/11/cdcon-2022-graphics-snackable.jpg
     :height: 300px
   :call_to_action: 
     :text: Register for cdCon


### PR DESCRIPTION
## Use cdCon 2022 image

Image URL taken from the opengraph image used on the CDF site at https://events.linuxfoundation.org/cdcon/
