### PR TITLE
Add: Independent scrolling in documentation sidebar

### DIFF
--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -27,8 +27,8 @@ section: doc
 
 .container
   .row.body
-    .col-lg-3
-      .sidebar-nav.tour
+    #sidebar.sidebar-nav.tour
+      .mx-2
         %p
           = active_href('doc', '> User Documentation Home')
 
@@ -64,9 +64,19 @@ section: doc
             = active_href('doc/pipeline/steps', 'Pipeline Steps reference')
           %li
             = active_href('doc/upgrade-guide', 'LTS Upgrade guides', :fuzzy => true)
-
-    .col-lg-9
+    #toggle-btn.ml-1
+      %i#btn-icon.fa.fa-arrow-circle-right.fa-2x
+    .col-lg-9.ml-4
       - unless page.notitle
         %h1
           = page.title
       = content
+
+:javascript
+  $('#toggle-btn').click( function() {
+        var toggleWidth = $("#sidebar").width() == 0 ? "25%" : "0px";
+        $('#sidebar').width(toggleWidth);
+        $('body').css('marginLeft', toggleWidth);
+        $('#btn-icon').toggleClass("fa-arrow-circle-right");
+        $('#btn-icon').toggleClass("fa-arrow-circle-left");
+  });

--- a/content/_layouts/documentation.html.haml
+++ b/content/_layouts/documentation.html.haml
@@ -26,9 +26,9 @@ section: doc
 = partial('anchors.html.haml', :selector => '.container .row .col-lg-9')
 
 .container
-  .row.body
-    #sidebar.sidebar-nav.tour
-      .mx-2
+  .row.body.flex-lg-nowrap
+    #sidebar-menu.col-lg-3
+      #sidebar-content.sidebar-nav.tour
         %p
           = active_href('doc', '> User Documentation Home')
 
@@ -64,19 +64,9 @@ section: doc
             = active_href('doc/pipeline/steps', 'Pipeline Steps reference')
           %li
             = active_href('doc/upgrade-guide', 'LTS Upgrade guides', :fuzzy => true)
-    #toggle-btn.ml-1
-      %i#btn-icon.fa.fa-arrow-circle-right.fa-2x
-    .col-lg-9.ml-4
+        
+    .col-lg-9
       - unless page.notitle
         %h1
           = page.title
       = content
-
-:javascript
-  $('#toggle-btn').click( function() {
-        var toggleWidth = $("#sidebar").width() == 0 ? "25%" : "0px";
-        $('#sidebar').width(toggleWidth);
-        $('body').css('marginLeft', toggleWidth);
-        $('#btn-icon').toggleClass("fa-arrow-circle-right");
-        $('#btn-icon').toggleClass("fa-arrow-circle-left");
-  });

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1396,30 +1396,27 @@ table {
     margin-bottom: 1.25rem;
 }
 
-/* sidebar used for documentation */
-.sidebar-nav {
-  height: 80vh;
-  width: 0;
-  position: fixed;
-  z-index: 1;
-  background: white;
-  left: 0;
-  overflow-x: auto;
+/* Making the sidebar scroll independently */
+#sidebar-content {
+  top: 4rem;
+  z-index: 3;
+  max-height: calc(100vh - 4rem);
   overflow-y: auto;
+  margin-bottom: 1rem;
 }
 
-/* sidebar toggle button */
-#toggle-btn {
-  cursor: pointer;
-  position: fixed;
-  z-index: 2;
-  transition: 0.2s;
+@supports ((position:-webkit-sticky) or (position:sticky)) {
+  #sidebar-content {
+    position: -webkit-sticky;
+    position: sticky;
+  }
 }
 
-#toggle-btn:hover {
-  transform: scale(1.2);
-  transition: 0.2s;
+#sidebar-menu {
+  border-right: 1px solid #dee2e6;
+  padding-right: 2px;
 }
+
 /** Project page **/
 
 .sidebar-nav h4 {

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1396,6 +1396,30 @@ table {
     margin-bottom: 1.25rem;
 }
 
+/* sidebar used for documentation */
+.sidebar-nav {
+  height: 80vh;
+  width: 0;
+  position: fixed;
+  z-index: 1;
+  background: white;
+  left: 0;
+  overflow-x: auto;
+  overflow-y: auto;
+}
+
+/* sidebar toggle button */
+#toggle-btn {
+  cursor: pointer;
+  position: fixed;
+  z-index: 2;
+  transition: 0.2s;
+}
+
+#toggle-btn:hover {
+  transform: scale(1.2);
+  transition: 0.2s;
+}
 /** Project page **/
 
 .sidebar-nav h4 {


### PR DESCRIPTION
This pull request closes task https://issues.jenkins.io/browse/WEBSITE-799.

It introduces independent scrolling in the documentation sidebar, which is also made collapsible to facilitate the mobile experience. 

Upon expanding the sidebar, the main content gets pushed rightwards, and the footer is shrunk adequately. 

### An Alternative Approach
Upon expanding, we can overlap the sidebar on the content. This will make the toggling much faster for pages with large content.

Tagging the mentors - @kwhetstone @arpoch 