### PR TITLE
[DOCS-5691] update jenkins parameters

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -138,7 +138,7 @@ Note that enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, a
 
 ==== Java 11, Java 8u252, and later
 
-IMPORTANT: Starting with weekly release line *2.353* Java 11 will be required.
+IMPORTANT: Starting with weekly release line *2.357*, Java 11 will be required.
 The Long Term Support release line will not require Java 11 until September, at which point Java 8 support will be depreciated.
 
 Java 11, Java 8 update 252 and Java 8 versions after update 252 can run the ALPN TLS extension by installing the Jetty ALPN java server jar and passing it as a java command line argument.

--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -139,7 +139,7 @@ Note that enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, a
 ==== Java 11, Java 8u252, and later
 
 IMPORTANT: Starting with weekly release line *2.357*, Java 11 will be required.
-The Long Term Support release line will not require Java 11 until September, at which point Java 8 support will be depreciated.
+The Long Term Support release line will not require Java 11 until September, at which point Java 8 support will be deprecated.
 
 Java 11, Java 8 update 252 and Java 8 versions after update 252 can run the ALPN TLS extension by installing the Jetty ALPN java server jar and passing it as a java command line argument.
 Steps to install the extension are:

--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -138,7 +138,10 @@ Note that enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, a
 
 ==== Java 11, Java 8u252, and later
 
-Java 11,  Java 8 update 252 and Java 8 versions after update 252 can run the ALPN TLS extension by installing the Jetty ALPN java server jar and passing it as a java command line argument.
+IMPORTANT: Starting with weekly release line *2.353* Java 11 will be required.
+The Long Term Support release line will not require Java 11 until September, at which point Java 8 support will be depreciated.
+
+Java 11, Java 8 update 252 and Java 8 versions after update 252 can run the ALPN TLS extension by installing the Jetty ALPN java server jar and passing it as a java command line argument.
 Steps to install the extension are:
 
 * Identify the Jetty version included in your Jenkins server by searching the Jenkins startup log for the string `org.eclipse.jetty.server.Server#doStart`. For example: +

--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -141,7 +141,7 @@ Note that enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, a
 IMPORTANT: Starting with weekly release line *2.357*, Java 11 will be required.
 The Long Term Support release line will not require Java 11 until September, at which point Java 8 support will be deprecated.
 
-Java 11, Java 8 update 252 and Java 8 versions after update 252 can run the ALPN TLS extension by installing the Jetty ALPN java server jar and passing it as a java command line argument.
+Java 11 and Java 8 versions later than update 252 can run the ALPN TLS extension by installing the Jetty ALPN Java server jar and passing it as a Java command line argument.
 Steps to install the extension are:
 
 * Identify the Jetty version included in your Jenkins server by searching the Jenkins startup log for the string `org.eclipse.jetty.server.Server#doStart`. For example: +


### PR DESCRIPTION
added note informing users that Java 11 will be required on the weekly release line starting 2.353 and eventually the LTS in september