### PR TITLE
Remove dashes from changelog entries of 2.373

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -17867,7 +17867,7 @@
           - basil
         pr_title: Improve log record icon
         message: |-
-          - Use a more appropriate icon for log records.
+          Use a more appropriate icon for log records.
 
       - type: rfe
         category: rfe
@@ -17876,7 +17876,7 @@
           - basil
         pr_title: Improve `OldDataMonitor` icon
         message: |-
-          - Use a more appropriate Manage Old Data icon.
+          Use a more appropriate Manage Old Data icon.
           
       - type: bug
         category: regression
@@ -17900,8 +17900,8 @@
          - url: https://github.com/jenkinsci/winstone/pull/287
            title: Remove unused JSP options
         message: |-
-          - Deprecate the <code>--extraLibFolder</code> option for removal on or after January 1, 2023.
-          - Remove the <code>--toolsJar</code> and <code>--useJasper</code> options.
+          Deprecate the <code>--extraLibFolder</code> option for removal on or after January 1, 2023.
+          Remove the <code>--toolsJar</code> and <code>--useJasper</code> options.
 
   # pull: 7192 (PR title: Use enhanced `InboundAgentRule`)
   # pull: 7210 (PR title: Consolidate node provisioning tests)


### PR DESCRIPTION
The change proposed removes the dashes from the recent weekly changelog. No idea where they are coming from, but they don't match the past design scheme.

**Current**:

![Screenshot 2022-10-11 at 17 45 28](https://user-images.githubusercontent.com/13383509/195140939-17bdb143-5440-4104-a3c5-47e224dbc935.png)

**Proposed change**:

![Screenshot 2022-10-11 at 17 54 32](https://user-images.githubusercontent.com/13383509/195140918-da201c26-3b5f-4653-9b12-f8df33baa0f5.png)
