### PR TITLE
Describe reverse proxy warning when using Tomcat

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-troubleshooting.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-troubleshooting.adoc
@@ -88,6 +88,15 @@ expecting, e.g. if your reverse proxy is forwarding requests at
 `+java -jar jenkins.war --prefix=/foobar+` to start jenkins using
 `+/foobar+` as the context path
 
+== If the WAR file is being deployed in a Tomcat instance, without a reverse proxy
+
+This warning will appear if the WAR file is being used within a Tomcat installation.
+Edit `TOMCAT/conf/catalina.properties` and add: 
+
+    org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+
+Restart Tomcat and the warning will go away.    
+
 == Further Diagnosis
 
 For further diagnosis, try using cURL:


### PR DESCRIPTION
This change covers a situation that happens when there is no reverse proxy used, and is not related to the note above about setting the correct Jenkins URL. This was tricky to figure out and I think it should be in this page, because this page is where users look if they are seeing this reverse proxy warning.