### PR TITLE
Remove stapler and chinese org from code page

### DIFF
--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -10,7 +10,7 @@ tags:
 Jenkins project includes a lot of code, and we invite everyone to contribute to the project.
 There is a diverse set of programming languages used in Jenkins,
 including but not limited to: Java, JavaScript, Groovy, Golang, Ruby, Shell scripts.
-And, since Jenkins is an automation server with hundreds of plugins, there is a huge number of technologies involved.
+And, since Jenkins is an automation server with roughly 1,800 plugins, there is a huge number of technologies involved.
 If you are an expert or just want to study something new while contributing,
 you may find interesting opportunities in our project.
 
@@ -25,8 +25,6 @@ You are welcome to contribute to **any** repository in **any** of those organiza
 ** plugins are named "*-plugin"
 ** libraries are named "lib-*"
 * https://github.com/jenkins-infra[jenkins-infra] - Jenkins infrastructure, including the website and other services
-* https://github.com/stapler/[stapler] - Stapler Web Framework which is currently maintained by the Jenkins community
-* https://github.com/jenkins-zh[jenkins-zh] - organization of the link:/sigs/chinese-localization/[Chinese Localization SIG]
 
 Various components in Jenkins have differing review and delivery policies,
 so please see the repositories for specific contributing guidelines.
@@ -42,8 +40,8 @@ Most Jenkins contributors work on plugins and it is often the best way to start 
 Here are some documentation links:
 
 * link:/doc/developer/[Jenkins developer documentation]
-* https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial[The plugin tutorial will get you started with Jenkins plugin development]
-* https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[The complete guide to hosting and publishing plugins]
+* link:/doc/developer/plugin-development/[The plugin tutorial will get you started with Jenkins plugin development]
+* link:/doc/developer/publishing/requesting-hosting/[The complete guide to hosting and publishing plugins]
 * link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopt a plugin]
 * https://wiki.jenkins.io/display/JENKINS/Before+starting+a+new+plugin[Advice before creating a new plugin]
 * https://wiki.jenkins.io/display/JENKINS/Pull+Request+to+Repositories[How we handle pull requests to plugin repositories]

--- a/content/participate/code.adoc
+++ b/content/participate/code.adoc
@@ -10,7 +10,7 @@ tags:
 Jenkins project includes a lot of code, and we invite everyone to contribute to the project.
 There is a diverse set of programming languages used in Jenkins,
 including but not limited to: Java, JavaScript, Groovy, Golang, Ruby, Shell scripts.
-And, since Jenkins is an automation server with roughly 1,800 plugins, there is a huge number of technologies involved.
+And, since Jenkins is an automation server with hundreds of plugins, there is a huge number of technologies involved.
 If you are an expert or just want to study something new while contributing,
 you may find interesting opportunities in our project.
 


### PR DESCRIPTION
We transferred everything of use from stapler to jenkinsci and the chinese org is inactive for years; hence this PR removes both organizations from the code page. Let's focus on organizations that are active and guide people's contributions here.