### PR TITLE
Jenkins - adding candidate announcement blog post

### DIFF
--- a/content/blog/2022/11/2022-11-17-jenkins-election-candidates.adoc
+++ b/content/blog/2022/11/2022-11-17-jenkins-election-candidates.adoc
@@ -16,7 +16,7 @@ opengraph:
   image: /images/governance/elections/2022/2022-opengraph.png
 ---
 
-Hello all, voter registration and candidate nominations for the 2023 Jenkins elections are now complete.
+Hello all, voter registration and candidate nominations for the 2022 Jenkins elections are now complete.
 Thanks to everyone who registered to vote and to all those who submitted nominations.
 Special thanks to the candidates that have accepted the nominations.
 
@@ -26,7 +26,7 @@ This announcement shares the candidates and their statements, and serves as an a
 
 == New Board Members
 
-=== Board Member - Alexander Brandes
+=== Board Member - link:https://www.jenkins.io/blog/authors/notmyfault/[Alexander Brandes]
 
 I am a Jenkins user, contributor to the Jenkins project, and core maintainer.
 I maintain many plugins, and have helped organize Jenkins online meetups, which I also have been part of.
@@ -44,7 +44,7 @@ Affiliations: Student of business science
 link:https://github.com/NotMyFault[GitHub]  
 link:https://twitter.com/NotMyFault_OG[Twitter]
 
-=== Board Member - Ullrich Hafner
+=== Board Member - link:https://www.jenkins.io/blog/authors/uhafner/[Ullrich Hafner]
 
 I have been an active contributor in the Jenkins project since 2007.
 Currently, I am the maintainer of several Jenkins plugins, mostly in the area of build result visualization using modern JS based user interfaces: e.g., I am the maintainer of the warnings, code coverage and git-forensics plugins as well as several UI related JS wrapper plugins like Bootstrap or ECharts.
@@ -60,7 +60,7 @@ link:https://github.com/uhafner[Github]
 
 == New Officers
 
-=== Release Officer - Tim Jacomb
+=== Release Officer - link:https://www.jenkins.io/blog/authors/timja/[Tim Jacomb]
 
 I have been a user of Jenkins for the last 10 years and a regular contributor since 2018.
 I began with maintaining the Slack plugin and over the last couple of years I have since expanded that to many more plugins and the Jenkins core.
@@ -72,25 +72,25 @@ Affiliations: Kainos
 
 link:https://github.com/timja[Github]
 
-=== Events Officer - Alyssa Tong
+=== Events Officer - link:https://www.jenkins.io/blog/authors/alyssat/[Alyssa Tong]
 
-"It has been a privilege for me to be part of the Jenkins community and serve as Events Officer in 2022.
-I would be honored to serve as Events Officer for another term if given the opportunity.
+It has been a privilege for me to be part of the Jenkins community and serve as Events Officer in 2022.
+I am honored to serve as Events Officer for another term.
 I am passionate about open source, collaboration, and education.
 My goal is to build welcoming communities, and coordinating events is part of this role.
-More importantly, I strive to bring the community together through events and conferences, so we can share best practices and collaborate for the betterment of the project."
+More importantly, I strive to bring the community together through events and conferences, so we can share best practices and collaborate for the betterment of the project.
 
 Affiliations: CloudBees
 
 link:https://github.com/alyssat[Github]
 
-=== Security Officer - Wadeck Follonier
+=== Security Officer - link:https://www.jenkins.io/blog/authors/wadeck/[Wadeck Follonier]
 
 I joined the Jenkins adventure in 2017, as long as the Jenkins Security team and was coached by Oleg Nenashev and Daniel Beck about how to best contribute to the community effort, especially related to security tasks.
 I am working full time at CloudBees, managing two teams, including the security team dedicated to Jenkins.
 I got inspired by Daniel's work in terms of tooling, to create an application helping both the security people and the maintainers through multiple bot commands (in SECURITY tickets and in Hosting request).
 During the year as the Security Officer, I spent a good amount of my time onboarding the future experts, finding ways to increase efficiency of the team by left shifting tasks, to reduce the size of our backlog and to put the focus on important tasks.
-For the next year, I would like to be able to continue the effort to make Jenkins an even more secure place.
+For the next year, I would like to continue the effort to make Jenkins an even more secure place.
 One of the topic that I want to push forward is about the Content Security Policy introduction in the Jenkins ecosystem.
 
 Affiliations: CloudBees
