### PR TITLE
docs(pipeline): Add a missing intro to abort previous build option

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -701,7 +701,7 @@ in a subdirectory of the workspace. For example: `options { checkoutToSubdirecto
 
 disableConcurrentBuilds:: Disallow concurrent executions of the Pipeline. Can
 be useful for preventing simultaneous accesses to shared resources, etc. For
-example: `options { disableConcurrentBuilds() }`
+example: `options { disableConcurrentBuilds() }` to queue a build when there's already an executing build of the Pipeline, or `options { disableConcurrentBuilds(abortPrevious: true) }` to abort the running one and start the new build.
 
 disableResume:: Do not allow the pipeline to resume if the controller restarts.
 For example: `options { disableResume() }`


### PR DESCRIPTION
In [User Handbook](https://www.jenkins.io/doc/book/), there's no introduction about how to abort previous build when pipeline concurrency occurred by writing Jenkinsfile. I ended up finding it by using [Snippet Generator](https://www.jenkins.io/doc/book/pipeline/getting-started/#snippet-generator).

It would be a bit confusing for Jenkins rookies like me, so I think it would be better to add this example.
