### PR TITLE
fix the documention of post

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -417,26 +417,26 @@ shown below.
 
 `always`:: Run the steps in the `post` section regardless of the completion
 status of the Pipeline's or stage's run.
-`changed`:: Only run the steps in `post` if the current Pipeline's or stage's
+`changed`:: Only run the steps in `post` if the current Pipeline's
 run has a different completion status from its previous run.
-`fixed`:: Only run the steps in `post` if the current Pipeline's or
-stage's run is successful and the previous run failed or was unstable.
+`fixed`:: Only run the steps in `post` if the current Pipeline's
+run is successful and the previous run failed or was unstable.
 `regression`:: Only run the steps in `post` if the current Pipeline's
-or stage's run's status is failure, unstable, or aborted and the previous run
+or status is failure, unstable, or aborted and the previous run
 was successful.
-`aborted`:: Only run the steps in `post` if the current Pipeline's or stage's
+`aborted`:: Only run the steps in `post` if the current Pipeline's
 run has an "aborted" status, usually due to the Pipeline being manually aborted.
 This is typically denoted by gray in the web UI.
 `failure`:: Only run the steps in `post` if the current Pipeline's or stage's
 run has a "failed" status, typically denoted by red in the web UI.
 `success`:: Only run the steps in `post` if the current Pipeline's or stage's
 run has a "success" status, typically denoted by blue or green in the web UI.
-`unstable`:: Only run the steps in `post` if the current Pipeline's or stage's
+`unstable`:: Only run the steps in `post` if the current Pipeline's
 run has an "unstable" status, usually caused by test failures, code violations,
 etc. This is typically denoted by yellow in the web UI.
 `unsuccessful`:: Only run the steps in `post` if the current Pipeline's or stage's
 run has not a "success" status. This is typically denoted in the web UI depending
-on the status previously mentioned.
+on the status previously mentioned (for stages this may fire if the build itself is unstable).
 `cleanup`:: Run the steps in this `post` condition after every other
 `post` condition has been evaluated, regardless of the Pipeline or
 stage's status.


### PR DESCRIPTION
#1267 incorrectly (and very optimistically) provided incorrect documentation on how post works.

the post conditions are not always working at the stage level - success and failure can and do look at the stage, but others (unstable) look at the build results not the stage result.

the original was written before https://issues.jenkins.io/browse/JENKINS-52114?focusedCommentId=341713&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-341713 from @abayer that said as much, and whilst some work has gone into making the posts work at a stage level this has not been completed and now people are complaining about it https://issues.jenkins.io/browse/JENKINS-57801

Whilst it would be nice to get this fixed so the code does behave like the documentation, until that happens the documentation should be correct.

@car-roll 