### PR TITLE
Jenkins voter registration group update

### DIFF
--- a/content/blog/2022/10/2022-10-20-jenkins-election-announcement.adoc
+++ b/content/blog/2022/10/2022-10-20-jenkins-election-announcement.adoc
@@ -38,6 +38,7 @@ The election consists of 4 phases:
 Participation in the election process requires registering an account with link:https://community.jenkins.io[community.jenkins.io] and at least one <<contributing,contribution>> made before September 1, 2022.
 When registering, you can use an existing Github account or create a new account specifically for link:https://community.jenkins.io[the Jenkins community].
 We ask all community members who are interested in voting, and meet the requirements, to join the link:https://community.jenkins.io/g/election-voter-2022[election-voter-2022] group on link:https://community.jenkins.io[community.jenkins.io] during the registration period.
+Previous elections utilized their own groups, so joining the link:https://community.jenkins.io/g/election-voter-2022[election-voter-2022 group] is required for participation.
 
 We have made the decision to trust participants and not require that you provide evidence of contribution as part of your voter registration.
 We reserve the right to ban any account from the election process if we identify abuse.

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -109,6 +109,7 @@ As long as you are contributing to the Jenkins project or community, you are eli
 
 Voter registration is announced through the Jenkins mailing lists, blog, and social media accounts.
 Users can register to vote in the election by joining the link:https://community.jenkins.io/g/election-voter-2022[2022 election voter group].
+Previous elections utilized their own groups, so joining the link:https://community.jenkins.io/g/election-voter-2022[2022 group] is required for participation.
 
 To register, you must have an account on link:https://community.jenkins.io[community.jenkins.io].
 You can use your existing Github account, or create a new account specifically for link:https://community.jenkins.io[Jenkins community discussion].


### PR DESCRIPTION
As @jmMeessen noted, previous participants would need to join the new group for the 2022 election, and I wanted to make sure that it is made clear in the blog post & election process page.