### PR TITLE
Improve advisory layout to provide plugin ID(s) and severity inline

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -71,6 +71,33 @@ notitle: true
       - if issue.cve
         \/
         = issue.cve
+    - if issue.cvss
+      %br
+      %strong
+        Severity (CVSS):
+      - if issue.cvss.vector.start_with? "CVSS:3.0"
+        %a{ :href => 'https://www.first.org/cvss/calculator/3.0#' + issue.cvss.vector }
+          = issue.cvss.severity
+      - elsif issue.cvss.vector.start_with? "CVSS:3.1"
+        %a{ :href => 'https://www.first.org/cvss/calculator/3.1#' + issue.cvss.vector }
+          = issue.cvss.severity
+      - else
+        = issue.cvss.severity
+    - if issue.plugins
+      %br
+      %strong
+        Affected plugin(s):
+        - issue.plugins.each_with_index do | plugin, idx |
+          %a{ :href => 'https://plugins.jenkins.io/' + plugin.name }
+            %code
+              %nobr
+                = plugin.name
+          - if idx < issue.plugins.length - 1
+            ,
+    %br
+    %strong
+      Description:
+
     - if plugin_name
       = Asciidoctor.convert issue.description.gsub(/PLUGIN_NAME/, "#{plugin_name} Plugin"), safe: :safe, attributes: { 'icons' => 'font' }
     - else

--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -86,14 +86,17 @@ notitle: true
     - if issue.plugins
       %br
       %strong
-        Affected plugin(s):
+        - if issue.plugins.length > 1
+          Affected plugins:
+        - else
+          Affected plugin:
         - issue.plugins.each_with_index do | plugin, idx |
-          %a{ :href => 'https://plugins.jenkins.io/' + plugin.name }
-            %code
-              %nobr
+          %nobr
+            %a{ :href => 'https://plugins.jenkins.io/' + plugin.name }
+              %code
                 = plugin.name
-          - if idx < issue.plugins.length - 1
-            ,
+            - if idx < issue.plugins.length - 1
+              ,
     %br
     %strong
       Description:


### PR DESCRIPTION
It's not super nice (e.g. core entries do not say they're about core, there's no specification of affected/fixed versions), but it's a start and does not require changes to the advisory data format.

Some examples from preview deployment:

* [Simple core entry](https://deploy-preview-5313--jenkins-io-site-pr.netlify.app/security/advisory/2022-06-22/#SECURITY-2566)
* [Complex core entry](https://deploy-preview-5313--jenkins-io-site-pr.netlify.app/security/advisory/2022-06-22/#SECURITY-2781)
* [Simple plugin entry](https://deploy-preview-5313--jenkins-io-site-pr.netlify.app/security/advisory/2022-06-22/#SECURITY-2760)
* [Multiple plugins entry](https://deploy-preview-5313--jenkins-io-site-pr.netlify.app/security/advisory/2022-02-15/#SECURITY-2613)
* [Silly plugins entry](https://deploy-preview-5313--jenkins-io-site-pr.netlify.app/security/advisory/2022-06-22/#SECURITY-2784)
