### PR TITLE
Add MSI parameters packaging fix to 2.338 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -14662,6 +14662,16 @@
         pr_title: Allow missing logger name in log viewer
         message: |-
           Display log entries with missing logger names in the log viewer.
+      - type: bug
+        category: bug
+        authors:
+          - JPRuskin
+        pr_title: Fixes MSI Parameters Port and InstallDir
+        references:
+          - url: https://github.com/jenkinsci/packaging/pull/287
+            title: pull 287
+        message: |-
+          Honor MSI installer parameter values for <code>PORT</code> and <code>INSTALLDIR</code>.
       - type: rfe
         category: developer
         pull: 6317


### PR DESCRIPTION
## Add MSI packaging fix to 2.338 changelog

The packaging fix for MSI was not included in the 2.338 changelog.
