### PR TITLE
Correct platform SIG examples

### DIFF
--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -61,8 +61,7 @@ on topics related to Cloud-Native platforms like Kubernetes or Docker.
 * Defining platform support policies (e.g. “defining Windows support policy”)
 * Coordinating effort on new platform support (e.g. jep:211[Java 11 Support in Jenkins])
 * Working with external communities on better platform support and packaging
-(e.g. improving support of IBM Java, enabling OpenIndiana packaging,
-ARM architecture support, adapting RedHat packaging to best practices, etc.)
+(e.g. ARM architecture support, adapting RedHat packaging to best practices, using systemd, etc.)
 * Reviewing JEPs submitted in the area
 
 == Projects


### PR DESCRIPTION
## Correct the Platform SIG examples

IBM Java support has been dropped due to lack of investment from anyone in the project.

OpenIndiana packaging has not been an active discussion topic in the Platform SIG since the SIG was formed.
