### PR TITLE
Update all gitter links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Gitter chat
-    url: https://gitter.im/jenkinsci/docs
+    url: https://app.gitter.im/#/room/#jenkins/docs:matrix.org
     about: Jenkins Documentation SIG chat

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -4,7 +4,7 @@
 
 = Contributing to jenkins.io
 
-image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
+image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://app.gitter.im/#/room/#jenkins/docs:matrix.org"]
 
 toc::[]
 
@@ -28,7 +28,7 @@ image::https://gitpod.io/button/open-in-gitpod.svg[Open in Gitpod]
 === Information for newcomers
 
 The documentation below describes common cases for contributors.
-If you have any questions, please do not hesitate to ask in link:https://gitter.im/jenkinsci/newcomer-contributors[newcomers] or link:https://gitter.im/jenkinsci/docs[Documentation SIG] Gitter chats.
+If you have any questions, please do not hesitate to ask in link:https://app.gitter.im/#/room/#jenkinsci_newcomer-contributors:gitter.im[newcomers] or link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Documentation SIG] Gitter chats.
 If you have any feedback about your contributor experience, please also share it with us in these channels so that we can improve our guidelines.
 
 You can also find some newbie-friendly issues in our task trackers:
@@ -46,7 +46,7 @@ If you need any help, please ask in the xref:contacts[].
 Jenkins website is largely maintained by the link:https://jenkins.io/sigs/docs/[Jenkins documentation] special interest group.
 This group has various communication channels which can be used to discuss contributing to the website:
 
-* link:https://gitter.im/jenkinsci/docs[Gitter chat]
+* link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter chat]
 * link:https://jenkins.io/sigs/docs/#meetings[Regular meetings]
 
 [[forking]]
@@ -672,7 +672,7 @@ Some tips for contributors:
   If you are interested to review changes, please just do so (and thanks in advance!). 
   No special permissions needed
 * If you need help with reviews for documentation changes,
-  you can ask in the link:https://gitter.im/jenkinsci/docs[Documentation SIG Gitter channel].
+  you can ask in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Documentation SIG Gitter channel].
 
 [[merging-common]]
 === Merging changes in common areas

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = jenkins.io
 
-image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
+image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://app.gitter.im/#/room/#jenkins/docs:matrix.org"]
 
 This repository powers the link:https://jenkins.io/[Jenkins website].
 This uses link:https://github.com/awestruct/awestruct[Awestruct]

--- a/content/_partials/connect-links.html.haml
+++ b/content/_partials/connect-links.html.haml
@@ -49,7 +49,7 @@
 
 - if gitter
   %li
-    %a{:href => "https://gitter.im/#{gitter}", :target => "_blank", :rel => "noreferrer noopener"}
+    %a{:href => "https://app.gitter.im/#/room/##{gitter}", :target => "_blank", :rel => "noreferrer noopener"}
       %img{:title => "Gitter", :src => "https://badges.gitter.im/#{gitter}.svg"}
 - elsif chat
   %li

--- a/content/_partials/wip.adoc
+++ b/content/_partials/wip.adoc
@@ -2,6 +2,6 @@
 ====
 This section is a work in progress.
 Want to help?
-Check out the link:https://gitter.im/jenkinsci/docs[jenkinsci/docs gitter channel].
+Check out the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[jenkinsci/docs gitter channel].
 For other ways to contribute to the Jenkins project, see link:/participate[this page about participating and contributing].
 ====

--- a/content/blog/2016/2016-04-01-march-2016-jam-st-petersburg.adoc
+++ b/content/blog/2016/2016-04-01-march-2016-jam-st-petersburg.adoc
@@ -38,7 +38,7 @@ make this part more official.
 * link:https://events.yandex.ru/events/yagosti/10-march-2016/[Event page on the Yandex.Events portal]
 * link:https://twitter.com/jenkins_spb[St. Petersburg Meetup Twitter]
 * link:https://twitter.com/jenkins_ru[Jenkins RU Twitter]
-* link:https://gitter.im/jenkinsci-ru/public[Jenkins RU Gitter Chat]
+* link:https://app.gitter.im/#/room/#jenkinsci-ru_public:gitter.im[Jenkins RU Gitter Chat]
 
 == Acknowledgments
 

--- a/content/blog/2016/2016-05-23-external-workspace-manager-plugin.adoc
+++ b/content/blog/2016/2016-05-23-external-workspace-manager-plugin.adoc
@@ -171,7 +171,7 @@ link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Jenkins developers] m
 
 === Links
 
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
 
 * link:https://goo.gl/fq3RAe[Design document]
 * link:https://summerofcode.withgoogle.com/[GSoC program]

--- a/content/blog/2016/2016-06-30-ewm-alpha-version.adoc
+++ b/content/blog/2016/2016-06-30-ewm-alpha-version.adoc
@@ -46,7 +46,7 @@ and every Thursday at
 link:https://www.timeanddate.com/worldclock/fixedtime.html?msg=External+Workspace+Manager+Plugin+(Thursdays+weekly+recurring)&iso=20160609T05&p1=1440&ah=1[5 PM UTC].
 
 If you have any issues in setting up or using the plugin, please feel free to ask me on the plugin's Gitter
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin[chat].
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[chat].
 The plugin is open-source, having the repository on
 link:https://github.com/jenkinsci/external-workspace-manager-plugin[GitHub], and you may contribute to it.
 Any feedback is welcome, and you may provide it either on the Gitter chat, or on
@@ -54,7 +54,7 @@ link:https://issues.jenkins.io[Jira] by using the __external-workspace-manager-p
 
 === Links
 
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
 
 * link:https://github.com/jenkinsci/external-workspace-manager-plugin[Project repository]
 * link:https://wiki.jenkins.io/display/JENKINS/External+Workspace+Manager+Plugin[Plugin wiki page]

--- a/content/blog/2016/2016-08-03-st-petersburg-jam-3-4-report.adoc
+++ b/content/blog/2016/2016-08-03-st-petersburg-jam-3-4-report.adoc
@@ -56,14 +56,14 @@ We hope to finally organize a "Jenkins & Docker" meetup at some point.
 == Q&A
 
 If you have any questions, all speakers can be contacted via 
-link:https://gitter.im/jenkinsci-ru/public[Jenkins RU Gitter Chat].
+link:https://app.gitter.im/#/room/#jenkinsci-ru_public:gitter.im[Jenkins RU Gitter Chat].
 
 == Links
 
 * link:https://www.meetup.com/St-Petersburg-Jenkins-Meetup/[St. Petersburg Meetup page] (follow the events here)
 * link:https://twitter.com/jenkins_spb[St. Petersburg Meetup Twitter]
 * link:https://twitter.com/jenkins_ru[Jenkins RU Twitter]
-* link:https://gitter.im/jenkinsci-ru/public[Jenkins RU Gitter Chat]
+* link:https://app.gitter.im/#/room/#jenkinsci-ru_public:gitter.im[Jenkins RU Gitter Chat]
 * link:https://piter-united.ru/itgm8/itgm.html[IT Global Meetup]
 
 == Acknowledgments

--- a/content/blog/2016/2016-08-09-ewm-beta-version.adoc
+++ b/content/blog/2016/2016-08-09-ewm-beta-version.adoc
@@ -158,13 +158,13 @@ When this feature is completed, the plugin will enter a final testing phase.
 If all goes to plan, a stable version should be released in about two weeks.
 
 If you have any issues in setting up or using the plugin, please feel free to ask me on the plugin's Gitter
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin[chat].
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[chat].
 Any feedback is welcome, and you may provide it either on the Gitter chat, or on
 link:https://issues.jenkins.io[Jira] by using the __external-workspace-manager-plugin__ component.
 
 === Links
 
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
 
 * link:https://github.com/jenkinsci/external-workspace-manager-plugin[Project repository]
 * link:/blog/2016/05/23/external-workspace-manager-plugin/[Project intro blog post]

--- a/content/blog/2016/2016-08-22-ewm-stable-release.adoc
+++ b/content/blog/2016/2016-08-22-ewm-stable-release.adoc
@@ -57,13 +57,13 @@ link:https://github.com/martinda[Martin d'Anjou] for all their support, good adv
 Also, thanks to the Jenkins contributors with which I have interacted and helped me during this period.
 
 If you have any issues in setting up or using the plugin, please feel free to ask me on the plugin's Gitter
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin[chat].
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[chat].
 Any feedback is welcome, and you may provide it either on the Gitter chat, or on
 link:https://issues.jenkins.io[Jira] by using the __external-workspace-manager-plugin__ component.
 
 === Links
 
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
 
 * link:https://github.com/jenkinsci/external-workspace-manager-plugin[Project repository]
 * link:https://alexsomai.github.io/gsoc-2016/[Work product page]

--- a/content/blog/2017/01/2017-01-13-blueocean-dev-log-jan.adoc
+++ b/content/blog/2017/01/2017-01-13-blueocean-dev-log-jan.adoc
@@ -62,5 +62,5 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!
 

--- a/content/blog/2017/01/2017-01-20-blueocean-dev-log-jan2.adoc
+++ b/content/blog/2017/01/2017-01-20-blueocean-dev-log-jan2.adoc
@@ -70,4 +70,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/01/2017-01-27-blueocean-dev-log-jan4.adoc
+++ b/content/blog/2017/01/2017-01-27-blueocean-dev-log-jan4.adoc
@@ -89,4 +89,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/02/2017-02-03-blueocean-devlog-feb.adoc
+++ b/content/blog/2017/02/2017-02-03-blueocean-devlog-feb.adoc
@@ -60,5 +60,5 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!
 

--- a/content/blog/2017/02/2017-02-10-blueocean-devlog-feb2.adoc
+++ b/content/blog/2017/02/2017-02-10-blueocean-devlog-feb2.adoc
@@ -69,4 +69,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/02/2017-02-15-pipeline-editor-preview.adoc
+++ b/content/blog/2017/02/2017-02-15-pipeline-editor-preview.adoc
@@ -52,5 +52,5 @@ We are looking forward to your feedback to help make the Visual Pipeline Editor
 the easiest way to get started with Jenkins Pipeline. To report bugs or to
 request features link:/projects/blueocean#join-the-community[please follow the instructions on the project page].
 
-And don't forget to join us on our Gitter community chat image:https://badges.gitter.im/jenkinsci/blueocean-plugin.svg[link="https://gitter.im/jenkinsci/blueocean-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
+And don't forget to join us on our Gitter community chat image:https://badges.gitter.im/jenkinsci/blueocean-plugin.svg[link="https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
 - drop by and say hello!

--- a/content/blog/2017/02/2017-02-24-blueocean-devlog-feb4.adoc
+++ b/content/blog/2017/02/2017-02-24-blueocean-devlog-feb4.adoc
@@ -14,7 +14,7 @@ In the last 10 days, 2 betas went out: b22 and b23, and a preview release of
 the editor. We expect the next release will be named a release candidate (we
 know there is still more to go in, but want to signal that things are getting
 into the final stages!). The
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter chat room] is
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter chat room] is
 getting busier, so join in!
 
 Also last week, the Blue Ocean Pipeline Editor was presented at the
@@ -74,4 +74,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/03/2017-03-03-blueocean-devlog-mar1.adoc
+++ b/content/blog/2017/03/2017-03-03-blueocean-devlog-mar1.adoc
@@ -32,7 +32,7 @@ released in a beta:
 * Many many bug fixes and polishing.
 
 There has also been an uptick in activity on the
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter channel] with an
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter channel] with an
 increased number of questions about usage and Pipelines. But also questions
 from people starting to extend, or add features, to Blue Ocean, which is very
 nice to see.
@@ -59,4 +59,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/03/2017-03-10-blueocean-devlog-mar2.adoc
+++ b/content/blog/2017/03/2017-03-10-blueocean-devlog-mar2.adoc
@@ -59,4 +59,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/03/2017-03-17-blueocean-devlog-mar3.adoc
+++ b/content/blog/2017/03/2017-03-17-blueocean-devlog-mar3.adoc
@@ -59,4 +59,4 @@ Enjoy!
 
 If you're interested in helping to make Blue Ocean a great user experience for
 Jenkins, please join the Blue Ocean development team on
-link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/04/2017-04-05-say-hello-blueocean-1-0.adoc
+++ b/content/blog/2017/04/2017-04-05-say-hello-blueocean-1-0.adoc
@@ -105,4 +105,4 @@ Jenkins one of the experiences for software developers worldwide!
 
 If you’re interested in joining us to make Blue Ocean a great user experience
 for Jenkins, please join the Blue Ocean development
-team on link:https://gitter.im/jenkinsci/blueocean-plugin[Gitter]!
+team on link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[Gitter]!

--- a/content/blog/2017/11/2017-11-27-tutorials-in-the-jenkins-user-documentation.adoc
+++ b/content/blog/2017/11/2017-11-27-tutorials-in-the-jenkins-user-documentation.adoc
@@ -105,7 +105,7 @@ whenever a new tutorial is published.
 
 Also, if you have any suggestions for tutorials or other content you'd like to
 see in the documentation, please post your suggestions in the
