### PR TITLE
fix(blogpost): correct links for cdf Jenkins awards 2022

### DIFF
--- a/content/blog/2022/03/2022-03-22-jenkins-contributor-awards.adoc
+++ b/content/blog/2022/03/2022-03-22-jenkins-contributor-awards.adoc
@@ -20,9 +20,9 @@ Voting will open in April.
 
 Nominate contributors or vote with reactions/comments for all three Jenkins awards:
 
-* link:https://github.com/cdfoundation/foundation/issues/318[Most Valuable Jenkins Contributor]
-* link:https://github.com/cdfoundation/foundation/issues/320[Most Valuable Jenkins Advocate]
-* link:https://github.com/cdfoundation/foundation/issues/319[Jenkins Security MVP]
+* link:https://github.com/cdfoundation/foundation/issues/366[Most Valuable Jenkins Contributor]
+* link:https://github.com/cdfoundation/foundation/issues/368[Most Valuable Jenkins Advocate]
+* link:https://github.com/cdfoundation/foundation/issues/367[Jenkins Security MVP]
 
 The winners will be announced at cdCon 2022 on June 7.
 


### PR DESCRIPTION
The previous ones were pointing to the 2021 edition issues