### PR TITLE
More verbose description of finding backup plugins

### DIFF
--- a/content/doc/book/system-administration/backing-up.adoc
+++ b/content/doc/book/system-administration/backing-up.adoc
@@ -53,7 +53,7 @@ They are supported by:
 === Plugins for backup
 
 Several plugins are available for backup.
-Go to menu:Manage Jenkins[Manage Plugins>Available] and search for **backup**.
+From the main menu select _Manage Jenkins_, then go to _Manage Plugins>Available_ and search for **backup**.
 Note that none of the open source plugins are currently being maintained.
 You can try these plugins but you may have problems with them.
 


### PR DESCRIPTION
I think using words instead of special symbols increases readability.

Fixes #5433