### PR TITLE
Fix regression in `make run` from webrick 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'awestruct', '~> 0.6.4'
 gem 'awestruct-ibeams', '~> 0.4'
 gem 'asciidoctor', '~> 2.0.18'
 gem 'asciidoctor-jenkins-extensions', '~> 0.9.0'
-gem 'webrick', '~> 1.8.0'
+gem 'webrick', '~> 1.7.0'
 
 gem 'sassc'
 gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    webrick (1.8.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -148,7 +148,7 @@ DEPENDENCIES
   rss
   rubyzip (~> 2.3.2)
   sassc
-  webrick (~> 1.8.0)
+  webrick (~> 1.7.0)
 
 BUNDLED WITH
    2.4.1


### PR DESCRIPTION
## Fix regression in `make run` from webrick 1.8.0

The upgrade from webrick 1.7.0 to 1.8.0 causes `make run` to report that it cannot modify frozen strings.  Page generation fails for the top level page and for the changelog page that I was trying to check.

Exact failure message was:

```
[2023-01-31 13:24:07] INFO  WEBrick 1.8.0
[2023-01-31 13:24:07] INFO  ruby 3.2.0 (2022-12-25) [x86_64-linux]
[2023-01-31 13:24:07] INFO  WEBrick::HTTPServer#start: pid=1 port=4242
Regenerate /home/mwaite/git/jenkins/jenkins.io/content/index.html.haml
[2023-01-31 13:24:11] ERROR FrozenError: can't modify frozen String: ""
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/rack-2.2.6.2/lib/rack/handler/webrick.rb:120:in `block in service'
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/rack-2.2.6.2/lib/rack/handler/webrick.rb:119:in `each'
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/rack-2.2.6.2/lib/rack/handler/webrick.rb:119:in `service'
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/webrick-1.8.0/lib/webrick/httpserver.rb:140:in `service'
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/webrick-1.8.0/lib/webrick/httpserver.rb:96:in `run'
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/webrick-1.8.0/lib/webrick/server.rb:310:in `block in start_thread'
        /home/mwaite/git/jenkins/jenkins.io/vendor/gems/ruby/3.2.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
172.16.16.185 - - [31/Jan/2023:13:24:10 UTC] "GET / HTTP/1.1" 500 333
- -> /
```

Don't want to delay availability of the weekly changelog while the regression is investigated.  Revert now, then investigation can happen at a time that is convenient.

This reverts commit 0a7b884ed287b6bdb0ff7bb2748374fb7bb628d9.
