### PR TITLE
Jenkins - Update nginx reverse proxy docs

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -80,7 +80,7 @@ server {
       proxy_set_header   Connection        $connection_upgrade;
       proxy_set_header   Upgrade           $http_upgrade;
 
-      proxy_set_header   Host              $host;
+      proxy_set_header   Host              $http_host;
       proxy_set_header   X-Real-IP         $remote_addr;
       proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Resolves [issue #5882 ](https://github.com/jenkins-infra/jenkins.io/issues/5882)

Updating instruction to include `proxy_set_header $http_host;`as the nginx documentation has been updated.