### PR TITLE
Fix remoting reference for LTS

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -7288,11 +7288,11 @@
     references:
       - pull: 6576
       - issue: 68542
-      - url: https://github.com/jenkinsci/remoting/releases/tag/3025.vf64a_a_3da_6b_55
-        title: Remoting 3025.vf64a_a_3da_6b_55 changelog
+      - url: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.13.2
+        title: Remoting 4.13.2 changelog
     message: |-
       Fix WebSocket reconnection in edge cases.
-      Upgrade from Remoting 4.13 to 3025.vf64a_a_3da_6b_55.
+      Upgrade from Remoting 4.13 to 4.13.2.
 
   - type: bug
     category: developer


### PR DESCRIPTION
cf. https://github.com/jenkinsci/jenkins/pull/6618/commits/b86bfab1358f78bd9aa878cd2c94044e0a9eff71

I'm not really familiar with the usual process to update changelog, feel free to enlight me.