### PR TITLE
Add details on dependabot auto labeling config

### DIFF
--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -39,8 +39,6 @@ updates:
   target-branch: master
   reviewers:
   - <insert-maintainers-here-one-per-line-use-github-handle>
-  labels:
-  - skip-changelog
 END-OF-HERE-DOC
 ----
 

--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -12,7 +12,7 @@ title: Check dependencies
 .Automate dependency checks with dependabot
 video::2c8wK2jkcIA[youtube,width=800,height=420,start=980]
 
-Jenkins plugins frequently depend on external libraries and other plugins. 
+Jenkins plugins frequently depend on external libraries and other plugins.
 Automatic dependency checks help assure that new releases of dependencies are reviewed by plugin maintainers.
 
 The GitHub `dependabot` tool can be configured to periodically check for new releases of dependencies.
@@ -44,13 +44,13 @@ updates:
 END-OF-HERE-DOC
 ----
 
-Note that, with the above configuration file, the generated PRs will be labeled `skip-changelog`. 
+Note that, with the above configuration file, the generated PRs will be labeled `skip-changelog`.
 This is handy if you want to exclude the dependabot PRs from the changelog generation.
 Note that, if that label does not exist in the plugin repository, the label assignment will fail.
 
 For the default behavior, just remove the definition of a custom label in the dependabot configuration.
 The `dependency` flag will then be assigned to the PR.
-The dependabot generated change will appear in the changelog. 
+The dependabot generated change will appear in the changelog.
 This can be an interesting and desired behavior.
 
 Commit the file and push it to GitHub with the commands:

--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -44,6 +44,15 @@ updates:
 END-OF-HERE-DOC
 ----
 
+Note that, with the above configuration file, the generated PRs will be labeled `skip-changelog`. 
+This is handy if you want to exclude the dependabot PRs from the changelog generation.
+Note that, if that label does not exist in the plugin repository, the label assignment will fail.
+
+For the default behavior, just remove the definition of a custom label in the dependabot configuration.
+The `dependency` flag will then be assigned to the PR.
+The dependabot generated change will appear in the changelog. 
+This can be an interesting and desired behavior.
+
 Commit the file and push it to GitHub with the commands:
 
 // Create a pull request


### PR DESCRIPTION
This PR wants to give more details on how to configure the auto-labeling feature of dependabot and what are the pitfalls to use this technique rather then the default behavior.