### PR TITLE
Exchange jelly with xml syntax highlighting

### DIFF
--- a/content/doc/developer/internationalization/i18n-jelly-views.adoc
+++ b/content/doc/developer/internationalization/i18n-jelly-views.adoc
@@ -20,7 +20,7 @@ Any changes of `.properties` do not require a restart of Jenkins.
 As an example, consider the following jelly page:
 
 `src/main/resources/org/example/package/index.jelly`:
-[source, jelly]
+[source, xml]
 ----
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:s="/lib/form">


### PR DESCRIPTION
Asciidoc does not know about Jelly syntax highlighting, exchanging it with xml does render the snippet properly.
![](https://i.imgur.com/AAInBDP.png)