### PR TITLE
Migrate object persistence documentation from old wiki

### DIFF
--- a/content/doc/developer/persistence/_chapter.yml
+++ b/content/doc/developer/persistence/_chapter.yml
@@ -1,2 +1,5 @@
 ---
 sections:
+- backward-compatibility
+- custom-converter
+- incompatible-releases

--- a/content/doc/developer/persistence/backward-compatibility.adoc
+++ b/content/doc/developer/persistence/backward-compatibility.adoc
@@ -1,0 +1,153 @@
+---
+title: Backward Compatibility with XStream
+summary: How to make object model changes with XStream while preserving backward compatibility.
+layout: developersection
+---
+
+== Add a new field
+
+Persistence is XML-based,
+and when the data is read back from disk and the XML does not contain data for a particular field,
+the existing field value is left as-is.
+"As-is" normally means the JVM default value (0, `false`, `null`, etc.),
+because the persistence logic does not invoke your constructor to create your object as Java serialization would.
+
+There are a few exceptions to this, where objects first create themselves and then load XML onto themselves.
+These include https://javadoc.jenkins.io/jenkins/model/Jenkins.html[`Jenkins`] and https://javadoc.jenkins.io/hudson/model/Item.html[`Item`],
+but these exceptions are limited to the root object of persistence.
+In these exceptional cases, the values set in the constructor will survive.
+
+If you want to fill in your field with a non-trivial default value,
+you can write a `readResolve` method, which gets invoked right after your object is resurrected from persistence.
+`readResolve` is called by XStream, but it is not part of the Jenkins class hierachy, so there is no `@Override` annotation.
+Just put it right in your class alongside your fields. For example:
+
+[source,java]
+----
+protected Object readResolve() {
+  if (gridBuilder == null) {
+    if (selectedJob != null) {
+      gridBuilder = new DownstreamProjectGridBuilder(selectedJob);
+    }
+  }
+  return this;
+}
+----
+
+If you need to force the _Manage Old Data_ screen to list jobs, builds, etc. using your data in the old format so that it can be saved in the new format in bulk,
+you cannot use `readResolve`, since it will not notify this system of the problem.
+Instead you must create a static nested class called `ConverterImpl` extending `XStream2.PassthruConverter`,
+which should clean up the storage of your instance and finally call `OldDataMonitor#report` to record the conversion.
+
+== Remove a field
+
+Removing a field requires that you leave the field with the `transient` keyword.
+When Jenkins reads the old XML, XStream will set the value for this field,
+but it will no longer be written back to XML when data is saved.
+
+== Rename a field
+
+Renaming a field is a combination of the above:
+mark your old field as `transient`, declare your new field, and then migrate the data from the old format to the new in your `readResolve` method:
+
+[source,java]
+----
+protected transient Long myObjectId;
+protected List<Long> myObjectIds;
+
+protected Object readResolve() {
+  if (myObjectId != null) {
+   myObjectIds = Arrays.asList(myObjectId)
+  }
+  return this;
+}
+----
+
+== Make a class abstract and introduce concrete subtypes
+
+=== Before
+
+* You decide to extend a class and create new choosable classes; for example, adding additional browsers to an SCM plugin.
+* The old data structure looked like this when you had only one class `SCMBrowser`:
++
+[source,xml]
+----
+<browser>
+  <url>http://example.com/</url>
+</browser>
+----
+
+=== After
+
+* Now you decide to add a new `NewSCMBrowser`. All your `SCMBrowsers` extend `SCMBrowserBase` and your XML suddenly looks like this:
++
+[source,xml]
+----
+<browser class="org.jenkinsci.plugins.foo.NewSCMBrowser">
+  <url>http://example.com/</url>
+</browser>
+----
++
+or
++
+[source,xml]
+----
+<browser class="org.jenkinsci.plugins.foo.SCMBrowser">
+  <url>http://example.com/</url>
+</browser>
+----
+
+* With new jobs, no problem. Old jobs however will probably break.
+* In your `SCMBrowserBase` class add a `readResolve` method (see the link:https://x-stream.github.io/faq.html[XStream FAQ]):
++
+[source,java]
+----
+// compatibility with earlier plugins
+public Object readResolve() {
+  if (this.getClass() != SCMBrowserBase.class) {
+    return this;
+  }
+  // make sure to return the default SCMBrowser only if we no class is given in config.
+  try {
+    return new SCMBrowser(url.toExternalForm());
+  } catch (MalformedURLException e) {
+    throw new RuntimeException(e);
+  }
+}
+----
+
+== Rename a class
+
+Sometimes, you need to rename packages or class names.
+If your serialization data includes a fully qualified class name (which happens, for example, if you have a collection of them),
+then measures must be taken to maintain backward compatibility.
+
+To do this, use `XSTREAM2#addCompatibilityAlias(String, Class)` to register aliases.
+You need to do this against the right XStream instance,
+as a few different instances are used to persist different parts of data.
+
+`Items#XSTREAM2` is used for serializing project configuration,
+and `Run#XSTREAM2` is used for serializing builds and their associated link:https://javadoc.jenkins.io/hudson/model/Action.html[`Action`]s.
+
+For example, to alias `Foo` in the "old" package to the "updated" one,
+you can use this method call:
+
+[source,java]
+----
+Items.XSTREAM2.addCompatibilityAlias("org.acme.old.Foo", org.acme.updated.Foo.class);
+----
+
+To ensure your alias is registered early in the Jenkins boot sequence,
+you can use the link:https://javadoc.jenkins.io/hudson/init/Initializer.html[`Initializer`] annotation on a static method, e.g. in your `DescriptorImpl`:
+
+[source,java]
+----
+@Initializer(before = InitMilestone.PLUGINS_STARTED)
+public static void addAliases() {
+  Items.XSTREAM2.addCompatibilityAlias("org.acme.old.Foo", Foo.class);
+}
+----
+
+== Rename or move the descriptor class of a plugin
+
+Since 1.507 https://javadoc.jenkins.io/hudson/model/Descriptor.html#getConfigFile--[`Descriptor#getConfigFile`] is overridable and https://javadoc.jenkins.io/hudson/XmlFile.html[`XmlFile`] can be instantiated with any XStream instance.

--- a/content/doc/developer/persistence/custom-converter.adoc
+++ b/content/doc/developer/persistence/custom-converter.adoc
@@ -1,0 +1,49 @@
+---
+title: Registering a Custom Converter
+summary: How to register a custom XStream converter to serialize complex data structures.
+layout: developersection
+---
+
+Normally, you would register converter to the class you are writing,
+and in that case the easiest thing to do is to write a nested type `ConverterImpl` that gets picked up automatically.
+If you search by that class name, you will see a number of implementations.
+
+== Registering a custom converter without modifying the original class
+
+If you want to register a custom XStream converter that will convert items that have already been persisted to disk,
+and you do not want to modify the source code for the class you want to convert,
+then you need to hook it up to Jenkins before it reads in those items.
+Here is one way:
+
+[source,java]
+----
+public class MyPlugin extends Plugin {
+  public void start() throws Exception {
+    Items.XSTREAM.registerConverter(new MyCoolConverter());
+  }
+}
+----
+
+The `Items#XSTREAM` portion should be adjusted to point to the right XStream instance (such as `Jenkins#XSTREAM`),
+depending on the persistence context in which your object participates.
+The converter would look something like this:
+
+[source,java]
+----
+import com.thoughtworks.xstream.converters.Converter;
+
+public class MyCoolConverter implements Converter {
+  public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+    throw new UnsupportedOperationException("Sorry, no example for marshalling yet!");
+  }
+
+  public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+    // Traverse the reader to get structure and attributes of the thing you are converting from
+    return new MyThing(some, attrs, etc);
+  }
+
+  public boolean canConvert(Class type) {
+    return my.plugin.special.MyThing.class == type;
+  }
+}
+----

