### PR TITLE
Adjust jenkins-logo-dark.svg colors

### DIFF
--- a/content/images/jenkins-logo-title-dark.svg
+++ b/content/images/jenkins-logo-title-dark.svg
@@ -78,7 +78,7 @@
                 <path d="m 121.55,91.434 c 0,-1.0121 -0.821,-1.8328 -1.834,-1.8328 -1.012,0 -1.833,0.8207 -1.833,1.8328 0,1.0121 0.821,1.834 1.833,1.834 1.013,0 1.834,-0.8219 1.834,-1.834" style="fill:#1d1919;fill-opacity:1;fill-rule:evenodd;stroke:none" id="path136" inkscape:connector-curvature="0" />
 			</g>
         <text xml:space="preserve" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Georgia" x="231.70523" y="-71.714066" id="text5675" sodipodi:linespacing="100%" transform="scale(1,-1)">
-				<tspan sodipodi:role="line" fill="#ffffff" id="tspan5677" x="231.70523" y="-71.714066" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Georgia">Jenkins</tspan>
+				<tspan sodipodi:role="line" fill="#c9d1d9" id="tspan5677" x="231.70523" y="-71.714066" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Georgia">Jenkins</tspan>
 			</text>
 		</g>
 </svg>

--- a/content/images/jenkins-logo-title.svg
+++ b/content/images/jenkins-logo-title.svg
@@ -78,7 +78,7 @@
                 <path d="m 121.55,91.434 c 0,-1.0121 -0.821,-1.8328 -1.834,-1.8328 -1.012,0 -1.833,0.8207 -1.833,1.8328 0,1.0121 0.821,1.834 1.833,1.834 1.013,0 1.834,-0.8219 1.834,-1.834" style="fill:#1d1919;fill-opacity:1;fill-rule:evenodd;stroke:none" id="path136" inkscape:connector-curvature="0" />
 			</g>
         <text xml:space="preserve" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Georgia" x="231.70523" y="-71.714066" id="text5675" sodipodi:linespacing="100%" transform="scale(1,-1)">
-				<tspan sodipodi:role="line" fill="#000000" id="tspan5677" x="231.70523" y="-71.714066" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Georgia">Jenkins</tspan>
+				<tspan sodipodi:role="line" fill="#242925" id="tspan5677" x="231.70523" y="-71.714066" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Georgia">Jenkins</tspan>
 			</text>
 		</g>
 </svg>


### PR DESCRIPTION
Addresses https://github.com/jenkinsci/jenkins/pull/6610#pullrequestreview-988663998

The colors chosen are part of GH's dark theme color palette:

![Bildschirmfoto 2022-05-29 um 23 29 52](https://user-images.githubusercontent.com/13383509/170892124-44f03b92-855c-4be7-aa7e-19fcd2481c86.png)

cc @timja I agree, the white is quite aggressive compared to the regular, darker, white.

