### PR TITLE
Include remoting 3025.vf64a_a_3da_6b_55 in 2.354 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -16081,8 +16081,14 @@
         authors:
           - Vlatombe
         pr_title: "[JENKINS-68542] Store inbound cookie key in connection state"
+        references:
+          - pull: 6576
+          - issue: 68542
+          - url: https://github.com/jenkinsci/remoting/releases/tag/3025.vf64a_a_3da_6b_55
+            title: Remoting 3025.vf64a_a_3da_6b_55 changelog
         message: |-
           Fix websocket reconnection in edge cases.
+          Upgrade from  Remoting 4.13 to 3025.vf64a_a_3da_6b_55.
       - type: rfe
         category: developer
         pull: 6615


### PR DESCRIPTION
Upgrade was part of the inbound cooke key fix for connection state.

Thanks to Konstantin Bulanov for reporting it as part of [JENKINS-68739](https://issues.jenkins.io/browse/JENKINS-68739)
