### PR TITLE
Update groupId wording for hosting requests

### DIFF
--- a/content/doc/developer/publishing/style-guides.adoc
+++ b/content/doc/developer/publishing/style-guides.adoc
@@ -28,8 +28,8 @@ Including _Jenkins_ or _Plugin_ in the name to indicate that it is a plugin for 
 
 === Group ID
 
-We recommend use of `io.jenkins.plugins` or `org.jenkins-ci.plugins` group IDs, but do not prohibit other group IDs unless they're in bad faith (e.g. referencing an organization you have no relationship with).
-
+All new hosting requests are instructed to use `io.jenkins.plugins` as group ID. +
+We do not strictly prohibit other group IDs unless they're in bad faith (e.g. referencing an organization you have no relationship with), but we strongly recommend using `io.jenkins.plugins` to avoid confusion and use a standardized pattern.
 
 == Java Source Code
 


### PR DESCRIPTION
New hosting requests use `io.jenkins.plugins`, given that's the base archetypes generates and our documentation points to.
The hosting tooling has been updated some time ago to ensure all new hosting requests follow the standard groupId pattern of `io.jenkins.plugins`.