### PR TITLE
Fix: Broken links to documentation model

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -280,15 +280,14 @@ can be broken down into three categories:
 
 . *Jenkins User Documentation* - for people who want to _use_ Jenkins's existing
   functionality and plugin features. The documentation model that the content is
-  based on is described in Daniele Procida's blog post
-  "link:https://www.divio.com/en/blog/documentation/[What nobody tells you about
-  documentation]". Refer to the
+  based on is described in Michael Nicholson's blog post
+  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]". Refer to the
   <<jenkins-user-documentation,Jenkins User Documentation>> section below for
   details on how this content is structured.
 . *Extend Jenkins Documentation* - this documentation is for people who want to
   _extend_ the functionality of Jenkins by developing their own Jenkins plugins.
   Like the Jenkins User Documentation (above), the content is based on the same
-  link:https://www.divio.com/en/blog/documentation/[documentation model]. The
+  link:https://www.divio.com/blog/beginners_guide_to_documentation/[documentation model]. The
   content for this set of documentation is written up as a combination of
   `.haml` and `.adoc` files located in the
   link:content/doc/developer[`content/doc/developer/`]
@@ -310,9 +309,8 @@ The Jenkins User Documentation consists of the following parts:
 * *Tutorials* - these are step-by-step guides that teach users, relatively new to
   Continuous Integration (CI) / Continuous Delivery (CD), concepts about how to
   implement their project (of a particular tech stack) in Jenkins. A tutorial's
-  content is based on the "tutorial" description in Daniele Procida's blog post
-  "link:https://www.divio.com/en/blog/documentation/[What nobody tells you about
-  documentation]". Read more about
+  content is based on the "tutorial" description in Michael Nicholson's blog post
+  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]". Read more about
   <<adding-a-tutorial-page,Adding a Tutorial page>>.
 * *How-to guides* - these are short guides consisting of procedures to get the
   reader started with specific/common use-case scenarios. They could also be
@@ -321,9 +319,8 @@ The Jenkins User Documentation consists of the following parts:
   beyond the more general scope of a topic in the User Handbook, but these
   guides do not hand-hold or teach the reader using very specific scenarios
   (e.g. forking a given repo), as the *Tutorials* do. A how-to guide's content
-  is based on the "how-to guide" description in Daniele Procida's blog post
-  "link:https://www.divio.com/en/blog/documentation/[What nobody tells you about
-  documentation]". While there are currently no "how-to guides" yet, this
+  is based on the "how-to guide" description in Michael Nicholson's blog post
+  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]". While there are currently no "how-to guides" yet, this
   section will be added when good candidate guides arise.
 * *User Handbook* - rich and in-depth documentation, separated into chapters,
   each of which covers a given topic/feature of Jenkins. This is conceptually
@@ -331,10 +328,9 @@ The Jenkins User Documentation consists of the following parts:
   link:https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/[FreeBSD
   Handbook]. The User Handbook covers the fundamentals on how to use Jenkins as
   well as content which is not explained in the *Tutorials* or *How-to Guides*
-  (above). This content is based predominantly on the "reference" description in
-  Daniele Procida's blog post
-  "link:https://www.divio.com/en/blog/documentation/[What nobody tells you about
-  documentation]" blog post, with appropriate "discussion"- (i.e.
+  (above). This content is based predominantly on the "technical reference" description in
+  Michael Nicholson's blog post
+  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]" blog post, with appropriate "discussion"- (i.e.
   background/overview material) and general "how-to guide"- (i.e. specific to
   the chapter/topic in question) like material. Read more about
   <<adding-user-handbook-content,Adding User Handbook content>>.


### PR DESCRIPTION
Daniele Procida’s blog post on "What nobody tells you about documentation" is no longer available. Seems like it is replaced by Michael Nicholson’s blog post "Beginner’s Guide to Documentation: Here’s What You Need to Know" on the same website (link: https://www.divio.com/blog/beginners_guide_to_documentation/). All the links directing to the first blog post are replaced by the new one.