### PR TITLE
Need to validate for matrix support

### DIFF
--- a/content/verifications/matrix-1660367039.txt
+++ b/content/verifications/matrix-1660367039.txt
@@ -1,0 +1,1 @@
+aDQMbjvJhbCyfDjsywWwthytUlJWOdcCTHLFiRghGxU8Q4xjXsvV7ozJhO3Wr8sj


### PR DESCRIPTION
Working to recover #jenkins-admin:matrix.org (currently mapped to freenode channel), support wants us to validate. This will make a simple text file that shows we own things.