### PR TITLE
Use 2.361.4 as jenkins.version in tutorials and guides

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -133,7 +133,7 @@ For a regular component whose version number is not that meaningful, let the ver
 -        <revision>1.23</revision>
 -        <changelist>-SNAPSHOT</changelist>
 +        <changelist>999999-SNAPSHOT</changelist>
-         <jenkins.version>2.346.3</jenkins.version>
+         <jenkins.version>2.361.4</jenkins.version>
      </properties>
 ----
 +
@@ -176,7 +176,7 @@ If you do not want to have large major version numbers, like with fully automate
 -    <changelist>-SNAPSHOT</changelist>
 +    <revision>1</revision>
 +    <changelist>999999-SNAPSHOT</changelist>
-     <jenkins.version>2.346.3</jenkins.version>
+     <jenkins.version>2.361.4</jenkins.version>
 ----
 +
 Here the version numbers will look like `1.321.vabcdef456789` or `1.999999-SNAPSHOT`, respectively.
@@ -210,7 +210,7 @@ Similar to the previous option, for a component whose version number ought to re
 -    <changelist>-SNAPSHOT</changelist>
 +    <revision>4.0.0</revision>
 +    <changelist>999999-SNAPSHOT</changelist>
-     <jenkins.version>2.346.3</jenkins.version>
+     <jenkins.version>2.361.4</jenkins.version>
 ----
 +
 Here the version numbers will look like `4.0.0-123.vabcdef456789` or `4.0.0-999999-SNAPSHOT`, respectively.

--- a/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
+++ b/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
@@ -42,9 +42,9 @@ The `git diff` might look like this:
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
 -        <artifactId>bom-2.319.x</artifactId>
-+        <artifactId>bom-2.346.x</artifactId>
--        <version> OLDER_VERSION_NUMBER </version>
-+        <version>1607.va_c1576527071</version>
++        <artifactId>bom-2.361.x</artifactId>
+-        <version>1466.v85a_616ea_b_87c</version>
++        <version>1723.vcb_9fee52c9fc</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/content/doc/developer/tutorial-improve/use-plugin-bill-of-materials.adoc
+++ b/content/doc/developer/tutorial-improve/use-plugin-bill-of-materials.adoc
@@ -30,8 +30,8 @@ For example, the addition might look like:
   <dependencies>
     <dependency>
       <groupId>io.jenkins.tools.bom</groupId>
-      <artifactId>bom-2.346.x</artifactId>
-      <version>1607.va_c1576527071</version>
+      <artifactId>bom-2.361.x</artifactId>
+      <version>1723.vcb_9fee52c9fc</version>
       <scope>import</scope>
       <type>pom</type>
     </dependency>


### PR DESCRIPTION
## Use 2.361.4 as jenkins.version in tutorials and guides

https://github.com/jenkinsci/archetypes/pull/546 has switched the default baseline for new plugins to 2.361.4.

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ recommends either 2.346.3 or 2.361.4 as the core dependency.

Jenkins plugin development tools are switching to require Java 11 as well.
