### PR TITLE
Document allowUnsupportedRemotingVersions escape hatch

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1069,6 +1069,15 @@ properties:
   description: |
     How frequently to possibly provision nodes.
 
+- name: hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions
+  tags:
+  - escape
+  def: |
+    `false`
+  since: 2.343
+  description: |
+    Allow connection by agents running unsupported remoting versions.
+
 - name: hudson.slaves.WorkspaceList
   tags:
   - tuning
@@ -2246,7 +2255,7 @@ If you find these useful, please file a ticket to promote it to an official feat
 == Properties in Jenkins Core
 
 [NOTE]
-Due to the very large number of system properties used, often just added as a "safety valve" or "escape hatch" in case a change causes problems, this is list is not expected to be complete.
+Due to the very large number of system properties used, often just added as a "safety valve" or "escape hatch" in case a change causes problems, this list is not expected to be complete.
 
 ++++
 <style>


### PR DESCRIPTION
Since it is [proposed to be included](https://github.com/jenkinsci/jenkins/pull/4579) in the Jenkins 2.346.1 upgrade guide as part of [JENKINS-50211](https://issues.jenkins.io/browse/JENKINS-50211), I think that it should be included in the list of system properties.

Propoerty first introduced in Jenkins 2.343

https://www.jenkins.io/changelog/#v2.343
