### PR TITLE
More quickly pick up new LTS releases in version recommendations

### DIFF
--- a/content/_layouts/corebaseline.html.haml
+++ b/content/_layouts/corebaseline.html.haml
@@ -12,8 +12,11 @@ layout: developersection
 
     lts = site._generated[:core_tiers].stableCores
     oldest_lts = lts[0]
+    all_lts = site._generated[:lts_releases].results.map { |v| v.version }
 
-    next_lts_1 = lts.select { |v| v =~ /[.]1$/ }[-1]
-    previous_lts_highs = lts.map { |v| v[0...-1] }.uniq[0...-1].map { |l| lts.select { |v| v.start_with?(l) }[-1] }
+    next_lts_1 = all_lts.select { |v| v =~ /[.]1$/ }[0]
+    # We assume that lts will contain at least one release of the previous LTS line, which is reasonable.
+    # Surely there's going to be at least one plugin depending on the old .1 by the time the next .1 is available.
+    previous_lts_highs = lts.map { |v| v[0...-1] }.uniq[0...-1].map { |l| all_lts.select { |v| v.start_with?(l) }[0] }
 
 = page.content.gsub('PLACEHOLDER_NEWER_LTS_POINT_ONE', next_lts_1).gsub('PLACEHOLDER_RECENT_LTS_POINT_HIGHS', previous_lts_highs[-2...].join(' and ')).gsub('PLACEHOLDER_OLDER_LTS_POINT_HIGHS', previous_lts_highs[0...-2].join(' and ')).gsub('PLACEHOLDER_OLDEST_LTS', oldest_lts).gsub('PLACEHOLDER_OLDEST_WEEKLY', oldest_weekly).gsub('PLACEHOLDER_LATEST_SPLIT', latest_split)

--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -45,6 +45,12 @@ RESOURCES = [
     nil
   ],
   [
+    'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.?',
+    'content/_data/_generated/lts_releases.yml',
+    nil,
+    nil
+  ],
+  [
     'https://updates.jenkins.io/update-center.actual.json',
     'content/_data/_generated/update_center.yml',
     nil,


### PR DESCRIPTION
Fixes #5316.

I couldn't quite reuse the existing resource we downloaded (only .1) and was too lazy to adapt https://www.jenkins.io/doc/developer/javadoc/ , so this adds a resource download.