### PR TITLE
Fixups to Java 17 preview blog post

### DIFF
--- a/content/blog/2022/03/2022-03-21-java17-preview-availability.adoc
+++ b/content/blog/2022/03/2022-03-21-java17-preview-availability.adoc
@@ -21,7 +21,7 @@ Please refer to the link:/doc/administration/requirements/jenkins-on-java-17[Run
 
 image:/images/logos/formal/256.png[Jenkins Java, role=center, float=right]
 
-Jenkins, one of the leading open-source automation servers, does not yet support Java 17.
+Jenkins, one of the leading open-source automation servers, does not yet officially support Java 17.
 On September 14, 2021, OpenJDK 17 was released.
 This is a Long-Term-Support (LTS) release, and it will stay around for years.
 The Jenkins project is eager to offer full support of this version.
@@ -44,7 +44,7 @@ A group of contributors has been working on Java 17 support,
 focusing on enabling Java 17 support in development tools, testing, and addressing known compatibility issues.
 See the link:/sigs/platform/#meetings[Platform SIG meeting notes] for detailed status updates.
 Starting with Jenkins 2.339, Jenkins successfully runs with latest OpenJDK 17 releases on various Linux and Windows platforms.
-We performed a LOT of automated and exploratory tests.
+We performed a _lot_ of automated and exploratory tests.
 Jenkins plugins appear to work well.
 There is ongoing test automation effort toward the GA release,
 but we were able to successfully run Jenkins core tests and link:https://github.com/jenkinsci/plugin-compat-tester[Plugin Compatibility Tester] for recommended plugins.
@@ -52,13 +52,13 @@ but we were able to successfully run Jenkins core tests and link:https://github.
 == Running Jenkins and Java 17 in Docker
 
 For several months, we have provided Docker images for the Jenkins controller and agent.
-All these images are based on the official link:https://hub.docker.com/_/debian[Debian stable] and link:https://hub.docker.com/_/eclipse-temurin[Eclipse Temurin] images maintained by the Docker community.
+All these images are based on the official link:++https://hub.docker.com/_/debian++[Debian stable] and link:++https://hub.docker.com/_/eclipse-temurin++[Eclipse Temurin] images maintained by the Docker community.
 
 === Jenkins controller image
 
 Java 17 support is now provided as a part of the official
 link:https://hub.docker.com/r/jenkins/jenkins[jenkins/jenkins] image.
-You can run the Jenkins with Java 17 simply as:
+You can run Jenkins with Java 17 simply as:
 
 ```
 docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:jdk17-preview


### PR DESCRIPTION
Fixing a few problems with this blog post discovered after it went live, notably two broken links. I resolved the broken links using the strategy described [here](https://docs.asciidoctor.org/asciidoc/latest/macros/complex-urls/).