### PR TITLE
Shorten the example exclusion

### DIFF
--- a/content/doc/developer/tutorial-improve/add-more-spotbugs-checks.adoc
+++ b/content/doc/developer/tutorial-improve/add-more-spotbugs-checks.adoc
@@ -68,26 +68,32 @@ An example excludes filter file is also included here:
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
   <!--
-    Exclusions in this section have been triaged and determined to be false positives.
+    Exclusions in this section have been triaged and determined to be
+    false positives.
   -->
 
   <!--
-    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
-    on this section, pick an exclusion to triage, then:
-    - If it is a false positive, add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
-      annotation indicating the reason why it is a false positive, then remove the exclusion from
-      this section.
-    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
+    Here lies technical debt. Exclusions in this section have not yet
+    been triaged. When working on this section, pick an exclusion to
+    triage, then:
+
+    - Add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
+      annotation if it is a false positive.  Indicate the reason why
+      it is a false positive, then remove the exclusion from this
+      section.
+
+    - If it is not a false positive, fix the bug, then remove the
+      exclusion from this section.
    -->
   <Match>
     <Or>
       <And>
         <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ"/>
-        <Class name="com.orctom.jenkins.plugin.buildtimestamp.ShiftExpressionHelper"/>
+        <Class name="io.jenkins.plugin.example.ExampleAction"/>
       </And>
       <And>
         <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/>
-        <Class name="com.orctom.jenkins.plugin.buildtimestamp.ShiftExpressionHelper"/>
+        <Class name="io.jenkins.plugin.example.SomeFeature"/>
       </And>
     </Or>
   </Match>


### PR DESCRIPTION
## Shorten spotbugs exclusion example

Reduce the risk of a horizontal scroll bar on the sample file and remove
a duplicated word in the description text.
