### PR TITLE
Clarify state on issue assignees

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -36,6 +36,8 @@ You can also find some newbie-friendly issues in our task trackers:
 * link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good First Issues on GitHub]
 * link:https://issues.jenkins.io/issues/?filter=18650&jql=project%20%3D%20WEBSITE%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Jenkins Jira query]
 
+If you found an issue that you would like to work on, you are welcome to go ahead and start contributing. Please don't ask to be assigned to an issue, we don't assign individuals to issues, just go ahead and start working on it. If you need any help, please ask in the xref:contacts[].
+
 [[contacts]]
 === Communication channels
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -36,7 +36,9 @@ You can also find some newbie-friendly issues in our task trackers:
 * link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good First Issues on GitHub]
 * link:https://issues.jenkins.io/issues/?filter=18650&jql=project%20%3D%20WEBSITE%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Jenkins Jira query]
 
-If you found an issue that you would like to work on, you are welcome to go ahead and start contributing. Please don't ask to be assigned to an issue, we don't assign individuals to issues, just go ahead and start working on it. If you need any help, please ask in the xref:contacts[].
+If you found an issue that you would like to work on, you are welcome to go ahead and start contributing.
+Please don't ask to be assigned to an issue, we don't assign individuals to issues, just go ahead and start working on it.
+If you need any help, please ask in the xref:contacts[].
 
 [[contacts]]
 === Communication channels


### PR DESCRIPTION
Historically, assigning newbies to issues didn't have a much positive impact on the issue, in terms of delivering an acceptable solution; hence we typically don't assign people to issues. Anyone is welcome to contribute anything they feel comfortable with.
This PR adds this state to the contributing documentation.