### PR TITLE
Remove jenkinsci-docs from documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Mailing list
-    url: https://groups.google.com/forum/#!forum/jenkinsci-docs
-    about: Jenkins Documentation SIG mailing list
   - name: Gitter chat
     url: https://gitter.im/jenkinsci/docs
     about: Jenkins Documentation SIG chat

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -42,7 +42,6 @@ You can also find some newbie-friendly issues in our task trackers:
 Jenkins website is largely maintained by the link:https://jenkins.io/sigs/docs/[Jenkins documentation] special interest group.
 This group has various communication channels which can be used to discuss contributing to the website:
 
-* link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Mailing list]
 * link:https://gitter.im/jenkinsci/docs[Gitter chat]
 * link:https://jenkins.io/sigs/docs/#meetings[Regular meetings]
 

--- a/content/_partials/wip.adoc
+++ b/content/_partials/wip.adoc
@@ -2,6 +2,6 @@
 ====
 This section is a work in progress.
 Want to help?
-Check out the link:https://groups.google.com/forum/#!forum/jenkinsci-docs[jenkinsci-docs mailing list].
+Check out the link:https://gitter.im/jenkinsci/docs[jenkinsci/docs gitter channel].
 For other ways to contribute to the Jenkins project, see link:/participate[this page about participating and contributing].
 ====

--- a/content/blog/2017/11/2017-11-27-tutorials-in-the-jenkins-user-documentation.adoc
+++ b/content/blog/2017/11/2017-11-27-tutorials-in-the-jenkins-user-documentation.adoc
@@ -105,10 +105,7 @@ whenever a new tutorial is published.
 
 Also, if you have any suggestions for tutorials or other content you'd like to
 see in the documentation, please post your suggestions in the
-link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Jenkins
-Documentation Google Group], which you can also post (and reply) to by emailing
-`jenkinsci-docs@googlegroups.com`.
-
+link:https://gitter.im/jenkinsci/docs[jenkinsci/docs gitter channel].
 
 [.boxshadow]
 image:/images/post-images/2017-11/sydney-office-team.jpg[The "Sydney Office"

--- a/content/blog/2021/03/2021-03-19-SheCodeAfrica-announcement.adoc
+++ b/content/blog/2021/03/2021-03-19-SheCodeAfrica-announcement.adoc
@@ -56,5 +56,5 @@ The top 10 Pipeline plugins that have received the most feedback are:
 
 == What about my plugin?
 
-If you are a plugin maintainer and would like help to add examples and online help for the Pipeline steps in your plugin, send email to the link:mailto:jenkinsci-docs@googlegroups.com[Jenkins Documentation mailing list].
+If you are a plugin maintainer and would like help to add examples and online help for the Pipeline steps in your plugin, let us know in the link:https://gitter.im/jenkinsci/docs[jenkinsci/docs gitter channel].
 We'll consider including additional plugins as we better understand the development pace for She Code Africa participants.

--- a/content/doc/book/blueocean/activity.adoc
+++ b/content/doc/book/blueocean/activity.adoc
@@ -6,7 +6,6 @@ wip: false
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -5,7 +5,6 @@ title: Dashboard
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -6,7 +6,6 @@ title: Getting started with Blue Ocean
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/blueocean/pipeline-editor.adoc
+++ b/content/doc/book/blueocean/pipeline-editor.adoc
@@ -5,7 +5,6 @@ title: Pipeline Editor
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/blueocean/pipeline-run-details.adoc
+++ b/content/doc/book/blueocean/pipeline-run-details.adoc
@@ -5,7 +5,6 @@ title: Pipeline Run Details View
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/installing/docker.adoc
+++ b/content/doc/book/installing/docker.adoc
@@ -5,7 +5,6 @@ title: Docker
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/initial-settings.adoc
+++ b/content/doc/book/installing/initial-settings.adoc
@@ -5,7 +5,6 @@ title: Initial Settings
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -5,7 +5,6 @@ title: Kubernetes
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -5,7 +5,6 @@ title: Linux
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/macos.adoc
+++ b/content/doc/book/installing/macos.adoc
@@ -5,7 +5,6 @@ title: macOS
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/offline.adoc
+++ b/content/doc/book/installing/offline.adoc
@@ -5,7 +5,6 @@ title: Offline Installations
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/other.adoc
+++ b/content/doc/book/installing/other.adoc
@@ -5,7 +5,6 @@ title: Other Systems
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/servlet-containers.adoc
+++ b/content/doc/book/installing/servlet-containers.adoc
@@ -5,7 +5,6 @@ title: Other Servlet Containers
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/war-file.adoc
+++ b/content/doc/book/installing/war-file.adoc
@@ -5,7 +5,6 @@ title: WAR file
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -5,7 +5,6 @@ title: Windows
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/managing/about-jenkins.adoc
+++ b/content/doc/book/managing/about-jenkins.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :hide-uri-scheme:

--- a/content/doc/book/managing/change-system-timezone.adoc
+++ b/content/doc/book/managing/change-system-timezone.adoc
@@ -5,7 +5,6 @@ title: Change System Time Zone
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc: left
 endif::[]

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :hide-uri-scheme:

--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :hide-uri-scheme:

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description: Jenkins Script Console
 :author: Sam Gleske
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc: macro
 :hide-uri-scheme:

--- a/content/doc/book/managing/spawning-processes.adoc
+++ b/content/doc/book/managing/spawning-processes.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/managing/system-configuration.adoc
+++ b/content/doc/book/managing/system-configuration.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc: left
 endif::[]

--- a/content/doc/book/managing/system-info.adoc
+++ b/content/doc/book/managing/system-info.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :hide-uri-scheme:

--- a/content/doc/book/managing/tools.adoc
+++ b/content/doc/book/managing/tools.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :hide-uri-scheme:

--- a/content/doc/book/managing/ui-themes.adoc
+++ b/content/doc/book/managing/ui-themes.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/managing/user-content.adoc
+++ b/content/doc/book/managing/user-content.adoc
@@ -5,7 +5,6 @@ title: User Content
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/managing/users.adoc
+++ b/content/doc/book/managing/users.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :hide-uri-scheme:

--- a/content/doc/book/pipeline/cps-method-mismatches.adoc
+++ b/content/doc/book/pipeline/cps-method-mismatches.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]

