### PR TITLE
Add 2021 Hacktoberfest link, update 2020 link

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -270,7 +270,8 @@ See link:/events/hacktoberfest/faq[Hacktoberfest in Jenkins FAQ].
 
 == Previous years
 
-* link:https://groups.google.com/g/jenkinsci-dev/c/pz3kqPnC2wA/m/-FJDJ8KKAgAJ[2020]
+* link:/blog/2021/10/31/hacktoberfest-results-2021/[2021]
+* link:/blog/2021/01/12/new-year-report/#jenkins-in-hacktoberfest-2020[2020]
 * link:/blog/2019/10/01/hacktoberfest/[2019]
 * link:/blog/2018/10/01/hacktoberfest/[2018]
 * link:/blog/2017/10/06/hacktoberfest/[2017]


### PR DESCRIPTION
## Add 2021 Hacktoberfest link, update 2020 link

Thge 2021 Hacktoberfest link was missing and the 2020 link was pointing to a mailing list thread.  No summary blog post was created for Hacktoberfest 2021, but a summary was provided in the 2021 "Happy New Year" post.  Use that "Happy New Year" summary post as the link for 2020, since it is a reasonable summary of the results.
