### PR TITLE
Fix formatting of old security changelog entries, link advisories

### DIFF
--- a/content/_partials/changelog-old.html
+++ b/content/_partials/changelog-old.html
@@ -48,7 +48,7 @@
 <h3 id=v2.44>What's new in 2.44 (2017/02/01)</h3>
 <ul class=image>
   <li class="security">
-    <strong>Important security fixes</strong>
+    Important security fixes
     (<a href="/security/advisory/2017-02-01">security advisory</a>)
 </ul>
 <h3 id=v2.43>What's new in 2.43 (2017/01/29)</h3>
@@ -295,7 +295,7 @@
 <h3 id=v2.32>What's new in 2.32 (2016/11/16)</h3>
 <ul class=image>
   <li class="security">
-    <strong>Important security fixes</strong>
+    Important security fixes
     (<a href="/security/advisory/2016-11-16">security advisory</a>)
   <li class="rfe">
     Allow disabling the Jenkins CLI over HTTP and JNLP agent port by setting the System property <tt>jenkins.CLI.disabled</tt> to <tt>true</tt>.
@@ -1182,7 +1182,7 @@
 <h3 id=v2.3>What's new in 2.3 (2016/05/11)</h3>
 <ul class=image>
   <li class="security">
-    <strong>Important security fixes</strong>
+    Important security fixes
     (see the <a href="/security/advisory/2016-05-11">security advisory</a> for details and plugin compatibility issues)
 </ul>
 <h3 id=v2.2>What's new in 2.2 (2016/05/08)</h3>
@@ -1455,8 +1455,8 @@
 </ul>
 <h3 id=v1.650>What's new in 1.650 (2016/02/24)</h3>
 <ul class=image>
-  <li class="major bug">
-    <strong>Important security fixes</strong>
+  <li class="security">
+    Important security fixes
     (<a href="/security/advisory/2016-02-24">security advisory</a>)
 </ul>
 <h3 id=v1.649>What's new in 1.649 (2016/02/21)</h3>
@@ -1569,8 +1569,8 @@
 </ul>
 <h3 id=v1.641>What's new in 1.641 (2015/12/09)</h3>
 <ul class=image>
-  <li class="major bug">
-    <strong>Important security fixes</strong>
+  <li class="security">
+    Important security fixes
     (<a href="/security/advisory/2015-12-09">security advisory</a>)
 </ul>
 <h3 id=v1.640>What's new in 1.640 (2015/12/07)</h3>
@@ -1613,8 +1613,8 @@
 </ul>
 <h3 id=v1.638>What's new in 1.638 (2015/11/11)</h3>
 <ul class=image>
-  <li class="major bug">
-    <strong>Important security fixes</strong>
+  <li class="security">
+    Important security fixes
     (<a href="/security/advisory/2015-11-11">security advisory</a>)
 </ul>
 <h3 id=v1.637>What's new in 1.637 (2015/11/08)</h3>
@@ -2103,7 +2103,7 @@
   <li class=rfe>
     JNLP agents can now connect to controller through HTTP proxy.
     (<a href="https://issues.jenkins.io/browse/JENKINS-6167">issue 6167</a>)
-  <li class='major bug'>
+  <li class='security'>
     Fixes to several security vulnerabilities.
     (<a href="/security/advisory/2015-03-23">advisory</a>)
 </ul>
@@ -2154,7 +2154,7 @@
 </ul>
 <h3 id=v1.600>What's new in 1.600 (2015/02/28)</h3>
 <ul class=image>
-  <li class="major bug">
+  <li class="security">
     Fixes to multiple security vulnerabilities.
     (<a href="/security/advisory/2015-02-27">security advisory</a>)
   <li class="rfe">
@@ -2370,9 +2370,9 @@
   <li class=bug>
     JNA update for deprecated JNA-POSIX library.
     (<a href="https://issues.jenkins.io/browse/JENKINS-24527">issue 24527</a>)
-  <li class='major bug'>
+  <li class='security'>
     Introduced agent-to-controller security mechanism to defend a controller from agents.
-    (<a href="https://jenkins-ci.org/security-144">SECURITY-144</a>)
+    (<a href="https://jenkins-ci.org/security-144">SECURITY-144</a>, <a href="/security/advisory/2014-10-30/">security advisory</a>)
 </ul>
 <h3 id=v1.586>What's new in 1.586 (2014/10/26)</h3>
 <ul class=image>
