### PR TITLE
Resolves #5455 - Link from "Step" glossary entry to Pipeline pages

### DIFF
--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -139,6 +139,9 @@ Stage::
 Step::
     A single task; fundamentally steps tell Jenkins _what_ to do inside of a
     <<pipeline,Pipeline>> or <<job,job>>.
+    See link:/doc/book/pipeline/getting/started/[Pipelines / Getting Started]
+    and link:/doc/book/pipeline/jenkinsfile/[Pipeline / Using a jenkinsfile]
+    for more info.
 Trigger:: [[trigger]]
     A criteria for triggering a new <<pipeline,Pipeline>> run or
     <<job,job>>.


### PR DESCRIPTION
Adding the two links mentioned in #5455 into the "Step" glossary entry.