### PR TITLE
Move Platform SIG meeting 1 hour later

### DIFF
--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -119,7 +119,7 @@ Scope of interest:
 
 == Meetings
 
-We have regular meetings on Fridays every two weeks, at *15:00 UTC*.
+We have regular meetings on Fridays every two weeks, at *16:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded via Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].


### PR DESCRIPTION
Avoid a conflict with another meeting

@gounthar this matches with the change I made in the Jenkins calendar.