### PR TITLE
Fix javadoc links for LTS versions

### DIFF
--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -22,16 +22,22 @@ title: Javadoc
       Latest Core Javadoc
 
 %h3
-  LTS Baselines
+  LTS
 
 %ul
-  - site._generated[:lts_baselines].results[0..9].each do | entry |
-    - version = entry.version.reverse[2..-1].reverse
-    %li
-      %a{:href => "https://javadoc.jenkins.io/archive/jenkins-#{version}", :target => '_blank', :rel => 'noreferrer noopener'}
-        Jenkins Core
-        = version
-        Javadoc
+  - previous = ''
+  -# No more than 15 LTS releases because update center does not generally extend beyond 12 months
+  - site._generated[:lts_releases].results[0..14].each do | entry |
+    - version = entry.version
+    -# Show the javadoc for the most recent release of each LTS baseline
+    -# Assumes releases have form x.y.z as in 2.346.2
+    - if version.split('.')[0..1] != previous.split('.')[0..1]
+      - previous = version
+      %li
+        %a{:href => "https://javadoc.jenkins.io/archive/jenkins-#{version}", :target => '_blank', :rel => 'noreferrer noopener'}
+          Jenkins Core
+          = version
+          Javadoc
 
 %h2
   Stapler Javadoc

--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -18,7 +18,7 @@ title: Javadoc
 
 %ul
   %li
-    %a{:href => 'https://javadoc.jenkins.io/', :target => '_blank', :rel => 'noreferrer noopener'}
+    %a{:href => 'https://javadoc.jenkins.io/index-core.html', :target => '_blank', :rel => 'noreferrer noopener'}
       Latest Core Javadoc
 
 %h3

--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -58,14 +58,6 @@ title: Javadoc
   describes Jenkins components and libraries (currently a partial list of components).
 
 %h2
-  Modules Javadoc
-
-%p
-  %a{:href => 'https://javadoc.jenkins.io/module/', :target => '_blank', :rel => 'noreferrer noopener'}
-    Modules Javadoc
-  describes the latest versions of Jenkins Core modules (Jenkins releases may use earlier versions)
-
-%h2
   Plugins Javadoc
 
 %p

--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -7,8 +7,11 @@ title: Javadoc
   Jenkins Core
 
 %p
-  This is the Javadoc for Jenkins core. Multiple versions are available: The latest weekly release, as well as the most recent LTS baselines.
-  Unless a plugin requires very recent functionality, it should generally use one of the LTS baselines for its Jenkins core dependency.
+  This is the Javadoc for Jenkins core. Javadoc is available for the latest weekly release and for recent LTS releases.
+  See
+  %a{:href => '/doc/developer/plugin-development/choosing-jenkins-baseline/'}
+    choosing a Jenkins baseline
+  for guidance choosing the minimum Jenkins core version for a plugin.
 
 %h3
   Weekly


### PR DESCRIPTION
## Fix Javadoc links for LTS versions

The LTS Javadoc links on https://www.jenkins.io/doc/developer/javadoc/ are broken.  They state that they point to the LTS baseline Javadoc when it would be better if they pointed to the LTS Javadoc.  The most recent release of the LTS Javadoc is computed in the new layout and the link is pointed to that most recent release of the LTS Javadoc.  Only provides Javadoc links to the most recent five LTS baselines because update center stops providing updates after about 12 months.

Link to the page that describes how plugin maintainers can best choose a minimum Jenkins version rather than offering an overly simplified recommendation for minimum Jenkins version.

Links to modules Javadoc are broken because there are no more modules in Jenkins core.  Removes the modules section.

Link to the weekly Javadoc was linking to the top level page that requires one more pick to reach the weekly Javadoc.  Link to the weekly Javadoc directly instead.

- 867d31a9c63f71452095e15f1bea2a95419b9de7 Point developers to Choosing a Jenkins version
- 1f217257252fa4d62dd750d136ed6034dad1f092 Link to the weekly javadoc, not the top page
- ef0e3d14f016e8f5a19b74432a2d82c083264108 Fix LTS javadoc links
- 7ed4f16d5436b8c602d795f5a6f46a19b0e240f3 No more modules, remove the modules link

## Before

![before](https://user-images.githubusercontent.com/156685/199576943-5be32071-75a3-4463-8ae4-920e0a857121.png)

## After

![after](https://user-images.githubusercontent.com/156685/199576964-eab54b31-4984-40ac-9224-4af2a61d3a93.png)