### PR TITLE
Recognize 'hacktoberfest-accepted' label

### DIFF
--- a/content/events/hacktoberfest/faq.adoc
+++ b/content/events/hacktoberfest/faq.adoc
@@ -123,9 +123,10 @@ You need to be a member of a respective GitHub organization to send such request
 
 Unfortunately there is no way to get organization-wide metrics for Hacktoberfest,
 because the event organizers do not share info about registered users.
-This is why we recommend to mark pull request with `hacktoberfest` label or "Hacktoberfest" in the title.
+This is why we recommend to mark pull requests with `hacktoberfest`, `hacktoberfest-accepted` label or "Hacktoberfest" in the title.
 Some queries which can help to get insights:
 
+*link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Apr+created%3A%3E2022-09-29+label%3Ahacktoberfest-accepted&type=Issues[Hacktoberfest 2022 pull requests with the "hacktoberfest-accepted" label]
 * link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Apr+created%3A%3E2022-09-29+label%3Ahacktoberfest&type=Issues[Hacktoberfest 2022 pull requests with the "hacktoberfest" label]
 * link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+is%3Apr+created%3A%3E2022-09-29+-label%3Ahacktoberfest+hacktoberfest&type=Issues[Hacktoberfest 2022 pull requests with the "hacktoberfest" text which have not been labeled yet]
 


### PR DESCRIPTION
The `hacktoberfest-accepted` label may also be used to label already accepted PRs, before they are approved by a maintainer and merged at a later point.