### PR TITLE
Document backporting procedures for security fixes

### DIFF
--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -129,7 +129,7 @@ Make sure to follow instructions provided by the Jenkins security team if they d
 At this point, consider the need for backports.
 Some administrators may be unable to install the latest version of your plugin.
 Usually this is because the plugin depends on a recent weekly release of Jenkins.
-Users of the https://www.jenkins.io/download/lts/[LTS line of Jenkins releases] will not be offered a plugin update that requires a weekly version of Jenkins higher than the LTS baseline, even when they're already on the latest version of Jenkins available to them.
+Users of the link:/download/lts/[LTS line of Jenkins releases] will not be offered a plugin update that requires a weekly version of Jenkins higher than the LTS baseline, even when they're already on the latest version of Jenkins available to them.
 
 We recommend that all security fixes are made available to both current weekly and current LTS releases.
 If the current LTS release is the first in its line (e.g., 2.375.1), also consider making the security fix available to users of the previous release, as many administrators may not immediately update.

--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -150,11 +150,11 @@ Instances on the weekly release line will be able to install a security fix prov
 So the plugin should get updates with the security fix based on top of version 2.2 (e.g., 2.2.1 or 2.3) _and_ 2.0 (e.g., 2.0.1 or 2.0.0.1, whichever version would be between 2.0 and the next release that already exists).
 
 Now consider the case of the plugin version 2.1 previously raising the core dependency from 2.361.2 to Jenkins 2.370 (before 2.2 raised it to 2.380).
-In this care, three separate releases are now needed to cover users of Jenkins 2.361.4, 2.375.1, and 2.387:
+In this case, three separate releases are now needed to cover users of Jenkins 2.361.4, 2.375.1, and 2.387:
 
 * Jenkins 2.361.4 needs a backport on top of plugin version 2.0 (e.g., 2.0.1 or 2.0.0.1) with a Jenkins dependency of 2.361.2.
-* Jenkins 2.375.1 needs a backport on top of plugin version 2.1 (e.g., 2.1.1 or 2.1.0.1) with a Jenkins dependency of 2.370. While they could in theory install the backport on top of version 2.0, this would effectively be a downgrade, and remove all features added between versions 2.0 and 2.1 of the plugin (if this is even possibly without data loss).
-* Only weekly releases like 2.387 will be able to the next regular plugin release (e.g., 2.2.1 or 2.3) with a Jenkins dependency of 2.380.
+* Jenkins 2.375.1 needs a backport on top of plugin version 2.1 (e.g., 2.1.1 or 2.1.0.1) with a Jenkins dependency of 2.370. While they could in theory install the backport on top of version 2.0, this would effectively be a downgrade, and remove all features added between versions 2.0 and 2.1 of the plugin (if this is even possible without data loss).
+* Only weekly releases like 2.387 will be able to update to the next regular plugin release (e.g., 2.2.1 or 2.3) with a Jenkins dependency of 2.380.
 
 
 [[merging]]

--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -193,6 +193,8 @@ Create a new branch based on the release that the fix should be backported to:
 * For plugins with link:/doc/developer/publishing/releasing-manually/[manual release process] this is the `prepare for next development iteration` commit.
 * For plugins delivered with link:/doc/developer/publishing/releasing-cd/[JEP-229 CD automated releases]), it is the commit that got tagged as a release.
 
+IMPORTANT: If the plugin recently switched from manual releases to JEP-229 CD automated releases (or vice versa), each branch may require different procedures.
+
 The branch is conventionally named something like `2.18.x` (if it's based on 2.18) or `1234.x`` (if it's based on the JEP-229 version 1234.vabdef123).
 
 ====== Plugins with manual releases
@@ -224,7 +226,7 @@ The `pom.xml` needs to be changed as follows:
    <packaging>hpi</packaging>
 ----
 
