### PR TITLE
Use a 3 part Blue ocean admonition

### DIFF
--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -9,6 +9,16 @@ Blue Ocean will not receive further functionality updates.
 Blue Ocean will continue to provide easy-to-use Pipeline visualization, but will not be enhanced further.
 It will only receive selective updates for significant security issues or functional defects.
 
+ifdef::pipeline-visualization-admonition[]
 Alternative options for Pipeline visualization, such as the link:https://plugins.jenkins.io/pipeline-stage-view/[Pipeline: Stage View] and link:https://plugins.jenkins.io/pipeline-graph-view/[Pipeline Graph View] plugins, are available and offer some of the same functionality.
 While not complete replacements for Blue Ocean, contributions are encouraged from the community for continued development of these plugins.
+endif::[]
+
+ifdef::pipeline-creation-admonition[]
+The link:/doc/book/pipeline/getting-started/#snippet-generator[Pipeline syntax snippet generator] guides users as they define Pipeline steps with their arguments.
+It is the preferred tool for Jenkins Pipeline creation.
+It uses the plugins installed on your Jenkins controller to generate the Pipeline syntax.
+It provides online help for the Pipeline steps available in your Jenkins controller.
+The link:/doc/pipeline/steps/[Pipeline steps reference] provides online help for all available Pipeline steps.
+endif::[]
 ====

--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -15,10 +15,9 @@ While not complete replacements for Blue Ocean, contributions are encouraged fro
 endif::[]
 
 ifdef::pipeline-creation-admonition[]
-The link:/doc/book/pipeline/getting-started/#snippet-generator[Pipeline syntax snippet generator] guides users as they define Pipeline steps with their arguments.
-It is the preferred tool for Jenkins Pipeline creation.
+The link:/doc/book/pipeline/getting-started/#snippet-generator[Pipeline syntax snippet generator] assists users as they define Pipeline steps with their arguments.
+It is the preferred tool for Jenkins Pipeline creation, as it provides online help for the Pipeline steps available in your Jenkins controller.
 It uses the plugins installed on your Jenkins controller to generate the Pipeline syntax.
-It provides online help for the Pipeline steps available in your Jenkins controller.
-The link:/doc/pipeline/steps/[Pipeline steps reference] provides online help for all available Pipeline steps.
+Refer to the link:/doc/pipeline/steps/[Pipeline steps reference] page for information on all available Pipeline steps.
 endif::[]
 ====

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -13,6 +13,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show only 1/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition:
+// :pipeline-creation-admonition:
 
 = Activity View
 

--- a/content/doc/book/blueocean/creating-pipelines.adoc
+++ b/content/doc/book/blueocean/creating-pipelines.adoc
@@ -11,6 +11,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show 3/3 of the Blue ocean admonitions
+:pipeline-visualization-admonition: true
+:pipeline-creation-admonition: true
 
 
 = Creating a Pipeline

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -12,6 +12,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show 1/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition: true
+// :pipeline-creation-admonition: true
 
 
 = Dashboard

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -13,6 +13,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show 1/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition: true
+// :pipeline-creation-admonition: true
 
 
 = Getting started with Blue Ocean

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -12,6 +12,9 @@ ifdef::backend-html5[]
 :imagesdir: ../resources
 :toc:
 endif::[]
+// Show 3/3 of the Blue ocean admonitions
+:pipeline-visualization-admonition: true
+:pipeline-creation-admonition: true
 
 
 [[blue-ocean]]

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -12,6 +12,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show 2/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition: true
+:pipeline-creation-admonition: true
 
 = Pipeline Editor
 

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -12,6 +12,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show 1/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition: true
+// :pipeline-creation-admonition: true
 
 = Pipeline Run Details View
 

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -13,6 +13,9 @@ ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
 ifdef::basebackend-dockbook[:imagesdir: doc/book/resources]
+// Show 2/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition: true
+:pipeline-creation-admonition: true
 
 = Pipeline Development Tools
 
@@ -23,16 +26,6 @@ when developing Pipelines. They provide detailed help and information that is cu
 to the currently installed version of Jenkins and related plugins.
 In this section, we'll discuss other tools and resources
 that may help with development of Jenkins Pipelines.
-
-== Blue Ocean Editor
-
-The
-<<../blueocean/pipeline-editor#, Blue Ocean Pipeline Editor>> provides a
-link:https://en.wikipedia.org/wiki/WYSIWYG[WYSIWYG]
-way to create Declarative Pipelines. The editor offers a structural view of all the stages,
-parallel branches, and steps in a Pipeline. The editor validates Pipeline changes as they are
-made, eliminating many errors before they are even committed.  Behind the scenes
-it still generates Declarative Pipeline code.
 
 [[linter]]
 == Command-line Pipeline Linter
