### PR TITLE
Add participant name to Advoacy and Outreach SIG index page

### DIFF
--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -18,7 +18,7 @@ leads:
 - "markewaite"
 participants:
 - "jmMeessen"
-
+- "krisstern"
 
 links:
   gitter: "jenkinsci/advocacy-and-outreach-sig"


### PR DESCRIPTION
Add particpant name to Advocacy and Outreach SIG index/home page. 