### PR TITLE
Default to k8s for agent selection in tutorials

### DIFF
--- a/content/doc/developer/publishing/continuous-integration.adoc
+++ b/content/doc/developer/publishing/continuous-integration.adoc
@@ -8,12 +8,12 @@ It will build all plugin repositories in the `jenkinsci` organization that have 
 
 The typical plugin build (Maven or Gradle) can be run by just having the following statement in the `Jenkinsfile`:
 ----
-buildPlugin()
+buildPlugin(useContainerAgent: true)
 ----
 
 Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use:
 ----
-buildPluginWithGradle()
+buildPluginWithGradle(useContainerAgent: true)
 ----
 
 To learn more about the Pipeline library providing this functionality, see https://github.com/jenkins-infra/pipeline-library[its GitHub repository].

--- a/content/doc/developer/tutorial-improve/add-a-jenkinsfile.adoc
+++ b/content/doc/developer/tutorial-improve/add-a-jenkinsfile.adoc
@@ -22,7 +22,7 @@ include::doc/developer/tutorial-improve/_create-a-branch.adoc[]
 Create a file named `Jenkinsfile` with the single line content:
 
 ``` groovy
-buildPlugin()
+buildPlugin(useContainerAgent: true)
 ```
 
 // Create a pull request


### PR DESCRIPTION
This aligns with the default Jenkinsfile generated by archetypes for newly created plugins, and what is used widely for components and plugins already.

Also, Kubernetes are usually faster to spin up and generate less cost than a VM.