-link:https://gitter.im/jenkinsci/docs[jenkinsci/docs gitter channel].
+link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[jenkinsci/docs gitter channel].
 
 [.boxshadow]
 image:/images/post-images/2017-11/sydney-office-team.jpg[The "Sydney Office"

--- a/content/blog/2018/04/2018-04-06-jenkins-essentials.adoc
+++ b/content/blog/2018/04/2018-04-06-jenkins-essentials.adoc
@@ -140,7 +140,7 @@ to make the full feedback loop operate, without which we would not be able to
 safely deliver new upgrades to Jenkins Essentials installations.
 
 If you're interested in getting involved, you can check out our
-link:https://gitter.im/jenkins-infra/evergreen?[Gitter channel]
+link:https://app.gitter.im/#/room/#jenkins-infra_evergreen:gitter.im[Gitter channel]
 or our
 link:https://issues.jenkins.io/secure/RapidBoard.jspa?rapidView=406[Jira issues board].
 

--- a/content/blog/2018/04/2018-04-18-blueocean-1-5-0.adoc
+++ b/content/blog/2018/04/2018-04-18-blueocean-1-5-0.adoc
@@ -77,5 +77,5 @@ If you are using the Blue Ocean UI, click Administration in the page's header to
 Installing the primary Blue Ocean plugin will update its dependencies as well.
 
 == Providing Feedback
-* Chat with us at Gitter: https://gitter.im/jenkinsci/blueocean-plugin
+* Chat with us at Gitter: https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im
 * Report issues at https://issues.jenkins.io/

--- a/content/blog/2018/04/2018-04-27-essentials-versions-are-numbered.adoc
+++ b/content/blog/2018/04/2018-04-27-essentials-versions-are-numbered.adoc
@@ -112,4 +112,4 @@ foundation for continuous delivery of all subsequent improvements.
 You can follow our progress in the
 link:https://github.com/jenkins-infra/evergreen[jenkins-infra/evergreen]
 repository, or join us in our
-link:https://gitter.im/jenkins-infra/evergreen[Gitter chat]!
+link:https://app.gitter.im/#/room/#jenkins-infra_evergreen:gitter.im[Gitter chat]!

--- a/content/blog/2018/06/2018-06-08-jenkins-java10-hackathon.adoc
+++ b/content/blog/2018/06/2018-06-08-jenkins-java10-hackathon.adoc
@@ -67,7 +67,7 @@ for synchronization before the event.
 What will we have?
 
 * Communications in link:/chat[#jenkins-hackhouse IRC] and in the
-link:https://gitter.im/jenkinsci/jenkins[Jenkins Gitter channel]
+link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[Jenkins Gitter channel]
 * Daily recorded sync-up calls in Hangouts
 * Knowledge transfer sessions during the event
 

--- a/content/blog/2018/06/2018-06-13-code-coverage-api-plugin.adoc
+++ b/content/blog/2018/06/2018-06-13-code-coverage-api-plugin.adoc
@@ -135,7 +135,7 @@ The Alpha version now has many parts which still need to be implemented before t
 Also, I have released the Alpha version in the https://jenkins.io/doc/developer/publishing/releasing-experimental-updates/#configuring-jenkins-to-use-experimental-update-center[Experimental Update Center]. If you can give me some of your valuable advice about it, I will very appreciate.
 
 === Links
-- https://gitter.im/jenkinsci/code-coverage-api-plugin[image:https://badges.gitter.im/jenkinsci/code-coverage-api-plugin.svg[title: "Gitter"]]
+- https://app.gitter.im/#/room/#jenkinsci_code-coverage-api-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/code-coverage-api-plugin.svg[title: "Gitter"]]
 - https://issues.jenkins.io/issues/?jql=project+%3D+JENKINS+AND+component+%3D+code-coverage-api-plugin[JIRA Component]
 - https://jenkins.io/projects/gsoc/2018/code-coverage-api-plugin/[Project Page]
 - https://github.com/jenkinsci/code-coverage-api-plugin[Project Repository]

--- a/content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
+++ b/content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
@@ -260,14 +260,14 @@ https://issues.jenkins.io/browse/Jenkins-51809[Jira Epic]
 === How to reach me
 
 * Email: gautamabhishek46@gmail.com
-* Gitter room: link:https://gitter.im/Jenkinsci/simple-pull-request-job-plugin[]
+* Gitter room: https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[]
 
 === References
 
 * link:https://docs.google.com/document/d/1cuC0AvQG3e4GCjIoCwK3J0tcJVAz1eNDKV8d_zXxlO8/edit[Initial proposal of the project]
 * link:https://github.com/Jenkinsci/simple-pull-request-job-plugin[Project repository]
 * link:https://Jenkins.io/projects/gsoc/2018/simple-pull-request-job-plugin/[Project page]
-* link:https://gitter.im/Jenkinsci/simple-pull-request-job-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[Gitter chat]
+* link:https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[Gitter chat]
 * link:https://issues.jenkins.io/issues/?jql=project%20%3D%20Jenkins%20AND%20component%20%3D%20simple-pull-request-job-plugin[Bug Tracker]
 * https://github.com/gautamabhishek46/dummy[Demo Repository]
 * https://www.youtube.com/watch?v=qWHM8S0fzUw[Phase 1 Presentation video](June 14, 2018)

--- a/content/blog/2018/06/2018-06-18-remoting-over-message-bus.adoc
+++ b/content/blog/2018/06/2018-06-18-remoting-over-message-bus.adoc
@@ -89,7 +89,7 @@ You can try to run a demo of the plugin by following the https://github.com/jenk
 
 === Links
 
-* https://gitter.im/jenkinsci/remoting[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
+* https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
 * https://github.com/jenkinsci/remoting-kafka-plugin[GitHub Repository]
 * https://jenkins.io/projects/gsoc/2018/remoting-over-message-bus/[Project Page]
 * https://youtu.be/qWHM8S0fzUw[Phase 1 Presentation Video]

--- a/content/blog/2018/06/2018-06-19-jenkins-java10-hackathon-day2.adoc
+++ b/content/blog/2018/06/2018-06-19-jenkins-java10-hackathon-day2.adoc
@@ -93,7 +93,7 @@ According to the requests from hackathon paticipants, we will have an intro sess
    Java 10/11 adoption
 ** link:https://www.youtube.com/watch?v=ns5eieSR9WE[YouTube link]
 
-We will also post participant links in link:https://gitter.im/jenkinsci/jenkins[our Gitter channel]
+We will also post participant links in link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[our Gitter channel]
 15 minutes before the meetings.
 If you have any questions, please join the meetings or raise questions in the chat during the call.
 
@@ -102,7 +102,7 @@ If you have any questions, please join the meetings or raise questions in the ch
 Yes, you can!
 It is possible to hop in and hop off at any time.
 Just respond to the link:https://docs.google.com/forms/d/1ReYyuyCGC0PIz2quh6XehnjpH2K52inx-veHLPlNreE/edit[registration form],
-join link:https://gitter.im/jenkinsci/jenkins[our Gitter channel] and start hacking/testing.
+join link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[our Gitter channel] and start hacking/testing.
 
 We also have a number of
 link:https://issues.jenkins.io/issues/?jql=labels%20%3D%20java10_hackathon%20and%20labels%20%3D%20newbie-friendly%20and%20assignee%20is%20EMPTY[newbie-friendly issues]

--- a/content/blog/2018/06/2018-06-26-jenkins-essentials-at-eclipsecon-france.adoc
+++ b/content/blog/2018/06/2018-06-26-jenkins-essentials-at-eclipsecon-france.adoc
@@ -46,4 +46,4 @@ video::RmngK8tc-94[youtube]
 You can learn more about Jenkins Essentials from
 link:https://github.com/jenkins-infra/evergreen[GitHub repository], or join us
 on our
-link:https://gitter.im/jenkins-infra/evergreen[Gitter channel].
+link:https://app.gitter.im/#/room/#jenkins-infra_evergreen:gitter.im[Gitter channel].

--- a/content/blog/2018/07/2018-07-05-remoting-over-message-bus-alpha-release.adoc
+++ b/content/blog/2018/07/2018-07-05-remoting-over-message-bus-alpha-release.adoc
@@ -18,13 +18,13 @@ Current versions of Jenkins Remoting are based on the TCP protocol. If it fails,
 https://github.com/jenkinsci/remoting-kafka-plugin[Remoting Kafka Plugin] is a plugin developed under link:/projects/gsoc/[Jenkins Google Summer of Code 2018]. The plugin is developed to add support of a popular message queue/bus technology (Kafka) as a fault-tolerant communication layer in Jenkins. A quick introduction of the project can be found in this  link:/blog/2018/06/18/remoting-over-message-bus/[introduction blogpost].
 
 === How to use the plugin?
-The instructions to run the plugin in alpha version are written https://github.com/jenkinsci/remoting-kafka-plugin#how-to-use-the-plugin-in-alpha-version[here]. Feel free to have a try and let us know your feedback on https://gitter.im/jenkinsci/remoting[Gitter] or the https://groups.google.com/forum/?nomobile=true#!forum/jenkinsci-dev[mailing list].
+The instructions to run the plugin in alpha version are written https://github.com/jenkinsci/remoting-kafka-plugin#how-to-use-the-plugin-in-alpha-version[here]. Feel free to have a try and let us know your feedback on https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[Gitter] or the https://groups.google.com/forum/?nomobile=true#!forum/jenkinsci-dev[mailing list].
 
 === Links
 
 * https://github.com/jenkinsci/remoting-kafka-plugin/blob/master/CHANGELOG.md#100-alpha-1[Alpha Changelog]
 * link:/blog/2018/06/18/remoting-over-message-bus/[Introduction Blogpost]
-* https://gitter.im/jenkinsci/remoting[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
+* https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
 * https://github.com/jenkinsci/remoting-kafka-plugin[GitHub Repository]
 * link:/projects/gsoc/2018/remoting-over-message-bus/[Project Page]
 * https://youtu.be/qWHM8S0fzUw[Phase 1 Presentation Video]

--- a/content/blog/2018/07/2018-07-10-jenkins-essentials-on-aws.adoc
+++ b/content/blog/2018/07/2018-07-10-jenkins-essentials-on-aws.adoc
@@ -31,4 +31,4 @@ While there are still many items to complete to provide a usable version for end
 You can learn more about Jenkins Essentials from the
 link:https://github.com/jenkins-infra/evergreen[GitHub repository], or join us
 on our
-link:https://gitter.im/jenkins-infra/evergreen[Gitter channel].
+link:https://app.gitter.im/#/room/#jenkins-infra_evergreen:gitter.im[Gitter channel].

--- a/content/blog/2018/07/2018-07-17-simple-pull-request-plugin.adoc
+++ b/content/blog/2018/07/2018-07-17-simple-pull-request-plugin.adoc
@@ -193,13 +193,13 @@ Video:
 === How to reach me
 
 * Email: gautamabhishek46@gmail.com
-* Gitter room: link:https://gitter.im/Jenkinsci/simple-pull-request-job-plugin[]
+* Gitter room: https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[]
 
 === References
 
 * link:https://github.com/jenkinsci/simple-pull-request-job-plugin[Project repository]
 * link:/projects/gsoc/2018/simple-pull-request-job-plugin/[Project page]
-* link:https://gitter.im/jenkinsci/simple-pull-request-job-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[Gitter chat]
+* link:https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[Gitter chat]
 * link:https://issues.jenkins.io/issues/?jql=project%20%3D%20Jenkins%20AND%20component%20%3D%20simple-pull-request-job-plugin[Bug Tracker]
 * link:https://github.com/gautamabhishek46/dummy[Demo Repository]
 * link:https://www.youtube.com/watch?v=tuTODhJOTBU&t=3229s[Phase 2 Presentation video](July 12, 2018)

--- a/content/blog/2018/07/2018-07-23-remoting-kafka-plugin-1.0-release.adoc
+++ b/content/blog/2018/07/2018-07-23-remoting-kafka-plugin-1.0-release.adoc
@@ -97,7 +97,7 @@ Features in the demo:
 ++++
 
 === Links
-* https://gitter.im/jenkinsci/remoting[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
+* https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
 * https://github.com/jenkinsci/remoting-kafka-plugin[GitHub Repository]
 * https://wiki.jenkins.io/display/JENKINS/Remoting+Kafka+Plugin[Wiki]
 * https://plugins.jenkins.io/remoting-kafka[Plugin Site]

--- a/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
+++ b/content/blog/2018/07/2018-07-30-introducing-cloud-native-sig.adoc
@@ -240,7 +240,7 @@ all resources are listed on the link:/sigs/cloud-native[SIG's page on jenkins.io
 If you want to participate in the SIG's activities, just do the following:
 
 1. Subscribe to the link:https://groups.google.com/forum/#!forum/jenkins-cloud-native-sig[mailing list]
-2. Join our link:https://gitter.im/jenkinsci/cloud-native-sig[Gitter channel]
+2. Join our link:https://app.gitter.im/#/room/#jenkinsci_cloud-native-sig:gitter.im[Gitter channel]
 3. Join our public meetings
 
 I am also working on organizing a face-to-face Cloud Native SIG meeting at the

--- a/content/blog/2018/08/2018-08-14-simple-pull-request-plugin-final-evaluation.adoc
+++ b/content/blog/2018/08/2018-08-14-simple-pull-request-plugin-final-evaluation.adoc
@@ -138,12 +138,12 @@ Jenkins and the services offered by it. I am allowed to work on the project afte
 === How to reach me
 
 * Email: gautamabhishek46@gmail.com
-* Gitter room: link:https://gitter.im/Jenkinsci/simple-pull-request-job-plugin[]
+* Gitter room: https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[]
 
 === References
 
 * link:https://github.com/jenkinsci/simple-pull-request-job-plugin[Project repository]
 * link:/projects/gsoc/2018/simple-pull-request-job-plugin/[Project page]
-* link:https://gitter.im/jenkinsci/simple-pull-request-job-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[Gitter chat]
+* link:https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[Gitter chat]
 * link:https://issues.jenkins.io/issues/?jql=project%20%3D%20Jenkins%20AND%20component%20%3D%20simple-pull-request-job-plugin[Bug Tracker]
 * link:https://github.com/gautamabhishek46/dummy[Demo Repository]

--- a/content/blog/2018/08/2018-08-17-code-coverage-api-plugin-1.0-release.adoc
+++ b/content/blog/2018/08/2018-08-17-code-coverage-api-plugin-1.0-release.adoc
@@ -191,7 +191,7 @@ If you want implement a new coverage format that we did not provide abstract lay
 ++++
 
 === Links
-- https://gitter.im/jenkinsci/code-coverage-api-plugin[image:https://badges.gitter.im/jenkinsci/code-coverage-api-plugin.svg[title: "Gitter"]]
+- https://app.gitter.im/#/room/#jenkinsci_code-coverage-api-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/code-coverage-api-plugin.svg[title: "Gitter"]]
 - https://issues.jenkins.io/issues/?jql=project+%3D+JENKINS+AND+component+%3D+code-coverage-api-plugin[JIRA Component]
 - https://jenkins.io/projects/gsoc/2018/code-coverage-api-plugin/[Project Page]
 - https://github.com/jenkinsci/code-coverage-api-plugin[Project Repository]

--- a/content/blog/2018/08/2018-08-23-speaker-blog-casc-part-1.adoc
+++ b/content/blog/2018/08/2018-08-23-speaker-blog-casc-part-1.adoc
@@ -81,7 +81,7 @@ image::/images/post-images/2018-casc/image4.jpg[Cattle not pets, 800]
 You can read more about the Jenkins Configuration-as-Code plugin on the project’s
 link:https://github.com/jenkinsci/configuration-as-code-plugin[github repository].
 To chat with the community and contributors join our
-link:https://gitter.im/jenkinsci/configuration-as-code-plugin[gitter channel],
+link:https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im[gitter channel],
 or come see us in person at
 link:link:https://www.cloudbees.com/devops-world[Jenkins World] to discuss the JCasC project and its future!
 

--- a/content/blog/2018/09/2018-09-18-automatically-upgrading-with-evergreen.adoc
+++ b/content/blog/2018/09/2018-09-18-automatically-upgrading-with-evergreen.adoc
@@ -86,4 +86,4 @@ link:https://devopsworldjenkinsworld2018.sched.com/event/F9Nn/safely-upgrading-j
 link:https://devopsworldjenkinsworld2018.sched.com/event/F9Nf/continuously-delivering-an-easy-to-use-jenkins-with-jenkins-evergreen[my talk] at 11:15am in Golden Gate Ballroom B.
 
 If you can't join us here in San Francisco, we hope to hear your feedback and thoughts in our
-link:https://gitter.im/jenkins-infra/evergreen[Gitter channel]!
+link:https://app.gitter.im/#/room/#jenkins-infra_evergreen:gitter.im[Gitter channel]!

--- a/content/blog/2018/10/2018-10-01-hacktoberfest.adoc
+++ b/content/blog/2018/10/2018-10-01-hacktoberfest.adoc
@@ -95,7 +95,7 @@ Here is a list of Jenkins subprojects with maintainers who have committed to del
   You can help to create new packaging, new features, testing flows, or cleanup issues
   link:https://github.com/search?q=org%3Ajenkinsci+setAccessible%28true%29+path%3A%22src%2Fmain%22&type=Code[Illegal Reflective Access] in the code.
 
-  link:https://gitter.im/jenkinsci/platform-sig[Gitter chat],
+  link:https://app.gitter.im/#/room/#jenkinsci_platform-sig:gitter.im[Gitter chat],
   link:https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20%3D%20newbie-friendly%20AND%20labels%20%3D%20java11[newbie-friendly issues]
 
 | Docker Packaging
@@ -161,7 +161,7 @@ Here are some links which may help:
 * link:/participate/[Participate] - landing page for newcomer contributors
 * link:/blog/2017/08/07/intro-to-plugin-development/[Plugin Development Tutorials]
 * link:/doc/developer/[Developer Documentation]
-* link:https://gitter.im/jenkinsci/jenkins[Gitter channel] for Q&A
+* link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[Gitter channel] for Q&A
 
 Projects in the table above also have their own documentation to help newcomers.
 
@@ -170,17 +170,17 @@ Projects in the table above also have their own documentation to help newcomers.
 All projects in the list above are monitored by their maintainers,
 and you will likely get a review within few days.
 Reviews in other repositories and plugins may take longer.
-In the case of delays, ping us in the link:https://gitter.im/jenkinsci/hacktoberfest-help[hacktoberfest-help] channel in Gitter.
+In the case of delays, ping us in the link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[hacktoberfest] channel in Gitter.
 Unmerged pull-requests also count in Hacktoberfest,
 so merge delays won't block you from getting prizes.
 
 ==== Q: I am stuck. How do I get help?
 
-* For non-technical questions (process and general direction) use our link:https://gitter.im/jenkinsci/hacktoberfest-help[hacktoberfest-help]
+* For non-technical questions (process and general direction) use our link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[hacktoberfest]
 channel in Gitter.
 * For technical questions please use the link:/chat[IRC chat],
 link:/mailing-lists/[Developer mailing lists],
-or the main link:https://gitter.im/jenkinsci/jenkins[jenkinsci/jenkins] channel.
+or the main link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[jenkinsci/jenkins] channel.
 Many subprojects also have their own chats.
 
 ==== Q: Does Jenkins project send special swag?

--- a/content/blog/2018/10/2018-11-13-martinda-gsoc-mentor-summit-experience.adoc
+++ b/content/blog/2018/10/2018-11-13-martinda-gsoc-mentor-summit-experience.adoc
@@ -179,7 +179,7 @@ There is a third role which is:
 * *Subject Matter Expert*: these individuals are not mentors, but we reach out to them 3-4 times during the project for advice and guidance, and sometimes complicated programming challenges.
 
 If you have questions or are curious about the program,
-contact us on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter SIG chat].
+contact us on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter SIG chat].
 
 [NOTE]
 ====

--- a/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
+++ b/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
@@ -9,7 +9,7 @@ tags:
 - platform-sig
 author: oleg_nenashev
 links:
-  gitter: /jenkinsci/platform-sig
+  gitter: jenkinsci_platform-sig:gitter.im
   sig: platform
 ---
 

--- a/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
+++ b/content/blog/2018/12/2018-12-14-java11-preview-availability.adoc
@@ -215,7 +215,7 @@ The process for this team is link:https://github.com/jenkinsci/jep/tree/master/j
 We do not expect the _Java 11 Support Team_ to be able to fix all discovered issues,
 and we will be working with Jenkins core and plugin maintainers to get the fixes delivered.
 If you are interested to join the team,
-reach out to us in the link:https://gitter.im/jenkinsci/platform-sig[Platform SIG Gitter Channel].
+reach out to us in the link:https://app.gitter.im/#/room/#jenkinsci_platform-sig:gitter.im[Platform SIG Gitter Channel].
 
 === Contributing
 

--- a/content/blog/2018/12/2018-12-26-gsoc-2019-call-for-mentors.adoc
+++ b/content/blog/2018/12/2018-12-26-gsoc-2019-call-for-mentors.adoc
@@ -9,7 +9,7 @@ tags:
 - developer
 author: martinda
 links:
-  gitter: jenkinsci/gsoc-sig
+  gitter: jenkinsci_gsoc-sig:gitter.im
   googlegroup: jenkins-gsoc-all-public
   sig: gsoc
 ---

--- a/content/blog/2018/12/2018-12-26-gsoc-2019-call-for-mentors.adoc
+++ b/content/blog/2018/12/2018-12-26-gsoc-2019-call-for-mentors.adoc
@@ -41,7 +41,7 @@ Quick start:
 1. Copy the link:https://docs.google.com/document/d/1l5SdcLnlCwWA6qH8FKT9XC714Dl1XJ9lyy1CKDdKKAU[project proposal template], 
 add a short description of your project idea 
 2. Open the document for public view and comments, reference communication channels there (if any)
-3. Let us know about the project idea via link:https://gitter.im/jenkinsci/gsoc-sig[our gitter channel].
+3. Let us know about the project idea via link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[our gitter channel].
 4. After getting initial feedback from org admins, share your idea with other contributors who might be interested 
 (via the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[developer mailing list], link:/chat[chats], or link:/sigs[special interest groups])
 
@@ -56,6 +56,6 @@ There are also many opportunities to engage with the Jenkins community (meetups,
 GSoC is a pretty good return on the investment!
 
 For any question, you can find the GSoC admins,
-mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter chat].
+mentors and participants on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG Gitter chat].
 
 The Jenkins GSoC Org Admin Team 2019

--- a/content/blog/2019/01/2019-01-21-fosdem-2019.adoc
+++ b/content/blog/2019/01/2019-01-21-fosdem-2019.adoc
@@ -60,4 +60,4 @@ Meals, snacks, and beverages will be provided for the hackfest.  Come join us, a
 Questions? feel free to contact
 link:mailto:alytong13@gmail.com[Alyssa Tong] or
 link:mailto:baptiste@mathus.fr[Baptiste Mathus] or join us on the
-link:https://gitter.im/jenkinsci/advocacy-and-outreach-sig[advocacy-and-outreach gitter channel].
+link:https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im[advocacy-and-outreach gitter channel].

--- a/content/blog/2019/02/2019-02-01-windows-installers.adoc
+++ b/content/blog/2019/02/2019-02-01-windows-installers.adoc
@@ -101,7 +101,7 @@ can be overridden will be available soon.
 ## Next Steps
 
 The new installer is under review by the members of the Platform SIG, but we need people to test the installer and give feedback. If you are interested in testing 
-the new installer, please join the link:https://gitter.im/jenkinsci/platform-sig[Platform SIG gitter room] for more information.
+the new installer, please join the link:https://app.gitter.im/#/room/#jenkinsci_platform-sig:gitter.im[Platform SIG gitter room] for more information.
 
 There are still some things that are being researched and implemented in the new installer (e.g., keeping port and other selections when doing an upgrade), but it is
 getting close to release.

--- a/content/blog/2019/03/2019-03-04-gsoc2019-announcement.adoc
+++ b/content/blog/2019/03/2019-03-04-gsoc2019-announcement.adoc
@@ -44,7 +44,7 @@ We encourage interested students to reach out to the Jenkins community early and
 All project ideas have chats and mailing lists referenced on their pages.
 We will be also organizing office hours for students,
 and you can use these meetings to meet org admins and mentors and to ask questions.
-Also, join our link:https://gitter.im/jenkinsci/gsoc-sig[Gitter channel] to receive information about such incoming events in the project.
+Also, join our link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Gitter channel] to receive information about such incoming events in the project.
 
 The application period starts on March 25th, but you can prepare now!
 Use the time before the application period to discuss and improve your project proposals.

--- a/content/blog/2019/03/2019-03-11-let-s-celebrate-java-11-support.adoc
+++ b/content/blog/2019/03/2019-03-11-let-s-celebrate-java-11-support.adoc
@@ -9,7 +9,7 @@ tags:
 - platform-sig
 author: alecharp
 links:
-  gitter: /jenkinsci/platform-sig
+  gitter: jenkinsci_platform-sig:gitter.im
   sig: platform
 ---
 

--- a/content/blog/2019/05/2019-05-09-templating-engine.adoc
+++ b/content/blog/2019/05/2019-05-09-templating-engine.adoc
@@ -253,7 +253,7 @@ definition to a centralized location, the Templating Engine plugin allows DevOps
 
 The plugin:templating-engine[Templating Engine Plugin] has been open sourced and made available in the Jenkins Update Center.
 
-We always appreciate feedback and contributions! If you have an interesting use case or would like to ask questions, try the link:https://gitter.im/jenkinsci/templating-engine-plugin[templating-engine-plugin on Gitter]. 
+We always appreciate feedback and contributions! If you have an interesting use case or would like to ask questions, try the link:https://app.gitter.im/#/room/#jenkinsci_templating-engine-plugin:gitter.im[templating-engine-plugin on Gitter].
 
 == Advanced Features
 

--- a/content/blog/2019/06/2019-06-21-performance-testing-jenkins.adoc
+++ b/content/blog/2019/06/2019-06-21-performance-testing-jenkins.adoc
@@ -188,7 +188,7 @@ when annotated with `@JmhBenchmark`.
 == Links and Feedback
 
 If you have any feedback, comments or questions, please feel free to reach out to me through either
-the link:https://gitter.im/jenkinsci/role-strategy-plugin[Role Strategy Plugin Gitter chat] or through 
+the link:https://app.gitter.im/#/room/#jenkinsci_role-strategy-plugin:gitter.im[Role Strategy Plugin Gitter chat] or through
 the link:mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list].
 
 * link:https://drive.google.com/file/d/1gig6u64rzvSzGKjN_PTTXTkSXQ9Ah7E5/view?usp=sharing[Presentation slides]

--- a/content/blog/2019/07/2019-07-02-plugin-management-tool-alpha-release.adoc
+++ b/content/blog/2019/07/2019-07-02-plugin-management-tool-alpha-release.adoc
@@ -53,7 +53,7 @@ More robust input parsing, support for security warnings and available updates, 
 == Links and Feedback
 
 Feel free to reach out through
-the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[Plugin Installation Manager CLI Tool Gitter chat] or through
+the link:https://app.gitter.im/#/room/#jenkinsci_plugin-installation-manager-cli-tool:gitter.im[Plugin Installation Manager CLI Tool Gitter chat] or through
 the link:mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list]. I would love to get your questions, comments, and feedback!
 We have meetings Tuesdays and Thursdays at 6PM UTC.
 

--- a/content/blog/2019/07/2019-07-09-Phase1-Updates-On-Working-Hours-Plugin.adoc
+++ b/content/blog/2019/07/2019-07-09-Phase1-Updates-On-Working-Hours-Plugin.adoc
@@ -105,7 +105,7 @@ Several useful links are listed below:
 * link:https://github.com/jenkinsci/working-hours-plugin[Main Repo]
 * link:https://docs.google.com/document/d/1SezLtQejur2ji-KUur3dC3TXK8ivxrttiwHYbTkA8Yk/edit#[Design Doc]
 * link:https://drive.google.com/open?id=1JLRCDg9JNBWR0Dfq8w3pTI9mrl6i9JU29pBoH6bO0J8[Doc for React Integration Solution ]
-* link:https://gitter.im/jenkinsci/working-hours-plugin[
+* link:https://app.gitter.im/#/room/#jenkinsci_working-hours-plugin:gitter.im[
     Gitter Chat
 ]
 * link:https://docs.google.com/presentation/d/1Psz6MrYvw81D_7d8pfW04FDoBtexlSVdgrbqp99Wjm0/edit?usp=sharing[

--- a/content/blog/2019/07/2019-07-11-remoting-kafka-kubernetes-phase-1.adoc
+++ b/content/blog/2019/07/2019-07-11-remoting-kafka-kubernetes-phase-1.adoc
@@ -128,4 +128,4 @@ statefulset.apps/demo-zookeeper   1/1     6m30s
 * link:https://docs.google.com/presentation/d/1yIPwwL7P051XaSE2EOJYAtbVsd6YvGvvKp9QcJE4J1Y/edit?usp=sharing[Phase 1 Presentation Slides]
 * link:https://github.com/jenkinsci/remoting-kafka-plugin[Remoting over Apache Kafka plugin]
 * link:/projects/gsoc/2019/remoting-over-apache-kafka-docker-k8s-features/[Project Page]
-* link:https://gitter.im/jenkinsci/remoting[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[Gitter Channel]

--- a/content/blog/2019/07/2019-07-30-plugin-management-tool-phase2-updates.adoc
+++ b/content/blog/2019/07/2019-07-30-plugin-management-tool-phase2-updates.adoc
@@ -81,7 +81,7 @@ in San Francisco in a few weeks.  You can use the code PREVIEW for a discounted 
 
 
 Feel free to reach out through
-the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[Plugin Installation Manager CLI Tool Gitter chat] or through
+the link:https://app.gitter.im/#/room/#jenkinsci_plugin-installation-manager-cli-tool:gitter.im[Plugin Installation Manager CLI Tool Gitter chat] or through
 the link:mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list]. I would love to get your questions, comments, and feedback!
 We have meetings Tuesdays and Thursdays at 6PM UTC.
 

--- a/content/blog/2019/08/2019-08-16-folder-auth-plugin.adoc
+++ b/content/blog/2019/08/2019-08-16-folder-auth-plugin.adoc
@@ -119,7 +119,7 @@ APIs, documentation and more optimizations for improving the plugin's performanc
 == Links and Feedback
 I would love to hear your comments and suggestions. Please feel free to reach
 out to me through either the
