### PR TITLE
Correct the Apache reverse proxy configuration with mod_rewrite

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-apache.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-apache.adoc
@@ -272,7 +272,10 @@ A typical mod_rewrite configuration would look like this:
 [source]
 ----
 # Use last flag because no more rewrite can be applied after proxy pass
-RewriteRule       ^/jenkins(.*)$  http://localhost:8081/jenkins$1 [P,L,NE]
+# NE makes sure slashes are not re-encoded.
+# Apache does not re-encode spaces though, we ask Apache to encode it again with the B flag
+# BNP tells apache to use %20 instead of + to re-encode the space
+RewriteRule       ^/jenkins(.*)$  http://localhost:8081/jenkins$1 [P,L,NE,B=\ \,BNP]
 ProxyPassReverse  /jenkins        http://localhost:8081/jenkins
 ProxyRequests     Off
 

--- a/content/doc/book/system-administration/reverse-proxy-configuration-apache.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-apache.adoc
@@ -272,9 +272,11 @@ A typical mod_rewrite configuration would look like this:
 [source]
 ----
 # Use last flag because no more rewrite can be applied after proxy pass
-RewriteRule       ^/jenkins(.*)$  http://localhost:8081/jenkins$1 [P,L]
+RewriteRule       ^/jenkins(.*)$  http://localhost:8081/jenkins$1 [P,L,NE]
 ProxyPassReverse  /jenkins        http://localhost:8081/jenkins
 ProxyRequests     Off
+
+AllowEncodedSlashes NoDecode
 
 # Local reverse proxy authorization override
 # Most unix distribution deny proxy by default
@@ -283,6 +285,10 @@ ProxyRequests     Off
   Order deny,allow
   Allow from all
 </Proxy>
+
+# If using HTTPS, add the following directives
+# RequestHeader set X-Forwarded-Proto "https"
+# RequestHeader set X-Forwarded-Port "443"
 ----
 
 This assumes that you run Jenkins on port 8081.


### PR DESCRIPTION
The reverse proxy check in Jenkins uses URL-encoded slashes, which Apache URL-encodes by default. This change adds the "NoEscape" flag on the rewrite rule to prevent that. It also adds a small reminder of the HTTPS options.