### PR TITLE
Rephrase the section on unresolved vulnerabilities, link from advisory

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -167,6 +167,9 @@ notitle: true
       %li
         = site._generated[:update_center].plugins[plugin.name]&.title || plugin.title || plugin.name
         Plugin
+  %p
+    %a{:href => expand_link('/security/plugins/') + '#unresolved'}
+      Learn why we announce these issues.
 
 
 - if credits.length > 0

--- a/content/security/advisory/2022-01-12.adoc
+++ b/content/security/advisory/2022-01-12.adoc
@@ -281,7 +281,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Overall/Administer permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: publish-over-ssh
     title: Publish Over SSH
@@ -300,7 +300,7 @@ issues:
 
     Additionally, these connection tests methods do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: publish-over-ssh
     title: Publish Over SSH
@@ -317,7 +317,7 @@ issues:
 
     This results in a path traversal vulnerability allowing attackers with Item/Configure permission to discover the name of the Jenkins controller files.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: publish-over-ssh
     title: Publish Over SSH
@@ -334,7 +334,7 @@ issues:
 
     This password can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: publish-over-ssh
     title: Publish Over SSH
@@ -351,7 +351,7 @@ issues:
 
     These vulnerabilities allow attackers with Overall/Read access to retrieve logs, build or delete a batch task.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: batch-task
     title: batch task
@@ -368,7 +368,7 @@ issues:
 
     This allows attackers able to control agent processes to decrypt secrets stored in Jenkins obtained through another method.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: conjur-credentials
     previous: 1.0.9
@@ -385,7 +385,7 @@ issues:
 
     This allows attackers able to control agent processes to retrieve those credentials.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: conjur-credentials
     previous: 1.0.9
@@ -401,7 +401,7 @@ issues:
 
     This allows attackers able to control agent processes to invoke arbitrary OS commands on the controller.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: debian-package-builder
     title: Debian Package Builder

--- a/content/security/advisory/2022-02-15.adoc
+++ b/content/security/advisory/2022-02-15.adoc
@@ -332,7 +332,7 @@ issues:
 
     NOTE: This issue is caused by an incomplete fix of link:/security/advisory/2019-08-07/#SECURITY-796[SECURITY-796].
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: gitlab-oauth
     previous: '1.13'
@@ -351,7 +351,7 @@ issues:
     NOTE: This vulnerability is only exploitable in Jenkins 2.318 and earlier, LTS 2.303.2 and earlier.
     See the link:/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-3[LTS upgrade guide].
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: hashicorp-vault-plugin
     previous: 336.v182c0fbaaeb7
@@ -369,7 +369,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: scp
     previous: '1.8'
@@ -388,7 +388,7 @@ issues:
 
     Additionally, these HTTP endpoints do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: checkmarx
     previous: 2022.1.2
@@ -404,7 +404,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Overall/Administer permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: promoted-builds-simple
     previous: '1.9'
@@ -420,7 +420,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Overall/Read permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: team-views
     title: Team Views
@@ -437,7 +437,7 @@ issues:
 
     Additionally, error messages allow attackers able to control agent processes to determine whether a file with a given name exists.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: doktor
     previous: 0.4.1
@@ -457,7 +457,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: dbCharts
     previous: 0.5.2
@@ -478,7 +478,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: sinatra-chef-builder
     title: Chef Sinatra
@@ -495,7 +495,7 @@ issues:
 
     This allows attackers with Item/Configure permission to capture passwords of the jobs that will be configured.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: convertigo-mobile-platform
     previous: '1.1'
@@ -514,7 +514,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: swamp
     title: SWAMP

--- a/content/security/advisory/2022-03-15.adoc
+++ b/content/security/advisory/2022-03-15.adoc
@@ -132,7 +132,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: extended-choice-parameter
     previous: 346.vd87693c5a_86c
@@ -146,7 +146,7 @@ issues:
   description: |-
     PLUGIN_NAME 346.vd87693c5a_86c and earlier allows attackers with Item/Configure permission to read values from arbitrary JSON and Java properties files on the Jenkins controller.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: extended-choice-parameter
     previous: 346.vd87693c5a_86c
@@ -163,7 +163,7 @@ issues:
 
     Additionally, these form validation methods do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: extended-choice-parameter
     previous: 346.vd87693c5a_86c
@@ -179,7 +179,7 @@ issues:
 
     This client secret can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: gitlab-oauth
     previous: '1.13'
@@ -195,7 +195,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Overall/Administer permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: global-build-stats
     previous: '1.5'
@@ -211,7 +211,7 @@ issues:
 
     PLUGIN_NAME 2.3.1 and earlier allows users with Credentials/Create or Credentials/Update permission to read arbitrary files on the Jenkins controller by defining a 'From a file on the Jenkins master' Kubeconfig source for such a credential.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: kubernetes-cd
     previous: 2.3.1
