### PR TITLE
Update to chat page channels

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -6,6 +6,10 @@ title: Chat
 The Jenkins project meets to discuss various topics on Gitter and IRC.
 In addition to the general purpose rooms and channels listed below, link:../sigs/[special interest groups] and link:/projects[sub-projects] have their own spaces, and you will see chat rooms linked from their pages.
 
+For the `#jenkins-infra` and `#jenkins-release` rooms, the IRC, Matrix, and Gitter channels have been connected.
+This means you can use your preferred chat client to keep up to date with Jenkins and not miss anything!
+Other channels will be connected similarly as we move forward.
+
 == Gitter
 
 The Jenkins community discusses various topics in multiple rooms on https://gitter.im/jenkinsci/home[Gitter].


### PR DESCRIPTION
Adding in a small section to inform users that the IRC, Matrix, and Gitter channels for Infra & Release are now interconnected