### PR TITLE
Correct publication year of 2.375.2

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -8405,7 +8405,7 @@
       Ensure that temporary network partitions do not cancel the WebSocket ping thread (regression in 2.363).
 
 - version: "2.375.2"
-  date: 2022-01-11
+  date: 2023-01-11
   changes:
 
   - type: rfe


### PR DESCRIPTION
It seems incrementing the year was accidentally omitted during <https://github.com/jenkins-infra/jenkins.io/pull/5793>.