-link:https://gitter.im/jenkinsci/role-strategy-plugin[Role Strategy Plugin Gitter chat] or through
+link:https://app.gitter.im/#/room/#jenkinsci_role-strategy-plugin:gitter.im[Role Strategy Plugin Gitter chat] or through
 link:mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list].
 
 * link:https://drive.google.com/file/d/1IVe3T8WdTILmb62PAIJveR4KbBWzPt1k/view?usp=sharing[Presentation slides for second phase evaluations]

--- a/content/blog/2019/08/2019-08-19-remoting-kafka-kubernetes-release-2.0.adoc
+++ b/content/blog/2019/08/2019-08-19-remoting-kafka-kubernetes-release-2.0.adoc
@@ -83,4 +83,4 @@ You are welcome to try out the plugin and integrate it into your current setup. 
 * link:https://docs.google.com/presentation/d/1yIPwwL7P051XaSE2EOJYAtbVsd6YvGvvKp9QcJE4J1Y/edit?usp=sharing[Phase 1 Presentation Slides]
 * link:https://github.com/jenkinsci/remoting-kafka-plugin[Remoting over Apache Kafka plugin source code]
 * link:/projects/gsoc/2019/remoting-over-apache-kafka-docker-k8s-features/[Project Page]
-* link:https://gitter.im/jenkinsci/remoting[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[Gitter Channel]

--- a/content/blog/2019/08/2019-08-23-introducing-gitlab-branch-source-plugin.adoc
+++ b/content/blog/2019/08/2019-08-23-introducing-gitlab-branch-source-plugin.adoc
@@ -192,7 +192,7 @@ You can also use `JCasC` to directly create job from a Job DSL script. For examp
 
 * Send your mail in the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Developer Mailing list].
 
-* Join our link:https://gitter.im/jenkinsci/gitlab-branch-source-plugin[Gitter channel].
+* Join our link:https://app.gitter.im/#/room/#jenkinsci_gitlab-branch-source-plugin:gitter.im[Gitter channel].
 
 == Future work
 

--- a/content/blog/2019/08/2019-08-26-role-strategy-performance.adoc
+++ b/content/blog/2019/08/2019-08-26-role-strategy-performance.adoc
@@ -87,7 +87,7 @@ more information about the plugin.
 ==== Links and Feedback
 I would love to hear your comments and suggestions. Please feel free to reach
 out to me through either the
-link:https://gitter.im/jenkinsci/role-strategy-plugin[Role Strategy Plugin Gitter chat] or through
+link:https://app.gitter.im/#/room/#jenkinsci_role-strategy-plugin:gitter.im[Role Strategy Plugin Gitter chat] or through
 link:mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list].
 
 * link:https://drive.google.com/file/d/1lAXDljWXypCq6noiqPHI-eZJqBqaSYue/view?usp=sharing[Presentation slides for final evaluation of GSoC]

--- a/content/blog/2019/10/2019-10-01-hacktoberfest.adoc
+++ b/content/blog/2019/10/2019-10-01-hacktoberfest.adoc
@@ -21,7 +21,7 @@ Any GitHub pull request counts!
 == Quick start
 
 1. Sign-up to Hacktoberfest on link:https://hacktoberfest.digitalocean.com[the event website].
-2. Join link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter channel].
+2. Join link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[our Gitter channel].
 3. Everything is set, just start creating pull-requests!
 ** This year Hacktoberfest does not require labeling pull requests,
    but please mention Hacktoberfest in your pull requests for faster reviews
@@ -74,7 +74,7 @@ See link:https://jenkins-x.io/blog/2019/09/27/hacktoberfest2019/[this blogpost] 
 
 If you are stuck or have any question,
 see our link:/events/hacktoberfest/faq[Hacktoberfest FAQ] page for the common questions.
-If it does not help, please reach out to us in link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter chat].
+If it does not help, please reach out to us in link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[our Gitter chat].
 
 == Any meetups this year?
 
@@ -91,7 +91,7 @@ You can find the full list link:/events/hacktoberfest/#local-events[here].
 
 * link:https://hacktoberfest.digitalocean.com[Hacktoberfest website]
 * link:/events/hacktoberfest/[Hacktoberfest in Jenkins]
-* link:https://gitter.im/jenkinsci/hacktoberfest[Our Gitter channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[Our Gitter channel]
 * link:/events/hacktoberfest/faq[Frequently asked questions]
 * link:/participate/[Contributing to Jenkins]
 

--- a/content/blog/2019/10/2019-10-08-jcasc-phase1-blog.adoc
+++ b/content/blog/2019/10/2019-10-08-jcasc-phase1-blog.adoc
@@ -101,7 +101,7 @@ c)Integration with a live Jenkins instance.
 
 We would love to get feedback from you on the stuff we are working on. Contributions to the project would be highly appreciated.
 
-a)link:https://gitter.im/jenkinsci/jcasc-devtools-project[Gitter Chat]
+a)link:https://app.gitter.im/#/room/#jenkinsci_jcasc-devtools-project:gitter.im[Gitter Chat]
 
 b)link:https://github.com/jenkinsci/configuration-as-code-plugin[Github Repository]
 

--- a/content/blog/2019/10/2019-10-21-plugin-docs-on-github.adoc
+++ b/content/blog/2019/10/2019-10-21-plugin-docs-on-github.adoc
@@ -100,7 +100,7 @@ Migrating documentation:
 
 
 If you have any questions about contributing to the documentation, 
-please see link:/participate/#document[this page] or reach out to us in the link:https://gitter.im/jenkinsci/docs[Docs SIG Gitter chat].
+please see link:/participate/#document[this page] or reach out to us in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Docs SIG Gitter chat].
 
 
 

--- a/content/blog/2019/11/2019-11-22-jenkins-health-advisor-by-cloudbees.adoc
+++ b/content/blog/2019/11/2019-11-22-jenkins-health-advisor-by-cloudbees.adoc
@@ -42,7 +42,7 @@ image:/images/post-images/jenkins-health-advisor-by-cloudbees/overview.png[Jenki
 
 We hope that you will appreciate this service and it will help you to keep your controllers healthy. 
 
-Take a few minutes to read our https://docs.cloudbees.com/docs/admin-resources/latest/plugins/cloudbees-jenkins-advisor?utm_medium=blog&utm_source=jenkins.io&utm_campaign=cloudbees-jenkins-advisor-plugin[documentation], discover the service and don’t hesitate to contact us on the Jenkins community channels (https://gitter.im/jenkinsci/jenkins[Gitter], https://groups.google.com/forum/#!forum/jenkinsci-users[jenkinsci-users@googlegroups.com], ...).
+Take a few minutes to read our https://docs.cloudbees.com/docs/admin-resources/latest/plugins/cloudbees-jenkins-advisor?utm_medium=blog&utm_source=jenkins.io&utm_campaign=cloudbees-jenkins-advisor-plugin[documentation], discover the service and don’t hesitate to contact us on the Jenkins community channels (https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[Gitter], https://groups.google.com/forum/#!forum/jenkinsci-users[jenkinsci-users@googlegroups.com], ...).
 
 Don't miss also the opportunity to meet our support team on the "Ask the experts" booth at link:https://www.cloudbees.com/devops-world/lisbon[DevOps World | Jenkins World 2019].
 

--- a/content/blog/2019/12/2019-12-20-call-for-mentors.adoc
+++ b/content/blog/2019/12/2019-12-20-call-for-mentors.adoc
@@ -9,7 +9,7 @@ tags:
 - developer
 author: martinda
 links:
-  gitter: jenkinsci/gsoc-sig
+  gitter: jenkinsci_gsoc-sig:gitter.im
   googlegroup: jenkins-gsoc-all-public
   sig: gsoc
 ---

--- a/content/blog/2019/12/2019-12-20-call-for-mentors.adoc
+++ b/content/blog/2019/12/2019-12-20-call-for-mentors.adoc
@@ -76,4 +76,4 @@ on the kind of experience this was.
 GSoC is a pretty good return on the investment!
 
 For any question, you can find the GSoC Org Admins,
-mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter chat].
+mentors and participants on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG Gitter chat].

--- a/content/blog/2020/01/2020-01-10-fosdem-is-coming.adoc
+++ b/content/blog/2020/01/2020-01-10-fosdem-is-coming.adoc
@@ -19,7 +19,7 @@ I hope that this year will be as great as it always been and for that, we organi
 
 == Things we'll do
 
-During the whole event, we'll be virtually on the link:https://gitter.im/jenkinsci/fosdem[Gitter]
+During the whole event, we'll be virtually on the link:https://app.gitter.im/#/room/#jenkinsci_fosdem:gitter.im[Gitter]
 
 On the Thursday 30 of January, there will be two workshops one about link:https://www.eventbrite.com/e/jenkins-pipeline-fundamentals-training-tickets-87080214265[Jenkins Pipelines] lead by Mark Waite, and a second one about link:https://www.eventbrite.com/e/workshop-cloud-native-kubernetes-first-serverless-continuous-delivery-with-jenkins-x-kubernetes-and-tickets-87082627483[JenkinsX] by Viktor Farcic.
 

--- a/content/blog/2020/02/2020-02-25-vscode-caseStudy.adoc
+++ b/content/blog/2020/02/2020-02-25-vscode-caseStudy.adoc
@@ -69,5 +69,5 @@ image:/images/projects/jcasc/VSCode/userDocs2.png[]
 
 
 We are holding an online link:https://www.meetup.com/Jenkins-online-meetup/events/268823268[meetup] on the 26th February regarding this plugin and how you could use it to validate your YAML configuration files.
-For any suggestions or discussions regarding the schema feel free to join our link:https://gitter.im/jenkinsci/jcasc-devtools-project[gitter channel].
+For any suggestions or discussions regarding the schema feel free to join our link:https://app.gitter.im/#/room/#jenkinsci_jcasc-devtools-project:gitter.im[gitter channel].
 Issues can be created on link:https://github.com/jenkinsci/configuration-as-code-plugin/issues[Github].

--- a/content/blog/2020/03/2020-03-02-pipeline-authoring-sig-update.adoc
+++ b/content/blog/2020/03/2020-03-02-pipeline-authoring-sig-update.adoc
@@ -63,5 +63,5 @@ We will finally then start working to build out tools to help the community with
 === Contact Us
 
 If you would like to get in touch with the Pipeline-Authoring SIG, you can by joining the
-link:https://gitter.im/jenkinsci/pipeline-authoring-sig/[Pipeline-Authoring SIG gitter channel] or via the
+link:https://app.gitter.im/#/room/#jenkinsci_pipeline-authoring-sig:gitter.im[Pipeline-Authoring SIG gitter channel] or via the
 link:https://groups.google.com/forum/#!forum/jenkins-pipeline-authoring-sig/[Pipeline-Authoring SIG mailing list]

--- a/content/blog/2020/04/2020-04-16-github-app-authentication.adoc
+++ b/content/blog/2020/04/2020-04-16-github-app-authentication.adoc
@@ -99,5 +99,5 @@ It will look at integrating with the link:https://developer.github.com/v3/checks
 with a focus on reporting issues found using the link:https://plugins.jenkins.io/warnings-ng/[warnings-ng plugin]
 directly onto the GitHub pull requests, along with test results summary on GitHub.
 Hopefully it will make the Pipeline example below much simpler for Jenkins users :) 
-If you want to get involved with this, join the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel]
+If you want to get involved with this, join the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel]
 and ask how you can help.

--- a/content/blog/2020/05/2020-05-12-uiux-hackfest-announcement.adoc
+++ b/content/blog/2020/05/2020-05-12-uiux-hackfest-announcement.adoc
@@ -14,7 +14,7 @@ tags:
 authors:
 - oleg_nenashev
 links:
-  gitter: jenkinsci/hackfest
+  gitter: jenkinsci_hackfest:gitter.im
 opengraph:
   image: /images/post-images/jenkins-is-the-way/jenkins-is-the-way-hackfest-opengraph.png
 ---

--- a/content/blog/2020/05/2020-05-12-uiux-hackfest-announcement.adoc
+++ b/content/blog/2020/05/2020-05-12-uiux-hackfest-announcement.adoc
@@ -42,7 +42,7 @@ Everybody can spend as much time as they are willing to dedicate.
 Spending a few days or just a few hours is fine, any contributions matter regardless of their size.
 Jenkins development experience is not required,
 we have newcomer-friendly stories for those who want to start contributing to the project.
-We will also have a 24/7 link:https://gitter.im/jenkinsci/hackfest[jenkinsci/hackfest] Gitter chat for Q&A and coordination between contributors.
+We will also have a 24/7 link:https://app.gitter.im/#/room/#jenkinsci_hackfest:gitter.im[jenkinsci/hackfest] Gitter chat for Q&A and coordination between contributors.
 
 There will be link:/events/online-hackfest/2020-uiux/#tracks-and-project-ideas[3 main tracks]:
 
@@ -83,7 +83,7 @@ We would appreciate your response there!_
 
 Please use the following contacts to contact organizers:
 
-* link:https://gitter.im/jenkinsci/hackfest[Gitter chat]
+* link:https://app.gitter.im/#/room/#jenkinsci_hackfest:gitter.im[Gitter chat]
 * link:https://groups.google.com/forum/#!forum/jenkins-advocacy-and-outreach-sig[Mailing list]
 
 == Resources

--- a/content/blog/2020/06/2020-06-08-hackfest-docs-results.adoc
+++ b/content/blog/2020/06/2020-06-08-hackfest-docs-results.adoc
@@ -106,7 +106,7 @@ image:/images/post-images/2020-06-08-docs-from-hackfest/plugins-site.png[Plugins
 There is still much to do in Jenkins documentation and we need your help to do it.
 There are many ways to link:/participate/[participate] in the Jenkins project, including link:/participate/document[documentation].
 See the link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[contributing guidelines] for detailed instructions.
-Join the https://gitter.im/jenkinsci/docs[documentation chat] for personalized help and encouragement.
+Join the https://app.gitter.im/#/room/#jenkins/docs:matrix.org[documentation chat] for personalized help and encouragement.
 
 The Jenkins project has been also accepted to link:https://developers.google.com/season-of-docs[Google Season of Docs] this year.
 This open-source mentorship program brings together open source and technical writers communities for the benefit of both.

--- a/content/blog/2020/06/2020-06-08-hackfest-docs-results.adoc
+++ b/content/blog/2020/06/2020-06-08-hackfest-docs-results.adoc
@@ -11,7 +11,7 @@ authors:
 - markewaite
 - tracymiranda
 links:
-  gitter: jenkinsci/docs
+  gitter: jenkins/docs:matrix.org
 opengraph:
   image: /images/post-images/2020-06-08-docs-from-hackfest/docs-from-hackfest-opengraph.png
 ---

--- a/content/blog/2020/06/2020-06-26-ui-ux-hackfest-ui-track.adoc
+++ b/content/blog/2020/06/2020-06-26-ui-ux-hackfest-ui-track.adoc
@@ -10,7 +10,7 @@ tags:
 authors:
 - oleg_nenashev
 links:
-  gitter: jenkinsci/hackfest
+  gitter: jenkinsci_hackfest:gitter.im
 opengraph:
   image: /images/post-images/jenkins-is-the-way/uiux-hackfest-results/ui-opengraph.png
 ---

--- a/content/blog/2020/06/2020-06-27-external-fingerprint-storage.adoc
+++ b/content/blog/2020/06/2020-06-27-external-fingerprint-storage.adoc
@@ -147,7 +147,7 @@ Special thanks to link:https://github.com/oleg-nenashev[Oleg Nenashev], link:htt
 
 == Reaching Out
 
-Feel free to reach out to us for any questions, feedback, etc. on the project's link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list]
+Feel free to reach out to us for any questions, feedback, etc. on the project's link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list]
 
 We use Jenkins link:https://issues.jenkins.io/[Jira] to track issues.
 Feel free to file issues under `redis-fingerprint-storage-plugin` component.
@@ -159,5 +159,5 @@ Feel free to file issues under `redis-fingerprint-storage-plugin` component.
 * link:https://github.com/jenkinsci/redis-fingerprint-storage-plugin[Redis Fingerprint Storage Plugin]
 * link:https://issues.jenkins.io/browse/JENKINS-62344[Issue Tracker for Phase 1]
 * jep:226[]
-* link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel]
 * link:/projects/gsoc/2020/projects/external-fingerprint-storage/[Project Page]

--- a/content/blog/2020/06/2020-07-27-custom-distribution-service.adoc
+++ b/content/blog/2020/06/2020-07-27-custom-distribution-service.adoc
@@ -83,4 +83,4 @@ https://youtu.be/HQLhakpx5mk[Demo]
 
 === Feedback channel
 
-link:https://gitter.im/jenkinsci/jenkins-custom-distribution-service[Gitter Channel Link].
+link:https://app.gitter.im/#/room/#jenkinsci_jenkins-custom-distribution-service:gitter.im[Gitter Channel Link].

--- a/content/blog/2020/07/2020-07-08-winsw-yaml-support.adoc
+++ b/content/blog/2020/07/2020-07-08-winsw-yaml-support.adoc
@@ -190,6 +190,6 @@ Also, you can communicate with us in the WinSW Gitter channel, which is a great 
 
 * link:/projects/gsoc/2020/projects/winsw-yaml-configs[Project Page]
 * https://github.com/winsw/winsw[Project Repository]
-* https://gitter.im/winsw/winsw[Gitter Channel]
+* https://app.gitter.im/#/room/#winsw_winsw:gitter.im[Gitter Channel]
 * https://github.com/aaubry/YamlDotNet[YamlDotNet library]
 * https://github.com/commandlineparser/commandline[Command Line Parser library]

--- a/content/blog/2020/07/2020-07-09-git-performance-improvement-phase1.adoc
+++ b/content/blog/2020/07/2020-07-09-git-performance-improvement-phase1.adoc
@@ -83,4 +83,4 @@ To help, you can
 * Review the benchmarks in the link:https://github.com/jenkinsci/git-client-plugin/tree/master/src/test/java/jmh/benchmark[benchmarks module]
 * Analyse the benchmarks results available on link:https://ci.jenkins.io/job/Plugins/job/git-client-plugin/job/master/[ci.jenkins.io] [soon]
 
-Come visit our Gitter channel: https://gitter.im/jenkinsci/git-plugin
+Come visit our Gitter channel: https://app.gitter.im/#/room/#jenkinsci_git-plugin:gitter.im

--- a/content/blog/2020/07/2020-07-09-github-checks-api-plugin-coding-phase-1.adoc
+++ b/content/blog/2020/07/2020-07-09-github-checks-api-plugin-coding-phase-1.adoc
@@ -108,7 +108,7 @@ After that, pipeline support will be added: users can publish checks directly in
 
 * link:https://github.com/jenkinsci/checks-api-plugin[GitHub Repository]
 * link:/projects/gsoc/2020/projects/github-checks/[Project Page]
-* link:https://gitter.im/jenkinsci/github-checks-api[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_github-checks-api:gitter.im[Gitter Channel]
 
 == References
 

--- a/content/blog/2020/07/2020-07-23-windows-support-updates.adoc
+++ b/content/blog/2020/07/2020-07-23-windows-support-updates.adoc
@@ -166,4 +166,4 @@ link:/blog/2020/07/08/winsw-yaml-support/[Coding Phase 1 Report].
 In addition to that, there is ongoing work on a new link:https://github.com/winsw/winsw/tree/v3[Windows Service Wrapper 3.0] release which will redesign CLI and introduce a lot more improvements.
 If you are interested in contributing to Windows Service Wrapper,
 see the guidelines link:https://github.com/winsw/winsw/blob/master/CONTRIBUTING.md[here].
-We will also appreciate your feedback on the link:https://gitter.im/winsw/winsw[WinSW Gitter channel].
+We will also appreciate your feedback on the link:https://app.gitter.im/#/room/#winsw_winsw:gitter.im[WinSW Gitter channel].

--- a/content/blog/2020/07/2020-07-24-external-fingerprint-storage-phase-2.adoc
+++ b/content/blog/2020/07/2020-07-24-external-fingerprint-storage-phase-2.adoc
@@ -149,7 +149,7 @@ by PostgreSQL), tracing, etc.
 
 == Reaching Out
 
-Feel free to reach out to us for any questions, feedback, etc. on the project's link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins
+Feel free to reach out to us for any questions, feedback, etc. on the project's link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins
 Developer Mailing list].
 We use Jenkins link:https://issues.jenkins.io/[Jira] to track issues.
 Feel free to file issues under `redis-fingerprint-storage-plugin` component.
@@ -159,6 +159,6 @@ Feel free to file issues under `redis-fingerprint-storage-plugin` component.
 * link:https://github.com/jenkinsci/redis-fingerprint-storage-plugin[Redis Fingerprint Storage Plugin]
 * link:https://issues.jenkins.io/browse/JENKINS-62754[Issue Tracker for Phase 2]
 * jep:226[]
-* link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel]
 * link:/projects/gsoc/2020/projects/external-fingerprint-storage/[Project Page]
 * link:/blog/2020/06/27/external-fingerprint-storage/[Phase 1 Blog Post]

--- a/content/blog/2020/07/2020-07-29-git-performance-improvement-phase2.adoc
+++ b/content/blog/2020/07/2020-07-29-git-performance-improvement-phase2.adoc
@@ -96,7 +96,7 @@ In phase three, we wish to:
 
 == Reaching Out
 
-Feel free to reach out to us for any questions or feedback on the project's link:https://gitter.im/jenkinsci/git-plugin[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins
+Feel free to reach out to us for any questions or feedback on the project's link:https://app.gitter.im/#/room/#jenkinsci_git-plugin:gitter.im[Gitter Channel] or the mailto:jenkinsci-dev@googlegroups.com[Jenkins
 Developer Mailing list].
 
 * link:/projects/gsoc/2020/projects/git-plugin-performance/[Project Page]

