### PR TITLE
update plugin build step

### DIFF
--- a/content/doc/developer/publishing/continuous-integration.adoc
+++ b/content/doc/developer/publishing/continuous-integration.adoc
@@ -7,9 +7,13 @@ The Jenkins project runs its own Jenkins instance for CI builds on link:https://
 It will build all plugin repositories in the `jenkinsci` organization that have a `Jenkinsfile` in the root of the repository.
 
 The typical plugin build (Maven or Gradle) can be run by just having the following statement in the `Jenkinsfile`:
-
 ----
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin()
+----
+
+Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use:
+----
+buildPluginWithGradle()
 ----
 
 To learn more about the Pipeline library providing this functionality, see https://github.com/jenkins-infra/pipeline-library[its GitHub repository].


### PR DESCRIPTION
- Remove `configurations: buildPlugin.recommendedConfigurations()`, because it was deprecated.  see: https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy#L336 .
- Add build step for Gradle. see: https://github.com/jenkins-infra/pipeline-library#buildplugin .