### PR TITLE
Add JSON file for Extensions reference

### DIFF
--- a/content/doc/developer/extensions/contents.json.haml
+++ b/content/doc/developer/extensions/contents.json.haml
@@ -1,0 +1,2 @@
+- extensions_dir = File.expand_path(File.dirname(__FILE__))
+= sections_from(extensions_dir).map{|section| File.basename(section[1][:path], ".*")}.uniq.to_json


### PR DESCRIPTION
Adds a JSON file at `jenkins.io/doc/developer/extensions` that can be consumed by the plugin site. So each plugin page use this list to check if there is any extensions available for the plugin before showing extensions link.

Reference: https://github.com/jenkins-infra/plugin-site/issues/1131#issuecomment-1179221394