### PR TITLE
Resolves #5456 - Add a "Kubernetes" entry to the glossary

### DIFF
--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -90,6 +90,11 @@ Jenkins URL:: [[jenkins-url]]
 Job:: [[job]]
     A user-configured description of work which Jenkins should perform, such as
     building a piece of software, etc.
+Kubernetes:: [[kubernetes]]
+    Kubernetes (K8s) is an open-source system for automating deployment, scaling,
+    and management of containerized applications.
+    See link:/doc/book/installing/kubernetes/[Installing Jenkins / Kubernetes]
+    for more info.
 Label:: [[label]]
     User-defined text for grouping <<agent,Agents>>, typically by similar
     functionality or capability. For example `linux` for Linux-based agents or


### PR DESCRIPTION
As requested in issue #5456, added an entry in glossary for Kubernetes, including a link to the related installation page.