### PR TITLE
Include `remove` label in changelogs

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -6938,6 +6938,17 @@
       JRuby support has been removed from the Stapler web framework used in Jenkins core.
       Plugins written in JRuby and Jython have not been distributed by update center since January 22, 2022.
 
+  # JNDI setting of Jenkins home directory removed
+
+  - type: rfe
+    category: rfe
+    pull: 6111
+    authors:
+      - basil
+    pr_title: Remove JNDI support
+    message: |-
+      Remove support for setting the Jenkins home directory via Java Naming and Directory Interface (JNDI).
+
   - type: rfe
     category: developer
     pull: 5524

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -14603,6 +14603,18 @@
         pr_title: Add Brazilian Portuguese translation property files
         message: |-
           Add Brazilian Portuguese translation property files.
+      - type: rfe
+        category: rfe
+        pull: 6323
+        authors:
+          - basil
+        pr_title: Remove JNR
+        references:
+          - pull: 6323
+          - url: https://github.com/jnr
+            title: Java Native Runtime project
+        message: |-
+          Remove the Java Native Runtime (JNR) library from Jenkins core.
       - type: bug
         category: regression
         pull: 6342

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -13730,6 +13730,14 @@
           A small number of JRuby-based plugins are affected; see the blog post for migration notes.
       - type: rfe
         category: rfe
+        pull: 6111
+        authors:
+          - basil
+        pr_title: Remove JNDI support
+        message: |-
+          Remove support for setting the Jenkins home directory via Java Naming and Directory Interface (JNDI).
+      - type: rfe
+        category: rfe
         pull: 6096
         authors:
           - daniel-beck

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -14038,6 +14038,17 @@
           Code
         message: |-
           Update site warnings can now be configured with Configuration as Code.
+      - type: rfe
+        category: rfe
+        pull: 6209
+        authors:
+          - basil
+        pr_title: "EOL support for JRuby"
+        references:
+          - url: https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+            title: Deprecating non-Java plugins blog post
+        message: |-
+          Remove support for plugins written in Ruby.
       - type: bug
         category: regression
         pull: 6193

--- a/content/_data/upgrades/2-332-1.adoc
+++ b/content/_data/upgrades/2-332-1.adoc
@@ -34,3 +34,8 @@ A repackaged version of ObjectWebASM 5 and the upstream version of ASM were both
 Jenkins core no longer provides the repackaged version of ASM 5.
 Users of SCM API must upgrade SCM API to the latest version prior to upgrading Jenkins.
 Plugins that use the repackaged version of ASM 5 must be updated to use the upstream version of ASM instead.
+
+==== JNDI setting of Jenkins home directory removed
+
+Support for setting the Jenkins home directory via Java Naming and Directory Interface (JNDI) has been removed.
+The Jenkins home directory may still be set using Java system properties or OS environment variables.


### PR DESCRIPTION
## Include `remove` labeled pull requests in changelogs

Automated changelog generator missed the `remove` label in previous releases.  Include them.

See https://github.com/jenkins-infra/jenkins.io/pull/4960#issuecomment-1070519721 for more details.

- Include core PR #6111 in changelog and upgrade guide
- Add 2.333 changelog entry for JRuby removal
- Add JNR removal to 2.338 changelog
