### PR TITLE
Removed broken link to community tracks

### DIFF
--- a/content/blog/2016/2016-08-10-rails-cd-with-pipeline.adoc
+++ b/content/blog/2016/2016-08-10-rails-cd-with-pipeline.adoc
@@ -69,7 +69,7 @@ ____
 
 I chose this Rails app, not only because it's a sizable application with lots
 of tests, but it's actually the application we used to collect talk proposals
-for the "link:https://www.cloudbees.com/juc/agenda[Community Tracks]" at this
+for the "Community Tracks" at this
 year's link:https://jenkinsworld.com[Jenkins World]. For the most part,
 cfp-app is a standard Rails application. It uses
 link:https://www.postgresql.org/[PostgreSQL] for its database,


### PR DESCRIPTION
The same article on https://www.cloudbees.com/blog/continuous-security-rails-apps-pipeline-and-brakeman has had the link removed. There are no appropriate links to replace this link with (other than https://www.cloudbees.com/newsroom/steve-wozniak-2021-devops-world-keynote which I think is largely irrelevant)