@@ -52,9 +45,9 @@ Jenkins for secure command-line access.
 [source,bash]
 ----
 # ssh (Jenkins CLI)
-# JENKINS_SSHD_PORT=[sshd port on controller]
-# JENKINS_HOSTNAME=[Jenkins controller hostname]
-ssh -p $JENKINS_SSHD_PORT $JENKINS_HOSTNAME declarative-linter < Jenkinsfile
+# JENKINS_PORT=[sshd port on controller]
+# JENKINS_HOST=[Jenkins controller hostname]
+ssh -p $JENKINS_PORT $JENKINS_HOST declarative-linter < Jenkinsfile
 ----
 
 .Linting via HTTP POST using `curl`
@@ -128,6 +121,18 @@ pipeline {
 ssh -p 8675 localhost declarative-linter < ./Jenkinsfile
 Jenkinsfile successfully validated.
 ----
+
+== Blue Ocean Editor
+
+The
+<<../blueocean/pipeline-editor#, Blue Ocean Pipeline Editor>> provides a
+link:https://en.wikipedia.org/wiki/WYSIWYG[WYSIWYG]
+way to create Declarative Pipelines. The editor offers a structural view of all the stages,
+parallel branches, and steps in a Pipeline. The editor validates Pipeline changes as they are
+made, eliminating many errors before they are even committed.  Behind the scenes
+it still generates Declarative Pipeline code.
+
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 [[replay]]
 == "Replay" Pipeline Runs with Modifications

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -124,13 +124,10 @@ Jenkinsfile successfully validated.
 
 == Blue Ocean Editor
 
-The
-<<../blueocean/pipeline-editor#, Blue Ocean Pipeline Editor>> provides a
-link:https://en.wikipedia.org/wiki/WYSIWYG[WYSIWYG]
-way to create Declarative Pipelines. The editor offers a structural view of all the stages,
-parallel branches, and steps in a Pipeline. The editor validates Pipeline changes as they are
-made, eliminating many errors before they are even committed.  Behind the scenes
-it still generates Declarative Pipeline code.
+The <<../blueocean/pipeline-editor#, Blue Ocean Pipeline Editor>> provides a link:https://en.wikipedia.org/wiki/WYSIWYG[WYSIWYG] way to create Declarative Pipelines.
+The editor offers a structural view of all the stages, parallel branches, and steps in a Pipeline.
+The editor validates Pipeline changes as they are made, eliminating many errors before they are even committed.  
+Behind the scenes it still generates Declarative Pipeline code.
 
 include::doc/book/blueocean/_blue-ocean-status.adoc[]
 

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -13,7 +13,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
-
+// Show 2/3 of the Blue ocean admonitions
+// :pipeline-visualization-admonition: true
+:pipeline-creation-admonition: true
 
 = Getting started with Pipeline
 
@@ -93,6 +95,7 @@ control.
 Read more about Blue Ocean in the link:../../blueocean[Blue Ocean] chapter and
 link:../../blueocean/getting-started[Getting started with Blue Ocean] page.
 
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 === Through the classic UI
 

--- a/content/doc/book/pipeline/running-pipelines.adoc
+++ b/content/doc/book/pipeline/running-pipelines.adoc
@@ -13,6 +13,9 @@ ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]
 :hide-uri-scheme:
 endif::[]
+// Show 2/3 of the Blue ocean admonitions
+:pipeline-visualization-admonition: true
+// :pipeline-creation-admonition: true
 
 == Running a Pipeline
 
@@ -72,6 +75,8 @@ or fails, you can click on the node which represents the stage.  You can then cl
 that stage.
 
 image::pipeline/pipeline-restart-stages-blue-ocean.png[Click on Restart link for stage]
+
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 ==== Preserving `stash`es for Use with Restarted Stages
 


### PR DESCRIPTION
## Use 3 part Blue Ocean admonition

Show selected portions of the Blue Ocean admonition based on the context.  If the page refers to Blue Ocean in general terms, use only the first paragraph of the admonition.  If the page refers to Blue Ocean Pipeline visualization, then include the portion of the admonition for Pipeline visualization.  If the page refers to Blue Ocean Pipeline creation, then include the portion of the admonition for Pipeline creation.

Thanks to the Docs office hours (Asia) for the suggestion to make the admonition content based on context.

Thanks to Gavin Mogan for the request to make it clear that Blue Ocean is not being actively developed.

Thanks to Kevin Martens for the original Blue Ocean admonition pull request.