### PR TITLE
more java 8 removal

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -11,10 +11,10 @@ Java 8 or Java 11 are required for running modern versions of Jenkins. Upgrading
 
 Java 11 Docker installation instructions are included in link:/doc/book/installing/docker/#downloading-and-running-jenkins-in-docker["Downloading and running Jenkins in Docker"]
 
-Starting with the weekly release line 2.353, Java 11 or Java 17 will be required to use Jenkins.
-Java 8 will still be supported in the https://www.jenkins.io/download/lts/[Long Term Support] release line, but the LTS release line will eventually mirror the weekly release line requirements for Java 11 or Java 17.
+Starting with the Jenkins 2.357 weekly release, Java 11 or Java 17 will be required.
+Java 8 is supported on the https://www.jenkins.io/download/lts/[Long Term Support] release line until the September 2022 LTS release.
 
-Early adopters may use Java 17 as provided in the `jenkins/jenkins:jdk17-preview` Docker image.
+Java 17 users can run the `jenkins/jenkins:jdk17` Docker image.
 
 All other Java versions are not supported.
 
@@ -23,8 +23,8 @@ all types of agents, CLI clients, and other components.
 
 Jenkins project performs a full test flow with the following JDK/JREs:
 
-* OpenJDK JDK / JRE 8 - 64 bits
 * OpenJDK JDK / JRE 11 - 64 bits
+* OpenJDK JDK / JRE 17 - 64 bits
 
 JRE/JDKs from other vendors are supported and may be used.
 See link:/redirect/issue-tracker[our Issue tracker] for known Java compatibility issues.

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -32,7 +32,7 @@ If you need to upgrade Jenkins as well as the JVM, we recommend that you:
 If you use Docker containers to run Jenkins, the default Docker containers use Java 11 beginning with link:/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-1[Jenkins 2.303.1].
 If you need to remain with Java 8 in a Docker container, append `-jdk8` to the Docker image tag.
 
-Starting with the 2.357 weekly release, Java 11 will be required for weekly releases.
+Starting with the 2.357 weekly release, Java 11 is required for weekly releases.
 These instructions will still apply to the Long Term Support release line until September 2022, when the LTS release line will mirror the weekly release line Java requirements.
 
 == Upgrading Plugins

--- a/content/doc/administration/requirements/upgrade-java-guidelines.adoc
+++ b/content/doc/administration/requirements/upgrade-java-guidelines.adoc
@@ -32,7 +32,7 @@ If you need to upgrade Jenkins as well as the JVM, we recommend that you:
 If you use Docker containers to run Jenkins, the default Docker containers use Java 11 beginning with link:/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-1[Jenkins 2.303.1].
 If you need to remain with Java 8 in a Docker container, append `-jdk8` to the Docker image tag.
 
-Starting with the 2.353 weekly release line, Java 11 will be required for future weekly release lines.
+Starting with the 2.357 weekly release, Java 11 will be required for weekly releases.
 These instructions will still apply to the Long Term Support release line until September 2022, when the LTS release line will mirror the weekly release line Java requirements.
 
 == Upgrading Plugins

--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -139,25 +139,6 @@ java --extraLibFolder=/opt/java/jetty-alpn-java-server-9.4.27.v20200227.jar \
     --httpsKeyStorePassword=keystorePassword
 ----
 
-==== Java 8u242 and earlier
-
-Java 8 update 242 and earlier can run the ALPN TLS extension by installing the Jetty ALPN boot library corresponding to the _exact OpenJDK version_ you are using into the Java boot classpath.
-Steps to install the extension are:
-
-* Identify the Java version running your Jenkins server from the "Manage Jenkins" -> "System Information" page
-* Find the link:https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions[boot library] for your OpenJDK version
-* Download the matching link:https://repo1.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/[alpn-boot.jar] file to a directory accessible to the JVM
-* Add the alpn-boot.jar to the JVM boot classpath by adding `-Xbootclasspath/p:/path/to/alpn-boot.jar` to the Java command line arguments that start Jenkins
-
-[source,bash]
-----
-java -Xbootclasspath/p:/opt/java/alpn-boot-8.1.13.v20181017.jar \
-    -jar target/jenkins.war \
-    --http2Port=9090 \
-    --httpsKeyStore=path/to/keystore \
-    --httpsKeyStorePassword=keystorePassword
-----
-
 === HTTPS certificates with Windows
 
 These instructions use a stock Jenkins installation on Windows Server.

--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -19,7 +19,7 @@ For this tour, you will require:
 ** Java 8 or 11 (either a JRE or Java Development Kit (JDK) is fine)
 ** https://docs.docker.com/[Docker] (navigate to https://docs.docker.com/get-docker/[*Get Docker*] site to access the Docker download that's suitable for your platform)
 
-NOTE: If using the weekly release line starting with 2.353, Java 11 is required.
+NOTE: If using the weekly release line starting with 2.357, Java 11 or Java 17 is required.
 The Long Term Support release line will continue to support Java 8 until September 2022, when it will match the weekly release line requirement of Java 11.
 
 === Download and run Jenkins

--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -19,8 +19,8 @@ For this tour, you will require:
 ** Java 11 or Java 17
 ** https://docs.docker.com/[Docker] (navigate to https://docs.docker.com/get-docker/[*Get Docker*] site to access the Docker download that's suitable for your platform)
 
-NOTE: If using the weekly release line starting with 2.357, Java 11 or Java 17 is required.
-The Long Term Support release line will continue to support Java 8 until September 2022, when it will match the weekly release line requirement of Java 11.
+NOTE: Java 11 or Java 17 are required by Jenkins 2.357 (weekly) and later.
+The Long Term Support release line (Jenkins 2.346.x) will continue to support Java 8 until the September 2022 release.
 
 === Download and run Jenkins
 

--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -16,7 +16,7 @@ For this tour, you will require:
 ** 256 MB of RAM, although more than 2 GB is recommended
 ** 10 GB of drive space (for Jenkins and your Docker image)
 * The following software installed:
-** Java 8 or 11 (either a JRE or Java Development Kit (JDK) is fine)
+** Java 11 or Java 17
 ** https://docs.docker.com/[Docker] (navigate to https://docs.docker.com/get-docker/[*Get Docker*] site to access the Docker download that's suitable for your platform)
 
 NOTE: If using the weekly release line starting with 2.357, Java 11 or Java 17 is required.


### PR DESCRIPTION
- Weekly release 2.357 requires Java 11
- Use Java 11 or Java 17 in guided tour
- Jenkins 2.357 requires Java 11 (not 2.353)
- Remove ALPN instructions for JDK 8u242 and earlier
- Use Java 11 or Java 17 in guided tour
