### PR TITLE
Fix the Jenkins Board and Officers page

### DIFF
--- a/content/_partials/community-role-holder.html.haml
+++ b/content/_partials/community-role-holder.html.haml
@@ -1,26 +1,22 @@
 - authorId = page.author || ''
 - author = site.authors[authorId]
 - if author
-  %div{:id => "about-the-author"}
-    - unless page.blogroll.nil?
-      %h2 #{author.name}
-    %table.author.box
-      %tr
-        %td
-          = partial("avatar.html.haml", :author => author, :authorId => authorId)
-        %td
-          - if page.blogroll.nil?
-            %b.author.name
-              %a{:href => author_link(authorId)}
-                = author.name
-          %p
-            - if author.content.empty?
-              This contributor has no biography defined.
-              See social media links referenced below.
-            - else
-              = author.content
-          - if page.term_begin
-            %p
-              %b
-                = "Term: #{page.term_begin} - #{page.term_end}"
-          = partial("social-media-buttons.html.haml", :author => author)
+  %div.app-author{:id => "about-the-author"}
+    = partial("avatar.html.haml", :author => author, :authorId => authorId)
+    %div.app-author__content
+      - if page.blogroll.nil?
+        %p.app-author__name
+          %a{:href => author_link(authorId)}
+            = author.name
+      - else
+        %p.app-author__name #{author.name}
+      - if author.content.empty?
+        This author has no biography defined.
+        See social media links referenced below.
+      - else
+        = author.content
+      - if page.term_begin
+        %p.app-author__biography
+          %b
+            = "Term: #{page.term_begin} - #{page.term_end}"
+      = partial("social-media-buttons.html.haml", :author => author)

--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -38,8 +38,9 @@ The board can be contacted confidentially by emailing to
 %h2
   Current board members
 
-- board_members.each do |member_id, term_begin, term_end|
-  = partial("community-role-holder.html.haml", :author => member_id, :term_begin => term_begin, :term_end => term_end)
+%div.app-authors
+  - board_members.each do |member_id, term_begin, term_end|
+    = partial("community-role-holder.html.haml", :author => member_id, :term_begin => term_begin, :term_end => term_end)
 
 %h2
   Officers
@@ -49,10 +50,11 @@ In accordance with the
   Team Leads
 structure the following individuals have been empowered with executive authority by the Governance Board.
 
-- officers.each do |officer_type, member_id, term_begin, term_end|
-  %h3
-    = officer_type
-  = partial("community-role-holder.html.haml", :author => member_id, :term_begin => term_begin, :term_end => term_end)
+%div.app-authors
+  - officers.each do |officer_type, member_id, term_begin, term_end|
+    %h3
+      = officer_type
+    = partial("community-role-holder.html.haml", :author => member_id, :term_begin => term_begin, :term_end => term_end)
 
 %h2 References
 

--- a/content/stylesheets/components/_author.scss
+++ b/content/stylesheets/components/_author.scss
@@ -1,3 +1,9 @@
+.app-authors {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .app-author {
   display: grid;
   grid-template-columns: auto 1fr;


### PR DESCRIPTION
As reported by Tim in https://github.com/jenkins-infra/jenkins.io/issues/5413, the board and officers page got a little messed up with the blog post redesign. This PR fixes that by using the same markup as the author component.

Fixes https://github.com/jenkins-infra/jenkins.io/issues/5413

**Before**
<img width="809" alt="Screenshot 2022-09-03 at 21 43 16" src="https://user-images.githubusercontent.com/43062514/188287121-93d3f1ab-6233-459d-adbf-d730aba81275.png">

**After**
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/43062514/188287114-2b08fa4e-3962-4b1a-bea8-86fc0f281999.png">