--- a/content/doc/developer/persistence/incompatible-releases.adoc
+++ b/content/doc/developer/persistence/incompatible-releases.adoc
@@ -1,0 +1,55 @@
+---
+title: Marking Incompatible Releases
+summary: How to mark a plugin release as having incompatible on-disk format changes.
+layout: developersection
+---
+
+NOTE: The need for this should be rare. Jenkins has an automatic data format upgrade capability, which should be used whenever possible for the best user experience.
+
+At times, changes will be made to a plugin which result in the new version of the plugin no longer being compatible with the configuration used for older versions.
+When this is the case, you will probably want to be sure that your plugin's users are aware of this incompatibility.
+There is now (as of version 1.322 of Jenkins and version 1.42 of `maven-hpi-plugin`) support for marking the oldest version which is compatible with the configuration of your plugin's current version.
+
+== Recording the oldest compatible version
+
+Starting with https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md#333[plugin parent POM 3.33],
+it is possible to set the `hpi.compatibleSinceVersion` property to define the oldest compatible version.
+
+[source,xml]
+----
+<properties>
+  <jenkins.version>2.60.3</jenkins.version>
+  <java.level>8</java.level>
+  <hpi.compatibleSinceVersion>1.0</hpi.compatibleSinceVersion>
+</properties>
+----
+
+If you use an older plugin parent POM (not recommended), add the following to your plugin's POM file:
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.jenkins-ci.tools</groupId>
+      <artifactId>maven-hpi-plugin</artifactId>
+      <extensions>true</extensions>
+      <configuration>
+        <compatibleSinceVersion>1.0</compatibleSinceVersion>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+----
+
+You only need to specify the `maven-hpi-plugin` version if your plugin's parent POM is version 1.321 or earlier.
+Later versions of the plugin parent POM will get the proper `maven-hpi-plugin` version automatically.
+`compatibleSinceVersion` should be the oldest version which is compatible with the configuration for the new version of your plugin.
+If your new version is not configuration-compatible with any previous versions, `compatibleSinceVersion` would use the new version number.
+
+== Modifiying the list of available plugin upgrades
+
+When a new plugin version is available as an update, and that new plugin version has a `compatibleSinceVersion` defined,
+the Update Center will check to see whether the installed version of the plugin is compatible with the new plugin.
+If the installed version is not configuration-compatible,
+the plugin will show up in the available updates list with a note, in red, that jobs may need to be reconfigured.

