### PR TITLE
Update references to the recently renamed IntelliJ IDEA plugin

### DIFF
--- a/content/doc/developer/development-environment/ide-configuration.adoc
+++ b/content/doc/developer/development-environment/ide-configuration.adoc
@@ -6,8 +6,9 @@ references:
   title: Developing with JRebel # TODO find someone who can write actual documentation for this
 ---
 
-== IntelliJ
-https://plugins.jetbrains.com/plugin/1885-stapler-plugin-for-intellij-idea (source code https://github.com/stapler/idea-stapler-plugin)
+== IntelliJ IDEA
+
+link:https://plugins.jetbrains.com/plugin/1885-jenkins-development-support/[Jenkins Development Support] (source code https://github.com/jenkinsci/idea-stapler-plugin)
 
 This IDEA plugin makes it easy to develop Jenkins and its plugins on IntelliJ IDEA
 

--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -69,7 +69,7 @@ You are advised to use the link:https://github.com/stapler/netbeans-stapler-plug
 
 IntelliJ users just need to open the project and all should work out of the box.
 
-You are advised to use the link:https://plugins.jetbrains.com/plugin/1885-stapler-framework-support[IntelliJ IDEA plugin for Stapler], features it provides can be found in it's link:https://github.com/jenkinsci/idea-stapler-plugin#stapler[documentation].
+You are advised to use the link:https://plugins.jetbrains.com/plugin/1885-jenkins-development-support/[IntelliJ IDEA plugin for Jenkins Development], features it provides can be found in its link:https://github.com/jenkinsci/idea-stapler-plugin#stapler[documentation].
 
 You can create a new plugin using one of the Jenkins plugin link:https://github.com/jenkinsci/archetypes/[archetypes]. 
 Create a new Maven project using **Create from archetype** and **Add an Archetype**.


### PR DESCRIPTION
https://github.com/jenkinsci/idea-stapler-plugin/issues/43 was completed which involved moving the repo from stapler to jenkinsci org and renaming of the plugin.