### PR TITLE
Address ruby deprecations

### DIFF
--- a/content/_layouts/corebaseline.html.haml
+++ b/content/_layouts/corebaseline.html.haml
@@ -7,7 +7,7 @@ layout: developersection
 
     # For this file, assume that the the entries are in increasing order and get the second column (which is the last pre-split version)
     # TODO Figure out a way to obtain this content differently, this is terrible
-    split_versions = open('https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/resources/jenkins/split-plugins.txt').read.lines.select { |l| l.strip.length > 0 && !(l.strip =~ /^#/) }.map { |l| l.split(' ')[1] }
+    split_versions = URI.open('https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/resources/jenkins/split-plugins.txt').read.lines.select { |l| l.strip.length > 0 && !(l.strip =~ /^#/) }.map { |l| l.split(' ')[1] }
     latest_split = split_versions[-1]
 
     lts = site._generated[:core_tiers].stableCores

--- a/content/_partials/changelog-changes.xml.haml
+++ b/content/_partials/changelog-changes.xml.haml
@@ -6,26 +6,26 @@
     %description
 
       - if release.lts_changes
-        = "<strong>Changes since #{release.lts_baseline}:</strong>".encode( { :xml => :text } )
+        = "<strong>Changes since #{release.lts_baseline}:</strong>".encode(xml: :text)
 
-      = "<ul>".encode( { :xml => :text } )
+      = "<ul>".encode(xml: :text)
       - release.changes.each do | change |
-        = "<li>".encode( { :xml => :text } )
+        = "<li>".encode(xml: :text)
         #{change.type.gsub(/\w+/, &:capitalize).gsub(/rfe/i, 'RFE')}:
-        = change.message.encode( { :xml => :text } )
-        = "</li>".encode( { :xml => :text } )
-      = "</ul>".encode( { :xml => :text } )
+        = change.message.encode(xml: :text)
+        = "</li>".encode(xml: :text)
+      = "</ul>".encode(xml: :text)
 
       - if release.lts_changes
-        = "<strong>Notable changes since #{release.lts_predecessor}:</strong>".encode( { :xml => :text } )
+        = "<strong>Notable changes since #{release.lts_predecessor}:</strong>".encode(xml: :text)
 
-        = "<ul>".encode( { :xml => :text } )
+        = "<ul>".encode(xml: :text)
         - release.lts_changes.each do | change |
-          = "<li>".encode( { :xml => :text } )
+          = "<li>".encode(xml: :text)
           #{change.type.gsub(/\w+/, &:capitalize).gsub(/rfe/i, 'RFE')}:
-          = change.message.encode( { :xml => :text } )
-          = "</li>".encode( { :xml => :text } )
-        = "</ul>".encode( { :xml => :text } )
+          = change.message.encode(xml: :text)
+          = "</li>".encode(xml: :text)
+        = "</ul>".encode(xml: :text)
     %guid(isPermaLink='false')
       jenkins-#{release.version}
     - if release.date

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -94,7 +94,7 @@ title: Jenkins download and deployment
               Generic Java package (.war)
               %div{:style => 'font-size: x-small;overflow-wrap: break-word; word-wrap: break-word;'}
                 SHA-256:
-                = open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.stable + '/jenkins-war-' + site.jenkins.stable + '.war.sha256').read()
+                = URI.open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.stable + '/jenkins-war-' + site.jenkins.stable + '.war.sha256').read
           %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins'}
             %span.icon
             %span.title
@@ -153,7 +153,7 @@ title: Jenkins download and deployment
             Generic Java package (.war)
             %div{:style => 'font-size: x-small;overflow-wrap: break-word; word-wrap: break-word;'}
               SHA-256:
-              = open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.latest + '/jenkins-war-' + site.jenkins.latest + '.war.sha256').read()
+              = URI.open('https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/' + site.jenkins.latest + '/jenkins-war-' + site.jenkins.latest + '.war.sha256').read
         %a.list-group-item.list-group-item-action{:href=>'https://hub.docker.com/r/jenkins/jenkins/'}
           %span.icon
           %span.title

--- a/content/security/advisories/rss.xml.haml
+++ b/content/security/advisories/rss.xml.haml
@@ -35,18 +35,18 @@
         %description
           - if page.issues or page.index_details
             - if page.index_details
-              = Asciidoctor.convert(page.index_details, safe: :safe).encode( { :xml => :text } )
+              = Asciidoctor.convert(page.index_details, safe: :safe).encode(xml: :text)
             - else
-              = "<ul>".encode( { :xml => :text } )
+              = "<ul>".encode(xml: :text)
               - if page.core
-                = "<li>Affects Jenkins Core</li>".encode( { :xml => :text } )
+                = "<li>Affects Jenkins Core</li>".encode(xml: :text)
               - plugins = page.issues.collect { |issue| issue.plugins }.flatten.keep_if { |p| p }.collect { |p| Plugin.new(p.name, p.title) }.uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
               - plugins.each do | plugin |
                 - if site._generated[:update_center].plugins[plugin.name]
-                  = "<li>Affects plugin: <a href='https://plugins.jenkins.io/#{plugin.name}'>#{site._generated[:update_center].plugins[plugin.name].title}</a></li>".encode( { :xml => :text } )
+                  = "<li>Affects plugin: <a href='https://plugins.jenkins.io/#{plugin.name}'>#{site._generated[:update_center].plugins[plugin.name].title}</a></li>".encode(xml: :text)
                 - else
-                  = "<li>Affects plugin: #{plugin.title || plugin.name}".encode( { :xml => :text } )
+                  = "<li>Affects plugin: #{plugin.title || plugin.name}".encode(xml: :text)
               - components = page.issues.collect { |issue| issue.components }.flatten.keep_if { |c| c }
               - components.each do | component |
                 = "<li>Affects #{component.title || component.name}</li>"
-              = "</ul>".encode( { :xml => :text } )
+              = "</ul>".encode(xml: :text)


### PR DESCRIPTION
This PR addresses the removal of `Kernel#open` in favor of `URI.open` in ruby 3 and migrates legacy syntax to supported syntax.

Taking a look over the generated feeds and xml structured texts reveal no difference between the current layout.