@@ -2451,7 +2451,7 @@
 </ul>
 <h3 id=v1.583>What's new in 1.583 (2014/10/01)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Fixes to multiple security vulnerabilities.
     (<a href="/security/advisory/2014-10-01">security advisory</a>)
 </ul>
@@ -2719,7 +2719,7 @@
   <li class=bug>
     <code>IllegalArgumentException</code> from <code>AbstractProject.getEnvironment</code> when trying to get environment variables from an offline agent.
     (<a href="https://issues.jenkins.io/browse/JENKINS-23517">issue 23517</a>)
-  <li class=bug>
+  <li class=security>
     Overall.READ is sufficient to access /administrativeMonitor/hudsonHomeIsFull/
     (SECURITY-134)
   <li class=bug>
@@ -3219,7 +3219,7 @@
 </ul>
 <h3 id=v1.551>What's new in 1.551 (2014/02/14)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Valentine's day security release that contains more than a dozen security fixes.
     (<a href="/security/advisory/2014-02-14">security advisory</a>)
   <li class='major bug'>
@@ -4130,15 +4130,15 @@
   <li class=bug>
     <code>hpi:run</code> did not work for bundled plugins.
     (<a href="https://issues.jenkins.io/browse/JENKINS-18352">issue 18352</a>)
-  <li class=bug>
+  <li class=security>
     Fixed CSRF vulnerabilities
-    (SECURITY-63,SECURITY-69)
-  <li class=bug>
+    (SECURITY-63,SECURITY-69, <a href="/security/advisory/2013-05-02/">security advisory</a>)
+  <li class=security>
     Fixed an XSS vulnerability via stylesheet
-    (SECURITY-67)
-  <li class=bug>
+    (SECURITY-67, <a href="/security/advisory/2013-05-02/">security advisory</a>)
+  <li class=security>
     Fixed an XSS vulnerability to copy arbitrary text into clipboard
-    (SECURITY-71/CVE-2013-1808)
+    (SECURITY-71/CVE-2013-1808, <a href="/security/advisory/2013-05-02/">security advisory</a>)
 </ul>
 <h3 id=v1.512>What's new in 1.512 (2013/04/21)</h3>
 <ul class=image>
@@ -4410,8 +4410,8 @@
 </ul>
 <h3 id=v1.502>What's new in 1.502 (2013/02/16)</h3>
 <ul class=image>
-  <li class='major bug'>
-    Miscellaneous security vulnerability fixes. See the advisory for more details.
+  <li class='security'>
+    Miscellaneous security vulnerability fixes. See the <a href="/security/advisory/2013-02-16/">advisory</a> for more details.
     (SECURITY-13,16,46,47,54,55,59,60,61)
   <li class='major bug'>
     Builds disappear from build history after completion.
@@ -4520,9 +4520,9 @@
 </ul>
 <h3 id=v1.498>What's new in 1.498 (2013/01/07)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     The master key that was protecting all the sensitive data in <tt>$JENKINS_HOME</tt> was vulnerable.
-    (SECURITY-49)
+    (SECURITY-49, <a href="/security/advisory/2013-01-04/">security advisory</a>)
 </ul>
 <h3 id=v1.497>What's new in 1.497 (2013/01/06)</h3>
 <ul class=image>
@@ -5329,12 +5329,12 @@
 </ul>
 <h3 id=v1.453>What's new in 1.453 (2012/03/05)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Fixed a XSS vulnerability.
-    (SECURITY-26)
-  <li class='major bug'>
+    (SECURITY-26, <a href="/security/advisory/2012-03-05/">security advisory</a>)
+  <li class='security'>
     Fixed a directory traversal vulnerability.
-    (SECURITY-23)
+    (SECURITY-23, <a href="/security/advisory/2012-03-05/">security advisory</a>)
   <li class=bug>
     Fixed a file descriptor leak on Windows
     (<a href="https://issues.jenkins.io/browse/JENKINS-9882">issue 9882</a>)
@@ -5461,9 +5461,9 @@
   <li class=bug>
     Failure to check the username/groupname in the matrix security shouldn't hide the user name
     (<a href="https://issues.jenkins.io/browse/JENKINS-9519">issue 9519</a>)
-  <li class=bug>
+  <li class=security>
     Fixed a hash DoS vulnerability.