@@ -98,7 +98,7 @@ Affiliations: CloudBees
 link:https://github.com/Wadeck[Github]
 link:https://www.linkedin.com/in/wadeck/[Linkedin]
 
-=== Documentation Officer - Kevin Martens
+=== Documentation Officer - link:https://www.jenkins.io/blog/authors/kmartens27/[Kevin Martens]
 
 I am a technical documentation writer, and have been contributing to the Jenkins project consistently over the last seven months. 
 I have helped create the Blue Ocean status statement that is now in the documentation, DevOps World material, and was a mentor for the Jenkins Documentation area of Hacktoberfest 2022.
@@ -117,7 +117,7 @@ Affiliations: CloudBees
 
 link:https://github.com/kmartens27[Github]
 
-=== Infrastructure Officer - Damien Duportal
+=== Infrastructure Officer - link:https://www.jenkins.io/blog/authors/dduportal/[Damien Duportal]
 
 I am a Software Engineer working as a SRE for the Jenkins public infrastructure and as an IT teacher.
 I am active in the Platform SIG, and have been using Jenkins for over a decade.

--- a/content/blog/2022/11/2022-11-17-jenkins-election-candidates.adoc
+++ b/content/blog/2022/11/2022-11-17-jenkins-election-candidates.adoc
@@ -20,7 +20,7 @@ Hello all, voter registration and candidate nominations for the 2022 Jenkins ele
 Thanks to everyone who registered to vote and to all those who submitted nominations.
 Special thanks to the candidates that have accepted the nominations.
 
-As in years past, when a particular role receives only one nomination, no election is required.
+As in years past, when a particular role receives only one nomination, an election is not required.
 This year, all the board and officer positions are uncontested, with one person nominated to fill each available position.
 This announcement shares the candidates and their statements, and serves as an announcement that the candidates have been elected and will begin their service December 3, 2022.
 
@@ -31,7 +31,7 @@ This announcement shares the candidates and their statements, and serves as an a
 I am a Jenkins user, contributor to the Jenkins project, and core maintainer.
 I maintain many plugins, and have helped organize Jenkins online meetups, which I also have been part of.
 I attend and take part in documentation and user experience office hours frequently.
-Previously, I have led community initiatives, such as the  link:https://www.meetup.com/jenkins-online-meetup/events/285677298/[Jenkins plugin integration with Crowdin] and participated in the link:https://www.jenkins.io/blog/2022/06/28/require-java-11/#acknowledgments[Java 11 and 17 support campaigns].
+Previously, I led community initiatives, such as the link:https://www.meetup.com/jenkins-online-meetup/events/285677298/[Jenkins plugin integration with Crowdin] and participated in the link:https://www.jenkins.io/blog/2022/06/28/require-java-11/#acknowledgments[Java 11 and 17 support campaigns].
 
 I truly believe in Jenkins' future and would be happy to serve on the Jenkins governance board.
 I would like to make Jenkins a great place to contribute, and to get more beginners and regular contributors involved in the community on a regular basis.
@@ -47,12 +47,12 @@ link:https://twitter.com/NotMyFault_OG[Twitter]
 === Board Member - link:https://www.jenkins.io/blog/authors/uhafner/[Ullrich Hafner]
 
 I have been an active contributor in the Jenkins project since 2007.
-Currently, I am the maintainer of several Jenkins plugins, mostly in the area of build result visualization using modern JS based user interfaces: e.g., I am the maintainer of the warnings, code coverage and git-forensics plugins as well as several UI related JS wrapper plugins like Bootstrap or ECharts.
-I am a member of the Jenkins UX SIG and I formerly was a member of the Jenkins Governance Board during the 2019/2021 term.
+Currently, I am the maintainer of several Jenkins plugins, mostly in the area of build result visualization using modern JS based user interfaces: for example, I am the maintainer of the warnings, code coverage and git-forensics plugins as well as several UI related JS wrapper plugins like Bootstrap or ECharts.
+I am a member of the Jenkins UX SIG and I was a member of the Jenkins Governance Board during the 2019/2021 term.
 I am a professor of Software Engineering at the University of Applied Sciences Munich, where I also try to win new Jenkins contributors by letting students develop new features in their student projects and theses.
 I am also helping new contributors (and students) in our Jenkins forums or by giving some talks in our Jenkins Meetups.
 It would be a pleasure for me to serve again as a member of the governance board.
