### PR TITLE
[DOCS-5646] adding Java 11 requirement info

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -11,6 +11,9 @@ Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading
 
 Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
 
+Starting with the weekly release line 2.353, Java 11 or Java 17 will be required to use Jenkins.
+Java 8 will still be supported in the Long Term Support or LTS release line, but the LTS release line's requirements will eventually mirror the weekly release line requirements.
+
 Early adopters may use Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
 
 All other Java versions are not supported.

--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -12,7 +12,7 @@ Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading
 Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
 
 Starting with the weekly release line 2.353, Java 11 or Java 17 will be required to use Jenkins.
-Java 8 will still be supported in the Long Term Support or LTS release line, but the LTS release line's requirements will eventually mirror the weekly release line requirements.
+Java 8 will still be supported in the https://www.jenkins.io/download/lts/[Long Term Support] release line, but the LTS release line will eventually mirror the weekly release line requirements for Java 11 or Java 17.
 
 Early adopters may use Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
 


### PR DESCRIPTION
updated java requirements page to reflect upcoming weekly release line Java support (11 or 17), set expectations that Java 8 will be supported in the LTS until it eventually mirrors the weekly release line at a later time