### PR TITLE
Align Groovy i18n documentation with Jelly

### DIFF
--- a/content/doc/developer/internationalization/i18n-groovy-views.adoc
+++ b/content/doc/developer/internationalization/i18n-groovy-views.adoc
@@ -3,6 +3,8 @@ title: Internationalizing Messages in Groovy Views
 layout: developersection
 ---
 
+WARNING: We do not encourage creating views in Groovy for internationalization, Jelly is the preferred way to do this.
+
 == Introduction
 
 In Jenkins, you need add a similar `.properties` file with the `.groovy` file in the same directory. Any changes of `.properties` does not need restart Jenkins or plugins.

--- a/content/doc/developer/internationalization/i18n-groovy-views.adoc
+++ b/content/doc/developer/internationalization/i18n-groovy-views.adoc
@@ -1,7 +1,6 @@
 ---
 title: Internationalizing Messages in Groovy Views
 layout: developersection
-wip: true
 ---
 
 == Introduction
@@ -19,9 +18,9 @@ package jenkins.security.DownloadSettings
 
 def f = namespace(lib.FormTagLib)
 
-f.section(title:_("Plugin Manager")) {
-	f.entry(field: "useBrowser") {
-		f.checkbox(title: _("Use browser for metadata download"))
+f.section(title:_("title.pluginManager")) {
+	f.entry(field: "field.useBrowser") {
+		f.checkbox(title: _("title.browserCheckbox"))
 	}
 }
 ----
@@ -31,9 +30,9 @@ Then you could add, for example, a Chinese localization file simply as:
 `src/main/resources/org/example/package/index_zh_CN.properties`:
 [source, properties]
 ----
-Plugin\ Manager=\u63D2\u4EF6\u7BA1\u7406
-Use\ Browser=\u4F7F\u7528\u6D4F\u89C8\u5668
-Use\ browser\ for\ metadata\ download=\u4F7F\u7528\u6D4F\u89C8\u5668\u4E0B\u8F7D\u5143\u6570\u636E
+title.pluginManager=\u63D2\u4EF6\u7BA1\u7406
+field.useBrowser=\u4F7F\u7528\u6D4F\u89C8\u5668
+title.browserCheckbox=\u4F7F\u7528\u6D4F\u89C8\u5668\u4E0B\u8F7D\u5143\u6570\u636E
 ----
 
 In property files all non-ASCII characters need to be converted into hexcode. Modern IDEs do it automatically, so you can be just writing localizations in the target languages there.

--- a/content/doc/developer/internationalization/i18n-groovy-views.adoc
+++ b/content/doc/developer/internationalization/i18n-groovy-views.adoc
@@ -21,7 +21,7 @@ package jenkins.security.DownloadSettings
 def f = namespace(lib.FormTagLib)
 
 f.section(title:_("title.pluginManager")) {
-	f.entry(field: "field.useBrowser") {
+	f.entry(field: "useBrowser", title:_("useBrowser"))
 		f.checkbox(title: _("title.browserCheckbox"))
 	}
 }


### PR DESCRIPTION
In Groovy, you can work with the same key-like values you use in Jelly or Java for localization.
Aligning the Groovy documentation helps hardening existing standards. 