### PR TITLE
Remove requirement for docker label

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -28,15 +28,14 @@ Handbook.
 
 To get started quickly with Pipeline:
 
-. Install the link:https://plugins.jenkins.io/docker-workflow/[Docker Pipeline] plugin through the *Manage Jenkins > Manage Plugins* page.
-- Add the `docker` label to the node you would like to the containers on (can use the controller/built in node)
-. After installing the plugin, restart Jenkins so that plugin is ready to use.
+. Install the link:https://plugins.jenkins.io/docker-workflow/[*Docker Pipeline plugin*] through the *Manage Jenkins > Manage Plugins* page
+. After installing the plugin, restart Jenkins so that the plugin is ready to use
 . Copy one of the <<examples, examples below>> into your repository and name it `Jenkinsfile`
 . Click the *New Item* menu within Jenkins
 image:pipeline/classic-ui-left-column.png[alt="Classic UI left column",width=40%]
 . Provide a name for your new item (e.g. *My-Pipeline*) and select *Multibranch Pipeline*
-. Click the *Add Source* button, choose the type of repository you want to use and fill in the details.
-. Click the *Save* button and watch your first Pipeline run!
+. Click the *Add Source* button, choose the type of repository you want to use and fill in the details
+. Click the *Save* button and watch your first Pipeline run
 
 You may need to modify one of the example ``Jenkinsfile``'s to make it run with your project. Try modifying the `sh` command to run the same command you would run on your local machine.
 
@@ -68,7 +67,7 @@ pipeline {
 }
 // Scripted //
 /* Requires the Docker Pipeline plugin */
-node('docker') {
+node {
     stage('Build') {
         docker.image('maven:3.8.6-openjdk-11-slim').inside {
             sh 'mvn --version'
@@ -95,7 +94,7 @@ pipeline {
 }
 // Scripted //
 /* Requires the Docker Pipeline plugin */
-node('docker') {
+node {
     stage('Build') {
         docker.image('node:16.17.1-alpine').inside {
             sh 'node --version'
@@ -122,7 +121,7 @@ pipeline {
 }
 // Scripted //
 /* Requires the Docker Pipeline plugin */
-node('docker') {
+node {
     stage('Build') {
         docker.image('ruby:3.1.2-alpine').inside {
             sh 'ruby --version'
@@ -149,7 +148,7 @@ pipeline {
 }
 // Scripted //
 /* Requires the Docker Pipeline plugin */
-node('docker') {
+node {
     stage('Build') {
         docker.image('python:3.10.7-alpine').inside {
             sh 'python --version'
@@ -176,7 +175,7 @@ pipeline {
 }
 // Scripted //
 /* Requires the Docker Pipeline plugin */
-node('docker') {
+node {
     stage('Build') {
         docker.image('php:8.1.11-alpine').inside {
             sh 'php --version'
@@ -203,7 +202,7 @@ pipeline {
 }
 // Scripted //
 /* Requires the Docker Pipeline plugin */
-node('docker') {
+node {
     stage('Build') {
         docker.image('golang:1.19.1-alpine').inside {
             sh 'go version'


### PR DESCRIPTION
## Tutorial does not need `docker` label

Also remove trailing punctuation from the list items.

Thanks to https://github.com/jenkins-infra/jenkins.io/pull/5540#issuecomment-1266007580 for realizing that the `docker` label was only used by the scripted Pipeline variants in the tutorial and that it is not needed there any more than it is needed for the declarative variants.
