### PR TITLE
[WEBSITE-751] Issue #3335 Groovy Remote Control

### DIFF
--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -473,7 +473,7 @@ checks some conditions and changes accordingly the build result, puts badges
 next to the build in the build history and/or displays information on the build
 summary page.
 
-- https://plugins.jenkins.io/groovy-remote-control[Groovy Remote Control
+- https://plugins.jenkins.io/groovy-remote[Groovy Remote Control
 Plugin] — This plugin provides
 http://groovy.codehaus.org/modules/remote/[Groovy Remote Control]'s receiver,
 and allows to control external application from Jenkins.


### PR DESCRIPTION
Fixing a link to Groovy Remote Control Plugin page.

https://www.jenkins.io - Broken Links #3335