### PR TITLE
Remove less frequently used proxies from sidebar

### DIFF
--- a/content/doc/book/system-administration/_chapter.yml
+++ b/content/doc/book/system-administration/_chapter.yml
@@ -10,9 +10,5 @@ sections:
   - reverse-proxy-configuration-with-jenkins
   - reverse-proxy-configuration-apache
   - reverse-proxy-configuration-nginx
-  - reverse-proxy-configuration-haproxy
-  - reverse-proxy-configuration-squid
-  - reverse-proxy-configuration-iis
-  - reverse-proxy-configuration-iptables
   - reverse-proxy-configuration-troubleshooting
   - systemd-services


### PR DESCRIPTION
Pages are still available from the chapter summary page at
https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/

Reduces page length of the sidebar on the left
