### PR TITLE
Emphasizing that `.mvn/` must already exist for a plugin to be considered incrementalified

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -28,7 +28,7 @@ and an informational component with the Git commit hash.
 === Incrementals Enablement
 
 Verify that the plugin has already been link:../../plugin-development/incrementals[incrementalified].
-`pom.xml` should contain `<version>$\{revision}$\{changelist}</version>` before proceeding with subsequent steps.
+`pom.xml` should contain `<version>$\{revision}$\{changelist}</version>` and the files `.mvn/extensions.xml` and `.mvn/maven.config` should exist *before proceeding with subsequent steps*.
 
 NOTE: A new plugin created from the link:https://github.com/jenkinsci/archetypes/[archetypes] will already have this setup.
 


### PR DESCRIPTION
Still struggling to get people to read instructions. https://github.com/jenkinsci/lightstep-incident-response-plugin/pull/1#issuecomment-1132113366