### PR TITLE
Fix affected version range for SECURITY-2536

### DIFF
--- a/content/security/advisory/2022-02-15.adoc
+++ b/content/security/advisory/2022-02-15.adoc
@@ -288,7 +288,7 @@ issues:
     severity: Medium
     vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
   description: |-
-    PLUGIN_NAME 2.0 and earlier does not perform permission checks in methods implementing form validation.
+    PLUGIN_NAME 1.10 and earlier does not perform permission checks in methods implementing form validation.
 
     This allows attackers with Overall/Read permission to connect to an attacker-specified webserver using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.
 
@@ -297,7 +297,7 @@ issues:
     PLUGIN_NAME 2.0 requires POST requests and Overall/Administer permission for the affected form validation methods.
   plugins:
   - name: embotics-vcommander
-    previous: '2.0'
+    previous: '1.10'
     fixed: '2.0'
 - id: SECURITY-2545
   reporter: Daniel Beck, CloudBees, Inc.


### PR DESCRIPTION
We correctly specified which version is fixed, but claimed it was also affected. This fixes the issue in the advisory.