### PR TITLE
Remove neuvector-vulnerability-scanner from suspensions list

### DIFF
--- a/content/security/plugins.adoc
+++ b/content/security/plugins.adoc
@@ -64,7 +64,6 @@ This typically is the case when plugins have particularly severe security vulner
 * Kubernetes :: Pipeline :: Kubernetes Steps (`kubernetes-pipeline-steps`): link:/security/advisory/2019-09-25/#SECURITY-920%20(1)[SECURITY-920 (1)]
 * Literate (`literate`): link:/security/advisory/2020-03-09/#SECURITY-1750[SECURITY-1750]
 * Nerrvana (`nerrvana`): link:/security/advisory/2020-10-08/#SECURITY-2097[SECURITY-2097]
-* NeuVector Vulnerability Scanner (`neuvector-vulnerability-scanner`): link:/security/advisory/2022-10-19/#SECURITY-2865[SECURITY-2865]
 * Persona (`persona`): link:/security/advisory/2020-10-08/#SECURITY-2046[SECURITY-2046]
 * Pipeline: Classpath Step (`pipeline-classpath`): https://www.jenkins.io/security/advisory/2017-03-20/#pipeline-classpath-step-plugin-allowed-script-security-sandbox-bypass[SECURITY-336]
 * Pipeline: Phoenix AutoTest (`phoenix-autotest`): link:/security/advisory/2022-03-29/[multiple vulnerabilities announced on 2022-03-29]


### PR DESCRIPTION
Distribution is restored in https://github.com/jenkins-infra/update-center2/pull/652, warning is updated in https://github.com/jenkins-infra/update-center2/pull/653