### PR TITLE
Label conflicting PRs

### DIFF
--- a/.github/workflows/label-conflicting-prs.yml
+++ b/.github/workflows/label-conflicting-prs.yml
@@ -1,0 +1,21 @@
+name: "Label conflicting PRs"
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label conflicting PRs
+        uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # v2.1.0
+        with:
+          dirtyLabel: "unresolved-merge-conflict"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "Please take a moment and address the merge conflicts of your pull request. Thanks!"
+          continueOnMissingPermissions: true


### PR DESCRIPTION
Similar to core, I would like to notify PR authors and maintainers once a PR conflicts with the target branch.

I have been using the same workflow for about 5 months, and it helped a lot to keep review times short, by notifying people and allowing them to act in a timely manner.