### PR TITLE
feat(developers doc) clarify how to use 'docker' for plugin tests

### DIFF
--- a/content/doc/developer/publishing/continuous-integration.adoc
+++ b/content/doc/developer/publishing/continuous-integration.adoc
@@ -9,9 +9,9 @@ It will build all plugin repositories in the `jenkinsci` organization that have 
 The typical plugin build (Maven or Gradle) can be run by just having the following statement in the `Jenkinsfile`:
 ----
 buildPlugin(
-  useContainerAgent: true,
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17], // use 'docker' if you have containerized tests
+    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])
 ----
@@ -19,7 +19,7 @@ buildPlugin(
 Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use:
 ----
 buildPluginWithGradle(
-  useContainerAgent: true,
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],

--- a/content/doc/developer/tutorial-improve/add-a-jenkinsfile.adoc
+++ b/content/doc/developer/tutorial-improve/add-a-jenkinsfile.adoc
@@ -23,9 +23,9 @@ Create a file named `Jenkinsfile` with the content:
 
 ``` groovy
 buildPlugin(
-  useContainerAgent: true,
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17], // use 'docker' if you have containerized tests
+    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])
 ```


### PR DESCRIPTION
The goal is to help plugin maintainer to get a better understanding at "how to use docker in ci.jenkins.io for plugins dockerized tests".

It is a minor update, amending https://github.com/jenkins-infra/jenkins.io/pull/5774 that pre-dates the upstream change https://github.com/jenkinsci/archetypes/pull/552.

