### PR TITLE
fix: scroll overflow of navbar and dropdown

### DIFF
--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -1,4 +1,4 @@
-%nav#ji-toolbar.navbar.navbar-expand-lg.navbar-dark.top.bg-dark.fixed-top
+%nav#ji-toolbar.navbar.navbar-expand-lg.navbar-dark.bg-dark.fixed-top
   %a.navbar-brand{:href => expand_link('/')}
     = site.base_title
   %button.navbar-toggler{"data-target" => "#CollapsingNavbar", "data-toggle" => "collapse", :type => "button"}

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1706,7 +1706,7 @@ table.syntax > tbody > tr > th {
     - For better UI/UX in mobile resolutions.
 */
 @media (max-width : 991px) {
-  .navbar{
+  .navbar {
     max-height: 70vh;
     overflow-y: auto;
   }

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1490,7 +1490,9 @@ table.syntax > tbody > tr > th {
   .navbar.navbar-expand-lg .nav-link.btn {
     color: rgba(255, 255, 255, 0.75); }
   .navbar.navbar-expand-lg .dropdown-menu {
-    font-size: 0.875rem; }
+    font-size: 0.875rem; 
+    max-height: 80vh;
+    overflow-y: auto; }
   .navbar-toggler-icon {
     font-size: 0.8em; }
 
@@ -1704,6 +1706,10 @@ table.syntax > tbody > tr > th {
     - For better UI/UX in mobile resolutions.
 */
 @media (max-width : 991px) {
+  .navbar{
+    max-height: 70vh;
+    overflow-y: auto;
+  }
   /* search box container */
   .nav-item.searchbox {
     width: 100%;


### PR DESCRIPTION
### Issue
Currently, the navbar in the mobile is not scrollable. As a result of this, if we expand any section (for example `Community`), the navbar clips after the boundaries, and the user can not select the options that are present below the line. 
Also, the dropdowns of the navbars do not have scrolling and exceed the screen's height in some cases (`Community` dropdown). This pull request addresses both these issues.
### Dropdown
Before:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/77713537/169901398-f558edc9-4b86-468f-a5b9-69cfbc59ad27.png">

After:
<img width="959" alt="image" src="https://user-images.githubusercontent.com/77713537/169901294-3c2b7551-6b47-4b2e-ba65-de6c0504f623.png">

### Navbar (Mobile View)
Before: 
<img width="502" alt="image" src="https://user-images.githubusercontent.com/77713537/169901611-a255583c-9e3f-4e8f-bba7-7f76310b1c4a.png">

After:  (independent scrolling)
<img width="496" alt="image" src="https://user-images.githubusercontent.com/77713537/169901938-006f67fd-85dc-4405-b543-4e0e5cd4599a.png">

### Tests

I have tested both the changes thoroughly in both desktop and mobile views.