### PR TITLE
Clarify that HotSpot JVM is required

### DIFF
--- a/content/doc/administration/requirements/java.adoc
+++ b/content/doc/administration/requirements/java.adoc
@@ -33,6 +33,9 @@ The Jenkins project performs a full test flow with the following JDK/JREs:
 
 JRE/JDKs from other vendors are supported and may be used.
 Refer to link:https://issues.jenkins.io/issues/?jql=labels%3Djdk[our issue tracker] for known Java compatibility issues.
+Jenkins maintainers actively test link:https://en.wikipedia.org/wiki/HotSpot_(virtual_machine)[HotSpot based Java virtual machines] like those from OpenJDK, Eclipse Temurin, and Amazon Corretto.
+Jenkins maintainers do not test link:https://en.wikipedia.org/wiki/OpenJ9[Eclipse OpenJ9 based Java virtual machines].
+The link:/sigs/platform/[Platform SIG] stopped its work on OpenJ9 based Java virtual machines in August 2021.
 
 ## Running Java-based tools and builds on Jenkins
 


### PR DESCRIPTION
OpenJ9 is not tested

ZeroVM is too slow to be usable
