### PR TITLE
Don't need the /images/ prefix

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -634,9 +634,9 @@ Sample of such metadata file:
 ```yaml
 ---
 name: 'My Jenkins'
-url: '/logos/${imageId}/${imageId}.png'
-url_256: '/logos/${imageId}/256.png'
-vector: '/logos/${imageId}/${imageId}.svg'
+url: 'logos/${imageId}/${imageId}.png'
+url_256: 'logos/${imageId}/256.png'
+vector: 'logos/${imageId}/${imageId}.svg'
 credit: 'Your Name'
 credit_url: 'https://twitter.com/yourtwitteraccount'
 ```

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -634,9 +634,9 @@ Sample of such metadata file:
 ```yaml
 ---
 name: 'My Jenkins'
-url: '/images/logos/${imageId}/${imageId}.png'
-url_256: '/images/logos/${imageId}/256.png'
-vector: '/images/logos/${imageId}/${imageId}.svg'
+url: '/logos/${imageId}/${imageId}.png'
+url_256: '/logos/${imageId}/256.png'
+vector: '/logos/${imageId}/${imageId}.svg'
 credit: 'Your Name'
 credit_url: 'https://twitter.com/yourtwitteraccount'
 ```


### PR DESCRIPTION
1. Things Done
- Removed ` /images/ ` prefix from contributing guidelines 

See the Changes Requested here #4991 by @MarkEWaite 