### PR TITLE
Remove Hacktoberfest 2022 from Jumbotron

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,14 +1,3 @@
-# Hacktoberfest 2022
-- :href: https://hacktoberfest.com/
-  :title: Hacktoberfest 2022
-  :intro: Jenkins is participating in Hacktoberfest 2022. We are seeking contributors
-    and maintainers who want to join us to improve Jenkins in October!
-  :image:
-    :src: images/hacktoberfest/hacktoberfest_2022_social_600x300.png
-    :height: 300px
-  :call_to_action:
-    :text: More info
-    :href: "/events/hacktoberfest/"
 # Case Studies
 - :href: https://stories.jenkins.io/
   :title: Jenkins Stories!


### PR DESCRIPTION
Hacktoberfest 2022 is done. This PR removes the event announcement from the Jumbotron. 
(reverts PR #5526)