### PR TITLE
chore(`/press`): update installations and plugins numbers

### DIFF
--- a/content/press.adoc
+++ b/content/press.adoc
@@ -22,7 +22,7 @@ The leading open source automation server, Jenkins provides hundreds of plugins 
 
 .Blurb
 ""
-Jenkins is the leading open source automation server supported by a large and growing community of developers, testers, designers and other people interested in continuous integration, continuous delivery and modern software delivery practices. Built on the Java Virtual Machine (JVM), it provides more than 1,500 plugins that extend Jenkins to automate with practically any technology software delivery teams use. In 2019, Jenkins surpassed 200,000 known installations making it the most widely deployed automation server.
+Jenkins is the leading open source automation server supported by a large and growing community of developers, testers, designers and other people interested in continuous integration, continuous delivery and modern software delivery practices. Built on the Java Virtual Machine (JVM), it provides more than 1,800 plugins that extend Jenkins to automate with practically any technology software delivery teams use. In 2022, Jenkins surpassed 300,000 known installations making it the most widely deployed automation server.
 ""
 
 

--- a/content/press.adoc
+++ b/content/press.adoc
@@ -22,7 +22,7 @@ The leading open source automation server, Jenkins provides hundreds of plugins 
 
 .Blurb
 ""
-Jenkins is the leading open source automation server supported by a large and growing community of developers, testers, designers and other people interested in continuous integration, continuous delivery and modern software delivery practices. Built on the Java Virtual Machine (JVM), it provides more than 1,800 plugins that extend Jenkins to automate with practically any technology software delivery teams use. In 2022, Jenkins surpassed 300,000 known installations making it the most widely deployed automation server.
+Jenkins is the leading open source automation server supported by a large and growing community of developers, testers, designers and other people interested in continuous integration, continuous delivery and modern software delivery practices. Built on the Java Virtual Machine (JVM), it provides more than 1,800 plugins that extend Jenkins to automate with practically any technology software delivery teams use. In 2022, Jenkins reached 300,000 known installations making it the most widely deployed automation server.
 ""
 
 


### PR DESCRIPTION
Follow-up of https://github.com/jenkinsci/packaging/pull/320

[As noted](https://github.com/jenkinsci/packaging/pull/320#discussion_r904687776) by @daniel-beck :
> We recently went over 300k: http://stats.jenkins.io/jenkins-stats/svg/total-jenkins.svg
> 
> > If we want to change the "official" description of Jenkins, we should start there.
> 
> still applies.
> 
> "more than 1,800 plugins" would also be a current number per [updates.jenkins.io/current/pluginCount.txt](https://updates.jenkins.io/current/pluginCount.txt)