--- a/content/blog/2020/08/2020-08-03-github-checks-api-plugin-coding-phase-2.adoc
+++ b/content/blog/2020/08/2020-08-03-github-checks-api-plugin-coding-phase-2.adoc
@@ -143,4 +143,4 @@ Lastly, it is exciting to inform that we are currently making the checks feature
 * link:https://github.com/jenkinsci/checks-api-plugin[Checks API Plugin]
 * link:https://github.com/jenkinsci/github-checks-plugin[GitHub Checks Plugin]
 * link:/projects/gsoc/2020/projects/github-checks/[Project Page]
-* link:https://gitter.im/jenkinsci/github-checks-api[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_github-checks-api:gitter.im[Gitter Channel]

--- a/content/blog/2020/08/2020-08-09-custom-distribution-service-phase-2.adoc
+++ b/content/blog/2020/08/2020-08-09-custom-distribution-service-phase-2.adoc
@@ -128,7 +128,7 @@ For details, see:
 This feature has however been put on the back-burner for now because
 we are focusing on getting the project to be self hosted and therefore
 would like to implement this once we have a clear path for the project to be hosted by the jenkins-infra team.If you would like to participate in the discussion here are the links for the pull requests,
-link:https://github.com/jenkinsci/custom-distribution-service/pull/72[PR 1] and link: https://github.com/jenkinsci/custom-distribution-service/pull/66[PR 2], or you can even jump in our link:https://gitter.im/jenkinsci/jenkins-custom-distribution-service[gitter channel].
+link:https://github.com/jenkinsci/custom-distribution-service/pull/72[PR 1] and link: https://github.com/jenkinsci/custom-distribution-service/pull/66[PR 2], or you can even jump in our link:https://app.gitter.im/#/room/#jenkinsci_jenkins-custom-distribution-service:gitter.im[gitter channel].
 
 If you have been following my posts,
 I mentioned in my second week blog post that pulling in the json file consisting of more than
@@ -193,7 +193,7 @@ For details, see:
 
 === Other links
 
-https://gitter.im/jenkinsci/jenkins-custom-distribution-service[Gitter Channel Link] +
+https://app.gitter.im/#/room/#jenkinsci_jenkins-custom-distribution-service:gitter.im[Gitter Channel Link] +
 https://docs.google.com/document/d/1C7VQJ92Yhr0KRDcNVHYxn4ri7OL9IGZmgxY6UFON6-g/edit?usp=sharing[GSoC Proposal] +
 https://docs.google.com/document/d/1-ujWVJ2a5VYkUF6UA7m4bEpSDxmb3mJZhCbmoKO716U/edit?usp=sharing[Design Document] +
 https://docs.google.com/document/d/1DSCH-3wh6uV9Rm_j8PcBzq2lvQPhZ31AIwmWkEaLxvc/edit?usp=sharing[Daily Notes] +

--- a/content/blog/2020/08/2020-08-25-external-fingerprint-storage-phase-3.adoc
+++ b/content/blog/2020/08/2020-08-25-external-fingerprint-storage-phase-3.adoc
@@ -205,7 +205,7 @@ fingerprint storage, as mentioned in the previous section, and we welcome everyb
 == Reaching Out
 
 Feel free to reach out to us for any questions, feedback, etc. on the project's
-link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel] or the
+link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel] or the
 mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list].
 We use Jenkins link:https://issues.jenkins.io/[Jira] to track issues.
 Feel free to file issues under either the `postgresql-fingerprint-storage-plugin` or the
@@ -218,5 +218,5 @@ Feel free to file issues under either the `postgresql-fingerprint-storage-plugin
 * link:https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin[PostgreSQL Fingerprint Storage Plugin]
 * link:https://github.com/jenkinsci/redis-fingerprint-storage-plugin[Redis Fingerprint Storage Plugin]
 * jep:226[]
-* link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel]
 * link:/projects/gsoc/2020/projects/external-fingerprint-storage/[Project Page]

--- a/content/blog/2020/08/2020-08-27-winsw-yaml-support.adoc
+++ b/content/blog/2020/08/2020-08-27-winsw-yaml-support.adoc
@@ -159,7 +159,7 @@ I have started working on this feature and you can find the implementation in th
 == How to contribute
 
 You can find the GitHub repository in this https://github.com/winsw/winsw[link]. 
-Issues and Pull requests are always welcome. Also, you can communicate with us in the https://gitter.im/winsw/winsw[WinSW Gitter] channel, 
+Issues and Pull requests are always welcome. Also, you can communicate with us in the https://app.gitter.im/#/room/#winsw_winsw:gitter.im[WinSW Gitter] channel,
 which is a great way to get in touch and there are project sync up meetings every Tuesday at 13:30 UTC on the Gitter channel.
 
 == Some useful links
@@ -168,6 +168,6 @@ which is a great way to get in touch and there are project sync up meetings ever
 * link:/projects/gsoc/2020/projects/winsw-yaml-configs[Project Page]
 * https://github.com/winsw/winsw[Project Repository]
 * https://github.com/winsw/winsw/releases[Feature preview]
-* https://gitter.im/winsw/winsw[Gitter Channel]
+* https://app.gitter.im/#/room/#winsw_winsw:gitter.im[Gitter Channel]
 * https://github.com/aaubry/YamlDotNet[YamlDotNet library]
 * https://github.com/commandlineparser/commandline[Command Line Parser library]

--- a/content/blog/2020/08/2020-08-29-git-performance-improvement-phase3.adoc
+++ b/content/blog/2020/08/2020-08-29-git-performance-improvement-phase3.adoc
@@ -120,7 +120,7 @@ The reason for this change is the fact that `JGit` performs better than `command
 == Reaching out
 
 Feel free to reach out to us for any questions or feedback on the project's
-link:https://gitter.im/jenkinsci/git-plugin[Gitter Channel] or the
+link:https://app.gitter.im/#/room/#jenkinsci_git-plugin:gitter.im[Gitter Channel] or the
 mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list].
 Report an issue at Jenkins link:https://issues.jenkins.io/[Jira].
 

--- a/content/blog/2020/08/2020-08-31-custom-distribution-service.adoc
+++ b/content/blog/2020/08/2020-08-31-custom-distribution-service.adoc
@@ -229,7 +229,7 @@ of code added is not an indication of work done, however 800 lines of Code added
 
 === Other links
 
-https://gitter.im/jenkinsci/jenkins-custom-distribution-service[Gitter Channel Link] +
+https://app.gitter.im/#/room/#jenkinsci_jenkins-custom-distribution-service:gitter.im[Gitter Channel Link] +
 https://docs.google.com/document/d/1C7VQJ92Yhr0KRDcNVHYxn4ri7OL9IGZmgxY6UFON6-g/edit?usp=sharing[GSoC Proposal] +
 https://docs.google.com/document/d/1-ujWVJ2a5VYkUF6UA7m4bEpSDxmb3mJZhCbmoKO716U/edit?usp=sharing[Design Document] +
 https://docs.google.com/document/d/1DSCH-3wh6uV9Rm_j8PcBzq2lvQPhZ31AIwmWkEaLxvc/edit?usp=sharing[Daily Notes] +

--- a/content/blog/2020/08/2020-08-31-github-checks-api-plugin-coding-phase-3.adoc
+++ b/content/blog/2020/08/2020-08-31-github-checks-api-plugin-coding-phase-3.adoc
@@ -77,7 +77,7 @@ The whole link:/projects/gsoc/2020/projects/github-checks/[GitHub Checks API pro
 * link:https://github.com/jenkinsci/checks-api-plugin[Checks API Plugin]
 * link:https://github.com/jenkinsci/github-checks-plugin[GitHub Checks Plugin]
 * link:/projects/gsoc/2020/projects/github-checks/[Project Page]
-* link:https://gitter.im/jenkinsci/github-checks-api[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkinsci_github-checks-api:gitter.im[Gitter Channel]
 
 
 

--- a/content/blog/2020/09/2020-09-25-document-jenkins-on-kubernetes-introduction.adoc
+++ b/content/blog/2020/09/2020-09-25-document-jenkins-on-kubernetes-introduction.adoc
@@ -137,11 +137,11 @@ publishing a report of my experience as a participant in Season of Docs.
 Jenkins community is actively working towards improving its documentation to create a better 
 experience for Jenkins users and invites technical writers to join the community and contribute to the Jenkins on Kubernetes project.
 
-To contribute to the Jenkins on Kubernetes project, simply join the Jenkins documentation link:https://gitter.im/jenkinsci/docs[Gitter] channel and drop a message, 
+To contribute to the Jenkins on Kubernetes project, simply join the Jenkins documentation link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter] channel and drop a message,
 you can also find the Google season of docs office hour notes and recordings for Jenkins on Kubernetes link:https://docs.google.com/document/d/17cPLUrJ4Ul4Y8MREjDyfWBEN7PlnlrmPh6wuKMPFmPg/edit?usp=sharing[here]. 
 GSOD office hours take place twice a week on Mondays and Thursdays between 6pm GMT+1 and 7pm GMT+1, 
 if you would like to be part of these meetings, you can indicate interest in the Jenkins Documentation 
-link:https://gitter.im/jenkinsci/docs[Gitter] channel and we would be happy to have you.
+link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter] channel and we would be happy to have you.
 
 If you are also a newcomer and would like to contribute to Jenkins, documentation is a great place to contribute. 
 A lot of small patches can be done from the GitHub web interface even without cloning repositories locally. 
@@ -149,7 +149,7 @@ You can find some good first issues to get started with link:https://github.com/
 
 Find more information on contributing to Jenkins documentation link:/participate/document[here]. 
 If you have further questions about the Jenkins on Kubernetes project or contributing to Jenkins, 
-you can reach out on the Jenkins documentation link:https://gitter.im/jenkinsci/docs[Gitter] channel.
+you can reach out on the Jenkins documentation link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter] channel.
 
 ### **Additional Resources**
 

--- a/content/blog/2020/11/2020-11-05-installing-jenkins-on-kubernetes.adoc
+++ b/content/blog/2020/11/2020-11-05-installing-jenkins-on-kubernetes.adoc
@@ -46,9 +46,9 @@ With this chapter split into smaller sections, it’s neater, clearer and most i
 == Testing, Participating and Contributing
 
 The Jenkins Community invites the general public to try out these documentation updates and give feedback to help us further improve the documentation.
-If you have any feedback, suggestions, or would like to contribute to the Jenkins on Kubernetes project,  drop a message indicating your interest in the Jenkins documentation link:https://gitter.im/jenkinsci/docs[Gitter] channel.
+If you have any feedback, suggestions, or would like to contribute to the Jenkins on Kubernetes project,  drop a message indicating your interest in the Jenkins documentation link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter] channel.
 You can also find the Google season of docs office hour notes and recordings for Jenkins on Kubernetes link:https://docs.google.com/document/d/17cPLUrJ4Ul4Y8MREjDyfWBEN7PlnlrmPh6wuKMPFmPg/edit?usp=sharing[here].
-GSOD office hours take place twice a week on Mondays and Thursdays between 6 pm GMT+1 and 7 pm GMT+1, if you would like to be part of these meetings, you can indicate interest in the Jenkins Documentation link:https://gitter.im/jenkinsci/docs[Gitter] channel and we would be happy to have you.
+GSOD office hours take place twice a week on Mondays and Thursdays between 6 pm GMT+1 and 7 pm GMT+1, if you would like to be part of these meetings, you can indicate interest in the Jenkins Documentation link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter] channel and we would be happy to have you.
 
 == Additional Resources
 

--- a/content/blog/2020/12/2020-12-04-gsod-project-report.adoc
+++ b/content/blog/2020/12/2020-12-04-gsod-project-report.adoc
@@ -39,7 +39,7 @@ The goal of this project was to create a new Kubernetes Volume which would descr
 Find below an outline of my activities during the community bonding phase:
 
 * Setting up communication channels: meetings, mailings, chats: My mentors and I agreed on the right time and channel for communication due to time difference.
-We agreed to meet twice weekly, on Mondays and Thursdays at 7:00 PM GMT +1 and use Jenkins documentation link:https://gitter.im/jenkinsci/docs[gitter] channel for other communications.
+We agreed to meet twice weekly, on Mondays and Thursdays at 7:00 PM GMT +1 and use Jenkins documentation link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[gitter] channel for other communications.
 * Contacting Stakeholders and onboarding contributors: The project was  announced on social media and different Jenkins channels.
 I wrote a link:/blog/2020/09/25/document-jenkins-on-kubernetes-introduction/[blog post] to announce the project and created a link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/[project page] on Jenkins.io.
 * Knowledge transfer: I and my mentors planned knowledge sharing sessions and fixed tentative dates based on the availability of the trainers.
@@ -97,7 +97,7 @@ I also worked on creating a directory for Jenkins on kubernetes sample files in 
 This link:https://docs.google.com/spreadsheets/d/1Jvu9HkWmNycjMkGxUkgCQXhkgX4gzvTQsFn7i7c9NUA/edit?usp=sharing[spreadsheet] contains links to the published documentation on link:/[Jenkins.io].
 The link:https://docs.google.com/spreadsheets/d/1Jvu9HkWmNycjMkGxUkgCQXhkgX4gzvTQsFn7i7c9NUA/edit?usp=sharing[spreadsheet] also highlights the initial proposed tasks and the status of each of them.
 
-If you would like to contribute to the Jenkins on Kubernetes documentation, you can check out pending tasks link:https://docs.google.com/spreadsheets/d/1Jvu9HkWmNycjMkGxUkgCQXhkgX4gzvTQsFn7i7c9NUA/edit?usp=sharing[here] and reach out in the Jenkins documentation link:https://gitter.im/jenkinsci/docs[gitter] channel.
+If you would like to contribute to the Jenkins on Kubernetes documentation, you can check out pending tasks link:https://docs.google.com/spreadsheets/d/1Jvu9HkWmNycjMkGxUkgCQXhkgX4gzvTQsFn7i7c9NUA/edit?usp=sharing[here] and reach out in the Jenkins documentation link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[gitter] channel.
 
 
 ## Challenges

--- a/content/blog/2020/12/2020-12-16-call-for-mentors.adoc
+++ b/content/blog/2020/12/2020-12-16-call-for-mentors.adoc
@@ -74,4 +74,4 @@ about the 2019 in person Mentor Summit.
 GSoC is a fantastic program and the Jenkins project is happy to participate in GSoC again in 2021!
 
 For any question, you can find the GSoC Org Admins,
-mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter chat].
+mentors and participants on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG Gitter chat].

--- a/content/blog/2020/12/2020-12-16-call-for-mentors.adoc
+++ b/content/blog/2020/12/2020-12-16-call-for-mentors.adoc
@@ -9,7 +9,7 @@ tags:
 - developer
 author: marckk
 links:
-  gitter: jenkinsci/gsoc-sig
+  gitter: jenkinsci_gsoc-sig:gitter.im
   googlegroup: jenkins-gsoc-all-public
   sig: gsoc
 ---

--- a/content/blog/2021/03/2021-03-17-gsoc2021-announcement.adoc
+++ b/content/blog/2021/03/2021-03-17-gsoc2021-announcement.adoc
@@ -46,7 +46,7 @@ We encourage interested students to reach out to the Jenkins community early and
 All project ideas have chats and mailing lists referenced on their pages.
 We will be also organizing office hours for students,
 and you can use these meetings to meet org admins and mentors and to ask questions.
-Also, join our link:https://gitter.im/jenkinsci/gsoc-sig[Gitter channel]
+Also, join our link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Gitter channel]
 to receive information about such incoming events in the project.
 
 The application period starts on March 29th, but you can prepare now!

--- a/content/blog/2021/03/2021-03-19-SheCodeAfrica-announcement.adoc
+++ b/content/blog/2021/03/2021-03-19-SheCodeAfrica-announcement.adoc
@@ -56,5 +56,5 @@ The top 10 Pipeline plugins that have received the most feedback are:
 
 == What about my plugin?
 
-If you are a plugin maintainer and would like help to add examples and online help for the Pipeline steps in your plugin, let us know in the link:https://gitter.im/jenkinsci/docs[jenkinsci/docs gitter channel].
+If you are a plugin maintainer and would like help to add examples and online help for the Pipeline steps in your plugin, let us know in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[jenkinsci/docs gitter channel].
 We'll consider including additional plugins as we better understand the development pace for She Code Africa participants.

--- a/content/blog/2021/06/2021-06-17-libera-chat.adoc
+++ b/content/blog/2021/06/2021-06-17-libera-chat.adoc
@@ -47,7 +47,7 @@ Most notable channels:
 
 * `#jenkins-meeting` - the link:/project/governance-meeting/[Jenkins Governance Meeting] uses combination of Zoom and Google Docs at the moment. We do not longer use the IRC chat for that purpose.
 * `#jenkins-cert` - no private chat going forward. The link:/security[Security Team] will use mailing lists only going forward
-* `#jenkins-community` - Replaced by the link:https://gitter.im/jenkinsci/advocacy-and-outreach-sig[Advocacy&Outreach] Gitter channel.
+* `#jenkins-community` - Replaced by the link:https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im[Advocacy&Outreach] Gitter channel.
 
 === Freenode concerns and disclaimers
 

--- a/content/blog/2021/07/2021-07-30-introducing-conventional-commits-plugin-for-jenkins.adoc
+++ b/content/blog/2021/07/2021-07-30-introducing-conventional-commits-plugin-for-jenkins.adoc
@@ -12,7 +12,7 @@ opengraph:
   image: /images/gsoc/2021/conventional-commits/conventionalCommitsPluginForJenkins.png
 links:
   discourse: https://community.jenkins.io/t/introducing-the-conventional-commits-plugin/272
-  gitter: https://gitter.im/jenkinsci/conventional-commits-plugin
+  gitter: https://app.gitter.im/#/room/#jenkinsci_conventional-commits-plugin:gitter.im
 ---
 
 image:/images/gsoc/2021/conventional-commits/conventionalCommitsPluginForJenkins.png[GSoC, height=420, role=center, float=center]
@@ -171,4 +171,4 @@ video::_D0hiA1Cgz8[youtube,width=800,height=420,start=3219]
 
 We would love to hear your feedback & suggestions for the plugin.
 
-Please reach out on the plugin's link:https://github.com/jenkinsci/conventional-commits-plugin[GitHub] repository, the link:https://gitter.im/jenkinsci/conventional-commits-plugin[Gitter] channel or start a discussion on link:https://community.jenkins.io[community.jenkins.io].
+Please reach out on the plugin's link:https://github.com/jenkinsci/conventional-commits-plugin[GitHub] repository, the link:https://app.gitter.im/#/room/#jenkinsci_conventional-commits-plugin:gitter.im[Gitter] channel or start a discussion on link:https://community.jenkins.io[community.jenkins.io].

--- a/content/blog/2021/08/2021-08-28-conventional-commits-plugin-project-report.adoc
+++ b/content/blog/2021/08/2021-08-28-conventional-commits-plugin-project-report.adoc
@@ -14,7 +14,7 @@ opengraph:
   image: /images/gsoc/2021/conventional-commits/conventionalCommitsPluginForJenkins.png
 links:
   discourse: https://community.jenkins.io/t/introducing-the-conventional-commits-plugin/272
-  gitter: https://gitter.im/jenkinsci/conventional-commits-plugin
+  gitter: https://app.gitter.im/#/room/#jenkinsci_conventional-commits-plugin:gitter.im
 ---
 
 image:/images/gsoc/2021/conventional-commits/conventionalCommitsPluginForJenkins.png[GSoC, height=420, role=center, float=center]
@@ -86,4 +86,4 @@ Along with that, the plugin now can append "Pre-Release" and "Build Metadata" in
 
 We would love to hear your feedback & suggestions for the plugin.
 
-Please reach out on the plugin's link:https://github.com/jenkinsci/conventional-commits-plugin[GitHub] repository, the link:https://gitter.im/jenkinsci/conventional-commits-plugin[Gitter] channel or start a discussion on link:https://community.jenkins.io[community.jenkins.io].
+Please reach out on the plugin's link:https://github.com/jenkinsci/conventional-commits-plugin[GitHub] repository, the link:https://app.gitter.im/#/room/#jenkinsci_conventional-commits-plugin:gitter.im[Gitter] channel or start a discussion on link:https://community.jenkins.io[community.jenkins.io].

--- a/content/blog/2022/01/2022-01-07-gsoc-2022.adoc
+++ b/content/blog/2022/01/2022-01-07-gsoc-2022.adoc
@@ -71,4 +71,4 @@ Think about the projects that you’ve always wanted to do but never had the tim
 Mentoring is also an opportunity to improve your management and people skills, while giving back to the community.
 GSoC is a fantastic program and the Jenkins project is happy to participate in GSoC again in 2022!
 
-For any question, you can find the GSoC Org Admins, mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter] chat.
+For any question, you can find the GSoC Org Admins, mentors and participants on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG Gitter] chat.

--- a/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
+++ b/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
@@ -57,7 +57,7 @@ See the link:/projects/gsoc/students[Information for students] page for full app
 
 We encourage interested participants to reach out to the Jenkins community early and to start exploring project ideas.
 We also encourage participants to join the weekly link:https://docs.google.com/document/d/1OpvMWpzBKtKnYBAkhtQ1dK5zQix3D7RY5g3vDJXkSnc/edit?usp=sharing[Jenkins GSoC office hours], these meetings are set up for participants to meet org admins and mentors and to ask questions.
-Also, join our link:https://gitter.im/jenkinsci/gsoc-sig[Gitter channel] and our
+Also, join our link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Gitter channel] and our
 link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse server] 
 to receive information about such incoming events in the project.
 

