### PR TITLE
Correctly tag allowUnsupportedRemotingVersions escape hatch

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1071,7 +1071,7 @@ properties:
 
 - name: hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions
   tags:
-  - escape
+  - escape hatch
   def: |
     `false`
   since: 2.343


### PR DESCRIPTION
Thanks to @daniel-beck for reporting it in
https://github.com/jenkins-infra/jenkins.io/pull/5150#discussion_r900040013
