### PR TITLE
JDK distro is Eclipse Temurin, distributed by Eclipse Adoptium

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -501,10 +501,10 @@ categories:
       labels:
       - documentation
       - policies
-    - name: Migration to Adoptium JDK in distributions
+    - name: Migration to Eclipse Temurin JDK in distributions
       description: >
         Currently Jenkins uses OpenJDK in the most of official Docker packages.
-        We would like to migrate to Adoptium which offers wider range of supported platforms.
+        We would like to migrate to Eclipse Temurin which offers wider range of supported platforms.
       status: current
       link: https://issues.jenkins.io/browse/JENKINS-63286
       labels:

--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -19,7 +19,7 @@ references:
 Jenkins is based on Java, so to build Jenkins plugins you need to install a Java Development Kit (JDK).
 Java 11 is the version we recommend to users, so that's what we're using in this tutorial.
 
-You can download and install Java 11 from link:https://adoptium.net/[the Eclipse Temurin website].
+You can download and install Java 11 from the link:https://adoptium.net/[Eclipse Temurin website].
 
 NOTE: Many Linux distributions provide packages for Java for an easier install and upgrade experience.
 Consult your distribution's documentation for details.

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -103,8 +103,8 @@ See the current list of supported versions link:/doc/administration/requirements
 Scope of interest:
 
 * Maintaining Java 11 support in Jenkins and driving its adoption
-* Migration to link:https://adoptopenjdk.net/[AdoptOpenJDK] in Docker images
-* Support for future mainstream JVM versions (Java 14+)
+* Migration to link:https://adoptium.net/[Eclipse Temurin] in Docker images
+* Support for future mainstream JVM versions (Java 17)
 * Support for perspective virtual machines like link:https://www.graalvm.org/[GraalVM] or link:https://quarkus.io/[Quarkus], including native executable packaging
 
 === Windows support


### PR DESCRIPTION
## JDK distribution name correction

The [Eclipse Adoptium FAQ](https://adoptium.net/faq.html#temurinName) says:

**What is this "Eclipse Temurin" name?**

This is the project and brand name for the binaries that the Eclipse Foundation produces. You can think of these as the successor binaries to AdoptOpenJDK. However, it is important to note that these binaries are just one of many that will eventually be in the Eclipse Adoptium Marketplace. While we appreciate that the Adoptium/Temurin name split is more confusing that just “Adoptium”, this is similar to how other vendors brand their binaries, e.g. Amazon has Corretto, Azul has Zulu (and others). The “Adoptium” project and working group will deal with more than just Temurin so the distinction is important to maintain.
