### PR TITLE
[DOCS-5376] Adding Plugin installation video

### DIFF
--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -85,7 +85,7 @@ configured Update Center.
 [[install-with-cli]]
 === Using the Jenkins CLI
 
-.Installing Jenkins Plugins using Jenkins CLI
+.Installing Jenkins plugins using Jenkins CLI
 video::bTFMvXIkNIg[youtube,width=800,height=420]
 
 Administrators may also use the <<cli#,Jenkins CLI>> which provides a command


### PR DESCRIPTION
added youtube video for plugin installation via Jenkins CLI and removed trailing spaces from lines as needed