### PR TITLE
fix typos warnings

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -51,6 +51,8 @@ check-filename = false
 "Apr2ndMeeting" = "Apr2ndMeeting"
 "Jan22ndMeeting" = "Jan22ndMeeting"
 "4UmY4dDAlo0" = "4UmY4dDAlo0"
+"ND" = "ND"
+"nd" = "nd"
 
 [default.extend-words]
 "Jenkins CNA" = "Jenkins CNA"

--- a/content/security/advisory/2022-06-22.adoc
+++ b/content/security/advisory/2022-06-22.adoc
@@ -221,7 +221,7 @@ issues:
     * Sauce OnDemand 1.204 and earlier (SECURITY-2724 / CVE-2022-34197)
     * Stash Branch Parameter 0.3.0 and earlier (SECURITY-2725 / CVE-2022-34198)
 
-    This results in stored cross-site scripting (XSS) vulnerabilites exploitable by attackers with Item/Configure permission.
+    This results in stored cross-site scripting (XSS) vulnerabilities exploitable by attackers with Item/Configure permission.
 
     Exploitation of these vulnerabilities requires that parameters are listed on another page, like the "Build With Parameters" and "Parameters" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation.
     Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the "Build With Parameters" and "Parameters" pages since 2.44 and LTS 2.32.2 as part of the link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions[SECURITY-353 / CVE-2017-2601] fix.


### PR DESCRIPTION
- Fix vulnerabilities spelling error
- Exclude two more identifiers from typos
