### PR TITLE
Extend agent and related glossary entries with links to documentation sections 

### DIFF
--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -44,7 +44,7 @@ To ensure it is rendered appropriately.
 == General Terms
 
 [glossary]
-Agent::
+https://www.jenkins.io/doc/book/using/using-agents/[Agent]::
     An agent is typically a machine, or container, which connects to a Jenkins
     controller and executes tasks when directed by the controller.
 Artifact::
@@ -53,7 +53,7 @@ Artifact::
     later retrieval by users.
 Build:: [[build]]
     Result of a single execution of a <<job,job>>
-Cloud:: [[cloud]]
+https://www.jenkins.io/doc/book/security/controller-isolation/#agent-controller-access-control[Cloud]:: [[cloud]]
     A System Configuration which provides dynamic <<agent,Agent>>
     provisioning and allocation, such as that provided by the
     plugin:azure-vm-agents[Azure VM Agents]
@@ -105,7 +105,7 @@ LTS::
     See link:/download/lts/[this page] for more info.
 Master::
     A deprecated term, synonymous with <<controller,Controller>>.
-Node::
+https://www.jenkins.io/doc/book/managing/nodes/[Node]::
     A machine which is part of the Jenkins environment and capable
     of executing <<pipeline,Pipelines>> or <<job,jobs>>. Both the
     <<controller,Controller>> and <<agent,Agents>> are considered to be Nodes.

--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -105,7 +105,7 @@ LTS::
     See link:/download/lts/[this page] for more info.
 Master::
     A deprecated term, synonymous with <<controller,Controller>>.
-https://www.jenkins.io/doc/book/managing/nodes/[Node]::
+link:/doc/book/managing/nodes/[Node]::
     A machine which is part of the Jenkins environment and capable
     of executing <<pipeline,Pipelines>> or <<job,jobs>>. Both the
     <<controller,Controller>> and <<agent,Agents>> are considered to be Nodes.

--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -53,7 +53,7 @@ Artifact::
     later retrieval by users.
 Build:: [[build]]
     Result of a single execution of a <<job,job>>
-https://www.jenkins.io/doc/developer/extensions/alibabacloud-ecs/#ji-toolbar[Cloud]:: [[cloud]]
+Cloud:: [[cloud]]
     A System Configuration which provides dynamic <<agent,Agent>>
     provisioning and allocation, such as that provided by the
     plugin:azure-vm-agents[Azure VM Agents]

--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -53,7 +53,7 @@ Artifact::
     later retrieval by users.
 Build:: [[build]]
     Result of a single execution of a <<job,job>>
-https://www.jenkins.io/doc/book/security/controller-isolation/#agent-controller-access-control[Cloud]:: [[cloud]]
+https://www.jenkins.io/doc/developer/extensions/alibabacloud-ecs/#ji-toolbar[Cloud]:: [[cloud]]
     A System Configuration which provides dynamic <<agent,Agent>>
     provisioning and allocation, such as that provided by the
     plugin:azure-vm-agents[Azure VM Agents]

--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -44,7 +44,7 @@ To ensure it is rendered appropriately.
 == General Terms
 
 [glossary]
-https://www.jenkins.io/doc/book/using/using-agents/[Agent]::
+link:/doc/book/using/using-agents/[Agent]::
     An agent is typically a machine, or container, which connects to a Jenkins
     controller and executes tasks when directed by the controller.
 Artifact::


### PR DESCRIPTION
## What
I have added hyperlinks to Agent, Cloud and Node in Glossary.

## Closes
Extend agent and related glossary entries with links to documentation sections #5454 