### PR TITLE
added reference link to docs about agents

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -92,7 +92,8 @@ with which builds are scheduled depends on the configuration given to each
 project. For example, some projects may be configured to "restrict where this
 project is run" which ties the project to a specific agent or set of labeled
 agents. Other projects which omit this configuration will select an agent from
-the available pool in Jenkins.Learn more about Agents in link:doc/book/managing/nodes/#creating-agents/[Managing Nodes]
+the available pool in Jenkins.
+Learn more about Agents in link:/doc/book/managing/nodes/#creating-agents/[Managing Nodes]
 
 In a distributed builds environment, the Jenkins controller will use its resources
 to only handle HTTP requests and manage the build environment. Actual execution

--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -92,7 +92,7 @@ with which builds are scheduled depends on the configuration given to each
 project. For example, some projects may be configured to "restrict where this
 project is run" which ties the project to a specific agent or set of labeled
 agents. Other projects which omit this configuration will select an agent from
-the available pool in Jenkins.
+the available pool in Jenkins.Learn more about Agents in link:doc/book/managing/nodes/#creating-agents/[Managing Nodes]
 
 In a distributed builds environment, the Jenkins controller will use its resources
 to only handle HTTP requests and manage the build environment. Actual execution


### PR DESCRIPTION
closes #5489 
if i need to add more reference links throughout the [Architecting for scale](https://www.jenkins.io/doc/book/scaling/architecting-for-scale/) ,please let me know
