### PR TITLE
Remove a link to a suspended plugin

### DIFF
--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -479,9 +479,6 @@ and allows to control external application from Jenkins.
 Execution Strategy Plugin] — A plugin to decide the execution order and valid
 combinations of matrix projects.
 
-- https://plugins.jenkins.io/pipeline-classpath-step[Pipeline Classpath Step
-Plugin] Pipeline DSL step to add path to the groovy classpath
-
 - https://plugins.jenkins.io/scriptler[Scriptler Plugin] — Scriptler allows you
 to store/edit groovy scripts and execute it on any of the nodes... no need to
 copy/paste groovy code anymore.


### PR DESCRIPTION
Fixes  #6071 -- no need to mention a suspended plugin https://plugins.jenkins.io/pipeline-classpath/