### PR TITLE
fix(syntax.adoc) matrix section syntax typo

### DIFF
--- a/content/blog/2017/08/2017-08-18-declarative-pipelines-at-jenkinsworld.adoc
+++ b/content/blog/2017/08/2017-08-18-declarative-pipelines-at-jenkinsworld.adoc
@@ -31,7 +31,7 @@ here at CloudBees and another author of Declarative Pipeline. We'll be
 covering what's happened with Declarative over the last year, new features
 added since the 1.0 release, such as the `libraries` directive and more `when`
 conditions, what's planned for the upcoming 1.2 release (which is planned for
-shortly after Jenkins World!), including parallel ``stage``s, and what's on the
+shortly after Jenkins World!), including parallel `stages`, and what's on the
 roadmap for the future. In addition, we'll be demoing some of the features in
 1.2, and providing some pointers on best practices for writing your Declarative
 Pipeline.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1859,7 +1859,7 @@ matrix {
 [[matrix-stages]]
 ==== stages   
 
-The `stages` section specifies one or more ``stage``s to be executed sequentially in each cell.
+The `stages` section specifies one or more `stages` to be executed sequentially in each cell.
 This section is identical to any other
 <<#sequential-stages, `stages` section>>.  
 


### PR DESCRIPTION
The [declarative-matrix](https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-matrix) documentation here seems a small syntax typo. (see my screenshot)

![image](https://user-images.githubusercontent.com/3353385/217418620-9735c346-095f-403e-91b1-51e9d208bd3c.png)


![image](https://user-images.githubusercontent.com/3353385/217420174-81a8130a-eb65-45d7-b62b-d5ab6a576651.png)