--- a/content/blog/2022/07/2022-07-27-jenkins-contributor-summit-at-devops-world-2022-call-for-participation.adoc
+++ b/content/blog/2022/07/2022-07-27-jenkins-contributor-summit-at-devops-world-2022-call-for-participation.adoc
@@ -27,7 +27,7 @@ It is Free to attend. Sign up is required. Seats are limited. Conference registr
 image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://docs.google.com/forms/d/e/1FAIpQLSfg0t1iAlfyBU5GS9ihJy67gWTSIlr261NnqOGcc40nkrjb3w/viewform", role=center, height=48]
 
 == Call for Participation
-We invite anyone interested to join us in the planning, organization and/or speak at the contributor summit. Please reach out to us via link:https://gitter.im/jenkinsci/advocacy-and-outreach-sig[Gitter -Advocacy-and-Outreach SIG] and or join the discussion at link:https://community.jenkins.io[community.jenkins.io]. Please use the contributor-summit label. You can find all the related topics using the search query. link:https://community.jenkins.io/t/jenkins-contributor-summit-in-orlando-fl-on-september-27-2022-agenda-is-available/3104[Main Discussion Thread].
+We invite anyone interested to join us in the planning, organization and/or speak at the contributor summit. Please reach out to us via link:https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im[Gitter -Advocacy-and-Outreach SIG] and or join the discussion at link:https://community.jenkins.io[community.jenkins.io]. Please use the contributor-summit label. You can find all the related topics using the search query. link:https://community.jenkins.io/t/jenkins-contributor-summit-in-orlando-fl-on-september-27-2022-agenda-is-available/3104[Main Discussion Thread].
 
 == Proposed Agenda
 This is an initial draft of the agenda, additional input and participation is welcomed and appreciated.

--- a/content/blog/2022/08/2022-08-11-plugin-health-scoring.adoc
+++ b/content/blog/2022/08/2022-08-11-plugin-health-scoring.adoc
@@ -47,4 +47,4 @@ Whether you are the end user getting a more secure, stable, and quality plugin, 
 
 link:https://github.com/ryecb[Runxia Ye] and myself will be presenting this topic at this year's DevOps World 2022.
 Join us on Thursday, September 29th at 1:45 pm for this presentation where we will discuss in detail the ins and outs of this project and the benefits it will bring to the Jenkins community.
-We also welcome you to provide feedback on our project’s link:https://gitter.im/jenkinsci/GSoC-Plugin_Health_Score[Gitter channel] and follow the project on link:https://github.com/jenkins-infra/plugin-health-scoring[GitHub].
+We also welcome you to provide feedback on our project’s link:https://app.gitter.im/#/room/#jenkinsci_GSoC-Plugin_Health_Score:gitter.im[Gitter channel] and follow the project on link:https://github.com/jenkins-infra/plugin-health-scoring[GitHub].

--- a/content/blog/2022/10/2022-10-10-pipeline-steps-improvement-gsoc-report.adoc
+++ b/content/blog/2022/10/2022-10-10-pipeline-steps-improvement-gsoc-report.adoc
@@ -109,7 +109,7 @@ This can be done by manipulating the getPluginNameFromDescriptor method supplied
 
 == Acknowledgements and Insights
 
-I am grateful to my mentor, Kristin, and the community at link:https://gitter.im/jenkinsci/docs[docs-sig]. Their support was essential in making this project successful. I got consistent ideas and feedback from them throughout the project's tenure. 
+I am grateful to my mentor, Kristin, and the community at link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[docs-sig]. Their support was essential in making this project successful. I got consistent ideas and feedback from them throughout the project's tenure.
 Here are some tips for new contributors who wish to participate in GSoC at Jenkins.
 
 * Make sure you ask your queries in the right channel. This will maximize the chances of an accurate and fast reply.

--- a/content/blog/2022/10/2022-10-10-plugin-health-scoring-system-report.adoc
+++ b/content/blog/2022/10/2022-10-10-plugin-health-scoring-system-report.adoc
@@ -14,7 +14,7 @@ description: >
 opengraph:
   image: /images/gsoc/2022/plugin-health-score/introducing-the-plugin-health-scoring-system.png
 links:
-  gitter: https://gitter.im/jenkinsci/GSoC-Plugin_Health_Score
+  gitter: https://app.gitter.im/#/room/#jenkinsci_GSoC-Plugin_Health_Score:gitter.im
 ---
 
 image::/images/gsoc/2022/plugin-health-score/introducing-the-plugin-health-scoring-system.png[GSoC, height=400, role=center, float=center]
@@ -128,6 +128,6 @@ video::fM2SMbppRxw[youtube,width=800,height=420,start=342]
 - link:https://github.com/jenkins-infra/plugin-health-scoring[GitHub repository]
 - link:https://docs.google.com/document/d/1Dxyli1LPlHdFxLoE9zFtr_3bTjnwQDMZGCxcGS79Z_I/edit[Architecture Diagram]
 - link:https://docs.google.com/document/d/1HTbcWh5C1KrCgEzgqeVEPyfr1H5fH5eTj8KpbWrWsSY/edit#heading=h.efprktbggbop[GSoC Proposal Document]
-- Use the link:https://gitter.im/jenkinsci/GSoC-Plugin_Health_Score[Gitter channel] or link:https://community.jenkins.io[community.jenkins.io] in case you have any question(s) or feedback.
+- Use the link:https://app.gitter.im/#/room/#jenkinsci_GSoC-Plugin_Health_Score:gitter.im[Gitter channel] or link:https://community.jenkins.io[community.jenkins.io] in case you have any question(s) or feedback.
 
 ---

--- a/content/blog/2022/10/2022-10-31-jenkins-google-summer-of-code-archive-2022.adoc
+++ b/content/blog/2022/10/2022-10-31-jenkins-google-summer-of-code-archive-2022.adoc
@@ -45,5 +45,5 @@ GSoC Organization admins in 2022: link:https://github.com/jmMeessen[Jean-Marc Me
 == Other materials
 * GSoC 2022 project ideas
 * Public communication channel: link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse].
-* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for real time topics related to Jenkins in GSoC.
+* link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real time topics related to Jenkins in GSoC.
 * link:/projects/gsoc/#previous-years[Previous years] GSoC.

--- a/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
+++ b/content/blog/2022/11/2022-11-16-gsoc-2023.adoc
@@ -56,4 +56,4 @@ Think about the projects that you’ve always wanted to do but never had the tim
 Mentoring is also an opportunity to improve your management and people skills, while giving back to the community.
 GSoC is a fantastic program and the Jenkins project is looking forward to participating in GSoC again in 2023!
 
-For any question, you can find the GSoC Org Admins, mentors and participants on the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC SIG Gitter] chat.
+For any question, you can find the GSoC Org Admins, mentors and participants on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG Gitter] chat.

--- a/content/blog/2022/12/2022-12-09-GSoC-the-gift-of-mentorship.adoc
+++ b/content/blog/2022/12/2022-12-09-GSoC-the-gift-of-mentorship.adoc
@@ -48,4 +48,4 @@ You know enough about the Jenkins code to guide the GSoC contributor on coding.
 * link:/projects/gsoc/mentors/[In depth information for mentors]
 
 We look forward to welcoming you as mentors to this rewarding program! 
-link:https://gitter.im/jenkinsci/gsoc-sig[Reach out to us on the GSoC SIG Gitter chat]. 
+link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Reach out to us on the GSoC SIG Gitter chat].

--- a/content/blog/2023/02/2023-02-01-gsoc-update.adoc
+++ b/content/blog/2023/02/2023-02-01-gsoc-update.adoc
@@ -39,7 +39,7 @@ Please carefully review the guidelines for a successful application on the link:
 
 In a nutshell, select a project idea and begin thinking about how you will build a proposal to convince the mentors that you are the best candidate to bring the project to a successful end.
 
-We will help you through the currently available channels such as link:https://community.jenkins.io/[the Community forum] and link:https://gitter.im/jenkinsci/gsoc-sig[Gitter], and also with weekly on-line link:/projects/gsoc/#office-hours[office-hours].
+We will help you through the currently available channels such as link:https://community.jenkins.io/[the Community forum] and link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Gitter], and also with weekly on-line link:/projects/gsoc/#office-hours[office-hours].
 During these meetings you can ask for any clarification, disambiguation, or precision on the project ideas or the GSoC program.
 These sessions will be recorded so that everyone can benefit from them.
 
@@ -52,7 +52,7 @@ Previous years' experience shows that proposals not submitted for the public dis
 This may be a new and uncomfortable way of approaching such candidatures for you, but it is the Open Source way Further discussion and review is rewarding and gives you the best chances to be selected.     
 
 Collaborate as much as you can, as it is the best way to have a strong and successful proposal. 
-Actively use the link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Community topic], the link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel], or the Office Hour sessions.
+Actively use the link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Community topic], the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel], or the Office Hour sessions.
 
 === Some useful preparation notes
 

--- a/content/chat.adoc
+++ b/content/chat.adoc
@@ -15,11 +15,11 @@ Other channels will be connected similarly as we move forward.
 The Jenkins community discusses various topics in multiple rooms on https://app.gitter.im/#/room/#jenkins-ci:matrix.org[Gitter].
 Various link:../sigs/[special interest groups] also use Gitter to meet, and you will find their rooms linked on the SIGs overview page.
 
-=== https://gitter.im/jenkinsci/jenkins[jenkinsci/jenkins]
+=== https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[jenkinsci/jenkins]
 
 General discussions about Jenkins.
 
-=== https://gitter.im/jenkinsci/newcomer-contributors[jenkinsci/newcomer-contributors]
+=== https://app.gitter.im/#/room/#jenkinsci_newcomer-contributors:gitter.im[jenkinsci/newcomer-contributors]
 
 Q&A channel for newcomer contributors to Jenkins.
 Use this channel if you are not sure where to ask, and other contributors will help you.

--- a/content/doc/administration/requirements/linux.adoc
+++ b/content/doc/administration/requirements/linux.adoc
@@ -67,7 +67,7 @@ a|
 You are welcome to propose PR's that add support for other Linux platforms or to share feedback;
 we will appreciate your contributions!
 Linux support in Jenkins is link:/sigs/platform/[Platform Special Interest Group]
-which has a link:https://gitter.im/jenkinsci/platform-sig[chat], a link:https://community.jenkins.io/[forum]., and link:/sigs/platform/#meetings[regular meetings].
+which has a link:https://app.gitter.im/#/room/#jenkinsci_platform-sig:gitter.im[chat], a link:https://community.jenkins.io/[forum]., and link:/sigs/platform/#meetings[regular meetings].
 You are welcome to join these channels.
 
 == Version history

--- a/content/doc/administration/requirements/servlet-containers.adoc
+++ b/content/doc/administration/requirements/servlet-containers.adoc
@@ -63,5 +63,5 @@ a|
 You are welcome to propose PRs that add support or documentation for other servlet containers or to share feedback;
 we will appreciate your contributions!
 Servlet container support in Jenkins falls under the link:/sigs/platform/[Platform Special Interest Group]
-which has a link:https://gitter.im/jenkinsci/platform-sig[chat], a link:https://community.jenkins.io/[forum]., and link:/sigs/platform/#meetings[regular meetings].
+which has a link:https://app.gitter.im/#/room/#jenkinsci_platform-sig:gitter.im[chat], a link:https://community.jenkins.io/[forum]., and link:/sigs/platform/#meetings[regular meetings].
 You are welcome to join these channels.

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -167,7 +167,7 @@ The source code can be found on Github:
 As the development of Blue Ocean has frozen, we do not anticipate or expect any new contributions made to its codebase for new features.
 However, there are still a few ways you can join the community:
 
-. Chat with the community and development team on Gitter image:https://badges.gitter.im/jenkinsci/blueocean-plugin.svg[link="https://gitter.im/jenkinsci/blueocean-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"]
+. Chat with the community and development team on Gitter image:https://badges.gitter.im/jenkinsci/blueocean-plugin.svg[link="https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im"]
 . Request features or report bugs against the link:https://issues.jenkins.io/[`blueocean-plugin` component in JIRA].
 . Subscribe and ask questions on the link:https://groups.google.com/forum/#!forum/jenkinsci-users[Jenkins Users mailing list].
 . Developer? We've link:https://issues.jenkins.io/issues/?filter=16142[labeled a few issues] that are great for anyone wanting to get started developing Blue Ocean.

--- a/content/doc/book/installing/offline.adoc
+++ b/content/doc/book/installing/offline.adoc
@@ -30,7 +30,7 @@ It downloads user specified plugins and all dependencies of the user specified p
 The link:https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool] also reports available plugin updates and plugin security warnings.
 It is included in the official link:https://github.com/jenkinsci/docker/blob/master/README.md#plugin-installation-manager-cli-preview[Jenkins Docker images].
 It is also used to install plugins as part of the link:/doc/book/installing/docker/[Docker install instructions].
-Refer to the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[Gitter chat channel] for questions and answers
+Refer to the link:https://app.gitter.im/#/room/#jenkinsci_plugin-installation-manager-cli-tool:gitter.im[Gitter chat channel] for questions and answers
 
 If you want to transfer the individual plugins, you'll need to retrieve
 all dependencies as well. There are several dependency retrieval scripts and tools

--- a/content/doc/developer/blueocean-plugin-development/index.adoc
+++ b/content/doc/developer/blueocean-plugin-development/index.adoc
@@ -24,7 +24,7 @@ As Blue Ocean is still new, the extensibility aspects of JavaScript development 
 
 If you wish to make a plugin for blue ocean, some starting points: 
 
-* Introduce yourself to the https://gitter.im/jenkinsci/blueocean-plugin[gitter chat room]. This is often the best place to start. There are many people there to help you get going. 
+* Introduce yourself to the https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[gitter chat room]. This is often the best place to start. There are many people there to help you get going.
 * Contact the https://groups.google.com/forum/#!forum/jenkinsci-ux[jenkins-ux mailing list] (things move fast, ask someone for help)
 * Read the https://github.com/jenkinsci/blueocean-plugin#building-plugins-for-blue-ocean[README] with pointers on plugin development
 * Get familiar with regular Jenkins plugin development (at least a very simple plugin)

--- a/content/doc/developer/crowdin/troubleshooting.adoc
+++ b/content/doc/developer/crowdin/troubleshooting.adoc
@@ -28,5 +28,5 @@ The default workflow runs once every 24 hours. To sync your project manually, yo
 
 If there is a configuration issue, take a look at the workflow log. The crowdin action highlights issues like a wrong PAT, path to the source files, etc.
 
-If you need additional help to set up your project, you are welcome to ask on the link:https://community.jenkins.io/[community forums] or on link:https://gitter.im/jenkinsci/jenkins[gitter].
+If you need additional help to set up your project, you are welcome to ask on the link:https://community.jenkins.io/[community forums] or on link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[gitter].
 

--- a/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
+++ b/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
@@ -64,5 +64,5 @@ More information about Jelly tags provided by core to display icons can be found
 
 == I still need more help?
 
-Contact the link:/sigs/ux[UX sig] on link:https://gitter.im/jenkinsci/ux-sig[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[mailing list].
+Contact the link:/sigs/ux[UX sig] on link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[mailing list].
 

--- a/content/doc/developer/views/table-to-div-migration.adoc
+++ b/content/doc/developer/views/table-to-div-migration.adoc
@@ -134,4 +134,4 @@ def blockWrapper(Closure closure) {
 
 == I still need more help?
 
-Contact the link:/sigs/ux[UX sig] on link:https://gitter.im/jenkinsci/ux-sig[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-ux[mailing list].
+Contact the link:/sigs/ux[UX sig] on link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-ux[mailing list].

--- a/content/events/fosdem/archive/2016.adoc
+++ b/content/events/fosdem/archive/2016.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  jenkinsci_fosdem:gitter.im
+  gitter: jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2016.adoc
+++ b/content/events/fosdem/archive/2016.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  gitter: jenkinsci/fosdem
+  jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  jenkinsci_fosdem:gitter.im
+  gitter: jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2017.adoc
+++ b/content/events/fosdem/archive/2017.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  gitter: jenkinsci/fosdem
+  jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  jenkinsci_fosdem:gitter.im
+  gitter: jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2018.adoc
+++ b/content/events/fosdem/archive/2018.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  gitter: jenkinsci/fosdem
+  jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  jenkinsci_fosdem:gitter.im
+  gitter: jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2019.adoc
+++ b/content/events/fosdem/archive/2019.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  gitter: jenkinsci/fosdem
+  jenkinsci_fosdem:gitter.im
 ---
 
 NOTE: This is an archive page. See link:/events/fosdem[this page] for the recent and incoming FOSDEM events.

--- a/content/events/fosdem/archive/2020.adoc
+++ b/content/events/fosdem/archive/2020.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  gitter: jenkinsci/fosdem
+  gitter: jenkinsci_fosdem:gitter.im
 ---
 
 Jenkins project has participated in FOSDEM 2020.

--- a/content/events/fosdem/index.adoc
+++ b/content/events/fosdem/index.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  gitter: jenkinsci/fosdem
+  jenkinsci_fosdem:gitter.im
 ---
 
 link:https://fosdem.org/[FOSDEM] is a regular event for open-source projects developers and users.

--- a/content/events/fosdem/index.adoc
+++ b/content/events/fosdem/index.adoc
@@ -8,7 +8,7 @@ tags:
   - events
   - fosdem
 links:
-  jenkinsci_fosdem:gitter.im
+  gitter: jenkinsci_fosdem:gitter.im
 ---
 
 link:https://fosdem.org/[FOSDEM] is a regular event for open-source projects developers and users.

--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -36,7 +36,7 @@ See the link:/participate/[Contribute and Participate] page for more information
 == Quick start
 
 1. Sign-up to Hacktoberfest on link:https://hacktoberfest.com[the event website].
-2. Join link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter channel].
+2. Join link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[our Gitter channel].
 3. Everything is set, just start creating pull-requests!
 ** If a repository has no `hacktoberfest` topic set, contact the maintainers to see if they are willing to accecpt a contribution.
 
@@ -88,7 +88,7 @@ who have committed to assist contributors and to provide quick turnaround in pul
   Additionally, we invite new and experienced Jenkins developers to help improve the link:/doc/developer/[developer documentation].
   If you want to learn a Jenkins development topic and share your new knowledge with others, or want to help someone else learn, you're welcome to contribute here.
 
-  link:https://github.com/jenkins-infra/jenkins.io/projects/3[Board], https://gitter.im/jenkinsci/docs[chat]
+  link:https://github.com/jenkins-infra/jenkins.io/projects/3[Board], https://app.gitter.im/#/room/#jenkins/docs:matrix.org[chat]
 
 | link:https://github.com/jenkinsci/jenkins[Jenkins Core]
 | Java, +
@@ -103,7 +103,7 @@ LESS
   and add new features there.
 
   link:https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md[Contributing],
-  link:https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newcomer-friendly issues], https://gitter.im/jenkinsci/jenkins[chat]
+  link:https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20in%20(newbie-friendly)%20AND%20component%20in%20(core)[newcomer-friendly issues], https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[chat]
 
 | link:http://plugins.jenkins.io/[Jenkins Plugin Site]
 | Javascript, Java, React, Gatsby
@@ -261,7 +261,7 @@ See link:/events/hacktoberfest/faq[Hacktoberfest in Jenkins FAQ].
 
 == Contact us
 
-* Gitter: link:https://gitter.im/jenkinsci/hacktoberfest[jenkinsci/hacktoberfest]
+* Gitter: link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[jenkinsci/hacktoberfest]
 * GitHub: link:https://github.com/orgs/jenkinsci/teams/hacktoberfest[@jenkinsci/hacktoberfest], link:https://github.com/orgs/jenkins-infra/teams/hacktoberfest[@jenkins-infra/hacktoberfest]
 
 == Previous years

--- a/content/events/hacktoberfest/event-kit.adoc
+++ b/content/events/hacktoberfest/event-kit.adoc
@@ -36,7 +36,7 @@ Evening events could follow the recommended JAM schedule,
 but it is also possible to organize a full-day event.
 
 If you are not a meetup organizer but want to host a meetup,
-please ping us in link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter channel] so that we can help with reaching out to meetup organizers.
+please ping us in link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[our Gitter channel] so that we can help with reaching out to meetup organizers.
 
 Steps:
 

--- a/content/events/hacktoberfest/event-kit.adoc
+++ b/content/events/hacktoberfest/event-kit.adoc
@@ -10,7 +10,7 @@ tags:
   - programs
   - hacktoberfest
 links:
-  gitter: jenkinsci/hacktoberfest
+  gitter: jenkinsci_hacktoberfest:gitter.im
   discourse: https://community.jenkins.io/t/hacktoberfest-2022/3805
 opengraph:
   image: /images/hacktoberfest/2020_social.png

--- a/content/events/hacktoberfest/faq.adoc
+++ b/content/events/hacktoberfest/faq.adoc
@@ -9,7 +9,7 @@ tags:
   - programs
   - hacktoberfest
 links:
-  gitter: jenkinsci/hacktoberfest
+  gitter: jenkinsci_hacktoberfest:gitter.im
   discourse: https://community.jenkins.io/t/hacktoberfest-2022/3805
 opengraph:
   image: /images/hacktoberfest/hacktoberfest_2022_social.png

--- a/content/events/hacktoberfest/faq.adoc
+++ b/content/events/hacktoberfest/faq.adoc
@@ -45,7 +45,7 @@ We ask contributors to mark their pull requests so that we can help with having 
 ** link:https://github.com/search?q=org%3Ajenkinsci+org%3Ajenkins-infra+org%3Ajenkins-zh+topic%3Ahacktoberfest[List of repositories marked for Hacktoberfest]
 * If you are not a repository maintainer:
 .. Add "Hacktoberfest" to the beginning of your pull request title.
-.. Reference the pull request in link:https://gitter.im/jenkinsci/hacktoberfest[our Gitter chat].
+.. Reference the pull request in link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[our Gitter chat].
    We will contact maintainers to get the GitHub topic set.
 * If you are a repository maintainer, just add the `hacktoberfest` GitHub topic.
 
