### PR TITLE
Update Jenkins is the Way links

### DIFF
--- a/content/_data/adopters/Anchore.adoc
+++ b/content/_data/adopters/Anchore.adoc
@@ -1,6 +1,6 @@
 ---
 name: "Anchore"
 url: https://anchore.com/
-detailsUrl: https://jenkinsistheway.io/user-story/to-understand-and-simplify-your-software-lifecycle/
-detailsLinkText: User Story
+detailsUrl: https://anchore.com/blog/jenkins-at-scale-with-anchore-vulnerability-scanning-compliance/
+detailsLinkText: Blog post
 ---

--- a/content/_data/adopters/Avoris-Travel.adoc
+++ b/content/_data/adopters/Avoris-Travel.adoc
@@ -1,6 +1,6 @@
 ---
 name: "Avoris Travel"
 url: https://www.avoristravel.com/
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-do-things-quickly-simply-and-in-a-powerful-way/
+detailsUrl: https://jenkinsistheway.io/case-studies/jenkins-case-study-avoris-travel/
 detailsLinkText: User Story
 ---

--- a/content/_data/adopters/CERN.adoc
+++ b/content/_data/adopters/CERN.adoc
@@ -1,6 +1,6 @@
 ---
 name: "CERN"
 url: https://home.cern/
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-facilitate-day-to-day-work/
+detailsUrl: https://stories.jenkins.io/user-story/to-facilitate-day-to-day-work/
 detailsLinkText: User Story
 ---

--- a/content/_data/adopters/JDcom.adoc
+++ b/content/_data/adopters/JDcom.adoc
@@ -1,6 +1,6 @@
 ---
 name: "JD.com"
 url: http://jd.com/
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-cast-magic-of-continuous-delivery/
+detailsUrl: https://stories.jenkins.io/user-story/to-cast-magic-of-continuous-delivery/
 detailsLinkText: User Story
 ---

--- a/content/_data/adopters/KP-Labs.adoc
+++ b/content/_data/adopters/KP-Labs.adoc
@@ -1,6 +1,6 @@
 ---
 name: "KP Labs"
 url: https://www.kplabs.pl/en/
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-space/
+detailsUrl: https://jenkinsistheway.io/user-story/to-space/
 detailsLinkText: User Story
 ---

--- a/content/_data/adopters/Preply.adoc
+++ b/content/_data/adopters/Preply.adoc
@@ -1,6 +1,6 @@
 ---
 name: "Preply"
 url: https://preply.com/en/home
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-make-your-configuration-as-a-code-possible/
+detailsUrl: https://stories.jenkins.io/user-story/to-make-your-configuration-as-a-code-possible/
 detailsLinkText: User Story
 ---

--- a/content/_data/adopters/Topdanmark.adoc
+++ b/content/_data/adopters/Topdanmark.adoc
@@ -1,6 +1,6 @@
 ---
 name: "Topdanmark"
 url: "https://www.topdanmark.dk"
-detailsUrl: "https://jenkinsistheway.io/user-story/to-automate-continuous-delivery-pipelines/"
+detailsUrl: https://stories.jenkins.io/user-story/to-automate-continuous-delivery-pipelines/
 detailsLinkText: "User Story"
 ---

--- a/content/_data/adopters/Tymit.adoc
+++ b/content/_data/adopters/Tymit.adoc
@@ -1,6 +1,6 @@
 ---
 name: "Tymit"
 url: https://tymit.com/
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-scale-from-the-ground-up/
+detailsUrl: https://stories.jenkins.io/user-story/to-scale-from-the-ground-up/
 detailsLinkText: User Story
 ---

--- a/content/_data/adopters/Wright.adoc
+++ b/content/_data/adopters/Wright.adoc
@@ -1,6 +1,0 @@
----
-name: "Imascap/Wright"
-url: http://www.wright.com/
-detailsUrl: https://jenkinsistheway.io/user-story/jenkins-is-the-way-to-accelerate-automation-in-the-cloud-2/
-detailsLinkText: User Story
----

--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -12,8 +12,8 @@
     :text: Register for cdCon
     :href: https://events.linuxfoundation.org/cdcon/register/
 # Case Studies
-- :href: https://JenkinsIsTheWay.io/
-  :title: Jenkins is the Way!
+- :href: https://stories.jenkins.io/
+  :title: Jenkins Stories!
   :intro: We are looking for experiences of Jenkins users from around the world showcasing
     how they are building, deploying, and automating great software with Jenkins.
     Check out their user stories and share yours
@@ -22,7 +22,7 @@
     :height: 285px
   :call_to_action:
     :text: More info
-    :href: https://JenkinsIsTheWay.io/
+    :href: https://stories.jenkins.io/
 # Permanent
 # Participate
 - :href: participate

--- a/content/_data/logo/jenkins-is-the-way.yml
+++ b/content/_data/logo/jenkins-is-the-way.yml
@@ -6,4 +6,4 @@ vector:
 credit: 'CloudBees'
 credit_url: 'https://cloudbees.com/'
 source: 'abConsulting Network'
-source_url: 'https://jenkinsistheway.io/'
+source_url: 'https://stories.jenkins.io/'

--- a/content/project/adopters/index.html.haml
+++ b/content/project/adopters/index.html.haml
@@ -14,8 +14,10 @@ This page provides a list of Jenkins adopters.
 
 %h1 More adopters
 
-You can find more Jenkins adopters listed on its StackShare page.
-According to this site, Jenkins has more than 2500 adopter companies which you can discover using its web interface and API.
+%a{:href => "https://stackshare.io/jenkins"}
+  Stackshare
+lists many more Jenkins adopters.
+According to the site, Jenkins has more than 3000 adopter companies which you can discover using its web interface and API.
 %a{:href => "https://stackshare.io/jenkins"}
   Jenkins on Stackshare
 
@@ -30,8 +32,8 @@ According to this site, Jenkins has more than 2500 adopter companies which you c
     %a{:href => "https://stackshare.io/jenkins"}
       Jenkins on Stackshare
   %li
-    %a{:href => "https://jenkinsistheway.io/"}
-      JenkinsIsTheWay portal - more case studies
+    %a{:href => "https://stories.jenkins.io/"}
+      Jenkins stories - more case studies
   %li
     %a{:href => expand_link("/project/adopters/contributing#add-your-org")}
       Add your company to the listing


### PR DESCRIPTION
## Update Jenkins is the Way links

Link to https://stories.jenkins.io where the story is available.

Fix links to https://jenkinsistheway.io when story is not yet available on https://stories.jenkins.io

Remove one adopter because the story can't be found in either location

- Move Jumbotron from jenkinsistheway.io to stories.jenkins.io
- Replace non-existent Anchore story link with their blog post
- Replace Avoris Travel link with working link
- Use stories.jenkins.io for CERN story
- Use stories.jenkins.io for jd.com destination URL
- Use stories.jenkins.io for the Preply story
- Use stories.jenkins.io for Topdanmark story
- Use stories.jenkins.io for the Tymit story
- Correct the URL to KP Labs story
- Remove Wright Medical adopter page
- Update root adopter page

Would like reviews from either @alyssat or @halkeye 

https://deploy-preview-5063--jenkins-io-site-pr.netlify.app/project/adopters/ shows the Adopters page.

https://deploy-preview-5063--jenkins-io-site-pr.netlify.app/ shows the Jumbotron