### PR TITLE
GSoC 2023 status update

### DIFF
--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -119,8 +119,9 @@ Although we use Discourse as the main communication channel,
 we also have regular "office hours" video calls.
 During these time slots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
 
-* Schedule: weekly 30 minutes meeting. Office hours will be alternating between APAC (3AM UTC) and EMEA (2PM UTC) time zones. First meeting will be on February 4 at 3AM UTC.
-* link:https://docs.google.com/document/d/1OpvMWpzBKtKnYBAkhtQ1dK5zQix3D7RY5g3vDJXkSnc/edit?usp=sharing[Agenda]
+* Schedule: weekly 30 minutes meeting. Office hours will be held on Thursdays at 16:00 UTC.
+  Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
+* link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
 * Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
 
 This meeting will be used for Q&A with GSoC applicants/contributors and mentors before the announcement of accepted projects as well as during the GSoC program.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -27,8 +27,8 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 == GSoC 2023
 
-We have applied to participate in Google Summer of Code 2023. 
-See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Organisation Application Form]).
+We have have been accepted as a Google Summer of Code mentoring org for 2023. +
+See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
 
 
 // Uncomment when projects have been chosen
@@ -39,14 +39,12 @@ See the (link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP5
 // * link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance[Automatic git cache maintenance on the controller] by Hrushikesh Rao
 // * link:/projects/gsoc/2022/projects/pipeline-step-documentation-generator[Pipeline Step Documentation Generator Improvements] by Vihaan Thora
 
-We are currently waiting to know whether we will be accepted as a participating organisation (to be announced by Google on Feb 22, 2023). 
-A kick-off meeting will be organized right after.
+Would-be GSoC contributors are invited to work now on their application. 
+See the **link:./2023/project-ideas[2023 GSoC project ideas list]** for the possible subjects.
+To increase the selection likelihood, would-be GSoC contributors should request a review of their application by the Jenkins Community as soon as possible.
 
-**link:./2023/project-ideas[2023 GSoC project ideas list]**.
-
-We held two webinars explaining how to get prepared and how we will move forward. 
-One was focusing on students/contributors. (link:https://www.youtube.com/watch?v=k_sTkGtTix8[recording])
-The other was aimed at mentors and mentor candidates. (link:https://www.youtube.com/watch?v=gGTZtKjVlK0[recording])
+We will hold link:/projects/gsoc/#office-hours[weekly Office Hours] (Thursdays at 16:00 UTC) to answer any questions or clarify doubts.
+These sessions will be recorded and made available.
 
 
 //Uncomment when further in the selection process

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -41,7 +41,7 @@ See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51
 
 Would-be GSoC contributors are invited to work now on their application. 
 See the **link:./2023/project-ideas[2023 GSoC project ideas list]** for the possible subjects.
-To increase the selection likelihood, would-be GSoC contributors should request a review of their application by the Jenkins Community as soon as possible.
+To increase the selection likelihood, they should request a review of their application by the Jenkins Community as soon as possible.
 
 We will hold link:/projects/gsoc/#office-hours[weekly Office Hours] (Thursdays at 16:00 UTC) to answer any questions or clarify doubts.
 These sessions will be recorded and made available.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -27,7 +27,7 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 == GSoC 2023
 
-We have have been accepted as a Google Summer of Code mentoring org for 2023. +
+We have been accepted as a Google Summer of Code mentoring org for 2023. +
 See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
 
 


### PR DESCRIPTION
**WARNING**: 
Please hold merge until Google announced selected 2023 Mentoring Orgs (and if Jenkins is selected) => 22-Feb-2023 18:00 UTC

This PR changes the GSoC welcome page as we are entering a new phase.