### PR TITLE
Jenkins - GSoC 2022 archive blog post

### DIFF
--- a/content/blog/2022/10/2022-10-31-jenkins-google-summer-of-code-archive-2022.adoc
+++ b/content/blog/2022/10/2022-10-31-jenkins-google-summer-of-code-archive-2022.adoc
@@ -1,0 +1,44 @@
+---
+layout: post
+title: "Jenkins In Google Summer of Code 2022"
+tags:
+- jenkins
+- gsoc
+- contribute
+author: alyssat
+description: "archive of GSoC 2022"
+---
+
+The Jenkins project participated in Google Summer of Code 2022.
+Congratulations to all participants and we thank all participants for their contributions.
+Now that the event is over, this page contains an archive of the 2022 specific information.
+
+== Projects
+
+All four projects have been successfully completed in 2022.
+You can find the project information on the project pages:
+
+* link:https://www.jenkins.io/projects/gsoc/2022/projects/plugin-health-scoring-system/[Plugin Health Scoring System] by link:https://www.jenkins.io/blog/authors/dheerajodha/[Dheeraj Singh Jodha]
+* link:https://www.jenkins.io/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions[Jenkinsfile Runner Action for GitHub Actions] by link:https://www.jenkins.io/blog/authors/yiminggong/[Yiming Gong]
+* link:https://www.jenkins.io/projects/gsoc/2022/projects/automatic-git-cache-maintenance[Automatic git cache maintenance on the controller] by link:https://www.jenkins.io/blog/authors/hrushikeshrao/[Hrushikesh Rao]
+* link:https://www.jenkins.io/projects/gsoc/2022/projects/pipeline-step-documentation-generator[Pipeline Step Documentation Generator Improvements] by link:https://www.jenkins.io/blog/authors/vihaanthora/[Vihaan Thora]
+
+These were proposed and selected from the list of link:https://www.jenkins.io/projects/gsoc/2022/project-ideas/[GSoC 2022 project ideas].
+
+== Demos and results
+* Recordings:
+** link:https://youtu.be/loLSNdCv6K4[Midterm project demos]
+** link:https://youtu.be/fM2SMbppRxw[Final project demos]
+* Final blog posts:
+** link:https://www.jenkins.io/blog/2022/10/10/pipeline-steps-improvement-gsoc-report/[Pipeline Steps Documentation Generator Improvements] by Vihaan Thora
+** link:https://www.jenkins.io/blog/2022/10/10/plugin-health-scoring-system-report/[Plugin Health Scoring System] by Dheeraj Singh Jodha
+** link:https://www.jenkins.io/blog/2022/09/07/jenkinsfile-runner-as-github-actions/[Jenkinsfile Runner Action for GitHub Actions] by Yiming Gong
+
+== Org admins
+GSoC Organization admins in 2022: link:https://github.com/jmMeessen[Jean-Marc Meessen], link:https://github.com/krisstern[Kris Stern], link:https://github.com/alyssat[Alyssa Tong]
+
+== Other materials
+* GSoC 2022 project ideas
+* Public communication channel: link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse].
+* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for real time topics related to Jenkins in GSoC.
+* link:https://www.jenkins.io/projects/gsoc/#previous-years[Previous years] GSoC.


### PR DESCRIPTION
Now that the 2022 edition of GSoC has ended, this blog post is to collect and archive all the projects, links, and blogs by our participants and organizers