### PR TITLE
Document key store config when enabling HTTP/2

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -134,6 +134,8 @@ The link:https://tools.ietf.org/html/rfc7540[HTTP/2 protocol] allows web servers
 The Jetty server used by Jenkins supports HTTP/2 with the addition of the Application-Layer Protocol Negotiation (ALPN) TLS extension.
 The ALPN TLS extension is connected to the specific Jetty version and has specific requirements depending on the Java version.
 
+Note that enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, and as of Jenkins 2.339 (which uses Winstone 5.23) you have to also specify an HTTPS key store file.
+
 ==== Java 11, Java 8u252, and later
 
 Java 11,  Java 8 update 252 and Java 8 versions after update 252 can run the ALPN TLS extension by installing the Jetty ALPN java server jar and passing it as a java command line argument.
@@ -150,7 +152,9 @@ Steps to install the extension are:
 ----
 java --extraLibFolder=/opt/java/jetty-alpn-java-server-9.4.27.v20200227.jar \
     -jar target/jenkins.war \
-    --http2Port=9090
+    --http2Port=9090 \
+    --httpsKeyStore=path/to/keystore \
+    --httpsKeyStorePassword=keystorePassword
 ----
 
 ==== Java 8u242 and earlier
@@ -167,7 +171,9 @@ Steps to install the extension are:
 ----
 java -Xbootclasspath/p:/opt/java/alpn-boot-8.1.13.v20181017.jar \
     -jar target/jenkins.war \
-    --http2Port=9090
+    --http2Port=9090 \
+    --httpsKeyStore=path/to/keystore \
+    --httpsKeyStorePassword=keystorePassword
 ----
 
 === HTTPS certificates with Windows


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-68107