### PR TITLE
chore: Use a modern baseline for CD sample

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -136,7 +136,7 @@ For a regular component whose version number is not that meaningful, let the ver
 -        <revision>1.23</revision>
 -        <changelist>-SNAPSHOT</changelist>
 +        <changelist>999999-SNAPSHOT</changelist>
-         <jenkins.version>2.176.4</jenkins.version>
+         <jenkins.version>2.346.3</jenkins.version>
      </properties>
 ----
 +
@@ -179,7 +179,7 @@ If you do not want to have large major version numbers, like with fully automate
 -    <changelist>-SNAPSHOT</changelist>
 +    <revision>1</revision>
 +    <changelist>999999-SNAPSHOT</changelist>
-     <jenkins.version>2.176.4</jenkins.version>
+     <jenkins.version>2.346.3</jenkins.version>
 ----
 +
 Here the version numbers will look like `1.321.vabcdef456789` or `1.999999-SNAPSHOT`, respectively.
@@ -213,7 +213,7 @@ Similar to the previous option, for a component whose version number ought to re
 -    <changelist>-SNAPSHOT</changelist>
 +    <revision>4.0.0</revision>
 +    <changelist>999999-SNAPSHOT</changelist>
-     <jenkins.version>2.176.4</jenkins.version>
+     <jenkins.version>2.346.3</jenkins.version>
 ----
 +
 Here the version numbers will look like `4.0.0-123.vabcdef456789` or `4.0.0-999999-SNAPSHOT`, respectively.


### PR DESCRIPTION
Minor change, that updates the CD samples with an up-to-date baseline, rather of one, that is outdated by years and no longer supported by the update center.