### PR TITLE
ignore recommendations for API plugins

### DIFF
--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -32,6 +32,9 @@ There are link:https://stats.jenkins.io/pluginversions/[statistics of core versi
 These are updated monthly.
 When updating the core dependency, choose the link:/changelog-stable/[newest LTS version] that doesn't exclude a majority of your existing users (by requiring a newer Jenkins than they have).
 
+NOTE:  if you are packaging a pure API library (one that does not depend on Jenkins APIs) then you should ignore newer jenkins versions and pick an older LTS.
+Something around 1 year old that does not have too many detached plugins makes a good choice and *PLACEHOLDER_OLDEST_LTS* would be a reasonable candidate.
+
 ## Currently recommended versions
 
 At the moment, the Jenkins releases *PLACEHOLDER_RECENT_LTS_POINT_HIGHS* make good core dependencies.

--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -32,7 +32,7 @@ There are link:https://stats.jenkins.io/pluginversions/[statistics of core versi
 These are updated monthly.
 When updating the core dependency, choose the link:/changelog-stable/[newest LTS version] that doesn't exclude a majority of your existing users (by requiring a newer Jenkins than they have).
 
-NOTE:  if you are packaging a pure API library (one that does not depend on Jenkins APIs) then you should ignore newer jenkins versions and pick an older LTS.
+NOTE: If you are packaging a pure API library (one that does not depend on Jenkins APIs) then you should ignore newer Jenkins versions and pick an older LTS.
 Something around 1 year old that does not have too many detached plugins makes a good choice and *PLACEHOLDER_OLDEST_LTS* would be a reasonable candidate.
 
 ## Currently recommended versions


### PR DESCRIPTION
following these recommendations for API plugins would be wrong.  The reasons provided in the original PRs for doing so are ~all~ mostly completely moot with an API plugin, and would lock out of any older version getting API fixes - esp security related ones or at least make it much more effort than would be required to deliver it.