### PR TITLE
Explain why Jira is needed despite GH issue tracking

### DIFF
--- a/content/doc/developer/publishing/preparation.adoc
+++ b/content/doc/developer/publishing/preparation.adoc
@@ -34,4 +34,6 @@ See link:../documentation[Documentation] for more information.
 
 Jenkins plugins distributed via Jenkins project update sites need to be hosted in the https://github.com/jenkinsci[jenkinsci GitHub organization], so you will need a user account on GitHub.
 
-To actually release your plugin, you will need a https://accounts.jenkins.io[Jenkins community account] that will give you access to the https://issues.jenkins.io/[issue tracker] and https://repo.jenkins-ci.org/[Maven repository].
+To actually release your plugin, you will need a https://accounts.jenkins.io[Jenkins community account] that will give you access to the https://issues.jenkins.io/[Jira issue tracker] and https://repo.jenkins-ci.org/[Maven repository].
+
+Even if you choose to track your plugin's issues on GitHub, link:/security/for-maintainers/[you may be assigned security vulnerabilities in your plugin in Jira].


### PR DESCRIPTION
See https://deploy-preview-5368--jenkins-io-site-pr.netlify.app/doc/developer/publishing/preparation/#signup-required