### PR TITLE
Make example jelly tag visible in changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -15561,7 +15561,7 @@
           - ikedam
         pr_title: "[JENKINS-68286] Allow extra classes with <layout:icon>"
         message: |-
-          Allow extra CSS classes with <code><l:icon></code>.
+          Allow extra CSS classes with <code>&lt;l:icon&gt;</code>.
       - type: bug
         category: regression
         pull: 6493


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/pull/5108#discussion_r870231019~
notes that the example tag is not displayed in the changelog HTML page
