### PR TITLE
Add CDF info to press page

### DIFF
--- a/content/press.adoc
+++ b/content/press.adoc
@@ -88,6 +88,7 @@ image::/images/sponsors/cdf-logo-color-knockout.png[alt="CDF Logo", float=right,
 The link:https://cd.foundation[Continuous Delivery Foundation (CDF)] serves as the vendor-neutral home of many of the fastest-growing projects for continuous integration/continuous delivery (CI/CD).
 It fosters vendor-neutral collaboration between the industry’s top developers, end users and vendors to further CI/CD best practices and industry specifications.
 Its mission is to grow and sustain projects that are part of the broad and growing continuous delivery ecosystem.
+
 == Press Contacts
 
 The following individuals can be reached out to for comment, clarification


### PR DESCRIPTION
Jenkins Press information on https://jenkins.io/press/ is missing a summary about Continuous Delivery Foundation. 
It is updated with CDF's logo and summary.

This will resolve the issue #2933