### PR TITLE
Update Blue Ocean, Pipeline Groovy, and Maven in tutorials

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -92,7 +92,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk11
+FROM jenkins/jenkins:{jenkins-stable}
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \
@@ -103,7 +103,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.8 docker-workflow:521.v1a_a_dd2073b_2e"
+RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -241,7 +241,7 @@ docker run --name jenkins-docker --detach ^
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk11
+FROM jenkins/jenkins:{jenkins-stable}
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \
@@ -252,7 +252,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.8 docker-workflow:521.v1a_a_dd2073b_2e"
+RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -91,7 +91,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk11
+FROM jenkins/jenkins:{jenkins-stable}
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.8 docker-workflow:521.v1a_a_dd2073b_2e"
+RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -230,7 +230,7 @@ docker run --name jenkins-docker --rm --detach ^
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk11
+FROM jenkins/jenkins:{jenkins-stable}
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \
@@ -241,7 +241,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.25.8 docker-workflow:521.v1a_a_dd2073b_2e"
+RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -149,7 +149,7 @@ link:https://hub.docker.com/_/maven/[`maven` container],
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.6-eclipse-temurin-11'
             args '-v $HOME/.m2:/root/.m2'
         }
     }
@@ -164,7 +164,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('maven:3.8.1-adoptopenjdk-11').inside('-v $HOME/.m2:/root/.m2') {
+    docker.image('maven:3.8.6-eclipse-temurin-11').inside('-v $HOME/.m2:/root/.m2') {
         stage('Build') {
             sh 'mvn -B'
         }
@@ -191,7 +191,7 @@ pipeline {
     stages {
         stage('Back-end') {
             agent {
-                docker { image 'maven:3.8.1-adoptopenjdk-11' }
+                docker { image 'maven:3.8.6-eclipse-temurin-11' }
             }
             steps {
                 sh 'mvn --version'
@@ -212,7 +212,7 @@ node {
     /* Requires the Docker Pipeline plugin to be installed */
 
     stage('Back-end') {
-        docker.image('maven:3.8.1-adoptopenjdk-11').inside {
+        docker.image('maven:3.8.6-eclipse-temurin-11').inside {
             sh 'mvn --version'
         }
     }

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -174,13 +174,13 @@ accept Docker-based Pipelines, or on a node matching the optionally defined
 which may contain arguments to pass directly to a `docker run` invocation, and
 an `alwaysPull` option, which will force a `docker pull` even if the image
 name is already present.
-For example: `agent { docker 'maven:3.8.1-adoptopenjdk-11' }` or
+For example: `agent { docker 'maven:3.8.6-eclipse-temurin-11' }` or
 +
 [source,groovy]
 ----
 agent {
     docker {
-        image 'maven:3.8.1-adoptopenjdk-11'
+        image 'maven:3.8.6-eclipse-temurin-11'
         label 'my-defined-label'
         args  '-v /tmp:/tmp'
     }
@@ -343,7 +343,7 @@ This option is valid for `docker` and `dockerfile`.
 [source, groovy]
 ----
 pipeline {
-    agent { docker 'maven:3.8.1-adoptopenjdk-11' } // <1>
+    agent { docker 'maven:3.8.6-eclipse-temurin-11' } // <1>
     stages {
         stage('Example Build') {
             steps {
@@ -354,7 +354,7 @@ pipeline {
 }
 ----
 <1> Execute all the steps defined in this Pipeline within a newly created container
-of the given name and tag (`3.8.1-adoptopenjdk-11`).
+of the given name and tag (`maven:3.8.6-eclipse-temurin-11`).
 =====
 
 .Stage-level Agent Section
@@ -365,7 +365,7 @@ pipeline {
     agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker 'maven:3.8.1-adoptopenjdk-11' } // <2>
+            agent { docker 'maven:3.8.6-eclipse-temurin-11' } // <2>
             steps {
                 echo 'Hello, Maven'
                 sh 'mvn --version'

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -140,7 +140,7 @@ a Docker container (which will build your simple Java application). Also add a
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11' // <1>
+            image 'maven:3.8.6-eclipse-temurin-11' // <1>
             args '-v /root/.m2:/root/.m2' // <2>
         }
     }
@@ -155,7 +155,7 @@ pipeline {
 ----
 <1> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/maven/[`maven:3.8.1-adoptopenjdk-11` Docker image] (if it's not
+https://hub.docker.com/_/maven/[`maven:3.8.6-eclipse-temurin-11` Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Maven containers running locally in Docker.
@@ -251,7 +251,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.6-eclipse-temurin-11'
             args '-v /root/.m2:/root/.m2'
         }
     }
@@ -341,7 +341,7 @@ and add a `skipStagesAfterUnstable` option so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.6-eclipse-temurin-11'
             args '-v /root/.m2:/root/.m2'
         }
     }


### PR DESCRIPTION
## Update Blue Ocean, Pipeline Docker, and Maven

- Use latest blueocean and docker-workflow plugins
- Use Apache Maven 3.8.6, not 3.8.1

https://github.com/jenkins-docs/simple-java-maven-app/issues/503 reports
the issue with Maven 3.8.1.  Jenkins developers use Maven 3.8.6 almost
exclusively now.
