### PR TITLE
Fix multibranch pipeline tutorial

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -103,7 +103,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.3 docker-workflow:1.28"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.5 docker-workflow:1.28"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -123,37 +123,37 @@ if this hasn't been done before.
 ----
 docker run \
   --name jenkins-blueocean \# <1>
-  --rm \# <2>
-  --detach \# <3>
-  --network jenkins \# <4>
-  --env DOCKER_HOST=tcp://docker:2376 \# <5>
+  --detach \# <2>
+  --network jenkins \# <3>
+  --env DOCKER_HOST=tcp://docker:2376 \# <4>
   --env DOCKER_CERT_PATH=/certs/client \
   --env DOCKER_TLS_VERIFY=1 \
-  --publish 8080:8080 \# <6>
-  --publish 50000:50000 \# <7>
-  --volume jenkins-data:/var/jenkins_home \# <8>
-  --volume jenkins-docker-certs:/certs/client:ro \# <9>
-  --volume "$HOME":/home \# <10>
-  myjenkins-blueocean:{jenkins-stable}-1 # <11>
+  --publish 8080:8080 \# <5>
+  --publish 50000:50000 \# <6>
+  --volume jenkins-data:/var/jenkins_home \# <7>
+  --volume jenkins-docker-certs:/certs/client:ro \# <8>
+  --volume "$HOME":/home \# <9>
+  --restart=on-failure \# <10>
+  --env JAVA_OPTS="-Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true" \# <11>
+  myjenkins-blueocean:{jenkins-stable}-1 # <12>
 ----
 <1> ( _Optional_ ) Specifies the Docker container name for this instance of
 the Docker image.
-<2> ( _Optional_ ) Automatically removes the Docker container when it is shut down.
-<3> ( _Optional_ ) Runs the current container in the background
+<2> ( _Optional_ ) Runs the current container in the background
 (i.e. "detached" mode) and outputs the container ID. If you do not specify this
 option, then the running Docker log for this container is output in the terminal
 window.
-<4> Connects this container to the `jenkins` network defined in the earlier
+<3> Connects this container to the `jenkins` network defined in the earlier
 step. This makes the Docker daemon from the previous step available to this
 Jenkins container through the hostname `docker`.
-<5> Specifies the environment variables used by `docker`, `docker-compose`, and
+<4> Specifies the environment variables used by `docker`, `docker-compose`, and
 other Docker tools to connect to the Docker daemon from the previous step.
