### PR TITLE
Align icon path -> icon class transition examples

### DIFF
--- a/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
+++ b/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
@@ -31,21 +31,35 @@ img(width:"16", height:"16", src:"${imagesURL}/16x16/next.gif")
 
 Jelly offers a couple of properties to access an icon class instead of an icon path. Jenkins core will display a GIF, a PNG or an SVG, based on the Jenkins version used. The properties `<l:icon class>` and `<l:task icon>` are used based on the location the icon is displayed in.
 
+The format is `icon-<icon> icon-<size>`. `<icon>` represents the name of the icon that used to be read from a path.
+`<size>` represents the icon size.
+The following values for `<size>` are available:
+[options="header"]
+|=======================
+|Path size attribute|`<size>` attribute
+|16x16    |sm
+|24x24    |md
+|32x32    |lg
+|48x48    |xlg
+|=======================
+
+Pick the appropriate `<size>` attribute according to the path size the icon has.
+
 Jelly example:
 [source, xml]
 ----
-<l:task icon="icon-gear2 icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+<l:icon class="icon-fingerprint icon-sm" />
 <!-- or -->
-<l:icon class="icon-gear2 icon-md" />
+<l:task icon="icon-document icon-md" href="" title="${%Modules}" />
 ----
 
 Groovy example:
 [source, groovy]
 ----
-l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
+l.task(icon:"icon-next icon-sm")
 ----
 
-More information about Jelly tags provided by core to display icons can be found in it's link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html#layout:icon[jelly documentation].
+More information about Jelly tags provided by core to display icons can be found in its link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html#layout:icon[jelly documentation].
 
 
 == I still need more help?


### PR DESCRIPTION
The examples are now aligned to prevent confusion.
Additionally, I added a table of all path-sizes with their corresponding icon size provided by the API.