### PR TITLE
Revise UX SIG page and add forum link

### DIFF
--- a/content/_partials/connect-links.html.haml
+++ b/content/_partials/connect-links.html.haml
@@ -24,7 +24,7 @@
 
 -if googlegroup
   %li
-    %a{:href => "https://groups.google.com/forum/#!forum/#{googlegroup}", :target => "_blank", :rel => "noreferrer noopener"}
+    %a{:href => "https://groups.google.com/forum/g/#{googlegroup}", :target => "_blank", :rel => "noreferrer noopener"}
       Mailing List
 -elsif mailinglist
   %li
@@ -100,3 +100,18 @@
   %li
     %a{:href => (meetings.start_with? "http") ? meetings : expand_link(meetings), :target => "_blank", :rel => "noreferrer noopener"}
       Meetings
+
+- ####
+- # Forum
+- ####
+- if page.links && page.links.forum
+  - forum = page.links.forum
+- elsif project && project.links && project.links.forum
+  - forum = project.links.forum
+- elsif sig && sig.links && sig.links.forum
+  - forum = sig.links.forum
+
+- if forum
+  %li
+    %a{href: "https://community.jenkins.io/c/contributing/#{forum}", target: "_blank", rel: "noreferrer noopener"}
+      Forum

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -9,6 +9,7 @@ links:
   chat: "/chat/#jenkins-infra"
   mailinglist: "/mailing-lists/#infralists-jenkins-ci-org"
   meetings: "/projects/infrastructure/#meetings"
+  forum: "infra"
 ---
 
 == Overview

--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -24,6 +24,7 @@ links:
   gitter: "jenkinsci/advocacy-and-outreach-sig"
   googlegroup: "jenkins-advocacy-and-outreach-sig"
   meetings: "https://docs.google.com/document/d/1K5dTSqe56chFhDSGNfg_MCy-LmseUs_S3ys_tg60sTs/edit#heading=h.9jh09t587y90"
+  forum: "advocacy-and-outreach"
 overview: >
   This special interest group offers a venue for discussions around
   advocacy and outreach in the Jenkins community.

--- a/content/sigs/gsoc/index.adoc
+++ b/content/sigs/gsoc/index.adoc
@@ -18,6 +18,7 @@ participants:
 links:
   gitter: "jenkinsci/gsoc-sig"
   googlegroup: "jenkinsci-gsoc-all-public"
+  forum: "gsoc"
 overview: >
   This special interest group organizes Google Summer of Code program within the Jenkins organization.
   The scope of work includes coordinating GSoC activities and working with potentials mentors and contributors

--- a/content/sigs/index.html.haml
+++ b/content/sigs/index.html.haml
@@ -25,7 +25,7 @@ title: Jenkins Special Interest Groups
         %ul
           - if item.links.googlegroup
             %li
-              %a{:href => "https://groups.google.com/forum/#!forum/#{item.links.googlegroup}", :target => "_blank", :rel => "noreferrer noopener"}
+              %a{:href => "https://groups.google.com/forum/g/#{item.links.googlegroup}", :target => "_blank", :rel => "noreferrer noopener"}
                 Mailing List
           - if item.links.gitter
             %li

--- a/content/sigs/ux/index.adoc
+++ b/content/sigs/ux/index.adoc
@@ -11,10 +11,15 @@ tags:
   - ui
   - user_experience
   - user_interface
+leads:
+- "notmyfault"
+- "janfaracik"
+- "uhafner"
+- "timja"
 links:
   gitter: "jenkinsci/ux-sig"
-  googlegroup: "jenkinsci-ux"
   meetings: "https://docs.google.com/document/d/1QttPwdimNP_120JukigKsRuBvMr34KZhVfsbgq1HFLM/edit?usp=sharing"
+  forum: "ux-sig"
 overview: >
   The User Experience SIG focuses on improving the Jenkins' user interface and user experience.
   The SIG seeks regular feedback from the community on the current UI and UX and new designs proposed by SIG members and others.


### PR DESCRIPTION
This PR removes the link to the UX/SIG mailing list in favor of a link to the forums on community.jenkins.io and lists active sig members.

Additionally, I added a placeholder to link to community forums in the sidebar and added it to a few active sigs, which use the forums.

I also fixed the link redirection to google groups.