### PR TITLE
Split docs contributions by difficulty

### DIFF
--- a/content/participate/document.adoc
+++ b/content/participate/document.adoc
@@ -21,7 +21,7 @@ See the contacts on the right sidebar.
 
 There are many documentation sources in Jenkins.
 This website and the link:https://plugins.jenkins.io/[plugins site] are the most notable ones,
-but we also have docs in other places (GitHub repositories, various sites like link:https://github.com/jenkins-infra/javadoc[javadoc.jenkins.io] or link:https://wiki.jenkins.io/[Jenkins Wiki] which is currently being deprecated).
+but we also have docs in other places (GitHub repositories, various sites like link:https://github.com/jenkins-infra/javadoc[javadoc.jenkins.io] or the link:https://wiki.jenkins.io/[deprecated Jenkins Wiki]).
 For the most of the repositories we try to follow the documentation-as-code approach.
 
 [%header]
@@ -61,15 +61,41 @@ Useful links:
 
 == Featured projects
 
+=== Good first issues
+
+The documentation issue list includes issues that are good for first time contributors.
+See the link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22["good first issues"] list.
+
+If you decide to work on an issue, add a comment to the issue that tells others you are working on it.
+For example, add the comment "I'm working on this issue".
+You do not need to wait for someone to assign you an issue.
+Choose an issue, add a comment, and start writing.
+
+=== Migrating Plugin Documentation to GitHub
+
 Currently we are working on migrating the documentation from Jenkins Wiki to GitHub and jenkins.io.
 See link:/blog/2019/10/21/plugin-docs-on-github/[this blog post] for more information about the reasons why we do this migration.
 This migration involves modification of hundreds of pages and repositories, and we invite everyone to contribute.
 
-* link:/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github[Migrating plugin documentation from Wiki to GitHub]
-+
-video::BaEJ8v7INNQ[youtube,width=640,height=360]
-* link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#moving-documentation-from-jenkins-wiki[Moving documentation from Jenkins Wiki to jenkins.io]
-+
+link:/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github[**Migrating plugin documentation to GitHub**]
+
+video::GseBgDOaa0A[youtube,width=640,height=360,start=317]
+
+=== Migrating Other Documentation to www.jenkins.io
+
+Jenkins user documentation was initially created in the link:https://wiki.jenkins.io[Jenkins Wiki].
+The Jenkins wiki was made read-only in 2019.
+Jenkins documentation improvements are now made on the Jenkins documentation site at www.jenkins.io.
+
+Some of the documentation on the deprecated link:https://wiki.jenkins.io[Jenkins Wiki] is still useful.
+Skilled Jenkins users and administrators may find Wiki information that is still accurate and can be added to www.jenkins.io.
+They are encouraged to submit pull requests for those cases.
+
+This is **not** a task for new contributors or for those who are not experienced with Jenkins.
+New contributors and inexperienced Jenkins users should assist with other documentation tasks rather than attempting to migrate documentation from the wiki to www.jenkins.io.
+
+link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#moving-documentation-from-jenkins-wiki[**Moving other documentation from wiki to www.jenkins.io**]
+
 video::KB-NPlRvLoY[youtube,width=640,height=360]
 
 There are also other ongoing projects which you can find on the link:/sigs/docs/#ongoing-projects[Documentation SIG page] and in the link:/project/roadmap[project roadmap].


### PR DESCRIPTION
### Split docs contribution areas by difficulty

Replace outdated wiki migration video and make it clearer that there are several distinct tasks.  Some of the tasks are well-suited to new contributors.  Others are not well-suited to new contributors and should only be attempted by experienced administrators or experiences users.
