### PR TITLE
Use Apache Maven 3.8.7 for examples, not 3.8.6

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -149,7 +149,7 @@ link:https://hub.docker.com/_/maven/[`maven` container],
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.6-eclipse-temurin-11'
+            image 'maven:3.8.7-eclipse-temurin-11'
             args '-v $HOME/.m2:/root/.m2'
         }
     }
@@ -164,7 +164,7 @@ pipeline {
 // Script //
 node {
     /* Requires the Docker Pipeline plugin to be installed */
-    docker.image('maven:3.8.6-eclipse-temurin-11').inside('-v $HOME/.m2:/root/.m2') {
+    docker.image('maven:3.8.7-eclipse-temurin-11').inside('-v $HOME/.m2:/root/.m2') {
         stage('Build') {
             sh 'mvn -B'
         }
@@ -191,7 +191,7 @@ pipeline {
     stages {
         stage('Back-end') {
             agent {
-                docker { image 'maven:3.8.6-eclipse-temurin-11' }
+                docker { image 'maven:3.8.7-eclipse-temurin-11' }
             }
             steps {
                 sh 'mvn --version'
@@ -212,7 +212,7 @@ node {
     /* Requires the Docker Pipeline plugin to be installed */
 
     stage('Back-end') {
-        docker.image('maven:3.8.6-eclipse-temurin-11').inside {
+        docker.image('maven:3.8.7-eclipse-temurin-11').inside {
             sh 'mvn --version'
         }
     }

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -174,13 +174,13 @@ accept Docker-based Pipelines, or on a node matching the optionally defined
 which may contain arguments to pass directly to a `docker run` invocation, and
 an `alwaysPull` option, which will force a `docker pull` even if the image
 name is already present.
-For example: `agent { docker 'maven:3.8.6-eclipse-temurin-11' }` or
+For example: `agent { docker 'maven:3.8.7-eclipse-temurin-11' }` or
 +
 [source,groovy]
 ----
 agent {
     docker {
-        image 'maven:3.8.6-eclipse-temurin-11'
+        image 'maven:3.8.7-eclipse-temurin-11'
         label 'my-defined-label'
         args  '-v /tmp:/tmp'
     }
@@ -343,7 +343,7 @@ This option is valid for `docker` and `dockerfile`.
 [source, groovy]
 ----
 pipeline {
-    agent { docker 'maven:3.8.6-eclipse-temurin-11' } // <1>
+    agent { docker 'maven:3.8.7-eclipse-temurin-11' } // <1>
     stages {
         stage('Example Build') {
             steps {
@@ -354,7 +354,7 @@ pipeline {
 }
 ----
 <1> Execute all the steps defined in this Pipeline within a newly created container
-of the given name and tag (`maven:3.8.6-eclipse-temurin-11`).
+of the given name and tag (`maven:3.8.7-eclipse-temurin-11`).
 =====
 
 .Stage-level Agent Section
@@ -365,7 +365,7 @@ pipeline {
     agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker 'maven:3.8.6-eclipse-temurin-11' } // <2>
+            agent { docker 'maven:3.8.7-eclipse-temurin-11' } // <2>
             steps {
                 echo 'Hello, Maven'
                 sh 'mvn --version'

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -56,7 +56,7 @@ various languages.
 // Declarative //
 /* Requires the Docker Pipeline plugin */
 pipeline {
-    agent { docker { image 'maven:3.8.6-eclipse-temurin-11' } }
+    agent { docker { image 'maven:3.8.7-eclipse-temurin-11' } }
     stages {
         stage('build') {
             steps {
@@ -69,7 +69,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('maven:3.8.6-eclipse-temurin-11').inside {
+        docker.image('maven:3.8.7-eclipse-temurin-11').inside {
             sh 'mvn --version'
         }
     }

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -140,7 +140,7 @@ a Docker container (which will build your simple Java application). Also add a
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.6-eclipse-temurin-11' // <1>
+            image 'maven:3.8.7-eclipse-temurin-11' // <1>
             args '-v /root/.m2:/root/.m2' // <2>
         }
     }
@@ -155,7 +155,7 @@ pipeline {
 ----
 <1> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/maven/[`maven:3.8.6-eclipse-temurin-11` Docker image] (if it's not
+https://hub.docker.com/_/maven/[`maven:3.8.7-eclipse-temurin-11` Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Maven containers running locally in Docker.
@@ -251,7 +251,7 @@ so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.6-eclipse-temurin-11'
+            image 'maven:3.8.7-eclipse-temurin-11'
             args '-v /root/.m2:/root/.m2'
         }
     }
@@ -341,7 +341,7 @@ and add a `skipStagesAfterUnstable` option so that you end up with:
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.6-eclipse-temurin-11'
+            image 'maven:3.8.7-eclipse-temurin-11'
             args '-v /root/.m2:/root/.m2'
         }
     }


### PR DESCRIPTION
## Use Apache Maven 3.8.7 instead of 3.8.6

Recently released and has been confirmed that it works with Jenkins core and with many Jenkins plugins.
