### PR TITLE
Use same maven in tutorial as is used elsewhere

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -56,7 +56,7 @@ various languages.
 // Declarative //
 /* Requires the Docker Pipeline plugin */
 pipeline {
-    agent { docker { image 'maven:3.8.6-openjdk-11-slim' } }
+    agent { docker { image 'maven:3.8.6-eclipse-temurin-11' } }
     stages {
         stage('build') {
             steps {
@@ -69,7 +69,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('maven:3.8.6-openjdk-11-slim').inside {
+        docker.image('maven:3.8.6-eclipse-temurin-11').inside {
             sh 'mvn --version'
         }
     }


### PR DESCRIPTION
The hello world tutorial was using a different maven container than the
other locations in the documentation.  Use the same maven container in
this location as is used in the other locations.
