### PR TITLE
Include Java version and vendor in bug report snippet

### DIFF
--- a/content/doc/book/troubleshooting/diagnosing-errors.adoc
+++ b/content/doc/book/troubleshooting/diagnosing-errors.adoc
@@ -72,6 +72,7 @@ For easier bug reporting, you can get the full list of plugins with this Groovy 
 ```
 println("Jenkins: ${Jenkins.instance.getVersion()}")
 println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")
+println("Java: ${System.getProperty('java.version')} - ${System.getProperty('java.vm.vendor')} (${System.getProperty('java.vm.name')})")
 println "---"
 
 Jenkins.instance.pluginManager.plugins

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -124,8 +124,9 @@ nodes'),
 ...) and the parameters set.
 * *Jenkins and plugin versions*, use the below snippet in **Jenkins > Manage Jenkins > Script Console**:
 ```
-println("Jenkins: " + Jenkins.instance.getVersion())
-println("OS: " + System.getProperty('os.name') + " - " +System.getProperty('os.version'))
+println("Jenkins: ${Jenkins.instance.getVersion()}")
+println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")
+println("Java: ${System.getProperty('java.version')} - ${System.getProperty('java.vm.vendor')} (${System.getProperty('java.vm.name')})")
 println "---"
 
 Jenkins.instance.pluginManager.plugins


### PR DESCRIPTION
The change proposed adds the Java version output to the copy/paste snippet, to provide helpful insights in what people are using, given plugins and core can behave differently between Java 11, 17 or newer.