### PR TITLE
Remove version specifier from demo plugin installs

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -103,7 +103,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
+RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -252,7 +252,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
+RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -102,7 +102,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
+RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -241,7 +241,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.26.0 docker-workflow:563.vd5d2e5c4007f"
+RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +


### PR DESCRIPTION
The version specifiers like `blueocean:1.26.0` were originally added because it is a strongly preferred practice to precisely define the versions of plugins that are being installed.  However, the default behavior of the plugin installation manager is to install the most recent release of the plugin, even if a plugin version is specified.

If a user wants to install an older version, the `--latest false` argument is used.  However, that installs outdated versions of many plugins when the plugins and their versions are not fully specified.

Using `blueocean` is better than `blueocean:1.26.0` in this case because it avoid a precise version specification that is then ignored by the plugin installation manager and instead relies on the plugin installation manager to choose the most recent release that is supported on this Jenkins version.

This is a precursor to a workaround for 

* https://github.com/jenkins-infra/jenkins.io/issues/5864