### PR TITLE
Jenkins - Update 2.377 changelog entries

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -18222,7 +18222,7 @@
           - StefanSpieker
         pr_title: Removed unused `UnbufferedBase64InputStream`
         message: |-
-          Removed deprecated and unused class <code>UnbufferedBase64InputStream</code>.
+          Remove deprecated and unused class <code>UnbufferedBase64InputStream</code>.
       - type: rfe
         category: developer
         pull: 7303

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -18217,28 +18217,36 @@
     changes:
       - type: rfe
         category: rfe
-        pull: 7303
-        authors:
-          - car-roll
-        pr_title: Allow detached plugin location to be overridden
-        message: |-
-          Developer: Allow detached plugin location to be overridden.
-      - type: rfe
-        category: rfe
         pull: 7335
         authors:
           - StefanSpieker
         pr_title: Removed unused `UnbufferedBase64InputStream`
         message: |-
-          Remove deprecated and unused class <code>UnbufferedBase64InputStream</code>.
+          Removed deprecated and unused class <code>UnbufferedBase64InputStream</code>.
       - type: rfe
-        category: rfe
+        category: developer
+        pull: 7303
+        authors:
+          - car-roll
+        pr_title: Allow detached plugin location to be overridden
+        message: |-
+          Developer: Allow detached plugin location to be overridden.          
+      - type: rfe
+        category: developer
         pull: 7322
         authors:
           - dependabot[bot]
         pr_title: Upgrade Spring Security from 5.7.4 to 5.7.5
+        references:
+          - url: https://github.com/spring-projects/spring-security/releases/tag/5.7.5
+            title: Spring Security Release 5.7.5
+          - url: https://tanzu.vmware.com/security/cve-2022-31690
+            title: CVE-2022-31690
+          - url: https://tanzu.vmware.com/security/cve-2022-31692
+            title: CVE-2022-31692            
         message: |-
-          Upgrade Spring Security from 5.7.4 to 5.7.5. Spring Security 5.7.5 includes a fix for [CVE-2022-31690](https://tanzu.vmware.com/security/cve-2022-31690) affecting the mapping of authorized scopes in <code>spring-security-oauth2-client</code> and a fix for [CVE-2022-31692](https://tanzu.vmware.com/security/cve-2022-31692) affecting <code>org.springframework.security.web.access.intercept.AuthorizationFilter</code>.
+          Upgrade Spring Security from 5.7.4 to 5.7.5. 
+          Spring Security 5.7.5 includes fixes for two authorization mapping issues affecting the scopes in <code>spring-security-oauth2-client</code> and <code>org.springframework.security.web.access.intercept.AuthorizationFilter</code>.
 
   # pull: 7317 (PR title: Update dependency babel-loader to v9)
   # pull: 7324 (PR title: Update more bundled plugins)


### PR DESCRIPTION
This is to update the 2.377 changelog entries, as they are currently still in the original format submitted by dependabot.