### PR TITLE
Bump asciidoc to 2.0.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'colorize'
 gem 'awestruct', '~> 0.6.1'
 gem 'awestruct-ibeams', '~> 0.4'
-gem 'asciidoctor', '~> 2.0.0'
+gem 'asciidoctor', '~> 2.0.18'
 gem 'asciidoctor-jenkins-extensions', '~> 0.9.0'
 
 gem 'sassc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ansi (1.5.0)
-    asciidoctor (2.0.10)
+    asciidoctor (2.0.18)
     asciidoctor-jenkins-extensions (0.9.0)
       asciidoctor (>= 1.5.5)
       coderay (~> 1.1.1)
@@ -148,7 +148,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  asciidoctor (~> 2.0.0)
+  asciidoctor (~> 2.0.18)
   asciidoctor-jenkins-extensions (~> 0.9.0)
   awestruct (~> 0.6.1)
   awestruct-ibeams (~> 0.4)


### PR DESCRIPTION
The recent ruby upgrades allow us to use an up-to-date version of this gem.