### PR TITLE
Hacktoberfest - Remove project from list

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -147,17 +147,6 @@ a| The plugin site is used to find information about 1700+ plugins available in 
   link:https://github.com/jenkinsci/tekton-client-plugin/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good first issues],
   link:https://github.com/jenkinsci/tekton-client-plugin/issues[All open issues]
 
-| Non-inclusive Terminology cleanup
-| Java, Documentation, Web UI, Asciidoc, Markdown, Localization
-a| In 2016, the Jenkins community started changing the potentially offensive terminology within the project.
-  The "slave" term was deprecated and replaced by "agent".
-  In July 2020 we also link:https://cd.foundation/blog/2020/08/25/jenkins-terminology-changes/[adopted] the "controller" term instead of "master", and deprecated the "whitelist/blacklist" terms.
-  There are many places where the old terminology still needs to be replaced.
-  We invite contributors to join us and participate in cleaning up Jenkins documentation, Web and CLI interfaces, localizations, and the codebase:
-
-  * link:https://community.jenkins.io/t/jenkins-terminology-cleanup-initiative-coordination/180[Contributing guidelines and newcomer issue links]
-  * link:/sigs/advocacy-and-outreach/#inclusive-namingg[Inclusive naming project by Jenkins Advocacy&Outreach SIG]
-
 | link:/artwork[Jenkins Artwork]
 | Design
 | Create new images and logos for link:/projects/jam/[Jenkins area meetups],


### PR DESCRIPTION
removing the inclusive naming project as it requires direct coaching/more resources, in favor of projects that can be completed within the timeline