### PR TITLE
Document Pipeline: Nodes and Processes tunables

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -2060,7 +2060,37 @@ properties:
   def: 20 seconds
   since: workflow-durable-task-step-plugin 2.29
   description: |
-    How long to wait for remote calls (see https://issues.jenkins.io/browse/JENKINS-46507[JENKINS-46507]).
+    How long to wait, in seconds, before interrupting remote calls and forcing cleanup when the step is stopped.
+    See https://issues.jenkins.io/browse/JENKINS-46507[JENKINS-46507] for more information.
+
+- name: org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING
+  tags:
+  - feature
+  def: |
+    `false`
+  since: workflow-durable-task-step-plugin 2.22
+  description: |
+    `true` to enable the experimental push mode for durable task logging.
+    See https://issues.jenkins.io/browse/JENKINS-52165[JENKINS-52165] for more information.
+
+- name: org.jenkinsci.plugins.workflow.support.pickles.ExecutorPickle.timeoutForNodeMillis
+  tags:
+  - tuning
+  def: 5 minutes (300,000 milliseconds)
+  since: workflow-durable-task-step-plugin 2.14
+  description: |
+    How long to wait, in milliseconds, before aborting the build if an agent has been removed.
+    See https://issues.jenkins.io/browse/JENKINS-36013[JENKINS-36013] for more information.
+
+- name: org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution.REMOVED_NODE_DETECTION
+  tags:
+  - feature
+  def: |
+    `true`
+  since: workflow-durable-task-step-plugin 2.32
+  description: |
+    `false` to prevent Jenkins from aborting the build if an agent has been removed.
+    See https://issues.jenkins.io/browse/JENKINS-49707[JENKINS-49707] for more information.
 
 - name: org.kohsuke.stapler.RequestImpl.ALLOWED_HTTP_VERBS_FOR_FORMS
   tags:


### PR DESCRIPTION
While working on [JENKINS-68080](https://issues.jenkins.io/browse/JENKINS-68080) I noticed that most of the tunables for the [Pipeline: Nodes and Processes](https://plugins.jenkins.io/workflow-durable-task-step/) plugin were undocumented. So I decided to fix that.

This plugin seems to have nonexistent plugin documentation, so for now I am including this documentation on the main [Jenkins Features Controlled with System Properties](https://www.jenkins.io/doc/book/managing/system-properties/) page. Perhaps once this plugin gets its own documentation these could be moved to a different page, but it seemed awkward to create brand new plugin documentation with nothing other than tunable information.

CC'ing @jglick as the author of many of these tunables to make sure I described them accurately based on my reading of the code.

It would be helpful for reviewers to verify that I correctly identified the first release where the tunable appeared. One way of doing this is to run `git log -S <string>` to find the first commit that mentioned the string, then finding the first release where that commit is present by running `git tag --contains <commit>`. I am sure there are other ways to do this using the GitHub UI, but this is the way I know of (on the command-line).