### PR TITLE
Add anchor for ip address step in AWS tutorial

### DIFF
--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -84,7 +84,7 @@ For this tutorial, you will create a security group and add the following rules:
 
 To create and configure your security group:
 
-. Decide who may access your instance.
+. [[step1-security-group]]Decide who may access your instance.
 For example, a single computer or all trusted computers on a network.
 For this tutorial, you can use the public IP address of your computer.
 * To find your IP address, use the
@@ -108,7 +108,7 @@ image::tutorials/AWS/create_security_group.png[Amazon security group creation sc
 . Select your VPC from the list. You can use the default VPC.
 . On the **Inbound tab**, add the rules as follows:
 .. Select *Add Rule*, and then select *SSH* from the Type list.
-.. Under *Source*, select *Custom*, and in the text box, enter <<Decide who may access your instance,the IP address from step 1>>, followed by /32 indicating a single IP Address.
+.. Under *Source*, select *Custom*, and in the text box, enter <<step1-security-group,the IP address from step 1>>, followed by /32 indicating a single IP Address.
 For example, 104.34.241.123/32 is a single IP address, while 198.51.100.2/24 results in a range of 256 IP addresses.
 .. Select *Add Rule*, and then select *HTTP* from the Type list.
 .. Select *Add Rule*, and then select *Custom TCP Rule* from the


### PR DESCRIPTION
addendum to https://github.com/jenkins-infra/jenkins.io/pull/5574

added anchor so step 4 could refer back to 1 in the "security group" section