### PR TITLE
[GSoC] reverting gitlab plugin modernization to discussion

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -4,7 +4,7 @@ title: "GitLab Plugin Modernization"
 goal: "Cleaning and modernizing the extensively used GitLab plugin"
 category: Plugin improvement
 year: 2023
-status: draft
+status: discussion
 sig: platform
 skills:
 - Java


### PR DESCRIPTION
Putting the "GitLab Plugin Modernization" back to discussion status in order to solve the comments made in https://github.com/jenkins-infra/jenkins.io/pull/5836#discussion_r1087096858 and https://github.com/jenkins-infra/jenkins.io/pull/5836#issuecomment-1404202964