### PR TITLE
Jenkins - update election process page for 2022

### DIFF
--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -229,4 +229,3 @@ Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting
 === 2015-09-30
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.log.html[raw]
-

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -30,12 +30,12 @@ A board comprised fully of write-in candidates runs the risk of being overweighe
 NOTE: Jenkins 2021 Elections are over, thanks to all participants!
 Please see the link:/blog/2021/12/03/election-results[results announcement].
 
-During the 2021 elections we elected two governing board members and five officers, namely:
+During the 2021 elections, we elected two governing board members and five officers, namely:
 link:/project/team-leads/#security[Security], link:/project/team-leads/#events[Events], link:/project/team-leads/#release[Release], link:/project/team-leads/#infrastructure[Infrastructure], and link:/project/team-leads/#documentation[Documentation].
 The terms of office for these elected positions are:
 
-* Officer positions (1 year): December 03, 2021 to December 2, 2022
-* Governing board member (2 years): December 03, 2021 to December 2, 2023
+* Officer positions (one year): December 03, 2021 to December 2, 2022
+* Governing board member (two years): December 03, 2021 to December 2, 2023
 
 === References
 
@@ -67,15 +67,15 @@ Please use this link for any queries and feedback regarding the elections.
 
 == Process
 
-. The Governance Board includes 5 members
+. The Governance Board includes five members
 ** link:/blog/authors/kohsuke[Kohsuke] holds a permanent board seat until such a time he decides to resign.
-** 4 members are elected.
-If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected.
-. Election occurs every year, normally electing 2 people to the board in each year.
-. There will be a period of at least 3 weeks designated for the board to encourage the community to submit nominations.
+** Four members are elected.
+If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all five members will be elected.
+. Election occurs every year, normally electing two people to the board in each year.
+. There will be a period of at least three weeks designated for the board to encourage the community to submit nominations.
 The board will meet in private to select final candidates
 . Any company should not dominate in the board (link:/project/board-election-process/#corporate-involvement[see below])
-* The number of board members affiliated with one company must be less than 50%
+* The number of board members affiliated with one company must be less than 50%.
 * If a board member gets employed by a company and the limitation gets violated, somebody must step down and the board will follow the link:/project/board-election-process/#interim-procedures[#Interim Procedures]
 . Use the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] as the method to elect multiple people in one vote.
 
@@ -96,7 +96,7 @@ This information is published by the election committee before the voting starts
 === Voter sign-up and eligibility
 
 Any Jenkins project and/or community contributor is eligible to vote in the election if there is a contribution made before September 01 of the election year.
-Contributing does not only mean a _code contribution_, link:/participate[contributions] could be:
+Contributing does not only mean a _code contribution_, as link:/participate[contributions] could be:
 
 * Documentation udpates or creation
 * Code reviews