-In the board I can help the Jenkins project to evolve and follow a strict vision, that will focus on the needs of the users. 
+On the board, I can help the Jenkins project evolve and follow a strict vision that will focus on the needs of the users. 
 
 Affiliations: University of Applied Sciences Munich
 
@@ -63,7 +63,7 @@ link:https://github.com/uhafner[Github]
 === Release Officer - link:https://www.jenkins.io/blog/authors/timja/[Tim Jacomb]
 
 I have been a user of Jenkins for the last 10 years and a regular contributor since 2018.
-I began with maintaining the Slack plugin and over the last couple of years I have since expanded that to many more plugins and the Jenkins core.
+I began with maintaining the Slack plugin, and over the last couple of years, I have expanded my experience with several more plugins and the Jenkins core.
 These are some of the components I maintain when I have time: Slack, Azure Key Vault, Junit, most of the Database plugins, Dark theme, Plugin installation manager, Jenkins Helm chart, and Configuration as code plugin.
 I am also a member of the Jenkins infrastructure team, and I was involved in the release automation project and the mirrors modernisation effort, along with the day to day support helping people regain access to accounts etc.
 As a Release Officer I would like to increase automation, ease onboarding of new contributors to the release team, and ensure that responsibilities rotate among people so that I wouldn't be a bottleneck for any task.
@@ -86,9 +86,9 @@ link:https://github.com/alyssat[Github]
 
 === Security Officer - link:https://www.jenkins.io/blog/authors/wadeck/[Wadeck Follonier]
 
-I joined the Jenkins adventure in 2017, as long as the Jenkins Security team and was coached by Oleg Nenashev and Daniel Beck about how to best contribute to the community effort, especially related to security tasks.
+I joined the Jenkins adventure in 2017, as part of the Jenkins Security team and was coached by Oleg Nenashev and Daniel Beck about how to best contribute to the community effort, especially related to security tasks.
 I am working full time at CloudBees, managing two teams, including the security team dedicated to Jenkins.
-I got inspired by Daniel's work in terms of tooling, to create an application helping both the security people and the maintainers through multiple bot commands (in SECURITY tickets and in Hosting request).
+I was inspired by Daniel's work in terms of tooling, to create an application helping both the security people and the maintainers through multiple bot commands (in SECURITY tickets and in Hosting request).
 During the year as the Security Officer, I spent a good amount of my time onboarding the future experts, finding ways to increase efficiency of the team by left shifting tasks, to reduce the size of our backlog and to put the focus on important tasks.
 For the next year, I would like to continue the effort to make Jenkins an even more secure place.
 One of the topic that I want to push forward is about the Content Security Policy introduction in the Jenkins ecosystem.
@@ -101,12 +101,12 @@ link:https://www.linkedin.com/in/wadeck/[Linkedin]
 === Documentation Officer - link:https://www.jenkins.io/blog/authors/kmartens27/[Kevin Martens]
 
 I am a technical documentation writer, and have been contributing to the Jenkins project consistently over the last seven months. 
-I have helped create the Blue Ocean status statement that is now in the documentation, DevOps World material, and was a mentor for the Jenkins Documentation area of Hacktoberfest 2022.
+I helped create the Blue Ocean status statement that is now in the documentation, DevOps World material, and was a mentor for the Jenkins Documentation area of Hacktoberfest 2022.
 I have recently been added to the copy-editor team due to my involvement with the Jenkins Documentation SIG and contributions.
 
-I have learned constantly by contributing link:/blog/authors/kmartens27/[blog posts] to Jenkins and the link:https://cd.foundation/blog/2022/09/07/jenkins-18th-birthday-%f0%9f%8e%82-and-retrospective/[CD Foundation], documentation updates and creation, and screenshot updates.
-I have also contributed recent LTS release changelogs and upgrade guides, and am currently reviewing the weekly release lines.
-I review open pull requests, issues, and feedback, so that we can discuss further with the community and work to improve things as needed.
+I continue to learn by contributing link:/blog/authors/kmartens27/[blog posts] to Jenkins and the link:https://cd.foundation/blog/2022/09/07/jenkins-18th-birthday-%f0%9f%8e%82-and-retrospective/[CD Foundation], documentation updates and creation, and screenshot updates.
+I have also contributed to recent LTS release changelogs and upgrade guides, and am currently reviewing the weekly release lines.
+I review open pull requests, issues, and feedback, so that we can discuss further with the community and work to improve as needed.
 I've also developed a passion for open source, through reviewing documentation and building my own Jenkins environments.
 
 I am currently hosting the EU Docs office hours, and would love to expand my knowledge, along with others.

