### PR TITLE
chore(helpdesk-3087) switch URL of the pipeline generated steps to reports.jenkins.io

### DIFF
--- a/scripts/fetch-external-resources
+++ b/scripts/fetch-external-resources
@@ -33,7 +33,7 @@ RESOURCES = [
     'content/_tmp/examples'
   ],
   [
-    'https://ci.jenkins.io/job/Infra/job/pipeline-steps-doc-generator/job/master/lastSuccessfulBuild/artifact/allAscii.zip',
+    'https://reports.jenkins.io/allAscii.zip',
     'content/_tmp/allAscii.zip',
     nil,
     'content/doc/pipeline/steps'
@@ -63,7 +63,7 @@ RESOURCES = [
     nil
   ],
   [
-    'https://ci.jenkins.io/job/Infra/job/backend-extension-indexer/job/master/lastSuccessfulBuild/artifact/*.adoc/*zip*/extension-indexer.zip',
+    'https://reports.jenkins.io/extension-indexer.zip',
     'content/_tmp/extension-indexer.zip',
     nil,
     'content/doc/developer/extensions'


### PR DESCRIPTION
This PR is related to https://github.com/jenkins-infra/helpdesk/issues/3087.

Tested locally with a `make && make run` command: the page http://localhost:4242/doc/pipeline/steps/ show the steps as expected.

I would like at least 2 technical approvals on this one to make sure that I did not break anything. Ping @MarkEWaite @timja @halkeye @lemeurherve @daniel-beck 