### PR TITLE
Moving Jenkins X to their own security tracker

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -28,13 +28,13 @@ Please report issues present in the following components:
 
 * Jenkins, including installers and Docker images published by the Jenkins project
 * Jenkins plugins published by the Jenkins project (listed on https://plugins.jenkins.io/[plugins.jenkins.io] and/or hosted in https://github.com/jenkinsci[the jenkinsci GitHub organization])
-* Jenkins X (see https://jenkins-x.io/community/security/[reporting guidelines])
 * Additional components published by the Jenkins project for general use, such as Docker images
 
 
 The following components are out of scope:
 
 * Issues specific to CloudBees Jenkins products https://www.cloudbees.com/security-policy[should be reported to CloudBees directly].
+* Issues specific Jenkins X https://jenkins-x.io/community/security/#how-to-report-a-security-vulnerability[should be reported directly to them].
 
 === Vulnerability Types
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -34,7 +34,7 @@ Please report issues present in the following components:
 The following components are out of scope:
 
 * Issues specific to CloudBees Jenkins products https://www.cloudbees.com/security-policy[should be reported to CloudBees directly].
-* Issues specific Jenkins X https://jenkins-x.io/community/security/#how-to-report-a-security-vulnerability[should be reported directly to them].
+* Issues specific to Jenkins X https://jenkins-x.io/community/security/#how-to-report-a-security-vulnerability[should be reported directly to them].
 
 === Vulnerability Types
 


### PR DESCRIPTION
Currently the Jenkins X issues are tracked inside the SECURITY tracker of Jenkins CI, which I want to keep focus on Jenkins CI.

- [ ] This change is waiting for the page https://jenkins-x.io/community/security to be adjusted to manage their own security tracker.

@rawlingsj related to our discussion