### PR TITLE
Add markewaite as GitLab plugin project mentor

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -12,6 +12,7 @@ skills:
 - GitLab
 mentors:
 - "basil"
+- "markewaite"
 
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-active-modernization-of-gitlab-plugin/5039
@@ -20,7 +21,7 @@ links:
 ---
 === Background
 
-The https://plugins.jenkins.io/gitlab-plugin/[GitLab] Jenkins plugin is widely used (58,727 installations),
+The https://plugins.jenkins.io/gitlab-plugin/[GitLab] Jenkins plugin is widely used (over 55,000 installations),
 but it has not had an active maintainer for a long time.
 Several CloudBees employees have volunteered to keep it afloat over the years, including Owen, Basil, Bruno, Jean-Marc, and Mark.
 However, it could use a sprint of active development.
@@ -82,4 +83,7 @@ The success criteria of this project would be a release of the GitLab plugin
 without a RESTEasy dependency and with a `gitlab4j-api` dependency,
 all without regression to end users.
 
-// === Newbie Friendly Issues
+=== Newbie Friendly Issues
+
+link:https://github.com/jenkinsci/gitlab-plugin/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue[Good first issues]
+will help a new contributor better understand the plugin and how to debug and diagnose it.


### PR DESCRIPTION
Also adds links to good first issues so that candidates have some
initial areas that they can investigate.
