### PR TITLE
Clarify that the thin-backup plugin is being maintained

### DIFF
--- a/content/doc/book/system-administration/backing-up.adoc
+++ b/content/doc/book/system-administration/backing-up.adoc
@@ -54,8 +54,8 @@ They are supported by:
 
 Several plugins are available for backup.
 From the main menu select _Manage Jenkins_, then go to _Manage Plugins>Available_ and search for **backup**.
-Note that none of the open source plugins are currently being maintained.
-You can try these plugins but you may have problems with them.
+Note that only the link:https://plugins.jenkins.io/thinBackup/[thinBackup Plugin] of the open source plugins is currently being maintained.
+You can try the other plugins but you may have problems with them.
 
 === Writing a shell script for backups
 


### PR DESCRIPTION
Clarify that the thin-backup plugin is being maintained and only the backup plugin is not, but I kept the plural if other plugins I'm unaware of are also available but unmaintained.