### PR TITLE
Remove java.level property from examples

### DIFF
--- a/content/doc/developer/persistence/incompatible-releases.adoc
+++ b/content/doc/developer/persistence/incompatible-releases.adoc
@@ -18,8 +18,7 @@ it is possible to set the `hpi.compatibleSinceVersion` property to define the ol
 [source,xml]
 ----
 <properties>
-  <jenkins.version>2.60.3</jenkins.version>
-  <java.level>8</java.level>
+  <jenkins.version>2.289.3</jenkins.version>
   <hpi.compatibleSinceVersion>1.0</hpi.compatibleSinceVersion>
 </properties>
 ----

--- a/content/doc/developer/plugin-development/mark-a-plugin-incompatible.adoc
+++ b/content/doc/developer/plugin-development/mark-a-plugin-incompatible.adoc
@@ -16,8 +16,7 @@ Starting from Plugin POM 3.33, it is possible to set a `hpi.compatibleSinceVersi
 [source,xml]
 ----
 <properties>
-    <jenkins.version>2.60.3</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.289.3</jenkins.version>
     <hpi.compatibleSinceVersion>1.0</hpi.compatibleSinceVersion>
 </properties>
 ----


### PR DESCRIPTION
## Remove `java.level` from examples

The `java.level` property is deprecated and will be removed from a future plugin parent pom.

See https://github.com/jenkinsci/plugin-pom/pull/522 for the plugin pom deprecation of `java.level`.

See the following additional references:

* https://github.com/jenkinsci/plugin-pom/pull/478#discussion_r809561384
* https://github.com/jenkinsci/plugin-pom/pull/478#issuecomment-1082144103
* https://github.com/jenkinsci/plugin-pom/pull/522#issuecomment-1083320869

Also uses newer Jenkins version in the example.  Would have liked to use the automatic replacement as is done in the "Choosing a Jenkins version" baseline page, but that was a larger change than I'm ready to make in this pull request.
