### PR TITLE
Add information about silent install on Windows

### DIFF
--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -118,10 +118,11 @@ MSI installers can be installed via a silent method, which can show basic UI (/q
 msiexec.exe /i "path\to\jenkins.msi" /qn /norestart
 ----
 
-This will use all of the default values for things that would normally be a prompt such as:
+.This will use all of the default values for things that would normally be a prompt such as:
 * Installation directory
-* Service account
+* Service account username/password
 * Java installation directory
+* The port for Jenkins to listen on
 
 Each of these things can be overridden by passing a `NAME=VALUE` property pair for what you want to override:
 
@@ -145,7 +146,7 @@ Each of these things can be overridden by passing a `NAME=VALUE` property pair f
 |The password for the SERVICE_USERNAME account. This should only be provided if SERVICE_USERNAME is provided. (Default: In silent mode, none for LOCALSYSTEM)
 |===
 
-A more complex example, including the creation of a log file for the installer is shown below:
+A more complex example, including the creation of a log file for the installation process is shown below:
 [source,bat]
 ----
 msiexec.exe /i "path\to\jenkins.msi" /qn /norestart INSTALLDIR="D:\Jenkins" JAVA_HOME="C:\Program Files\SomeJava" PORT=80 /L*v "path\to\logfile.txt"

--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -109,6 +109,50 @@ image:tutorials/windows-jenkins-service.png[alt="Windows Jenkins Service",width=
 
 NOTE: See the link:https://www.jenkins.io/blog/2020/08/12/windows-installers-upgrade/#next-steps[upgrade steps] when you upgrade to a new release.
 
+== Silent Install with the MSI installers
+
+MSI installers can be installed via a silent method, which can show basic UI (/qb) or no UI at all (/qn). The silent method does not prompt for user input so there are properties that you can pass to the installer to set the specific values. A very basic command line is shown below for a silent install.
+
+[source,bat]
+----
+msiexec.exe /i "path\to\jenkins.msi" /qn /norestart
+----
+
+This will use all of the default values for things that would normally be a prompt such as:
+* Installation directory
+* Service account
+* Java installation directory
+
+Each of these things can be overridden by passing a `NAME=VALUE` property pair for what you want to override:
+
+[cols="1,1"]
+|===
+|Property Name|Description 
+
+|INSTALLDIR
+|Path to the directory to install Jenkins. (Default: C:\Program Files\Jenkins)
+
+|PORT
+|The port Jenkins will listen on. (Default: 8080)
+
+|JAVA_HOME
+|The directory where java.exe can be found. (Default: The first Java runtime found in the registry with Java 11 being higher priority than Java 17)
+
+|SERVICE_USERNAME
+|The username that the service should run as. The account must have LogonAsService permissions. (Default: In silent mode, the LOCALSYSTEM account)
+
+|SERVICE_PASSWORD
+|The password for the SERVICE_USERNAME account. This should only be provided if SERVICE_USERNAME is provided. (Default: In silent mode, none for LOCALSYSTEM)
+|===
+
+A more complex example, including the creation of a log file for the installer is shown below:
+[source,bat]
+----
+msiexec.exe /i "path\to\jenkins.msi" /qn /norestart INSTALLDIR="D:\Jenkins" JAVA_HOME="C:\Program Files\SomeJava" PORT=80 /L*v "path\to\logfile.txt"
+----
+
+This would install Jenkins into D:\Jenkins, use the Java runtime from C:\Program Files\SomeJava and Jenkins would be listening on port 80.
+
 == Post-installation setup wizard
 
 After downloading, installing and running Jenkins, the post-installation setup wizard begins.


### PR DESCRIPTION
This adds information on performing a silent install using the MSI installer on Windows. It gives an overview of the properties that can be used to override default values during the installation and some examples of how to use them on the command line.