### PR TITLE
Only check dependencies once a month

### DIFF
--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -34,11 +34,9 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
   target-branch: master
-  reviewers:
-  - <insert-maintainers-here-one-per-line-use-github-handle>
 END-OF-HERE-DOC
 ----
 


### PR DESCRIPTION
The [plugin archetype](https://www.jenkins.io/doc/developer/tutorial/create/) now includes dependabot checks once a month. That is sufficient for a plugin that is maintained less frequently and avoids the distraction of dependabot pull requests every week.

Also removes the "insert maintainers here" because there have been several cases where a new contributor did not replace that text with the name of a maintainer.

@jmMeessen, @gounthar, and @dheerajodha were involved with this file previously and may want to comment on it.