### PR TITLE
Exchange Gitter namespace URL with matrix home

### DIFF
--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -12,7 +12,7 @@ Other channels will be connected similarly as we move forward.
 
 == Gitter
 
-The Jenkins community discusses various topics in multiple rooms on https://gitter.im/jenkinsci/home[Gitter].
+The Jenkins community discusses various topics in multiple rooms on https://app.gitter.im/#/room/#jenkins-ci:matrix.org[Gitter].
 Various link:../sigs/[special interest groups] also use Gitter to meet, and you will find their rooms linked on the SIGs overview page.
 
 === https://gitter.im/jenkinsci/jenkins[jenkinsci/jenkins]

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -108,7 +108,7 @@ All link:/mailing-lists[mailing lists] hosted on Google Groups and other platfor
 ==== Chats
 
 * All chats documented on the link:/chat[this page], e.g. IRC channels: `#jenkins`, `#jenkins-meeting`, `#jenkins-infra`, etc.
-* Gitter channels within the link:https://gitter.im/jenkinsci/home[https://gitter.im/jenkinsci/] space
+* Gitter channels within the link:https://app.gitter.im/#/room/#jenkins-ci:matrix.org[https://gitter.im/jenkinsci/] space
 * Jenkins chats hosted by Linux Foundation and its subsidiaries including Continuous Delivery Foundation 
 
 ==== Events


### PR DESCRIPTION
As of yesterday, Gitter runs exclusively on Matrix, the web ui changed from Gitter's custom one, to the default element.io concept.
This transition broke our "home" URL used to list all channels: https://gitter.im/jenkinsci/home

The new URL, available on https://app.gitter.im/#/room/#jenkins-ci:matrix.org, is a drop-in replacement listing all Gitter channels, plus bridged IRC <-> Matrix channels.