### PR TITLE
Remove ppc64le from roadmap and example platforms

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -468,12 +468,6 @@ categories:
       link: https://issues.jenkins.io/browse/JENKINS-61773
       labels:
       - feature
-    - name: Docker images for PowerPC 64
-      status: current
-      description: Docker image support for IBM PowerPC 64 running Java 8 and Java 11
-      link: https://issues.jenkins.io/browse/JENKINS-61774
-      labels:
-      - feature
     - name: Docker images for ARM 64
       status: released
       description: Docker image support for ARM 64 running Java 8 and Java 11

--- a/content/doc/administration/requirements/linux.adoc
+++ b/content/doc/administration/requirements/linux.adoc
@@ -35,8 +35,8 @@ a|
   * 64-bit (amd64) Linux versions that use the Debian packaging format as link:https://ci.jenkins.io/job/Packaging/job/packaging/job/master/[tested on ci.jenkins.io]
   * 64-bit (amd64) Linux versions that use the Red Hat rpm packaging format as link:https://ci.jenkins.io/job/Packaging/job/packaging/job/master/[tested on ci.jenkins.io]
   * 64-bit (amd64) Linux versions that use the OpenSUSE rpm packaging format as link:https://ci.jenkins.io/job/Packaging/job/packaging/job/master/[tested on ci.jenkins.io]
-  * 64-bit (arm64, s390x, ppc64le) Linux versions that use the Debian packaging format as link:https://ci.jenkins.io/job/Infra/job/acceptance-tests/[tested on ci.jenkins.io]
-  * 64-bit (arm64, s390x, ppc64le) Linux versions that use the rpm packaging format as link:https://ci.jenkins.io/job/Infra/job/acceptance-tests/[tested on ci.jenkins.io]
+  * 64-bit (arm64, s390x) Linux versions that use the Debian packaging format as link:https://ci.jenkins.io/job/Infra/job/acceptance-tests/[tested on ci.jenkins.io]
+  * 64-bit (arm64, s390x) Linux versions that use the rpm packaging format as link:https://ci.jenkins.io/job/Infra/job/acceptance-tests/[tested on ci.jenkins.io]
   * Linux container images (amd64, arm64, s390x) as published for the link:https://hub.docker.com/r/jenkins/jenkins[controller] and various agents
 
 | **Level 2** - Patches considered


### PR DESCRIPTION
## Remove ppc64le from roadmap and platform support

IBM no longer provides the ppc64le agents that we used for verification testing.  Without those agents, we cannot reasonably claim to support ppc64le.
