### PR TITLE
Update Hacktoberfest event page

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -16,8 +16,8 @@ opengraph:
 
 image:/images/hacktoberfest/hacktoberfest_2022.svg[Hacktoberfest, role=center]
 
-NOTE: Hacktoberfest 2022 is coming soon! We are going to participate as the Jenkins community,
-and we are looking for contributors and maintainers who want to join us in October!
+NOTE: Hacktoberfest 2022 is here! We are participating as the Jenkins community,
+and we are looking for contributors and maintainers who want to join us!
 See link:https://community.jenkins.io/t/hacktoberfest-2022/3805[this conversation] for more information and Q&A.
 
 link:https://hacktoberfest.com/[Hacktoberfest]
@@ -39,7 +39,7 @@ See the link:/participate/[Contribute and Participate] page for more information
 
 == Quick start
 
-1. Sign-up to Hacktoberfest on link:https://hacktoberfest.digitalocean.com[the event website].
+1. Sign-up to Hacktoberfest on link:https://hacktoberfest.com[the event website].
 2. Join link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter channel].
 3. Everything is set, just start creating pull-requests!
 ** If a repository has no `hacktoberfest` topic set, contact the maintainers to see if they are willing to accecpt a contribution.


### PR DESCRIPTION
The header `NOTE:` currently is in the future-tense, but since Hacktoberfest has started, it makes more sense for it to be in the present-tense. 

I also updated the sign-up URL to the new one used this year. It formerly was a digitalocean subdomain, but has its own domain.