### PR TITLE
Jenkins - Adding 2.375 changelog manually

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -18134,7 +18134,7 @@
           - dependabot[bot]
         pr_title: Upgrade Spring Security from 5.7.3 to 5.7.4
         references:
-          - url:https://github.com/spring-projects/spring-security/releases/tag/5.7.4
+          - url: https://github.com/spring-projects/spring-security/releases/tag/5.7.4
             title: Spring Security Release 5.7.4
         message: |-
           Upgrade Spring Security from 5.7.3 to 5.7.4. 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -17990,6 +17990,174 @@
   # pull: 7263 (PR title: Update dependency node to v16.18.0)
   # pull: 7264 (PR title: Address `set-output` deprecation)
 
+  - version: '2.375'
+    date: 2022-10-25
+    changes:
+
+      - &1
+      - type: major rfe
+        category: major rfe
+        pull: 6912
+        authors:
+          - janfaracik
+          - timja
+          - basil
+        pr_title: Improve breadcrumb bar accessibility
+        message: |-
+          Improve breadcrumb bar accessibility.
+      - &2
+      - type: major rfe
+        category: major rfe
+        pull: 7049
+        authors:
+          - janfaracik
+          - timja
+          - NotMyFault
+        pr_title: Update the design of notifications
+        message: |-
+          Update the design of notifications.
+      - &3
+      - type: major rfe
+        category: major rfe
+        pull: 7208
+        issue: 65124
+        authors:
+          - janfaracik
+          - timja
+        pr_title: "[JENKINS-65124] Update weather icons"
+        message: |-
+          Update the weather and status icons.
+      - *1
+      - *2
+      - *3
+      - type: rfe
+        category: rfe
+        pull: 7281
+        authors:
+          - jglick
+        pr_title: Do not print at `INFO` every time `AsyncPeriodicWork` starts/stops
+        message: |-
+          Suppress log messages from periodically running background tasks, such as "Periodic background build discarder".
+      - type: rfe
+        category: rfe
+        pull: 7197
+        authors:
+          - janfaracik
+        pr_title: Update design of Manage Users page
+        message: |-
+          Update design of Manage Users page.
+      - type: bug
+        category: regression
+        pull: 7286
+        references:
+        - issue: 69904
+        - pull: 7091
+        authors:
+          - dwnusbaum
+        pr_title: "[JENKINS-69904] _safeRestart.jelly must not use parentheses in localizable messages"
+        message: |-
+          Prevent exception from being thrown when attempting to initiate a safe restart. (regression in 2.374)
+      - type: rfe
+        category: bug
+        pull: 7277
+        references:
+         - issue: 69509
+         - url: https://github.com/jenkinsci/winstone/pull/296
+           title: Align HTTP keep-alive with Jetty default
+        authors:
+          - basil
+        pr_title: Align HTTP keep-alive timeout with Jetty default
+        message: |-
+          Align the default value of the HTTP keep-alive timeout in Winstone with that of the upstream Jetty project by changing it from 5 seconds to 30 seconds.
+          Remove unused <code>--ajp13Port</code>, <code>--ajp13ListenAddress</code>, <code>--handlerCountMax</code>, and <code>--handlerCountMaxIdle</code> options.
+      - type: bug
+        category: bug
+        pull: 7155
+        issue: 69689
+        authors:
+          - ridemountainpig
+          - NotMyFault
+          - timja
+        pr_title:  "[JENKINS-69689] Table columns shadow is overlapping with other button shadow"
+        message: |-
+          Table column header highlight is overlapping with other header highlight.
+      - type: bug
+        category: bug
+        pull: 7140
+        issue: 69637
+        authors:
+          - loganmzz
+          - basil
+        pr_title: "[JENKINS-69637] Fix ClassCastException when param list is empty"
+        message: |-
+          Fix ClassCastException when trying to build a Job whose parameter list is empty.
+      - type: bug
+        category: bug
+        pull: 7270
+        authors:
+          - basil
+        pr_title: Unable to serialize `AtomicBoolean` on Java 17
+        references:
+        - url: https://github.com/jenkinsci/docker-plugin/issues/905
+          title: Unable to serialize AtomicBoolean on Java 17
+        message: |-
+          Allow serialization of atomic boolean data types on Java 17.
+      - type: rfe
+        category: developer
+        pull: 7275
+        authors:
+          - daniel-beck
+          - timja
+        pr_title: Update bundled script-security and workflow-support plugins
+        references:
+          - url: https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2824%20(1)
+            title: 2022-10-19 Security Advisory
+          - url: https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2881
+            title: 2022-10-19 Security Advisory
+        message: |-
+          Update bundled Script Security Plugin from 1172.v35f6a_0b_8207e to 1189.vb_a_b_7c8fd5fde.
+          Update bundled Pipeline: API Plugin from 1144.v61c3180fa_03f to 1164.v760c223ddb_32.
+          Update bundled Pipeline: Supporting APIs Plugin from 813.vb_d7c3d2984a_0 to 839.v35e2736cfd5c.
+          Update bundled SCM API Plugin from 602.v6a_81757a_31d2 to 608.vfa_f971c5a_a_e9.
+      - type: rfe
+        category: developer
+        pull: 7282
+        authors:
+          - dependabot[bot]
+        pr_title: Bump remoting from 3063.v26e24490f041 to 3068.v09b_895d8da_14
+        message: |-
+          Developer: Improve JNLP Port Unreachable error message with host value.
+      - type: rfe
+        category: developer
+        pull: 7274
+        authors:
+          - dependabot[bot]
+        pr_title: Upgrade Spring Security from 5.7.3 to 5.7.4
+        references:
+          - url:https://github.com/spring-projects/spring-security/releases/tag/5.7.4
+            title: Spring Security Release 5.7.4
+        message: |-
+          Upgrade Spring Security from 5.7.3 to 5.7.4. 
+          Spring Security 5.7.4 includes dependency upgrades and minor fixes.
+
+  # pull: 7184 (PR title: Use a destructive button for deleting API tokens)
+  # pull: 7243 (PR title: Removed deprecated ApiTokenTestHelper)
+  # pull: 7269 (PR title: UserProperty could be null (quality warning))
+  # pull: 7271 (PR title: Small terminology update)
+  # pull: 7278 (PR title: Remove optional block scrolling)
+  # pull: 7279 (PR title: Update dependency @babel/core to v7.19.6)
+  # pull: 7279 (PR title: Update dependency @babel/core to v7.19.6)
+  # pull: 7283 (PR title: Upgrade ATH from 5450.v1cfec809d04b to 5458.v911b_2f0818ee)
+  # pull: 7289 (PR title: Use `setText` rather than `type` in `ViewDescriptorTest`)
+  # pull: 7290 (PR title: Bump script-security from 1183.v774b_0b_0a_a_451 to 1189.vb_a_b_7c8fd5fde)
+  # pull: 7291 (PR title: Loosen assertion in `NodeProvisionerTest` to account for conservative estimation in production code)
+  # pull: 7292 (PR title: Ignore `BuildKeepsRunningWhenFaultySubTasksTest`)
+  # pull: 7294 (PR title: Update dependency eslint to v8.26.0)
+  # pull: 7296 (PR title: Bump cloudbees-folder from 6.770.ve57b_a_fb_6a_67c to 6.773.vd2dcc704ee7e)
+  # pull: 7297 (PR title: Bump jenkins from 1.88 to 1.89)
+  # pull: 7298 (PR title: Bump jenkins-test-harness from 1865.vc314fb_c2fa_a_4 to 1868.v03b_7c6673e2e)
+  # pull: 7300 (PR title: Bump jenkins from 1.89 to 1.90)
+
 # DO NOT EDIT THIS FILE DIRECTLY ON GITHUB IF YOU HAVE COMMIT ACCESS
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS
 # MALFORMED FILE CONTENTS WILL BREAK THE SITE BUILD


### PR DESCRIPTION
The [auto-generated changelog](https://github.com/jenkins-infra/jenkins.io/pull/5610) had an issue, so this is manually adding the changelog. 