### PR TITLE
Remove incorrect documentation about certificates

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -107,13 +107,6 @@ to use an existing certificate for HTTPS:
 --httpsKeyStorePassword=keystorePassword
 ----
 
-The keystore should be in JKS format (as created by the JDK 'keytool')
-and the keystore and target key must have the same password. (Placing
-the keystore arguments after Jenkins-specific parameters does not seem
-to work; either they are not forwarded to Winstone or Winstone ignores
-them coming after unknown parameters. So, make sure they are adjacent to
-the working `+--httpsPort+` argument.)
-
 If your keystore contains multiple certificates (e.g. you are using CA
 signed certificate) Jenkins might end-up using a incorrect one. In this
 case you can


### PR DESCRIPTION
I tested with a PFX file and:

```
java -jar war/target/jenkins.war --httpsKeyStore=/tmp/certificate.pfx --httpsKeyStorePassword=Password12 --httpsPort=8443
```

Using this guide:
https://gist.github.com/mrcunninghamz/4f4ebbeeb4cfa9667870b8af4db24dc6

noticed during https://github.com/jenkinsci/winstone/pull/232