### PR TITLE
Document Winstone 6.6 changes in 2.375.1 upgrade guide

### DIFF
--- a/content/_data/upgrades/2-375-1.adoc
+++ b/content/_data/upgrades/2-375-1.adoc
@@ -1,15 +1,20 @@
-==== Winstone 6.4 and Jetty 10.0.12
+==== Winstone 6.6 and Jetty 10.0.12
 
 Since Jenkins 2.361.1, there have been several Winstone and Jetty updates.
-Jenkins has updated its Winstone version all the way from 6.0 to 6.4, and the Jetty version has been updated from 9.4.46.v20220331 to 10.0.12.
+Jenkins has updated its Winstone version all the way from 6.1 to 6.6, and the Jetty version has been updated from 9.4.46.v20220331 to 10.0.12.
 
 The Winstone and Jetty updates include upgrades that users should perform.
 
 When upgrading Winstone to 6.1 and Jetty to 10.0.11, some flags have been modified.
 Support for OpenSSL-style PEM-encoded RSA private keys has been removed when running Jenkins with the embedded Jetty (Winstone) container and TLS.
+
 Specifically, the `--httpsPrivateKey` and `--httpsCertificate` flags have been removed in favor of the `--httpsKeyStore` flag.
-The removed flags have printed deprecation warnings since 2016 and were implemented with non-standard APIs that have since been removed from Java 17.
-The recommendation is to migrate to the `--httpsKeyStore` option, which takes a keystore as described in the documentation.
+The removed flags have printed deprecation warnings since 2016 and were implemented with non-standard APIs that have since been removed from Java 17. +
+The recommendation is to migrate to the `--httpsKeyStore` option, which takes a keystore as described in the documentation. +
 As of link:https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc[JEP 229], PKCS12 is the recommended keystore type.
 
-The Winstone 6.4 and Jetty 10.0.12 update makes it so that a previously added `--extraLibFolder` option for use with HTTP/2, can now be removed.
+Additionally, the `--toolsJar` and `--useJasper` flags have been removed, because they no longer serve a purpose with Java 11 or newer. +
+`--ajp13Port` and `--ajp13ListenAddress` have been removed, they are obsolote since Jetty 9, release 6 years ago. +
+Finally, the handler count flags `--handlerCountMax` and `--handlerCountMaxIdle` have been removed, after being deprecated for 4 years doing nothing.
+
+The Winstone 6.6 and Jetty 10.0.12 update makes it so that a previously added `--extraLibFolder` option for use with HTTP/2, can now be removed.

--- a/content/_data/upgrades/2-375-1.adoc
+++ b/content/_data/upgrades/2-375-1.adoc
@@ -14,7 +14,7 @@ The recommendation is to migrate to the `--httpsKeyStore` option, which takes a 
 As of link:https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc[JEP 229], PKCS12 is the recommended keystore type.
 
 Additionally, the `--toolsJar` and `--useJasper` flags have been removed, because they no longer serve a purpose with Java 11 or newer. +
-`--ajp13Port` and `--ajp13ListenAddress` have been removed, they are obsolote since Jetty 9, release 6 years ago. +
+`--ajp13Port` and `--ajp13ListenAddress` have been removed, they are obsolote since Jetty 9, which has been released 6 years ago. +
 Finally, the handler count flags `--handlerCountMax` and `--handlerCountMaxIdle` have been removed, after being deprecated for 4 years doing nothing.
 
 The Winstone 6.6 and Jetty 10.0.12 update makes it so that a previously added `--extraLibFolder` option for use with HTTP/2, can now be removed.


### PR DESCRIPTION
2.375.1 bundles winstone 6.6, not 6.4.

This PR also documents flag removals between 6.4 and 6.6, plus fixes the version 2.361.4 includes, which is 6.1.
I've added a few linebreaks to improve readibility.