### PR TITLE
Add announcement of DevOps World to jumbotron

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,16 +1,3 @@
-# cdCon
-- :href: https://events.linuxfoundation.org/cdcon/
-  :title: cdCon
-  :intro: Join Jenkins at cdCon on June 7-8, 2022! 
-    The event is focused on improving the world's capacity to deliver software with security and speed. 
-    Become part of the conversation that drives continuous delivery by meeting peers, 
-    sharing ideas and talking to industry leaders on all things software delivery and DevOps.
-  :image:
-    :src: https://events.linuxfoundation.org/wp-content/uploads/2021/11/cdcon-2022-graphics-snackable.jpg
-    :height: 300px
-  :call_to_action: 
-    :text: Register for cdCon
-    :href: https://events.linuxfoundation.org/cdcon/register/
 # Case Studies
 - :href: https://stories.jenkins.io/
   :title: Jenkins Stories!

--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -2,7 +2,7 @@
 - :href: https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome
   :title: Join Jenkins at DevOps World!
   :intro:  
-    Get ready for the DevOps remix at the Live and In-Person DevOps World 2022 on September 27-29, 2022 — the largest 
+    Get ready for the DevOps remix at the Live and In-Person DevOps World 2022 on September 27-29 — the largest 
     global gathering of DevOps thought leaders, practitioners, and contributors, and all those dedicated to 
     shaping the future of modern software delivery. The tempo will be faster, more energized, 
     and more harmonious in keeping with the accelerated pace of the DevOps transformation.

--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,3 +1,17 @@
+# DevOps World 2022
+- :href: https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome
+  :title: Join Jenkins at DevOps World!
+  :intro:  
+    Get ready for the DevOps remix at the Live and In-Person DevOps World 2022 on September 27-29, 2022 — the largest 
+    global gathering of DevOps thought leaders, practitioners, and contributors, and all those dedicated to 
+    shaping the future of modern software delivery. The tempo will be faster, more energized, 
+    and more harmonious in keeping with the accelerated pace of the DevOps transformation.
+  :image:
+    :src: https://static.rainfocus.com/cloudbees/devopsworld22/static/staticfile/staticfile/DW22-Hero-2600x1000-with-logo_1653326971514001aAEZ.png
+    :height: 300px
+  :call_to_action: 
+    :text: Register for DevOps World
+    :href: https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome
 # Case Studies
 - :href: https://stories.jenkins.io/
   :title: Jenkins Stories!


### PR DESCRIPTION
Replacing the cdCon announcement by the DevOps World one on the Jenkins "Jumbotron"