### PR TITLE
Fix advisory link

### DIFF
--- a/content/security/plugins.adoc
+++ b/content/security/plugins.adoc
@@ -53,7 +53,7 @@ This typically is the case when plugins have particularly severe security vulner
 * CryptoMove (`cryptomove`): link:/security/advisory/2020-03-09/#SECURITY-1635[SECURITY-1635]
 * CVS Tagging (`cvs-tag`): link:/security/advisory/2017-04-10/#cvs-tagging-plugin[SECURITY-459]
 * Debian Package Builder (`debian-package-builder`): link:/security/advisory/2022-01-12/#SECURITY-2546[SECURITY-2546]
-* DotCi (`DotCi`): link:/security/advisory/2022-09-20/#SECURITY-1737[SECURITY-1737]
+* DotCi (`DotCi`): link:/security/advisory/2022-09-21/#SECURITY-1737[SECURITY-1737]
 * Dynamic Parameter (`dynamicparameter`): link:/security/advisory/2017-04-10/#dynamic-parameter-plugin[SECURITY-462]
 * ElasticBox Jenkins Kubernetes CI/CD (`kubernetes-ci`): link:/security/advisory/2020-07-02/#SECURITY-1738[SECURITY-1738]
 * Grails (`grails`): link:/security/advisory/2017-04-10/#grails-plugin[SECURITY-458]


### PR DESCRIPTION
SECURITY-1737 was released in advisory one day later, clearly just a typo