### PR TITLE
Amend backporting guidelines

### DIFF
--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -94,7 +94,6 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 
 Any user can propose that a issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
 For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface.
-Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 
 Aside from the model set out above, backporters apply some subjective selection — for example whether a fix is easy and safe to backport, confidence in the fix, importance/impact of the problem, how much time is left until the end of backporting window and so on.


### PR DESCRIPTION
Based on his comments in https://github.com/jenkinsci/jenkins/pull/7026, @wadeck clearly lacks confidence in the backporting process with regard to quieting scanners.