### PR TITLE
Workaround end to end tutorial issue

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -104,6 +104,10 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
+RUN curl -L -s -o $REF/plugins/git-client.jpi \
+  https://updates.jenkins.io/download/plugins/git-client/3.13.1/git-client.hpi
+RUN curl -L -s -o $REF/plugins/git.jpi \
+  https://updates.jenkins.io/download/plugins/git/4.14.3/git.hpi
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -253,6 +257,10 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
+RUN curl -L -s -o $REF/plugins/git-client.jpi \
+  https://updates.jenkins.io/download/plugins/git-client/3.13.1/git-client.hpi
+RUN curl -L -s -o $REF/plugins/git.jpi \
+  https://updates.jenkins.io/download/plugins/git/4.14.3/git.hpi
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -103,6 +103,10 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
+RUN curl -L -s -o $REF/plugins/git-client.jpi \
+  https://updates.jenkins.io/download/plugins/git-client/3.13.1/git-client.hpi
+RUN curl -L -s -o $REF/plugins/git.jpi \
+  https://updates.jenkins.io/download/plugins/git/4.14.3/git.hpi
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -242,6 +246,10 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
+RUN curl -L -s -o $REF/plugins/git-client.jpi \
+  https://updates.jenkins.io/download/plugins/git-client/3.13.1/git-client.hpi
+RUN curl -L -s -o $REF/plugins/git.jpi \
+  https://updates.jenkins.io/download/plugins/git/4.14.3/git.hpi
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +


### PR DESCRIPTION
## Workaround issue in end to end tutorial

https://github.com/jenkins-infra/jenkins.io/issues/5864 correctly reports that git client plugin 4.0.0 provides a newer JGit version than the blue ocean 1.26.0 plugin is ready to use for Pipeline creation with git.

This is a short term workaround to allow users to continue running the tutorials while we work on the better solution.

Pipeline creation from the Blue Ocean interface is a rarely used feature in most Jenkins installations.  We can make it work in this demonstration configuration for now and then remove this workaround in a future change.
