### PR TITLE
[WEBSITE-728] Remove wiki references from governance document

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -118,8 +118,9 @@ Infrastructure administrators have root access to the various servers and build 
 
 Because of the sensitive nature of this work, infrastructure admins are by invitation only, and some of the activity happen behind closed doors. Infrastructure admins often appoint others to delegate some partial access to the system to complete some tasks.
 
-A list of admins of some of the public infrastructure components can be found here: link:https://wiki.jenkins.io/display/JENKINS/Infrastructure+Admins[Infrastructure Admins]
-
+Infrastructure components are maintained by the link:/projects/infrastructure/[infrastructure project].
+See the link:/projects/infrastructure/#contributing[contributing guidelines] for more information.
+Open a link:https://github.com/jenkins-infra/helpdesk[help desk issue] for infrastructure problems.
 
 === Core committers
 
@@ -260,14 +261,15 @@ Some plugins are actively maintained by a small number of people and they may ha
 
 Since much of such local culture is implicit, it's often difficult to tell from outside the operating culture of a given plugin. The safe rule of thumb is to contact existing developers upfront before doing any commit (but if there's no timely response in a week so, you should feel free to commit.) Less actively maintained plugins tend not to have such local culture, so in those cases, if you feel lucky you can commit changes ahead and send a heads-up simultaneously, (and accept the possibility that the changes get reverted.)
 
-Maintainer information should be listed in the info box of the plugin's wiki page. If you have trouble figuring out who to contact, the good fallback option is the developers' mailing list.
+Maintainer information is listed on https://plugins.jenkins.io/ and is defined in the link:https://github.com/jenkins-infra/repository-permissions-updater[repository permissions updater].
+If you have trouble figuring out who to contact, the good fallback option is the developers' mailing list.
 
 === Plugin Site
 
 Each published plugin has its own page on https://plugins.jenkins.io/, such as link:https://plugins.jenkins.io/git[this].
 These pages provide documentation and information about the plugin: installation statistics, changelogs, known issues, etc.
-Documentation can be either retrieved from the plugin's GitHub repository or from a now-deprecated wiki.jenkins.io.
-See the link:/doc/developer/publishing/documentation/[Plugin Documentation Page] in the DEveloper guide for more information about how it works.
+Documentation is retrieved from the GitHub repository of the plugin or from an archived copy of the decommissioned Jenkins wiki.
+See the link:/doc/developer/publishing/documentation/[Plugin Documentation Page] in the Developer guide for more information about how it works.
 
 == How we develop code
 
@@ -351,7 +353,6 @@ As discussed above, Jenkins project uses pull requests as one of the main workfl
 
 We do try to be attentive to inbound pull requests, unfortunately we may fail to review some of them in a timely fashion.
 If you notice that your pull requests aren’t getting attended to within a week or two, please drop us a note at the dev list or ping us in the GitHub pull request.
-See link:https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[Pull Request to Repositories] for more recommendations about pull request.
 
 == This document
 


### PR DESCRIPTION
# [WEBSITE-728](https://issues.jenkins.io/browse/WEBSITE-728) Remove wiki references from governance page

The Jenkins wiki has been decommissioned.  Current information is stored in other locations.  Update the governance document to refer to those other locations rather than providing a link to outdated pages.
