### PR TITLE
Jenkins Events: update DevOps World URL

### DIFF
--- a/content/events/devops-world/index.adoc
+++ b/content/events/devops-world/index.adoc
@@ -26,7 +26,7 @@ Join us in person in Orlando, Florida where ideas and experiences from a wide ra
 
 == Registration
 
-image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://reg.devopsworld.com/flow/cloudbees/devopsworld22/Landing/page/welcome", role=center, height=48]
+image:/images/post-images/jenkins-is-the-way/register-button.png[link="http://www.devopsworld.com/", role=center, height=48]
 
 == Discussion channels
 


### PR DESCRIPTION
updating URL again, as basic DevOps World link (http://www.devopsworld.com/) leads to the ideal landing page