### PR TITLE
Remove chinese mailing list

### DIFF
--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -20,20 +20,12 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkins-infra")
 
-%h2 Discussion lists in other languages
-
-= partial(group, :name => "jenkinsci-zh",
-  :description => "Jenkins 中文用户及开发者邮件组 ");
-
 %h2 Read-only lists
 
 = partial(group, :name => "jenkinsci-advisories")
 
 = partial(group, :name => "jenkinsci-commits",
   :description => "Automated core and plugin commit notifications.")
-
-= partial(group, :name => "jenkinsci-issues",
-  :description => "Automated notifications from JIRA (JENKINS project only).")
 
 %h2 Special Interest Groups Mailing Lists
 


### PR DESCRIPTION
This PR follows up my previous PR (https://github.com/jenkins-infra/jenkins.io/pull/5897/) to remove the chinese mailing list, which is full of ads, and we are in the process to retire the chinese website, which used this mailing list.