### PR TITLE
Document removal of '--daemon' flag

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -18779,7 +18779,7 @@
           - basil
         pr_title: De-duplicate file-based logging implementations
         message: |-
-          Remove support for log rotation via <code>SIGALRM</code>.
+          Remove support for log rotation via <code>SIGALRM</code>. The command-line argument <code>--daemon</code> has been removed.
       - type: bug
         category: regression
         pull: 7539


### PR DESCRIPTION
The logic itself is long gone and the removal of the flag is considered code cleanup, however, not removing the flag from your Jenkins startup flags causes Jenkins to not start at all.