### PR TITLE
Use correct destination version in changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15476,7 +15476,7 @@
           - url: https://github.com/spring-projects/spring-security/releases/tag/5.6.3
             title: Spring project spring-security 5.6.3 release notes
         message: |-
-          Developer: Upgrade Spring Security from 5.6.2 (released on February 21, 2022) to 5.6.2 (released on April 18, 2022).
+          Developer: Upgrade Spring Security from 5.6.2 (released on February 21, 2022) to 5.6.3 (released on April 18, 2022).
 
   # pull: 6490 (PR title: Emphasize Jenkins project in idea)
   # pull: 6492 (PR title: Restore incrementals publishing)


### PR DESCRIPTION
Upgrading from 5.6.2 (Feb 2022) to 5.6.2 (Apr 2022) does not make sense.

Upgrade is from 5.6.2 to 5.6.3
