### PR TITLE
Remove Ubuntu 18 reference

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables.adoc
@@ -27,8 +27,8 @@ use _iptables_ on Linux to forward traffic.
 
 == Ubuntu Installations
 
-Follow the link:/doc/book/installing/#debianubuntu[Ubuntu installation instructions] to install and configure the initial Jenkins installation on Ubuntu 18.04 or later.
-These instructions are known to not work on Ubuntu versions prior to 18.04.
+Follow the link:/doc/book/installing/#debianubuntu[Ubuntu installation instructions] to install and configure the initial Jenkins installation on a supported version of Ubuntu.
+These instructions are known to not work on Ubuntu versions that are no longer supported by the Ubuntu project.
 
 == Prerequisites
 


### PR DESCRIPTION
Prepare for Ubuntu 18 end of life in Apr 2023
