### PR TITLE
Use most recent spotbugs improvements in tutorial

### DIFF
--- a/content/doc/developer/tutorial-improve/add-more-spotbugs-checks.adoc
+++ b/content/doc/developer/tutorial-improve/add-more-spotbugs-checks.adoc
@@ -58,14 +58,14 @@ Sometimes the number of spotbugs exclusions make it inconvenient or tedious to p
 In those cases, a spotbugs exclusions file can be used to list the spotbugs warnings that are being excluded and the classes, methods, and fields involved.
 
 A good example of the spotbugs exclusions file and its configuration is available from Jenkins core.
-See the link:https://github.com/jenkinsci/jenkins/blob/master/src/spotbugs/spotbugs-excludes.xml[src/spotbugs/spotbugs-excludes.xml] source file for examples.
-See the link:https://github.com/jenkinsci/build-timestamp-plugin/blob/master/pom.xml#L25[pom.xml file] for the property that enables the spotbugs `excludeFilterFile`.
+See the link:https://github.com/jenkinsci/jenkins/blob/master/src/spotbugs/excludesFilter.xml[src/spotbugs/excludesFilter.xml] source file for examples.
+The exclusions in the filter file are enabled automatically with recent versions so long as the exclusion file is named `src/spotbugs/excludesFilter.xml`.
 
 An example excludes filter file is also included here:
 
 [source,xml]
 ----
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <FindBugsFilter>
   <!--
     Exclusions in this section have been triaged and determined to be


### PR DESCRIPTION
## Use most recent spotbugs improvements

The spotbugs excludes filter file is now enabled automatically if a file with the correct name is found.  There is no longer any need to add the entry into the pom.xml file.

See https://github.com/jenkinsci/pom/releases/tag/jenkins-1.91 and https://github.com/jenkinsci/pom/pull/333