--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -5,7 +5,6 @@ title: Pipeline Development Tools
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -5,7 +5,6 @@ title: Using Docker with Pipeline
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -6,7 +6,6 @@ title: Getting started with Pipeline
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -5,7 +5,6 @@ title: Using a Jenkinsfile
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/pipeline/multibranch.adoc
+++ b/content/doc/book/pipeline/multibranch.adoc
@@ -5,7 +5,6 @@ title: Branches and Pull Requests
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]

--- a/content/doc/book/pipeline/pipeline-best-practices.adoc
+++ b/content/doc/book/pipeline/pipeline-best-practices.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author: Alex Taylor
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]

--- a/content/doc/book/pipeline/running-pipelines.adoc
+++ b/content/doc/book/pipeline/running-pipelines.adoc
@@ -5,7 +5,6 @@ title: Running Pipelines
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/pipeline/scaling-pipeline.adoc
+++ b/content/doc/book/pipeline/scaling-pipeline.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author: Sam Van Oort
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -6,7 +6,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 ifdef::env-github[:imagesdir: ../resources]
 ifndef::env-github[:imagesdir: ../../resources]

--- a/content/doc/book/security/managing-security.adoc
+++ b/content/doc/book/security/managing-security.adoc
@@ -5,7 +5,6 @@ ifdef::backend-html5[]
 :notitle:
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 ifdef::env-github[:imagesdir: ../resources]

--- a/content/doc/book/using/change-time-zone.adoc
+++ b/content/doc/book/using/change-time-zone.adoc
@@ -5,7 +5,6 @@ title: Change time zone
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/using/searchbox.adoc
+++ b/content/doc/book/using/searchbox.adoc
@@ -5,7 +5,6 @@ title: Search Box
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -5,7 +5,6 @@ title: Using Jenkins agents
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -5,7 +5,6 @@ title: Using credentials
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/using/using-jmeter-with-jenkins.adoc
+++ b/content/doc/book/using/using-jmeter-with-jenkins.adoc
@@ -5,7 +5,6 @@ title: Using JMeter with Jenkins
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/book/using/using-local-language.adoc
+++ b/content/doc/book/using/using-local-language.adoc
@@ -5,7 +5,6 @@ title: Using local language
 ifdef::backend-html5[]
 :description:
 :author:
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :toclevels: 4

