### PR TITLE
Update 2022-03-08-gsoc2022-announcement.adoc

### DIFF
--- a/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
+++ b/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
@@ -88,12 +88,16 @@ GSoC org admins will help to find advisers if special expertise is required.
 
 == Important dates for GSoC 2022
 
-* Mar 7 thru Apr 3 - Potential GSoC contributors discuss application ideas with mentoring organizations. Show link:https://community.jenkins.io/c/contributing/gsoc/6[us] your proposal!
-* Apr 4 - GSoC contributor application period begins
-* Apr 19 - deadline for student applications
-* May 20 - accepted GSoC contributor projects announced, teams start community bonding and coding
-* Sep 04 - coding period ends
-* Sep 20 - Results announced
-
+* March 7 - April 3 - Potential GSoC contributors discuss application ideas with mentoring organizations. Show link:https://community.jenkins.io/c/contributing/gsoc/6[us] your proposal!
+* April 4 - GSoC contributor application period begins
+* April 19 - GSoC contributor application deadline
+* May 12 - GSoC contributor slot requests due from Org Admins
+* May 20 - Accepted GSoC contributor projects announced
+* May 20 - June 12 - Community Bonding Period | GSoC contributors get to know mentors, read documentation, get up to speed to begin working on their projects
+* June 13 - Coding officially begins!
+* July 25 - September 4 - Work Period | GSoC contributors work on their project with guidance from Mentors
+* September 5 - September 12 - Final week: GSoC contributors submit their final work product
+* September 20 - Initial results of Google Summer of Code 2022
+* November 21 - Final date for all GSoC contributors to submit their final work product
 See the link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline] for more info.
 

--- a/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
+++ b/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
@@ -99,5 +99,6 @@ GSoC org admins will help to find advisers if special expertise is required.
 * September 5 - September 12 - Final week: GSoC contributors submit their final work product
 * September 20 - Initial results of Google Summer of Code 2022
 * November 21 - Final date for all GSoC contributors to submit their final work product
+
 See the link:https://developers.google.com/open-source/gsoc/timeline[GSoC Timeline] for more info.
 


### PR DESCRIPTION
- Entered the accurate dates from Official GSOC 2022 timeline.
- Updated it in more readable format.