### PR TITLE
Update board and officers page

### DIFF
--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -15,16 +15,16 @@ links:
   board_members = [
     ["kohsuke"],
     ["oleg_nenashev", "2019/12/03", "2023/12/03"],
-    ["halkeye", "2020/12/03", "2022/12/02"],
-    ["ewelinawilkosz", "2020/03/10", "2022/12/02"],
+    ["notmyfault", "2022/12/03", "2024/12/02"],
+    ["uhafner", "2022/12/03", "2024/12/02"],
     ["markewaite", "2021/12/03", "2023/12/02"],
   ]
   officers = [
-    ["Security", "wadeck", "2021/12/03", "2022/12/02"],
-    ["Release", "timja", "2020/12/03", "2022/12/02"],
-    ["Infrastructure", "dduportal", "2021/12/03", "2022/12/02"],
-    ["Events", "alyssat", "2021/12/03", "2022/12/02"],
-    ["Documentation", "markewaite", "2020/12/03", "2021/12/02"]
+    ["Security", "wadeck", "2021/12/03", "2023/12/02"],
+    ["Release", "timja", "2020/12/03", "2023/12/02"],
+    ["Infrastructure", "dduportal", "2021/12/03", "2023/12/02"],
+    ["Events", "alyssat", "2021/12/03", "2023/12/02"],
+    ["Documentation", "kmartens27", "2022/12/03", "2023/12/02"]
   ]
 
 As per the Jenkins project


### PR DESCRIPTION
Match the results from the November 2022 election.

https://github.com/jenkins-infra/jenkins.io/issues/5870 is fixed by this pull request
