### PR TITLE
docs: Update design library documentation

### DIFF
--- a/content/doc/developer/views/symbols.adoc
+++ b/content/doc/developer/views/symbols.adoc
@@ -3,7 +3,7 @@ title: Symbols
 layout: developerguide
 ---
 
-[.docs__version]#Available since Jenkins 2.235.#
+[.docs__version]#Available since Jenkins 2.335.#
 
 
 image::/images/developer/views/symbols.svg[Selection of Symbols]
@@ -24,40 +24,4 @@ in buttons and in tables. Symbols are scalable, support different weights and ad
 
 === Using Symbols
 
-Using symbols in your view is simple. Use the existing `icon` component and set the `src`
-value to the symbol you want, prefixed with `"symbol-"`.
-
-*Jelly example:*
-[source, xml]
-----
-<l:icon src="symbol-search" />
-----
-
-*Groovy example:*
-[source, groovy]
-----
-l.icon(src: 'symbol-search')
-----
-
-It's possible to add alt text and custom classes to symbols, for example:
-
-*Jelly example:*
-[source, xml]
-----
-<l:icon src="symbol-search" alt="Search" class="custom-class" />
-----
-
-*Groovy example:*
-[source, groovy]
-----
-l.icon(src: 'symbol-search', alt: 'Search', class: 'custom-class')
-----
-
----
-
-=== Custom Symbols
-
-[.docs__version]#Coming soon#
-
-As a plugin developer, you'll soon be able to add your own symbols for use in your plugin for when
-there isn't an appropriate existing symbol to use.
+Read more about symbols and how to use them in your plugin on the link:https://weekly.ci.jenkins.io/design-library/Symbols/[design library documentation] page.


### PR DESCRIPTION
Documentation was only meant to be temporary here, until ui-samples turned into design-library, which happened months ago.