### PR TITLE
Improve 2.332.1 LTS upgrade guide

### DIFF
--- a/content/_data/upgrades/2-332-1.adoc
+++ b/content/_data/upgrades/2-332-1.adoc
@@ -38,4 +38,20 @@ Plugins that use the repackaged version of ASM 5 must be updated to use the upst
 ==== JNDI setting of Jenkins home directory removed
 
 Support for setting the Jenkins home directory via Java Naming and Directory Interface (JNDI) has been removed.
-The Jenkins home directory may still be set using Java system properties or OS environment variables.
+The Jenkins home directory may still be set using the `-DJENKINS_HOME` Java system property or the `JENKINS_HOME` environment variable.
+
+Users who load `jenkins.war` via a servlet container like Tomcat should refer to their servlet container's documentation
+for information on how to customize Java system properties or environment variables.
+
+For example, the Tomcat servlet container accepts custom Java system properties in the `CATALINA_OPTS` environment variable.
+
+==== Windows batch file and PowerShell script encoding
+
+In traditional job types, the scripts used in Windows batch file and PowerShell steps are encoded in the JVM's default encoding.
+In previous releases, characters in these scripts that could not be encoded in the JVM's default encoding were silently converted to ? (question mark) characters.
+In the current release, a script that contains characters that cannot be encoded in the JVM's default encoding will result in an explicit and intentional failure of the batch file or PowerShell step.
+
+Users who encounter such failures should either rewrite the script to be compatible with the JVM's default encoding,
+or they should change the JVM's default encoding to be compatible with the script.
+In most cases, the solution is to change the JVM's default encoding from Windows-1252 to UTF-8
+by setting the `-Dfile.encoding=UTF-8` Java system property on the JVM of the node that executes the script.


### PR DESCRIPTION
Improves the 2.332.1 LTS upgrade guide to cover complaints from users about stuff I broke.

See [JENKINS-67602](https://issues.jenkins.io/browse/JENKINS-67602) for context.