### PR TITLE
DevOps World 2022: update registration link for virtual edition

### DIFF
--- a/content/events/devops-world/index.adoc
+++ b/content/events/devops-world/index.adoc
@@ -26,7 +26,7 @@ Join us in person in Orlando, Florida where ideas and experiences from a wide ra
 
 == Registration
 
-image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome", role=center, height=48]
+image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://www.techstrongevents.com/devops-world-2022/begin-registration", role=center, height=48]
 
 == Discussion channels
 


### PR DESCRIPTION
The previous register link was still pointing to the original (no longer applicable) DevOps world page, so this has been updated to coincide with the virtual event.