-Commit this change.
+Commit this change, e.g.: `git commit -a -m "Prepare for 12345.x"``
 As a result, the backport will typically have a version like `12345.12347.vabdef123`.
 
 [NOTE]
@@ -249,6 +251,9 @@ Trying to squash-merge the fix branch will also merge in all unrelated changes b
 
 Beware of potential merge conflicts if the security fix changes lines that were modified between the baseline against which the fix was developed, and the version you're backporting to.
 In extreme cases, it can be useful to basically develop the fix multiple times, with individual PRs each targeting a different (backporting) branch, to let reviewers confirm conflict resolution was done correctly.
+
+[NOTE]
+It's a good practice to run `mvn clean verify` now, even when there are no merge conflicts, to ensure that all tests pass.
 
 
 [[upload]]

--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -72,7 +72,7 @@ Security fixes should be developed on a branch that will be submitted as a pull 
   This limits the potential risk of regressions in the security update due to unrelated changes.
   Please also refrain from reformatting code you're not otherwise changing to make it easier to review the security fix.
 * *Keep the security update minimal.*
-  If the target branch of the security fix has unrelated changes, branch off from the previous release (specifically the `prepare for next development iteration` commit) and target that branch instead, or make sure to release the plugin's unrelated changes a week or two before the security release.
+  If the target branch of the security fix has unrelated changes, branch off from the previous release (specifically the `prepare for next development iteration` commit in case of manual releases, and the tagged commit in case of JEP-229 CD) and target that branch instead, or make sure to release the plugin's unrelated changes a week or two before the security release.
   This also limits the potential risk of regressions in the security update due to unrelated changes.
 * *Keep source code private until the security updates are published.*
   The staging instructions below prevent pushing the release commits, which would result in premature disclosure due to delays in the infrastructure, or the staging process.
@@ -123,6 +123,40 @@ This strikes a balance between allowing the longest possible time for reviews an
 The Jenkins security team needs to prepare a Maven staging repository before security updates can be staged, so follow the instructions below only once you know the Maven repository to stage to.
 Make sure to follow instructions provided by the Jenkins security team if they deviate from the instructions below.
 
+[[backporting]]
+=== Backporting
+
+At this point, consider the need for backports.
+Some administrators may be unable to install the latest version of your plugin.
+Usually this is because the plugin depends on a recent weekly release of Jenkins.
+Users of the https://www.jenkins.io/download/lts/[LTS line of Jenkins releases] will not be offered a plugin update that requires a weekly version of Jenkins higher than the LTS baseline, even when they're already on the latest version of Jenkins available to them.
+
+We recommend that all security fixes are made available to both current weekly and current LTS releases.
+If the current LTS release is the first in its line (e.g., 2.375.1), also consider making the security fix available to users of the previous release, as many administrators may not immediately update.
+
+Additionally, the security fixes should generally be made available to users who are already on the latest version of the plugin available to them, rather than an earlier version.
+This will make it easy to update to a version with the fix through the plugin manager, without potentially losing features by doing what amounts to a manual downgrade.
+
+
+==== Backporting Example
+
+Suppose it is early 2023 and you're preparing a security fix for a plugin you maintain.
+The most recent LTS releases are Jenkins 2.361.4 and Jenkins 2.375.1, and the current weekly release is 2.387.
+The plugin's latest release, version 2.2, has a Jenkins dependency of 2.380 because it makes use of a new feature in that release.
+The most recent lower Jenkins dependency of the plugin was Jenkins 2.361.3 in plugin version 2.0.
+
+In this case, instances on both 2.361.4 and 2.375.1 will be able to install a security fix provided on top of version 2.0 of the plugin.
+Instances on the weekly release line will be able to install a security fix provided on top of version 2.2.
+So the plugin should get updates with the security fix based on top of version 2.2 (e.g., 2.2.1 or 2.3) _and_ 2.0 (e.g., 2.0.1 or 2.0.0.1, whichever version would be between 2.0 and the next release that already exists).
+
+Now consider the case of the plugin version 2.1 previously raising the core dependency from 2.361.2 to Jenkins 2.370 (before 2.2 raised it to 2.380).
+In this care, three separate releases are now needed to cover users of Jenkins 2.361.4, 2.375.1, and 2.387:
+
+* Jenkins 2.361.4 needs a backport on top of plugin version 2.0 (e.g., 2.0.1 or 2.0.0.1) with a Jenkins dependency of 2.361.2.
+* Jenkins 2.375.1 needs a backport on top of plugin version 2.1 (e.g., 2.1.1 or 2.1.0.1) with a Jenkins dependency of 2.370. While they could in theory install the backport on top of version 2.0, this would effectively be a downgrade, and remove all features added between versions 2.0 and 2.1 of the plugin (if this is even possibly without data loss).
+* Only weekly releases like 2.387 will be able to the next regular plugin release (e.g., 2.2.1 or 2.3) with a Jenkins dependency of 2.380.
+
+
 [[merging]]
 === Merge the Fix
 
@@ -130,6 +164,11 @@ First, prepare the release branch:
 If there are unrelated, unreleased changes on the default branch, create a new branch based on the previous release.
 For plugins with link:/doc/developer/publishing/releasing-manually/[manual release process] this is the `prepare for next development iteration` commit.
 For plugins delivered with link:/doc/developer/publishing/releasing-cd/[JEP-229 CD automated releases]), it is the commit that got tagged as a release.
+
+[NOTE]
+If all unreleased changes are unlikely to introduce regressions, e.g., minor documentation fixes or similar, it's also reasonable to include those changes in the security fix.
+In general we recommend caution when doing this however: even safe-looking dependency updates can easily cause regressions and make administrators choose between a plugin release that is safe and one that works.
+It is always safest to not include unrelated changes in security fixes.
 
 Next, use the Git command line to *squash-merge pull request branches* in the private jenkinsci-cert repository (`git merge --squash <BRANCH>`).
 
@@ -141,6 +180,75 @@ It would by default add a reference to the private PR (like `#1`), which is conf
 At this point, it may not be clear exactly how the fix will be announced and documented, and discrepancies between the commit message and security advisory would be confusing.
 If you didn't develop the fix, make sure to credit the original author by adding `--author='Actual Author <author@example.org>'` to the `git commit` command.
 To find out what name and email address to put there, see `git log <BRANCH>`.
