### PR TITLE
Add missing detail regarding jenkins.io components

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
@@ -43,6 +43,8 @@ While the tasks of the project are very clearly defined, the scope may vary depe
 
 The outcome of this project is expected to produce visible impact they can showcase in their portfolio of the link:https://www.jenkins.io/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
 
+Please note that for the UI/UX improvement portion we may need to deal with the link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo], where the code for the link:https://www.jenkins.io/[jenkins.io] website is currently hosted.
+
 === Quick Start
 
 Documentation quick start steps include:
@@ -66,6 +68,7 @@ Documentation quick start steps include:
 *** Docker containers
 *** Syntax and spelling checks
 * Fix several link:https://github.com/jenkins-infra/jenkins.io/labels/good%20first%20issue/["good first issues"]
+* Explore link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo]
 * Explore link:https://antora.org/[Antora]
 * Review version specific documentation techniques (some of them are Antora sites)
 ** link:https://docs.cloudbees.com/docs/cloudbees-ci/latest/cloud-secure-guide/folders-plus[CloudBees documentation site]

--- a/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool.adoc
@@ -43,7 +43,7 @@ While the tasks of the project are very clearly defined, the scope may vary depe
 
 The outcome of this project is expected to produce visible impact they can showcase in their portfolio of the link:https://www.jenkins.io/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
 
-Please note that for the UI/UX improvement portion we may need to deal with the link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo], where the code for the link:https://www.jenkins.io/[jenkins.io] website is currently hosted.
+Please note that for the UI/UX improvement portion we may need to deal with the link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo], where the code for components shared by various Jenkins websites (link:https://www.jenkins.io/[jenkins.io], link:https://plugins.jenkins.io/[plugins.jenkins.io], etc.) is currently hosted.
 
 === Quick Start
 


### PR DESCRIPTION
## Description

To provide links to the https://github.com/jenkins-infra/jenkins-io-components where the code of the components for the jenkins.io are currently hosted for the GSoC "Alternative jenkins.io build tool(s)" project contributor should decide to work also on improving the UI/UX design of jenkins.io. 