-<6> Maps (i.e. "publishes") port 8080 of the current container to
+<5> Maps (i.e. "publishes") port 8080 of the current container to
 port 8080 on the host machine. The first number represents the port on the host
 while the last represents the container's port. Therefore, if you specified `-p
 49000:8080` for this option, you would be accessing Jenkins on your host machine
 through port 49000.
-<7> ( _Optional_ ) Maps port 50000 of the current container to
+<6> ( _Optional_ ) Maps port 50000 of the current container to
 port 50000 on the host machine. This is only necessary if you have set up one or
 more inbound Jenkins agents on other machines, which in turn interact with
 your `jenkins-blueocean` container (the Jenkins "controller").
@@ -168,7 +168,7 @@ Jenkins controller and the first value is the port number on the machine hosting
 the Jenkins controller. Inbound Jenkins agents communicate with the
 Jenkins controller on that port (52000 in this example).
 Note that link:/blog/2020/02/02/web-socket/[WebSocket agents] do not need this configuration.
-<8> Maps the `/var/jenkins_home` directory in the container to the Docker
+<7> Maps the `/var/jenkins_home` directory in the container to the Docker
 link:https://docs.docker.com/engine/admin/volumes/volumes/[volume] with the name
 `jenkins-data`. Instead of mapping the `/var/jenkins_home` directory to a Docker
 volume, you could also map this directory to one on your machine's local file
@@ -179,27 +179,32 @@ directory on your local machine, which would typically be
 `/Users/<your-username>/jenkins` or `/home/<your-username>/jenkins`.
 Note that if you change the source volume or directory for this, the volume
 from the `docker:dind` container above needs to be updated to match this.
-<9> Maps the `/certs/client` directory to the previously created
+<8> Maps the `/certs/client` directory to the previously created
 `jenkins-docker-certs` volume. This makes the client TLS certificates needed
 to connect to the Docker daemon available in the path specified by the
 `DOCKER_CERT_PATH` environment variable.
-<10> Maps the `$HOME` directory on the host (i.e. your local) machine (usually
+<9> Maps the `$HOME` directory on the host (i.e. your local) machine (usually
 the `/Users/<your-username>` directory) to the `/home` directory in the
 container. Used to access local changes to the tutorial repository.
-<11> The name of the Docker image, which you built in the previous step.
+<10> Configure the Docker container restart policy to restart on failure as described in the link:/blog/2022/05/27/docker-image-new-lifecycle/[blog post].
+<11> Allow local checkout for the tutorial.
+See link:/security/advisory/2022-05-17/#SECURITY-2478[SECURITY-2478] for the reasons why this argument should not be used on a production installation.
+<12> The name of the Docker image, which you built in the previous step.
 +
 *Note:* If copying and pasting the command snippet above does not work, try
 copying and pasting this annotation-free version here:
 +
 [source,bash,subs="attributes+"]
 ----
-docker run --name jenkins-blueocean --rm --detach \
+docker run --name jenkins-blueocean --detach \
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 \
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 \
   --publish 8080:8080 --publish 50000:50000 \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
   --volume "$HOME":/home \
+  --restart=on-failure \
+  --env JAVA_OPTS="-Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true" \
   myjenkins-blueocean:{jenkins-stable}-1
 ----
 . Proceed to the <<setup-wizard,Post-installation setup wizard>>.
@@ -223,7 +228,7 @@ docker network create jenkins
 +
 [source]
 ----
-docker run --name jenkins-docker --rm --detach ^
+docker run --name jenkins-docker --detach ^
   --privileged --network jenkins --network-alias docker ^
   --env DOCKER_TLS_CERTDIR=/certs ^
   --volume jenkins-docker-certs:/certs/client ^
@@ -247,7 +252,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.3 docker-workflow:1.28"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.5 docker-workflow:1.28"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -264,12 +269,14 @@ if this hasn't been done before.
 +
 [source,subs="attributes+"]
 ----
-docker run --name jenkins-blueocean --rm --detach ^
+docker run --name jenkins-blueocean --detach ^
   --network jenkins --env DOCKER_HOST=tcp://docker:2376 ^
   --env DOCKER_CERT_PATH=/certs/client --env DOCKER_TLS_VERIFY=1 ^
   --volume jenkins-data:/var/jenkins_home ^
   --volume jenkins-docker-certs:/certs/client:ro ^
   --volume "%HOMEDRIVE%%HOMEPATH%":/home ^
+  --restart=on-failure ^
+  --env JAVA_OPTS="-Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true" ^
   --publish 8080:8080 --publish 50000:50000 myjenkins-blueocean:{jenkins-stable}-1
 ----
 . Proceed to the <<setup-wizard,Setup wizard>>.

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.3 docker-workflow:1.28"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.5 docker-workflow:1.28"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -241,7 +241,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.3 docker-workflow:1.28"
+RUN jenkins-plugin-cli --plugins "blueocean:1.25.5 docker-workflow:1.28"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +


### PR DESCRIPTION
Short term fix for https://github.com/jenkins-infra/jenkins.io/issues/5222 until the tutorials can be reworked to use docker compose to provide a better solution than checkout from a local file system.

Also updates Blue Ocean plugins from 1.25.3 to 1.25.5.

Also updates the restart behavior to match latest Docker packaging per https://www.jenkins.io/blog/2022/05/27/docker-image-new-lifecycle/

Confirmed multibranch pipeline tutorial works on Windows with these changes and confirmed that without these changes, the tutorial fails with various problems, like:

* https://github.com/jenkins-infra/jenkins.io/issues/5222 - no local checkout
* Docker process now correctly restarts after plugin updates

## Preview environment

* [multibranch pipeline](https://deploy-preview-5223--jenkins-io-site-pr.netlify.app/doc/tutorials/build-a-multibranch-pipeline-project/)
* [maven](https://deploy-preview-5223--jenkins-io-site-pr.netlify.app/doc/tutorials/build-a-java-app-with-maven/)
* [python](https://deploy-preview-5223--jenkins-io-site-pr.netlify.app/doc/tutorials/build-a-python-app-with-pyinstaller/) 