+
+
+==== Backporting
+
+===== Backport Branch Preparation
+
+Similar to when there are unreleased changes on the default branch, a new branch needs to be created when backporting, unless a branch with the correct baseline already exists, e.g., from an earlier security update.
+
+Create a new branch based on the release that the fix should be backported to:
+
+* For plugins with link:/doc/developer/publishing/releasing-manually/[manual release process] this is the `prepare for next development iteration` commit.
+* For plugins delivered with link:/doc/developer/publishing/releasing-cd/[JEP-229 CD automated releases]), it is the commit that got tagged as a release.
+
+The branch is conventionally named something like `2.18.x` (if it's based on 2.18) or `1234.x`` (if it's based on the JEP-229 version 1234.vabdef123).
+
+====== Plugins with manual releases
+
+For plugins with link:/doc/developer/publishing/releasing-manually/[manual release process], you could set the version number used for releases from the backport branch at this point, for example:
+
+[source]
+mvn versions:set -DnewVersion=2.18.1-SNAPSHOT -DgenerateBackupPoms=false
+
+This is optional, as the version number can still be specified when staging.
+
+====== Plugins with JEP-229 CD
+
+For plugins delivered with link:/doc/developer/publishing/releasing-cd/[JEP-229 CD automated releases], you also need to manually specify a custom version number for the backport branch.
+Otherwise, the automatically generated, linearly increasing version number would not indicate the existence of a backport branch.
+
+Edit all applicable `pom.xml` files (usually just one) and add a prefix corresponding to the baseline version prefix to the `<version>` footnote:[`mvn versions:set` does not work, it really needs to be done manually.]
+For example, suppose the plugin should get a backport on top of the version `12345.vabdef123`.
+The `pom.xml` needs to be changed as follows:
+
+[source,diff]
+----
+--- a/pom.xml
++++ b/pom.xml
+@@ -10,12 +10,12 @@
+   <artifactId>very-cool-plugin</artifactId>
+-  <version>${changelist}</version>
++  <version>12345.${changelist}</version>
+   <packaging>hpi</packaging>
+----
+
+Commit this change.
+As a result, the backport will typically have a version like `12345.12347.vabdef123`.
+
+[NOTE]
+====
+In case of manually managed version prefixes, keep those. For example:
+[source,diff]
+----
+--- a/pom.xml
++++ b/pom.xml
+@@ -10,12 +10,12 @@
+  <artifactId>very-cool-plugin</artifactId>
+-  <version>${revision}.${changelist}</version>
++  <version>${revision}.12345.${changelist}</version>
+  <packaging>hpi</packaging>
+----
+====
+
+===== Applying the Fix
+
+When backporting the fix to an earlier line, you need to use `git cherry-pick -x <commit-id>`, specifying the commit that you merged earlier, instead of `git merge --squash <branch>`.
+Trying to squash-merge the fix branch will also merge in all unrelated changes between the baseline that the fix was developed on, and the earlier line you're trying to merge it into.
+
+Beware of potential merge conflicts if the security fix changes lines that were modified between the baseline against which the fix was developed, and the version you're backporting to.
+In extreme cases, it can be useful to basically develop the fix multiple times, with individual PRs each targeting a different (backporting) branch, to let reviewers confirm conflict resolution was done correctly.
 
 
 [[upload]]


### PR DESCRIPTION
Backports are sometimes needed to make sure LTS instances receive the security fix, so document that.

Also, mention that "safe" unreleased changes do not necessitate a branch off the previous release, but advise caution.