### PR TITLE
Revise IRC part on chat page

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -36,8 +36,6 @@ https://libera.chat/guides/clients[Find an IRC client].
 
 General discussions channel for Jenkins users and developers.
 It used to be the primary one until non-IRC communication options were introduced.
-link:/project/board[Board members and officers] typically have _op_ (@) in this channel.
-Established contributors typically have _voice_ (+) in this channel.
 
 **Tip:** If you have a question about Jenkins, just ask it. Don't ask whether you can ask a question.
 It's common to not receive an answer for quite a while if no active contributors are currently checking IRC.
@@ -45,7 +43,7 @@ In that case, just stick around, and periodically (every few hours) ask your que
 
 === `#jenkins-infra`
 
-Discussions of the link:/projects/infrastructure/[Jenkins project infrastructure], i.e. most services running on `jenkins.io`, `jenkins-ci.org`, and related domains.
+Discussions of the link:/projects/infrastructure/[Jenkins project infrastructure], i.e. most services running on `jenkins.io`, `ci.jenkins.io`, and related domains.
 
 === `#jenkins-release`
 


### PR DESCRIPTION
The removal of the couple of lines follows up the current and past board and office terms, where this wasn't the case.
I think we can safely drop this requirement, given the IRC channels don't quire as much moderation as other parts of the Jenkins project because many people use Gitter/Matrix these days.

Currently, Tim and Gavin are OP on all IRC channels, which is a strong yet sufficient choice, in case we need to get something sorted.