### PR TITLE
Jenkins Award nominations extended to April 11, 2022

### DIFF
--- a/content/blog/2022/03/2022-03-29-jenkins-contributor-awards.adoc
+++ b/content/blog/2022/03/2022-03-29-jenkins-contributor-awards.adoc
@@ -1,0 +1,32 @@
+---
+layout: post
+title: "Jenkins Contributor Awards - Nominations Extended"
+tags:
+- awards
+- jenkins
+- cdcon
+- community
+author: cdfoundation
+description: "Nominate someone for the Jenkins Contributor Awards. Deadline is April 11, 2022."
+opengraph:
+  image: /images/post-images/2022/jenkins-awards-2022.png
+---
+Jenkins Contributor Awards for 2022 are being run by the Continuous Delivery Foundation (CDF) along with many other link:https://cd.foundation/cdf-community-awards/[CDF Community Awards].
+
+The nominations are open and are being accepted using GitHub issues to make the process transparent.
+Any contributor is eligible!
+The deadline to nominate someone has been extended to April 11, 2022.
+Voting will open later in April.
+
+Nominate contributors or vote with reactions/comments for all three Jenkins awards:
+
+* link:https://github.com/cdfoundation/foundation/issues/366[Most Valuable Jenkins Contributor]
+* link:https://github.com/cdfoundation/foundation/issues/368[Most Valuable Jenkins Advocate]
+* link:https://github.com/cdfoundation/foundation/issues/367[Jenkins Security MVP]
+
+The winners will be announced at cdCon 2022 on June 7.
+
+You can also nominate Jenkins community members for global awards like "Top CDF Ambassador", "Top CDF Contributor", or "Top CDF End User"!
+For all CDF Community Awards and more details, visit the link:https://cd.foundation/cdf-community-awards/[CDF Award Page].
+
+image::/images/post-images/2022/jenkins-awards-2022.png[https://cd.foundation/cdf-community-awards/]


### PR DESCRIPTION
## Jenkins award nominations extended to April 11, 2022

The Jenkins Awards that will be presented at cdCon 2022 in June are accepting nominations until April 11, 2022.  Voting will start April 14, 2022.
