### PR TITLE
[Jenkins for Scaling]: `jenkins.model.Jenkins.buildsDir` as alternative to symlinks 

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -397,10 +397,11 @@ different approaches to expandable storage:
 * *ZFS for Solaris* - ZFS is even more flexible than LVM and spanned volumes
   and just requires that the _$JENKINS_HOME_ be on its own filesystem. This
   makes it easier to create snapshots, backups, etc.
-* *Symbolic Links* - For systems with existing Jenkins installations and who
-  cannot use any of the above-mentioned methods, symbolic links (symlinks) may
-  be used instead to store job folders on separate volumes with symlinks to
-  those directories.
+* *Moving the Build Folder to a separate volumen* - For systems with existing Jenkins. Two options:
+  installations and who cannot use any of the above-mentioned methods
+** The System Property link:https://www.jenkins.io/doc/book/managing/system-properties/#jenkins-model-jenkins-buildsdir[jenkins.model.Jenkins.buildsDir]
+** *Symbolic Links* (symlinks) may be used instead to store job 
+  folders on separate volumes with symlinks to those directories.
 
 Additionally, to easily prevent a _$JENKINS_HOME_ folder from becoming bloated,
 make it mandatory for jobs to discard build records after a specific time


### PR DESCRIPTION
adding comment on `jenkins.model.Jenkins.buildsDir` as an alternative to Symbolic Links for allocating Builds into  a different volumen