### PR TITLE
Jenkins - Add Declarative vs Scripted syntax video

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -2236,7 +2236,7 @@ XXX: REWRITE
 ////
 
 video::GJBlskiaRrI[youtube,width=800,height=420]
-This video shares some differences between Scripted and Declarative Pipleine syntax.
+This video shares some differences between Scripted and Declarative Pipeline syntax.
 
 When Jenkins Pipeline was first created, Groovy was selected as the foundation.
 Jenkins has long shipped with an embedded Groovy engine to provide advanced

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -2235,6 +2235,9 @@ for more information.
 XXX: REWRITE
 ////
 
+video::GJBlskiaRrI[youtube,width=800,height=420]
+This video shares some differences between Scripted and Declarative Pipleine syntax.
+
 When Jenkins Pipeline was first created, Groovy was selected as the foundation.
 Jenkins has long shipped with an embedded Groovy engine to provide advanced
 scripting capabilities for admins and users alike. Additionally, the


### PR DESCRIPTION
This is to add the recently created video https://www.youtube.com/watch?v=GJBlskiaRrI which shows differences between the two syntax options.