### PR TITLE
Updating "jenkins.ui.refresh" due to removal

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -2056,6 +2056,7 @@ properties:
     `true` to enable the new experimental UX on Jenkins.
     See https://issues.jenkins.io/browse/JENKINS-60920[JENKINS-60920].
     Also see link:/sigs/ux/[Jenkins UX SIG].
+    Has no effect since https://github.com/jenkinsci/jenkins/commit/51e7142d5705c10833e0959fdf2534a32b0e7d86[2.344] as the feature has been removed.
 
 - name: jenkins.util.ProgressiveRendering.DEBUG_SLEEP
   def: |


### PR DESCRIPTION
The feature was removed, so the system property description has to be updated to not confuse people trying to use it.

Related to https://github.com/jenkinsci/jenkins/pull/4463