### PR TITLE
Misc Hacktoberfest fixes

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -20,7 +20,7 @@ NOTE: Hacktoberfest 2022 is coming soon! We are going to participate as the Jenk
 and we are looking for contributors and maintainers who want to join us in October!
 See link:https://community.jenkins.io/t/hacktoberfest-2022/3805[this conversation] for more information and Q&A.
 
-link:https://hacktoberfest.digitalocean.com/[Hacktoberfest]
+link:https://hacktoberfest.com/[Hacktoberfest]
 is a month long celebration of open source software.
 It happens every year in October.
 During this event everyone can support open-source by contributing changes, and then earn a limited edition swag.
@@ -47,14 +47,14 @@ See the link:/participate/[Contribute and Participate] page for more information
 
 == Where to contribute?
 
-The Jenkins project is spread across several organizations on GitHub (`jenkinsci`, `jenkins-infra`, `jenkins-zh`).
+The Jenkins project is spread across several organizations on GitHub (`link:https://github.com/jenkinsci/[jenkinsci]`, `link:https://github.com/jenkins-infra/[jenkins-infra]`, `link:https://github.com/jenkins-zh/[jenkins-zh]`).
 You are welcome to contribute to **any** repository in **any** of those organizations, or any other Jenkins-related repository on GitHub.
 Repositories may have different contribution guidelines, review and merge policies.
 If you adopt Jenkins in your open-source projects (e.g. Jenkins Pipeline or Configuration as Code),
 it counts as well!
-Note that not all pull requests will automatically count towards Hacktoberfest in 2020.
+Note that not all pull requests will automatically count towards Hacktoberfest.
 
-* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+org%3Astapler+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest] -
+* link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest] -
   you can just submit pull requests, no extra steps needed.
 * for other repositories, we will need to get the repo marked for Hacktoberfest so that your pull request counts towards the goal.
   Please follow link:/events/hacktoberfest/faq/#how-do-i-mark-my-pull-requests[FAQ: Marking Pull requests].
@@ -95,17 +95,23 @@ who have committed to assist contributors and to provide quick turnaround in pul
   link:https://github.com/jenkins-infra/jenkins.io/projects/3[Board], https://gitter.im/jenkinsci/docs[chat]
 
 | link:https://github.com/jenkinsci/jenkins[Jenkins Core]
-| Java
+| Java, +
+Jelly, +
+Groovy, +
+Javascript, +
+HTML, +
+CSS, +
+LESS
 | There is always something to improve in Jenkins core itself.
   You can address various issues, improve the codebase,
   and add new features there.
 
   link:https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md[Contributing],
-  link:https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newcomer-friendly issues]
+  link:https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newcomer-friendly issues], https://gitter.im/jenkinsci/jenkins[chat]
 
 | link:http://plugins.jenkins.io/[Jenkins Plugin Site]
 | Javascript, Java, React, Gatsby
-a| The plugin site is used to find information about 1700+ plugins available in Jenkins.
+a| The plugin site is used to find information about 1800+ plugins available in Jenkins.
    It provides plugin documentation, changelogs, open issues, and other data needed for Jenkins admins and end users.
    We are interested to keep improving the plugin site's UI/UX,
    provide more search options, and to provide deeper integration with GitHub and other services.

--- a/content/events/hacktoberfest/faq.adoc
+++ b/content/events/hacktoberfest/faq.adoc
@@ -16,7 +16,7 @@ opengraph:
 ---
 
 
-NOTE: You can find Hacktoberfest FAQ link:https://hacktoberfest.digitalocean.com/faq[here].
+NOTE: You can find Hacktoberfest FAQ link:https://hacktoberfest.com/about/[here].
 Below you can find answers to some Jenkins-specific questions.
 
 
@@ -34,7 +34,7 @@ You can also submit your own issue and propose a fix.
 
 === How do I mark my pull requests?
 