@@ -105,7 +105,7 @@ Contributing does not only mean a _code contribution_, link:/participate[contrib
 * Connecting with or assisting the community
 * Code testing
 
-As long as you are contributing to the Jenkins project or community,  
+As long as you are contributing to the Jenkins project or community, you are eligible to register for voting. 
 
 Voter registration is announced through the Jenkins mailing lists, blog, and social media accounts.
 Users can register to vote in the election by joining the link:https://community.jenkins.io/g/election-voter-2022[2022 election voter group].
@@ -149,7 +149,7 @@ If a board member resigns, the board is allowed to appoint an interim board memb
 == Corporate Involvement
 
 As an independent community, it is important to us that the Jenkins board does not become overly influenced by any one single corporate entity.
-More on our philosophy can be found in the link:/project/governance[Governance Document].
+You can find out more about our philosophy in the link:/project/governance[Governance Document].
 
 To handle this within the election cycle, we do not wish to limit the candidacy for employees of any given company.
 
@@ -196,7 +196,7 @@ Jenkins LDAP account is no longer required.
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.log.html[raw]
 
-* 3 Board positions are elected instead of 2 in the base document (Dean Yu's seat + 2 new seats).
+* Three Board positions are elected instead of two in the base document (Dean Yu's seat + two new seats).
 With this change, the 2020 election will have only one board member elected unless a board member steps down.
 * Continuous Delivery Foundation will supervise the election.
 * We will run the voting using The Condorcet Internet voting system instead of Single Transferable Vote.
@@ -214,7 +214,7 @@ Decisions:
 
 * Formally approve the Governance board election process.
 This page represents the process.
-* Expand the board from 3 people to 5 people;
+* Expand the board from three people to five people;
 link:/blog/authors/kohsuke[Kohsuke] holding a permanent board seat until such a time he decides to resign.
 
 Related decisions:

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -13,153 +13,127 @@ This document outlines the link:/project/governance/#governance-board[Jenkins Go
 The election process is driven by the Jenkins Governance board members who are not up for reelection (aka the _election committee_).
 More contributors might be added to the election committee if approved by the link:/project/governance-meeting/[regular governance meeting].
 
-The charter of the Jenkins board is to ensure the health of not only the software project, but of the communities of plugin developers and users. To do this effectively, members of the board must bring various perspectives to the table: what are the needs of users; of committers; of organizations, both large and small; of commercial interests. As the composition of the Jenkins board changes over time, we want to ensure that this balance of viewpoints is maintained. Current board members best understand this balance, and so are in the best position to select candidates for inclusion onto the board. A board comprised fully of write-in candidates runs the risk of being overweighed with one type of perspective over all others.
+The charter of the Jenkins board is to ensure the health of not only the software project, but of the communities of plugin developers and users.
+To do this effectively, members of the board must bring various perspectives to the table: what are the needs of users; of committers; of organizations, both large and small; of commercial interests.
+As the composition of the Jenkins board changes over time, we want to ensure that this balance of viewpoints is maintained.
+Current board members best understand this balance, and are in the best position to select candidates for inclusion onto the board.
+A board comprised fully of write-in candidates runs the risk of being overweighed with one type of perspective over all others.
 
-## Goal
+== Goal
 
 . Make sure that the board reflects "the will of project participants" instead of just being self-appointed.
 . Make sure that the board reflects the balance of different viewpoints — the needs of users; of committers; of organizations, both large and small; of commercial interests.
 . Maintain stability and avoid sudden direction changes.
 
-## 2020 Elections
+== 2021 Elections
 
-NOTE: Jenkins 2020 Elections are over, thanks to all participants!
-Please see the link:/blog/2020/12/03/election-results[results announcement].
+NOTE: Jenkins 2021 Elections are over, thanks to all participants!
+Please see the link:/blog/2021/12/03/election-results[results announcement].
 
-During the 2020 elections we elected two governing board members and five officers, namely:
+During the 2021 elections we elected two governing board members and five officers, namely:
 link:/project/team-leads/#security[Security], link:/project/team-leads/#events[Events], link:/project/team-leads/#release[Release], link:/project/team-leads/#infrastructure[Infrastructure], and link:/project/team-leads/#documentation[Documentation].
 The terms of office for these elected positions are:
 
-* Officer positions (1 year): December 03, 2020 to December 2, 2021
-* Governing board member (2 years): December 03, 2020 to December 2, 2022
+* Officer positions (1 year): December 03, 2021 to December 2, 2022
+* Governing board member (2 years): December 03, 2021 to December 2, 2023
 
-### References
+=== References
 
-* link:/blog/2020/12/03/election-results[Election results]
-* link:/blog/2020/10/28/election-candidates[Election candidates]
-* link:/blog/2020/09/24/board-elections/[Election announcement]
+* link:/blog/2021/12/03/election-results[Election results]
+* link:/blog/2021/10/25/jenkins-elections/[Voter registration]
+* link:/blog/2021/09/20/election-period-opened/[Election announcement]
 
-### Key dates
+=== Key dates
 
-* **Sep 24** - Nominations open
-* **Sep 24** - Voting sign-up begins
-* **Oct 15** - Nominations deadline
-** After the deadline, the election committee will process nominations and notify the candidates
-* **Oct 26** or later - Election candidates are published, including personal statements
-* **Nov 10** - Voting begins
-** Email is distributed to all registered voters through link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service]
-* **Nov 08** - Voting sign-up is over
+* *October 20* - Nominations open
+* *October 20* - Voting registration begins
 ** During the registration period, the election committee will monitor the sign-ups and update the list of voters.
-* **Nov 27** - Voting ends, 11PM UTC
-* **Dec 03** - Results are announced and take effect.
+* *November 10* - Nominations deadline
+** After the deadline, the election committee will process nominations and notify the candidates
+* *November 17* - Voting registration is closed
+* *November 17* - Election candidates are published, including personal statements
+* *November 17* - Voting begins
+** Email is distributed to all registered voters through link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service]
+* *December 02* - Voting ends, 11PM UTC
+* *December 07* - Results are announced.
 
-### Elections Committee
+=== Elections Committee
 
-The 2020 elections are coordinated by the Jenkins Governance Board members who are not up for re-election this year:
-link:/blog/authors/slide_o_mix/[Alex Earl],
-link:/blog/authors/uhafner/[Ullrich Hafner], and
-link:/blog/authors/oleg_nenashev/[Oleg Nenashev].
-These contributors are responsible for managing the process,
-preparing the nominee list for elections,
-forming and verifying the voter list,
-and processing/announcing the election results.
+The elections are coordinated by the Jenkins Governance Board members who are not up for re-election this year.
+These contributors are responsible for managing the process, preparing the nominee list for elections, forming and verifying the voter list, and processing/announcing the election results.
 
-You can contact the election committee via mailto:jenkins-2020-elections@googlegroups.com[jenkins-2020-elections@googlegroups.com].
-Please use this email for any queries and feedback regarding the elections.
+You can contact the election committee via link:https://community.jenkins.io/g/election-committee[Jenkins Election Committee].
+Please use this link for any queries and feedback regarding the elections.
 
-## Process
+== Process
 
 . The Governance Board includes 5 members
 ** link:/blog/authors/kohsuke[Kohsuke] holds a permanent board seat until such a time he decides to resign.
-** 4 members are elected. If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected.
-. Have election every year, normally electing 2 people in each year (that means the term is 2 years, without term limit: you can be a candidate and be re-elected indefinitely)
-. There will be a period of at least 3 weeks designated for the board to encourage the community to submit nominations. The board will meet in private to select final candidates
+** 4 members are elected.
+If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all 5 members will be elected.
+. Election occurs every year, normally electing 2 people to the board in each year.
+. There will be a period of at least 3 weeks designated for the board to encourage the community to submit nominations.
+The board will meet in private to select final candidates
 . Any company should not dominate in the board (link:/project/board-election-process/#corporate-involvement[see below])
-.. The number of board members affiliated with one company must be less than 50%
-.. If a board member gets employed by a company and the limitation gets violated, somebody must step down and the board will follow the link:/project/board-election-process/#interim-procedures[#Interim Procedures]
-. Use link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] as the algorithm to elect multiple people in one vote.
+* The number of board members affiliated with one company must be less than 50%
+* If a board member gets employed by a company and the limitation gets violated, somebody must step down and the board will follow the link:/project/board-election-process/#interim-procedures[#Interim Procedures]
+. Use the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] as the method to elect multiple people in one vote.
 
