### PR TITLE
Make GSoC Org Admin runbook writable again

### DIFF
--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -71,8 +71,7 @@ For 2022, Org Admins are:
 
 The following checklists and documents describe the role.
 
-// TODO: duplicate the document to take ownership
-* link:https://docs.google.com/document/d/1AeeIBfzst3VeI-hdRNlfPvp8NgcGneqI2uEkQoZ88q4/edit?usp=sharing[Org Admin runbook for the Jenkins project]
+* link:https://docs.google.com/document/d/1tShnTyka5fdBxaE0c93ptu-J_XTlSf3tKwJemhx5_nA/edit?usp=sharing[Org Admin runbook for the Jenkins project]
 * link:https://developers.google.com/open-source/gsoc/help/oa-tips[Org Admin tips by Google]
 
 == Contacts


### PR DESCRIPTION
Changing the URL of the linked runbook to a cloned version of the document as the previous one was not 
writable anymore.
