### PR TITLE
Promote GitLab plugin modernization project to draft state

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -4,7 +4,7 @@ title: "GitLab Plugin Modernization"
 goal: "Cleaning and modernizing the extensively used GitLab plugin"
 category: Plugin improvement
 year: 2023
-status: discussion
+status: draft
 sig: platform
 skills:
 - Java
@@ -20,27 +20,43 @@ links:
 ---
 === Background
 
-The GitLab plugin is widely used (58,727 installations) but has not had an active maintainer for a long time. 
-Many of us at CloudBees have volunteered to keep it afloat over the years, including Owen, Basil, Bruno, Jean-Marc, and Mark. 
-But it could use a sprint of active development. 
-Maybe GSoC could be a good way to staff this with an intern?
+The https://plugins.jenkins.io/gitlab-plugin/[GitLab] Jenkins plugin is widely used (58,727 installations),
+but it has not had an active maintainer for a long time.
+Several CloudBees employees have volunteered to keep it afloat over the years, including Owen, Basil, Bruno, Jean-Marc, and Mark.
+However, it could use a sprint of active development.
 
-At first sight, there are a number of things that need to be done to keep this plugin afloat in the long term:
+The primary maintenance issue with the GitLab plugin is the use of a very old version of https://resteasy.dev/[RESTEasy].
+The goal of this GSoC project would be to replace usages of this library
+with usages of https://github.com/gitlab4j/gitlab4j-api[`gitlab4j-api`]
+via the https://plugins.jenkins.io/gitlab-api/[GitLab API] Jenkins library plugin,
+normalizing the GitLab plugin's use of the GitLab API with regard to
+the https://plugins.jenkins.io/gitlab-oauth/[GitLab Authentication],
+https://plugins.jenkins.io/gitlab-branch-source/[GitLab Branch Source],
+and https://plugins.jenkins.io/gitlab-logo/[GitLab Logo] plugins.
 
-* Migrate from the very old version of RESTEasy it is using to the GitLab API plugin (just like GitLab Authentication, GitLab Branch Source, and GitLab Logo)
-* Revive the Docker-based functional test suite. It has been broken for some time and is currently disabled.
-* Fix any of the dozens of outstanding bugs.
+This project is on the easy side, but it requires a large amount of careful porting of existing code
+to call equivalent APIs with slightly different calling conventions.
+At each stage, care must be taken to ensure that errors remain propagated correctly.
 
-The objectives could be expanded to cover the "sister" `gitlab-branch-source` plugin.
+A particular challenge with this project is to ensure that there are no regressions for corner cases:
 
-This would be a good GSoC project for the following reasons:
+* Unauthenticated proxy servers
+* Authenticated proxy servers
+* Proxy servers and TLS URLs
 
-* While boasting less of a brag factor than the link:/projects/gsoc/2023/project-ideas/agent_reconnections_exponential_backoff/[exponential backoff and jitter idea], impact to a large number of users might be brag factor enough.
-* Would be ideal for someone who wants to get GitLab experience and get paid along the way.
-* Feasible within three months: Nothing prohibitively hard here, just a matter of doing the work (cutting code and testing).
-* Stretchable and shrinkable scope: If the intern is struggling, we can drop one of the two main changes. 
-If the intern is doing better than expected, we can fix more bugs.
-* Not fatal if the project fails: People still seem to keep using this plugin no matter how poorly maintained it is.
+Handling these corner cases should be feasible with the new library,
+but the existing logic will likely need some modifications.
+Testing proxy authentication is a bit laborious, but it can be done with various Docker images.
+
+There is no substitute for functional testing, so testing changes to the GitLab plugin
+would also require setting up a local instance of GitLab.
+This would be a good opportunity to gain experience with the setup and administration of GitLab.
+The idea would be to exercise existing code against a real GitLab installation,
+then to test that the ported version still works in the same manner.
+Unfortunately, unit and integration tests will be of little value for this project.
+
+If additional time is available, the GSoC contributor could look into reviving the Docker-based functional test suite.
+It has been broken for some time and is currently disabled.
 
 // === Quick Start
 // TBD
@@ -48,12 +64,13 @@ If the intern is doing better than expected, we can fix more bugs.
 === Skills to Study and Improve
 
 - Java
-- Docker
 - GitLab
+- Code cleanup
+- Docker
 
 === Project Difficulty Level
 
-Beginner to Intermediate
+Easy but long
 
 === Project Size
 
@@ -61,8 +78,8 @@ Beginner to Intermediate
 
 === Expected outcomes
 
-A new release of the GitLab plugin that uses the GitLab API instead of RESTEasy, many bugs fixed, and a revamped docker-based functional test suite.
-
-Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase. 
+The success criteria of this project would be a release of the GitLab plugin
+without a RESTEasy dependency and with a `gitlab4j-api` dependency,
+all without regression to end users.
 
 // === Newbie Friendly Issues


### PR DESCRIPTION
Cleans up this project proposal so that it can be ready for draft state, addressing previous concerns. Reduced the scope of the project to be consistent with a 175-hour project size and clarified the difficulty level: the project is "easy" in one sense but long and tedious in another. Clarified the expected outcome, documented known challenges, and provided links to other examples of this migration.

CC @jmMeessen 