### PR TITLE
Reorder entries in 2022-11-15 security advisory

### DIFF
--- a/content/security/advisory/2022-11-15.adoc
+++ b/content/security/advisory/2022-11-15.adoc
@@ -156,6 +156,53 @@ issues:
   - name: dockerhub-notification
     previous: 2.6.2
     fixed: 2.6.2.1
+- id: SECURITY-2912
+  reporter: Daniel Beck, CloudBees, Inc.
+  title: Passwords stored in plain text by PLUGIN_NAME
+  cve: CVE-2022-45392
+  cvss:
+    severity: Medium
+    vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+  description: |-
+    PLUGIN_NAME 4.8.0.143 and earlier stores passwords unencrypted in job `config.xml` files on the Jenkins controller as part of its configuration.
+
+    These passwords can be viewed by attackers with Item/Extended Read permission or access to the Jenkins controller file system.
+
+    PLUGIN_NAME 4.8.0.146 stores passwords encrypted once job configurations are saved again.
+  plugins:
+  - name: cavisson-ns-nd-integration
+    previous: 4.8.0.143
+    fixed: 4.8.0.146
+- id: SECURITY-2910 (1)
+  reporter: Daniel Beck, CloudBees, Inc.
+  title: SSL/TLS certificate validation globally and unconditionally disabled by PLUGIN_NAME
+  cve: CVE-2022-45391
+  cvss:
+    severity: Medium
+    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
+  description: |-
+    PLUGIN_NAME 4.8.0.143 and earlier globally and unconditionally disables SSL/TLS certificate and hostname validation for the entire Jenkins controller JVM.
+
+    PLUGIN_NAME 4.8.0.146 no longer disables SSL/TLS certificate and hostname validation globally.
+  plugins:
+  - name: cavisson-ns-nd-integration
+    previous: 4.8.0.143
+    fixed: 4.8.0.146
+- id: SECURITY-2910 (2)
+  reporter: Daniel Beck, CloudBees, Inc.
+  title: SSL/TLS certificate validation unconditionally disabled by PLUGIN_NAME
+  cve: CVE-2022-38666
+  cvss:
+    severity: Medium
+    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
+  description: |-
+    PLUGIN_NAME 4.8.0.146 and earlier unconditionally disables SSL/TLS certificate and hostname validation for several features.
+
+    As of publication of this advisory, there is no fix.
+    link:/security/plugins/#unresolved[Learn why we announce this.]
+  plugins:
+  - name: cavisson-ns-nd-integration
+    previous: 4.8.0.146
 - id: SECURITY-766
   reporter: Daniel Beck, CloudBees, Inc.
   title: XXE vulnerability on agents in PLUGIN_NAME
@@ -248,53 +295,6 @@ issues:
   plugins:
   - name: loaderio-jenkins-plugin
     previous: 1.0.1
-- id: SECURITY-2910 (1)
-  reporter: Daniel Beck, CloudBees, Inc.
-  title: SSL/TLS certificate validation globally and unconditionally disabled by PLUGIN_NAME
-  cve: CVE-2022-45391
-  cvss:
-    severity: Medium
-    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
-  description: |-
-    PLUGIN_NAME 4.8.0.143 and earlier globally and unconditionally disables SSL/TLS certificate and hostname validation for the entire Jenkins controller JVM.
-
-    PLUGIN_NAME 4.8.0.146 no longer disables SSL/TLS certificate and hostname validation globally.
-  plugins:
-  - name: cavisson-ns-nd-integration
-    previous: 4.8.0.143
-    fixed: 4.8.0.146
-- id: SECURITY-2910 (2)
-  reporter: Daniel Beck, CloudBees, Inc.
-  title: SSL/TLS certificate validation unconditionally disabled by PLUGIN_NAME
-  cve: CVE-2022-38666
-  cvss:
-    severity: Medium
-    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
-  description: |-
-    PLUGIN_NAME 4.8.0.146 and earlier unconditionally disables SSL/TLS certificate and hostname validation for several features.
-
-    As of publication of this advisory, there is no fix.
-    link:/security/plugins/#unresolved[Learn why we announce this.]
-  plugins:
-  - name: cavisson-ns-nd-integration
-    previous: 4.8.0.146
-- id: SECURITY-2912
-  reporter: Daniel Beck, CloudBees, Inc.
-  title: Passwords stored in plain text by PLUGIN_NAME
-  cve: CVE-2022-45392
-  cvss:
-    severity: Medium
-    vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
-  description: |-
-    PLUGIN_NAME 4.8.0.143 and earlier stores passwords unencrypted in job `config.xml` files on the Jenkins controller as part of its configuration.
-
-    These passwords can be viewed by attackers with Item/Extended Read permission or access to the Jenkins controller file system.
-
-    PLUGIN_NAME 4.8.0.146 stores passwords encrypted once job configurations are saved again.
-  plugins:
-  - name: cavisson-ns-nd-integration
-    previous: 4.8.0.143
-    fixed: 4.8.0.146
 - id: SECURITY-2920
   reporter: CC Bomber, Kitri BoB
   title: CSRF vulnerability and missing permission check in PLUGIN_NAME


### PR DESCRIPTION
We generally group advisory entries by resolved, then unresolved.

The fix version for two entries of https://plugins.jenkins.io/cavisson-ns-nd-integration/ arrived unexpectedly this morning, after we had intended to announce them as unresolved. We forgot to reorder to keep the grouping when adapting the advisory. This doesn't change the content, just the order in which the entries appear. Anchors are generated for issue IDs and remain the same.

@yaroslavafenkin