### PR TITLE
Updates the GSoC Project's Office Hours details

### DIFF
--- a/content/projects/gsoc/2022/projects/plugin-health-scoring-system.adoc
+++ b/content/projects/gsoc/2022/projects/plugin-health-scoring-system.adoc
@@ -45,8 +45,8 @@ Deploy the health scores via a JSON file similar to how Jenkins Update Center do
 A separate section on the Jenkins Plugin Site which displays the detailed report of the health score of each plugin by fetching the JSON data generated above.
 
 === Office hours
-(General) Official weekly Jenkins office hours: Thursdays 3pm to 3:30pm UTC
-(Project-based) Weekly project-specific office hours: Tuesdays 12:30pm to 1:30pm UTC
+* (General) Official weekly Jenkins office hours: Thursdays 3pm to 3:30pm UTC
+* (Project-based) Details regarding the Weekly project-specific office hours can be found inside our link:https://docs.google.com/document/d/1YZr527mYmEYmGy00RaDEbi1bi1gpdVR13031KSi_NmM/[Meeting Document], along with the past recordings and important links.
 
 === Project Links
 


### PR DESCRIPTION
This PR adds the [Meeting Document](https://docs.google.com/document/d/1YZr527mYmEYmGy00RaDEbi1bi1gpdVR13031KSi_NmM/edit) link under the "Office hours" section of the [project page](https://www.jenkins.io/projects/gsoc/2022/projects/plugin-health-scoring-system/).