--- a/content/blog/2022/11/2022-11-17-jenkins-election-candidates.adoc
+++ b/content/blog/2022/11/2022-11-17-jenkins-election-candidates.adoc
@@ -1,0 +1,131 @@
+---
+:layout: post
+:title: "Jenkins Elections Announcement"
+:tags:
+- community
+- governance
+- governance-board
+- elections
+authors:
+- kmartens27
+description: >
+    Announcement for Jenkins Board elections 2022.
+links:
+  discourse: true
+opengraph:
+  image: /images/governance/elections/2022/2022-opengraph.png
+---
+
+Hello all, voter registration and candidate nominations for the 2023 Jenkins elections are now complete.
+Thanks to everyone who registered to vote and to all those who submitted nominations.
+Special thanks to the candidates that have accepted the nominations.
+
+As in years past, when a particular role receives only one nomination, no election is required.
+This year, all the board and officer positions are uncontested, with one person nominated to fill each available position.
+This announcement shares the candidates and their statements, and serves as an announcement that the candidates have been elected and will begin their service December 3, 2022.
+
+== New Board Members
+
+=== Board Member - Alexander Brandes
+
+I am a Jenkins user, contributor to the Jenkins project, and core maintainer.
+I maintain many plugins, and have helped organize Jenkins online meetups, which I also have been part of.
+I attend and take part in documentation and user experience office hours frequently.
+Previously, I have led community initiatives, such as the  link:https://www.meetup.com/jenkins-online-meetup/events/285677298/[Jenkins plugin integration with Crowdin] and participated in the link:https://www.jenkins.io/blog/2022/06/28/require-java-11/#acknowledgments[Java 11 and 17 support campaigns].
+
+I truly believe in Jenkins' future and would be happy to serve on the Jenkins governance board.
+I would like to make Jenkins a great place to contribute, and to get more beginners and regular contributors involved in the community on a regular basis.
+Onboarding more individual contributors would be one of my key targets, for example, through Jenkins' continued participation in Google Summer of Code.
+
+On the technical aspect, I plan to move automatic plugin and component releases forward, and focus on the support and extension of modern technologies, such as Java 17 and beyond.
+
+Affiliations: Student of business science
+
+link:https://github.com/NotMyFault[GitHub]  
+link:https://twitter.com/NotMyFault_OG[Twitter]
+
+=== Board Member - Ullrich Hafner
+
+I have been an active contributor in the Jenkins project since 2007.
+Currently, I am the maintainer of several Jenkins plugins, mostly in the area of build result visualization using modern JS based user interfaces: e.g., I am the maintainer of the warnings, code coverage and git-forensics plugins as well as several UI related JS wrapper plugins like Bootstrap or ECharts.
+I am a member of the Jenkins UX SIG and I formerly was a member of the Jenkins Governance Board during the 2019/2021 term.
+I am a professor of Software Engineering at the University of Applied Sciences Munich, where I also try to win new Jenkins contributors by letting students develop new features in their student projects and theses.
+I am also helping new contributors (and students) in our Jenkins forums or by giving some talks in our Jenkins Meetups.
+It would be a pleasure for me to serve again as a member of the governance board.
+In the board I can help the Jenkins project to evolve and follow a strict vision, that will focus on the needs of the users. 
+
+Affiliations: University of Applied Sciences Munich
+
+link:https://github.com/uhafner[Github]
+
+== New Officers
+
+=== Release Officer - Tim Jacomb
+
+I have been a user of Jenkins for the last 10 years and a regular contributor since 2018.
+I began with maintaining the Slack plugin and over the last couple of years I have since expanded that to many more plugins and the Jenkins core.
+These are some of the components I maintain when I have time: Slack, Azure Key Vault, Junit, most of the Database plugins, Dark theme, Plugin installation manager, Jenkins Helm chart, and Configuration as code plugin.
+I am also a member of the Jenkins infrastructure team, and I was involved in the release automation project and the mirrors modernisation effort, along with the day to day support helping people regain access to accounts etc.
+As a Release Officer I would like to increase automation, ease onboarding of new contributors to the release team, and ensure that responsibilities rotate among people so that I wouldn't be a bottleneck for any task.
+
+Affiliations: Kainos
+
+link:https://github.com/timja[Github]
+
+=== Events Officer - Alyssa Tong
+
+"It has been a privilege for me to be part of the Jenkins community and serve as Events Officer in 2022.
+I would be honored to serve as Events Officer for another term if given the opportunity.
+I am passionate about open source, collaboration, and education.
+My goal is to build welcoming communities, and coordinating events is part of this role.
+More importantly, I strive to bring the community together through events and conferences, so we can share best practices and collaborate for the betterment of the project."
+
+Affiliations: CloudBees
+
+link:https://github.com/alyssat[Github]
+
+=== Security Officer - Wadeck Follonier
+
+I joined the Jenkins adventure in 2017, as long as the Jenkins Security team and was coached by Oleg Nenashev and Daniel Beck about how to best contribute to the community effort, especially related to security tasks.
+I am working full time at CloudBees, managing two teams, including the security team dedicated to Jenkins.
+I got inspired by Daniel's work in terms of tooling, to create an application helping both the security people and the maintainers through multiple bot commands (in SECURITY tickets and in Hosting request).
+During the year as the Security Officer, I spent a good amount of my time onboarding the future experts, finding ways to increase efficiency of the team by left shifting tasks, to reduce the size of our backlog and to put the focus on important tasks.
+For the next year, I would like to be able to continue the effort to make Jenkins an even more secure place.
+One of the topic that I want to push forward is about the Content Security Policy introduction in the Jenkins ecosystem.
+
+Affiliations: CloudBees
+
+link:https://github.com/Wadeck[Github]
+link:https://www.linkedin.com/in/wadeck/[Linkedin]
+
+=== Documentation Officer - Kevin Martens
+
+I am a technical documentation writer, and have been contributing to the Jenkins project consistently over the last seven months. 
+I have helped create the Blue Ocean status statement that is now in the documentation, DevOps World material, and was a mentor for the Jenkins Documentation area of Hacktoberfest 2022.
+I have recently been added to the copy-editor team due to my involvement with the Jenkins Documentation SIG and contributions.
+
+I have learned constantly by contributing link:/blog/authors/kmartens27/[blog posts] to Jenkins and the link:https://cd.foundation/blog/2022/09/07/jenkins-18th-birthday-%f0%9f%8e%82-and-retrospective/[CD Foundation], documentation updates and creation, and screenshot updates.
+I have also contributed recent LTS release changelogs and upgrade guides, and am currently reviewing the weekly release lines.
+I review open pull requests, issues, and feedback, so that we can discuss further with the community and work to improve things as needed.
+I've also developed a passion for open source, through reviewing documentation and building my own Jenkins environments.
+
+I am currently hosting the EU Docs office hours, and would love to expand my knowledge, along with others.
+I want to empower the community further to increase activity and investment in the Jenkins project.
+My main goal is to help extend the community and ensure the documentation is accessible for both new and experienced users. 
+
+Affiliations: CloudBees
+
+link:https://github.com/kmartens27[Github]
+
+=== Infrastructure Officer - Damien Duportal
+
+I am a Software Engineer working as a SRE for the Jenkins public infrastructure and as an IT teacher.
+I am active in the Platform SIG, and have been using Jenkins for over a decade.
+I am a fervent open-source citizen and active in other communities including Docker, Asciidoctor and Updatecli.
+
+Affiliations: CloudBees
+
+link:https://github.com/dduportal[Github]
+
+We want to congratulate the nominees and share thanks to the community for joining us in this year's election.
+

