### PR TITLE
Link to GitHub org default contrib guide

### DIFF
--- a/content/doc/developer/tutorial-improve/add-a-contributing-guide.adoc
+++ b/content/doc/developer/tutorial-improve/add-a-contributing-guide.adoc
@@ -9,7 +9,7 @@ title: Add a contributing guide
 
 = Add a contributing guide
 
-If the plugin does not already include a contributing guide, add a contributing guide so that others understand how to help with plugin development.
+If the plugin does not already include a contributing guide and if it would benefit from more detail than is provided in the link:https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md[default contributing guide], add a contributing guide so that others understand how to help with plugin development.
 Look for existing contributing instructions in files like `README.md`.
 Move the content from the `README.md` file to the `CONTRIBUTING.md` file so that the README file stays focused on user documentation.
 
@@ -25,6 +25,7 @@ The contributing guide often includes instructions to:
 
 Refer to the contributing guides of other plugins for common examples, like:
 
+* link:https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md[Jenkins GitHub organization contributing guide]
 * link:https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/CONTRIBUTING.md[Configuration as code plugin]
 * link:https://github.com/jenkinsci/warnings-ng-plugin/blob/master/CONTRIBUTING.md[Warnings Next Generation plugin]
 * link:https://github.com/jenkinsci/credentials-plugin/blob/master/CONTRIBUTING.md[Credentials plugin]


### PR DESCRIPTION
## Link to GitHub org default contributing guide

The default guide is available as a hyperlink during pull request creation for all repositories in the jenkinsci GitHub organization.  A separate top level contributing guide can be more readily discovered, but if it is only a copy of the default, that is probably not enough justification to create a separate contributing guide in each plugin.
