### PR TITLE
chore(ircbot): `rename` and `archive` repository commands documentation

### DIFF
--- a/content/projects/infrastructure/ircbot.adoc
+++ b/content/projects/infrastructure/ircbot.adoc
@@ -154,6 +154,21 @@ jenkins-admin: Create REPO on github
 jenkins-admin: Create REPO on github for SOMEONE
 ----
 
+*Rename a GitHub repository*
+
+[source]
+----
+jenkins-admin: rename REPO to NEWNAME
+----
+
+*Archive a GitHub repository and optionally replace its description*
+
+[source]
+----
+jenkins-admin: archive REPO
+jenkins-admin: archive REPO DESCRITION
+----
+
 
 In the latter form, the specified someone will get the commit access to the
 repository right away.


### PR DESCRIPTION
The existing command to rename a GitHub repository wasn't documented.

I'm adding the new command to archive a repository [here](https://github.com/jenkins-infra/ircbot/pull/111), and putting this PR in draft until merged.