### PR TITLE
Noting that storing AWS credentials is sketchy

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -512,6 +512,11 @@ the case in the <<#usernames-and-passwords,Usernames and passwords>> Pipeline
 example below), then these `AWS_...` environment variables would only be scoped
 to the steps in that stage.
 
+TIP: Storing static AWS keys in Jenkins credentials is not very secure.
+If you can run Jenkins itself in AWS (at least the agent),
+it is preferable to use IAM roles for a link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html[computer]
+or link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[EKS service account].
+It is also possible to use link:https://github.com/jenkinsci/oidc-provider-plugin#accessing-aws[web identity federation].
 
 ===== Usernames and passwords
 


### PR DESCRIPTION
There are better ways, including what I recently documented in https://github.com/jenkinsci/oidc-provider-plugin/pull/10.

Noticed this because https://github.com/dagger/dagger/pull/2102 copies the questionable advice.