### PR TITLE
Add placeholder to indicate additional information is needed

### DIFF
--- a/content/participate/report-issue/redirect.html.haml
+++ b/content/participate/report-issue/redirect.html.haml
@@ -93,7 +93,7 @@ uneditable: true
                 Report a security issue privately.
                 %a{:href => '/security/reporting/' }
                     Learn more...
-            %a.btn.btn-security.bl{:href => 'https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103&components=17329' }
+            %a.btn.btn-security.bl{:href => 'https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103&components=17329&summary=[INSERT_PLUGIN_ID_HERE]%20Insert%20Summary%20Here' }
                 Continue
 
 :javascript


### PR DESCRIPTION
We've seen a few issues reported that lack any kind of information about the identity of the affected plugin. Our guess is that they were submitted through this form, with submitters not realizing that, unlike in JENKINS, there's no component identifying the plugin.

This adds a fixed placeholder to the summary as a first step, let's see how well this works.
