### PR TITLE
Update webrick to 1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'awestruct', '~> 0.6.4'
 gem 'awestruct-ibeams', '~> 0.4'
 gem 'asciidoctor', '~> 2.0.18'
 gem 'asciidoctor-jenkins-extensions', '~> 0.9.0'
-gem 'webrick', '~> 1.7.0'
+gem 'webrick', '~> 1.8.1'
 
 gem 'sassc'
 gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    webrick (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -148,7 +148,7 @@ DEPENDENCIES
   rss
   rubyzip (~> 2.3.2)
   sassc
-  webrick (~> 1.7.0)
+  webrick (~> 1.8.1)
 
 BUNDLED WITH
    2.4.1


### PR DESCRIPTION
The PR https://github.com/jenkins-infra/jenkins.io/pull/5971 updating to 1.8.0 had to be reverted in https://github.com/jenkins-infra/jenkins.io/pull/5987 because of [a bug](https://github.com/ruby/webrick/issues/106).
Update to 1.8.1 should be safe since said bug was fixed in the last release (see https://github.com/ruby/webrick/pull/103)