### PR TITLE
GSoC 2023 blog post

### DIFF
--- a/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
+++ b/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
@@ -1,0 +1,59 @@
+---
+layout: post
+title: "Google Summer of Code 2023 Call for Project Ideas and Mentors"
+tags:
+- gsoc
+- gsoc2022
+- community
+- events
+- developer
+authors:
+- alyssat
+- jmMeessen
+- krisstern
+- gounthar
+description: >
+  This blogpost calls for projects and mentors for the 2023 edition of Google Summer of Code.
+links:
+  discourse: https://community.jenkins.io/t/jenkins-in-gsoc-2023-mentors-org-admins-project-ideas-wanted/4387
+---
+
+link:https://summerofcode.withgoogle.com[Google Summer of Code] (GSoC) is a global, online mentoring program focused on introducing new contributors to open source software development.
+GSoC contributors work on a 12+ week programming project with the guidance of mentors from their open source organization.
+During GSoC, participating contributors are paired with mentors from open source organizations, gaining exposure to real-world software development techniques.
+GSoC contributors will learn from experienced open source developers while writing code for real-world projects!
+A small stipend is provided as an incentive.
+
+See GSoC contributor eligibility link:https://summerofcode.withgoogle.com/get-started[here].
+
+We are looking for project ideas and mentors to participate in GSoC 2023.
+GSoC project ideas are coding projects that potential GSoC contributors can accomplish in about 12+ weeks.
+The coding projects can be new features, plugins, test frameworks, infrastructure, etc.
+Anyone can submit a project idea, but of course we like it even better if you mentor your project idea.
+
+Please send us your project ideas before the beginning of February so they can get a proper review by the GSoC committee and by the community.
+
+=== How to submit a project idea
+Create a pull-request with your idea in a .adoc file in the link:https://github.com/jenkins-infra/jenkins.io/tree/master/content/projects/gsoc/2023/project-ideas[project ideas]. 
+It is not necessary to submit a Google Doc, but it will still work if you want to do that.
+See the link:/projects/gsoc/proposing-project-ideas/[instructions] on submitting ideas which include an .adoc template and some examples.
+
+
+=== What does mentoring involve?
+Potential mentors are invited to read the link:/projects/gsoc/mentors[information for mentors].
+Note that being a GSoC mentor does not require expert knowledge of Jenkins.
+Mentors do not work alone. We make sure that every project has at least two mentors.
+GSoC org admins will help to find technical advisers, so you can study together with your GSoC contributor.
+Mentoring takes about 5 to 8 hours of work per week (more at the start, less at the end).
+Mentors provide guidance, coaching, and sometimes a bit of cheerleading.
+They review GSoC contributor proposals, pull-requests and contributor presentations at the evaluation phase.
+They fill in the Google provided final evaluations at the end of the coding period.
+
+=== What do you get in exchange?
+Mentor interaction is a vital part of GSoC.
+In return for mentoring, a GSoC contributor works on your project full time for 12+ weeks.
+Think about the projects that you’ve always wanted to do but never had the time…
+Mentoring is also an opportunity to improve your management and people skills, while giving back to the community.
+GSoC is a fantastic program and the Jenkins project is happy to participate in GSoC again in 2022!
+
+For any question, you can find the GSoC Org Admins, mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter] chat.

--- a/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
+++ b/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
@@ -51,7 +51,7 @@ They fill in the Google provided final evaluations at the end of the coding peri
 
 === What do you get in exchange?
 Mentor interaction is a vital part of GSoC.
-In return for mentoring, a GSoC contributor works on your project full time for 12+ weeks.
+In return for mentoring, a GSoC contributor works on your project full time for 10-22 weeks.
 Think about the projects that you’ve always wanted to do but never had the time…
 Mentoring is also an opportunity to improve your management and people skills, while giving back to the community.
 GSoC is a fantastic program and the Jenkins project is looking forward to participating in GSoC again in 2023!

--- a/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
+++ b/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
@@ -18,8 +18,8 @@ links:
   discourse: https://community.jenkins.io/t/jenkins-in-gsoc-2023-mentors-org-admins-project-ideas-wanted/4387
 ---
 
-link:https://summerofcode.withgoogle.com[Google Summer of Code] (GSoC) is a global, online mentoring program focused on introducing new contributors to open source software development.
-GSoC contributors work on a 12+ week programming project with the guidance of mentors from their open source organization.
+link:https://summerofcode.withgoogle.com[Google Summer of Code] (GSoC) is a global, online mentoring program focused on introducing students and new contributors to open source software development.
+GSoC contributors work on a 10-22 weeks programming project with the guidance of mentors from their open source organization.
 During GSoC, participating contributors are paired with mentors from open source organizations, gaining exposure to real-world software development techniques.
 GSoC contributors will learn from experienced open source developers while writing code for real-world projects!
 A small stipend is provided as an incentive.
