### PR TITLE
Update GSoC page with current status

### DIFF
--- a/content/projects/gsoc/2022/index.adoc
+++ b/content/projects/gsoc/2022/index.adoc
@@ -26,7 +26,7 @@ in completing their projects.
 
 == GSoC 2022
 
-We are participating in Google Summer of Code 2022. (link:./2022/application[Jenkins GSoC Organisation Application Form])
+We are participating in Google Summer of Code 2022. (link:./application[Jenkins GSoC Organisation Application Form])
 
 The selected projects are 
 

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -39,7 +39,7 @@ See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP5
 // * link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance[Automatic git cache maintenance on the controller] by Hrushikesh Rao
 // * link:/projects/gsoc/2022/projects/pipeline-step-documentation-generator[Pipeline Step Documentation Generator Improvements] by Vihaan Thora
 
-We are currently waiting to know whether we will be accepted as a participating organisation (to be announced by Google on Feb 23). 
+We are currently waiting to know whether we will be accepted as a participating organisation (to be announced by Google on Feb 22, 2023). 
 A kick-off meeting will be organized right after.
 
 **link:./2023/project-ideas[2023 GSoC project ideas list]**.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -27,7 +27,7 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 == GSoC 2023
 
-We applied to participate in Google Summer of Code 2023. 
+We have applied to participate in Google Summer of Code 2023. 
 See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Organisation Application Form]).
 
 
@@ -39,7 +39,7 @@ See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP5
 // * link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance[Automatic git cache maintenance on the controller] by Hrushikesh Rao
 // * link:/projects/gsoc/2022/projects/pipeline-step-documentation-generator[Pipeline Step Documentation Generator Improvements] by Vihaan Thora
 
-We are currently waiting to know whether we are accepted as a participating organisation (to be announced on Feb 22). 
+We are currently waiting to know whether we will be accepted as a participating organisation (to be announced by Google on Feb 22). 
 A kick-off meeting will be organized right after.
 
 **link:./2023/project-ideas[2023 GSoC project ideas list]**.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -27,10 +27,8 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 == GSoC 2023
 
-We are applying to participate in Google Summer of Code 2023. 
-
-// Uncomment when application is worked on and submitted (Feb 2023)
-//(link:./2022/application[Jenkins GSoC Organisation Application Form])
+We applied to participate in Google Summer of Code 2023. 
+See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Organisation Application Form]).
 
 
 // Uncomment when projects have been chosen
@@ -41,10 +39,14 @@ We are applying to participate in Google Summer of Code 2023.
 // * link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance[Automatic git cache maintenance on the controller] by Hrushikesh Rao
 // * link:/projects/gsoc/2022/projects/pipeline-step-documentation-generator[Pipeline Step Documentation Generator Improvements] by Vihaan Thora
 
-We are currently collecting project ideas. 
-Add your ideas by submitting an ad-hoc pull request as explained in our latest link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
+We are currently waiting to know whether we are accepted as a participating organisation (to be announced on Feb 22). 
+A kick-off meeting will be organized right after.
 
 **link:./2023/project-ideas[2023 GSoC project ideas list]**.
+
+We held two webinars explaining how to get prepared and how we will move forward. 
+One was focusing on students/contributors. (link:https://www.youtube.com/watch?v=k_sTkGtTix8[recording])
+The other was aimed at mentors and mentor candidates. (link:https://www.youtube.com/watch?v=gGTZtKjVlK0[recording])
 
 
 //Uncomment when further in the selection process

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -39,7 +39,7 @@ See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP5
 // * link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance[Automatic git cache maintenance on the controller] by Hrushikesh Rao
 // * link:/projects/gsoc/2022/projects/pipeline-step-documentation-generator[Pipeline Step Documentation Generator Improvements] by Vihaan Thora
 
-We are currently waiting to know whether we will be accepted as a participating organisation (to be announced by Google on Feb 22). 
+We are currently waiting to know whether we will be accepted as a participating organisation (to be announced by Google on Feb 23). 
 A kick-off meeting will be organized right after.
 
 **link:./2023/project-ideas[2023 GSoC project ideas list]**.


### PR DESCRIPTION
- updating status (Application sent)
- added link to application data
- mention kick-off Office Hours
- link to recordings of Student webinar and Mentor webinar
- corrected broken link in GSoC2022 archive