### PR TITLE
Revise 2.363 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -17100,6 +17100,31 @@
     changes:
       - type: rfe
         category: rfe
+        pull: 6801
+        issue: 68694
+        authors:
+          - basil
+        pr_title: "[JENKINS-68694] Winstone 6.1: Upgrade Jetty from 9.4.46.v20220331\
+          \ to 10.0.11"
+        references:
+          - pull: 6801
+          - issue: 68694
+          - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.0
+            title: Winstone 6.0 changelog
+          - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.1
+            title: Winstone 6.1 changelog
+          - url: https://webtide.com/jetty-10-and-11-have-arrived
+            title: Jetty 10 and 11 blog post
+          - url: https://github.com/jenkinsci/winstone/pull/232
+            title: Remove ability to load pem cert for winstone
+          - url: https://www.jenkins.io/doc/book/installing/initial-settings/#https-with-an-existing-certificate
+            title: Documentation
+        message: |-
+          Winstone 6.1: Upgrade Jetty from 9.4.46.v20220331 to 10.0.11.
+          Remove support for OpenSSL-style PEM-encoded RSA private keys when running Jenkins with the embedded Jetty (Winstone) container and TLS.
+          The flags <code>--httpsPrivateKey</code> and <code>--httpsCertificate</code> have been removed.
+      - type: rfe
+        category: rfe
         pull: 6956
         issue: 69202
         authors:
@@ -17107,17 +17132,6 @@
         pr_title: "[JENKINS-69202] Computer status icon is misleading"
         message: |-
           Replace magnifying glass icon with computer icon in node overview.
-      - type: rfe
-        category: rfe
-        pull: 6801
-        issue: 68694
-        authors:
-          - basil
-        pr_title: "[JENKINS-68694] Winstone 6.1: Upgrade Jetty from 9.4.46.v20220331\
-          \ to 10.0.11"
-        message: |-
-          - Winstone 6.1: Upgrade Jetty from 9.4.46.v20220331 to 10.0.11 ([Winstone changelog](https://github.com/jenkinsci/winstone/releases/tag/winstone-6.1), [Jetty blog post](https://webtide.com/jetty-10-and-11-have-arrived/)).
-          - Remove support for OpenSSL-style PEM-encoded RSA private keys when running Jenkins with the embedded Jetty (Winstone) container and TLS (jenkinsci/winstone#232).
       - type: bug
         category: regression
         pull: 6971


### PR DESCRIPTION
Add references for Jetty 10 upgrade and more text for the removal of support for PEM-encoded private keys.  Place the Jetty 10 upgrade at the top of the list.

![Screenshot 2022-08-09 075354](https://user-images.githubusercontent.com/156685/183667802-50206e01-0ce9-4071-b0bf-a27d3cac03c9.png)
