### PR TITLE
Update deprecating-or-removing-plugin.adoc

### DIFF
--- a/content/doc/developer/plugin-governance/deprecating-or-removing-plugin.adoc
+++ b/content/doc/developer/plugin-governance/deprecating-or-removing-plugin.adoc
@@ -11,7 +11,7 @@ references:
 Some plugins may be replaced by others or just become irrelevant (e.g. integration with a service which was shut down).
 We do not recommend deleting source code outright, even a stale or no-longer-relevant code can still be educational.
 However, we do have a mechanism for deprecating or hiding plugins in the Jenkins update centers.
-This page describes the processes for marking a plugin as deprecated, or suspending its distribution entirely.
+This page describes the processes for marking a plugin as deprecated or suspending its distribution entirely.
 
 == Deprecating a plugin
 
@@ -31,9 +31,8 @@ This page describes the processes for marking a plugin as deprecated, or suspend
   Specifying a URL will also cause a deprecation message to appear.
 . Archive the plugin's GitHub repository.
 ** If you have admin permissions in the repository, it is possible to do it from the GitHub's web interface.
-** Otherwise, create a link:https://github.com/jenkins-infra/helpdesk/issues/new?labels=github-permissions&template=3-github-permissions.yml[help desk] ticket to archive the plugin's repository.
+** Otherwise, create a link:https://github.com/jenkins-infra/helpdesk/issues/new?labels=triage&template=1-report-issue.yml[help desk] ticket to archive the plugin's repository.
 
-// TODO: Is this the correct link? The template seems inapplicable.
 
 == Reverting deprecation/removal
 

--- a/content/doc/developer/plugin-governance/deprecating-or-removing-plugin.adoc
+++ b/content/doc/developer/plugin-governance/deprecating-or-removing-plugin.adoc
@@ -20,7 +20,7 @@ This page describes the processes for marking a plugin as deprecated or suspendi
    If you have multiple plugins inside a single repository, it will apply to all of them.
    This is the preferred approach.
 ** Add a `deprecated` label to the plugin entry in the Update Center's link:https://github.com/jenkins-infra/update-center2/blob/master/resources/label-definitions.properties[label-definitions.properties] file.
-   Choose this approach if only some of the plugins in the GitHub repository are to be deprecated.
+   Choose this approach if the GitHub repository contains multiple plugins and only some of the plugins in the repository are to be deprecated.
 . Update the plugin's documentation to explain the reason of the deprecation.
 
 == Removing a plugin from Update Centers

--- a/content/doc/developer/plugin-governance/deprecating-or-removing-plugin.adoc
+++ b/content/doc/developer/plugin-governance/deprecating-or-removing-plugin.adoc
@@ -11,27 +11,31 @@ references:
 Some plugins may be replaced by others or just become irrelevant (e.g. integration with a service which was shut down).
 We do not recommend deleting source code outright, even a stale or no-longer-relevant code can still be educational.
 However, we do have a mechanism for deprecating or hiding plugins in the Jenkins update centers.
-This page describes the process.
+This page describes the processes for marking a plugin as deprecated, or suspending its distribution entirely.
 
 == Deprecating a plugin
 
-. Set a `deprecated` label for the plugin. It can be done in 2 ways:
+. Set a `deprecated` label for the plugin that will be visible on plugins.jenkins.io and in the Jenkins plugin manager. This can be done in two ways:
 ** Put a `deprecated` topic in the plugin's GitHub repository.
-   If you have multiple plugins inside a single repository, it will apply to all of them
-** Add a `deprecated` label to the plugin entry in the Update Center's link:https://github.com/jenkins-infra/update-center2/blob/master/resources/label-definitions.properties[label-definitions.properties] file
-. Update the plugin's documentation to explain the reason of the deprecation
-. Release the plugin and put the deprecation notice into the changelog
+   If you have multiple plugins inside a single repository, it will apply to all of them.
+   This is the preferred approach.
+** Add a `deprecated` label to the plugin entry in the Update Center's link:https://github.com/jenkins-infra/update-center2/blob/master/resources/label-definitions.properties[label-definitions.properties] file.
+   Choose this approach if only some of the plugins in the GitHub repository are to be deprecated.
+. Update the plugin's documentation to explain the reason of the deprecation.
 
 == Removing a plugin from Update Centers
 
-. Deprecate the plugin as documented above
-. Submit a pull request to the Update Center's https://github.com/jenkins-infra/update-center2/blob/master/resources/artifact-ignores.properties[artifact-ignores.properties] file
-. Archive the plugin's repository
-** If you have admin permissions in the repository, it is possible to do it from the GitHub's web interface
-** Otherwise, create a link:https://github.com/jenkins-infra/helpdesk/issues/new?labels=github-permissions&template=2-github-permissions.yml[help desk] ticket to archive the plugin's repository
+. Submit a pull request to the Update Center's https://github.com/jenkins-infra/update-center2/blob/master/resources/artifact-ignores.properties[artifact-ignores.properties] file.
+  Use the artifact ID as key.
+  As value, provide a URL to a web page (usually documentation) that explains to users why distribution is suspended.
+  Specifying a URL will also cause a deprecation message to appear.
+. Archive the plugin's GitHub repository.
+** If you have admin permissions in the repository, it is possible to do it from the GitHub's web interface.
+** Otherwise, create a link:https://github.com/jenkins-infra/helpdesk/issues/new?labels=github-permissions&template=3-github-permissions.yml[help desk] ticket to archive the plugin's repository.
+
+// TODO: Is this the correct link? The template seems inapplicable.
 
 == Reverting deprecation/removal
 
 If required, it is possible to revert all the actions above.
-A Jenkins Jira ticket is required to unarchive a plugin,
-but the rest can be done via pull requests to the respective update center files mentioned above.
+A helpdesk ticket is required to unarchive a plugin, but the rest can be done via pull requests to the respective update center files mentioned above.


### PR DESCRIPTION
- No separate deprecation is needed when suspending: https://github.com/jenkins-infra/update-center2/blob/master/README.adoc#deprecations
- Requirement of a new release is weird, removed it.
- Switched from "Jira ticket" to helpdesk in the last change, as that seemed wrong since the helpdesk exists.
- Fixed the link broken by https://github.com/jenkins-infra/helpdesk/pull/3236 (but it really looks like an inapplicable template?).

Plus some minor rephrasings. Not 100% sure about all of these so requesting more than minimal review of possible.