### PR TITLE
Update haml and tilt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'sassc'
 gem 'rouge'
 
 # Support for various template engines we use
-gem 'haml', '~> 5.1.0'
+gem 'haml', '~> 5.2.0'
 gem 'liquid', '~> 5.4.0'
 gem 'kramdown', '~> 2.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       guard (~> 2.8)
       guard-compat (~> 1.0)
       multi_json (~> 1.8)
-    haml (5.1.2)
+    haml (5.2.2)
       temple (>= 0.8.0)
       tilt
     http-accept (1.7.0)
@@ -121,9 +121,9 @@ GEM
     sassc (2.4.0)
       ffi (~> 1.9)
     shellany (0.0.1)
-    temple (0.8.2)
+    temple (0.10.0)
     thor (1.2.1)
-    tilt (2.0.9)
+    tilt (2.0.11)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -141,7 +141,7 @@ DEPENDENCIES
   concurrent-ruby (~> 1.1)
   faraday (~> 2.7.2)
   faraday-follow_redirects (~> 0.3.0)
-  haml (~> 5.1.0)
+  haml (~> 5.2.0)
   kramdown (~> 2.4.0)
   liquid (~> 5.4.0)
   rouge

--- a/content/_ext/activenav.rb
+++ b/content/_ext/activenav.rb
@@ -45,4 +45,9 @@ module ActiveNav
       '</a>',
         ].join('')
   end
+
+  def tooltip_href(url, title)
+    tooltip = {'data-bs-toggle' => 'tooltip', 'data-bs-placement' => 'top', 'title' => title}
+    url != null ? tooltip.merge({:href => url, :target => "_blank", :rel => "noreferrer noopener"}) : tooltip
+  end
 end

--- a/content/_ext/get_plugins.rb
+++ b/content/_ext/get_plugins.rb
@@ -1,0 +1,10 @@
+
+module GetPlugins
+
+  Plugin = Struct.new(:name, :title)
+
+  def get_plugins(issues)
+    issues.collect { |issue| issue.plugins }.flatten.keep_if { |p| p }.collect { |p| Plugin.new(p.name, p.title) }
+  end
+
+end

--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -63,6 +63,7 @@ Awestruct::Extensions::Pipeline.new do
   helper Authorship
   helper Legacy
   helper AsciidocRender
+  helper GetPlugins
 
   helper Awestruct::Extensions::GoogleAnalytics
   helper Awestruct::IBeams::AsciidocSections

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -4,10 +4,7 @@ title: Jenkins download and deployment
 ---
 
 :ruby
-  def third_party_href(url)
-    third_party = {'data-bs-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => 'This is a package supported by a third party which may be not as frequently updated as packages supported by the Jenkins project directly'}
-    return third_party.merge({:href => url})
-  end
+  third_party = 'This is a package supported by a third party which may be not as frequently updated as packages supported by the Jenkins project directly'
 
 %p
   The Jenkins project produces two release lines: Stable (LTS) and regular (Weekly).
@@ -115,25 +112,25 @@ title: Jenkins download and deployment
             %span.icon
             %span.title
               openSUSE
-          %a.list-group-item.list-group-item-action{third_party_href('https://www.freshports.org/devel/jenkins-lts')}
+          %a.list-group-item.list-group-item-action{tooltip_href('https://www.freshports.org/devel/jenkins-lts', third_party)}
             %span.icon
             %span.title
               FreeBSD
             %ion-icon{:name=>"library-outline"}
-          %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
+          %a.list-group-item.list-group-item-action{tooltip_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin', third_party)}
             %span.title
               Gentoo
             %span
               &nbsp;
             %ion-icon{:name=>"library-outline"}
-          %a.list-group-item.list-group-item-action{third_party_href('/download/lts/macos')}
+          %a.list-group-item.list-group-item-action{tooltip_href('/download/lts/macos', third_party)}
             %span.icon
             %span.title
               macOS
             %span
               &nbsp;
             %ion-icon{:name=>"library-outline"}
-          %a.list-group-item.list-group-item-action{third_party_href('http://openports.se/devel/jenkins/stable')}
+          %a.list-group-item.list-group-item-action{tooltip_href('http://openports.se/devel/jenkins/stable', third_party)}
             %span.title
               OpenBSD
             %span
@@ -174,38 +171,38 @@ title: Jenkins download and deployment
           %span.icon
           %span.title
             openSUSE
-        %a.list-group-item.list-group-item-action{third_party_href('https://www.archlinux.org/packages/community/any/jenkins/')}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://www.archlinux.org/packages/community/any/jenkins/', third_party)}
           %span.title
             Arch Linux
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{third_party_href('https://www.freshports.org/devel/jenkins')}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://www.freshports.org/devel/jenkins', third_party)}
           %span.title
             FreeBSD
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{third_party_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin')}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://packages.gentoo.org/packages/dev-util/jenkins-bin', third_party)}
           %span.title
             Gentoo
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{third_party_href('/download/weekly/macos')}
+        %a.list-group-item.list-group-item-action{tooltip_href('/download/weekly/macos', third_party)}
           %span.icon
           %span.title
             macOS
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{third_party_href('http://openports.se/devel/jenkins/devel')}
+        %a.list-group-item.list-group-item-action{tooltip_href('http://openports.se/devel/jenkins/devel', third_party)}
           %span.title
             OpenBSD
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{third_party_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins')}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins', third_party)}
           %span.title
             OpenIndiana Hipster
           %span

