### PR TITLE
Use icon admonitions for security advisories

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -72,9 +72,9 @@ notitle: true
         \/
         = issue.cve
     - if plugin_name
-      = Asciidoctor.convert issue.description.gsub(/PLUGIN_NAME/, "#{plugin_name} Plugin"), safe: :safe
+      = Asciidoctor.convert issue.description.gsub(/PLUGIN_NAME/, "#{plugin_name} Plugin"), safe: :safe, attributes: { 'icons' => 'font' }
     - else
-      = Asciidoctor.convert issue.description, safe: :safe
+      = Asciidoctor.convert issue.description, safe: :safe, attributes: { 'icons' => 'font' }
 - else
   - # If there is any content, it's the issue descriptions -- but only show if there are none in the data
   = content


### PR DESCRIPTION
This makes admonitions in security advisories consistent with the rest of the site.

## Before

<img width="1383" alt="Screenshot 2022-06-09 at 18 52 27" src="https://user-images.githubusercontent.com/1831569/172901797-1358c3d8-467d-4642-b919-46d476e9d93a.png">

## After

<img width="1392" alt="Screenshot 2022-06-09 at 18 52 16" src="https://user-images.githubusercontent.com/1831569/172901815-91f2e9a5-ab7e-4234-b81d-3d0b3b4b25aa.png">
