### PR TITLE
Adding details about CVEs in third party dependencies

### DIFF
--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -40,18 +40,8 @@ Even if you run Jenkins on a private network and trust everyone in your team, se
 == How to Report a Security Vulnerability
 
 If you find a vulnerability in Jenkins, please report it in the issue tracker under the link:https://issues.jenkins.io/browse/SECURITY[SECURITY project].
-This project is configured in such a way that only the reporter, the maintainers, and the Jenkins security team can see the details.
-Restricting access to this potentially sensitive information allows core and plugin maintainers to develop effective security fixes that are safe to apply.
+
 We provide issue reporting guidelines and an overview of our process on link:reporting[Reporting Security Vulnerabilities].
-
-If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
-`jenkinsci-cert@googlegroups.com`
-
-IMPORTANT: Do not contact the Jenkins security team asking us for compliance documents, certifications, or to fill out a questionnaire.
-We will not respond to such queries.
-If we consider it necessary to provide a statement in response to incidents such as link:/blog/2021/12/10/log4j2-rce-CVE-2021-44228/[log4shell] or link:/blog/2022/03/31/spring-rce-CVE-2022-22965/[SpringShell], you will find a response in our link:/node/[blog].
-
-To show our appreciation for your help, we'll send you link:/security/gift/[a small reward] for privately reported, valid vulnerability reports.
 
 
 == Learn More

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -58,6 +58,24 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
 * Jobs started by a specific user can run on agents where the user lacks Agent/Build permission and can themselves trigger builds of jobs where the user lacks Job/Build permission.
   link:/doc/book/security/build-authorization/[See the documentation on Access Control for Builds].
 
+
+=== CVEs in dependencies
+
+In the case of CVEs found in third party dependencies included in the Jenkins project, if the ticket does not include reproduction steps, a proof or at least a good argument, we are closing them.
+Those CVEs are internally analysed and most of the time the project is not impacted.
+
+When a CVE has an impact, we are including them in an advisory, like link:https://www.jenkins.io/security/advisory/2022-09-09/#SECURITY-2868[CVE-2022-2048 in Jetty] or https://www.jenkins.io/security/advisory/2022-02-09/#SECURITY-2602[CVE-2021-43859 in XStream].
+
+Instead of announcing a continuous flow of non-impacting vulnerabilities, our approach is to publish information only for those that we consider interesting, like critical score, widely spread, etc.
+For them you will find an article in our link:/node/[blog], like: link:/blog/2021/12/10/log4j2-rce-CVE-2021-44228/[Log4Shell] or link:/blog/2022/03/31/spring-rce-CVE-2022-22965/[SpringShell].
+
+
+=== Compliance
+
+IMPORTANT: Do not contact the Jenkins security team asking us for compliance documents, certifications, or to fill out a questionnaire.
+We will not respond to such queries.
+
+
 == Issue Handling Process
 
 Once reported, the Jenkins security team will perform an evaluation of the issue to determine affected components and whether the report is a valid security vulnerability.


### PR DESCRIPTION
As the reporting of CVEs is a recurrent topic within the security team, I would like to clarify our standpoint.