### PR TITLE
Update GSoC project idea template

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
@@ -20,7 +20,7 @@ mentors:
 // links:
 //   emailThread:  Link to the Discourse thread. (*** FOR EXAMPLE *** -> https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
 //   gitter: Link to the gitter channel (*** FOR EXAMPLE *** -> "jenkinsci/plugin-installation-manager-cli-tool")
-//   draft: Link to the draft detailed project idea (example -> https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
+//   draft: Link to the draft detailed project idea ( *** FOR EXAMPLE *** -> https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
 ---
 
 // TODO: Fill the project idea details following bellow template.

--- a/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
@@ -19,7 +19,7 @@ mentors:
 // TODO: Uncomment and update links to the project idea discussion on community.jenkins.io, the gitter channel, and the draft document 
 // links:
 //   emailThread:  Link to the Discourse thread. (*** FOR EXAMPLE *** -> https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
-//   gitter: Link to the gitter channel (example -> "jenkinsci/plugin-installation-manager-cli-tool")
+//   gitter: Link to the gitter channel (*** FOR EXAMPLE *** -> "jenkinsci/plugin-installation-manager-cli-tool")
 //   draft: Link to the draft detailed project idea (example -> https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
 ---
 

--- a/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
@@ -18,9 +18,9 @@ mentors:
 
 // TODO: Uncomment and update links to the project idea discussion on community.jenkins.io, the gitter channel, and the draft document 
 // links:
-//   emailThread:  Link to the Discourse thread. (*** FOR EXAMPLE *** -> https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
-//   gitter: Link to the gitter channel (*** FOR EXAMPLE *** -> "jenkinsci/plugin-installation-manager-cli-tool")
-//   draft: Link to the draft detailed project idea ( *** FOR EXAMPLE *** -> https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
+//   emailThread:  Link to the Discourse thread. (*** FOR EXAMPLE *** → https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
+//   gitter: Link to the gitter channel (*** FOR EXAMPLE *** → "jenkinsci/plugin-installation-manager-cli-tool")
+//   draft: Link to the draft detailed project idea ( *** FOR EXAMPLE *** → https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
 ---
 
 // TODO: Fill the project idea details following bellow template.
@@ -41,7 +41,7 @@ mentors:
 // 
 // === Project Size
 // 
-// 175 hours
+// (*** FOR EXAMPLE *** → 175 hours)
 // 
 // === Expected outcomes
 // 

--- a/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
@@ -18,7 +18,7 @@ mentors:
 
 // TODO: Uncomment and update links to the project idea discussion on community.jenkins.io, the gitter channel, and the draft document 
 // links:
-//   emailThread:  Link to the Discourse thread. (example -> https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
+//   emailThread:  Link to the Discourse thread. (*** FOR EXAMPLE *** -> https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
 //   gitter: Link to the gitter channel (example -> "jenkinsci/plugin-installation-manager-cli-tool")
 //   draft: Link to the draft detailed project idea (example -> https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
 ---

--- a/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2023/project-ideas/prj-idea-template.adoc_text
@@ -12,13 +12,20 @@ skills:
 - Command line tools
 - Package management tool theory
 mentors:
+// TODO: enter mentors as jenkins.io authors ( see content/_data/authors)
+// Note: renderer will fail if mentor does not exist
 - "gsoc"
 
+// TODO: Uncomment and update links to the project idea discussion on community.jenkins.io, the gitter channel, and the draft document 
 // links:
-//   emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
-//   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+//   emailThread:  Link to the Discourse thread. (example -> https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
+//   gitter: Link to the gitter channel (example -> "jenkinsci/plugin-installation-manager-cli-tool")
+//   draft: Link to the draft detailed project idea (example -> https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
 ---
+
+// TODO: Fill the project idea details following bellow template.
+// When uncommented, the following sections will only be rendered when the project idea is promoted to "draft" or "accepted" status.
+
 // === Background
 // TBD
 //


### PR DESCRIPTION
Update the project idea template with comments to avoid misunderstandings for contributors and reviewers.

For full guidance see projects/gsoc/proposing-project-ideas/