### PR TITLE
Remove leading dash from changelog entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -17529,7 +17529,7 @@
           - Vlatombe
         pr_title: "[JENKINS-69543] Fix thread safety in websockets handling."
         message: |-
-          - Fix thread safety in websockets handling.
+          Fix thread safety in websockets handling.
 
   # pull: 7069 (PR title: Update babel monorepo to v7.19.0)
   # pull: 7070 (PR title: Remove .jelly from editorconfig rules)


### PR DESCRIPTION
Mistakenly included a leading "dash" character in the 2.368 changelog

## Before this change

![Screenshot 2022-09-13 084551](https://user-images.githubusercontent.com/156685/189932726-758ec35e-3e47-432a-9011-dab83c7d9bca.png)

## After this change

![Screenshot 2022-09-13 084908](https://user-images.githubusercontent.com/156685/189933339-bc989d5d-84e8-4dfa-806b-2697bdf11207.png)

