### PR TITLE
Add Windows installer warning for Java 8 to changelogs

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -6978,6 +6978,18 @@
   date: 2022-04-06
   changes:
 
+  - type: rfe
+    category: rfe
+    authors:
+      - slide
+    issue: 68170
+    pr_title: "[JENKINS-68170] Show warning dialog if Java 8 is selected"
+    references:
+      - issue: 68170
+      - url: https://github.com/jenkinsci/packaging/pull/306
+        title: pull 306
+    message: |-
+      Show warning dialog if Java 8 is selected in Windows installer.
   - type: bug
     category: bug
     authors:

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15054,6 +15054,18 @@
         pr_title: Miscellaneous modernization cleanup
         message: |-
           Miscellaneous polishing of various components.
+      - type: rfe
+        category: rfe
+        authors:
+          - slide
+        issue: 68170
+        pr_title: "[JENKINS-68170] Show warning dialog if Java 8 is selected"
+        references:
+          - issue: 68170
+          - url: https://github.com/jenkinsci/packaging/pull/306
+            title: pull 306
+        message: |-
+          Show warning dialog if Java 8 is selected in Windows installer.
       - type: bug
         category: bug
         pull: 6402


### PR DESCRIPTION
## [JENKINS-68170](https://issues.jenkins.io/browse/JENKINS-68170) Windows installer now warns if user chooses Java 8

Packaging pull requests are not automatically included in the changelog.  The Docs review team needs to monitor the packaging pull requests for changes.

Added to the 2.332.2 LTS changelog and the 2.342 weekly changelog
