### PR TITLE
Add `semicolons-in-urls` redirect for SECURITY-1774 in Jenkins 2.222.1

### DIFF
--- a/content/redirect/semicolons-in-urls.adoc
+++ b/content/redirect/semicolons-in-urls.adoc
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_url: /doc/upgrade-guide/2.204/#changes-to-csrf-protection
+# https://github.com/jenkinsci/jenkins/blob/44e96a82b9df68c82033e6b8966b88dfbb1997c0/core/src/main/java/jenkins/security/SuspiciousRequestFilter.java#L35
+---


### PR DESCRIPTION
Oversight when preparing https://github.com/jenkins-infra/jenkins.io/commit/bdc8944b41911c1470c207ce0cf001c07434e2a2