### PR TITLE
Use spring framework changelog link

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15247,7 +15247,7 @@
         pr_title: Upgrade Spring Framework from 5.3.18 to 5.3.19
         references:
           - pull: 6474
-          - url: https://github.com/jenkinsci/jackson2-api-plugin/releases
+          - url: https://github.com/spring-projects/spring-framework/releases/tag/v5.3.19
             title: Spring Framework 5.3.19 changelog
         message: |-
           Upgrade Spring Framework from 5.3.18 (released on March 31, 2022) to 5.3.19 (released on April 13, 2022).


### PR DESCRIPTION
Saying "Spring Framework changelog" and then linking to the jackson2
api changelog is confusing and not helpful.
