### PR TITLE
Use archetype 1.17 in tutorial

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -44,23 +44,25 @@ Choose archetype:
 5: remote -> io.jenkins.archetypes:scripted-pipeline (Uses the Jenkins Pipeline Unit mock library to test the logic inside a Pipeline script.)
 Choose a number or apply filter (format: [groupId:]artifactId, case sensitive contains): : *4* // <1>
 Choose io.jenkins.archetypes:hello-world-plugin version:
-1: 1.1
-2: 1.2
-3: 1.3
-4: 1.4
-5: 1.5
-6: 1.6
-7: 1.7
-8: 1.8
-9: 1.9
-10: 1.10
-11: 1.11
-12: 1.12
-13: 1.13
-14: 1.14
-15: 1.15
+1: 1.0
+2: 1.1
+3: 1.2
+4: 1.3
+5: 1.4
+6: 1.5
+7: 1.6
+8: 1.7
+9: 1.8
+10: 1.9
+11: 1.10
+12: 1.11
+13: 1.12
+14: 1.13
+15: 1.14
+16: 1.15
+17: 1.16
 
-Choose a number: 15: *15* // <2>
+Choose a number: 17: *17* // <2>
 …
 [INFO] Using property: groupId = unused // <3>
 [INFO] Using property: package = io.jenkins.plugins.sample


### PR DESCRIPTION
## Use archetype 1.16 in tutorial

Archetype now uses Jenkins 2.361.4 as minimum Jenkins version

https://github.com/jenkinsci/archetypes/releases/tag/archetypes-1.16

https://github.com/jenkinsci/archetypes/pull/546
