### PR TITLE
Fixed horizontal scroll issue on mobile

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1002,6 +1002,9 @@ ion-icon {
     padding-bottom: .5rem;
     margin-bottom: .5rem;
   }
+  iframe {
+    width: 100%; 
+  }
 }
 
 @media ( min-width : 992px ) and ( max-width : 1200px ) {

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -3,6 +3,11 @@
   scroll-margin-top: 55px;
 }
 
+html, body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 /* hide anchors unless they're hovered to offset the weird margin/padding
    needed for anchored links to not hide the target behind the navigation bar */
 *:hover > .anchorjs-link {


### PR DESCRIPTION
## Description 
* Yesterday I visited the website on mobile and noticed that it was possible to scroll horizontally on the website.

* The screenshot below shows that the menu icon isn't completely visible on screen. 
<img width="723" alt="Schermafbeelding 2022-11-23 om 11 50 37" src="https://user-images.githubusercontent.com/75273616/203529022-64a42c9b-0662-43ba-a3d3-005244e0d5eb.png">

* As you can see here, there is still some overflow to the right, which enables horizontal scroll. (I changed the background to red to make it easier to spot). 
<img width="720" alt="Schermafbeelding 2022-11-23 om 11 50 50" src="https://user-images.githubusercontent.com/75273616/203529239-41af5b53-5442-4c3e-9f0e-b80951a06b55.png">

* The CSS that I added fixes this issue. 

