### PR TITLE
Bump rubyzip to 2.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'kramdown', '~> 2.4.0'
 group :fetcher do
   gem 'faraday', '~> 1.10.2'
   gem 'faraday_middleware', '~> 1.2.0'
-  gem 'rubyzip', '~> 2.3.0'
+  gem 'rubyzip', '~> 2.3.2'
 end
 
 gem "concurrent-ruby", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       ansi
       ast
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
     shellany (0.0.1)
@@ -161,7 +161,7 @@ DEPENDENCIES
   liquid (~> 5.0)
   rouge
   rss
-  rubyzip (~> 2.3.0)
+  rubyzip (~> 2.3.2)
   sassc
 
 BUNDLED WITH


### PR DESCRIPTION
There are no changes between 2.3.0 and 2.3.2, but deprecation annotations, outlining what will change in 3.x