### PR TITLE
Break hardlinks to jenkins.io

### DIFF
--- a/content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
+++ b/content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
@@ -266,7 +266,7 @@ https://issues.jenkins.io/browse/Jenkins-51809[Jira Epic]
 
 * link:https://docs.google.com/document/d/1cuC0AvQG3e4GCjIoCwK3J0tcJVAz1eNDKV8d_zXxlO8/edit[Initial proposal of the project]
 * link:https://github.com/Jenkinsci/simple-pull-request-job-plugin[Project repository]
-* link:https://Jenkins.io/projects/gsoc/2018/simple-pull-request-job-plugin/[Project page]
+* link:/projects/gsoc/2018/simple-pull-request-job-plugin/[Project page]
 * link:https://app.gitter.im/#/room/#jenkinsci_simple-pull-request-job-plugin:gitter.im[Gitter chat]
 * link:https://issues.jenkins.io/issues/?jql=project%20%3D%20Jenkins%20AND%20component%20%3D%20simple-pull-request-job-plugin[Bug Tracker]
 * https://github.com/gautamabhishek46/dummy[Demo Repository]

--- a/content/blog/2022/11/2022-11-23-get-prepared-for-gsoc.adoc
+++ b/content/blog/2022/11/2022-11-23-get-prepared-for-gsoc.adoc
@@ -53,10 +53,10 @@ You can find open newbie friendly issues link:https://issues.jenkins.io/issues/?
 Issues describe problems that need fixing or enhancement ideas.
 To move forward, use the documentation available on Jenkins.io (https://www.jenkins.io/doc/developer/) or ask for advice/help on the developer mailing list, Discourse, or the Gitter channels (see https://www.jenkins.io/projects/gsoc/#contacts for the details). 
 
-Another way to get experience is to follow the suggestions of the link:https://www.jenkins.io/doc/developer/tutorial-improve/[**"Improve a Plugin Tutorial"**].
+Another way to get experience is to follow the suggestions of the link:/doc/developer/tutorial-improve/[**"Improve a Plugin Tutorial"**].
 
 And of course read the rules and general advice specific to Google Summer of Code: https://www.jenkins.io/projects/gsoc/students/ and https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html.
-Also a useful reading are link:https://www.jenkins.io/projects/gsoc/#previous-years[previous year's submission] and recorded meetings.
+Also a useful reading are link:/projects/gsoc/#previous-years[previous year's submission] and recorded meetings.
 
 Remember it is always a good idea to let others know about your contributions to the community especially via IRC conversations, GitHub issues, as well as pull requests. 
 Be sure to ask questions when and where appropriate. 

--- a/content/blog/2022/12/2022-12-09-GSoC-the-gift-of-mentorship.adoc
+++ b/content/blog/2022/12/2022-12-09-GSoC-the-gift-of-mentorship.adoc
@@ -39,9 +39,9 @@ You know enough about the Jenkins code to guide the GSoC contributor on coding.
 * Collaborate with another mentor on the chosen project, ensuring that no one is working alone.
 
 == What will you work on?
-* You may choose to be a mentor/co-mentor for any of the link:https://www.jenkins.io/projects/gsoc/2023/project-ideas/[listed project ideas]. 
+* You may choose to be a mentor/co-mentor for any of the link:/projects/gsoc/2023/project-ideas/[listed project ideas].
   Please note, this list is still evolving.
-* You can also link:https://www.jenkins.io/projects/gsoc/proposing-project-ideas/[propose] a project that is near and dear to your heart. 
+* You can also link:/projects/gsoc/proposing-project-ideas/[propose] a project that is near and dear to your heart.
 
 == Additional info:
 * link:https://developers.google.com/open-source/gsoc/timeline[GSoC 2023 program timeline]

--- a/content/blog/2022/12/2022-12-09-jfrog-maintenance.adoc
+++ b/content/blog/2022/12/2022-12-09-jfrog-maintenance.adoc
@@ -37,7 +37,7 @@ Despite not being directly used by the usual Jenkins users, the link:https://rep
 
 The entire Jenkins Infrastructure uses this repository to build and publish Jenkins itself, and also all of its plugins and side projects.
 
-It's also heavily used by the link:https://www.jenkins.io/security/team/[Jenkins Security Team] as part of their advisory publication.
+It's also heavily used by the link:/security/team/[Jenkins Security Team] as part of their advisory publication.
 
 This migration is an important requirement to ensure that JFrog is able to monitor the service and provide the best availability and infrastructure health.
 If you are curious or interested, you can find more details on the Jenkins Infrastructure issue tracker: link:https://github.com/jenkins-infra/helpdesk/issues/3288[Jenkins Infrastructure Helpdesk Issue #3288]

--- a/content/blog/2023/02/2023-02-21-thoughts-on-FOSDEM-2023.adoc
+++ b/content/blog/2023/02/2023-02-21-thoughts-on-FOSDEM-2023.adoc
@@ -88,7 +88,7 @@ image:/images/post-images/2023/02/21/2023-02-21-thoughts-on-FOSDEM-2023/image2.p
 [quote, Jean-Marc Meessen]
 It was with great pleasure that I could attend this incredible event.
 Meeting contributors and members of the community in person was such a change after these years hiding from the pandemic.
-I particularly enjoyed the great conversations on so many subjects such as the Jenkins day to day experience, where the project is heading (or should head to), and particularly, my personal pet interests: link:https://www.jenkins.io/projects/gsoc/[GSoC] or how to start contributing.
+I particularly enjoyed the great conversations on so many subjects such as the Jenkins day to day experience, where the project is heading (or should head to), and particularly, my personal pet interests: link:/projects/gsoc/[GSoC] or how to start contributing.
 Even after attending this conference since 2009, my amazement never fades for this incredible explosion of ideas, enthusiasm, diversity, dedication, and generosity for the Open Source movement.
 
 Many thanks to the FOSDEM organizers for their hard work and dedication to make this event possible for so many open-source communities.

--- a/content/doc/tutorials/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
+++ b/content/doc/tutorials/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
@@ -27,7 +27,7 @@ For this tutorial, you will need:
 * A GitHub repository
 * Git installed locally
 * Fundamental knowledge link:https://docs.github.com/en/actions[of GitHub Actions and how they work].
-* If you want to integrate Jenkins plugins, you also need to know what link:https://www.jenkins.io/projects/jcasc/[JCasC] is. 
+* If you want to integrate Jenkins plugins, you also need to know what link:/projects/jcasc/[JCasC] is.
 This tutorial reviews some basic concepts of JCasC.
 
 === Create a GitHub repository
@@ -323,7 +323,7 @@ with:
 === Configure ephemeral Jenkins instance (optional)
 
 Sometimes, JCasC might not be able to provide the configurations you need. 
-In this case, refer to link:https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/[Groovy Hook Scripts] to set up the ephemeral Jenkins instance. 
+In this case, refer to link:/doc/book/managing/groovy-hook-scripts/[Groovy Hook Scripts] to set up the ephemeral Jenkins instance.
 These Groovy scripts will have full access to the ephemeral Jenkins server and will be executed right after Jenkins starts up.
 
 NOTE: This option and its core are still in progress, so it’s not mentioned in the Jenkinsfile Runner GitHub Actions official guide.
@@ -424,5 +424,5 @@ You can also find additional examples in the link:https://github.com/jenkinsci/j
 
 To learn more about the contributions of Jenkinsfile Runner GitHub Actions, refer to:
 
-* link:https://www.jenkins.io/blog/2022/09/07/jenkinsfile-runner-as-github-actions/[The related GSoC blog post]
+* link:/blog/2022/09/07/jenkinsfile-runner-as-github-actions/[The related GSoC blog post]
 * link:https://jenkinsci.github.io/jfr-action-doc/developer-guide[The official developer guide]

--- a/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
+++ b/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
@@ -33,7 +33,7 @@ The proof of concept could be the docker-compose based. It would works under Win
 It should be easily transposable to a production environment.
 The demo/proof-of-concept would be composed of a Jenkins controller (configured with JCasc), an Android agent, a generic Docker agent, an Android emulator, and an Android device farm (link:https://github.com/DeviceFarmer[STF]).
 
-The idea is to have a more precise status of what can be done now with Jenkins. We could then amend the existing link:https://www.jenkins.io/solutions/android/[documentation] and describe architectures for:
+The idea is to have a more precise status of what can be done now with Jenkins. We could then amend the existing link:/solutions/android/[documentation] and describe architectures for:
 
 * Standalone Android projects
 * Android apps building farms

--- a/content/security/advisory/2022-04-12.adoc
+++ b/content/security/advisory/2022-04-12.adoc
@@ -34,7 +34,7 @@ issues:
     This results in stored cross-site scripting (XSS) vulnerabilities exploitable by attackers with Item/Configure permission.
 
     Exploitation of these vulnerabilities requires that parameters are listed on another page, like the "Build With Parameters" and "Parameters" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation.
-    Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the "Build With Parameters" and "Parameters" pages since 2.44 and LTS 2.32.2 as part of the link:https://www.jenkins.io/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions[SECURITY-353 / CVE-2017-2601] fix.
+    Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the "Build With Parameters" and "Parameters" pages since 2.44 and LTS 2.32.2 as part of the link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions[SECURITY-353 / CVE-2017-2601] fix.
     Additionally, the following plugins have been updated to list parameters in a way that prevents exploitation by default.
 
     * plugin:m2release[Maven Release Plugin] 0.16.3 (SECURITY-2669)

--- a/content/security/advisory/2022-05-17.adoc
+++ b/content/security/advisory/2022-05-17.adoc
@@ -253,7 +253,7 @@ issues:
     This results in stored cross-site scripting (XSS) vulnerabilities exploitable by attackers with Item/Configure permission.
 
     Exploitation of these vulnerabilities requires that parameters are listed on another page, like the "Build With Parameters" and "Parameters" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation.
-    Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the "Build With Parameters" and "Parameters" pages since 2.44 and LTS 2.32.2 as part of the link:https://www.jenkins.io/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions[SECURITY-353 / CVE-2017-2601] fix.
+    Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the "Build With Parameters" and "Parameters" pages since 2.44 and LTS 2.32.2 as part of the link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions[SECURITY-353 / CVE-2017-2601] fix.
     Additionally, several plugins have previously been updated to list parameters in a way that prevents exploitation by default, see link:/security/advisory/2022-04-12/#SECURITY-2617[SECURITY-2617 in the 2022-04-12 security advisory for a list].
 
     The following plugins have been updated to escape the name and description of the parameter types they provide in the versions specified:


### PR DESCRIPTION
This PR picks up my comment on https://github.com/jenkins-infra/jenkins.io/pull/6079#discussion_r1118107550, to break hardlinks to jenkins.io.
This ensures redirections lead to the domain URL, and not jenkins.io. A typical use-case of this scenario is browsing pages locally or on netlify, without redirects to jenkins.io.