### PR TITLE
Remove internal process details

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -30,7 +30,6 @@ Please report issues present in the following components:
 * Jenkins plugins published by the Jenkins project (listed on https://plugins.jenkins.io/[plugins.jenkins.io] and/or hosted in https://github.com/jenkinsci[the jenkinsci GitHub organization])
 * Additional components published by the Jenkins project for general use, such as Docker images
 * Jenkins infrastructure projects, such as https://www.jenkins.io/[jenkins.io] or more generally the repositories hosted in the https://github.com/jenkins-infra[jenkins-infra GitHub organization]
-** The infrastructure security reports will be triaged by the Jenkins security team, but worked on by the link:/project/team-leads/#infrastructure[Infrastructure Officer] and their team
 
 
 The following components are out of scope:


### PR DESCRIPTION
This is irrelevant to the audience of this page and duplicates part of https://www.jenkins.io/project/team-leads/#infrastructure

If the intention is to document the "forwarding" of reports, that could be added to https://www.jenkins.io/project/team-leads/#security as a team lead responsibility.