### PR TITLE
Fix spelling errors

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -51,6 +51,7 @@ check-filename = false
 "Apr2ndMeeting" = "Apr2ndMeeting"
 "Jan22ndMeeting" = "Jan22ndMeeting"
 "4UmY4dDAlo0" = "4UmY4dDAlo0"
+"loLSNdCv6K4" = "loLSNdCv6K4"
 "ND" = "ND"
 "nd" = "nd"
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -65,3 +65,5 @@ check-filename = false
 "CNA" = "CNA"
 "Ser" = "Ser"
 "Synopsys" = "Synopsys"
+# content/security/advisory/2022-06-30.adoc
+"testng" = "testng"

--- a/content/blog/2022/11/2022-11-17-hacktoberfest-recap.adoc
+++ b/content/blog/2022/11/2022-11-17-hacktoberfest-recap.adoc
@@ -90,7 +90,7 @@ However, these are learning experiences, as each one is an opportunity to unders
 
 image:/images/post-images/2022-11-14-hacktoberfest-recap/teona.png[Teona Mushambadze, width=20%]
 
-link:https://github.com/StefanSpieker[Stefan Spieker] is a solutions architecht and DevOps engineer from Aachen, Germany.
+link:https://github.com/StefanSpieker[Stefan Spieker] is a solutions architect and DevOps engineer from Aachen, Germany.
 He has been participating in Hacktoberfest since 2019, with a strong focus on Jenkins core and plugin development.
 Hacktoberfest was the trigger to start participating, and Stefan has continued to contribute regularly.
 Stefan likes to contribute to open source in his free time and has found that there are always ways to improve.

--- a/content/doc/book/managing/ui-themes.adoc
+++ b/content/doc/book/managing/ui-themes.adoc
@@ -30,7 +30,7 @@ There are several plugins that provide built-in themes, the most popular are
   provides Solarized (light and dark) themes.
 
 Installing any of these will also install their common dependency: the plugin:theme-manager[Theme Manager Plugin].
-This plugin allows administrators to set the default theme for a Jenkins installation via _Manage Jenkins > Configure System > Buit-in Themes_
+This plugin allows administrators to set the default theme for a Jenkins installation via _Manage Jenkins > Configure System > Built-in Themes_
 and users can set their preferred theme in their personal settings.
 You can also configure this plugin using plugin:configuration-as-code[Configuration-as-Code Plugin].
 See the plugin documentation for more details.

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -98,7 +98,7 @@ This information is published by the election committee before the voting starts
 Any Jenkins project and/or community contributor is eligible to vote in the election if there is a contribution made before September 01 of the election year.
 Contributing does not only mean a _code contribution_, as link:/participate[contributions] could be:
 
-* Documentation udpates or creation
+* Documentation updates or creation
 * Code reviews
 * Issue reporting
 * Translating resources

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -169,7 +169,7 @@ With major multi-national corporations, such as Amazon, which have hundreds of a
 There are several motivations behind the above proposal:
 
 . Odd number of people prevents the tie problem
-. Given the variety of ways to contribute, we couldn't identify a singluar criteria to define the right to vote in board elections. 
+. Given the variety of ways to contribute, we couldn't identify a singular criteria to define the right to vote in board elections. 
 At the same time, we wanted to preserve stability by limiting voting rights to only those with some involvement in the project.
 
 == Previous elections

--- a/content/security/advisory/2022-10-19.adoc
+++ b/content/security/advisory/2022-10-19.adoc
@@ -422,7 +422,7 @@ issues:
   description: |-
     PLUGIN_NAME 1.4 and earlier does not escape the name and description of the parameter types it provides.
 
-    This results in stored cross-site scripting (XSS) vulnerabilites exploitable by attackers with Item/Configure permission.
+    This results in stored cross-site scripting (XSS) vulnerabilities exploitable by attackers with Item/Configure permission.
 
     Exploitation of this vulnerability requires that parameters are listed on another page, like the "Build With Parameters" and "Parameters" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation.
     Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the "Build With Parameters" and "Parameters" pages since 2.44 and LTS 2.32.2 as part of the link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions[SECURITY-353 / CVE-2017-2601] fix.


### PR DESCRIPTION
## Fix spelling errors

Spelling errors have crept into the documentation even though `typos` is flagging them for us.

@kmartens27 does this look OK to you?

- Fix spelling error Buit -> Built
- Another YouTube URL that is not a typo
- Spelling fix for architect
- Spelling fix of singular
- Spelling fix updates
- Spelling fix for vulnerabilities
- Allow testng for testng-plugin in advisory

Squash merge this (individual commits were used to assure that I was removing one issue at a time).
