### PR TITLE
Fixups to `agent kubernetes` example

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -257,25 +257,23 @@ For example, if you want a pod with a Kaniko container inside it, you would defi
 ----
 agent {
     kubernetes {
-        label podlabel
-        yaml """
+        defaultContainer 'kaniko'
+        yaml '''
 kind: Pod
-metadata:
-  name: jenkins-agent
 spec:
   containers:
   - name: kaniko
     image: gcr.io/kaniko-project/executor:debug
     imagePullPolicy: Always
     command:
-    - /busybox/cat
-    tty: true
+    - sleep
+    args:
+    - 99d
     volumeMounts:
       - name: aws-secret
         mountPath: /root/.aws/
       - name: docker-registry-config
         mountPath: /kaniko/.docker
-  restartPolicy: Never
   volumes:
     - name: aws-secret
       secret:
@@ -283,7 +281,7 @@ spec:
     - name: docker-registry-config
       configMap:
         name: docker-registry-config
-"""
+'''
    }
 ----
 +


### PR DESCRIPTION
Bringing this closer to https://github.com/jenkinsci/kubernetes-plugin/blob/85e0d7e61db337abfbf46eb42af205ae159c65ab/examples/kaniko-declarative.groovy#L16-L43.