### PR TITLE
Fix carousel, remove redundant docsearch

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -123,15 +123,3 @@
           $body.removeClass("no-outline");
         })
       })
-    - if not page.barebone
-      %script{:type => "text/javascript", :src => "https://cdn.jsdelivr.net/npm/@docsearch/js@3"}
-      %script{:type => "text/javascript"}
-        :plain
-          docsearch({
-            container: document.querySelector('input.searchbox').parentNode,
-            indexName: 'jenkins',
-            appId: "M6L7Q4Z8HS",
-            apiKey: "52f8dfbff76ffd9106f1c68fee16154b",
-            algoliaOptions: { 'facetFilters': ["tags:en"] },
-            debug: false
-          });

--- a/content/_partials/projectcarousel.html.haml
+++ b/content/_partials/projectcarousel.html.haml
@@ -22,12 +22,12 @@
     background: #{carousel_background};
   }
 
-.carousel.slide#ProjectCarousel{:id => carousel_id, :class => "carousel_#{carousel_id}", :data => {:ride => "carousel"}}
+.carousel.slide#ProjectCarousel{:id => carousel_id, :class => "carousel_#{carousel_id}", :data => { :bs => {:ride => "carousel"}}}
   .container
     - if page.slides.length > 1
-      %ol.carousel-indicators
+      %div.carousel-indicators
         - page.slides.each_with_index do |slide, index|
-          %li{:class => index == 0 && "active", :data => {:target => "#ProjectCarousel_#{carousel_id}", :slide => {:to => index }}}
+          %button{:class => index == 0 && "active", :data => {:bs => {:target => "#ProjectCarousel_#{carousel_id}", :slide => {:to => index }}}}
     .carousel-inner{:class => "carousel_#{carousel_id}"}
       - page.slides.each_with_index do |slide, index|
         - slide_background = slide.background || "rgba(0,0,0,0)"
@@ -37,9 +37,7 @@
           :style => "background: #{slide_background};"}
           .container
             -# Spacing to make content more even
-            .pt-4
-              &nbsp;
-            .row
+            .row.mt-5.mb-5
               .col-md-12.col-lg-8.order-first.order-lg-last
                 - if slide.image
                   - image_height = slide.image.height || '300px'
@@ -55,8 +53,3 @@
                   %div
                     %a.btn.btn-primary{:href => expand_link(slide.call_to_action.href)}
                       = slide.call_to_action.text
-            -# Spacing to make content more even
-            .pt-4
-              &nbsp;
-
-

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -157,11 +157,6 @@ body h1.page-title .in-tag {
     }
 }
 
-/* https://issues.jenkins.io/browse/WEBSITE-148  */
-.carousel-inner {
-  z-index: 8;
-}
-
 #ji-download {
  top: 18rem;
  right: 0;


### PR DESCRIPTION
Fix #5911 by using Bootstrap 5 attribute names; z-index needed changing to allow navigating carousel by clicking the indicators.

Also fixes the console error related to docsearch being loaded by the site -- no longer needed since it's loaded by the header component instead. 