-### Nominations
+=== Nominations
 
 The opinion of members of the community at large is highly valued, and the board welcomes additional nominations beyond who we might consider.
-If you feel that a particular person is well suited to help guide Jenkins, please submit a name and the reason for your nomination to jenkinsci-board@googlegroups.com.
+If you feel that a particular person is well suited to help guide Jenkins, please submit a name and the reason for your nomination to the link:https://community.jenkins.io/g/election-committee[Jenkins Election Committee].
 
 The election committee will review all submissions and compile a final list of candidates to be voted on by the community, for the board member seats and officer roles up for election.
-The board reserves the right to omit nominations from the final ballot if they feel that a particular viewpoint is already well represented on the board,
-or if there are other reasons preventing a nominee from being effective in the target role.
+The board reserves the right to omit nominations from the final ballot if they feel that a particular viewpoint is already well represented on the board, or if there are other reasons preventing a nominee from being effective in the target role.
 In the case of rejection, a justification must be provided to the contributor who submitted the nomination.
 The decision may be escalated to the link:/project/governance-meeting/[Jenkins governance meeting] and overridden by voting there.
 
-After receiving and vetting the nominations,
-the election committee is responsible for contacting the nominees and confirming whether they want to run in the election.
-The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), and account/social media links which may help voters to get more information about them and plans if they are elected to the role.
+After receiving and vetting the nominations, the election committee is responsible for contacting the nominees and confirming whether they want to run in the election.
+The candidates should also provide their statements, list of affiliations (see <<Corporate Disclosure>>), any account/social media links which may help voters to get more information about them, and plans if they are elected to the role.
 This information is published by the election committee before the voting starts.
 