@@ -228,7 +228,7 @@ issues:
     This allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins.
     Those can be used as part of an attack to capture the credentials using another vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: kubernetes-cd
     previous: 2.3.1
@@ -247,7 +247,7 @@ issues:
 
     Additionally, this endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: kubernetes-cd
     previous: 2.3.1
@@ -264,7 +264,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: list-git-branches-parameter
     previous: 0.0.9
@@ -280,7 +280,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with View/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: environment-dashboard
     title: Environment Dashboard
@@ -299,7 +299,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: release-helper
     previous: 1.3.3
@@ -315,7 +315,7 @@ issues:
 
     These passwords can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: dbCharts
     previous: 0.5.2
@@ -331,7 +331,7 @@ issues:
 
     These passwords can be viewed by users with Item/Extended Read permission or access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: vmware-vrealize-codestream
     previous: '1.2'
@@ -347,7 +347,7 @@ issues:
 
     These tokens can be viewed by users with Item/Extended Read permission or access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: incapptic-connect-uploader
     title: incapptic connect uploader

--- a/content/security/advisory/2022-03-29.adoc
+++ b/content/security/advisory/2022-03-29.adoc
@@ -251,7 +251,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ownership
     previous: 0.13.0
@@ -272,7 +272,7 @@ issues:
     NOTE: This CSRF vulnerability is only exploitable in Jenkins 2.286 and earlier, LTS 2.277.1 and earlier.
     See the link:/doc/upgrade-guide/2.277/#upgrading-to-jenkins-lts-2-277-2[LTS upgrade guide].
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ownership
     previous: 0.13.0
@@ -288,7 +288,7 @@ issues:
 
     This vulnerability allows attackers to restore the default ownership of a job.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ownership
     previous: 0.13.0
@@ -304,7 +304,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: sitemonitor
     previous: '0.6'
@@ -320,7 +320,7 @@ issues:
 
     This allows attackers able to control the input files for the 'Public Coverage / Complexity Scatter Plot' post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: covcomplplot
     previous: 1.1.1
@@ -336,7 +336,7 @@ issues:
 
     This allows attackers able to control the input files for the `readXml` or `writeXml` build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: phoenix-autotest
     title: 'Pipeline: Phoenix AutoTest'
@@ -353,7 +353,7 @@ issues:
 
     This allows attackers with Item/Configure permission to copy arbitrary files and directories from the Jenkins controller to the agent workspace.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: phoenix-autotest
     title: 'Pipeline: Phoenix AutoTest'
@@ -370,7 +370,7 @@ issues:
 
     This allows attackers with Item/Configure permission to upload arbitrary files from the Jenkins controller via FTP to an attacker-specified FTP server.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: phoenix-autotest
     title: 'Pipeline: Phoenix AutoTest'
@@ -388,7 +388,7 @@ issues:
     This allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins.
     Those can be used as part of an attack to capture the credentials using another vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: phoenix-autotest
     title: 'Pipeline: Phoenix AutoTest'
@@ -405,7 +405,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: selected-tests-executor
     previous: 1.3.3
@@ -419,7 +419,7 @@ issues:
   description: |-
     PLUGIN_NAME 1.3.3 and earlier allows users with Item/Configure permission to read arbitrary files on the Jenkins controller using the Choosing Tests parameter.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: selected-tests-executor
     previous: 1.3.3

--- a/content/security/advisory/2022-04-12.adoc
+++ b/content/security/advisory/2022-04-12.adoc
@@ -73,6 +73,8 @@ issues:
 
     * Extended Choice Parameter Plugin (SECURITY-2704 / CVE-2022-29038)
     * Job Generator (SECURITY-2263 / CVE-2022-29042)
+
+    link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: credentials
     previous: 1111.v35a_307992395

--- a/content/security/advisory/2022-05-17.adoc
+++ b/content/security/advisory/2022-05-17.adoc
@@ -201,7 +201,7 @@ issues:
     This allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins.
     Those can be used as part of an attack to capture the credentials using another vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ssh
     previous: 2.6.1
@@ -220,7 +220,7 @@ issues:
 
     Additionally, this endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ssh
     previous: 2.6.1
@@ -270,6 +270,8 @@ issues:
     * Random String Parameter Plugin 1.0 and earlier (SECURITY-2722 / CVE-2022-30966)
     * Selection tasks Plugin 1.0 and earlier (SECURITY-2728 / CVE-2022-30967)
     * vboxwrapper Plugin 1.3 and earlier (SECURITY-2734 / CVE-2022-30968)
