### PR TITLE
Update 2022-09-19-digital-ocean-sponsorship.adoc

### DIFF
--- a/content/blog/2022/09/2022-09-19-digital-ocean-sponsorship.adoc
+++ b/content/blog/2022/09/2022-09-19-digital-ocean-sponsorship.adoc
@@ -16,7 +16,7 @@ We are excited to announce that the relationship between DigitalOcean and Jenkin
 We want to thank DigitalOcean for providing such incredible support to the Jenkins project.
 
 DigitalOcean has provided a substantial donation of $18,000 to the Jenkins project.
-This is in addition to their previous sponsorship link:https://www.jenkins.io/blog/2022/05/04/DigitalOcean/[described here]. 
+This is in addition to their link:https://www.jenkins.io/blog/2022/05/04/DigitalOcean/[previous sponsorship]. 
 Combining these, DigitalOcean has granted over *$20,000* to the Jenkins project.
 The funding aspect is clear, but there are several other benefits to working with DigitalOcean in this capacity.
 Jenkins has access to more resources than ever before, such as utilizing the DigitalOcean platform to continue development and share progress made.


### PR DESCRIPTION
Generally linking to "here" is bad practice. A screen reader will say there's a link and here doesn't give a lot of info. "previous sponsorship" is slightly better.