### PR TITLE
Update documentation on themes

### DIFF
--- a/content/doc/book/managing/ui-themes.adoc
+++ b/content/doc/book/managing/ui-themes.adoc
@@ -16,12 +16,11 @@ endif::[]
 
 It is possible to customize Jenkins' appearance with custom themes.
 This feature is not a part of the Jenkins core, but it is supported through plugins.
-These are the most popular plugins:
 
-* plugin:simple-theme-plugin[Simple Theme Plugin] -
-  allows customizing the Jenkins UI by providing custom CSS and Javascript files.
-  It also supports replacing the Favicon.
-  There are many link:https://github.com/jenkinsci/simple-theme-plugin#themes[themes] created by Jenkins users.
+== Using built-in themes
+
+There are several plugins that provide built-in themes, the most popular are
+
 * plugin:dark-theme[Dark Theme Plugin] -
   provides a dark theme for Jenkins.
   Supports configuration as code to select the theme configuration.
@@ -29,21 +28,29 @@ These are the most popular plugins:
   port of Afonso F's link:http://afonsof.com/jenkins-material-theme/[Jenkins material theme] to use Theme Manager.
 * plugin:solarized-theme[Solarized Theme Plugin] -
   provides Solarized (light and dark) themes.
-* plugin:login-theme[Login Theme Plugin] -
-  allows modifying or replacing the Jenkins login screen.
-  It is required to customize login screens starting from Jenkins 2.128 (link:/blog/2018/06/27/new-login-page/[announcement]).
 
-## Using themes
+Installing any of these will also install their common dependency: the plugin:theme-manager[Theme Manager Plugin].
+This plugin allows administrators to set the default theme for a Jenkins installation via _Manage Jenkins > Configure System > Buit-in Themes_
+and users can set their preferred theme in their personal settings.
+You can also configure this plugin using plugin:configuration-as-code[Configuration-as-Code Plugin].
+See the plugin documentation for more details.
 
-// TODO: Add configuration examples and screenshots one documentation is added to plugins
+== Using custom themes
 
-To configure a theme, you need to first install a theme management plugin and then configure it.
-Both plugins can be managed in the Jenkins Web UI or by the plugin:configuration-as-code[Configuration-as-Code Plugin].
-See the plugin documentation for the detailed usage guidelines.
+To be able to fully customize Jenkins appearance you can install the plugin:simple-theme-plugin[Simple Theme Plugin].
+It allows customizing the Jenkins UI by providing custom CSS and Javascript files.
+It also supports replacing the Favicon.
 
-Example for the link:https://tobix.github.io/jenkins-neo2-theme/[Jenkins Neo2] theme:
+To configure a theme, you can go to _Manage Jenkins > Configure System > Theme_ and enter the URL of your stylesheet and/or Javascript file.
+You can also configure this plugin using plugin:configuration-as-code[Configuration-as-Code Plugin].
+See the plugin documentation for the detailed usage guidelines and links to sample themes.
 
-image::managing/simple-theme-plugin-neo2.png["Jenkins Neo2 Theme", role=center]
+=== Customizing the login screen
+
+Since Jenkins 2.128 themes configured using Simple Theme Plugin do not allow you to customize the login screen
+(link:/blog/2018/06/27/new-login-page/[announcement]).
+To customize the login screen you can install the plugin:login-theme[Login Theme Plugin].
+
 
 == Themes support policy
 
@@ -60,7 +67,6 @@ but minor changes may not be included there.
 
 There is an ongoing effort focused on improving Jenkins look-and-feel, accessibility, and user experience.
 This area is mission-critical to the project.
-Currently, the Jenkins user interface (UI) is widely considered dated, and we want to change this perception.
 There are multiple initiatives in the link:/project/roadmap/[Jenkins Roadmap] being coordinated by the link:/sigs/ux/[Jenkins User Experience SIG].
 
 Major UI changes imply incompatible changes in layouts and the CSS structure which is critical for theme plugins.
@@ -70,10 +76,8 @@ Later, once the Jenkins UI rework reaches its destination and the UI becomes mor
 
 == Reporting and fixing issues
 
-Users are welcome to report discovered compatibility issues to theme maintainers,
+For built-in themes users are welcome to report discovered compatibility issues to theme maintainers,
 and to submit patches there.
-It is possible to just fix a theme locally,
-but other theme users would appreciate compatibility fixes in upstream repositories.
 
 We will generally reject bug reports to the Jenkins core/plugins involving broken UI elements with a custom theme.
 We will consider pull requests which restore compatibility and do not block further Web UI evolvement.

--- a/content/doc/book/managing/ui-themes.adoc
+++ b/content/doc/book/managing/ui-themes.adoc
@@ -76,7 +76,7 @@ Later, once the Jenkins UI rework reaches its destination and the UI becomes mor
 
 == Reporting and fixing issues
 
-For built-in themes users are welcome to report discovered compatibility issues to theme maintainers,
+For built-in themes, users are welcome to report discovered compatibility issues to theme maintainers,
 and to submit patches there.
 
 We will generally reject bug reports to the Jenkins core/plugins involving broken UI elements with a custom theme.


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/jenkins.io/issues/4678

I think it makes little sense to list all theme-related plugins by popularity. Since all themes referenced by Simple Theme plugin were either converted to plugins or abandoned, the roles of Simple Theme and Theme Manager became quite independent: one allows people to create their own theme, the other lets them use community-maintained themes, so each of them deserves their own section. 

CC @timja 