### PR TITLE
Replace broken OpenBSD links

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -130,7 +130,7 @@ title: Jenkins download and deployment
             %span
               &nbsp;
             %ion-icon{:name=>"library-outline"}
-          %a.list-group-item.list-group-item-action{tooltip_href('http://ports.su/devel/jenkins/stable', third_party)}
+          %a.list-group-item.list-group-item-action{tooltip_href('https://openports.pl/path/devel/jenkins/stable', third_party)}
             %span.title
               OpenBSD
             %span

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -130,7 +130,7 @@ title: Jenkins download and deployment
             %span
               &nbsp;
             %ion-icon{:name=>"library-outline"}
-          %a.list-group-item.list-group-item-action{tooltip_href('http://openports.se/devel/jenkins/stable', third_party)}
+          %a.list-group-item.list-group-item-action{tooltip_href('https://www.openbsd.org/faq/faq4.html#Download', third_party)}
             %span.title
               OpenBSD
             %span
@@ -196,7 +196,7 @@ title: Jenkins download and deployment
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{tooltip_href('http://openports.se/devel/jenkins/devel', third_party)}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://www.openbsd.org/faq/faq4.html#Download', third_party)}
           %span.title
             OpenBSD
           %span

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -130,7 +130,7 @@ title: Jenkins download and deployment
             %span
               &nbsp;
             %ion-icon{:name=>"library-outline"}
-          %a.list-group-item.list-group-item-action{tooltip_href('https://www.openbsd.org/faq/faq4.html#Download', third_party)}
+          %a.list-group-item.list-group-item-action{tooltip_href('http://ports.su/devel/jenkins/stable', third_party)}
             %span.title
               OpenBSD
             %span
@@ -196,7 +196,7 @@ title: Jenkins download and deployment
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{tooltip_href('https://www.openbsd.org/faq/faq4.html#Download', third_party)}
+        %a.list-group-item.list-group-item-action{tooltip_href('http://ports.su/devel/jenkins/devel ', third_party)}
           %span.title
             OpenBSD
           %span

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -196,7 +196,7 @@ title: Jenkins download and deployment
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{tooltip_href('http://ports.su/devel/jenkins/devel', third_party)}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://openports.pl/path/devel/jenkins/devel', third_party)}
           %span.title
             OpenBSD
           %span

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -196,7 +196,7 @@ title: Jenkins download and deployment
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{tooltip_href('http://ports.su/devel/jenkins/devel ', third_party)}
+        %a.list-group-item.list-group-item-action{tooltip_href('http://ports.su/devel/jenkins/devel', third_party)}
           %span.title
             OpenBSD
           %span


### PR DESCRIPTION
I am writing to propose a fix for broken links in the  repository. While reviewing the repository, I noticed that the links on lines 133 and 199 of a particular file were not working. I have since made the necessary changes to update these links and ensure that they are functional.

To make these changes, I forked the  repository and cloned it to my local machine. I then made the necessary updates to the file, testing the changes to ensure that the links were working properly. I have committed the changes to my local Git repository and pushed the changes to my forked repository on GitHub.

I am now creating a pull request to propose these changes to the repository.