-    (<a href="https://www.ocert.org/advisories/ocert-2011-003.html">SECURITY-22</a>)
+    (<a href="https://www.ocert.org/advisories/ocert-2011-003.html">SECURITY-22</a>, <a href="/security/advisory/2012-01-12/">security advisory</a>)
   <li class=bug>
     Fixed "Deploy artifacts to Maven repository" as a promotion action.
     Requires promoted-builds plugin 2.5+.
@@ -5501,7 +5501,7 @@
 </ul>
 <h3 id=v1.447>What's new in 1.447 (2012/01/09)</h3>
 <ul class=image>
-  <li class=bug>
+  <li class=security>
     Fixed a hash DoS vulnerability.
     (<a href="https://www.ocert.org/advisories/ocert-2011-003.html">SECURITY-22</a>)
   <li class=bug>
@@ -5688,9 +5688,9 @@
 </ul>
 <h3 id=v1.438>What's new in 1.438 (2011/11/07)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Thanks to Luca De Fulgentis, fixed XSS vulnerability with the built-in servlet container.
-    (SECURITY-17)
+    (SECURITY-17, <a href="/security/advisory/2011-11-08/">security advisory</a>)
   <li class=bug>
     Repeated ids, expandTextArea() and multiple "Invoke Ant" build steps.
     (<a href="https://issues.jenkins.io/browse/JENKINS-10989">issue 10989</a>)
@@ -6489,7 +6489,7 @@
 </ul>
 <h3 id=v1.407>What's new in 1.407 (2011/04/15)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Implemented comprehensive preventive measure against cross-site scripting.
     (SECURITY-14)
   <li class=bug>
@@ -7093,7 +7093,7 @@
 </ul>
 <h3 id=v1.383>What's new in 1.383 (2010/10/29)</h3>
 <ul class=image>
-  <li class="major bug">
+  <li class="security">
     Fix security issue where a user with job configure permission could obtain
     admin permission for their session.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7256">issue 7256</a>)
@@ -7332,7 +7332,7 @@
 </ul>
 <h3 id=v1.371>What's new in 1.371 (2010/08/09)</h3>
 <ul class=image>
-  <li class="major bug">
+  <li class="security">
     A security hole in CLI command implementations enable unauthorized users
     from executing commands.
     (SECURITY-5)
@@ -7418,7 +7418,7 @@
 </ul>
 <h3 id=v1.366>What's new in 1.366 (2010/07/09)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Fixed a possible security issue where a malicious user with the project
     configuration access can trick Hudson into leaking the proxy password,
     if Hudson is configured with a proxy with username/password.
@@ -7453,7 +7453,7 @@
 </ul>
 <h3 id=v1.365>What's new in 1.365 (2010/07/05)</h3>
 <ul class=image>
-  <li class='major bug'>
+  <li class='security'>
     Fixed a critical security problem. See <a href="/security/advisory/2010-07-05/">the advisory</a> for more details.
 </ul>
 <h3 id=v1.364>What's new in 1.364 (2010/06/25)</h3>
@@ -13212,8 +13212,8 @@
   <li>Fixed a bug where the javadoc link in the job top page becomes broken
       when the javadoc archiving is configured but no javadoc has built yet.
       (<a href="https://issues.jenkins.io/browse/JENKINS-433">issue 433</a>)
-  <li><strike>Improved the fix for <a href="https://issues.jenkins.io/browse/JENKINS-389">#389</a>
-      to only do this on Windows.</strike> The fix was broken and fixed properly in
+  <li><s>Improved the fix for <a href="https://issues.jenkins.io/browse/JENKINS-389">#389</a>
+      to only do this on Windows.</s> The fix was broken and fixed properly in
       <a href="#v102">1.102</a>.
   <li>Fixed a security problem. The configuration page was accessible to non-authorized users,
       even though the submission fails.


### PR DESCRIPTION
Since we use `font-weight: bolder` for `<strong>` (thanks bootstrap), some old entries looked wrong.

This cleans them up a bit without substantially changing content:

* Move security fix entries from `(major) bug` to `security`.
* Remove `<strong>` tags from them.
* Link to the advisory if one was published.
* Change one instance of `<strike>…</strike>` to `<s>…</s>`.

Some entries older than 1.97 were left alone, as they don't use the colored list entry type indicators, so that would have been a larger change.