### PR TITLE
[JENKINS-69638] Update HTTP/2 documentation

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -108,31 +108,15 @@ If you're setting up Jenkins using the built-in Winstone server and want to use 
 
 The link:https://tools.ietf.org/html/rfc7540[HTTP/2 protocol] allows web servers to reduce latency over encrypted connections by pipelining requests, multiplexing requests, and allowing servers to push, in some cases, before receiving a client request for the data.
 The Jetty server used by Jenkins supports HTTP/2 with the addition of the Application-Layer Protocol Negotiation (ALPN) TLS extension.
-The ALPN TLS extension is connected to the specific Jetty version and has specific requirements depending on the Java version.
 
-Note that enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, and as of Jenkins 2.339, which uses Winstone 5.23, you have to also specify an HTTPS key store file.
-
-==== Java 11
-
-IMPORTANT: Starting with weekly release line *2.357* and Long Term Support release line *2.361.1*, Java 11 or Java 17 is required.
-
-Java 11 can run the ALPN TLS extension by installing the Jetty ALPN Java server jar and passing it as a Java command line argument.
-Steps to install the extension are:
-
-* Identify the Jetty version included in your Jenkins server by searching the Jenkins startup log for the string `org.eclipse.jetty.server.Server#doStart`. For example: +
-  `org.eclipse.jetty.server.Server#doStart: jetty-9.4.27.v20200227`
-* Locate the Java version on the "System Information" page of "Manage Jenkins" to confirm it is Java 11 or Java 17.
-* Download the link:https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-alpn-java-server[jetty-alpn-java-server] with the version number matching the Jetty version bundled with your Jenkins version
-* Place the jetty-alpn-java-server.jar file in a directory accessible to the JVM
-* Add `--extraLibFolder=/path/to/extra/lib/folder` to the Java command line arguments that start Jenkins
+NOTE: Enabling HTTP/2 implicitly enables TLS even if no HTTPS port is set, and as of Jenkins 2.339, which uses Winstone 5.23, you have to also specify an HTTPS key store file.
 
 [source,bash]
 ----
-java --extraLibFolder=/opt/java/jetty-alpn-java-server-9.4.27.v20200227.jar \
-    -jar target/jenkins.war \
-    --http2Port=9090 \
-    --httpsKeyStore=path/to/keystore \
-    --httpsKeyStorePassword=keystorePassword
+--httpPort=-1 \
+--http2Port=9090 \
+--httpsKeyStore=path/to/keystore \
+--httpsKeyStorePassword=keystorePassword
 ----
 
 === HTTPS certificates with Windows


### PR DESCRIPTION
As of https://github.com/jenkinsci/winstone/pull/282, which I am planning to release in 2.369, `jetty-alpn-java-server` is included by default, and there is no need for a special `--extraLibFolder` option. See also https://github.com/jenkinsci/winstone/pull/285.