### PR TITLE
Update text and icon pertaining to the gear-icon

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -214,8 +214,8 @@ title: Jenkins download and deployment
 
 %hr
   NOTE: Packages with the
-  %span.icon-gear-menu-o
-  gear icon are maintained by third parties.
+  %ion-icon{:name=>"library-outline"}
+  library icon are maintained by third parties.
   Such packages may be not as frequently updated as packages supported by the Jenkins project directly.
 
 %h2


### PR DESCRIPTION
Possible solution for https://github.com/jenkins-infra/jenkins.io/issues/5238
The gear icon has been replaced with a library icon, but the text still refers to "the gear icon"