### PR TITLE
Fix Jenkinsfile Windows example with '%' character

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -1043,7 +1043,7 @@ pipeline {
     stage('Example') {
       steps {
           /* CORRECT */
-          bat 'echo %SECRET_VALUE%'
+          bat 'echo %EXAMPLE_KEY%'
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/jenkins.io/issues/5072 by using
the same variable in the good example as was used in the bad example.

Thanks @AlexandreFenyo for the bug report
