### PR TITLE
No error report link in footer of error report page

### DIFF
--- a/content/participate/report-issue/redirect.html.haml
+++ b/content/participate/report-issue/redirect.html.haml
@@ -3,6 +3,7 @@ layout: simplepage
 title: Report an issue in a plugin
 section: participate
 noanchors: true
+uneditable: true
 ---
 
 :css


### PR DESCRIPTION
Having "report a problem" link for reporting a problem with the "report a problem" page is confusing, IIRC https://github.com/jenkins-infra/jenkins.io/issues/5364 is not the first case where a user clicked the wrong link.

Preview: https://deploy-preview-5365--jenkins-io-site-pr.netlify.app/participate/report-issue/redirect/