### PR TITLE
Extend description of global vars in pipeline

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -491,7 +491,7 @@ Use a static class or instantiate a local variable of a class instead.
 ====
 
 Though using fields for global variables is discouraged as per above, it is possible to define fields and use them as read-only.
-To define a feield you need to use an annotatation:
+To define a field you need to use an annotation:
 [source,groovy]
 ----
 @groovy.transform.Field

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -448,15 +448,6 @@ log.info 'Starting'
 log.warning 'Nothing to do!'
 ----
 
-Note that if you wish to use a field in your global for some state, annotate it as such:
-[source,groovy]
-----
-@groovy.transform.Field
-def yourField = [:]
-
-def yourFunction....
-----
-
 Declarative Pipeline does not allow method calls on objects outside "script" blocks.
 (link:https://issues.jenkins.io/browse/JENKINS-42360[JENKINS-42360]).
 The method calls above would need to be put inside a `script` directive:
@@ -494,9 +485,20 @@ as part of a successful Pipeline run.
 .Avoid preserving state in global variables
 [WARNING]
 ====
-Avoid defining global variables with methods that interact or preserve state.
+All global variables defined in a Shared Library should be stateless, i.e. they should act as collections of functions.
+If your pipeline tried to store some state in gobal variables, this state would be lost in case of Jenkins controller restart.
 Use a static class or instantiate a local variable of a class instead.
 ====
+
+Though using fields for global variables is discouraged as per above, it is possible to define fields and use them as read-only.
+To define a feield you need to use an annotatation:
+[source,groovy]
+----
+@groovy.transform.Field
+def yourField = "YourConstantValue"
+
+def yourFunction....
+----
 
 === Defining custom steps
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -486,7 +486,7 @@ as part of a successful Pipeline run.
 [WARNING]
 ====
 All global variables defined in a Shared Library should be stateless, i.e. they should act as collections of functions.
-If your pipeline tried to store some state in gobal variables, this state would be lost in case of Jenkins controller restart.
+If your pipeline tried to store some state in global variables, this state would be lost in case of Jenkins controller restart.
 Use a static class or instantiate a local variable of a class instead.
 ====
 


### PR DESCRIPTION
Fixes #4772 -- also there was information about fields that contradicts the stateless restriction that we impose later.

@jglick I hope this makes sense (?) Thanks for your input in the issue comments.