@@ -64,7 +64,7 @@ Here are some links which may help:
 * link:/participate/[Participate] - landing page for newcomer contributors
 * link:/blog/2017/08/07/intro-to-plugin-development/[Plugin Development Tutorials]
 * link:/doc/developer/[Developer Documentation]
-* link:https://gitter.im/jenkinsci/hacktoberfest[Gitter channel] for Q&A
+* link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[Gitter channel] for Q&A
 
 Suggested project ideas also have their own documentation to help newcomers.
 
@@ -73,13 +73,13 @@ Suggested project ideas also have their own documentation to help newcomers.
 All featured projects are monitored by their maintainers,
 and you will likely get a review within a few days.
 Reviews in other repositories and plugins may take longer.
-In case of delays, ping us in the link:https://gitter.im/jenkinsci/hacktoberfest[hacktoberfest] channel in Gitter.
+In case of delays, ping us in the link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[hacktoberfest] channel in Gitter.
 Unmerged pull-requests also count in Hacktoberfest,
 so merge delays won't block you from getting prizes.
 
 === I am stuck. How do I get help?
 
-* For general questions (process and general direction) use our link:https://gitter.im/jenkinsci/hacktoberfest[Hacktoberfest Gitter channel]
+* For general questions (process and general direction) use our link:https://app.gitter.im/#/room/#jenkinsci_hacktoberfest:gitter.im[Hacktoberfest Gitter channel]
 * You can also use other link:/chat[chats] or
 link:/mailing-lists/[mailing lists].
 Many subprojects also have their own chats, and we encourage using them if you want to reach out to the wider community.

--- a/content/events/online-hackfest/2020-uiux/faq.adoc
+++ b/content/events/online-hackfest/2020-uiux/faq.adoc
@@ -9,7 +9,7 @@ tags:
   - community
   - ux
 links:
-  gitter: jenkinsci/hackfest
+  gitter: jenkinsci_hackfest:gitter.im
 opengraph:
   image: /images/post-images/jenkins-is-the-way/jenkins-is-the-way-hackfest-opengraph.png
 ---

--- a/content/events/online-hackfest/2020-uiux/faq.adoc
+++ b/content/events/online-hackfest/2020-uiux/faq.adoc
@@ -15,7 +15,7 @@ opengraph:
 ---
 
 This page contains answers to some common questions we get during online hackfests.
-If you do not see an answer to your question, please ask in link:https://gitter.im/jenkinsci/hackfest[our Gitter chat].
+If you do not see an answer to your question, please ask in link:https://app.gitter.im/#/room/#jenkinsci_hackfest:gitter.im[our Gitter chat].
 
 link:/events/online-hackfest/2020-uiux/[> Back to the event page]
 

--- a/content/events/online-hackfest/2020-uiux/index.adoc
+++ b/content/events/online-hackfest/2020-uiux/index.adoc
@@ -57,7 +57,7 @@ At the end of the event we will be inviting participants to join our demo sessio
 == Getting started
 
 1. link:https://forms.gle/MrkASJagxNvdXBbdA[Register to the event] if you have not done it already.
-2. Join link:https://gitter.im/jenkinsci/hackfest[our Gitter channel].
+2. Join link:https://app.gitter.im/#/room/#jenkinsci_hackfest:gitter.im[our Gitter channel].
    We will use it for Q&A and discussions during the event.
 3. Join the link:https://www.meetup.com/Jenkins-online-meetup/events/270644129/[kick-off meeting] (May 25, 1PM UTC) or watch the first 20 minutes of the recording.
    If you want to start early, we will also have a small opening session at 8AM UTC.
@@ -83,7 +83,7 @@ You can find full guidelines link:https://github.com/jenkinsci/ui-ux-hackfest-20
 
 Here are the following communication channels at your disposal:
 
-* Chat: link:https://gitter.im/jenkinsci/hackfest[UI/UX Hackfest channel] in Gitter
+* Chat: link:https://app.gitter.im/#/room/#jenkinsci_hackfest:gitter.im[UI/UX Hackfest channel] in Gitter
 * Mailing lists:
   link:https://groups.google.com/d/forum/jenkinsci-ux[User Experience],
   link:https://groups.google.com/d/forum/jenkinsci-docs[Documentation],

--- a/content/events/online-hackfest/2020-uiux/index.adoc
+++ b/content/events/online-hackfest/2020-uiux/index.adoc
@@ -12,7 +12,7 @@ tags:
   - community
   - jenkins-is-the-way
 links:
-  gitter: jenkinsci/hackfest
+  gitter: jenkinsci_hackfest:gitter.im
 opengraph:
   image: /images/post-images/jenkins-is-the-way/jenkins-is-the-way-hackfest-opengraph.png
 ---

--- a/content/participate/document.adoc
+++ b/content/participate/document.adoc
@@ -14,7 +14,7 @@ Jenkins has lots of documentation, and we appreciate any contributions to it:
 new docs, design and styling, copy-editing, reviews, etc.
 
 We coordinate and discuss documentation efforts in the link:/sigs/docs[Documentation Special Interest Group].
-You can reach out to us in the mailing list or on link:https://gitter.im/jenkinsci/docs[Gitter], and you can also join our link:/sigs/docs/#meetings[regular meetings].
+You can reach out to us in the mailing list or on link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter], and you can also join our link:/sigs/docs/#meetings[regular meetings].
 See the contacts on the right sidebar.
 
 == Where to find documentation?

--- a/content/participate/index.html.haml
+++ b/content/participate/index.html.haml
@@ -239,10 +239,10 @@ description: >
   %b
     Help and feedback. 
   Please contact us in the 
-  %a{:href => 'https://gitter.im/jenkinsci/newcomer-contributors'}
+  %a{:href => 'https://app.gitter.im/#/room/#jenkinsci_newcomer-contributors:gitter.im'}
     Newcomer
   or
-  %a{:href => 'https://gitter.im/jenkinsci/advocacy-and-outreach-sig'}
+  %a{:href => 'https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im'}
     Advocacy and Outreach SIG
   channels if you have any questions about contributing to Jenkins.
   See the

--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -108,7 +108,7 @@ All link:/mailing-lists[mailing lists] hosted on Google Groups and other platfor
 ==== Chats
 
 * All chats documented on the link:/chat[this page], e.g. IRC channels: `#jenkins`, `#jenkins-meeting`, `#jenkins-infra`, etc.
-* Gitter channels within the link:https://app.gitter.im/#/room/#jenkins-ci:matrix.org[https://gitter.im/jenkinsci/] space
+* Gitter channels within the link:https://app.gitter.im/#/room/#jenkins-ci:matrix.org[jenkinsci] space
 * Jenkins chats hosted by Linux Foundation and its subsidiaries including Continuous Delivery Foundation 
 
 ==== Events

--- a/content/projects/blueocean/contribute/index.adoc
+++ b/content/projects/blueocean/contribute/index.adoc
@@ -17,7 +17,7 @@ image:/images/sunnyblueocean.png["Blue Ocean", role=right]
 
 Have a good idea for how Blue Ocean can be improved? There a few ways you can join the community and contribute to the project:
 
-* Chat with the community team link:https://gitter.im/jenkinsci/blueocean-plugin[on Gitter].
+* Chat with the community team link:https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[on Gitter].
 * Request features or report bugs against the link:https://issues.jenkins.io/[blueocean-plugin component in JIRA].
 * Subscribe and ask questions on the link:https://groups.google.com/forum/#!forum/jenkinsci-users[Jenkins Users mailing list].
 * Developer? We’ve link:https://issues.jenkins.io/issues/?filter=16142[labeled a few issues] that are great for anyone wanting to get started developing Blue Ocean. Don’t forget to drop by the Gitter chat and introduce yourself!

--- a/content/projects/gsoc/2018/code-coverage-api-plugin.adoc
+++ b/content/projects/gsoc/2018/code-coverage-api-plugin.adoc
@@ -11,7 +11,7 @@ mentors:
 - "jeffpearce"
 - "oleg_nenashev"
 links:
-  gitter: "jenkinsci/code-coverage-api-plugin"
+  gitter: "jenkinsci_code-coverage-api-plugin:gitter.im"
   github: "jenkinsci/code-coverage-api-plugin"
 ---
 

--- a/content/projects/gsoc/2018/eda-plugins.adoc
+++ b/content/projects/gsoc/2018/eda-plugins.adoc
@@ -9,7 +9,7 @@ mentors:
 - "martinda"
 - "oleg_nenashev"
 links:
-  gitter: "jenkinsci/hw-and-eda-sig"
+  gitter: "jenkinsci_hw-and-eda-sig:gitter.im"
 ---
 
 This project will enable Jenkins to be used as a CI platform for ASIC/FPGA designs.

--- a/content/projects/gsoc/2018/remoting-over-message-bus.adoc
+++ b/content/projects/gsoc/2018/remoting-over-message-bus.adoc
@@ -10,7 +10,7 @@ mentors:
 - "oleg_nenashev"
 - "supun94"
 links:
-  gitter: "jenkinsci/remoting"
+  gitter: "jenkinsci_remoting:gitter.im"
   github: "jenkinsci/remoting-kafka-plugin"
 ---
 

--- a/content/projects/gsoc/2018/remoting-over-message-bus.adoc
+++ b/content/projects/gsoc/2018/remoting-over-message-bus.adoc
@@ -132,7 +132,7 @@ Features in the demo:
 ++++
 
 === Useful Links
-* https://gitter.im/jenkinsci/remoting[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
+* https://app.gitter.im/#/room/#jenkinsci_remoting:gitter.im[image:https://badges.gitter.im/jenkinsci/remoting.svg[title: "Gitter"]]
 * https://github.com/jenkinsci/remoting-kafka-plugin[GitHub Repository]
 * https://wiki.jenkins.io/display/JENKINS/Remoting+Kafka+Plugin[Wiki]
 * https://plugins.jenkins.io/remoting-kafka[Plugin Site]

--- a/content/projects/gsoc/2018/simple-pull-request-job-plugin.adoc
+++ b/content/projects/gsoc/2018/simple-pull-request-job-plugin.adoc
@@ -10,7 +10,7 @@ mentors:
 - "jeff-knurek"
 - "martinda"
 links:
-  gitter: "jenkinsci/simple-pull-request-job-plugin"
+  gitter: "jenkinsci_simple-pull-request-job-plugin:gitter.im"
   github: "jenkinsci/simple-pull-request-job-plugin"
 ---
 

--- a/content/projects/gsoc/2018/simple-pull-request-job-plugin.adoc
+++ b/content/projects/gsoc/2018/simple-pull-request-job-plugin.adoc
@@ -109,6 +109,6 @@ to see it in your local time.
 === References
 
 * link:https://github.com/jenkinsci/simple-pull-request-job-plugin[Project repository]
-* link:https://gitter.im/jenkinsci/simple-pull-request-job-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[Gitter chat]
+* link:https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[Gitter chat]
 * link:https://issues.jenkins.io/issues/?jql=project%20%3D%20Jenkins%20AND%20component%20%3D%20simple-pull-request-job-plugin[Bug Tracker]
 * link:https://github.com/gautamabhishek46/dummy[Demo Repository]

--- a/content/projects/gsoc/2019/application.md
+++ b/content/projects/gsoc/2019/application.md
@@ -84,7 +84,7 @@ please feel free to contact us via the mailing list or the chat.
 
 #### Contents
 
-* Chat page URL: https://gitter.im/jenkinsci/gsoc-sig
+* Chat page URL: https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im
 
 ### Application
 

--- a/content/projects/gsoc/2019/artifact-promotion-plugin-for-jenkins-pipeline.adoc
+++ b/content/projects/gsoc/2019/artifact-promotion-plugin-for-jenkins-pipeline.adoc
@@ -17,7 +17,7 @@ mentors:
 - "MadsNielsen"
 links:
   draft: "https://docs.google.com/document/d/1UYi0jIYsKHE5IGS84B5W0XBoeMyF4yY_exu-21O99U8"
-  gitter: jenkinsci/promoted-builds-plugin
+  gitter: jenkinsci_promoted-builds-plugin:gitter.im
 
 ---
 

--- a/content/projects/gsoc/2019/ext-workspace-manager-cloud-features.adoc
+++ b/content/projects/gsoc/2019/ext-workspace-manager-cloud-features.adoc
@@ -14,7 +14,7 @@ mentors:
 - "hynespm"
 - "alexsomai"
 links:
-  gitter: "jenkinsci/external-workspace-manager-plugin"
+  gitter: "jenkinsci_external-workspace-manager-plugin:gitter.im"
   draft: https://docs.google.com/document/d/12qsvHSJpDaYALQQgzWpWw0-cmu6QOAmhr5THK3T1U0M
   sig: cloud-native
 ---

--- a/content/projects/gsoc/2019/gitlab-support-for-multibranch-pipeline.adoc
+++ b/content/projects/gsoc/2019/gitlab-support-for-multibranch-pipeline.adoc
@@ -12,7 +12,7 @@ mentors:
 - "justinharringa"
 - "jetersen"
 links:
-  gitter: jenkinsci/gitlab-branch-source-plugin
+  gitter: jenkinsci_gitlab-branch-source-plugin:gitter.im
   draft: https://docs.google.com/document/d/1Gqz4LyU5sw6I50OdAVsQSW_WPNDlvXg4Ic9NdcYj4Ts
 ---
 

--- a/content/projects/gsoc/2019/plugin-installation-manager-tool-cli.adoc
+++ b/content/projects/gsoc/2019/plugin-installation-manager-tool-cli.adoc
@@ -14,7 +14,7 @@ mentors:
 - "arnab1896"
 - "oleg_nenashev"
 links:
-  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
   draft: https://docs.google.com/document/d/1MW4qF6izW7_4R4x9SyFE1sW13TjU4wZj1wCf0dQdT6I
   sig: platform
 ---

--- a/content/projects/gsoc/2019/project-ideas/advanced-build-discard-strategy-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/advanced-build-discard-strategy-plugin.adoc
@@ -13,7 +13,7 @@ mentors:
 - "martinda"
 - "arnab1896"
 links:
-  gitter: jenkinsci/gsoc-build-discarder-project
+  gitter: jenkinsci_gsoc-build-discarder-project:gitter.im
   draft: https://docs.google.com/document/d/15LWsnNyZU2eDG56Zl4HW1_fgUSxuazujBypfAGVLrz8
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/ath-improvements.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ath-improvements.adoc
@@ -16,7 +16,7 @@ mentors:
 - "mramonleon"
 links:
   draft: https://docs.google.com/document/d/1M15rktOEOIPlDrlS13f42bSJLbI0P47hplBIAL_FX_g
-  gitter: jenkinsci/acceptance-test-harness
+  gitter: jenkinsci_acceptance-test-harness:gitter.im
 ---
 
 See Google Doc

--- a/content/projects/gsoc/2019/project-ideas/bitbucket-rest-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/bitbucket-rest-plugin.adoc
@@ -17,7 +17,7 @@ mentors:
 - "cdancy"
 - "shenyu_zheng"
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
   draft: https://docs.google.com/document/d/191aCm6zNLJxItQ5ebOKht3Ov46yqfZ73GlnvYiLOFTk
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/code-coverage-api-improvements.adoc
+++ b/content/projects/gsoc/2019/project-ideas/code-coverage-api-improvements.adoc
@@ -15,7 +15,7 @@ mentors:
 - "jeffpearce"
 links:
   draft: https://docs.google.com/document/d/1sIqGdrMs3pB9vNsv3BZFrOGa75FXFdI4C3BwYtRvWrU
-  gitter: jenkinsci/code-coverage-api-plugin
+  gitter: jenkinsci_code-coverage-api-plugin:gitter.im
 ---
 
 See Google doc

--- a/content/projects/gsoc/2019/project-ideas/docker-registries-polling-plugin.adoc
+++ b/content/projects/gsoc/2019/project-ideas/docker-registries-polling-plugin.adoc
@@ -13,7 +13,7 @@ mentors:
 - "justinharringa"
 - "ankit-jain"
 links:
-  gitter: jenkinsci/docker
+  gitter: jenkinsci_docker:gitter.im
   draft: https://docs.google.com/document/d/1r_wOqtzmiIyiNWri6U3FKINWdnyHWEMF_lbSCa4jPiw
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/eda-coverage-adapters.adoc
+++ b/content/projects/gsoc/2019/project-ideas/eda-coverage-adapters.adoc
@@ -19,7 +19,7 @@ mentors:
 - "udara28"
 - "shenyu_zheng"
 links:
-  gitter: "jenkinsci/hw-and-eda-sig"
+  gitter: "jenkinsci_hw-and-eda-sig:gitter.im"
   draft: https://docs.google.com/document/d/1pW9cSPTSekhMirHWKGnchmsDGsGLeN8MBEpMyN9HDEo
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/eda-plugins.adoc
+++ b/content/projects/gsoc/2019/project-ideas/eda-plugins.adoc
@@ -13,7 +13,7 @@ mentors:
 - "martinda"
 - "oleg_nenashev"
 links:
-  gitter: "jenkinsci/hw-and-eda-sig"
+  gitter: "jenkinsci_hw-and-eda-sig:gitter.im"
   draft: https://docs.google.com/document/d/1v54zvQVp2HqWyxZ5b4QZ-THeTRQYiIAsIOX4hbvGPa0
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
+++ b/content/projects/gsoc/2019/project-ideas/ext-workspace-manager-cloud-features.adoc
@@ -16,7 +16,7 @@ mentors:
 - "linuxsuren"
 - "alexsomai"
 links:
-  gitter: "jenkinsci/external-workspace-manager-plugin"
+  gitter: "jenkinsci_external-workspace-manager-plugin:gitter.im"
   draft: https://docs.google.com/document/d/12qsvHSJpDaYALQQgzWpWw0-cmu6QOAmhr5THK3T1U0M
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/gitlab-support-for-multibranch-pipeline.adoc
+++ b/content/projects/gsoc/2019/project-ideas/gitlab-support-for-multibranch-pipeline.adoc
@@ -14,7 +14,7 @@ mentors:
 - "jeffpearce"
 - "jetersen"
 links:
-  gitter: jenkinsci/gitlab-branch-source-plugin
+  gitter: jenkinsci_gitlab-branch-source-plugin:gitter.im
   draft: https://docs.google.com/document/d/1Gqz4LyU5sw6I50OdAVsQSW_WPNDlvXg4Ic9NdcYj4Ts
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/machine-learning.adoc
+++ b/content/projects/gsoc/2019/project-ideas/machine-learning.adoc
@@ -19,7 +19,7 @@ mentors:
 - "kinow"
 - "markyjackson-taulia"
 links:
-  gitter: "jenkinsci/gsoc-machine-learning-project"
+  gitter: "jenkinsci_gsoc-machine-learning-project:gitter.im"
   draft: https://docs.google.com/document/d/19ignQBMUr3qxfmkf8Sa9KG7wJlxs3js_kg4mJhX_dXo
 ---
 

--- a/content/projects/gsoc/2019/project-ideas/role-strategy-performance.adoc
+++ b/content/projects/gsoc/2019/project-ideas/role-strategy-performance.adoc
@@ -13,7 +13,7 @@ mentors:
 - "runzexia"
 - "pvtuan10"
 links:
-  gitter: "jenkinsci/role-strategy-plugin"
+  gitter: "jenkinsci_role-strategy-plugin:gitter.im"
 ---
 
 link:https://plugins.jenkins.io/role-strategy[Role Strategy Plugin] is widely used in Jenkins as an authorization engine,

--- a/content/projects/gsoc/2019/project-ideas/role-strategy-ux.adoc
+++ b/content/projects/gsoc/2019/project-ideas/role-strategy-ux.adoc
@@ -14,7 +14,7 @@ mentors:
 - "supun94"
 - "runzexia"
 links:
-  gitter: "jenkinsci/role-strategy-plugin"
+  gitter: "jenkinsci_role-strategy-plugin:gitter.im"
 ---
 
 link:https://plugins.jenkins.io/role-strategy[Role Strategy Plugin] is widely used in Jenkins as an authorization engine,

--- a/content/projects/gsoc/2019/role-strategy-performance.adoc
+++ b/content/projects/gsoc/2019/role-strategy-performance.adoc
@@ -25,7 +25,7 @@ The project is being tracked on Jenkins Jira:
 * link:https://issues.jenkins.io/browse/JENKINS-57416[Phase 1]
 * link:https://issues.jenkins.io/browse/JENKINS-18377[Phase 2 and Phase 3]
 
-Please follow our link:https://gitter.im/jenkinsci/role-strategy-plugin[Gitter chat] for more details.
+Please follow our link:https://app.gitter.im/#/room/#jenkinsci_role-strategy-plugin:gitter.im[Gitter chat] for more details.
 
 ===== Project Proposal
 You can find more details at the project proposal link:https://docs.google.com/document/d/1zUKRShhILzESwO7PIrYxXRSyLxxY-hAPclbREU8uE1o/edit[Google Doc].

--- a/content/projects/gsoc/2019/role-strategy-performance.adoc
+++ b/content/projects/gsoc/2019/role-strategy-performance.adoc
@@ -12,7 +12,7 @@ mentors:
 - "supun94"
 links:
   draft: "https://docs.google.com/document/d/1zUKRShhILzESwO7PIrYxXRSyLxxY-hAPclbREU8uE1o"
-  gitter: "jenkinsci/role-strategy-plugin"
+  gitter: "jenkinsci_role-strategy-plugin:gitter.im"
 ---
 
 The Role Strategy Plugin is one of the most popular Jenkins authorization plugin. On adding a large number of roles to the plugin,

--- a/content/projects/gsoc/2019/working-hours-improvements.adoc
+++ b/content/projects/gsoc/2019/working-hours-improvements.adoc
@@ -11,7 +11,7 @@ mentors:
 - "jeffpearce"
 - "kzantow"
 links:
