### PR TITLE
Remove duplicate security entry from dev docs

### DIFF
--- a/content/doc/developer/architecture/_chapter.yml
+++ b/content/doc/developer/architecture/_chapter.yml
@@ -4,4 +4,3 @@ sections:
 - web
 - extensions
 - remoting
-- security

--- a/content/doc/developer/architecture/security.adoc
+++ b/content/doc/developer/architecture/security.adoc
@@ -1,5 +1,0 @@
----
-title: Security
-layout: developersection
-wip: true
----


### PR DESCRIPTION
Keeps the green, removes the red (which was just empty):
![image](https://user-images.githubusercontent.com/1105305/159116400-ee7e8b25-af26-40ec-a6f4-dc2f56a6547d.png)