--- a/content/security/advisory/2022-11-15.adoc
+++ b/content/security/advisory/2022-11-15.adoc
@@ -156,6 +156,53 @@ issues:
   - name: dockerhub-notification
     previous: 2.6.2
     fixed: 2.6.2.1
+- id: SECURITY-2912
+  reporter: Daniel Beck, CloudBees, Inc.
+  title: Passwords stored in plain text by PLUGIN_NAME
+  cve: CVE-2022-45392
+  cvss:
+    severity: Medium
+    vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+  description: |-
+    PLUGIN_NAME 4.8.0.143 and earlier stores passwords unencrypted in job `config.xml` files on the Jenkins controller as part of its configuration.
+
+    These passwords can be viewed by attackers with Item/Extended Read permission or access to the Jenkins controller file system.
+
+    PLUGIN_NAME 4.8.0.146 stores passwords encrypted once job configurations are saved again.
+  plugins:
+  - name: cavisson-ns-nd-integration
+    previous: 4.8.0.143
+    fixed: 4.8.0.146
+- id: SECURITY-2910 (1)
+  reporter: Daniel Beck, CloudBees, Inc.
+  title: SSL/TLS certificate validation globally and unconditionally disabled by PLUGIN_NAME
+  cve: CVE-2022-45391
+  cvss:
+    severity: Medium
+    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
+  description: |-
+    PLUGIN_NAME 4.8.0.143 and earlier globally and unconditionally disables SSL/TLS certificate and hostname validation for the entire Jenkins controller JVM.
+
+    PLUGIN_NAME 4.8.0.146 no longer disables SSL/TLS certificate and hostname validation globally.
+  plugins:
+  - name: cavisson-ns-nd-integration
+    previous: 4.8.0.143
+    fixed: 4.8.0.146
+- id: SECURITY-2910 (2)
+  reporter: Daniel Beck, CloudBees, Inc.
+  title: SSL/TLS certificate validation unconditionally disabled by PLUGIN_NAME
+  cve: CVE-2022-38666
+  cvss:
+    severity: Medium
+    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
+  description: |-
+    PLUGIN_NAME 4.8.0.146 and earlier unconditionally disables SSL/TLS certificate and hostname validation for several features.
+
+    As of publication of this advisory, there is no fix.
+    link:/security/plugins/#unresolved[Learn why we announce this.]
+  plugins:
+  - name: cavisson-ns-nd-integration
+    previous: 4.8.0.146
 - id: SECURITY-766
   reporter: Daniel Beck, CloudBees, Inc.
   title: XXE vulnerability on agents in PLUGIN_NAME
