### PR TITLE
Include Alma and Rocky, reduce CentOS references

### DIFF
--- a/content/_partials/legacy/download.html.haml
+++ b/content/_partials/legacy/download.html.haml
@@ -44,7 +44,7 @@
                 %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/debian/"} Ubuntu/Debian
             %div
               %img{:src => "/images/os/redhat.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/redhat/"} Red Hat/Fedora/CentOS
+                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/redhat/"} Red Hat/Fedora/Alma/Rocky/CentOS
             %div
               %img{:src => "/images/os/os_macosx.png"}
                 %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/osx/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-os-x-installer')"} Mac OS X
@@ -94,7 +94,7 @@
                 %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/debian-stable/"} Ubuntu/Debian
             %div
               %img{:src => "/images/os/redhat.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/redhat-stable/"} Red Hat/Fedora/CentOS
+                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/redhat-stable/"} Red Hat/Fedora/Alma/Rocky/CentOS
             %div
               %img{:src => "/images/os/os_macosx.png"}
                 %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/osx-stable/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-os-x-installer#stable')"} Mac OS X

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -203,8 +203,8 @@ firewall-cmd --reload
 
 You can install Jenkins through `yum` on Red Hat Enterprise Linux, Alma Linux, Rocky Linux, Oracle Linux, and other Red Hat based distributions.
 
-.How To Install Jenkins on CentOS 7
-video::g7CnQnDQwuU[youtube, width=682, height=384]
+.How To Install Jenkins on Rocky Linux 9
+video::2-L0WohfsqY[youtube, width=640, height=360]
 
 You need to choose either the Jenkins Long Term Support release or the Jenkins weekly release.
 

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -17,7 +17,7 @@ Jenkins installers are available for several Linux distributions.
 
 * <<Debian/Ubuntu>>
 * <<Fedora>>
-* <<Red Hat / CentOS>>
+* <<red-hat-centos,Red Hat/Alma/Rocky>>
 
 include::doc/book/installing/_installation_requirements.adoc[]
 
@@ -198,9 +198,10 @@ firewall-cmd --reload
 
 ====
 
