### PR TITLE
chore(version dependency): some may need to upgrade the version too

### DIFF
--- a/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
+++ b/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
@@ -31,6 +31,8 @@ Update the minimum required Jenkins version by setting a `jenkins.version` value
 ----
 
 If the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching `artifactId` for the minimum required Jenkins version.
+The `version` may also need an upgrade see the link:https://www.jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-plugin-bom[developer documentation].
+
 The `git diff` might look like this:
 
 [source,xml]
@@ -41,7 +43,8 @@ The `git diff` might look like this:
         <groupId>io.jenkins.tools.bom</groupId>
 -        <artifactId>bom-2.319.x</artifactId>
 +        <artifactId>bom-2.346.x</artifactId>
-        <version>1607.va_c1576527071</version>
+-        <version> OLDER_VERSION_NUMBER </version>
++        <version>1607.va_c1576527071</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
as per https://www.jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-plugin-bom the <version> tag need to get upgrade too.