### PR TITLE
Retire wiki-exporter from docs

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -468,35 +468,6 @@ Redirects that need a shorter link are created by convention in the `content/red
 
 Oleg Nenashev has provided a link:https://youtu.be/-cGeb2wtg4I[brief video tutorial] that shows how to create and test a redirect with jenkins.io.
 
-==== Moving documentation from Jenkins Wiki
-
-The Jenkins project is moving documentation pages from the link:https://wiki.jenkins.io[Jenkins Wiki] to link:https://jenkins.io[www.jenkins.io].
-The link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter] tool uses link:https://pandoc.org/[Pandoc] to assist with the transition.
-Migrate a page from wiki.jenkins.io to www.jenkins.io with these steps:
-
-* Choose the page to convert from the link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen[GitHub issues] and leave an link:https://help.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues[issue comment] that you want to convert that page
-. Paste the URL of the Wiki page you want to export into the link:https://jenkins-wiki-exporter.jenkins.io/[Jenkins Wiki Exporter]
-. Select the _Asciidoc_ format for pages without images or _Asciidoc Zip_ format for pages with images
-. Click the _Convert_ button and wait till the files are generated
-. Place the Asciidoc content and the images in the correct repository locations
-. Review and correct the exported file formatting
-** Remove macro references in the top of the document
-** Remove any "Table of contents" or replace it by macros if needed
-** Repair converted code blocks from Pandoc generated tables to Asciidoc code blocks
-. Review the content
-** Replace any `todo-replace-by-actual-path` image paths in the exported pages with the actual images directory path (`/images/...`)
-** Correct flawed terminology and outdated naming.  For example, we use "agent" rather than "slave" and "pipeline" instead of "workflow")
-. Commit changes, push them to your fork and create a pull request against link:https://github.com/jenkins-infra/jenkins.io[the repository]
-. Once the pull request is merged, submit a pull request to the
-  link:https://github.com/jenkins-infra/jenkins-infra/blob/staging/dist/profile/templates/confluence/vhost.conf[`vhost.conf`] file in the
-  link:https://github.com/jenkins-infra/jenkins-infra[`jenkins-infra/jenkins-infra`] repository to redirect from `wiki.jenkins.io` to `jenkins.io`.
-  The pull request will usually add to a subsection under the "Non plugin rewrites" section, depending on the content of the redirected page +
-[source]
-----
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://www.jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
-----
-
 === Adding an event
 
 To add an event to the Jenkins event calendar, create a file in the

--- a/content/_data/authors/halkeye.adoc
+++ b/content/_data/authors/halkeye.adoc
@@ -11,5 +11,5 @@ Over the years I've managed to install and configure Jenkins at various jobs,
 and even was employed making internal and external plugins and integrations.
 You'll often find me on the Jenkins IRC and Gitter channels as well as the subreddit giving a hand to people who are stuck.
 I also try to get involved with Jenkins Infrastructure projects as much as I can.
-I currently maintain the plugin site, plugin site API, Jenkins Wiki exporter, and a bunch of other minor projects.
+I currently maintain the plugin site, plugin site API, and a bunch of other minor projects.
 I also help run Vancouver's chapter of Nodeschool.

--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -4,8 +4,8 @@ layout: developersection
 references:
 - url: ../documentation/
   title: Plugin documentation
-- url: https://jenkins-wiki-exporter.jenkins.io/
-  title: Jenkins Wiki Exporter
+- url: https://reports.jenkins.io/jenkins-plugin-migration.html
+  title: Plugin migration progress report
 ---
 
 WARNING: The Jenkins wiki was made 'read-only' in link:https://groups.google.com/d/msg/jenkinsci-dev/lNmas8aBRrI/eL3u7A6qBwAJ[October 2019]. 
@@ -26,7 +26,7 @@ Similarly, Asciidoc/Markdown preferences should be also discussed with maintaine
 
 There are the following migration steps:
 
-. Search for the plugin to update in the link:https://jenkins-wiki-exporter.jenkins.io/progress/[Jenkins Wiki Exporter]
+. Search for the plugin to update in the link:https://reports.jenkins.io/jenkins-plugin-migration.html[plugin migration progress report]
 ** If the status of the plugin is _TODO_ then move on to step 2, else retry step one with a different plugin.
 . Fork the plugin repository in GitHub and clone it to your local machine.
 . Search for and open the plugin page in the link:https://github.com/jenkins-infra/plugins-wiki-docs/[plugins-wiki-docs] repository

--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -194,7 +194,7 @@ a| We are moving plugin documentation from https://wiki.jenkins.io/ to GitHub,
   and it is a great opportunity to create small pull requests that benefit all Jenkins users.
 
   * Migrate plugin documentation as documented in these link:/blog/2019/10/21/plugin-docs-on-github/[guidelines]).
-  Plugins to convert can be found in the link:https://jenkins-wiki-exporter.jenkins.io/progress[Jenkins Wiki Exporter].
+  Plugins to convert can be found in the link:https://reports.jenkins.io/jenkins-plugin-migration.html[plugin migration progress report].
   * Move or improve existing documentation based on link:https://github.com/search?q=org%3Ajenkinsci+is%3Aissue+is%3Aopen+label%3Adocumentation[GitHub issues]
   * Review and renew the existing plugin documentation.  For example, cleanup the agent terminology usage as suggested in the jira:JENKINS-42816[] EPIC
 

--- a/content/events/online-hackfest/2020-uiux/index.adoc
+++ b/content/events/online-hackfest/2020-uiux/index.adoc
@@ -237,7 +237,7 @@ a| We are moving plugin documentation from Jenkins Wiki to Documentation as Code
    link:/sigs/docs/#plugin-documentation-on-github[More info].
 
 * Migrate plugin documentation as documented in these link:/blog/2019/10/21/plugin-docs-on-github/[guidelines]).
-  List of plugins for grabs can be found in the link:https://jenkins-wiki-exporter.jenkins.io/progress[Jenkins Wiki Exporter].
+  List of plugins for grabs can be found in the link:https://reports.jenkins.io/jenkins-plugin-migration.html[plugin migration progress report].
 * Review and renew the existing plugin documentation,
   e.g. cleanup the agent terminology usage as suggested in the jira:JENKINS-42816[] EPIC
 * Work on other documentation issues reported to plugins and other components:

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -95,9 +95,9 @@ Here is a non-exhaustive list of services that we provide and maintain.
 | https://polls.jenkins.io[Polls Site]                     |                                                                                   | https://github.com/jenkins-infra/charts/tree/master/charts/polls[helm chart]
 | https://reports.jenkins.io[Reports Site]                 |                                                                                   | https://github.com/jenkins-infra/charts/tree/master/charts/reports[helm chart]
 | https://uplink.jenkins.io[UpLink]                        | https://github.com/jenkins-infra/uplink/issues[GitHub issues]                     | https://github.com/jenkins-infra/uplink[Code],          https://github.com/jenkins-infra/charts/tree/master/charts/uplink[helm chart]
-| https://jenkins-wiki-exporter.jenkins.io/[Wiki Exporter] | link:https://github.com/jenkins-infra/jenkins-wiki-exporter/issues[GitHub issues] | https://github.com/jenkins-infra/jenkins-wiki-exporter/[Code], https://github.com/jenkins-infra/charts/tree/master/charts/jenkins-wiki-exporter[helm chart]
 | https://wiki.jenkins.io[Wiki - static pages]             | https://github.com/jenkins-infra/docker-confluence-data/issues[GitHub issues]     | https://github.com/jenkins-infra/docker-confluence-data[Code], https://github.com/jenkins-infra/confluence[Docker]
 | Rating metric                                            | link:https://github.com/jenkins-infra/rating/issues[GitHub issues]                | https://github.com/jenkins-infra/rating/[Code], https://github.com/jenkins-infra/kubernetes-management/blob/c6abb908544ad38490b4ea47c273fdc49b21c118/clusters/prodpublick8s.yaml#L248-L255[helm chart]
+| https://reports.jenkins.io/jenkins-plugin-migration.html[Plugin migration progress] | https://github.com/jenkins-infra/infra-reports/issues[GitHub issues] | https://github.com/jenkins-infra/infra-reports/tree/main/plugin-migration[Code], https://github.com/jenkins-infra/kubernetes-management/blob/main/config/reports.yaml[helm config]
 |===
 
 === Self-hosted services


### PR DESCRIPTION
See https://github.com/jenkins-infra/helpdesk/issues/3059 for the help
desk ticket to retire the wiki exporter service.
