### PR TITLE
Correct CoC link

### DIFF
--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -144,7 +144,7 @@ Board] page).
 
 If the desired resolution cannot be reached on the Jenkins community level,
 an issue can be escalated to the Continuous Delivery Foundation (CDF) by contacting the project team at `conduct@cd.foundation`.
-See the link:https://github.com/cdfoundation/toc/blob/master/CODE_OF_CONDUCT.md[CDF Code of Conduct] for more information about reporting and enforcement in this case.
+See the link:https://github.com/cdfoundation/.github/blob/main/CODE_OF_CONDUCT.md[CDF Code of Conduct] for more information about reporting and enforcement in this case.
 
 == Handling of violations
 


### PR DESCRIPTION
The previous link was broken, leading to a 404 in GitHub

💡 Could be interesting to have some dead links detection tooling