### PR TITLE
Fix broken links on attribution page

### DIFF
--- a/content/project/trademark/index.adoc
+++ b/content/project/trademark/index.adoc
@@ -17,9 +17,9 @@ It doesn’t matter if your trademark is unregistered, or if you do not plan to 
 Answering the following questions (which break out each of the key issues) may help you determine if you need to follow the policy.
 If the answer to all three of the following questions is "yes," then you need to follow the trademark usage policy.
 
-- Is my mark a trademark (see how the Linux Foundation defines "trademark" in link:https://www.linuxfoundation.org/programs/legal/trademark/faq[FAQ])?
+- Is my mark a trademark (see how the Linux Foundation defines "trademark" in link:https://www.linuxfoundation.org/legal/the-linux-mark#faq[FAQ])?
 - Does my mark contain the following string of adjacent letters, in this order: "Jenkins"? These letters may or may not be capitalized, and in the case of foreign characters, phonetic translations also apply.
-- Do I use my mark to identify software-related goods or services (see how that phrase is link:https://www.linuxfoundation.org/programs/legal/trademark/faq[defined] again in the Linux Foundation)?
+- Do I use my mark to identify software-related goods or services (see how that phrase is link:https://www.linuxfoundation.org/legal/the-linux-mark#faq[defined] again in the Linux Foundation)?
 
 If you are still in doubt, please contact the Jenkins Governance Board.
 
@@ -50,7 +50,7 @@ A list of trademark usages approved by the project can be found on the link:appr
 == Trademark Attribution
 
 These trademark attribution guidelines are derived from the Linux Foundation's
-link:https://lmi.linuxfoundation.org/programs/legal/trademark/attribution[trademark attribution]
+link:https://www.linuxfoundation.org/legal/the-linux-mark[trademark attribution]
 guidelines.
 
 Even if your use of the Jenkins trademark does not fall under the scope of the
@@ -78,8 +78,8 @@ approval.
 == References
 
 * link:https://trademarks.justia.com/854/47/jenkins-85447465.html[Jenkins - Trademark Details #4664929]
-* https://www.linuxfoundation.org/en/trademarks/[Linux Foundation Trademarks]
-* https://www.linuxfoundation.org/trademark-usage/[Linux Foundation Trademark Usage Guidelines]
+* https://www.linuxfoundation.org/trademarks/[Linux Foundation Trademarks]
+* https://www.linuxfoundation.org/legal/trademark-usage/[Linux Foundation Trademark Usage Guidelines]
 * link:approved-usage[Approved Trademark Usage (before Feb 24, 2021)]
 
 == Change History
@@ -90,7 +90,7 @@ The Jenkins Trademark was officially transferred from
 link:https://spi-inc.org[Software in the Public Interest, Inc.] 
 to the Linux Foundation (its "LF Charities, Inc." subsidiary).
 
-* link:https://www.linuxfoundation.org/trademark-usage/[Linux Foundation trademark usage guidelines]
+* link:https://www.linuxfoundation.org/legal/trademark-usage/[Linux Foundation trademark usage guidelines]
 are now strictly followed by the project.
 * There is no longer a sublicense process since it is not available for non-Linux trademarks in the Linux Foundation.
 


### PR DESCRIPTION
The wayback machine revealed the new target destination of the broken redirects, which I put in place. This PR ensures there are no broken redirects left on this page.