### PR TITLE
[DOCS-5843] Adding Blue Ocean statement

### DIFF
--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -2,8 +2,6 @@
 This file is only meant to be included as a snippet in other documents.
 ////
 
-=== Blue Ocean status
-
-Blue Ocean will not receive further functionality updates.
+IMPORTANT: Blue Ocean will not receive further functionality updates.
 Blue Ocean will continue to provide easy-to-use Pipeline visualization, but will not be enhanced further.
 It will only receive selective updates for significant security issues or functional defects.

--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -4,4 +4,6 @@ This file is only meant to be included as a snippet in other documents.
 
 IMPORTANT: Blue Ocean will not receive further functionality updates.
 Blue Ocean will continue to provide easy-to-use Pipeline visualization, but will not be enhanced further.
-It will only receive selective updates for significant security issues or functional defects.
+It will only receive selective updates for significant security issues or functional defects. +
+Alternative options for Pipeline visualization, such as the link:https://plugins.jenkins.io/pipeline-stage-view/[Pipeline: Stage View] and link:https://plugins.jenkins.io/pipeline-graph-view/[Pipeline Graph View] plugins, are available and offer some of the same functionality.
+While not complete replacements for Blue Ocean, contributions are encouraged from the community for continued development of these plugins.

--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -6,4 +6,4 @@ This file is only meant to be included as a snippet in other documents.
 
 Blue Ocean will not receive further functionality updates.
 Blue Ocean will continue to provide easy-to-use Pipeline visualization, but will not be enhanced further.
-It will only receive selective updates for significant security issues or functional defects. 
+It will only receive selective updates for significant security issues or functional defects.

--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -2,8 +2,13 @@
 This file is only meant to be included as a snippet in other documents.
 ////
 
-IMPORTANT: Blue Ocean will not receive further functionality updates.
+[NOTE]
+.Blue Ocean status
+====
+Blue Ocean will not receive further functionality updates.
 Blue Ocean will continue to provide easy-to-use Pipeline visualization, but will not be enhanced further.
-It will only receive selective updates for significant security issues or functional defects. +
+It will only receive selective updates for significant security issues or functional defects.
+
 Alternative options for Pipeline visualization, such as the link:https://plugins.jenkins.io/pipeline-stage-view/[Pipeline: Stage View] and link:https://plugins.jenkins.io/pipeline-graph-view/[Pipeline Graph View] plugins, are available and offer some of the same functionality.
 While not complete replacements for Blue Ocean, contributions are encouraged from the community for continued development of these plugins.
+====

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -20,6 +20,8 @@ The Blue Ocean Activity View shows all activities related to one Pipeline.
 
 image:blueocean/activity/overview.png[Overview of the Activity View, role=center]
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 == Navigation Bar
 
 The Activity View includes the <<getting-started#navigation-bar, standard navigation bar>>
@@ -33,8 +35,6 @@ The local navigation bar includes:
 * *Tabs*
 (<<activity, Activity>>, <<branches, Branches>>, <<pull-requests, Pull Requests>>) -
 Clicking one of these will display that tab of the Activity View.
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Activity
 

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -1,7 +1,7 @@
 ---
 layout: section
 title: Activity View
-wip: true
+wip: false
 ---
 ifdef::backend-html5[]
 :description:
@@ -33,6 +33,8 @@ The local navigation bar includes:
 * *Tabs*
 (<<activity, Activity>>, <<branches, Branches>>, <<pull-requests, Pull Requests>>) -
 Clicking one of these will display that tab of the Activity View.
+
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Activity
 

--- a/content/doc/book/blueocean/blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/blue-ocean-status.adoc
@@ -1,0 +1,9 @@
+////
+This file is only meant to be included as a snippet in other documents.
+////
+
+=== Blue Ocean status
+
+Blue Ocean will not receive further functionality updates.
+Blue Ocean will continue to provide easy to use Pipeline visualization, but will not be enhanced further.
+It will only receive selective updates for significant security issues or functional defects. 

--- a/content/doc/book/blueocean/blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/blue-ocean-status.adoc
@@ -5,5 +5,5 @@ This file is only meant to be included as a snippet in other documents.
 === Blue Ocean status
 
 Blue Ocean will not receive further functionality updates.
-Blue Ocean will continue to provide easy to use Pipeline visualization, but will not be enhanced further.
+Blue Ocean will continue to provide easy-to-use Pipeline visualization, but will not be enhanced further.
 It will only receive selective updates for significant security issues or functional defects. 

--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -22,7 +22,6 @@ you can use the link:../pipeline-editor[Blue Ocean Pipeline editor] to create a
 new Pipeline for you (as a `Jenkinsfile` that will be committed to source
 control).
 
-
 == Setting up your Pipeline project
 
 To start setting up your Pipeline project in Blue Ocean, at the top-right of the
@@ -43,9 +42,9 @@ You now have a choice of creating your new Pipeline project from a:
 
 * link:#for-a-git-repository[standard Git repository]
 * link:#for-a-repository-on-github[repository on GitHub] or GitHub Enterprise
-* link:#for-a-repository-on-bitbucket-cloud[repository on Bitbucket Cloud] or
-  Bitbucket Server
+* link:#for-a-repository-on-bitbucket-cloud[repository on Bitbucket Cloud] or Bitbucket Server
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 === For a Git repository
 

--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -22,6 +22,8 @@ you can use the link:../pipeline-editor[Blue Ocean Pipeline editor] to create a
 new Pipeline for you (as a `Jenkinsfile` that will be committed to source
 control).
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 == Setting up your Pipeline project
 
 To start setting up your Pipeline project in Blue Ocean, at the top-right of the
