### PR TITLE
Fix a few typos highlighted by the typo checker

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,7 +9,7 @@ extend-exclude = [
   "Gemfile.lock",
   "*.svg",
   # French
-  "content/blog/2022/2022-12-09-GSoC-the-gift-of-mentorship.adoc",
+  "content/blog/2022/12/2022-12-09-GSoC-the-gift-of-mentorship.adoc",
   "content/blog/2016/2016-03-02-toulousejam-hackergarten.adoc",
   "content/blog/2012/2012-05-28-jenkins-a-besoin-de-vous.adoc",
   # Spanish

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,7 @@ extend-exclude = [
   "Gemfile.lock",
   "*.svg",
   # French
+  "content/blog/2022/2022-12-09-GSoC-the-gift-of-mentorship.adoc",
   "content/blog/2016/2016-03-02-toulousejam-hackergarten.adoc",
   "content/blog/2012/2012-05-28-jenkins-a-besoin-de-vous.adoc",
   # Spanish

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node('docker&&linux') {
         curl -qsL https://github.com/halkeye/typos-json-to-checkstyle/releases/download/v0.1.1/typos-checkstyle-v0.1.1-x86_64 > typos-checkstyle && chmod 0755 typos-checkstyle
         ./typos --format json | ./typos-checkstyle - > checkstyle.xml || true
       '''
-      recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')])
+      recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')], qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]])
     }
 
     stage('Build site') {

--- a/content/blog/2022/11/2022-11-23-get-prepared-for-gsoc.adoc
+++ b/content/blog/2022/11/2022-11-23-get-prepared-for-gsoc.adoc
@@ -10,7 +10,7 @@ tags:
 authors:
 - jmMeessen
 description: >
-  This blogpost advises on how to best prepare for submitting a succesful proposal for the 2023 edition of Google Summer of Code with Jenkins.
+  This blogpost advises on how to best prepare for submitting a successful proposal for the 2023 edition of Google Summer of Code with Jenkins.
 opengraph:
   image: /images/gsoc/opengraph.png
 links:
@@ -29,7 +29,7 @@ First of all, welcome to the Jenkins Community!
 Thank you for your interest in Jenkins in general and for GSoC 2023 in particular. 
 
 Only a limited number of GSoC slots are made available by Google.
-We will select the best proposals with the highest chance for a succesful outcome. 
+We will select the best proposals with the highest chance for a successful outcome.
 It is thus a wise step to prepare early. 
 It will put all the chances on your side. 
 You will find hereafter some advice about activities to build the muscle required to be selected.

--- a/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
@@ -59,7 +59,7 @@ video::fM2SMbppRxw[youtube,width=800,height=420,start=328]
 * has enabled incremental builds
 * has replace Nonnull and CHeckForNull annotations
 
-Exisiting probes are listed at link:https://plugin-health.jenkins.io/probes[Plugin Health Scoring :: Probes]
+Existing probes are listed at link:https://plugin-health.jenkins.io/probes[Plugin Health Scoring :: Probes]
 
 === Skills to Study and Improve
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -54,7 +54,7 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
 * Cookies not set to `Secure` due to misconfiguration of Jenkins.
   If a cookie is `Secure` on https://ci.jenkins.io, then it's a matter of configuration.
 * Cookies not set to `HttpOnly` when they contain no sensitive information (e.g. "screen size")
-* Users with Overall/Administer permission (or the deprecated Overall/RunScripts permisson) are able to execute arbitrary code using the Script Console, related APIs (`/eval`, `/script`, `/scriptText`), and many plugins.
+* Users with Overall/Administer permission (or the deprecated Overall/RunScripts permission) are able to execute arbitrary code using the Script Console, related APIs (`/eval`, `/script`, `/scriptText`), and many plugins.
   This is a feature.
 * Jobs started by a specific user can run on agents where the user lacks Agent/Build permission and can themselves trigger builds of jobs where the user lacks Job/Build permission.
   link:/doc/book/security/build-authorization/[See the documentation on Access Control for Builds].


### PR DESCRIPTION
Also shifted the quality gate from a green tick to a higher severity, to no longer return a successful status if a PR introduces typos, this is misleading.

The change proposed to the Jenkinsfile changes the state accordingly:
![Screenshot 2022-12-18 at 23 04 35](https://user-images.githubusercontent.com/13383509/208321799-fd7c0f2c-cd88-4469-94aa-c4dfef379f61.png)