### PR TITLE
Add anchors to artwork page's artwork so they can be direct linked to

### DIFF
--- a/content/_ext/id_generator.rb
+++ b/content/_ext/id_generator.rb
@@ -1,0 +1,28 @@
+module IdGenerator
+  def text_to_id(text, prepend: "", delimiter: "-")
+    id = text.downcase.strip
+    id = "#{prepend} #{id}" unless prepend.empty?
+    id = id.gsub(/\s/, delimiter).strip
+    id = id.delete_prefix(delimiter).delete_suffix(delimiter).strip
+    id
+  end
+
+  def self.test!
+    eval "class TestIdGenerator; include IdGenerator; end;"
+
+    tests = [
+      [["Willie Nelson"], "willie-nelson"],
+      [["Willie Nelson", prepend:"prepend"], "prepend-willie-nelson"],
+      [["Willie Nelson", prepend:"prepend",delimiter: "$"], "prepend$willie$nelson"],
+    ]
+
+    tests.each do |params, expected|
+      got = TestIdGenerator.new.text_to_id(*params)
+      if got != expected
+        raise "From '#{params}' expected '#{expected}' got '#{got}'"
+      end
+    end
+  end
+end
+
+IdGenerator.test! if __FILE__ == $PROGRAM_NAME

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -58,6 +58,7 @@ Awestruct::Extensions::Pipeline.new do
 
   helper AuthorList::AuthorLink
   helper ActiveNav
+  helper IdGenerator
   helper Authorship
   helper Legacy
   helper AsciidocRender

--- a/content/artwork/index.html.haml
+++ b/content/artwork/index.html.haml
@@ -38,12 +38,12 @@ title: Jenkins Artwork
 
 %hr/
 
-.container
+.container.artwork-container
   .row
     - site.logo.sort.to_h.each_pair do |key, logo|
       .col-12.col-md-6.col-lg-4
         .text-center
-          %h3
+          %h3{:id => text_to_id(logo['name'])}
             = logo['name']
           %a{:href => expand_link("images/#{logo['url']}"), :target => '_blank', :rel => 'noreferrer noopener'}
             %img.logo-thumb{:src => expand_link("images/#{logo['url_256'] || logo['vector']}"), :alt => logo['name']}
@@ -101,3 +101,4 @@ title: Jenkins Artwork
         %a{:href => 'https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-a-logo'}
           CONTRIBUTING guidelines.
 
+= partial('anchors.html.haml', :selector => '.artwork-container');


### PR DESCRIPTION
I had a discussion come into the press email at one point and I wanted to direct link to a certain logo.

This will make it easier.