+
+    link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: multiselect-parameter
     previous: '1.3'
@@ -305,7 +307,7 @@ issues:
 
     This vulnerability allows attackers to execute arbitrary code without sandbox protection if the victim is an administrator.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: autocomplete-parameter
     title: Autocomplete Parameter
@@ -324,7 +326,7 @@ issues:
 
     NOTE: While this looks similar to SECURITY-2729, this is an independent problem and exploitable even on views rendering parameters that otherwise attempt to prevent XSS vulnerabilities in parameter names.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: autocomplete-parameter
     title: Autocomplete Parameter
@@ -343,7 +345,7 @@ issues:
 
     Additionally, the HTTP endpoint calling the XML parser does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: storable-configs-plugin
     title: Storable Configs

--- a/content/security/advisory/2022-06-22.adoc
+++ b/content/security/advisory/2022-06-22.adoc
@@ -250,6 +250,8 @@ issues:
     * Repository Connector 2.2.0 and earlier (SECURITY-2666 / CVE-2022-34195)
     * Sauce OnDemand 1.204 and earlier (SECURITY-2724 / CVE-2022-34197)
     * Stash Branch Parameter 0.3.0 and earlier (SECURITY-2725 / CVE-2022-34198)
+
+    link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: agent-server-parameter
     previous: '1.1'
@@ -297,7 +299,7 @@ issues:
 
     These passwords can be viewed by users with Item/Extended Read permission or access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: convertigo-mobile-platform
     previous: '1.1'
@@ -315,7 +317,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: convertigo-mobile-platform
     previous: '1.1'
@@ -331,7 +333,7 @@ issues:
 
     These passwords can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: easyqa
     previous: '1.0'
@@ -349,7 +351,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: easyqa
     previous: '1.0'
@@ -367,7 +369,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: jianliao
     previous: '1.1'
@@ -385,7 +387,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: beaker-builder
     previous: '1.10'
@@ -403,7 +405,7 @@ issues:
 
     Additionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: threadfix
     previous: 1.5.4
@@ -421,7 +423,7 @@ issues:
 
     Additionally, this HTTP endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: vmware-vrealize-orchestrator
     previous: '3.0'
@@ -437,7 +439,7 @@ issues:
 
     These passwords can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: squashtm-publisher
     title: Squash TM Publisher (Squash4Jenkins)

--- a/content/security/advisory/2022-06-30.adoc
+++ b/content/security/advisory/2022-06-30.adoc
@@ -111,7 +111,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: plot
     previous: 2.1.10
@@ -127,7 +127,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Build/Update permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: build-metrics
     previous: '1.3'
@@ -143,7 +143,7 @@ issues:
 
     This allows attackers with Overall/Read permission to obtain information about jobs otherwise inaccessible to them.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: build-metrics
     previous: '1.3'
@@ -159,7 +159,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to configure jobs.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: rich-text-publisher-plugin
     previous: '1.4'
@@ -175,7 +175,7 @@ issues:
 
     This results in a cross-site scripting (XSS) vulnerability exploitable by attackers able to control the reason a queue item is blocked.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: project-inheritance
     previous: 21.04.03
@@ -191,7 +191,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Agent/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: matrix-reloaded
     previous: 1.1.3
@@ -207,7 +207,7 @@ issues:
 
     This vulnerability allows attackers to rebuild previous matrix builds.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: matrix-reloaded
     previous: 1.1.3
@@ -223,7 +223,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: xfpanel
     previous: 2.0.1
@@ -241,7 +241,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: validating-email-parameter
     previous: '1.10'
@@ -266,7 +266,7 @@ issues:
     Additionally, the plugin allows users to export the full configuration of jobs as part of a recipe, granting access to job configuration XML data to every user with Item/Read permission.
     The encrypted values of secrets stored in the job configuration are not redacted, as they would be by the config.xml API for users without Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: recipe
     title: Recipe
@@ -283,7 +283,7 @@ issues:
 
     This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with View/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ec2-deployment-dashboard
     previous: 1.0.10
@@ -300,7 +300,7 @@ issues:
     This allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins.
     Those can be used as part of an attack to capture the credentials using another vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ec2-deployment-dashboard
     previous: 1.0.10
@@ -318,7 +318,7 @@ issues:
 
     Additionally, these endpoints do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ec2-deployment-dashboard
     previous: 1.0.10
@@ -334,7 +334,7 @@ issues:
 
     This password can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: ec2-deployment-dashboard
     previous: 1.0.10
@@ -356,7 +356,7 @@ issues:
 
     These tokens can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: build-notifications
     previous: 1.5.0
@@ -373,7 +373,7 @@ issues:
 
     These secrets can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: rocketchatnotifier
     previous: 1.5.2
