### PR TITLE
Add Open in Gitpod button

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -18,6 +18,12 @@ from that branch to the `master` branch of this repository.
 Forking only needs to be done once, after which you can push changes to your fork
 using the GitHub website file editor or from a local clone, as described below.
 
+You can also open this project as a https://www.gitpod.io/[Gitpod workspace] which comes pre-configured with all the tools you will need.
+
+[link="https://gitpod.io/#https://github.com/jenkins-infra/jenkins.io"]
+image::https://gitpod.io/button/open-in-gitpod.svg[Open in Gitpod]
+
+
 [[newcomers]]
 === Information for newcomers
 


### PR DESCRIPTION
Adding open in Gitpod button to Contributing doc to make it easier for contributors to work on Gitpod 
<img width="517" alt="image" src="https://user-images.githubusercontent.com/37153406/167884619-3448b580-2885-4aaa-9319-9ae0e902ed45.png">
