### PR TITLE
Improvements to "Require Java 11 or newer" blog post

### DIFF
--- a/content/blog/2022/06/2022-06-28-require-java-11.adoc
+++ b/content/blog/2022/06/2022-06-28-require-java-11.adoc
@@ -232,7 +232,6 @@ Exception in thread "main" java.lang.UnsupportedClassVersionError: hudson/remoti
 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
 	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
 	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:601)
-Exception in thread "`main`" `java.lang.UnsupportedClassVersionError`: `hudson/remoting/Launcher` has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
 ----
 
 Therefore, it is critical to upgrade both the controller _and_ agents to Java 11 or newer prior to upgrading Jenkins to 2.357 or 2.361.1.

--- a/content/blog/2022/06/2022-06-28-require-java-11.adoc
+++ b/content/blog/2022/06/2022-06-28-require-java-11.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Jenkins requires Java 11"
+title: "Jenkins requires Java 11 or newer"
 tags:
 - announcement
 - core
@@ -25,7 +25,7 @@ At the core of this experience is https://www.java.com/[Java], an https://dl.acm
 Since its inception, the Jenkins project has been a major consumer of Java, distributing over 1,800 plugins to an installed base of over 300,000 controllers,
 and Jenkins regularly appears on https://blogs.oracle.com/javamagazine/post/the-top-25-greatest-java-apps-ever-written[lists of the top Java applications of all time].
 
-**Beginning with Jenkins 2.357 (released on June 28, 2022) and the forthcoming September LTS release, Jenkins requires Java 11.**
+**Beginning with Jenkins 2.357 (released on June 28, 2022) and the forthcoming 2.361.1 LTS release, Jenkins requires Java 11 or newer.**
 Additionally, beginning with Jenkins 2.355 (released on June 14, 2022) and Jenkins 2.346.1 LTS (released on June 22, 2022), Jenkins supports Java 17.
 Plugins have already been prepared in https://issues.jenkins.io/browse/JENKINS-68446[JENKINS-68446].
 **Use the Plugin Manager to upgrade all plugins before _and_ after upgrading to Jenkins 2.357.**
@@ -199,11 +199,54 @@ and we can say with confidence that the migration from Java 11 to Java 17 will n
 
 == Upgrading to Java 11 or 17
 
+=== Order of operations
+
+Beginning with Jenkins 2.357 (released on June 28, 2022) and the forthcoming 2.361.1 LTS release,
+Jenkins requires Java 11 or newer on both the controller JVM (i.e., the JVM running `jenkins.war`) and agent JVMs (i.e., JVMs running `remoting.jar`).
+
+This does not imply that you need to build your application with the same version of Java.
+You can continue to use any desired JDK to build your application,
+so long as the JVM used for running Jenkins itself is version 11 or newer.
+For example, the Global Tool Configuration page can still be used to provide a JDK 8 installation for building your application.
+Similarly, you can set up ephemeral or static agents with two installations of Java:
+Java 11 or newer to run `remoting.jar` for Jenkins and Java 8 to build your application.
+
+Since Jenkins 2.296, we have been recommending that users run the controller on Java 11.
+Prior to Jenkins 2.357 and Jenkins 2.361.1, running the controller on Java 11 and agents on Java 8, though not recommended, did not result in errors.
+Beginning with Jenkins 2.357 and Jenkins 2.361.1, running the controller on Java 11 and agents on Java 8 will result in the following error:
+
+[source]
+----
+Error: A JNI error has occurred, please check your installation and try again
+Exception in thread "main" java.lang.UnsupportedClassVersionError: hudson/remoting/Launcher has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+	at java.lang.ClassLoader.defineClass1(Native Method)
+	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
+	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
+	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
+	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
+	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
+	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
+	at java.security.AccessController.doPrivileged(Native Method)
+	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
+	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
+	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
+	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
+	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:601)
+Exception in thread "`main`" `java.lang.UnsupportedClassVersionError`: `hudson/remoting/Launcher` has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+----
+
+Therefore, it is critical to upgrade both the controller _and_ agents to Java 11 or newer prior to upgrading Jenkins to 2.357 or 2.361.1.
+Use the https://plugins.jenkins.io/versioncolumn/[Versions Node Monitors] plugin to verify that agents are running a compatible version of Java.
+
 === Docker images
 
-The https://hub.docker.com/r/jenkins/jenkins/[official Jenkins Docker images] have been based on Java 11 for many months, with Java 8 available as a fallback and Java 17 available in preview mode.
+The official Jenkins Docker images for https://hub.docker.com/r/jenkins/jenkins/[the controller] and https://hub.docker.com/r/jenkins/inbound-agent/[agents] have been based on Java 11 for many months,
+with Java 8 available as a fallback and Java 17 available in preview mode.
 Beginning with Jenkins 2.357, the Java 8 images will be retired and the Java 17 images will transition from preview to general availability (GA).
 Users of the official Jenkins Docker images need not install or configure Java on their own, as it comes preinstalled in the image.
+
+If you are using a Docker image to run both the agent Java process (i.e., `remoting.jar`) and your own application build and your application build still requires Java 8,
+you will need to provide a Java 11 or newer runtime for the Jenkins agent process and a Java 8 environment for your application build.
 
 === OS packages
 
@@ -256,13 +299,6 @@ Refer to the following https://support.cloudbees.com/hc/en-us/articles/222446987
 ----
 
 NOTE: These options are explained in-depth in the https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-3B1CE181-CD30-4178-9602-230B800D4FAE[Oracle Java documentation] as well as the https://docs.cloudbees.com/docs/admin-resources/latest/jvm-troubleshooting/[CloudBees Jenkins JVM guide].
-
-=== Agents
-
-For best results, it is recommended to run agents with the same version of Java as the version used on the controller.
-Use the https://plugins.jenkins.io/versioncolumn/[Versions Node Monitors] plugin to verify that agents are running a compatible version of Java.
-
-NOTE: Running the Jenkins remoting process on an agent with Java 11 or 17 does not imply that you need to run your builds with the same version of Java. You can continue to use any desired version of Java for individual builds.
 
 === Reporting issues
 


### PR DESCRIPTION
Addresses the feedback provided in [JENKINS-68866](https://issues.jenkins.io/browse/JENKINS-68866) by moving the information about agents to earlier in the document and providing explicit guidance about order of operations.

Also goes out of the way to emphasize that Java 8 can still be used for individual builds, as we have received several questions about whether that will still be possible (it will be!), including whether Global Tool Configuration can still be used to install Java 8 for application builds (it still can!).

CC @kmartens27 @MarkEWaite 