### PR TITLE
Fixed broken extension link

### DIFF
--- a/content/doc/developer/extensibility/index.adoc
+++ b/content/doc/developer/extensibility/index.adoc
@@ -31,7 +31,7 @@ Extensibility in Jenkins is accomplished by combining the concepts discussed bel
 
 == Extension annotation
 
-https://javadoc.jenkins.io/hudson/Extension.html[Extension] is an annotation that allows Jenkins to discover classes, instantiate them, and register them in global lists of implementations of their supertypes and interfaces.
+link:https://javadoc.jenkins.io/hudson/Extension.html[Extension] is an annotation that allows Jenkins to discover classes, display them, and register them in global lists of implementations of their supertypes and interfaces.
 This works for implementations both directly in core, and contributed by plugins, so that plugins can provide implementations of extension points defined in core (or other plugins).
 Whenever Jenkins needs to provide a list, e.g. of security realm implementations (LDAP, Jenkins user database, etc.) it can query for all subtypes of `SecurityRealm` that are annotated with `@Extension`.
 // link:TODO[Learn more about `@Extension`].

--- a/content/doc/developer/extensibility/index.adoc
+++ b/content/doc/developer/extensibility/index.adoc
@@ -31,7 +31,7 @@ Extensibility in Jenkins is accomplished by combining the concepts discussed bel
 
 == Extension annotation
 
-link:https://javadoc.jenkins.io/hudson/Extension.html[Extension] is an annotation that allows Jenkins to discover classes, display them, and register them in global lists of implementations of their supertypes and interfaces.
+link:https://javadoc.jenkins.io/hudson/Extension.html[Extension] is an annotation that allows Jenkins to discover classes, instantiate them, and register them in global lists of implementations of their supertypes and interfaces.
 This works for implementations both directly in core, and contributed by plugins, so that plugins can provide implementations of extension points defined in core (or other plugins).
 Whenever Jenkins needs to provide a list, e.g. of security realm implementations (LDAP, Jenkins user database, etc.) it can query for all subtypes of `SecurityRealm` that are annotated with `@Extension`.
 // link:TODO[Learn more about `@Extension`].

--- a/content/doc/developer/extensibility/index.adoc
+++ b/content/doc/developer/extensibility/index.adoc
@@ -31,7 +31,7 @@ Extensibility in Jenkins is accomplished by combining the concepts discussed bel
 
 == Extension annotation
 
-`jenkinsdoc:Extension[]` is an annotation that allows Jenkins to discover classes, instantiate them, and register them in global lists of implementations of their supertypes and interfaces.
+https://javadoc.jenkins.io/hudson/Extension.html[Extension] is an annotation that allows Jenkins to discover classes, instantiate them, and register them in global lists of implementations of their supertypes and interfaces.
 This works for implementations both directly in core, and contributed by plugins, so that plugins can provide implementations of extension points defined in core (or other plugins).
 Whenever Jenkins needs to provide a list, e.g. of security realm implementations (LDAP, Jenkins user database, etc.) it can query for all subtypes of `SecurityRealm` that are annotated with `@Extension`.
 // link:TODO[Learn more about `@Extension`].


### PR DESCRIPTION
Extension link now goes to https://javadoc.jenkins.io/hudson/Extension.html