@@ -43,8 +45,6 @@ You now have a choice of creating your new Pipeline project from a:
 * link:#for-a-git-repository[standard Git repository]
 * link:#for-a-repository-on-github[repository on GitHub] or GitHub Enterprise
 * link:#for-a-repository-on-bitbucket-cloud[repository on Bitbucket Cloud] or Bitbucket Server
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 === For a Git repository
 

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -19,6 +19,8 @@ endif::[]
 Blue Ocean's "Dashboard" is the default view shown when you open Blue Ocean and
 shows an overview of all Pipeline projects configured on a Jenkins instance.
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 The Dashboard consists of a blue link:#navigation-bar[navigation bar] at the
 top, the link:#pipelines-list[Pipelines list], as well as the
 link:#favorites-list[Favorites list].
@@ -26,8 +28,6 @@ link:#favorites-list[Favorites list].
 [.boxshadow]
 image:blueocean/dashboard/overview.png[Overview of the
 Dashboard,role=center,width=100%]
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Navigation bar
 

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -27,6 +27,7 @@ link:#favorites-list[Favorites list].
 image:blueocean/dashboard/overview.png[Overview of the
 Dashboard,role=center,width=100%]
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Navigation bar
 

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -23,6 +23,7 @@ your Jenkins instance, as well as how to
 link:#accessing-blue-ocean[access the Blue Ocean UI] and
 link:#switching-to-the-classic-ui[return to the Jenkins classic UI].
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Installing Blue Ocean
 
@@ -121,8 +122,6 @@ If your Jenkins instance:
   link:../creating-pipelines[Creating a Pipeline]. +
 [.boxshadow]
 image:blueocean/creating-pipelines/create-a-new-pipeline-box.png['Welcome to Jenkins - Create a New Pipeline message box',width=50%]
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Navigation bar
 

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -32,7 +32,6 @@ Blue Ocean can be installed using the following methods:
   link:#on-an-existing-jenkins-instance[existing Jenkins instance]  
 * As a part of link:#as-part-of-jenkins-in-docker[Jenkins in Docker].
 
-
 === On an existing Jenkins instance
 
 When Jenkins is installed on most platforms, the
@@ -123,6 +122,7 @@ If your Jenkins instance:
 [.boxshadow]
 image:blueocean/creating-pipelines/create-a-new-pipeline-box.png['Welcome to Jenkins - Create a New Pipeline message box',width=50%]
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Navigation bar
 

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -37,9 +37,10 @@ This chapter is intended for Jenkins users of all skill levels, but beginners
 may need to refer to some sections of the <<pipeline#,Pipeline>> chapter to
 understand some topics covered in this Blue Ocean chapter.
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 For an overview of content in the Jenkins User Handbook, see
 <<getting-started#,User Handbook overview>>.
-
 
 [[blue-ocean-overview]]
 == What is Blue Ocean?
@@ -73,8 +74,6 @@ allowfullscreen></iframe>
 <br/>
 ++++
 endif::[]
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Frequently asked questions
 

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -74,6 +74,7 @@ allowfullscreen></iframe>
 ++++
 endif::[]
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Frequently asked questions
 

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -19,6 +19,8 @@ The Blue Ocean Pipeline Editor is the simplest way for anyone to get started wit
 creating Pipelines in Jenkins. It's also a great way for existing Jenkins users
 to start adopting Pipeline.
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 The editor allows users to create and edit Declarative Pipelines, add
 stages, and parallelized tasks that can run at the same time, depending on their
 needs. When finished, the editor saves the Pipeline to a source code repository
@@ -27,8 +29,6 @@ Blue Ocean makes it easy to jump back into the visual editor to modify the
 Pipeline at any time.
 
 video::FhDomw6BaHU[youtube, width=640, height=360, align="center"]
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Starting the editor
 

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -28,6 +28,8 @@ Pipeline at any time.
 
 video::FhDomw6BaHU[youtube, width=640, height=360, align="center"]
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 == Starting the editor
 
 To use the editor a user must first have

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -19,6 +19,8 @@ The Blue Ocean Pipeline Run Details view shows the information related to
 a single Pipeline Run and allows users to edit or replay that run.
 Below is a detailed overview of the parts of the Run Details view.
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
 image:blueocean/pipeline-run-details/overview.png[Overview of the Pipeline Run Details, role=center]
 
 . *Run Status* - This icon, along with the background color of the top menu bar,
@@ -39,8 +41,6 @@ The default is "<<pipeline, Pipeline>>".
 . *Completed Time* - How long ago was this run completed.
 . *Change Author* - Names of the authors with changes in this run.
 . *Tab View* - Shows the information for the selected tab.
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Pipeline Run Status
 

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -1,7 +1,6 @@
 ---
 layout: section
 title: Pipeline Run Details View
-wip: true
 ---
 ifdef::backend-html5[]
 :description:
@@ -40,6 +39,8 @@ The default is "<<pipeline, Pipeline>>".
 . *Completed Time* - How long ago was this run completed.
 . *Change Author* - Names of the authors with changes in this run.
 . *Tab View* - Shows the information for the selected tab.
+
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 == Pipeline Run Status
 


### PR DESCRIPTION
creating a new page for a statement on the status of Blue Ocean. Once approved, it will be added to existing Blue Ocean documentation using the `include:` call

@halkeye does this meet a portion of your concerns if we embed this text in each of the Blue Ocean pages?