-### Voter sign-up and eligibility
+=== Voter sign-up and eligibility
 
-Any Jenkins project and/or community contributor is eligible to vote in the election
-if there is a contribution made before September 01 of the election year.
-_Contribution_ does not mean a _code contribution_,
-all contributions count:
-documentation patches,
-code reviews,
-substantial issue reports,
-issues and mailing list responses,
-social media posts,
-testing,
-etc.
-Such a contribution should be public.
+Any Jenkins project and/or community contributor is eligible to vote in the election if there is a contribution made before September 01 of the election year.
+Contributing does not only mean a _code contribution_, link:/participate[contributions] could be:
 
-Voter registration is announced through Jenkins mailing lists, blog, and social media accounts.
-Voters can register to vote in the election using one of two ways:
+* Documentation udpates or creation
+* Code reviews
+* Issue reporting
+* Translating resources
+* Connecting with or assisting the community
+* Code testing
 
-1. Fill out the Google Form referenced in the announcement.
-2. Send a registration email to the election committee contact mailing list.
+As long as you are contributing to the Jenkins project or community,  
 
-In both cases, the following information should be provided during the sign up:
+Voter registration is announced through the Jenkins mailing lists, blog, and social media accounts.
+Users can register to vote in the election by joining the link:https://community.jenkins.io/g/election-voter-2022[2022 election voter group].
 
-* **Emails** that are required to send ballots through the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
-These emails are deleted after the election and not used for any communications except the election matters.
-* **I agree with storing my email** -
-  Mandatory checkbox which gets consent for storing the email for the election process purposes.
-* **I agree with election terms** -
-  Mandatory checkbox which links this page and describes the key expectations
-  (e.g. voting only once) .
-* **Link to a contribution** -
-  Public link to a contribution that happened before Sep 01 of the election year.
-* **Jenkins account ID** (optional) -
-  User ID used to log into the Jenkins services like Jenkins Jira. 
-* **GitHub account ID** (optional) -
-  ID of the GitHub users for those who contribute through GitHub. 
-* **Contribution description** (optional) -
-  Free-form field which can be used to describe and justify the contribution(s) if the link is not enough.
-* Maybe: optional form entries selected by the election committee (e.g. election-related poll).
-* **Any feedback to the election committee** -
-  Additional entry where poll participants can provide any feedback.
+To register, you must have an account on link:https://community.jenkins.io[community.jenkins.io].
+You can use your existing Github account, or create a new account specifically for link:https://community.jenkins.io[Jenkins community discussion].
 
 Once voter registration is over, the election committee will process the form submissions and prepare a list of the registered voters.
 In the case of rejection, one of the election committee members will send a rejection email.
 
-### Voting
+=== Voting
 
 Voting happens through the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
-Once the voting starts, all voters will receive a voting notification to the emails specified in the sign-up form.
+Once the voting period begins, all voters will receive a notification to the email used for your link:https://community.jenkins.io[Jenkins community account].
 There will be separate emails for each role (board members and each officer) with more than 1 candidate.
-If you have not received an email within 24 hours from the voting starting date, please contact the Jenkins Governance Board.
-Every contributor must vote only once.
-Intentional multiple votes will be considered as a violation and serious misbehavior subject to the link:/conduct[Jenkins Code of Conduct].
+If you have not received an email within 24 hours from the voting start date, please contact the link:https://community.jenkins.io/g/election-committee[Jenkins Election Committee].
+Every contributor can vote only once, and multiple intentional votes will be considered a violation and serious misbehavior, subject to the link:/conduct[Jenkins Code of Conduct].
 
 Voters will have at least two weeks to submit their votes.
 Voting is anonymous.
 Each voter ranks a set of possible choices.
 Individual voter rankings are then combined into an anonymous overall ranking of the choices.
