### PR TITLE
Link from ”Issue Reporting” to forum

### DIFF
--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -11,8 +11,9 @@ tags:
 == How-To Report an Issue
 
 The Jenkins JIRA is not a support site. If you need assistance or have
-general questions, visit us link:/chat/[in chat], or email
-one of the link:/mailing-lists[mailing lists].
+general questions, visit us link:/chat/[in chat], email
+one of the link:/mailing-lists[mailing lists], or post
+on the https://community.jenkins.io/[community forum].
 
 [[Howtoreportanissue-Beforecreatinganissue]]
 == Before creating an issue


### PR DESCRIPTION
Add a link from the ”Issue Reporting” page to the <https://community.jenkins.io/> forum, as another way to post support requests that don’t belong in Jira.

I considered linking directly to the [Ask a question](https://community.jenkins.io/c/using-jenkins/support/8) category, but I’m not sure how stable that URI will be.