### PR TITLE
Add params folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/
 # external - files unzipped from /content/_tmp/
 # generated pipeline step documentation
 content/doc/pipeline/steps/*.adoc
+content/doc/pipeline/steps/params/*.adoc
 
 # generated extension points documentation
 content/doc/developer/extensions/*.adoc


### PR DESCRIPTION
Adds `params` folder created inside `content/doc/pipeline/steps/` to `.gitignore` corresponding to the changes made under https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/211. This would keep local testing clean by keeping the asciidocs associated with Pipeline steps documentation (which are fetched as external resources) out of git's tracking.