### PR TITLE
GSoC: Promote most project ideas to "published" status

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/JCasC-drift-detector.adoc
+++ b/content/projects/gsoc/2023/project-ideas/JCasC-drift-detector.adoc
@@ -4,7 +4,7 @@ title: "Jenkins Configuration as Code (JCasC) drift detector"
 goal: "Report differences between a Jenkins active configuration and a given JCasC definition"
 category: Tools
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
@@ -4,7 +4,7 @@ title: "Add probes to \"Plugin Health Score\""
 goal: "First iteration of the tool provided a limited set of probes. To improve the effectiveness of the scoring system, more probes are needed."
 category: Tools
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/agent_reconnections_exponential_backoff.adoc
+++ b/content/projects/gsoc/2023/project-ideas/agent_reconnections_exponential_backoff.adoc
@@ -4,7 +4,7 @@ title: "Exponential backoff and jitter for agent reconnections"
 goal: "Add improved reconnection algorithm to agents"
 category: Functional improvement
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
@@ -4,7 +4,7 @@ title: "Building Jenkins.io with alternative tools"
 goal: "Using alternative tooling (i.e., Antora) to build the Jenkins static site and provide documentation per Jenkins version"
 category: Tools
 year: 2023
-status: draft
+status: published
 sig: documentation
 skills:
 - Web development

--- a/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
+++ b/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
@@ -4,7 +4,7 @@ title: "Building Android Apps with Jenkins"
 goal: "Describe best practices and provide architectural templates for building Android applications with Jenkins"
 category: Tools
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/displaying_plugin_health_scores.adoc
+++ b/content/projects/gsoc/2023/project-ideas/displaying_plugin_health_scores.adoc
@@ -4,7 +4,7 @@ title: "Displaying of Plugin Health Scores"
 goal: "Display a possibly filtered view of Plugin Health Scores on plugins.jenkins.io and the details for each individual plugin"
 category: Tools
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
@@ -4,7 +4,7 @@ title: "Docker-based Jenkins quickstart examples"
 goal: "Provide examples, sample code, and documentation on how to start a local Jenkins instance."
 category: Tools
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -4,7 +4,7 @@ title: "GitLab Plugin Modernization"
 goal: "Cleaning and modernizing the extensively used GitLab plugin"
 category: Plugin improvement
 year: 2023
-status: draft
+status: published
 sig: platform
 skills:
 - Java

--- a/content/projects/gsoc/2023/project-ideas/screenshot-automation.adoc
+++ b/content/projects/gsoc/2023/project-ideas/screenshot-automation.adoc
@@ -4,7 +4,7 @@ title: "Screenshot Automation for Jenkins Docs"
 goal: "To automate screenshot capture process for Jenkins docs"
 category: Dev Tools
 year: 2023
-status: draft
+status: published
 sig: docs
 skills:
 - Web Browser Automation


### PR DESCRIPTION
Project idea discussions are now stabilized. Time to mark most of the GSoC 2023 project ideas as "published".