@@ -27,7 +27,7 @@ A small stipend is provided as an incentive.
 See GSoC contributor eligibility link:https://summerofcode.withgoogle.com/get-started[here].
 
 We are looking for project ideas and mentors to participate in GSoC 2023.
-GSoC project ideas are coding projects that potential GSoC contributors can accomplish in about 12+ weeks.
+GSoC project ideas are coding projects that potential GSoC contributors can accomplish in about 10-22 weeks.
 The coding projects can be new features, plugins, test frameworks, infrastructure, etc.
 Anyone can submit a project idea, but of course we like it even better if you mentor your project idea.
 

--- a/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
+++ b/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
@@ -54,6 +54,6 @@ Mentor interaction is a vital part of GSoC.
 In return for mentoring, a GSoC contributor works on your project full time for 12+ weeks.
 Think about the projects that you’ve always wanted to do but never had the time…
 Mentoring is also an opportunity to improve your management and people skills, while giving back to the community.
-GSoC is a fantastic program and the Jenkins project is happy to participate in GSoC again in 2022!
+GSoC is a fantastic program and the Jenkins project is looking forward to participating in GSoC again in 2023!
 
 For any question, you can find the GSoC Org Admins, mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter] chat.

--- a/content/projects/gsoc/2023/index.adoc
+++ b/content/projects/gsoc/2023/index.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /projects/gsoc
+---

--- a/content/projects/gsoc/2023/project-ideas.html.haml
+++ b/content/projects/gsoc/2023/project-ideas.html.haml
@@ -1,0 +1,159 @@
+---
+layout: simplepage
+title: "GSoC 2023 Project Ideas"
+year: 2023
+tags:
+- gsoc
+- gsoc2023
+project: gsoc
+opengraph:
+  image: /images/gsoc/opengraph.png
+---
+
+:css
+  .pi_table {
+    width: 100%;
+  }
+  .pi_table_header {
+    text-align: center;
+  }
+  .pi_table_category {
+    width: 100px;
+  }
+  .pi_table_skills {
+    width: 175px;
+  }
+
+%img{:title => "Jenkins GSoC", :src => expand_link("/images/gsoc/jenkins-gsoc-logo_small.png"), :style => "float:right", :width => "128"}
+
+
+%p
+  = succeed '.' do
+    This page aggregates project ideas for Google Summer of Code
+    = page.year
+  = succeed '.' do
+    See more information about this project and applications
+    %a{:href => expand_link("/projects/gsoc/")}
+      on the Jenkins Google Summer of Code page
+%p
+  Below you can find project ideas which have been proposed for this year.
+  New ideas may be proposed by interested mentors or GSoC contributors (e.g. new features in the core, "write a plugin for MY_TOOL_OR_SERVICE", etc.).
+  Project ideas without potential mentors will be considered though applicants may need to work with the community and GSoC org admins to find mentors.
+  To add a new project idea, see:
+  = succeed '.' do
+    %a{:href => expand_link("/projects/gsoc/proposing-project-ideas/")}
+      proposing project ideas
+
+%h3
+  Accepted ideas
+
+%p
+  Below you can see the list of project ideas that fully match the Jenkins' project idea standard.
+  The scope of these ideas is well known and we don't normally expect deep changes.
+  All ideas have quick start guidelines and newbie-friendly issues referenced.
+  We welcome contributors to join the mentor teams, and we invite GSoC contributors to submit project proposal applications in relation to these ideas.
+
+%table.pi_table.grid-all
+  %thead
+    %tr.pi_table_header
+      %th Project
+      %th Category
+      %th Skills to study/improve
+  %tbody
+    // TODO: parameterize year
+    - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2022\/project-ideas\/[^\/]+.adoc/ }
+    - ideas.each do |item|
+      - if item.status == "published"
+        %tr
+          %td
+            %a{:href => item.url}
+              %strong
+                = item.title
+            %br
+            = succeed '.' do
+              = item.goal
+            %br
+            %b
+              Potential Mentor(s):
+            - item.mentors.each do |mentor|
+              = display_user_optional(mentor)
+          %td.pi_table_category
+            - if item.category
+              = item.category
+            - else
+              Undefined
+          %td.pi_table_skills
+            = item.skills.join(", ")
+
+%h3
+  Draft project ideas
+
+%p
+  Below you can see draft project ideas, which are currently under review.
+  The scope of such ideas may change during the discussions, but the idea is accepted in principle.
+  You are welcome to comment on the draft and to join the project as a mentor.
+  If you are a GSoC contributor, it is also fine to explore and to apply to the draft project ideas.
+
+%table.pi_table.grid-all
+  %thead
+    %tr.pi_table_header
+      %th Project
+      %th Category
+      %th Skills to study/improve
+  %tbody
+    // TODO: parameterize year
+    - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2022\/project-ideas\/[^\/]+.adoc/ }
+    - ideas.each do |item|
+      - if item.status == "draft"
+        %tr
+          %td
+            %a{:href => item.url}
+              %strong
+                = item.title
+            %br
+              = succeed '.' do
+                = item.goal
+            %b
+              Potential Mentor(s):
+            - item.mentors.each do |mentor|
+              = display_user_optional(mentor)
+          %td.pi_table_category
+            - if item.category
+              = item.category
+            - else
+              Undefined
+          %td.pi_table_skills
+            = item.skills.join(", ")
+
+// TODO parameterize year
+- ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2022\/project-ideas\/[^\/]+.adoc/ }
+- if ideas.length > 1
+  %h3
+    Ongoing discussion
+
+  %p.markdown
+    These are proposals in the mailing lists which have not been published as project ideas yet.
+    The feasibility is yet to be defined, and the idea may be dismissed depending on the feedback.
+    Everyone is welcome to participate in the discussion and to join as a potential mentor.
+
+  %table.pi_table.grid-all
+    %thead
+      %tr.pi_table_header
+        %th Project
+        %th Category
+    %tbody
+      - ideas.each do |item|
+        - if item.status == "discussion"
+          %tr
+            %td
+              %a{:href => item.links.emailThread}
+                %strong
+                  = item.title
+              %br
+                = succeed '.' do
+                  = item.goal
+            %td.pi_table_category
+              - if item.category
+                = item.category
+              - else
+                Undefined

