### PR TITLE
Remove Docs sig mailing list

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -20,7 +20,6 @@ participants:
 - "zaycodes"
 links:
   gitter: "jenkinsci/docs"
-  googlegroup: "jenkinsci-docs"
   meetings: "https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit"
 overview: >
   This special interest group improves Jenkins use and adoption through documentation.


### PR DESCRIPTION
## Remove docs SIG mailing list from Docs SIG page

No longer used, see community.jenkins.io and https://gitter.im/jenkinsci/docs
