### PR TITLE
Move ionicons to cdn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,6 @@ $(BUILD_DIR)/assets: $(BUILD_DIR)/node $(shell find . -ipath "./node_modules/*" 
 	done;
 	mkdir -p $(ASSETS_DIR)/anchor-js/
 	cp node_modules/anchor-js/*.js $(ASSETS_DIR)/anchor-js/
-	rm -rf $(ASSETS_DIR)/ionicons
-	cp -R node_modules/ionicons/dist $(ASSETS_DIR)/ionicons
 	@touch $(BUILD_DIR)/assets
 
 #######################################################

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -87,13 +87,12 @@
     %script{:src => expand_link("/assets/bower/anchor-js/anchor.min.js")}
     %script{:src => expand_link("/assets/bower/tether/js/tether.min.js")}
     %script{:src => expand_link("/assets/bower/bootstrap/js/bootstrap.min.js")}
-    %script{:src => expand_link("/assets/bower/ionicons/ionicons/ionicons.esm.js"),
+    %script{:src => "https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.esm.js",
       :type => "module",
       :data-stencil-namespace => "ionicons"}
-    %script{:src => expand_link("/assets/bower/ionicons/ionicons/ionicons.js"),
+    %script{:src => "https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.js",
       :nomodule => "",
       :data-stencil-namespace => "ionicons"}
-
     %footer#footer
       .container
         .row

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "anchor-js": "^4.2.0",
         "bootstrap": "^4.3.1",
-        "ionicons": "^5.5.2",
         "jquery": "^3.5.1",
         "popper.js": "^1.14.7",
         "tether": "^1.4.5"
@@ -19,18 +18,6 @@
         "broken-link-checker": "^0.7.8",
         "http-server": "^14.1.0",
         "npm-run-all": "^4.1.5"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -756,14 +743,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "node_modules/ionicons": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
-      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
-      "dependencies": {
-        "@stencil/core": "~2.10.0"
-      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -1924,11 +1903,6 @@
     }
   },
   "dependencies": {
-    "@stencil/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A=="
-    },
     "@types/node": {
       "version": "12.7.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.7.tgz",
@@ -2518,14 +2492,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "ionicons": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.4.tgz",
-      "integrity": "sha512-3ph8X9my3inhabWEZ7N0XRA0MnnNQ1v9a602mLNgWsIXnxE9G5BybIZ/pws/OZZ/hoNlvSjk801N03yL9/FNgQ==",
-      "requires": {
-        "@stencil/core": "~2.10.0"
-      }
     },
     "is-arrayish": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "anchor-js": "^4.2.0",
     "bootstrap": "^4.3.1",
-    "ionicons": "^5.5.2",
     "jquery": "^3.5.1",
     "popper.js": "^1.14.7",
     "tether": "^1.4.5"


### PR DESCRIPTION
plugins.jenkins.io (and stories next rebuild) are getting javascript +cors issues loading the ionicons.

Options:
1) Setup cors headers on jenkins.io
2) Load ionicons from somewhere with cdn

I chose CDN as it means it can cache between sites, and less work for us (don't have to configure and maintain cors).