@@ -248,53 +295,6 @@ issues:
   plugins:
   - name: loaderio-jenkins-plugin
     previous: 1.0.1
-- id: SECURITY-2910 (1)
-  reporter: Daniel Beck, CloudBees, Inc.
-  title: SSL/TLS certificate validation globally and unconditionally disabled by PLUGIN_NAME
-  cve: CVE-2022-45391
-  cvss:
-    severity: Medium
-    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
-  description: |-
-    PLUGIN_NAME 4.8.0.143 and earlier globally and unconditionally disables SSL/TLS certificate and hostname validation for the entire Jenkins controller JVM.
-
-    PLUGIN_NAME 4.8.0.146 no longer disables SSL/TLS certificate and hostname validation globally.
-  plugins:
-  - name: cavisson-ns-nd-integration
-    previous: 4.8.0.143
-    fixed: 4.8.0.146
-- id: SECURITY-2910 (2)
-  reporter: Daniel Beck, CloudBees, Inc.
-  title: SSL/TLS certificate validation unconditionally disabled by PLUGIN_NAME
-  cve: CVE-2022-38666
-  cvss:
-    severity: Medium
-    vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
-  description: |-
-    PLUGIN_NAME 4.8.0.146 and earlier unconditionally disables SSL/TLS certificate and hostname validation for several features.
-
-    As of publication of this advisory, there is no fix.
-    link:/security/plugins/#unresolved[Learn why we announce this.]
-  plugins:
-  - name: cavisson-ns-nd-integration
-    previous: 4.8.0.146
-- id: SECURITY-2912
-  reporter: Daniel Beck, CloudBees, Inc.
-  title: Passwords stored in plain text by PLUGIN_NAME
-  cve: CVE-2022-45392
-  cvss:
-    severity: Medium
-    vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
-  description: |-
-    PLUGIN_NAME 4.8.0.143 and earlier stores passwords unencrypted in job `config.xml` files on the Jenkins controller as part of its configuration.
-
-    These passwords can be viewed by attackers with Item/Extended Read permission or access to the Jenkins controller file system.
-
-    PLUGIN_NAME 4.8.0.146 stores passwords encrypted once job configurations are saved again.
-  plugins:
-  - name: cavisson-ns-nd-integration
-    previous: 4.8.0.143
-    fixed: 4.8.0.146
 - id: SECURITY-2920
   reporter: CC Bomber, Kitri BoB
   title: CSRF vulnerability and missing permission check in PLUGIN_NAME


### PR DESCRIPTION
This is a pull request to add a blog post for the Jenkins election candidate announcements. It also includes information pertaining to the election process this year.