### PR TITLE
Noting that `archetype:generate` can hang depending on mirror settings

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -103,3 +103,13 @@ Let's link:../run[run the plugin] and see what it does.
 == Troubleshooting
 
 NOTE: Anything not working for you? Ask for help in link:/chat[chat] or link:/mailing-lists[on the jenkinsci-dev mailing list].
+
+=== `archetype:generate` hangs
+
+If the `archetype:generate` command hangs, it could be link:https://issues.apache.org/jira/browse/ARCHETYPE-539[because you are using a repository mirror]. Try:
+
+[source,bash]
+----
+echo '<settings/>' > /tmp/empty.xml
+mvn -s /tmp/empty.xml -U archetype:generate -Dfilter=io.jenkins.archetypes:
+----


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARCHETYPE-539?focusedCommentId=17227010&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17227010

IIUC https://github.com/apache/maven-archetype/pull/109 was about this. Not sure about https://github.com/jenkinsci/archetypes/pull/42.