### PR TITLE
Reorder changelog entries, remove spurious entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15092,6 +15092,26 @@
   - version: '2.343'
     date: 2022-04-12
     changes:
+      - type: major bug
+        category: regression
+        pull: 6449
+        issue: 68122
+        authors:
+          - basil
+        pr_title: "[JENKINS-68122] Avoid deadlock involving `RingBufferLogHandler.LogRecordRef`\
+          \ class loading (III)"
+        message: |-
+          Avoid a deadlock between agent class loading and logging.
+      - type: major bug
+        category: regression
+        pull: 6447
+        issue: 67237
+        authors:
+          - MarkEWaite
+        pr_title: Revert "`BuildTrigger` waits until the dependency graph has been
+          updated (#6101)"
+        message: |-
+          Run downstream jobs (regression in 2.341).
       - type: rfe
         category: rfe
         pull: 6255
@@ -15133,16 +15153,6 @@
         pr_title: "[JENKINS-68055] retain label expressions when trimming labels"
         message: |-
           Preserve load statistics data for label expressions.
-      - type: major bug
-        category: regression
-        pull: 6449
-        issue: 68122
-        authors:
-          - basil
-        pr_title: "[JENKINS-68122] Avoid deadlock involving `RingBufferLogHandler.LogRecordRef`\
-          \ class loading (III)"
-        message: |-
-          Avoid a deadlock between agent class loading and logging.
       - type: bug
         category: regression
         pull: 6303
@@ -15153,16 +15163,6 @@
         pr_title: "[JENKINS-67846] Icon alignment of build status is wrong"
         message: |-
           Fix the position of icon and text (regression in 2.335).
-      - type: major bug
-        category: regression
-        pull: 6447
-        issue: 67237
-        authors:
-          - MarkEWaite
-        pr_title: Revert "`BuildTrigger` waits until the dependency graph has been
-          updated (#6101)"
-        message: |-
-          Run downstream jobs (regression in 2.341).
       - type: bug
         category: bug
         pull: 6456

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15181,16 +15181,6 @@
           \ when readOnlyMode is set"
         message: |-
           Hide textarea preview when the field is read only.
-      - type: bug
-        category: bug
-        pull: 6101
-        issue: 67237
-        authors:
-          - Si-So
-        pr_title: "[JENKINS-67237] BuildTrigger waits until the dependency graph has\
-          \ been updated"
-        message: |-
-          When triggering a new build while the build graph is currently being re-computed, jenkins waits for the re-computation to finish. This guarantees that recently updated build triggers are executed.
 
   # pull: 6116 (PR title: Removed legacy hudson update site logic)
   # pull: 6405 (PR title: [JENKINS-68121] Line under the "URL Copy" is out of place)


### PR DESCRIPTION
## Reorder 2.343 changelog entries, remove spurious entry

- Move major bug fixes to top of changelog
- Remove PR-6101 from 2.343 changelog, was already included in 2.341