@@ -391,7 +391,7 @@ issues:
 
     These API keys can be viewed by users with Item/Extended Read permission (job `config.xml` only) or access to the Jenkins controller file system (both).
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: opsgenie
     previous: '1.9'
@@ -407,7 +407,7 @@ issues:
 
     This password can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: skype-notifier
     previous: 1.1.0
@@ -423,7 +423,7 @@ issues:
 
     These passwords can be viewed by users with Item/Extended Read permission or access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: jigomerge
     previous: '0.9'
@@ -439,7 +439,7 @@ issues:
 
     This password can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: elasticsearch-query
     previous: '1.2'
@@ -455,7 +455,7 @@ issues:
 
     These bearer tokens can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: cisco-spark
     previous: 1.1.1
@@ -471,7 +471,7 @@ issues:
 
     This password can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: rqm-plugin
     previous: '2.8'
@@ -488,7 +488,7 @@ issues:
     This allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins.
     Those can be used as part of an attack to capture the credentials using another vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: rqm-plugin
     previous: '2.8'
@@ -507,7 +507,7 @@ issues:
     Given appropriate XPath expressions, this page grants access to job configuration XML data to every user with Item/Read permission.
     The encrypted values of secrets stored in the job configuration are not redacted, as they would be by the config.xml API for users without Item/Configure permission.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: xpath-config-viewer
     previous: 1.1.1
@@ -525,7 +525,7 @@ issues:
 
     Additionally, these HTTP endpoints do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: xpath-config-viewer
     previous: 1.1.1
@@ -541,7 +541,7 @@ issues:
 
     This allows attackers with Overall/Read permission to view an administrative configuration page listing pending requests.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: rrod
     previous: 1.1.0
@@ -557,7 +557,7 @@ issues:
 
     This vulnerability allows attackers to accept pending requests, thereby renaming or deleting jobs.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: rrod
     previous: 1.1.0
@@ -573,7 +573,7 @@ issues:
 
     These passwords can be viewed by users with access to the Jenkins controller file system.
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: hpe-network-virtualization
     previous: '1.0'
@@ -595,7 +595,7 @@ issues:
     NOTE: This CSRF vulnerability is only exploitable in Jenkins 2.286 and earlier, LTS 2.277.1 and earlier.
     See the link:/doc/upgrade-guide/2.277/#upgrading-to-jenkins-lts-2-277-2[LTS upgrade guide].
 
-    As of publication of this advisory, there is no fix.
+    As of publication of this advisory, there is no fix. link:/security/plugins/#unresolved[Learn why we announce this.]
   plugins:
   - name: failedJobDeactivator
     previous: 1.2.1

--- a/content/security/plugins.adoc
+++ b/content/security/plugins.adoc
@@ -8,15 +8,19 @@ section: security
 We strive to fix all security vulnerabilities in Jenkins and plugins in a timely manner.
 However, the structure of the Jenkins project, which gives plugin maintainers a lot of autonomy, and the number and diversity of plugins make this impossible to guarantee.
 
-== When Maintainers Cannot Be Reached
+[[unresolved]]
+== Announcing Unresolved Vulnerabilities
 
 In case of a plugin vulnerability, we try to contact the plugin maintainer(s) to inform them of it.
 If they decline (or otherwise fail) to fix the vulnerability, or don't respond in a timely manner, and the security team doesn't have the capacity to fix it, we follow the process outlined below in the interest of our users:
 
-. Publish a security advisory about the plugin, describing the nature of the vulnerability, but noting that there is no fix other than no longer using the plugin.
+. Publish a security advisory about the plugin, describing the nature of the vulnerability, but noting that there is no fix (other than no longer using the plugin).
   If there are workarounds, explain them.
-. In some cases of high severity vulnerabilities, link:#suspensions[stop publishing the vulnerable plugin on the Jenkins update sites].
-. Add metadata to the plugin site indicating vulnerable plugins to inform administrators who may already have the plugin installed.
+. In some cases of particularly severe vulnerabilities, link:#suspensions[stop publishing the vulnerable plugin on the Jenkins update sites].
+. Add metadata to update sites to inform administrators on the Jenkins UI about vulnerable plugins they have installed.
+. Display security warnings on https://plugins.jenkins.io/[the plugins site].
+
+This allows Jenkins administrators to make an informed decision about their continued use of plugins with unresolved security vulnerabilities.
 
 [[followup]]
 == Following Up Later


### PR DESCRIPTION
Some "journalists" think it's newsworthy when we announce for the 8th time this year that some plugins don't get their vulnerabilities fixed due to being abandoned, calling it "announcing 0 days". So let's make our policy on this even more discoverable.

Thoughts on phrasing etc?