--- a/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
@@ -1,0 +1,69 @@
+---
+layout: gsocprojectidea
+title: "Plugin Installation Manager Tool Improvements"
+goal: "Introduce new features and improvements in the plugin installation manager"
+category: Tools
+year: 2023
+status: published
+sig: platform
+skills:
+- Java
+- YAML
+- Command line tools
+- Package management tool theory
+mentors:
+- "markewaite"
+- "abhyudayasharma"
+links:
+  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+---
+=== Background
+
+In 2019 there was a Jenkins Google Summer of Code project to create a tool to automatically install plugins from the command line based on a provided input.
+This is meant to help with creating reproducible environments and other places where you would want to install a certain set of plugins.
+The project was successful in creating a useable tool to install plugins with a 1.0 release.
+Over time, the plugin installation manager was improved and added to other components like official Jenkins Docker images.
+
+As a part of this project,
+students are invited to introduce new features and improvements in the plugin installation manager.
+The list of enhancements is a subject for discovery as a part of the application process.
+Some of the ideas are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues[project tracker].
+
+=== Quick Start
+
+Visit the project page at https://github.com/jenkinsci/plugin-installation-manager-tool
+
+1. Clone the project
+2. Run the tests; there are several different lists of plugins
+3. Run the Plugin Installation Manager for various combinations of plugins with a real Jenkins instance.
+   See how the downloads and caching work.
+4. Try out some edge cases to see what could be improved.
+
+=== Skills to Study and Improve
+
+* Java
+* YAML/data structures/package management tools
+* Writing command line interfaces
+* How the Jenkins Docker image and Configuration as Code (CasC) work
+
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+=== Project Size
+
+175 hours
+
+=== Expected outcomes
+
+Improvements to existing tool
+
+Key improvements for the plugin installation manager tool will be identified, prioritized, and planned.
+Google Summer of Code contributor will propose the areas for improvement and work with mentors to plan those improvements.
+
+=== Newbie Friendly Issues
+
+Some good first issues are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[issue tracker].
+For information about how to contribute to and what to work on, please use the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[gitter channel].

--- a/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
@@ -1,0 +1,44 @@
+---
+layout: gsocprojectidea
+title: "a title"
+goal: "Goal"
+category: Tools
+year: 2022
+status: discussion
+sig: platform
+skills:
+- Java
+- YAML
+- Command line tools
+- Package management tool theory
+mentors:
+- "mentorname"
+
+// links:
+//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+---
+// === Background
+// TBD
+//
+// === Quick Start
+// TBD
+//
+// === Skills to Study and Improve
+// * TBD
+//
+// === Project Difficulty Level
+// 
+// Beginner to Intermediate
+// 
+// === Project Size
+// 
+// 175 hours
+// 
+// === Expected outcomes
+// 
+// New feature
+// 
+// Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase. 
+// 
+// === Newbie Friendly Issues


### PR DESCRIPTION
Blog post to announce GSoC 2023, especially calling for mentors and project ideas.

This PR is the first iteration to create the GSoC 2023 file structure so that project ideas can be submitted.