### PR TITLE
Jenkins Blog: remove unnecessary text

### DIFF
--- a/content/blog/2022/10/2022-10-13-jenkins-newsletter.adoc
+++ b/content/blog/2022/10/2022-10-13-jenkins-newsletter.adoc
@@ -14,6 +14,8 @@ opengraph:
 
 == September 2022
 
+image:/images/post-images/2022-10-13-jenkins-newsletter/image1.png[image,width=289,height=175]
+
 Welcome to the Jenkins Newsletter!
 This is a compilation of progress within the project, highlighted by Jenkins Special Interest Groups (SIGs) for the month of September.
 

--- a/content/blog/2022/10/2022-10-13-jenkins-newsletter.adoc
+++ b/content/blog/2022/10/2022-10-13-jenkins-newsletter.adoc
@@ -14,8 +14,6 @@ opengraph:
 
 == September 2022
 
-image:/images/post-images/2022-10-13-jenkins-newsletter/image1.png[image,width=289,height=175] Monthly Newsletter
-
 Welcome to the Jenkins Newsletter!
 This is a compilation of progress within the project, highlighted by Jenkins Special Interest Groups (SIGs) for the month of September.
 


### PR DESCRIPTION
This is to remove the extra text after the image used in the september newsletter post