### PR TITLE
Use site local links

### DIFF
--- a/content/blog/2022/09/2022-09-14-create-iOS-unity-build-pipelines-on-AWS-with-Jenkins-and-EC2-Mac-instances.adoc
+++ b/content/blog/2022/09/2022-09-14-create-iOS-unity-build-pipelines-on-AWS-with-Jenkins-and-EC2-Mac-instances.adoc
@@ -68,7 +68,7 @@ We will build upon these concepts and will use EC2 Spot instances for
 the compute-heavy phase of asset compilation in conjunction with the EC2
 Autoscaling feature. We will also use an EC2 Mac instance to complete
 the second, final Xcode build step. For the whole pipeline,
-orchestration is done with https://www.jenkins.io/[Jenkins CI/CD]. We
+orchestration is done with Jenkins CI/CD. We
 will also use the ability of the Unity engine to be Dockerized to
 implement scalability and flexibility.
 
@@ -265,7 +265,7 @@ reducing costs.
 In order to orchestrate Mac instances, the instance has to have port 22
 enabled as well as Java installed. You can add the instance manually, or
 launch it via CloudFormation or Terraform and use the self-registration
-method described https://www.jenkins.io/doc/book/managing/nodes/[here].
+method described link:/doc/book/managing/nodes/[here].
 
 Please note that currently dynamic provisioning of EC2 Mac instances via
 Auto Scaling groups is not possible due to the minimum 24 hour
@@ -283,7 +283,7 @@ pipeline. Note that on a screenshot above I use label “mac”.
 Every Jenkins pipeline can be described using a *Jenkinsfile* file. It
 is a YAML-formatted document which describes all the steps for the
 pipeline. You can read more
-https://www.jenkins.io/doc/book/pipeline/jenkinsfile/[here]. I already
+link:/doc/book/pipeline/jenkinsfile/[here]. I already
 have such a file stored in my repository. The file contents are
 following:
 
@@ -634,13 +634,12 @@ Pokemon Company and others. The pipelines speed being improved up to
 400% (Pokemon Company), Improving management time (Riot games) and
 reduced complexity (Jamcity).
 
-We will be speaking more on this topic at the https://www.jenkins.io/blog/2022/09/13/jenkins-contributor-summit-2022-agenda-orlando-florida/[Jenkins Contributor Summit], on September 27 at https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome[DevOps World in Orlando, Florida]. Hope to see you there!
+We will be speaking more on this topic at the link:/blog/2022/09/13/jenkins-contributor-summit-2022-agenda-orlando-florida/[Jenkins Contributor Summit], on September 27 at https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome[DevOps World in Orlando, Florida]. Hope to see you there!
 
 *Suggested tags:*
-https://aws.amazon.com/blogs/gametech/tag/amazon-game-development/[Amazon
-Game Development], Amazon EC2
-Mac, https://aws.amazon.com/blogs/gametech/tag/aws-for-games/[AWS for
-Games], https://aws.amazon.com/blogs/gametech/tag/aws-game-development/[AWS
-game
-development], https://aws.amazon.com/blogs/gametech/tag/aws-game-tech/[AWS
-Game Tech], https://aws.amazon.com/blogs/gametech/tag/unity/[Unity]
+https://aws.amazon.com/blogs/gametech/tag/amazon-game-development/[Amazon Game Development],
+Amazon EC2 Mac,
+https://aws.amazon.com/blogs/gametech/tag/aws-for-games/[AWS for Games],
+https://aws.amazon.com/blogs/gametech/tag/aws-game-development/[AWS game development],
+https://aws.amazon.com/blogs/gametech/tag/aws-game-tech/[AWS Game Tech],
+https://aws.amazon.com/blogs/gametech/tag/unity/[Unity]


### PR DESCRIPTION
## Use site local links

When we embed a link to https://www.jenkins.io in the site, we hinder local development of the site because clicked links jump away from the local development copy to the www.jenkins.io site.