-  gitter: jenkinsci/working-hours-plugin
+  gitter: jenkinsci_working-hours-plugin:gitter.im
 ---
 
 ==== Overview

--- a/content/projects/gsoc/2020/application.md
+++ b/content/projects/gsoc/2020/application.md
@@ -75,7 +75,7 @@ Participating in Google Summer of Code is a major time commitment requiring an a
 If it may overlap with your study, internship, work or other commitments, we recommend to think twice before applying.
 
 If you have any questions about the application process,
-please feel free to contact us via the [jenkinsci/gsoc-sig Gitter chat](https://gitter.im/jenkinsci/gsoc-sig).
+please feel free to contact us via the [jenkinsci/gsoc-sig Gitter chat](https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im).
 We also have [weekly meetings](https://jenkins.io/projects/gsoc/#office-hours) which are open to everyone.
 
 #### Proposal tags (max - 10)
@@ -95,7 +95,7 @@ TODO: Adjust according to project ideas
 
 #### Contacts
 
-* Chat page URL: https://gitter.im/jenkinsci/gsoc-sig
+* Chat page URL: https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im
 * Twitter: https://twitter.com/jenkinsci
 * Blog: https://jenkins.io/node/
 

--- a/content/projects/gsoc/2020/project-ideas/bitbucket-rest-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/bitbucket-rest-plugin.adoc
@@ -15,7 +15,7 @@ skills:
 mentors:
 - "shenyu_zheng"
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
   draft: https://docs.google.com/document/d/191aCm6zNLJxItQ5ebOKht3Ov46yqfZ73GlnvYiLOFTk
   emailThread: https://groups.google.com/forum/#!topic/jenkinsci-gsoc-all-public/_2B33C_R8UI
 ---

--- a/content/projects/gsoc/2020/project-ideas/code-coverage-api-improvements.adoc
+++ b/content/projects/gsoc/2020/project-ideas/code-coverage-api-improvements.adoc
@@ -15,7 +15,7 @@ mentors:
 - "jeffpearce"
 links:
   draft: https://docs.google.com/document/d/1sIqGdrMs3pB9vNsv3BZFrOGa75FXFdI4C3BwYtRvWrU
-  gitter: jenkinsci/code-coverage-api-plugin
+  gitter: jenkinsci_code-coverage-api-plugin:gitter.im
 ---
 
 See Google doc

--- a/content/projects/gsoc/2020/project-ideas/docker-registries-polling-plugin.adoc
+++ b/content/projects/gsoc/2020/project-ideas/docker-registries-polling-plugin.adoc
@@ -13,7 +13,7 @@ mentors:
 - "afalko"
 - "mikecirioli"
 links:
-  gitter: jenkinsci/docker
+  gitter: jenkinsci_docker:gitter.im
   draft: https://docs.google.com/document/d/1r_wOqtzmiIyiNWri6U3FKINWdnyHWEMF_lbSCa4jPiw
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/eda-coverage-adapters.adoc
+++ b/content/projects/gsoc/2020/project-ideas/eda-coverage-adapters.adoc
@@ -17,7 +17,7 @@ mentors:
 - "oleg_nenashev"
 - "shenyu_zheng"
 links:
-  gitter: "jenkinsci/hw-and-eda-sig"
+  gitter: "jenkinsci_hw-and-eda-sig:gitter.im"
   draft: https://docs.google.com/document/d/1pW9cSPTSekhMirHWKGnchmsDGsGLeN8MBEpMyN9HDEo
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/eda-plugins.adoc
+++ b/content/projects/gsoc/2020/project-ideas/eda-plugins.adoc
@@ -13,7 +13,7 @@ mentors:
 - "oleg_nenashev"
 - "ayush_agarwal"
 links:
-  gitter: "jenkinsci/hw-and-eda-sig"
+  gitter: "jenkinsci_hw-and-eda-sig:gitter.im"
   draft: https://docs.google.com/document/d/1v54zvQVp2HqWyxZ5b4QZ-THeTRQYiIAsIOX4hbvGPa0
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
+++ b/content/projects/gsoc/2020/project-ideas/git-plugin-caching.adoc
@@ -14,7 +14,7 @@ skills:
 - Java
 - Git
 links:
-  gitter: "jenkinsci/git-plugin"
+  gitter: "jenkinsci_git-plugin:gitter.im"
   draft: https://docs.google.com/document/d/1M9Na1eJxwGZ7fY1L-PsBGv62jL_pPBtqmGePpwogUBw
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/git-plugin-performance.adoc
+++ b/content/projects/gsoc/2020/project-ideas/git-plugin-performance.adoc
@@ -18,7 +18,7 @@ skills:
 - Benchmarking
 - JMH
 links:
-  gitter: "jenkinsci/git-plugin"
+  gitter: "jenkinsci_git-plugin:gitter.im"
   draft: https://docs.google.com/document/d/1bmpgW_8cg38ulp0uFdn2BRfVlIrZ03FFhWpe0MVHyyI
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/github-checks.adoc
+++ b/content/projects/gsoc/2020/project-ideas/github-checks.adoc
@@ -17,7 +17,7 @@ skills:
 - REST API
 - GitHub
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
   draft: https://docs.google.com/document/d/1fl3sF0mArtv2THOjPSZvNufGme4P24BtT0BirHMeMRY
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -13,7 +13,7 @@ mentors:
 - "linuxsuren"
 - "jeffpearce"
 links:
-  gitter: "jenkinsci/platform-sig"
+  gitter: "jenkinsci_platform-sig:gitter.im"
 ---
 
 For many users, they download Jenkins first, then select some plugins and configure them. 

--- a/content/projects/gsoc/2020/project-ideas/machine-learning.adoc
+++ b/content/projects/gsoc/2020/project-ideas/machine-learning.adoc
@@ -21,7 +21,7 @@ mentors:
 - "markyjackson-taulia"
 - "shivaylamba"
 links:
-  gitter: "jenkinsci/gsoc-machine-learning-project"
+  gitter: "jenkinsci_gsoc-machine-learning-project:gitter.im"
   draft: https://docs.google.com/document/d/19ignQBMUr3qxfmkf8Sa9KG7wJlxs3js_kg4mJhX_dXo
 ---
 

--- a/content/projects/gsoc/2020/project-ideas/machine-learning.adoc
+++ b/content/projects/gsoc/2020/project-ideas/machine-learning.adoc
@@ -95,4 +95,4 @@ Other tools that researchers use for experiment tracking (should not be seen as 
 * An example pipeline launching Tensorboard from a Jenkins pipeline can be found link:https://gist.github.com/imoutsatsos/256239cb2eb8a9a5932520e77601656b[here]
 
 === Newbie-friendly issues
-We currently do not have any issues but can readily answer questions via the gitter channel link:https://gitter.im/jenkinsci/gsoc-machine-learning-project[here]
+We currently do not have any issues but can readily answer questions via the gitter channel link:https://app.gitter.im/#/room/#jenkinsci_gsoc-machine-learning-project:gitter.im[here]

--- a/content/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment.adoc
+++ b/content/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment.adoc
@@ -17,7 +17,7 @@ skills:
 - YAML
 - Jenkins X
 links:
-  gitter: "jenkinsci/pipeline-authoring-plugin"
+  gitter: "jenkinsci_pipeline-authoring-plugin:gitter.im"
 ---
 
 Jenkins Pipeline is a widely used way to define jobs in Jenkins.

--- a/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool.adoc
@@ -15,7 +15,7 @@ mentors:
 - "kwhetstone"
 - "timja"
 links:
-  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
+++ b/content/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service.adoc
@@ -14,7 +14,7 @@ mentors:
 advisors:
 - "oleg_nenashev"
 links:
-  gitter: "jenkinsci/jenkins-custom-distribution-service"
+  gitter: "jenkinsci_jenkins-custom-distribution-service:gitter.im"
   draft: https://docs.google.com/document/d/1C7VQJ92Yhr0KRDcNVHYxn4ri7OL9IGZmgxY6UFON6-g/edit?usp=sharing
   idea: /projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service
   meetings:  /projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service#meetings

--- a/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
+++ b/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
@@ -298,7 +298,7 @@ for all the contribution to this project.
 === Reaching Out
 
 Feel free to reach out to us for any questions, feedback, etc. on the project's
-link:https://gitter.im/jenkinsci/external-fingerprint-storage[Gitter Channel] or the
+link:https://app.gitter.im/#/room/#jenkinsci_external-fingerprint-storage:gitter.im[Gitter Channel] or the
 mailto:jenkinsci-dev@googlegroups.com[Jenkins Developer Mailing list].
 We use Jenkins link:https://issues.jenkins.io/[Jira] to track issues.
 Feel free to file issues under `redis-fingerprint-storage-plugin` or `postgresql-fingerprint-storage-plugin`

--- a/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
+++ b/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
@@ -12,7 +12,7 @@ mentors:
 - "afalko"
 - "mikecirioli"
 links:
-  gitter: jenkinsci/external-fingerprint-storage
+  gitter: jenkinsci_external-fingerprint-storage:gitter.im
   draft: https://docs.google.com/document/d/10f3IXTA6UMLUOFMTH_atQ3XlyWB3S7KGNCtTZmOUGdM/edit?usp=sharing
   idea: /projects/gsoc/2020/project-ideas/external-fingerprint-storage-for-jenkins
 tags:

--- a/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
+++ b/content/projects/gsoc/2020/projects/git-plugin-performance.adoc
@@ -19,7 +19,7 @@ mentors:
 - "omkar_dsd"
 links:
   draft: https://docs.google.com/document/d/1vy9tkFbhl5KX7QcjH3QbzFzbKEONw6gaLZSmNXgB06Y/edit?usp=sharing
-  gitter: jenkinsci/git-plugin
+  gitter: jenkinsci_git-plugin:gitter.im
   idea: /projects/gsoc/2020/project-ideas/git-plugin-performance
   meetings: "/projects/gsoc/2020/projects/git-plugin-performance/#office-hours"
 ---

--- a/content/projects/gsoc/2020/projects/github-checks.adoc
+++ b/content/projects/gsoc/2020/projects/github-checks.adoc
@@ -16,7 +16,7 @@ tags:
 - gsoc2020
 - github
 links:
-  gitter: "jenkinsci/github-checks-api"
+  gitter: "jenkinsci_github-checks-api:gitter.im"
   draft: https://docs.google.com/document/d/1gpG7jeQmb9zz46t0ewNNRUrYbl7iHGScp5vgkn7MCXs/edit?usp=sharing
   idea: /projects/gsoc/2020/project-ideas/github-checks
 ---

--- a/content/projects/gsoc/2020/projects/machine-learning.adoc
+++ b/content/projects/gsoc/2020/projects/machine-learning.adoc
@@ -17,7 +17,7 @@ tags:
 - machine-learning
 - data-science
 links:
-  gitter: "jenkinsci/gsoc-machine-learning-project"
+  gitter: "jenkinsci_gsoc-machine-learning-project:gitter.im"
   draft: https://docs.google.com/document/d/1YaQfzvYV2G-wby2jcOzITKveaowTXMN77fkMq5hBe6E/edit?usp=sharing
   idea: /projects/gsoc/2020/project-ideas/machine-learning
 ---

--- a/content/projects/gsoc/2021/project-ideas/git-credentials-binding-for-pipeline.adoc
+++ b/content/projects/gsoc/2021/project-ideas/git-credentials-binding-for-pipeline.adoc
@@ -15,7 +15,7 @@ skills:
 - Java
 - Git
 links:
-  gitter: "jenkinsci/git-plugin"
+  gitter: "jenkinsci_git-plugin:gitter.im"
   draft: https://docs.google.com/document/d/1tu5g1bfwAY5vvL_2OoBIRDKfYaaOC6sDQdb7BIYBInY/edit?usp=sharing
 ---
 

--- a/content/projects/gsoc/2021/project-ideas/jenkins-custom-distribution-service-updates.adoc
+++ b/content/projects/gsoc/2021/project-ideas/jenkins-custom-distribution-service-updates.adoc
@@ -15,7 +15,7 @@ mentors:
 - "sladyn98"
 - "kwhetstone"
 links:
-  gitter: "jenkinsci/platform-sig"
+  gitter: "jenkinsci_platform-sig:gitter.im"
 ---
 
 Many users will download Jenkins and spend a great deal of time customizing their environment to be exactly what they need.

--- a/content/projects/gsoc/2021/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2021/project-ideas/plugin-installation-manager-tool.adoc
@@ -19,7 +19,7 @@ mentors:
 - "sladyn98"
 
 links:
-  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
+++ b/content/projects/gsoc/2021/projects/conventional-commits-plugin.adoc
@@ -16,7 +16,7 @@ mentors:
 - "olblak"
 - "dohbedoh"
 links:
-  gitter: "jenkinsci/conventional-commits-plugin"
+  gitter: "jenkinsci_conventional-commits-plugin:gitter.im"
   draft: https://docs.google.com/document/d/1E0FdxdXP1JZb88-sDqmilmz2gJ0qp4BANCTLlXJOaTQ/edit#
   idea: /projects/gsoc/2021/project-ideas/semantic-release-version
 ---

--- a/content/projects/gsoc/2021/projects/git-credentials-binding.adoc
+++ b/content/projects/gsoc/2021/projects/git-credentials-binding.adoc
@@ -16,7 +16,7 @@ mentors:
 - "rishabhbudhouliya"
 - "justinharringa"
 links:
-  gitter: "jenkinsci/git-plugin"
+  gitter: "jenkinsci_git-plugin:gitter.im"
   draft: https://docs.google.com/document/d/1dHFEHbVPNyGRGtMF30df4O0UXoqgmEJpVVNoxxXYT1w/edit?usp=sharing
   idea: /projects/gsoc/2021/project-ideas/git-credentials-binding-for-pipeline
   meetings: "/projects/gsoc/2021/projects/git-credentials-binding/#office-hours"

--- a/content/projects/gsoc/2022/application.adoc
+++ b/content/projects/gsoc/2022/application.adoc
@@ -162,7 +162,7 @@ Welcome and thank you for your interest!
 To apply to the organization, please follow the link:https:/projects/gsoc/students/#student-application-process[guidelines on our website].
 
 Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/students/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
-If you have any questions about the application process, please feel free to contact us via link:https://community.jenkins.io/tag/gsoc[Jenkins GSoC Discourse] or in the link:https://gitter.im/jenkinsci/gsoc-sig[jenkinsci/gsoc-sig Gitter] chat. We also have weekly meetings which are open to everyone.
+If you have any questions about the application process, please feel free to contact us via link:https://community.jenkins.io/tag/gsoc[Jenkins GSoC Discourse] or in the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[jenkinsci/gsoc-sig Gitter] chat. We also have weekly meetings which are open to everyone.
 
 
 {nbsp} +
@@ -172,7 +172,7 @@ If you have any questions about the application process, please feel free to con
 
 _How do you want potential contributors to interact with your organization? Select methods that your community uses daily as you will receive many inquiries if your org is selected._
 
-Jenkins GSoC communication channels: link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse], link:https://gitter.im/jenkinsci/gsoc-sig[Gitter]
+Jenkins GSoC communication channels: link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse], link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Gitter]
 
 
 {nbsp} +

--- a/content/projects/gsoc/2022/index.adoc
+++ b/content/projects/gsoc/2022/index.adoc
@@ -81,7 +81,7 @@ Projects may also have their own mailing lists, chats and meetings.
 See details on project pages.
 * We use link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse] for discussions.
   This is the **recommended** channel for communications
-* There is also a link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for real-time communications,
+* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications,
   but it is better to use Discourse to request technical feedback or to have long discussions
 * For private matters such as communication difficulties with mentors, GSoC contributors, or Org Admins, 
   please use the this mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
@@ -95,7 +95,7 @@ project proposal questions and discussions, process and timeline related questio
 
 === Chats
 
-* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
+* link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
 * Project-specific chats, see project and project idea pages
 * link:/chat/[Common developer chats] for technical topics
 

--- a/content/projects/gsoc/2022/index.adoc
+++ b/content/projects/gsoc/2022/index.adoc
@@ -9,7 +9,7 @@ sig: gsoc
 opengraph:
   image: /images/gsoc/opengraph.png
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
   meetings: "/projects/gsoc/#office-hours"
 ---
 

--- a/content/projects/gsoc/2022/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2022/project-ideas/plugin-installation-manager-tool.adoc
@@ -66,4 +66,4 @@ Google Summer of Code contributor will propose the areas for improvement and wor
 === Newbie Friendly Issues
 
 Some good first issues are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[issue tracker].
-For information about how to contribute to and what to work on, please use the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[gitter channel].
+For information about how to contribute to and what to work on, please use the link:https://app.gitter.im/#/room/#jenkinsci_plugin-installation-manager-cli-tool:gitter.im[gitter channel].

--- a/content/projects/gsoc/2022/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2022/project-ideas/plugin-installation-manager-tool.adoc
@@ -15,7 +15,7 @@ mentors:
 - "markewaite"
 - "abhyudayasharma"
 links:
-  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2022/projects/automatic-git-cache-maintenance.adoc
+++ b/content/projects/gsoc/2022/projects/automatic-git-cache-maintenance.adoc
@@ -14,7 +14,7 @@ mentors:
 - "rishabhbudhouliya"
 - "markewaite"
 links:
-  gitter: jenkinsci/git-plugin
+  gitter: jenkinsci_git-plugin:gitter.im
   draft: https://docs.google.com/document/d/1Jc0zyLtbh0lj1MwG9FdBY9PRed5falQGnUbU1KfREqk/edit#heading=h.63lwv71bjiiy 
   idea: /projects/gsoc/2022/project-ideas/automatic-git-cache-maintenance
   meetings: "/projects/gsoc/2022/projects/automatic-git-cache-maintenance/#office-hours"

--- a/content/projects/gsoc/2022/projects/blank_project.adoc
+++ b/content/projects/gsoc/2022/projects/blank_project.adoc
@@ -14,7 +14,7 @@ mentors:
 - "alecharp"
 - "jleon"
 links:
-  gitter: "jenkinsci/git-plugin"
+  gitter: "jenkinsci_git-plugin:gitter.im"
   draft: https://docs.google.com/document/d/1dHFEHbVPNyGRGtMF30df4O0UXoqgmEJpVVNoxxXYT1w/edit?usp=sharing
   idea: /projects/gsoc/2021/project-ideas/git-credentials-binding-for-pipeline
   meetings: "/projects/gsoc/2021/projects/git-credentials-binding/#office-hours"

--- a/content/projects/gsoc/2022/projects/pipeline-step-documentation-generator.adoc
+++ b/content/projects/gsoc/2022/projects/pipeline-step-documentation-generator.adoc
@@ -15,7 +15,7 @@ mentors:
 - "arpoch"
 - "koushartasneem"
 links:
-  gitter: "jenkinsci/docs"
+  gitter: "jenkins/docs:matrix.org"
   draft: https://docs.google.com/document/d/1gFA-EctmLyKWy_NfTfRL7cO-3mUjaS1aIcixyQ1ecBk/edit?usp=sharing
   idea: /projects/gsoc/2022/project-ideas/pipeline-step-documentation-generator
   meetings: "/projects/gsoc/2022/projects/pipeline-step-documentation-generator/#office-hours"

--- a/content/projects/gsoc/2022/projects/plugin-health-scoring-system.adoc
+++ b/content/projects/gsoc/2022/projects/plugin-health-scoring-system.adoc
@@ -15,7 +15,7 @@ mentors:
 - "adi10hero"
 - "jleon"
 links:
-  gitter: "jenkinsci/GSoC-Plugin_Health_Score"
+  gitter: "jenkinsci_GSoC-Plugin_Health_Score:gitter.im"
   draft: https://docs.google.com/document/d/1HTbcWh5C1KrCgEzgqeVEPyfr1H5fH5eTj8KpbWrWsSY/edit#
   idea: /projects/gsoc/2022/project-ideas/plugin-health-scoring-system
   meetings: "/projects/gsoc/2022/projects/plugin-health-scoring-system/#office-hours"

--- a/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
@@ -15,7 +15,7 @@ mentors:
 - "dheerajodha"
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-add-probes-to-plugin-health-score/4838
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2023/project-ideas/agent_reconnections_exponential_backoff.adoc
+++ b/content/projects/gsoc/2023/project-ideas/agent_reconnections_exponential_backoff.adoc
@@ -14,7 +14,7 @@ mentors:
 - "freyam"
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-exponential-backoff-and-jitter-for-agent-reconnections/5032
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
@@ -19,7 +19,7 @@ mentors:
 - "markewaite"
 links:
    emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-jenkins-io-with-alternative-tools/4863
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 

--- a/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
+++ b/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
@@ -18,7 +18,7 @@ mentors:
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-android-apps-with-jenkins/4798
 ---
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 
 === Background

--- a/content/projects/gsoc/2023/project-ideas/buiilding-ios-app.adoc
+++ b/content/projects/gsoc/2023/project-ideas/buiilding-ios-app.adoc
@@ -17,7 +17,7 @@ mentors:
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799
 ---
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 
 === Background

--- a/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
@@ -16,7 +16,7 @@ mentors:
 - "sbostandoust"
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-jenkins-io-with-docker-compose/4866
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -16,7 +16,7 @@ mentors:
 
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-active-modernization-of-gitlab-plugin/5039
-//   gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
@@ -16,7 +16,7 @@ mentors:
 - "abhyudayasharma"
 - "freyam"
 links:
-  gitter: "jenkinsci/plugin-installation-manager-cli-tool"
+  gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/plugin-installation-manager-tool.adoc
@@ -89,4 +89,4 @@ Some candidate ideas from the mentors include:
 === Newbie Friendly Issues
 
 Some good first issues are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[issue tracker].