-See link:https://civs.cs.cornell.edu/[this page] for more information about the ranking algorithm.
+Refer to link:https://civs.cs.cornell.edu/[this page] for more information about the ranking algorithm.
 
-Once voting is over,
-the election committee will process the results, notify the elected candidates, and prepare the announcement.
-The results should be announced shortly after the elections in the Jenkins mailing lists.
+Once voting is over, the election committee will process the results, notify the elected candidates, and prepare the announcement.
+The results should be announced shortly after the elections, in the Jenkins mailing lists, blog, and social accounts.
 
-### Post-announcement
+=== Post-announcement
 
 Voting results take effect immediately after the announcement.
 Board members and former officers are responsible to organize knowledge and permission transfers for the newly elected contributors.
@@ -168,84 +142,90 @@ with an expectation that the transition concludes within one month after the res
 
 The election committee is responsible to hold a retrospective for the elections and to make the results of it public.
 
-### Interim Procedures
+== Interim Procedures
 
-. If a board member resigns, the board is allowed to appoint an interim board member to fulfill the remainder of the term, subject to approval in a link:/project/governance-meeting/[regular governance meeting].
+If a board member resigns, the board is allowed to appoint an interim board member to fulfill the remainder of the term, subject to approval in a regular link:/project/governance-meeting/[governance meeting].
 
-## Corporate Involvement
+== Corporate Involvement
 
-As an independent community, it is important to us that the Jenkins board does not become overly influenced by any one single corporate entity (more on our philosophy can be found in the link:/project/governance[Governance Document]).
+As an independent community, it is important to us that the Jenkins board does not become overly influenced by any one single corporate entity.
+More on our philosophy can be found in the link:/project/governance[Governance Document].
 
-To handle this within the election cycle, we do not wish to limit the candidacy for employees of any given company:
+To handle this within the election cycle, we do not wish to limit the candidacy for employees of any given company.
 
-* Initially, number of candidates (or permanent seats) per company is ignored and candidates are eliminated as per normal.
-* Winners are calculated. If a company is over quota, including permanent seats, we take any permanent seats from that company, and the top zero, one or two candidates from that company, depending on how many permanent seats are held by affiliates of that company, and all the other candidates that aren't affiliated with that company, dropping the third, fourth, etc... placing candidates who are affiliated with that company.
-* Then re-run the calculation with the new pool.
+* Initially, the number of candidates per company is ignored and candidates are eliminated normally.
+* Winners are calculated. 
+If a company is over quota, we take any permanent seats from that company, and the top zero, one, or two candidates from that company (depending on how many permanent seats are held by affiliates of that company) and all the other candidates that aren't affiliated with that company, dropping the lower placing candidates who are affiliated with that company.
+* The calculation is then re-run with the new pool.
 
-## Corporate Disclosure
+== Corporate Disclosure
 
-Like many things in the Jenkins community, the disclosure of corporate affiliation is based on the honor system. With major multi-national corporations, such as Amazon, which have hundreds of affiliate companies we ask that candidates also disclose/mention any pertinent subsidiary relationship (e.g. "A9, an Amazon subsidiary").
+Like many things in the Jenkins community, the disclosure of corporate affiliation is based on the honor system. 
+With major multi-national corporations, such as Amazon, which have hundreds of affiliate companies, we ask that candidates also disclose any pertinent subsidiary relationship.
 
-## Motivations
+== Motivations
 
 There are several motivations behind the above proposal:
 
 . Odd number of people prevents the tie problem
-. Given the low bar for permission to commit, we couldn't identify precise criteria to define the right to vote in board elections.  At the same time, we wanted to preserve stability by limiting voting rights to only those with some involvement in the project.
+. Given the variety of ways to contribute, we couldn't identify a singluar criteria to define the right to vote in board elections. 
+At the same time, we wanted to preserve stability by limiting voting rights to only those with some involvement in the project.
 
-## Previous elections
+== Previous elections
+
+* 2021 - link:https://www.jenkins.io/blog/2021/12/03/election-results[results], link:https://www.jenkins.io/blog/2021/09/20/election-period-opened[announcement]
+
+* 2020 -
+link:https://www.jenkins.io/blog/2020/12/03/election-results[results], link:https://www.jenkins.io/blog/2020/10/28/election-candidates[candidates], link:https://www.jenkins.io/blog/2020/09/24/board-elections[announcement]
 
 * 2019 -
