### PR TITLE
chore(rating): add rating within the kubernetes self hosted services

### DIFF
--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -97,6 +97,7 @@ Here is a non-exhaustive list of services that we provide and maintain.
 | https://uplink.jenkins.io[UpLink]                        | https://github.com/jenkins-infra/uplink/issues[GitHub issues]                     | https://github.com/jenkins-infra/uplink[Code],          https://github.com/jenkins-infra/charts/tree/master/charts/uplink[helm chart]
 | https://jenkins-wiki-exporter.jenkins.io/[Wiki Exporter] | link:https://github.com/jenkins-infra/jenkins-wiki-exporter/issues[GitHub issues] | https://github.com/jenkins-infra/jenkins-wiki-exporter/[Code], https://github.com/jenkins-infra/charts/tree/master/charts/jenkins-wiki-exporter[helm chart]
 | https://wiki.jenkins.io[Wiki - static pages]             | https://github.com/jenkins-infra/docker-confluence-data/issues[GitHub issues]     | https://github.com/jenkins-infra/docker-confluence-data[Code], https://github.com/jenkins-infra/confluence[Docker]
+| Rating metric                                            | link:https://github.com/jenkins-infra/rating/issues[GitHub issues]                | https://github.com/jenkins-infra/rating/[Code], https://github.com/jenkins-infra/kubernetes-management/blob/c6abb908544ad38490b4ea47c273fdc49b21c118/clusters/prodpublick8s.yaml#L248-L255[helm chart]
 |===
 
 === Self-hosted services


### PR DESCRIPTION
Add[ the rating metric service](https://github.com/jenkins-infra/rating) to the list of services self-hosted on Kubernetes in [the Infrastructure project page](https://www.jenkins.io/projects/infrastructure/#self-hosted-services-in-kubernetes).

Part of https://github.com/jenkins-infra/helpdesk/issues/1627