### PR TITLE
Edit Alternative jenkins.io build tool doc for GSoC 2023

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
@@ -15,7 +15,6 @@ skills:
 mentors:
 - "krisstern"
 - "iamrajiv"
-- "freyam"
 - "kmartens27"
 - "markewaite"
 links:
@@ -39,6 +38,8 @@ Once the existing site is generated with Antora, the site should be extended to 
 The project has been discussed extensively at link:https://github.com/jenkins-infra/jenkins.io/issues/5474[GitHub issue #5474], where some existing proof-of-concept code can be found referenced there.
 
 There are multiple ways to approach the implementation, but from experimentation it has been found that the backend replacement requires minimal effort for the documentation, with the frontend implementation expected to require much effort to reproduce the look and feel of the current link:https://www.jenkins.io/[jenkins.io] website. However, the blog can be split from the documentation using something like link:https://www.gatsbyjs.com/[Gatsby], which is expected to make it easier for users to submit posts in the future.
+
+While the tasks of the project are very clearly defined, the scope may vary depending on the plans of the contributor. If we split the project into milestones, we see two important ones that can be tackled in sequence: The most urgent milestone is (1) to set up the user documentation using Antora with versioning, while next would be (2) to set up the developer documentation with Antora without versioning, and finally (3) to set up the blog using Gatsby. The contributor can choose either 1, or a combination of 1 + 2, or a combination of 1 + 2 + 3, but not in any other way. The expected project outcome is at least a drop-in replacement website that is building locally.
 
 The outcome of this project is expected to produce visible impact they can showcase in their portfolio of the link:https://www.jenkins.io/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
 
@@ -89,7 +90,7 @@ Beginner to Intermediate
 
 === Project Size
 
-175 hours
+175 to 350 hours
 
 === Expected outcomes
 

--- a/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
@@ -36,6 +36,12 @@ The preferred tool to replace Awestruct is link:https://antora.org/[Antora].
 The potential GSoC project would be to build a working site generator to demonstrate the existing site.
 Once the existing site is generated with Antora, the site should be extended to add version specific documentation.
 
+The project has been discussed extensively at link:https://github.com/jenkins-infra/jenkins.io/issues/5474[GitHub issue #5474], where some existing proof-of-concept code can be found referenced there.
+
+There are multiple ways to approach the implementation, but from experimentation it has been found that the backend replacement requires minimal effort for the documentation, with the frontend implementation expected to require much effort to reproduce the look and feel of the current link:https://www.jenkins.io/[jenkins.io] website. However, the blog can be split from the documentation using something like link:https://www.gatsbyjs.com/[Gatsby], which is expected to make it easier for users to submit posts in the future.
+
+The outcome of this project is expected to produce visible impact they can showcase in their portfolio of the link:https://www.jenkins.io/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
+
 === Quick Start
 
 Documentation quick start steps include:

--- a/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
@@ -75,7 +75,7 @@ Some candidate ideas from the mentors include:
 * link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/446[Retain comments when creating new file from existing file]
 * link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/428[List skipped plugins when broken downloads are skipped]
 * link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/321[Report the mirror URL and original URL on download failure]
-* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/312[Improve plugin-versions caching for container builds]\
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/312[Improve plugin-versions caching for container builds]
 * link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/270[Only download a plugin once per session (test if still an issue)]
 * link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/267[Allow security warnings report for only specified plugins]
 * link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/264[Read hpi files from maven cache if found there]


### PR DESCRIPTION
## Description
To add context and details to the "Alternative jenkins.io build tool" documentation for GSoC 2023, expecially the division of tasks into backend and frontend web development, as well as into documentation and blog. 