### PR TITLE
Remove irrelevant auto-tagging comments

### DIFF
--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -42,15 +42,6 @@ updates:
 END-OF-HERE-DOC
 ----
 
-Note that, with the above configuration file, the generated PRs will be labeled `skip-changelog`.
-This is handy if you want to exclude the dependabot PRs from the changelog generation.
-Note that, if that label does not exist in the plugin repository, the label assignment will fail.
-
-For the default behavior, just remove the definition of a custom label in the dependabot configuration.
-The `dependency` flag will then be assigned to the PR.
-The dependabot generated change will appear in the changelog.
-This can be an interesting and desired behavior.
-
 Commit the file and push it to GitHub with the commands:
 
 // Create a pull request


### PR DESCRIPTION
The auto-tagging comments were correct when the example contained tagging configuration. As it has been removed, the comments are not relevant anymore.