### PR TITLE
add explanations for `403 Forbidden`

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -296,6 +296,16 @@ This normally means that the secrets configured in the repository have expired, 
 
 Alternatively you can temporarily update the secrets yourself with your own personal credentials.
 
+=== The upload to the Maven repository fails with "403 Forbidden"
+
+The two most common explanations for this error:
+
+* You don't have permission to upload to the specified path.
+  link:../requesting-hosting/#request-upload-permissions[Learn more about how to request upload permissions].
+  Check that the path you're allowed to upload to matches the actual upload attempt (i.e. no typos).
+* The specified release already exists and you try to overwrite it.
+  We do not allow replacing existing releases.
+
 === Further troubleshooting help
 
 If none of the provided solutions help, send an email to the link:/mailing-lists[Jenkins developers mailing list] and explain what you did, and how it failed.

--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -298,7 +298,7 @@ Alternatively you can temporarily update the secrets yourself with your own pers
 
 === The upload to the Maven repository fails with "403 Forbidden"
 
-The two most common explanations for this error:
+The two most common explanations for this error are:
 
 * You don't have permission to upload to the specified path.
   link:../requesting-hosting/#request-upload-permissions[Learn more about how to request upload permissions].


### PR DESCRIPTION
I have found some issues about `403 Forbidden` on `helpdesk/issues` and `repository-permissions-updater/issues`.
such as:
- https://github.com/jenkins-infra/helpdesk/issues/3076
- https://github.com/jenkins-infra/helpdesk/issues/3069
- https://github.com/jenkins-infra/repository-permissions-updater/issues/2592

So I think this PR is valuable.
And the content from https://github.com/jenkins-infra/jenkins.io/blob/master/content/doc/developer/publishing/releasing-manually.adoc.