### PR TITLE
Revert "Update Bootstrap to 5.2, replace Tether with Popper (#5436)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(BUILD_DIR)/assets: $(BUILD_DIR)/node $(shell find . -ipath "./node_modules/*" 
 		echo "Copying $$f into $(FONTS_DIR)"; \
 		cp $$f $(FONTS_DIR); \
 	done;
-	@for d in bootstrap jquery '@popperjs/core'; do \
+	@for d in bootstrap jquery tether; do \
 		echo "Copying node_modules/$$d/dist/* into $(ASSETS_DIR)/$$d/"; \
 		mkdir -p $(ASSETS_DIR)/$$d; \
 		cp -R node_modules/$$d/dist/* $(ASSETS_DIR)/$$d/ ; \

--- a/content/_layouts/chapter.html.haml
+++ b/content/_layouts/chapter.html.haml
@@ -24,16 +24,19 @@ notitle: true
   end
 
 
-%div
+.container
   .row
     .col-md-4
-      - if previous_chapter
-        %a.prev.doc-page-link{:href =>  File.join('..', previous_chapter.key)}
-          ⇐ #{previous_chapter.title}
+      .row
+        - if previous_chapter
+          %a.prev.doc-page-link{:href =>  File.join('..', previous_chapter.key)}
+            ⇐ #{previous_chapter.title}
     .col-md-4
-      %a.index.doc-page-link{:href => '../'}
-        Index
+      .row
+        %a.index.doc-page-link{:href => '../'}
+          Index
     .col-md-4
+      .row
       - if next_chapter
         - if next_is_section
           %a.next.doc-page-link{:href =>  next_chapter.key}
@@ -42,7 +45,7 @@ notitle: true
           %a.next.doc-page-link{:href =>  File.join('..', next_chapter.key)}
             #{next_chapter.title} ⇒
 
-%div
+.container
   .row.body
     .section
       %h1
@@ -64,16 +67,19 @@ notitle: true
 
 %hr/
 
-%div
+.container
   .row
     .col-md-4
-      - if previous_chapter
-        %a.prev.doc-page-link{:href =>  File.join('..', previous_chapter.key)}
-          ⇐ #{previous_chapter.title}
+      .row
+        - if previous_chapter
+          %a.prev.doc-page-link{:href =>  File.join('..', previous_chapter.key)}
+            ⇐ #{previous_chapter.title}
     .col-md-4
-      %a.index.doc-page-link{:href => '../'}
-        Index
+      .row
+        %a.index.doc-page-link{:href => '../'}
+          Index
     .col-md-4
+      .row
       - if next_chapter
         - if next_is_section
           %a.next.doc-page-link{:href =>  next_chapter.key}
@@ -84,5 +90,5 @@ notitle: true
 
 %hr/
 
-%div
+.container
 = partial ('_feedback-footer.html')

--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -61,6 +61,9 @@
       %link{:href => expand_link("/assets/bower/bootstrap/css/bootstrap.min.css"),
         :rel => 'stylesheet',
         :media => 'screen'}/
+      %link{:href => expand_link("/assets/bower/tether/css/tether.min.css"),
+        :rel => 'stylesheet',
+        :media => 'screen'}/
       %link{:href => expand_link("/css/jenkins.css"),
         :rel => 'stylesheet',
         :media => 'screen'}/
@@ -85,7 +88,7 @@
     = content
 
     %script{:src => expand_link("/assets/bower/anchor-js/anchor.min.js")}
-    %script{:src => expand_link("/assets/bower/@popperjs/core/umd/popper.min.js")}
+    %script{:src => expand_link("/assets/bower/tether/js/tether.min.js")}
     %script{:src => expand_link("/assets/bower/bootstrap/js/bootstrap.min.js")}
     %script{:src => "https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.esm.js",
       :type => "module",

--- a/content/_layouts/section.html.haml
+++ b/content/_layouts/section.html.haml
@@ -32,27 +32,31 @@ notitle: true
     next_section = site.handbook.chapters[index + 1]
   end
 
-%div
+.container
   .row
     .col-md-4
-      - unless prev_section.nil?
-        %a.prev.doc-page-link{:href => File.join('..', prev_section.key)}
-          ⇐ #{prev_section.title}
+      .row
+        - unless prev_section.nil?
+          %a.prev.doc-page-link{:href => File.join('..', prev_section.key)}
+            ⇐ #{prev_section.title}
     .col-md-4
-      %a.up.doc-page-link{:href => '../'}
-        ⇑ #{chapter.title}
-      %a.index.doc-page-link{:href => '../../'}
-        Index
+      .row
+        %a.up.doc-page-link{:href => '../'}
+          ⇑ #{chapter.title}
+      .row
+        %a.index.doc-page-link{:href => '../../'}
+          Index
     .col-md-4
-      - unless next_section.nil?
-        - if next_is_chapter
-          %a.next.doc-page-link{:href => File.join('../../', next_section.key)}
-            #{next_section.title} ⇒
-        - else
-          %a.next.doc-page-link{:href => File.join('..', next_section.key)}
-            #{next_section.title} ⇒
+      .row
+        - unless next_section.nil?
+          - if next_is_chapter
+            %a.next.doc-page-link{:href => File.join('../../', next_section.key)}
+              #{next_section.title} ⇒
+          - else
+            %a.next.doc-page-link{:href => File.join('..', next_section.key)}
+              #{next_section.title} ⇒
 
-%div
+.container
   .row.body
     .section
       %h1
@@ -78,25 +82,29 @@ notitle: true
 
 %hr/
 
-%div
+.container
   .row
     .col-md-4
-      - unless prev_section.nil?
-        %a.prev.doc-page-link{:href => File.join('..', prev_section.key)}
-          ⇐ #{prev_section.title}
+      .row
+        - unless prev_section.nil?
+          %a.prev.doc-page-link{:href => File.join('..', prev_section.key)}
+            ⇐ #{prev_section.title}
     .col-md-4
-      %a.up.doc-page-link{:href => '../'}
-        ⇑ #{chapter.title}
-      %a.index.doc-page-link{:href => '../../'}
-        Index
+      .row
+        %a.up.doc-page-link{:href => '../'}
+          ⇑ #{chapter.title}
+      .row
+        %a.index.doc-page-link{:href => '../../'}
+          Index
     .col-md-4
-      - unless next_section.nil?
-        - if next_is_chapter
-          %a.next.doc-page-link{:href => File.join('../../', next_section.key)}
-            #{next_section.title} ⇒
-        - else
-          %a.next.doc-page-link{:href => File.join('..', next_section.key)}
-            #{next_section.title} ⇒
+      .row
+        - unless next_section.nil?
+          - if next_is_chapter
+            %a.next.doc-page-link{:href => File.join('../../', next_section.key)}
+              #{next_section.title} ⇒
+          - else
+            %a.next.doc-page-link{:href => File.join('..', next_section.key)}
+              #{next_section.title} ⇒
 
 %hr/
 

--- a/content/_partials/_feedback-footer.html
+++ b/content/_partials/_feedback-footer.html
@@ -22,7 +22,7 @@ $(document).ready(function() {
 </script>
 <script src="/js/feedback-form-functionality.js"></script>
 
-<p><a href="#feedback" data-bs-toggle="collapse">Was this page helpful?</a></p>
+<p><a href="#feedback" data-toggle="collapse">Was this page helpful?</a></p>
 
 <div id="feedback" class="collapse">
 

--- a/content/_partials/downloadbanner.html.haml
+++ b/content/_partials/downloadbanner.html.haml
@@ -29,10 +29,11 @@
           %a{ :href => "https://www.icrc.org/" }
             International Committee of the Red Cross
 
-        .mb-2
-          %a.btn.btn-secondary.m-1{:href => expand_link('doc')}
-            Documentation
-          %a.btn.btn-primary.m-1{:href => expand_link('download')}
-            Download
+        .container
+          .row
+            %a.btn.btn-secondary.m-1{:href => expand_link('doc')}
+              Documentation
+            %a.btn.btn-primary.m-1{:href => expand_link('download')}
+              Download
 
       .col-md-1.col-lg-2

--- a/content/_partials/dropdown.html.haml
+++ b/content/_partials/dropdown.html.haml
@@ -1,2 +1,2 @@
-%button.nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-bs-toggle" => "dropdown"}
+%button.nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown"}
   = page.name

--- a/content/_partials/media.html.haml
+++ b/content/_partials/media.html.haml
@@ -5,7 +5,7 @@
 
   - page.media.each do |media|
 
-    %a.card.media{'data-bs-toggle' => 'lightbox',
+    %a.card.media{'data-toggle' => 'lightbox',
       'data-gallery' => 'youtubevideos',
       'data-title' => media.title,
       :href => "https://youtu.be/#{media.id}"}

--- a/content/_partials/steps.html.haml
+++ b/content/_partials/steps.html.haml
@@ -8,7 +8,7 @@
       - icon = step.iconclass
 
       %li.card.step.col-lg-3.col-md-6 
-        %a.card-block{'data-bs-toggle' => 'popover',
+        %a.card-block{'data-toggle' => 'popover',
           'data-container' => '#ji-hover-layer',
           'data-placement' => 'top',
           'data-trigger' => 'hover focus',

--- a/content/_partials/toptoolbar.html.haml
+++ b/content/_partials/toptoolbar.html.haml
@@ -1,7 +1,7 @@
 %nav#ji-toolbar.navbar.navbar-expand-lg.navbar-dark.bg-dark.fixed-top
   %a.navbar-brand{:href => expand_link('/')}
     = site.base_title
-  %button.navbar-toggler{"data-bs-target" => "#CollapsingNavbar", "data-bs-toggle" => "collapse", :type => "button"}
+  %button.navbar-toggler{"data-target" => "#CollapsingNavbar", "data-toggle" => "collapse", :type => "button"}
     %span.navbar-toggler-icon
   #CollapsingNavbar.collapse.navbar-collapse
 

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -13,18 +13,6 @@ img {
   max-width: 100%;
 }
 
-a {
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-.btn:hover {
-  text-decoration: none;
-}
-
 .anchorjs-link:hover {
   opacity: 1;
 }
@@ -1380,8 +1368,6 @@ table {
 .doc-page-link {
     margin-left: auto;
     margin-right: auto;
-    text-align: center;
-    display: block;
 }
 
 
@@ -1438,33 +1424,9 @@ table.syntax > tbody > tr > th {
   font-weight: bold;
 }
 
-.mr-auto {
-  margin-right: auto;
-}
 
-.ml-auto {
-  margin-left: auto;
-}
-
-.jumbotron {
-  padding: 2rem 1rem;
-  margin-bottom: 2rem;
-  background-color: #e9ecef;
-  border-radius: 0.3rem;
-}
-
-@media (min-width: 576px) {
-  .jumbotron {
-    padding: 4rem 2rem;
-  }
-}
-
-.row {
-  --bs-gutter-x: 30px;
-}
 /** pilfered from blueocean-style.css **/
 .navbar.navbar-expand-lg {
-  padding: 0.5rem 1rem;
   font-size: 0.875rem; }
   .navbar.navbar-expand-lg.bg-dark {
     background-color: #212529!important; }

--- a/content/css/roadmap.css
+++ b/content/css/roadmap.css
@@ -168,12 +168,14 @@ table.roadmap-table {
         table.roadmap-table tbody tr td:last-child {
           padding-right: 16px; } }
 
-.tooltip {
-  --bs-tooltip-bg: #212529;
-}
-
 .tooltip-inner {
+  background-color: #354052;
   max-width: 260px;
   padding: 6px 12px;
   color: white;
-}
+  border-radius: 3px;
+  font-family: lato; }
+
+.tooltip.bs-tether-element-attached-bottom .tooltip-inner::before,
+.tooltip.tooltip-top .tooltip-inner::before {
+  border-top-color: #354052; }

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -5,7 +5,7 @@ title: Jenkins download and deployment
 
 :ruby
   def third_party_href(url)
-    third_party = {'data-bs-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => 'This is a package supported by a third party which may be not as frequently updated as packages supported by the Jenkins project directly'}
+    third_party = {'data-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => 'This is a package supported by a third party which may be not as frequently updated as packages supported by the Jenkins project directly'}
     return third_party.merge({:href => url})
   end
 

--- a/content/js/blueocean-landing-script.js
+++ b/content/js/blueocean-landing-script.js
@@ -10,7 +10,7 @@ $(function () {
 })
 
 function initToolTips() {
-  $('[data-bs-toggle="tooltip"]').tooltip();
+  $('[data-toggle="tooltip"]').tooltip();
 }
 
 setInterval(function() {

--- a/content/js/roadmap.js
+++ b/content/js/roadmap.js
@@ -45,10 +45,3 @@ function filterRoadmap() {
     }
   }
 }
-
-window.addEventListener("load", function() {
-  var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-  var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
-    return new bootstrap.Tooltip(tooltipTriggerEl);
-  });
-})

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -12,7 +12,7 @@ tags:
 
 :ruby
   def tooltip_href(url, title)
-    tooltip = {'data-bs-toggle' => 'tooltip', 'data-bs-placement' => 'top', 'title' => title}
+    tooltip = {'data-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => title}
     return url != null ? tooltip.merge({:href => url, :target => "_blank", :rel => "noreferrer noopener"}) : tooltip
   end
 

--- a/content/projects/blueocean/index.html.haml
+++ b/content/projects/blueocean/index.html.haml
@@ -38,7 +38,7 @@ links:
   .container
     .row
       .col-xs-12.col-sm-11.col-lg-10.col-xl-9
-        %a.video{"data-bs-target" => "#videoModal", "data-bs-toggle" => "modal", "data-video" => "https://www.youtube.com/embed/k_fVlU1FwP4"}
+        %a.video{"data-target" => "#videoModal", "data-toggle" => "modal", "data-video" => "https://www.youtube.com/embed/k_fVlU1FwP4"}
           %video{:autoplay => "", :loop => "", :muted => "", :poster => "img/video.png"}
             %source{:src => "img/video.webm", :type => "video/webm"}
               %source{:src => "img/video.mp4", :type => "video/mp4"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,16 @@
       "name": "jenkins.io-node-tooling",
       "version": "1.0.0",
       "dependencies": {
-        "@popperjs/core": "^2.11.6",
         "anchor-js": "^4.2.0",
-        "bootstrap": "^5.2.0",
-        "jquery": "^3.5.1"
+        "bootstrap": "^4.3.1",
+        "jquery": "^3.5.1",
+        "popper.js": "^1.14.7",
+        "tether": "^1.4.5"
       },
       "devDependencies": {
         "broken-link-checker": "^0.7.8",
         "http-server": "^14.1.0",
         "npm-run-all": "^4.1.5"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@types/node": {
@@ -125,21 +117,11 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/brace-expansion": {
@@ -1334,6 +1316,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/popper.js": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
+    },
     "node_modules/portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -1682,6 +1669,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/tether": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.5.tgz",
+      "integrity": "sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw=="
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1911,11 +1903,6 @@
     }
   },
   "dependencies": {
-    "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
-    },
     "@types/node": {
       "version": "12.7.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.7.tgz",
@@ -2006,10 +1993,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
-      "requires": {}
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2949,6 +2935,11 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
+    "popper.js": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -3253,6 +3244,11 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
+    },
+    "tether": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.5.tgz",
+      "integrity": "sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "author": "",
   "dependencies": {
     "anchor-js": "^4.2.0",
-    "bootstrap": "^5.2.0",
+    "bootstrap": "^4.3.1",
     "jquery": "^3.5.1",
-    "@popperjs/core": "^2.11.6"
+    "popper.js": "^1.14.7",
+    "tether": "^1.4.5"
   },
   "devDependencies": {
     "broken-link-checker": "^0.7.8",


### PR DESCRIPTION
## Revert Bootstrap upgrade

Drop-down menus were not appearing when I clicked the button at the top of the page for "Documentation", "Community", "Subprojects", and "About".

This reverts commit 8cfb4a85dcbd4d6e781d5f60fd5fe2f04c1ddb86.

@zbynek my apologies, but I don't understand why my menus no longer dropdown on any of the machines that I've tested.  Attempting this revert to see if I can duplicate the issue anywhere other than on the production site.