### PR TITLE
Use node:lts-alpine in tutorial

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -38,7 +38,7 @@ docker run \
   --volume jenkins-docker-certs:/certs/client \# <8>
   --volume jenkins-data:/var/jenkins_home \# <9>
   --publish 2376:2376 \# <10>
-  --publish 3000:3000 \# <11>
+  --publish 3000:3000 --publish 5000:5000 \# <11>
   docker:dind \# <12>
   --storage-driver overlay2 # <13>
 ----
@@ -67,7 +67,7 @@ from Jenkins.
 <10> ( _Optional_ ) Exposes the Docker daemon port on the host machine. This is
 useful for executing `docker` commands on the host machine to control this
 inner Docker daemon.
-<11> Exposes port 3000 from the docker in docker container, used by some of the tutorials.
+<11> Exposes ports 3000 and 5000 from the docker in docker container, used by some of the tutorials.
 <12> The `docker:dind` image itself. This image can be downloaded before running
 by using the command: `docker image pull docker:dind`.
 <13> The storage driver for the Docker volume. See
@@ -84,7 +84,7 @@ docker run --name jenkins-docker --rm --detach \
   --env DOCKER_TLS_CERTDIR=/certs \
   --volume jenkins-docker-certs:/certs/client \
   --volume jenkins-data:/var/jenkins_home \
-  --publish 3000:3000 --publish 2376:2376 \
+  --publish 3000:3000 --publish 5000:5000 --publish 2376:2376 \
   docker:dind --storage-driver overlay2
 ----
 . Customise official Jenkins Docker image, by executing below two steps:
@@ -233,7 +233,7 @@ docker run --name jenkins-docker --detach ^
   --env DOCKER_TLS_CERTDIR=/certs ^
   --volume jenkins-docker-certs:/certs/client ^
   --volume jenkins-data:/var/jenkins_home ^
-  --publish 3000:3000 --publish 2376:2376 ^
+  --publish 3000:3000 --publish 5000:5000 --publish 2376:2376 ^
   docker:dind
 ----
 . Customise official Jenkins Docker image, by executing below two steps:

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -207,7 +207,7 @@ process and a "Test" stage to check that the application renders satisfactorily.
 pipeline {
     agent {
         docker {
-            image 'node:6-alpine'
+            image 'node:lts-alpine'
             args '-p 3000:3000 -p 5000:5000' // <1>
         }
     }
@@ -317,7 +317,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'node:6-alpine'
+            image 'node:lts-alpine'
             args '-p 3000:3000 -p 5000:5000'
         }
     }


### PR DESCRIPTION
## Use node:lts-alpine container in tutorial

- Use LTS version of NodeJS, not NodeJS 6
- Export port 5000 for multibranch pipeline tutorial

Further improvements to the tutorial are now included in
https://github.com/jenkins-docs/building-a-multibranch-pipeline-project