--- a/content/doc/developer/persistence/index.adoc
+++ b/content/doc/developer/persistence/index.adoc
@@ -1,22 +1,19 @@
 ---
-title: Persistence
+title: Persistent Objects
+summary: Introduction to persistent objects in Jenkins.
 layout: developerchapter
 references:
-- url: https://wiki.jenkins.io/display/JENKINS/XStream+Tips
-  title: XStream Tips
-- url: https://wiki.jenkins.io/display/JENKINS/Hint+on+retaining+backward+compatibility
-  title: Hint on retaining backward compatibility
-- url: https://javadoc.jenkins.io/index.html?hudson/XmlFile.html
-  title: XmlFile Javadoc
-wip: true
+- title: XmlFile Javadoc
+  url: https://javadoc.jenkins.io/hudson/XmlFile.html
 ---
 
 Jenkins uses the file system to store its data.
-Directories are created inside `$JENKINS_HOME` in a way that models the object model structure.
-Some data, like console output, are stored just as plain text file, some are stored as Java property files.
-But the majority of the structured data, such as how a project is configured, or various records of the build, are persisted by using XStream.
+Directories are created inside `JENKINS_HOME` following the structure of the Java object model.
+Some data, like console output, is stored in plain text files; other data is stored in Java property files.
+But the majority of structured data, such as project configuration and build records, is stored in XML with link:https://x-stream.github.io/[XStream].
 
-This allows object state to be persisted relatively easily (including those from plugins), but one must pay attention to what's serialized in XML, and take measures to preserve backward compatibility.
-For example, in various parts of Jenkins you see the `transient` keyword (which instructs XStream not to bind the field to XML), fields left strictly for backward compatibility, or re-construction of in-memory data structure after data is loaded.
-
-// https://wiki.jenkins.io/display/JENKINS/Architecture#Architecture-Persistence
+This allows object state, whether from core or plugins, to be persisted relatively easily,
+but one must pay attention to what is serialized and take measures to preserve backward compatibility.
+For example, in various parts of Jenkins you see the `transient` keyword (which instructs XStream not to bind the field to XML),
+deprecated fields left behind strictly for backward compatibility,
+or reconstruction of in-memory data structures after data is loaded from disk.


### PR DESCRIPTION
One of the more tricky parts of Jenkins development, and a consistent source of confusion for newcomers, is object persistence. The XML-based object persistence framework used in Jenkins is dated, and many aspects of its implementation are not obvious to beginners. This particularly includes backward compatibility, which is a core value of the Jenkins project.

Most of the existing content was written by Kohsuke and lives on these outdated wiki pages:

- https://wiki.jenkins.io/JENKINS/XStream+Tips
- https://wiki.jenkins.io/JENKINS/Hint-on-retaining-backward-compatibility
- https://wiki.jenkins.io/JENKINS/Marking-a-new-plugin-version-as-incompatible-with-older-versions

Since I had to refer to this content recently, I decided to migrate it to the official developer documentation on `jenkins.io`.

Please don't criticize me too harshly for the content itself, since I didn't write it. I just moved it over to `jenkins.io`, added a little bit of structure, and did some light copyediting for English spelling and grammar. I also updated any broken links.

I am sure that this can be improved, but I think the main focus of this review should be to get the content migrate so that it can then be iteratively improved in its new home on `jenkins.io`.

CC @MarkEWaite @jmMeessen 