### PR TITLE
Jumbotron overlay should not steal mouse events

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1500,6 +1500,7 @@ table.syntax > tbody > tr > th {
   inset: 0;
   background: currentColor;
   opacity: 0.05;
+  pointer-events: none;
 }
 
 .author-list {


### PR DESCRIPTION
Fixes #5555

@janfaracik alternatively we can just remove the Jumbotron overlay (`.jumbotron:before`)-- why did you introduce it in #5415?