-On Oct 03, the Hacktoberfest organizers link:https://hacktoberfest.digitalocean.com/hacktoberfest-update[made an update] to reduce spam and to introduce maintainer opt-in.
+On Oct 03, the Hacktoberfest organizers link:https://hacktoberfest.com/participation/[made an update] to reduce spam and to introduce maintainer opt-in.
 We follow the same policy in the Jenkins community,
 and we do **NOT** require all maintainers to participate in Hacktoberfest.
 
@@ -42,7 +42,7 @@ We ask contributors to mark their pull requests so that we can help with having 
 
 * If a repository already has the `hacktoberfest` topic set,
   no extra steps required. Just submit a pull request!
-** link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+org%3Astapler+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest]
+** link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest]
 * If you are not a repository maintainer:
 .. Add "Hacktoberfest" to the beginning of your pull request title.
 .. Reference the pull request in link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter chat].
@@ -130,10 +130,10 @@ Some queries which can help to get insights:
 * link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Apr+created%3A%3E2022-09-29+-label%3Ahacktoberfest+hacktoberfest&type=Issues[Hacktoberfest 2022 pull requests with the "hacktoberfest" text which have not been labeled yet]
 
 Also, CD Foundation metrics can be used to get some insights. 
-These metrics apply to `jenkinsci` and `jenkins-infra` organizations only.
+These metrics apply to `link:https://github.com/jenkinsci/[jenkinsci]` and `https://github.com/jenkins-infra/[jenkins-infra]` organizations only.
 
-* link:https://jenkins.devstats.cd.foundation/d/52/new-contributors-table?orgId=1&from=1569756835000&to=1572652800000[New contributors, from Sep 30 to Nov 02]
-* link:https://jenkins.devstats.cd.foundation/d/14/new-and-episodic-pr-contributors?orgId=1&from=1569756835000&to=1572652800000[New and Episodic PR Contributors, from Sep 30 to Nov 02]
-* link:https://jenkins.devstats.cd.foundation/d/1/activity-repository-groups?orgId=1&from=1567337635000&to=1575158400000[Activity in GitHub repos, from Sep 01 to Dec 01]
-* link:https://jenkins.devstats.cd.foundation/d/61/documentation-committers-in-repository-groups?orgId=1&from=1567337635000&to=1575158400000[Documentation committers, from Sep 01 to Dec 01] (comment: not sure what are the filtering conditions)
-* link:https://jenkins.devstats.cd.foundation/d/10/pr-time-to-engagement?orgId=1&from=1567337635000&to=1575158400000[PR Time to Engagement, from Sep 01 to Dec 01]
+* link:https://jenkins.devstats.cd.foundation/d/52/new-contributors-table?orgId=1&from=1664451235000&to=1667347200000[New contributors, from Sep 30 to Nov 02]
+* link:https://jenkins.devstats.cd.foundation/d/14/new-and-episodic-pr-contributors?orgId=1&from=1664451235000&to=1667347200000[New and Episodic PR Contributors, from Sep 30 to Nov 02]
+* link:https://jenkins.devstats.cd.foundation/d/1/activity-repository-groups?orgId=1&from=1662032035000&to=1669852800000[Activity in GitHub repos, from Sep 01 to Dec 01]
+* link:https://jenkins.devstats.cd.foundation/d/61/documentation-committers-in-repository-groups?orgId=1&from=1662032035000&to=1669852800000[Documentation committers, from Sep 01 to Dec 01] (comment: not sure what are the filtering conditions)
+* link:https://jenkins.devstats.cd.foundation/d/10/pr-time-to-engagement?orgId=1&from=1662032035000&to=1669852800000[PR Time to Engagement, from Sep 01 to Dec 01]


### PR DESCRIPTION
The change proposed
- fixes a few broken URLs
- uses up-to-date metrics, provided by the CDF (mostly empty at the time of submitting this PR, given the timeframe for 2022 didn't take place yet)
- adds proper links to our GH organizations taking part
- removes the stapler org from the search query. There's no repository, that opted-in hacktoberfest, nor is the org much of use nowadays.
- adds a few more languages to the entry of core, it's not all about Java ;)
- uses the official metric of 1,800 plugins, as known from other sources (see press page)