--- a/content/project/roadmap/index.html.haml
+++ b/content/project/roadmap/index.html.haml
@@ -10,12 +10,6 @@ tags:
 %link{:href => "/css/roadmap.css", :rel => "stylesheet", :type => "text/css"}/
 %script{:src => expand_link('js/roadmap.js'), :type => "text/javascript"}
 
-:ruby
-  def tooltip_href(url, title)
-    tooltip = {'data-bs-toggle' => 'tooltip', 'data-bs-placement' => 'top', 'title' => title}
-    return url != null ? tooltip.merge({:href => url, :target => "_blank", :rel => "noreferrer noopener"}) : tooltip
-  end
-
 %p
   Jenkins project offers a public community-driven roadmap.
   It aggregates key initiatives in all areas: features, infrastructure, documentation, community, etc.
@@ -66,7 +60,7 @@ tags:
                   - itemTooltip = initiative.description.nil? ? status.description : initiative.description
                   %a{tooltip_href(itemLink, itemTooltip)}
                     = initiative.name
-%h2 
+%h2
   References
 %ul
   %li

--- a/content/security/advisories.html.haml
+++ b/content/security/advisories.html.haml
@@ -11,8 +11,6 @@ section: security
   adocs = Dir.glob(File.join(advisories_dir, '*.{ad,adoc}'))
   years = adocs.select { |it| it =~ /(20\d\d)/ }.map { |it| /(20\d\d)/.match(it)[1] }.uniq.sort
 
-  Plugin = Struct.new(:name, :title)
-
 .container
   .row
     %p
@@ -49,7 +47,7 @@ section: security
                         - if page.core
                           %li
                             Affects Jenkins Core
-                        - plugins = page.issues.collect { |issue| issue.plugins }.flatten.keep_if { |p| p }.collect { |p| Plugin.new(p.name, p.title) }.uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
+                        - plugins = get_plugins(page.issues).uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
                         - if plugins.size > 0
                           %li
                             %span{:style => 'white-space: nowrap;'}

--- a/content/security/advisories/rss.xml.haml
+++ b/content/security/advisories/rss.xml.haml
@@ -9,8 +9,6 @@
     pages_by_path = site.pages.map { |p| [p.source_path, p] }.to_h
     adocs = Dir.glob(File.join(advisories_dir, '*.{ad,adoc}'))
 
-    Plugin = Struct.new(:name, :title)
-
   %channel
     %title
       Jenkins Security Advisories
@@ -40,7 +38,7 @@
               = "<ul>".encode(xml: :text)
               - if page.core
                 = "<li>Affects Jenkins Core</li>".encode(xml: :text)
-              - plugins = page.issues.collect { |issue| issue.plugins }.flatten.keep_if { |p| p }.collect { |p| Plugin.new(p.name, p.title) }.uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
+              - plugins = get_plugins(page.issues).uniq.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
               - plugins.each do | plugin |
                 - if site._generated[:update_center].plugins[plugin.name]
                   = "<li>Affects plugin: <a href='https://plugins.jenkins.io/#{plugin.name}'>#{site._generated[:update_center].plugins[plugin.name].title}</a></li>".encode(xml: :text)


### PR DESCRIPTION
Since tilt changed the scope used for compiling ruby code inlined in haml, this moves bits of code out of haml to make things compile.