### PR TITLE
Fix: Broken Link Pipelines/ Getting Started

### DIFF
--- a/content/doc/book/glossary/index.adoc
+++ b/content/doc/book/glossary/index.adoc
@@ -139,7 +139,7 @@ Stage::
 Step::
     A single task; fundamentally steps tell Jenkins _what_ to do inside of a
     <<pipeline,Pipeline>> or <<job,job>>.
-    See link:/doc/book/pipeline/getting/started/[Pipelines / Getting Started]
+    See link:/doc/book/pipeline/getting-started/[Pipelines / Getting Started]
     and link:/doc/book/pipeline/jenkinsfile/[Pipeline / Using a jenkinsfile]
     for more info.
 Trigger:: [[trigger]]


### PR DESCRIPTION
Link to Pipelines / Getting Started is updated with the correct one