-== Red Hat / CentOS
+[#red-hat-centos]
+== Red Hat/Alma/Rocky
 
-You can install Jenkins through `yum` on Red Hat Enterprise Linux, CentOS, and other Red Hat based distributions.
+You can install Jenkins through `yum` on Red Hat Enterprise Linux, Alma Linux, Rocky Linux, Oracle Linux, and other Red Hat based distributions.
 
 .How To Install Jenkins on CentOS 7
 video::g7CnQnDQwuU[youtube, width=682, height=384]

--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -77,7 +77,7 @@ including configuration for installed plugins.
 *Manage Jenkins >> Manage Credentials* screen.
 You may want to delete this section from your YAML file;
 this is discussed in
-link:https://youtu.be/ANU7jkxbZSM?t=1673[How to Install Jenkins on CentOS 7 Using Ansible and JCasC].
+link:https://youtu.be/ANU7jkxbZSM?t=1673[How to Install Jenkins Using Ansible and JCasC].
 
 == YAML file syntax
 
@@ -259,8 +259,8 @@ that introduced the JCasC feature.
 * link:/blog/2021/05/20/configure-plugins-with-jcasc/[Configure Plugins with JCasC]
 is a blog post with video that demonstrates how to configure a plugin with JCasC.
 
-* link:https://www.youtube.com/watch?v=ANU7jkxbZSM[How to Install Jenkins on CentOS 7 Using Ansible and JCasC]
-is a video presentation with details about using JCasc.
+* link:https://www.youtube.com/watch?v=ANU7jkxbZSM[How to Install Jenkins Using Ansible and JCasC]
+is a video presentation with details about using JCasC.
 
 === Implementation details
 

--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -259,8 +259,7 @@ that introduced the JCasC feature.
 * link:/blog/2021/05/20/configure-plugins-with-jcasc/[Configure Plugins with JCasC]
 is a blog post with video that demonstrates how to configure a plugin with JCasC.
 
-* link:https://www.youtube.com/watch?v=ANU7jkxbZSM[How to Install Jenkins Using Ansible and JCasC]
-is a video presentation with details about using JCasC.
+* link:https://www.youtube.com/watch?v=ANU7jkxbZSM[How to Install Jenkins Using Ansible and JCasC] is a video presentation with details about using JCasC.
 
 === Implementation details
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -341,8 +341,8 @@ node {
      * In order to communicate with the MySQL server, this Pipeline explicitly
      * maps the port (`3306`) to a known port on the host machine.
      */
-    docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw"' +
-                                    ' -p 3306:3306') { c ->
+    docker.image('mysql:8-oracle').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw"' +
+                                           ' -p 3306:3306') { c ->
         /* Wait until mysql service is up */
         sh 'while ! mysqladmin ping -h0.0.0.0 --silent; do sleep 1; done'
         /* Run some tests which require MySQL */
@@ -360,12 +360,12 @@ link:https://docs.docker.com/engine/userguide/networking/default_network/dockerl
 ----
 node {
     checkout scm
-    docker.image('mysql:5').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw"') { c ->
-        docker.image('mysql:5').inside("--link ${c.id}:db") {
+    docker.image('mysql:8-oracle').withRun('-e "MYSQL_ROOT_PASSWORD=my-secret-pw"') { c ->
+        docker.image('mysql:8-oracle').inside("--link ${c.id}:db") {
             /* Wait until mysql service is up */
             sh 'while ! mysqladmin ping -hdb --silent; do sleep 1; done'
         }
-        docker.image('centos:7').inside("--link ${c.id}:db") {
+        docker.image('oraclelinux:9').inside("--link ${c.id}:db") {
             /*
              * Run some tests which require MySQL, and assume that it is
              * available on the host name `db`
@@ -503,7 +503,7 @@ node {
     checkout scm
 
     docker.withServer('tcp://swarm.example.com:2376', 'swarm-certs') {
-        docker.image('mysql:5').withRun('-p 3306:3306') {
+        docker.image('mysql:8-oracle').withRun('-p 3306:3306') {
             /* do things */
         }
     }

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables.adoc
@@ -139,7 +139,7 @@ So, you need to make sure you save the configuration to make the changes permane
 
 Saving the configuration is slightly different between Red Hat rpm based and
 Debian-based systems.
-On a Red Hat-based system (Fedora, CentOS, Red Hat Enterprise Linux, Oracle Linux, etc), issue the following command:
+On Red Hat-based systems (Red Hat Enterprise Linux, Fedora, Alma Linux, Rocky Linux, Oracle Linux, CentOS, etc), issue the following command:
 
 [source]
 ----
@@ -177,7 +177,7 @@ that system's documentation on how to update iptables configuration.
 
 == Using firewalld
 
-Some Linux distributions (CentOS 8, Red hat Enterprise Linux 8, CentOS 7, etc.)
+Some Linux distributions (Red Hat Enterprise Linux, Rocky Linux, Alma Linux, Oracle Linux, CentOS, etc.)
 ship with firewalld which serves as a front-end for iptables.
 Configuration thru firewalld is done via the *firewall-cmd* command.
 Instead of using any of the iptables commands mentioned above,

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -103,7 +103,7 @@ title: Jenkins download and deployment
           %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat-stable/'}
             %span.icon
             %span.title
-              CentOS/Fedora/Red Hat
+              Red Hat/Fedora/Alma/Rocky/CentOS
           %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer-stable'}
             %span.icon
             %span.title
@@ -162,7 +162,7 @@ title: Jenkins download and deployment
         %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/redhat/'}
           %span.icon
           %span.title
-            CentOS/Fedora/Red Hat
+            Red Hat/Fedora/Alma/Rocky/CentOS
         %a.list-group-item.list-group-item-action{:href=>'/download/thank-you-downloading-windows-installer'}
           %span.icon
           %span.title

--- a/content/download/verify.adoc
+++ b/content/download/verify.adoc
@@ -45,7 +45,7 @@ Refer to link:https://www.ghacks.net/2018/04/16/how-to-verify-digital-signatures
 
 === Linux Package Repositories
 
-The long term support Linux package repositories for link:https://pkg.jenkins.io/debian-stable/[Debian/Ubuntu] and link:https://pkg.jenkins.io/redhat-stable/[Red Hat/CentOS] have used the following GPG key since Jenkins 2.235.3:
+The long term support Linux package repositories for link:https://pkg.jenkins.io/debian-stable/[Debian/Ubuntu] and link:https://pkg.jenkins.io/redhat-stable/[Red Hat/Fedora/Alma/Rocky/CentOS] have used the following GPG key since Jenkins 2.235.3:
 
 [source]
 ----
@@ -55,7 +55,7 @@ uid                      Jenkins Project <jenkinsci-board@googlegroups.com>
 sub   rsa4096 2020-03-30 [E] [expires: 2023-03-30]
 ----
 
-The weekly Linux package repositories for link:https://pkg.jenkins.io/debian/[Debian/Ubuntu] and link:https://pkg.jenkins.io/redhat/[Red Hat/CentOS] have used the same GPG key since Jenkins 2.232 (April 2020).
+The weekly Linux package repositories for link:https://pkg.jenkins.io/debian/[Debian/Ubuntu] and link:https://pkg.jenkins.io/redhat/[Red Hat/Fedora/Alma/Rocky/CentOS] have used the same GPG key since Jenkins 2.232 (April 2020).
 
 == Verifying Plugin Downloads
 


### PR DESCRIPTION
## Include Alma and Rocky, reduce CentOS

The platform SIG, infrastructure team, and security team have all noted that CentOS 7 is approaching its end of life.  Container images for CentOS 7 are unmaintained.  Versions of crucial programs (like ssh and git) are badly outdated on CentOS 7 and provide a poorer user experience than more modern systems like Red Hat Enterprise Linux 8 and Red Hat Enterprise Linux 9.

CentOS 8 is already unmaintained and unsupported by the CentOS project.

- Include Alma and Rocky when referencing Red Hat
- Replace CentOS 7 video with Rocky 9 video
- Remove CentOS 7 title reference
- Use Oracle Linux 9 and MySQL 8 in example
