### PR TITLE
add the meeting url for weekly project-specific office hours

### DIFF
--- a/content/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions.adoc
+++ b/content/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions.adoc
@@ -14,7 +14,7 @@ mentors:
 - "krisstern"
 - "abhyudayasharma"
 links:
-  slack: "https://app.slack.com/client/TJWP1JXK6/C03H82VHCFJ"
+  chat: "/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions/#chat"
   draft: "https://docs.google.com/document/d/1SC__C6V8LFZvs99uR4fqoraJPcF_-JG5QhvBdaYaVFo/edit?usp=sharing"
   idea: "/projects/gsoc/2022/project-ideas/jenkinsfile-runner-action-for-github-actions"
   meetings: "/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions/#office-hours"
@@ -37,6 +37,12 @@ Users can extend these images to set up their customized environment.
 What's more, the user can install the plugins, which is enabled by Plugin Installation Manager Tool, and then configure Jenkins, which is enabled by Configuration-as-Code plugin.
 Jenkinsfile Runner Action also helps users to generate the configuration files which are prerequisites for launching the Jenkins pipeline inside the GitHub Actions.
 The user only need to push these configuration files as well as their own codes to the repositories for the setup to work.
+
+=== Chat
+
+We use the `#gsoc-jenkinsfile-runner` channel in the CDF Slack workspace.
+
+link:/chat/#continuous-delivery-foundation[Explanations about the CDF Slack] (the invitation link is at the end of the paragraph).
 
 === Office hours
 

--- a/content/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions.adoc
+++ b/content/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions.adoc
@@ -41,7 +41,7 @@ The user only need to push these configuration files as well as their own codes 
 === Office hours
 
 * (General) Official weekly Jenkins office hours: Thursdays 3pm to 3:30pm UTC
-* (Project-based) Weekly project-specific office hours: Mondays 12pm to 12:30pm UTC
+* (Project-based) link:https://us05web.zoom.us/j/81912236313?pwd=WGtHTHZnSHFhS3dYTmVHUXdrK05Sdz09[Weekly project-specific office hours]: Mondays 12pm to 12:30pm UTC
 
 === Project Links
 Here come some useful links:


### PR DESCRIPTION
Update the weekly Zoom meeting url for Jenkinsfile-runner-action-for-github-actions project in GSoC2022.