-  link:/blog/2019/12/16/board-election-results/[results],
-  link:/blog/2019/09/25/board-elections/[announcement],
-  link:https://docs.google.com/document/d/1Htgjq2Gnojz6a-FE62kgjIq6AVR8ctPcARbd-m2KctQ/edit?usp=sharing[retrospective],
-  link:https://groups.google.com/forum/#!msg/jenkinsci-dev/vKi9JpxTQxY/2KgDsKUeAQAJ[dev list discussion]
+link:/blog/2019/12/16/board-election-results/[results], link:/blog/2019/09/25/board-elections/[announcement], link:https://docs.google.com/document/d/1Htgjq2Gnojz6a-FE62kgjIq6AVR8ctPcARbd-m2KctQ/edit?usp=sharing[retrospective], link:https://groups.google.com/forum/#!msg/jenkinsci-dev/vKi9JpxTQxY/2KgDsKUeAQAJ[dev list discussion]
 
-## Change History
+== Change History
 
-### 2020-09-24
+=== 2020-09-24
 
 In 2020 we made changes to address the link:https://docs.google.com/document/d/1Htgjq2Gnojz6a-FE62kgjIq6AVR8ctPcARbd-m2KctQ/edit?usp=sharing[2019 retrospective freedback].
 
 * Add officer election to the document.
 * Modify the voter eligibility definition: all contributors are eligible if they contributed before Sep 01, 2020.
-  Jenkins LDAP account is no longer required.
+Jenkins LDAP account is no longer required.
 * Document the two-stage voting process de-facto used in 2019.
 
-### 2019-09-11
+=== 2019-09-11
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2019/jenkins-meeting.2019-09-11-18.04.log.html[raw]
 
 * 3 Board positions are elected instead of 2 in the base document (Dean Yu's seat + 2 new seats).
-  With this change, the 2020 election will have only one board member elected unless a board member steps down.
-* Continuous Delivery Foundation will supervise the election
-* We will run the voting using The Condorcet Internet voting system instead of Single Transferable Vote
+With this change, the 2020 election will have only one board member elected unless a board member steps down.
+* Continuous Delivery Foundation will supervise the election.
+* We will run the voting using The Condorcet Internet voting system instead of Single Transferable Vote.
 
 Related decisions:
 
-* Introduce a new link:/project/team-leads/#documentation[Documentation officer position] (content officer from the 2015 Proposal)
-* All link:/project/team-leads/[officer positions] will be voted on in 2019 and then in 2020
+* Introduce a new link:/project/team-leads/#documentation[Documentation officer position] (content officer from the 2015 Proposal).
+* All link:/project/team-leads/[officer positions] will be voted on in 2019 and then in 2020.
 
-#### 2015-12-09
+=== 2015-12-09
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-12-09-19.01.log.html[raw]
 
 Decisions:
 
 * Formally approve the Governance board election process.
-  This page represents the process
+This page represents the process.
 * Expand the board from 3 people to 5 people;
-  link:/blog/authors/kohsuke[Kohsuke] holding a permanent board seat until such a time he decides to resign.
+link:/blog/authors/kohsuke[Kohsuke] holding a permanent board seat until such a time he decides to resign.
 
 Related decisions:
 
 * link:/conduct[Jenkins Code of Conduct] is accepted and published.
-  Jenkins Governance Board will be responsible for processing escalations and enforcing the Code of Conduct if needed.
+Jenkins Governance Board will be responsible for processing escalations and enforcing the Code of Conduct if needed.
 
-### 2015-11-11
+=== 2015-11-11
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-11-11-19.01.log.html[raw]
 
-### 2015-09-30
+=== 2015-09-30
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.log.html[raw]

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -229,3 +229,4 @@ Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting
 === 2015-09-30
 
 Minutes link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.html[summary] and link:http://meetings.jenkins-ci.org/jenkins-meeting/2015/jenkins-meeting.2015-09-30-18.00.log.html[raw]
+


### PR DESCRIPTION
The election process page was only as recent as 2020, so this needed to be updated for 2022. Once the 2022 elections are over, this page can be updated again with the corresponding links.