### PR TITLE
Clarified allowed HOOK values

### DIFF
--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -28,7 +28,7 @@ For given hook _HOOK_, the following locations are searched:
 insert stuff into the hook without worrying about overwriting each
 other's code.
 
-The following events use this mechanism:
+The following events use this mechanism by replacing `+HOOK+` in `+HOOK.groovy.d+` or `+HOOK.groovy+` by one of the below mentioned types:
 
 * *init*: Post-initialization script
 * *boot-failure*: Boot failure hook


### PR DESCRIPTION
It wasn't immediately clear that "HOOK.groovy.d" really meant one of 'init.groovy.d' or 'boot-failure.groovy.d'. It is made clear by mentioning it at the bullet list "The following events use this mechanism:"

This will resolve the issue #3945 