### PR TITLE
Remove suggestion for PEM encoded certs

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -114,20 +114,6 @@ to work; either they are not forwarded to Winstone or Winstone ignores
 them coming after unknown parameters. So, make sure they are adjacent to
 the working `+--httpsPort+` argument.)
 
-If your keystore contains multiple certificates (e.g. you are using CA
-signed certificate) Jenkins might end-up using a incorrect one. In this
-case you can
-http://stackoverflow.com/questions/7528944/convert-ca-signed-jks-keystore-to-pem[convert
-the keystore to PEM] and use following command line options:
-
-[source,bash]
-----
---httpPort=-1 \
---httpsPort=443 \
---httpsCertificate=path/to/cert \
---httpsPrivateKey=path/to/privatekey
-----
-
 === Using HTTP/2
 
 The link:https://tools.ietf.org/html/rfc7540[HTTP/2 protocol] allows web servers to reduce latency over encrypted connections by pipelining requests, multiplexing requests, and allowing servers to push in some cases before receiving a client request for the data.


### PR DESCRIPTION
It's been warned against since 2016

see also https://github.com/jenkinsci/winstone/pull/232