### PR TITLE
fix(developer docs) use long flags for `curl` commands in releasing-cd

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -52,7 +52,7 @@ Create the CD workflow as a copy of the template:
 [source,shell]
 ----
 mkdir -p .github/workflows
-curl -so .github/workflows/cd.yaml https://raw.githubusercontent.com/jenkinsci/.github/master/workflow-templates/cd.yaml
+curl --silent --show-error --location --output .github/workflows/cd.yaml https://raw.githubusercontent.com/jenkinsci/.github/master/workflow-templates/cd.yaml
 git add .github/workflows/cd.yaml
 ----
 
@@ -88,7 +88,7 @@ If you did not yet have such a file, create it now:
 
 [source,shell]
 ----
-curl -so .github/dependabot.yml https://raw.githubusercontent.com/jenkinsci/archetypes/master/common-files/.github/dependabot.yml
+curl --silent --show-error --location --output .github/dependabot.yml https://raw.githubusercontent.com/jenkinsci/archetypes/master/common-files/.github/dependabot.yml
 ----
 
 === Update Maven POM and Config


### PR DESCRIPTION
Context: https://github.com/jenkins-infra/jenkins.io/pull/5676/files#r1015153359

- Using long flags helps developer to understand "what is the command doing"
- Adding the `--show-error / -S` flag to show errors to user if there is a network issue (HTTP proxy, GitHub outage, etc.)
- Adding the flag `--location / -L` to ensure that any redirection is followed (repository/organisation renaming, GitHub service name changes, etc.)