### PR TITLE
Fix broken URL on docker-based jenkins quickstart examples GSoC page

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
@@ -45,7 +45,7 @@ Of course, these snippets could also be run thanks to link:https://www.gitpod.io
 * link:https://docs.docker.com/compose/compose-file/compose-file-v3/[Docker Compose file format v3]
 * link:https://www.jenkins.io/projects/jcasc/[Jenkins Configuration as Code]
 * link:https://plugins.jenkins.io/job-dsl/[Job DSL]
-* link:/book/installing/kubernetes/[Kubernetes]
+* link:https://www.jenkins.io/doc/book/installing/kubernetes/[Kubernetes]
 
 === Project Difficulty Level
 

--- a/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
@@ -43,9 +43,9 @@ Of course, these snippets could also be run thanks to link:https://www.gitpod.io
 
 * link:https://docs.docker.com/compose/[Docker Compose]
 * link:https://docs.docker.com/compose/compose-file/compose-file-v3/[Docker Compose file format v3]
-* link:https://www.jenkins.io/projects/jcasc/[Jenkins Configuration as Code]
+* link:/projects/jcasc/[Jenkins Configuration as Code]
 * link:https://plugins.jenkins.io/job-dsl/[Job DSL]
-* link:https://www.jenkins.io/doc/book/installing/kubernetes/[Kubernetes]
+* link:/doc/book/installing/kubernetes/[Kubernetes]
 
 === Project Difficulty Level
 


### PR DESCRIPTION
The Kubernetes link led to an error 404. Fixed the link