### PR TITLE
Update 2.344 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15249,12 +15249,8 @@
           - pull: 6474
           - url: https://github.com/jenkinsci/jackson2-api-plugin/releases
             title: Spring Framework 5.3.19 changelog
-          - url: https://spring.io/blog/2022/04/13/spring-framework-data-binding-rules-vulnerability-cve-2022-22968
-            title: CVE-2022-22968 - Spring Framework Data Binding Rules Vulnerability
         message: |-
           Upgrade Spring Framework from 5.3.18 (released on March 31, 2022) to 5.3.19 (released on April 13, 2022).
-          Spring Framework 5.3.19 includes 12 fixes and improvements.
-          In addition, Spring Framework 5.3.19 includes a fix for CVE-2022-22968 - Spring Framework Data Binding Rules Vulnerability.
       - type: rfe
         category: rfe
         pull: 6442


### PR DESCRIPTION
## Update 2.344 changelog

- Add references to 2.344 changelog
- Remove reference to Spring CVE that doesn't affect Jenkins
