### PR TITLE
Add: search for steps reference

### DIFF
--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -16,15 +16,20 @@ title: "Pipeline Steps Reference"
   %a{:href => "/doc/book/pipeline/syntax"} Pipeline Syntax
   page.
 
+.input-group.mb-3
+  %input#filter.form-control.rounded{:name => "search", :placeholder => "Filter Steps", :type => "text", :autofocus => "true"}
+  #clear.btn.btn-outline-secondary.ml-1
+    Clear
+
 %div
   %ul
     - sections_from(steps_dir).sort_by { |it| it[0].downcase }.each do |section, file, url, children|
-      %li
+      %li.search
         %a{:href => url}
           = section
         %ul
           - children.each do |section, file, sect_url, sect_children|
-            %li
+            %li.search
               %a{:href => "#{url}##{sect_url}"}
                 = section
 
@@ -32,3 +37,20 @@ title: "Pipeline Steps Reference"
 
 .container
 = partial ('_feedback-footer.html')
+
+:javascript
+  $(document).ready(function(){
+    $("#filter").keypress(function(e) {
+      if(e.which == 13) {
+        var input = $(this).val().toLowerCase();
+        $(".search").filter(function() {
+          $(this).toggle($(this).text().toLowerCase().indexOf(input) > -1);
+        });
+      }
+    });
+
+    $("#clear").click(function() {
+      $("#filter").val("");
+      $(".search").show();
+    });
+  });

--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -16,7 +16,7 @@ title: "Pipeline Steps Reference"
   %a{:href => "/doc/book/pipeline/syntax"} Pipeline Syntax
   page.
 
-.input-group.mb-3
+.input-group.col-lg-3.mb-3
   %input#filter.form-control.rounded{:name => "search", :placeholder => "Filter Steps", :type => "search", :autofocus => "true"}
 
 %div

--- a/content/doc/pipeline/steps/index.html.haml
+++ b/content/doc/pipeline/steps/index.html.haml
@@ -17,9 +17,7 @@ title: "Pipeline Steps Reference"
   page.
 
 .input-group.mb-3
-  %input#filter.form-control.rounded{:name => "search", :placeholder => "Filter Steps", :type => "text", :autofocus => "true"}
-  #clear.btn.btn-outline-secondary.ml-1
-    Clear
+  %input#filter.form-control.rounded{:name => "search", :placeholder => "Filter Steps", :type => "search", :autofocus => "true"}
 
 %div
   %ul
@@ -39,18 +37,34 @@ title: "Pipeline Steps Reference"
 = partial ('_feedback-footer.html')
 
 :javascript
-  $(document).ready(function(){
-    $("#filter").keypress(function(e) {
-      if(e.which == 13) {
-        var input = $(this).val().toLowerCase();
+    function slowClear() {
+      $(".search").filter(function() {
+        setTimeout(() => $(this).show(), 20);
+      });
+    }
+
+    function debounce(func) {
+      let timer;
+      return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => { func.apply(this, args); }, 500);
+      };
+    }
+
+    $("#filter").keyup(debounce(() => {
+      var input = $("#filter").val().toLowerCase();
+      if($("#filter").val() === "") {
+        slowClear();
+      } else {
         $(".search").filter(function() {
           $(this).toggle($(this).text().toLowerCase().indexOf(input) > -1);
         });
       }
-    });
+    }));
 
-    $("#clear").click(function() {
-      $("#filter").val("");
-      $(".search").show();
+    $("#filter").on("search", function() {
+      console.log("yo");
+      if($("#filter").val() === "") {
+        slowClear();
+      }
     });
-  });


### PR DESCRIPTION
Follow up of #5245 

This PR adds a search filter on the top of the pipeline steps reference page, which can be used to enter keywords and filter out the results shown on the page. A user can use this page to view specific material of interest amongst the large data present. 

**Direct link** - https://deploy-preview-5277--jenkins-io-site-pr.netlify.app/doc/pipeline/steps/

Tagging the mentors: @kwhetstone @arpoch