-For information about how to contribute to and what to work on, please use the link:https://gitter.im/jenkinsci/plugin-installation-manager-cli-tool[gitter channel].
+For information about how to contribute to and what to work on, please use the link:https://app.gitter.im/#/room/#jenkinsci_plugin-installation-manager-cli-tool:gitter.im[gitter channel].

--- a/content/projects/gsoc/gsoc2016.adoc
+++ b/content/projects/gsoc/gsoc2016.adoc
@@ -41,7 +41,7 @@ continuous deployment flow powered by Jenkins and Pipeline Plugin.
 
 === External Workspace Manager Plugin
 
-link:https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=share-link&utm_medium=link&utm_campaign=share-link[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
+link:https://app.gitter.im/#/room/#jenkinsci_external-workspace-manager-plugin:gitter.im[image:https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg[title: "Gitter"]]
 
 Currently, Jenkins’ build workspace may become very large in size due to the
 fact that some compilers generate very large volumes of data. The existing

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -95,7 +95,7 @@ Projects may also have their own mailing lists, chats and meetings.
 See details on project pages.
 * We use link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse] for discussions.
   This is the **recommended** channel for communications
-* There is also a link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for real-time communications,
+* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications,
   but it is better to use Discourse to request technical feedback or to have long discussions
 * For private matters such as communication difficulties with mentors, GSoC contributors, or Org Admins, 
   please use the this mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
@@ -109,7 +109,7 @@ project proposal questions and discussions, process and timeline related questio
 
 === Chats
 
-* link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
+* link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
 * Project-specific chats, see project and project idea pages
 * link:/chat/[Common developer chats] for technical topics
 

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -9,7 +9,7 @@ sig: gsoc
 opengraph:
   image: /images/gsoc/opengraph.png
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
   meetings: "/projects/gsoc/#office-hours"
 ---
 

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -22,7 +22,7 @@ please read the instructions on the link:../students/[GSoC contributor page].
 If you would like to propose a project idea to the Jenkins community for the GSoC program,
 then you are a Jenkins GSoC Idea champion. You should follow the following steps:
 
-. Share your idea on the link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] or on the
+. Share your idea on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC gitter channel] or on the
 link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse channel]
 . On Discourse, use `[GSOC 2023 PROJECT IDEA] Title of idea` as the subject
 . The GSoC idea must:
@@ -78,7 +78,7 @@ The last step is to submit this new file as a pull-request.
 . add a link to the related Discourse thread
 . assign the gsoc Label to the PR if you can
 .. post the pull-request link to the
-link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC gitter channel] and to the
+link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC gitter channel] and to the
 link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse channel] as a follow up to your original thread.
 
 If your idea gets good feedback, and you want to proceed with it,

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -111,7 +111,7 @@ skills:
 - skills_go_here
 - add_more_if_needed
 links:
-  gitter: "jenkinsci/gsoc-sig" # This can be the gitter link of your project's chat room
+  gitter: "jenkinsci_gsoc-sig:gitter.im" # This can be the gitter link of your project's chat room
 ---
 
 Write your project idea here. Sometimes an abstract is enough, but you should include:

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -38,7 +38,7 @@ We cannot make any exception. Please:
 . Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
 . Join the link:https://community.jenkins.io/c/contributing/gsoc/[Discourse communication channel]
-. Join the link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC Gitter Chat]
+. Join the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC Gitter Chat]
 . Using the Discourse channel or the Gitter chat:
   .. Introduce yourself to the Jenkins GSoC community,
   .. Start a discussion about a Jenkins GSoC project.
@@ -280,7 +280,7 @@ GSoC contributors are expected to...
  * Timely notify mentors in the case of emergencies and outages (missing scheduled meetings, etc.).
  * Timely notify mentors and org admins about unexpected time commitments (life goes on, it is normal - mentors will let you know if they can't be reached too).
 . Be present on-line
- * Be around in the project chats during the working hours (the link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC Gitter Chat], and the Gitter Chat of your project)
+ * Be around in the project chats during the working hours (the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC Gitter Chat], and the Gitter Chat of your project)
  * Be proactive; reach out to the community if required
  * Optional: Attend Jenkins governance meetings if the timezone allows
 
@@ -374,7 +374,7 @@ Other mailing lists:
 
 === Chat
 
-We use the link:https://gitter.im/jenkinsci/gsoc-sig[Jenkins GSoC Gitter Chat]
+We use the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC Gitter Chat]
 for office hours and real-time discussions.
 Note that mentors and org-admins may be unavailable in the chat outside the Office Hours slots (see below).
 

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -125,7 +125,7 @@ Here is a non-exhaustive list of services that we provide and maintain.
 | https://github.com/jenkins-infra[GitHub]               | GitHub    | https://github.com/jenkins-infra/helpdesk/labels/github[GitHub issues]      | -
 | https://jenkins.datadoghq.com[Monitoring]              | Datadog   | https://github.com/jenkins-infra/helpdesk/labels/datadog[GitHub issues]     | https://github.com/jenkins-infra/jenkins-infra-monitoring[Code]
 | https://www.pagerduty.com[Pagerduty]                   | Pagerduty |                                                                             | -
-| https://gitter.im/jenkinsci/[Gitter chat system]       | GitLab    |                                                                             | -
+| https://app.gitter.im/#/room/#jenkins-ci:matrix.org[Gitter chat system]       | GitLab    |                                                                             | -
 | https://manage.fastly.com/[Content Delivery Network]   | Fastly    |                                                                             | -
 | https://www.namecheap.com/[DNS Registrar]              | Namecheap |                                                                             | -
 | https://issues.jenkins.io[Jira]                        | Linux Foundation | https://support.linuxfoundation.org[Linux Foundation Support]        | -

--- a/content/projects/jcasc/dev-tools.adoc
+++ b/content/projects/jcasc/dev-tools.adoc
@@ -11,7 +11,7 @@ mentors:
 - "timja"
 - "jetersen"
 links:
-  gitter: https://gitter.im/jenkinsci/jcasc-devtools-project
+  gitter: https://app.gitter.im/#/room/#jenkinsci_jcasc-devtools-project:gitter.im
   draft: https://docs.google.com/document/d/1aPfkmyMQRCcipVa0htFt-i7X_pkQHSVKfR5qT60HQZ8/edit?usp=sharing
 opengraph:
   image: /images/logos/JCasC/JCasC.png

--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -54,7 +54,7 @@ The meeting takes place on Wednesdays, 9am (UTC+1) every two weeks.
 Meetings will be announced at link:/event-calendar/[*Event Calendar*]
 
 Hangouts On Air is used to host and stream the meeting on link:https://www.youtube.com/channel/UC5JBtmoz7ePk-33ZHimGiDQ[*Jenkins Youtube channel*].
-Link to the actual meeting is always shared a few minutes before the meeting at link:https://gitter.im/jenkinsci/configuration-as-code-plugin[*configuration-as-code-plugin*] gitter channel
+Link to the actual meeting is always shared a few minutes before the meeting at link:https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im[*configuration-as-code-plugin*] gitter channel
 
 link:https://docs.google.com/document/d/1Hm07Q1egWL6VVAqNgu27bcMnqNZhYJmXKRvknVw4Y84/edit?usp=sharing[*Minutes of Meeting*] are available for everyone interested
 

--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -21,7 +21,7 @@ participants:
 - "krisstern"
 
 links:
-  gitter: "jenkinsci/advocacy-and-outreach-sig"
+  gitter: "jenkinsci_advocacy-and-outreach-sig:gitter.im"
   googlegroup: "jenkins-advocacy-and-outreach-sig"
   meetings: "https://docs.google.com/document/d/1K5dTSqe56chFhDSGNfg_MCy-LmseUs_S3ys_tg60sTs/edit#heading=h.9jh09t587y90"
   forum: "advocacy-and-outreach"

--- a/content/sigs/advocacy-and-outreach/outreach-programs/index.adoc
+++ b/content/sigs/advocacy-and-outreach/outreach-programs/index.adoc
@@ -41,7 +41,7 @@ For more information, see link:/projects/gsoc/[our GSoC project page].
 To contact us regarding this program,
 send us a message on the link:https://community.jenkins.io/c/contributing/gsoc/6[Jenkins Community Discourse]
 or contact us on the
-link:https://gitter.im/jenkinsci/gsoc-sig[GSoC Gitter channel].
+link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel].
 
 // The GSoC logo is a bit tall, so add some empty lines
 {empty} +
@@ -55,7 +55,7 @@ The https://sites.google.com/shecodeafrica.org/contributhon/home/guide/[She Code
  This program aims to create a more diverse, inclusive, and innovative culture within the African open source ecosystem by matching African women in technology with sponsors and mentors of open source organizations.
 
 To contact us regarding this program, send us a message on the
-link:https://gitter.im/jenkinsci/advocacy-and-outreach-sig[Advocacy and Outreach Gitter channel] or reach out to link:https://www.shecodeafrica.org/[She Code Africa].
+link:https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im[Advocacy and Outreach Gitter channel] or reach out to link:https://www.shecodeafrica.org/[She Code Africa].
 
 === Hacktoberfest
 

--- a/content/sigs/advocacy-and-outreach/outreach-programs/outreach-programs-history.adoc
+++ b/content/sigs/advocacy-and-outreach/outreach-programs/outreach-programs-history.adoc
@@ -29,7 +29,7 @@ Our first project on Community Bridge is link:/projects/jcasc/dev-tools/[Develop
 We are interested in onboarding more projects, and we invite Jenkins contributors and potential mentees to reach out to us.
 
 To contact us regarding this program, send us a message on the
-link:https://gitter.im/jenkinsci/advocacy-and-outreach-sig[Advocacy and Outreach Gitter channel].
+link:https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im[Advocacy and Outreach Gitter channel].
 
 == Google Season of Docs
 

--- a/content/sigs/chinese-localization/index.adoc
+++ b/content/sigs/chinese-localization/index.adoc
@@ -23,7 +23,7 @@ organizations:
   github: "alauda"
 
 links:
-  gitter: jenkinsci/chinese-localization-sig
+  gitter: "jenkinsci_chinese-localization-sig:gitter.im"
   googlegroup: jenkins-chinese-localization-sig
   meetings: "/sigs/chinese-localization/#meetings"
 

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -33,7 +33,7 @@ organizations:
   github: "RedHatOfficial"
 
 links:
-  gitter: "jenkinsci/cloud-native-sig"
+  gitter: "jenkinsci_cloud-native-sig:gitter.im"
   googlegroup: jenkins-cloud-native-sig
   meetings: "/sigs/cloud-native/#meetings"
 

--- a/content/sigs/cloud-native/index.adoc
+++ b/content/sigs/cloud-native/index.adoc
@@ -105,7 +105,7 @@ There is a separate link:https://calendar.google.com/event?action=TEMPLATE&tmeid
 Click on a link:https://calendar.google.com/event?action=TEMPLATE&tmeid=a28yZTc0cGdxcHZwcHJ1aWNjZWcyMnU5ZGdfMjAxODA5MTJUMDcwMDAwWiBld2VAcHJhcW1hLm5ldA&tmsrc=ewe%40praqma.net&scp=ALL[link] for an invitation.
 Anyone can join a meeting, meetings will be recorded via Jenkins Hangouts-on-Air.
 
-Participant links will be posted in the link:https://gitter.im/jenkinsci/configuration-as-code-plugin[Configuration as Code Gitter Chat] within 10 minutes before the meeting starts.
+Participant links will be posted in the link:https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im[Configuration as Code Gitter Chat] within 10 minutes before the meeting starts.
 
 When needed the topics discussed at Office Hours meeting will be reported back at Cloud Native SIG meeting.
 

--- a/content/sigs/docs/gsod/2020/application.md
+++ b/content/sigs/docs/gsod/2020/application.md
@@ -73,7 +73,7 @@ Contributions to Jenkins component documentation (e.g. plugin docs) are usually 
 We also have channels specifically dedicated to the documentation.
 These channels act as an additional contact point for technical writers in the community:
 
-* Chat on Gitter: https://gitter.im/jenkinsci/docs
+* Chat on Gitter: https://app.gitter.im/#/room/#jenkins/docs:matrix.org
 * Regular Documentation SIG meetings: https://www.jenkins.io/sigs/docs/#meetings
 
 ### What previous experience has your organization had mentoring individuals?

--- a/content/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes.adoc
+++ b/content/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes.adoc
@@ -70,7 +70,7 @@ techniques, and choices for Kubernetes users running Jenkins.
 === Reaching Out
 
 Feel free to reach out to us for any questions, feedback, etc. on the project's
-link:https://gitter.im/jenkinsci/docs[Gitter Channel].
+link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter Channel].
 
 === Other Links
 

--- a/content/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes.adoc
+++ b/content/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes.adoc
@@ -13,7 +13,7 @@ mentors:
 - kwhetstone
 - markyjackson-taulia
 links:
-  gitter: jenkinsci/docs
+  gitter: jenkins/docs:matrix.org
   draft: https://docs.google.com/document/d/1zTEKtOp2i1K2fw5RQ_a_KVOB2z0gz9987NYzTnIS6G8/edit?usp=sharing
   idea: /sigs/docs/#jenkins-on-kubernetes
 tags:

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -28,7 +28,7 @@ Significant documentation project opportunities are listed in the link:/sigs/doc
 
 If you are interested to participate in Google Season of Docs as a technical writer, please do the following:
 
-. Join our link:https://gitter.im/jenkinsci/docs[Gitter Channel].
+. Join our link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter Channel].
 . Explore the project ideas listed on this page, find areas which would be interesting to you.
 . Try link:/participate/document/[contributing to Jenkins documentation] to study our documentation tools and contribution process.
   There are some link:/participate/document/#newcomers[newcomer-friendly documentation tasks] you could try.
@@ -69,7 +69,7 @@ In such cases we document usage of these tools in link:https://github.com/jenkin
 
 We use the link:/sigs/docs[Documentation SIG] communication channels for GSoD project discussions during the application phases.
 
-* link:https://gitter.im/jenkinsci/docs[Gitter Channel]
+* link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter Channel]
 * link:/sigs/docs/#meetings[Regular SIG meetings]
 
 Once the projects are announced, other project-specific channels may be created as needed.
@@ -92,7 +92,7 @@ Once the projects are announced, other project-specific channels may be created 
 
 Documentation office hours are held each Tuesday at *02:00 UTC* (Asia and US West) and each Thursday at *16:00 UTC* (Europe and US East).
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
-Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] 10 minutes before the meeting starts.
 Participant links are also available in the link:/events[Jenkins event calendar].
 
 [#archive]

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -184,13 +184,13 @@ This project is tracked in the jira:WEBSITE-742[] EPIC.
 
 Documentation office hours are held each Thursday at *18:00 UTC* (Europe and US East) and each Friday at *02:00 UTC* (Asia and US West).
 Office hours are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
-Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] 10 minutes before the meeting starts.
 
 == Meetings
 
 The Documentation SIG meetings are part of the documentation office hours.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
-Participant links are posted in the link:https://gitter.im/jenkinsci/docs[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] 10 minutes before the meeting starts.
 
 === Meeting Agendas
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -19,7 +19,7 @@ participants:
 - "stackscribe"
 - "zaycodes"
 links:
-  gitter: "jenkinsci/docs"
+  gitter: "jenkins/docs:matrix.org"
   meetings: "https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit"
 overview: >
   This special interest group improves Jenkins use and adoption through documentation.

--- a/content/sigs/gsoc/index.adoc
+++ b/content/sigs/gsoc/index.adoc
@@ -16,7 +16,7 @@ participants:
 - "kwhetstone"
 - "markewaite"
 links:
-  gitter: "jenkinsci/gsoc-sig"
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
   forum: "gsoc"
 overview: >
   This special interest group organizes Google Summer of Code program within the Jenkins organization.

--- a/content/sigs/hw-and-eda/index.adoc
+++ b/content/sigs/hw-and-eda/index.adoc
@@ -12,7 +12,7 @@ leads:
 participants:
 
 links:
-  gitter: jenkinsci/hw-and-eda-sig
+  gitter: "jenkinsci_hw-and-eda-sig:gitter.im"
   meetings: "/sigs/hw-and-eda/#meetings"
 
 overview: >

--- a/content/sigs/index.html.haml
+++ b/content/sigs/index.html.haml
@@ -29,7 +29,7 @@ title: Jenkins Special Interest Groups
                 Mailing List
           - if item.links.gitter
             %li
-              %a{:href => "https://gitter.im/#{item.links.gitter}", :target => "_blank", :rel => "noreferrer noopener"}
+              %a{:href => "https://app.gitter.im/#/room/##{item.links.gitter}", :target => "_blank", :rel => "noreferrer noopener"}
                 %img{:title => "Gitter", :src => "https://badges.gitter.im/#{item.links.gitter}.svg"}
         %p
           %a{:href => item.url}

--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -34,7 +34,7 @@ organizations:
 
 
 links:
-  gitter: jenkinsci/pipeline-authoring-sig
+  gitter: "jenkinsci_pipeline-authoring-sig:gitter.im"
   googlegroup: jenkins-pipeline-authoring-sig
   meetings: "/sigs/pipeline-authoring/#meetings"
 

--- a/content/sigs/pipeline-authoring/index.adoc
+++ b/content/sigs/pipeline-authoring/index.adoc
@@ -68,7 +68,7 @@ The target audience are anyone who are interested to join the effort of improvin
 As such, anyone with interest to either (or both) join our SIG meetings or our Gitter channel are welcome to participate!
 
 ==== Gitter Channel
-While any and all with questions regarding writing a Jenkins Pipeline are welcome in our link:https://gitter.im/jenkinsci/pipeline-authoring-sig[Gitter channel], we ask that the question has been researched before it is posted.
+While any and all with questions regarding writing a Jenkins Pipeline are welcome in our link:https://app.gitter.im/#/room/#jenkinsci_pipeline-authoring-sig:gitter.im[Gitter channel], we ask that the question has been researched before it is posted.
 Indeed, there are multiple blog posts and guides on the internet discussing how both to _ask_ a question in a constructive manner, and how to _reply_ constructively.
 
 Some examples of such posts/guides:
@@ -82,7 +82,7 @@ Some examples of such posts/guides:
 === Meetings
 
 Meetings are held every Friday at 9:00 AM PST. You can find more details by visiting the link:/event-calendar/[community calendar]
-Prior to each meeting a link to the meeting and meeting notes are provided in the link:https://gitter.im/jenkinsci/pipeline-authoring-sig[Jenkins Pipeline-Authoring Gitter]
+Prior to each meeting a link to the meeting and meeting notes are provided in the link:https://app.gitter.im/#/room/#jenkinsci_pipeline-authoring-sig:gitter.im[Jenkins Pipeline-Authoring Gitter]
 The last Friday of every month, the meeting is dedicated to link:/project/roadmap/[roadmap] discussions and statuses.
 
 === Code of Conduct

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -123,7 +123,7 @@ We have regular meetings on Tuesday every two weeks, at *17:00 UTC*.
 See the link:/event-calendar/[Jenkins Event Calendar] for the schedule.
 At these meetings we discuss projects, share presentations, and demonstrate new capabilities.
 Meetings are conducted and recorded via Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO3VROIfVsobTciEkLnVtSM[Platform SIG play list].
-Participant links are posted in the link:https://gitter.im/jenkinsci/platform-sig[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are posted in the link:https://app.gitter.im/#/room/#jenkinsci_platform-sig:gitter.im[SIG Gitter Chat] 10 minutes before the meeting starts.
 
 === Meeting Agendas
 

--- a/content/sigs/platform/index.adoc
+++ b/content/sigs/platform/index.adoc
@@ -31,7 +31,7 @@ participants:
 - "alecharp"
 - "mramonleon"
 links:
-  gitter: "jenkinsci/platform-sig"
+  gitter: "jenkinsci_platform-sig:gitter.im"
   meetings: "/sigs/platform/#meetings"
 overview: >
   This special interest group offers a venue for all kinds of platform support discussions:

--- a/content/sigs/ux/index.adoc
+++ b/content/sigs/ux/index.adoc
@@ -36,11 +36,11 @@ Most of these results have been integrated into Jenkins core in the meantime.
 * Discussing impact of UI changes to existing plugins
 
 == Gitter Channel
-The UX SIG uses a link:https://gitter.im/jenkinsci/ux-sig[Gitter room] and the
+The UX SIG uses a link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter room] and the
 link:https://community.jenkins.io[Jenkins community] to discuss any relevant topics.
 
 == Contributing
-If you want to contribute we recommend that you join the Jenkins UX SIG. You can find details of when the next meetings are planned in the Jenkins Calendar or via the link:https://gitter.im/jenkinsci/ux-sig[jenkinsci/ux-sig Gitter room].
+If you want to contribute we recommend that you join the Jenkins UX SIG. You can find details of when the next meetings are planned in the Jenkins Calendar or via the link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[jenkinsci/ux-sig Gitter room].
 
 [[ongoing-projects]]
 == Projects

--- a/content/sigs/ux/index.adoc
+++ b/content/sigs/ux/index.adoc
@@ -17,7 +17,7 @@ leads:
 - "uhafner"
 - "timja"
 links:
-  gitter: "jenkinsci/ux-sig"
+  gitter: "jenkinsci/ux-sig:matrix.org"
   meetings: "https://docs.google.com/document/d/1QttPwdimNP_120JukigKsRuBvMr34KZhVfsbgq1HFLM/edit?usp=sharing"
   forum: "ux-sig"
 overview: >


### PR DESCRIPTION
Some existing links redirect to the new location, others, like in https://github.com/jenkins-infra/jenkins.io/pull/6039, vanished at all and others again like https://gitter.im/Jenkinsci/simple-pull-request-job-plugin just broke completely.
This PR is a follow-up to https://github.com/jenkins-infra/jenkins.io/pull/6039, updating all Gitter links pointing to their new location, to ensure continuity and no frustration caused by dead links.