### PR TITLE
Extend plugin install mgr project idea

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
@@ -33,7 +33,7 @@ Some of the ideas are available in the link:https://github.com/jenkinsci/plugin-
 
 Additional background information may be found in a video recording from 2021.
 
-video::QJcwcLnHjRw[youtube]
+video::QJcwcLnHjRw[youtube, width=640, height=360, align="center"]
 
 === Quick Start
 

--- a/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
@@ -31,6 +31,10 @@ students are invited to introduce new features and improvements in the plugin in
 The list of enhancements is a subject for discovery as a part of the application process.
 Some of the ideas are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues[project tracker].
 
+Additional background information may be found in a video recording from 2021.
+
+video::QJcwcLnHjRw[youtube]
+
 === Quick Start
 
 Visit the project page at https://github.com/jenkinsci/plugin-installation-manager-tool
@@ -48,7 +52,6 @@ Visit the project page at https://github.com/jenkinsci/plugin-installation-manag
 * Writing command line interfaces
 * How the Jenkins Docker image and Configuration as Code (CasC) work
 
-
 === Project Difficulty Level
 
 Beginner to Intermediate
@@ -63,6 +66,20 @@ Improvements to existing tool
 
 Key improvements for the plugin installation manager tool will be identified, prioritized, and planned.
 Google Summer of Code contributor will propose the areas for improvement and work with mentors to plan those improvements.
+
+Some candidate ideas from the mentors include:
+
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/237[Add subcommands to the command line arguments] requires a definition and design of the subcommands and their behavior
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/488[Generate plugins.txt file from existing directory]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/432[Optionally show progress bar during download]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/446[Retain comments when creating new file from existing file]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/428[List skipped plugins when broken downloads are skipped]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/321[Report the mirror URL and original URL on download failure]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/312[Improve plugin-versions caching for container builds]\
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/270[Only download a plugin once per session (test if still an issue)]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/267[Allow security warnings report for only specified plugins]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/264[Read hpi files from maven cache if found there]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/263[Allow logging to be increased for debug and diagnosis]
 
 === Newbie Friendly Issues
 


### PR DESCRIPTION
## Extend plugin installation manager tool project idea

Plugin installation manager tool project idea needed more details.  Those details are now included in the page, along with an embedded video from 2021 discussing enhancement ideas.