--- a/content/doc/pipeline/tour/agents.adoc
+++ b/content/doc/pipeline/tour/agents.adoc
@@ -2,7 +2,6 @@
 layout: documentation
 title: Defining execution environments
 ---
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :imagesdir: ../../../book/resources

--- a/content/doc/pipeline/tour/deployment.adoc
+++ b/content/doc/pipeline/tour/deployment.adoc
@@ -2,7 +2,6 @@
 layout: documentation
 title: Deployment
 ---
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :imagesdir: ../../../book/resources

--- a/content/doc/pipeline/tour/environment.adoc
+++ b/content/doc/pipeline/tour/environment.adoc
@@ -2,7 +2,6 @@
 layout: documentation
 title: Using environment variables
 ---
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :imagesdir: ../../../book/resources

--- a/content/doc/pipeline/tour/tests-and-artifacts.adoc
+++ b/content/doc/pipeline/tour/tests-and-artifacts.adoc
@@ -3,7 +3,6 @@ layout: documentation
 title: Recording tests and artifacts
 ---
 
-:email: jenkinsci-docs@googlegroups.com
 :sectanchors:
 :toc:
 :imagesdir: ../../../book/resources

--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -20,9 +20,6 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkins-infra")
 
-= partial(group, :name => "jenkinsci-docs",
-  :description => "Mailing list for collaborating on Jenkins user and developer documentation.")
-
 %h2 Discussion lists in other languages
 
 = partial(group, :name => "jenkinsci-zh",

--- a/content/sigs/docs/gsod/2020/application.md
+++ b/content/sigs/docs/gsod/2020/application.md
@@ -16,7 +16,6 @@ The data below represents the Google Season of Docs 2020 application draft.
 
 * Name: Jenkins project
 * Website: https://jenkins.io/
-* Contact email for GSoD: jenkinsci-docs@googlegroups.com 
 * GSoD page link: http://jenkins.io/sigs/docs/gsod
 * Does your organization want to accept the mentor stipend? => Yes
 * Link to project ideas list: https://jenkins.io/sigs/docs/gsod#project-ideas 
@@ -74,7 +73,6 @@ Contributions to Jenkins component documentation (e.g. plugin docs) are usually 
 We also have channels specifically dedicated to the documentation.
 These channels act as an additional contact point for technical writers in the community:
 
-* Mailing list: https://groups.google.com/forum/#!forum/jenkinsci-docs
 * Chat on Gitter: https://gitter.im/jenkinsci/docs
 * Regular Documentation SIG meetings: https://www.jenkins.io/sigs/docs/#meetings
 

--- a/content/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes.adoc
+++ b/content/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes.adoc
@@ -70,8 +70,7 @@ techniques, and choices for Kubernetes users running Jenkins.
 === Reaching Out
 
 Feel free to reach out to us for any questions, feedback, etc. on the project's
-link:https://gitter.im/jenkinsci/docs[Gitter Channel] or the
-mailto:jenkinsci-docs@googlegroups.com[Jenkins Documentation Mailing list].
+link:https://gitter.im/jenkinsci/docs[Gitter Channel].
 
 === Other Links
 

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -28,7 +28,7 @@ Significant documentation project opportunities are listed in the link:/sigs/doc
 
 If you are interested to participate in Google Season of Docs as a technical writer, please do the following:
 
-. Join our link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Mailing list] and link:https://gitter.im/jenkinsci/docs[Gitter Channel].
+. Join our link:https://gitter.im/jenkinsci/docs[Gitter Channel].
 . Explore the project ideas listed on this page, find areas which would be interesting to you.
 . Try link:/participate/document/[contributing to Jenkins documentation] to study our documentation tools and contribution process.
   There are some link:/participate/document/#newcomers[newcomer-friendly documentation tasks] you could try.
@@ -69,7 +69,6 @@ In such cases we document usage of these tools in link:https://github.com/jenkin
 
 We use the link:/sigs/docs[Documentation SIG] communication channels for GSoD project discussions during the application phases.
 
-* link:https://groups.google.com/forum/#!forum/jenkinsci-docs[Mailing list]
 * link:https://gitter.im/jenkinsci/docs[Gitter Channel]
 * link:/sigs/docs/#meetings[Regular SIG meetings]
 


### PR DESCRIPTION
Follow up to https://github.com/jenkins-infra/jenkins.io/pull/5906 to remove various spots the mailing list is still referenced in.