### PR TITLE
Unlink hard links in changelog and roadmap

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -62,13 +62,13 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2017-02-01/
+        - url: /security/advisory/2017-02-01/
           title: security advisory
     - type: major rfe
       message: Support displaying of warnings from the update site in the plugin manager and in administrative monitors.
       references:
         - issue: 40494
-        - url: https://jenkins.io/blog/2017/01/10/security-warnings/
+        - url: /blog/2017/01/10/security-warnings/
           title: announcement blog post
     - type: bug
       message: Correctly state that Jenkins will refuse to load plugins whose dependencies are not satisfied in plugin manager.
@@ -250,7 +250,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2017-04-26/
+        - url: /security/advisory/2017-04-26/
           title: security advisory
     - type: major rfe
       message: >
@@ -268,7 +268,7 @@
       message: <code>Computer#addAction</code> would throw an <code>UnsupportedOperationException</code> since Jenkins 2.30. Such a call site was released in SSH Build Agents Plugin 1.15 for SECURITY-161.
       references:
         - issue: 42969
-        - url: https://jenkins.io/security/advisory/2017-03-20/
+        - url: /security/advisory/2017-03-20/
           title: security advisory including SECURITY-161
       pull: 2819
     - type: bug
@@ -799,7 +799,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2017-10-11/
+        - url: /security/advisory/2017-10-11/
           title: security advisory
     - type: major bug
       message: >
@@ -813,7 +813,7 @@
         - issue: 45755
         - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#3102
           title: full changelog
-        - url: https://jenkins.io/doc/upgrade-guide/2.73/#known-issue-agent-connection-failures-involving-jenkins-masters-with-undefined-or-non-writable-home-directory
+        - url: /doc/upgrade-guide/2.73/#known-issue-agent-connection-failures-involving-jenkins-masters-with-undefined-or-non-writable-home-directory
           title: issue description in 2.73.1 upgrade guide
       pull: 3025
     - type: major rfe
@@ -831,7 +831,7 @@
     - type: security
       message: Security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2017-11-08/
+        - url: /security/advisory/2017-11-08/
           title: security advisory
     - type: major bug
       issue: 47448
@@ -873,7 +873,7 @@
         - issue: 47393
         - url: https://plugins.jenkins.io/command-launcher
           title: Command Launcher plugin site entry
-        - url: https://www.jenkins.io/security/advisory/2017-10-11/#arbitrary-shell-command-execution-on-controller-by-users-with-agent-related-permissions
+        - url: /security/advisory/2017-10-11/#arbitrary-shell-command-execution-on-controller-by-users-with-agent-related-permissions
           title: related security advisory
     - type: major bug
       message: >
@@ -1084,15 +1084,15 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2018-02-14/
+        - url: /security/advisory/2018-02-14/
           title: security advisory
     - type: rfe
       message: >
         Security hardening to prevent problems like SECURITY-624 in the future.
       references:
-        - url: https://jenkins.io/security/advisory/2017-12-05/
+        - url: /security/advisory/2017-12-05/
           title: 2017-12-05 security advisory
-        - url: https://jenkins.io/security/advisory/2018-01-22/#xss-vulnerability-in-job-configuration-forms-in-ant-plugin
+        - url: /security/advisory/2018-01-22/#xss-vulnerability-in-job-configuration-forms-in-ant-plugin
           title: Ant Plugin fix in 2018-01-22 security advisory
     - type: bug
       pull: 3187
@@ -1127,7 +1127,7 @@
   lts_predecessor: "2.89.4"
   lts_baseline: "2.107"
   banner: >
-    This is the first LTS release that includes <a href="https://jenkins.io/blog/2018/03/15/jep-200-lts/">the JEP-200 Remoting and XStream serialization allowlist</a>.
+    This is the first LTS release that includes <a href="/blog/2018/03/15/jep-200-lts/">the JEP-200 Remoting and XStream serialization allowlist</a>.
     This core change requires <a href="https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200">corresponding changes in many plugins</a> for them to be compatible.
     We strongly recommend that you read the <a href="/doc/upgrade-guide/2.107">LTS upgrade guide</a>, make sure you have good backups before upgrading, and validate this release in a staging environment first.
   lts_changes:
@@ -1253,7 +1253,7 @@
     - type: rfe
       references:
         - issue: 43786 # and 49129
-        - url: https://jenkins.io/blog/2018/01/21/overhaul-of-manage-jenkins-page/
+        - url: /blog/2018/01/21/overhaul-of-manage-jenkins-page/
           title: blog post
       pull: 2857 # and 3266
       message: >
@@ -1333,7 +1333,7 @@
     - type: security
       message: Security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2018-04-11/
+        - url: /security/advisory/2018-04-11/
           title: security advisory
 
     - type: major bug
@@ -1435,7 +1435,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2018-05-09/
+        - url: /security/advisory/2018-05-09/
           title: security advisory
     - type: rfe
       pull: 3403 # and 3404
@@ -1520,7 +1520,7 @@
       references:
         - issue: 9104
         - title: <code>ProcessKillingVeto</code> extension point implementations
-          url: https://jenkins.io/doc/developer/extensions/jenkins-core/#processkillingveto
+          url: /doc/developer/extensions/jenkins-core/#processkillingveto
 
     # Pipeline related
     - type: rfe
@@ -1669,7 +1669,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2018-07-18/
+        - url: /security/advisory/2018-07-18/
           title: security advisory
 
     - type: rfe
@@ -1775,7 +1775,7 @@
   - type: security
     message: Security fixes.
     references:
-      - url: https://jenkins.io/security/advisory/2018-08-15/
+      - url: /security/advisory/2018-08-15/
         title: security advisory
   - type: rfe
     message: Security hardening related to Stapler routing.
@@ -1826,13 +1826,13 @@
     references:
     - issue: 50447
     - title: announcement blog post
-      url: https://jenkins.io/blog/2018/06/27/new-login-page/
+      url: /blog/2018/06/27/new-login-page/
   - type: major rfe
     pull: 3271
     references:
     - issue: 32442
     - issue: 32776
-    - url: https://jenkins.io/blog/2018/07/02/new-api-token-system/
+    - url: /blog/2018/07/02/new-api-token-system/
       title: blog post
     message: >
       Replace single per-user API token with new system of multiple, revocable, unrecoverable API tokens with usage tracking.
@@ -1842,7 +1842,7 @@
     message: >
       The deprecated Jenkins CLI Protocol versions 1 and 2, and Java Web Start Agent Protocol versions 1, 2, and 3 have been disabled.
       If you still use these protocols (e.g. remoting-based CLI, or old <code>slave.jar</code>s on agents), you need to re-enable these protocols after upgrade, or upgrade the clients.
-      The same recommendations as in <a href="https://jenkins.io/doc/upgrade-guide/2.121/#remoting-update">The 2.121.x upgrade guide for remoting changes</a> apply here.
+      The same recommendations as in <a href="/doc/upgrade-guide/2.121/#remoting-update">The 2.121.x upgrade guide for remoting changes</a> apply here.
   - type: major rfe
     pull: 3356
     message: >
@@ -1886,7 +1886,7 @@
     pull: 3513
     references:
     - issue: 51837
-    - url: https://jenkins.io/redirect/java-support/
+    - url: /redirect/java-support/
       title: supported Java versions
     message: >
       Upgrade Bytecode Compatibility Transformer from 1.8 to 2.0-beta-2, upgrading ASM from 5.0.1 to 6.2 to improve support of Java 9+ runtimes.
@@ -1901,7 +1901,7 @@
       url: https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#140
     - title: Executable WAR 1.41 changelog
       url: https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#140
-    - url: https://jenkins.io/redirect/java-support/
+    - url: /redirect/java-support/
       title: supported Java versions
     message: >
       Update Executable WAR from 1.39 to 1.41 to allow running Jenkins with incompatible (too new) Java versions by setting the <code>--enable-future-java</code> flag.
@@ -1977,7 +1977,7 @@
       Developer: Introduce <code>SimplePageDecorator</code> extension point, which allows decorating the redesigned login page.
     references:
     - title: announcement blog post
-      url: https://jenkins.io/blog/2018/06/27/new-login-page/
+      url: /blog/2018/06/27/new-login-page/
 
   # Internal
   - type: rfe
@@ -2008,7 +2008,7 @@
   - type: security
     message: Important security fixes.
     references:
-    - url: https://jenkins.io/security/advisory/2018-10-10/
+    - url: /security/advisory/2018-10-10/
       title: security advisory
   - type: major rfe
     message: >
@@ -2084,7 +2084,7 @@
     - type: security
       message: Important security fixes.
       references:
-      - url: https://jenkins.io/security/advisory/2018-12-05/
+      - url: /security/advisory/2018-12-05/
         title: security advisory
 - version: 2.150.1
   date: 2018-12-05
@@ -2209,7 +2209,7 @@
     - type: security
       message: Important security fixes.
       references:
-      - url: https://jenkins.io/security/advisory/2018-12-05/
+      - url: /security/advisory/2018-12-05/
         title: security advisory
     - type: bug
       references:
@@ -2241,7 +2241,7 @@
   - type: security
     message: Important security fixes.
     references:
-    - url: https://jenkins.io/security/advisory/2019-01-16/
+    - url: /security/advisory/2019-01-16/
       title: security advisory
   - type: rfe
     message: Invalidate sessions and CLI authentication caches when changing the user password in the Jenkins user database.
@@ -2374,7 +2374,7 @@
   - type: security
     message: Security fixes.
     references:
-    - url: https://jenkins.io/security/advisory/2019-04-10/
+    - url: /security/advisory/2019-04-10/
       title: security advisory
   - type: bug
     pull: 3914
@@ -2426,7 +2426,7 @@
   - type: major rfe
     references:
       - pull: 3838
-      - url: https://jenkins.io/blog/2019/02/17/remoting-cli-removed/
+      - url: /blog/2019/02/17/remoting-cli-removed/
         title: announcement blog post
     message: >
       Support for the Remoting mode of the CLI (<code>-remoting</code> option) has been removed.
@@ -2562,7 +2562,7 @@
   - type: rfe
     references:
       - pull: 3967
-      - url: https://jenkins.io/doc/developer/security/secrets/
+      - url: /doc/developer/security/secrets/
         title: Storing Secrets in Jenkins
     message: |-
       Developer: Add Jelly UI component <code>f:secretTextarea</code> for multi-line secrets analogous to <code>f:password</code> for single-line.
@@ -2593,7 +2593,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2019-07-17/
+        - url: /security/advisory/2019-07-17/
           title: security advisory
     # backport tickets
     - type: bug
@@ -2626,7 +2626,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2019-08-28/
+        - url: /security/advisory/2019-08-28/
           title: security advisory
     - type: bug
       pull: 4001
@@ -2654,7 +2654,7 @@
     - type: security
       message: Security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2019-09-25/
+        - url: /security/advisory/2019-09-25/
           title: security advisory
 
 - version: 2.190.1
@@ -2665,9 +2665,9 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2019-09-25/
+        - url: /security/advisory/2019-09-25/
           title: 2019-09-25 security advisory
-        - url: https://jenkins.io/security/advisory/2019-08-28/
+        - url: /security/advisory/2019-08-28/
           title: 2019-08-28 security advisory
     - type: bug
       pull: 4188
@@ -2744,7 +2744,7 @@
     # Functional RFEs
     - type: rfe
       references:
-        - url: https://jenkins.io/doc/pipeline/steps/core/#fingerprint-record-fingerprints-of-files-to-track-usage
+        - url: /doc/pipeline/steps/core/#fingerprint-record-fingerprints-of-files-to-track-usage
           title: documentation
         - pull: 3915
       message: |-
@@ -2912,7 +2912,7 @@
       message: |-
         Deprecate the macOS native installer in favor of Homebrew.
       references:
-      - url: https://jenkins.io/blog/2019/11/25/macos-native-installer-deprecation/#rollout-plan
+      - url: /blog/2019/11/25/macos-native-installer-deprecation/#rollout-plan
         title: macOS Native Installer Deprecation blog post
       authors:
         - oleg-nenashev
@@ -2968,7 +2968,7 @@
     - type: security
       message: Important security fixes.
       references:
-        - url: https://jenkins.io/security/advisory/2020-01-29/
+        - url: /security/advisory/2020-01-29/
           title: security advisory
       authors:
         - daniel-beck
@@ -3295,7 +3295,7 @@
     message: |-
       Deprecate the macOS native installer packaging.
     references:
-      - url: https://jenkins.io/blog/2019/11/25/macos-native-installer-deprecation/
+      - url: /blog/2019/11/25/macos-native-installer-deprecation/
         title: Jenkins macOS native installer deprecation
     authors:
       - oleg-nenashev
@@ -3353,7 +3353,7 @@
       - issue: 60920
       - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
         title: JEP-223
-      - url: https://jenkins.io/sigs/ux/
+      - url: /sigs/ux/
         title: Jenkins UX SIG
   - type: major rfe
     category: major rfe
@@ -3406,9 +3406,9 @@
       - issue: 60266
       - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
         title: JEP-223
-      - url: https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+      - url: /security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
         title: 2017-04-10 security advisory for Matrix Authorization plugin
-      - url: https://jenkins.io/security/advisory/2017-04-10/#role-based-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+      - url: /security/advisory/2017-04-10/#role-based-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
         title: 2017-04-10 security advisory for Role-Based Authorization plugin
     message: |-
       Deprecate the <code>Overall/RunScripts</code>, <code>Overall/UploadPlugins</code>, and <code>Overall/ConfigureUpdateCenter</code> permissions.
@@ -3696,7 +3696,7 @@
     references:
     - issue: 61202
     - pull: 4479
-    - url: https://www.jenkins.io/blog/2020/05/25/read-only-jenkins-announcement/
+    - url: /blog/2020/05/25/read-only-jenkins-announcement/
       title: Read-only Jenkins Configuration blog post
     message: |-
       Users with extended read permission now get a more read-only looking UI.
@@ -3852,7 +3852,7 @@
   date: 2020-08-12
   banner: >
     A <strong>new GPG signing key</strong> is used for the Jenkins long term support package repositories.
-    Follow the instructions in the <a href="https://www.jenkins.io/blog/2020/07/27/repository-signing-keys-changing/">Linux repository signing blog post</a> to install the new public key on your computer.
+    Follow the instructions in the <a href="/blog/2020/07/27/repository-signing-keys-changing/">Linux repository signing blog post</a> to install the new public key on your computer.
   changes:
   - type: security
     message: Important security fixes.
@@ -4043,13 +4043,13 @@
     category: major rfe
     pull: 4823
     references:
-      - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/
+      - url: /blog/2020/07/23/windows-support-updates/
         title: announcement
-      - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/#use-cases-affected-by-net-framework-2-0-support-removal
+      - url: /blog/2020/07/23/windows-support-updates/#use-cases-affected-by-net-framework-2-0-support-removal
         title: upgrade guidelines
       - issue: 60005
       - issue: 61862
-      - url: https://www.jenkins.io/doc/administration/requirements/windows/
+      - url: /doc/administration/requirements/windows/
         title: Windows support policy
     authors:
     - NextTurn
@@ -4061,7 +4061,7 @@
     category: major rfe
     pull: 4823
     references:
-      - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/#windows-service-management-changes-in-jenkins-2-248
+      - url: /blog/2020/07/23/windows-support-updates/#windows-service-management-changes-in-jenkins-2-248
         title: changes summary
       - url: https://github.com/winsw/winsw/releases
         title: full WinSW changelog
@@ -4559,7 +4559,7 @@
     - PhilippHomann
     references:
       - pull: 4978
-      - url: "https://www.jenkins.io/doc/book/managing/system-properties/#historywidget-descriptionlimit"
+      - url: /doc/book/managing/system-properties/#historywidget-descriptionlimit
         title: Features controlled with System Properties
     message: |-
       Hide description panel in sidebar if historyWidget.descriptionLimit is 0.
@@ -4734,7 +4734,7 @@
     references:
       - pull: 5188
       - issue: 64632
-      - url: https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-1452
+      - url: /security/advisory/2021-01-13/#SECURITY-1452
         title: SECURITY-1452
     message: |-
       Fix the file handle leak inside DirectoryBrowserSupport (regression in 2.263.2).
@@ -4748,7 +4748,7 @@
       - pull: 5187
       - issue: 64621
       - issue: 61473
-      - url: https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-1452
+      - url: /security/advisory/2021-01-13/#SECURITY-1452
         title: SECURITY-1452
     message: |-
       Include root folder in downloaded zip files (regression in 2.263.2).
@@ -5820,7 +5820,7 @@
     references:
       - pull: 5320
       - issue: 65161
-      - url: https://www.jenkins.io/blog/2021/06/04/digester-removal/
+      - url: /blog/2021/06/04/digester-removal/
         title: Announcement and upgrade guidelines
 
   - type: bug
@@ -6697,7 +6697,7 @@
     references:
       - pull: 6180
       - issue: 67674
-      - url: https://www.jenkins.io/security/advisory/2022-01-12/
+      - url: /security/advisory/2022-01-12/
         title: 2022-01-12 security advisory
     message: |-
       Update the bundled Matrix Project plugin from 1.18 to 1.20.
@@ -6927,7 +6927,7 @@
       - pull: 6103
       - url: https://github.com/jenkinsci/jep/tree/master/jep/7#jep-7-deprecation-of-ruby-and-python-plugin-runtimes
         title: "JEP-7: Deprecation of Ruby and Python plugin runtimes"
-      - url: https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+      - url: /blog/2021/12/22/deprecated-ruby-runtime/
         title: Deprecating non-Java plugins (blog post)
       - url: https://github.com/jenkinsci/stapler
         title: Stapler repository
@@ -7313,7 +7313,7 @@
     pr_title: Update bundled plugins after 2022-05-17 security advisory
     references:
       - pull: 6582
-      - url: https://www.jenkins.io/security/advisory/2022-05-17/
+      - url: /security/advisory/2022-05-17/
         title: 2022-05-17 security advisory
     message: |-
       Update bundled Script Security Plugin from 1.75 to v35f6a_0b_8207e
@@ -7419,7 +7419,7 @@
     pr_title: Adapt to jenkinsci/remoting#490
     references:
       - pull: 5901
-      - url: https://www.jenkins.io/doc/developer/security/remoting-callables/
+      - url: /doc/developer/security/remoting-callables/
         title: Remoting callables documentation
     message: |-
       Remove support for <code>RoleChecker#check(RoleSensitive)</code> calls which were added again in Jenkins 2.319.
@@ -8271,7 +8271,7 @@
         title: Jetty 10 and 11 blog post
       - url: https://github.com/eclipse/jetty.project/releases/jetty-10.0.12
         title: Jetty 10.0.12 changelog
-      - url: https://www.jenkins.io/doc/book/installing/initial-settings/#https-with-an-existing-certificate
+      - url: /doc/book/installing/initial-settings/#https-with-an-existing-certificate
         title: HTTPS with an existing certificate
       - url: https://github.com/jenkinsci/winstone/pull/232
         title: Remove ability to load pem cert for winstone
@@ -8451,7 +8451,7 @@
       - daniel-beck
     pr_title: "[JENKINS-70083] Update bundled script-security and junit versions"
     references:
-      - url: https://www.jenkins.io/security/advisory/2022-11-15/
+      - url: /security/advisory/2022-11-15/
         title: Jenkins Security Advisory 2022-11-15
     message: |-
       Updated bundled Script Security plugin from 1189.vb_a_b_7c8fd5fde to 1190.v65867a_a_47126.

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -282,7 +282,7 @@
           1.15 for SECURITY-161.
         references:
           - issue: 42969
-          - url: https://jenkins.io/security/advisory/2017-03-20/
+          - url: /security/advisory/2017-03-20/
             title: security advisory including SECURITY-161
         pull: 2819
       - type: rfe
@@ -481,7 +481,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2017-04-26/
+          - url: /security/advisory/2017-04-26/
             title: security advisory
   - version: "2.58"
     date: 2017-04-30
@@ -640,11 +640,11 @@
           releases to include the fix for SECURITY-372, the SSH Build Agents plugin
           for SECURITY-161, and the Script Security plugin for SECURITY-258.
         references:
-          - url: https://jenkins.io/security/advisory/2017-03-20/
+          - url: /security/advisory/2017-03-20/
             title: SECURITY-372
-          - url: https://jenkins.io/security/advisory/2017-03-20/
+          - url: /security/advisory/2017-03-20/
             title: SECURITY-161
-          - url: https://jenkins.io/security/advisory/2016-04-11/
+          - url: /security/advisory/2016-04-11/
             title: SECURITY-258
         # pull: 2817
       - type: rfe
@@ -1243,7 +1243,7 @@
           - issue: 45755
           - url: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#312
             title: full changelog
-          - url: https://jenkins.io/doc/upgrade-guide/2.73/#known-issue-agent-connection-failures-involving-jenkins-masters-with-undefined-or-non-writable-home-directory
+          - url: /doc/upgrade-guide/2.73/#known-issue-agent-connection-failures-involving-jenkins-masters-with-undefined-or-non-writable-home-directory
             title: issue description in 2.73.1 upgrade guide
         pull: 3025
       - type: rfe
@@ -1389,7 +1389,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2017-10-11/
+          - url: /security/advisory/2017-10-11/
             title: security advisory
   - version: "2.85"
     date: 2017-10-15
@@ -1464,7 +1464,7 @@
           - issue: 47393
           - url: https://plugins.jenkins.io/command-launcher
             title: Command Launcher plugin site entry
-          - url: https://www.jenkins.io/security/advisory/2017-10-11/#arbitrary-shell-command-execution-on-controller-by-users-with-agent-related-permissions
+          - url: /security/advisory/2017-10-11/#arbitrary-shell-command-execution-on-controller-by-users-with-agent-related-permissions
             title: related security advisory
       - type: rfe
         issue: 36282
@@ -1617,7 +1617,7 @@
       - type: security
         message: Security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2017-11-08/
+          - url: /security/advisory/2017-11-08/
             title: security advisory
   - version: "2.90"
     date: 2017-11-12
@@ -2125,7 +2125,7 @@
       - type: rfe
         references:
           - issue: 43786
-          - url: https://jenkins.io/blog/2018/01/21/overhaul-of-manage-jenkins-page/
+          - url: /blog/2018/01/21/overhaul-of-manage-jenkins-page/
             title: blog post
         pull: 2857
         message: >
@@ -2333,15 +2333,15 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-02-14/
+          - url: /security/advisory/2018-02-14/
             title: security advisory
       - type: rfe
         message: >
           Security hardening to prevent problems like SECURITY-624 in the future.
         references:
-          - url: https://jenkins.io/security/advisory/2017-12-05/
+          - url: /security/advisory/2017-12-05/
             title: 2017-12-05 security advisory
-          - url: https://jenkins.io/security/advisory/2018-01-22/#xss-vulnerability-in-job-configuration-forms-in-ant-plugin
+          - url: /security/advisory/2018-01-22/#xss-vulnerability-in-job-configuration-forms-in-ant-plugin
             title: Ant Plugin fix in 2018-01-22 security advisory
   - version: "2.108"
     date: 2018-02-18
@@ -2759,7 +2759,7 @@
       - type: security
         message: Security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-04-11/
+          - url: /security/advisory/2018-04-11/
             title: security advisory
   - version: "2.117"
     date: 2018-04-15
@@ -2903,7 +2903,7 @@
         references:
           - issue: 9104
           - title: <code>ProcessKillingVeto</code> extension point implementations
-            url: https://jenkins.io/doc/developer/extensions/jenkins-core/#processkillingveto
+            url: /doc/developer/extensions/jenkins-core/#processkillingveto
       - type: rfe
         pull: 3416
         message: >
@@ -2956,7 +2956,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-05-09/
+          - url: /security/advisory/2018-05-09/
             title: security advisory
   - version: "2.122"
     date: 2018-05-14
@@ -3205,7 +3205,7 @@
         references:
           - issue: 50447
           - title: announcement blog post
-            url: https://jenkins.io/blog/2018/06/27/new-login-page/
+            url: /blog/2018/06/27/new-login-page/
       - type: major rfe
         pull: 3188
         issue: 48480
@@ -3215,7 +3215,7 @@
           If you still use these protocols (e.g. remoting-based CLI, or old <code>agent.jar</code>s
           on agents), you need to re-enable these protocols after upgrade, or upgrade
           the clients.
-          The same recommendations as in <a href="https://jenkins.io/doc/upgrade-guide/2.121/#remoting-update">The
+          The same recommendations as in <a href="/doc/upgrade-guide/2.121/#remoting-update">The
           2.121.x upgrade guide for remoting changes</a> apply here.
       - type: rfe
         references:
@@ -3254,7 +3254,7 @@
           allows decorating the redesigned login page.
         references:
           - title: announcement blog post
-            url: https://jenkins.io/blog/2018/06/27/new-login-page/
+            url: /blog/2018/06/27/new-login-page/
       - type: bug
         pull: 3489
         issue: 51955
@@ -3277,7 +3277,7 @@
         references:
           - issue: 32442
           - issue: 32776
-          - url: https://jenkins.io/blog/2018/07/02/new-api-token-system
+          - url: /blog/2018/07/02/new-api-token-system
             title: blog post
         message: >
           Replace single per-user API token with new system of multiple, revocable,
@@ -3292,7 +3292,7 @@
         pull: 3513
         references:
           - issue: 51837
-          - url: https://jenkins.io/redirect/java-support/
+          - url: /redirect/java-support/
             title: supported Java versions
         message: >
           Upgrade Bytecode Compatibility Transformer from 1.8 to 2.0-beta-2, upgrading
@@ -3312,7 +3312,7 @@
           - issue: 46622
           - url: https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#141
             title: Executable WAR 1.41 changelog
-          - url: https://jenkins.io/redirect/java-support/
+          - url: /redirect/java-support/
             title: supported Java versions
         message: >
           Update Executable WAR from 1.40 to 1.41 to link the Jenkins Java support
@@ -3420,7 +3420,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-07-18/
+          - url: /security/advisory/2018-07-18/
             title: security advisory
   - version: "2.134"
     date: 2018-07-22
@@ -3532,7 +3532,7 @@
       - type: security
         message: Security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-08-15/
+          - url: /security/advisory/2018-08-15/
             title: security advisory
       - type: rfe
         message: Security hardening related to Stapler routing.
@@ -3855,7 +3855,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-10-10/
+          - url: /security/advisory/2018-10-10/
             title: security advisory
       - type: major rfe
         message: >
@@ -4090,7 +4090,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2018-12-05/
+          - url: /security/advisory/2018-12-05/
             title: security advisory
   - version: "2.155"
     date: 2018-12-09
@@ -4107,7 +4107,7 @@
           Java 11 Support Preview is available starting from this version
         references:
           - issue: 52012
-          - url: https://jenkins.io/blog/2018/12/14/java11-preview-availability/
+          - url: /blog/2018/12/14/java11-preview-availability/
             title: Announcement and run guidelines
       - type: rfe
         pull: 3794
@@ -4266,7 +4266,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2019-01-16/
+          - url: /security/advisory/2019-01-16/
             title: security advisory
       - type: rfe
         message: Invalidate sessions and CLI authentication caches when changing the
@@ -4516,7 +4516,7 @@
       - type: major rfe
         references:
           - pull: 3838
-          - url: https://jenkins.io/blog/2019/02/17/remoting-cli-removed/
+          - url: /blog/2019/02/17/remoting-cli-removed/
             title: announcement blog post
         message: >
           Support for the Remoting mode of the CLI (<code>-remoting</code> option)
@@ -4680,7 +4680,7 @@
       - type: rfe
         references:
           - pull: 3967
-          - url: https://jenkins.io/doc/developer/security/secrets/
+          - url: /doc/developer/security/secrets/
             title: Storing Secrets in Jenkins
         message: |-
           Developer: Add Jelly UI component <code>f:secretTextarea</code> for multi-line secrets analogous to <code>f:password</code> for single-line.
@@ -4702,7 +4702,7 @@
       - type: security
         message: Security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2019-04-10/
+          - url: /security/advisory/2019-04-10/
             title: security advisory
   - version: '2.173'
     date: 2019-04-14
@@ -4894,7 +4894,7 @@
     changes:
       - type: rfe
         references:
-          - url: https://jenkins.io/doc/pipeline/steps/core/#fingerprint-record-fingerprints-of-files-to-track-usage
+          - url: /doc/pipeline/steps/core/#fingerprint-record-fingerprints-of-files-to-track-usage
             title: documentation
           - pull: 3915
         message: |-
@@ -5212,7 +5212,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2019-07-17/
+          - url: /security/advisory/2019-07-17/
             title: security advisory
       - type: major bug
         pull: 4111
@@ -5389,7 +5389,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2019-08-28/
+          - url: /security/advisory/2019-08-28/
             title: security advisory
   - version: '2.193'
     date: 2019-09-01
@@ -5502,7 +5502,7 @@
       - type: security
         message: Security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2019-09-25/
+          - url: /security/advisory/2019-09-25/
             title: security advisory
   - version: '2.198'
     date: 2019-09-29
@@ -5994,7 +5994,7 @@
         message: |-
           Deprecate the macOS native installer packaging.
         references:
-          - url: https://jenkins.io/blog/2019/11/25/macos-native-installer-deprecation/
+          - url: /blog/2019/11/25/macos-native-installer-deprecation/
             title: Jenkins macOS native installer deprecation
         authors:
           - oleg-nenashev
@@ -6160,9 +6160,9 @@
         message: |-
           Remove vulnerable Team Concert Plugin from setup wizard.
         references:
-          - url: https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1605%20(1)
+          - url: /security/advisory/2019-12-17/#SECURITY-1605%20(1)
             title: CSRF vulnerability
-          - url: https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1605%20(2)
+          - url: /security/advisory/2019-12-17/#SECURITY-1605%20(2)
             title: Credential enumeration vulnerability
         authors:
           - daniel-beck
@@ -6544,7 +6544,7 @@
       - type: security
         message: Important security fixes.
         references:
-          - url: https://jenkins.io/security/advisory/2020-01-29/
+          - url: /security/advisory/2020-01-29/
             title: security advisory
         authors:
           - daniel-beck
@@ -6832,7 +6832,7 @@
           - issue: 60920
           - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
             title: JEP-223
-          - url: https://jenkins.io/sigs/ux/
+          - url: /sigs/ux/
             title: Jenkins UX SIG
       - type: major rfe
         category: major rfe
@@ -6877,9 +6877,9 @@
           - issue: 60266
           - url: https://github.com/jenkinsci/jep/blob/master/jep/223/README.adoc
             title: JEP-223
-          - url: https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+          - url: /security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
             title: 2017-04-10 security advisory for Matrix Authorization plugin
-          - url: https://jenkins.io/security/advisory/2017-04-10/#role-based-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+          - url: /security/advisory/2017-04-10/#role-based-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
             title: 2017-04-10 security advisory for Role-Based Authorization plugin
         message: |-
           Deprecate the <code>Overall/RunScripts</code>, <code>Overall/UploadPlugins</code>, and <code>Overall/ConfigureUpdateCenter</code> permissions.
@@ -7302,7 +7302,7 @@
           - pull: 4561
           - url: https://github.com/jenkinsci/script-security-plugin/blob/master/CHANGELOG.md#version-170
             title: Script security plugin 1.70 changelog
-          - url: https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1754
+          - url: /security/advisory/2020-03-09/#SECURITY-1754
             title: SECURITY-1754 sandbox bypass vulnerability
         message: |-
           Update bundled Script Security Plugin from 1.70 to 1.71.
@@ -7753,7 +7753,7 @@
     date: 2020-04-16
     banner: |-
       <strong>NOTE:</strong> This is the first Jenkins weekly release delivered by the <a href="https://issues.jenkins.io/browse/INFRA-910">core release automation project</a>.
-      Some Jenkins Weekly distributables may not be accessible from the <a href="https://jenkins.io/download/">Jenkins Downloads</a> page.
+      Some Jenkins Weekly distributables may not be accessible from the <a href="/download/">Jenkins Downloads</a> page.
       In such case please see the package links on <a href="http://mirrors.jenkins-ci.org/"/>our mirrors</a> in the <b>Releases</b> section.
     changes:
       - type: bug
@@ -8066,7 +8066,7 @@
           - pull: 4707
           - url: https://javadoc.jenkins.io/jenkins/util/SystemProperties.html
             title: Javadoc
-          - url: https://www.jenkins.io/doc/book/managing/system-properties/
+          - url: /doc/book/managing/system-properties/
             title: Jenkins Features Controlled with System Properties
         message: |-
           Developer: Make the SystemProperties API available to plugins so that their properties could be managed by a standard engine.
@@ -8753,13 +8753,13 @@
         category: major rfe
         pull: 4823
         references:
-          - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/
+          - url: /blog/2020/07/23/windows-support-updates/
             title: announcement
-          - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/#use-cases-affected-by-net-framework-2-0-support-removal
+          - url: /blog/2020/07/23/windows-support-updates/#use-cases-affected-by-net-framework-2-0-support-removal
             title: upgrade guidelines
           - issue: 60005
           - issue: 61862
-          - url: https://www.jenkins.io/doc/administration/requirements/windows/
+          - url: /doc/administration/requirements/windows/
             title: Windows support policy
         authors:
           - NextTurn
@@ -8771,7 +8771,7 @@
         category: major rfe
         pull: 4823
         references:
-          - url: https://www.jenkins.io/blog/2020/07/23/windows-support-updates/#windows-service-management-changes-in-jenkins-2-248
+          - url: /blog/2020/07/23/windows-support-updates/#windows-service-management-changes-in-jenkins-2-248
             title: changes summary
           - url: https://github.com/winsw/winsw/releases
             title: full WinSW changelog
@@ -10510,7 +10510,7 @@
         references:
           - pull: 5188
           - issue: 64632
-          - url: https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-1452
+          - url: /security/advisory/2021-01-13/#SECURITY-1452
             title: SECURITY-1452
         message: |-
           Fix the file handle leak inside DirectoryBrowserSupport (regression in 2.275).
@@ -10524,7 +10524,7 @@
           - pull: 5187
           - issue: 64621
           - issue: 61473
-          - url: https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-1452
+          - url: /security/advisory/2021-01-13/#SECURITY-1452
             title: SECURITY-1452
         message: |-
           Include root folder in downloaded zip files (regression in 2.275).
@@ -11096,7 +11096,7 @@
           - dependabot[bot]
         references:
           - pull: 5366
-          - url: https://www.jenkins.io/security/advisory/2021-03-18/
+          - url: /security/advisory/2021-03-18/
             title: Security Advisory 2021-03-18
         message: |-
           Bump matrix-auth from 2.6.5 to 2.6.6.
@@ -11834,7 +11834,7 @@
         references:
           - pull: 5320
           - issue: 65161
-          - url: https://www.jenkins.io/blog/2021/06/04/digester-removal/
+          - url: /blog/2021/06/04/digester-removal/
             title: announcement and upgrade guidelines
       - type: bug
         category: bug
@@ -12220,7 +12220,7 @@
         authors:
           - daniel-beck
         references:
-          - url: https://www.jenkins.io/doc/book/managing/built-in-node-migration/
+          - url: /doc/book/managing/built-in-node-migration/
             title: Built-In Node Name and Label Migration
         message: |-
           Add migration code to change the node name (e.g. <code>NODE_NAME</code> environment variable) and label of the built-in node only after explicit migration by an administrator.
@@ -13438,7 +13438,7 @@
           - pull: 5423
           - url: https://javadoc.jenkins.io/jenkins/fingerprints/FingerprintStorage.html#getFileFingerprintStorage--
             title: FingerprintStorage.getFileFingerprintStorage javadoc
-          - url: https://www.jenkins.io/doc/developer/extensions/jenkins-core/#fingerprintstorage
+          - url: /doc/developer/extensions/jenkins-core/#fingerprintstorage
             title: FingerprintStorage Extension API
         message: |-
           Deprecate FingerprintStorage.getFileFingerprintStorage.
@@ -13718,7 +13718,7 @@
           - pull: 6103
           - url: https://github.com/jenkinsci/jep/tree/master/jep/7#jep-7-deprecation-of-ruby-and-python-plugin-runtimes
             title: "JEP-7: Deprecation of Ruby and Python plugin runtimes"
-          - url: https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+          - url: /blog/2021/12/22/deprecated-ruby-runtime/
             title: Deprecating non-Java plugins (blog post)
           - url: https://github.com/jenkinsci/stapler
             title: Stapler repository
@@ -13999,7 +13999,7 @@
         references:
           - pull: 6180
           - issue: 67674
-          - url: https://www.jenkins.io/security/advisory/2022-01-12/
+          - url: /security/advisory/2022-01-12/
             title: 2022-01-12 security advisory
         message: |-
           Update the bundled Mailer Plugin from 1.32.1 to 408.vd726a_1130320.
@@ -14014,7 +14014,7 @@
         references:
           - pull: 6180
           - issue: 67674
-          - url: https://www.jenkins.io/security/advisory/2022-01-12/
+          - url: /security/advisory/2022-01-12/
             title: 2022-01-12 security advisory
         message: |-
           Update the bundled Matrix Project Plugin from 1.18 to 1.20.
@@ -14044,7 +14044,7 @@
           - basil
         pr_title: "EOL support for JRuby"
         references:
-          - url: https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+          - url: /blog/2021/12/22/deprecated-ruby-runtime/
             title: Deprecating non-Java plugins blog post
         message: |-
           Remove support for plugins written in Ruby.
@@ -14251,7 +14251,7 @@
         pr_title: Adapt to jenkinsci/remoting#490
         references:
           - pull: 5901
-          - url: https://www.jenkins.io/doc/developer/security/remoting-callables/
+          - url: /doc/developer/security/remoting-callables/
             title: Remoting callables documentation
         message: |-
           Remove support for <code>RoleChecker#check(RoleSensitive)</code> calls which were added again in Jenkins 2.319.
@@ -15050,7 +15050,7 @@
             title: Spring project spring-framework 5.3.18 release notes
           - url: https://tanzu.vmware.com/security/cve-2022-22965
             title: CVE-2022-22965
-          - url: https://www.jenkins.io/blog/2022/03/31/spring-rce-CVE-2022-22965/
+          - url: /blog/2022/03/31/spring-rce-CVE-2022-22965/
             title: Spring vulnerability CVE-2022-22965 does not affect Jenkins core
         message: |-
           Upgrade Spring Framework from 5.3.16 to 5.3.18 (released on March 31, 2022).
@@ -15788,7 +15788,7 @@
         pr_title: Update bundled plugins after 2022-05-17 security advisory
         references:
           - pull: 6582
-          - url: https://www.jenkins.io/security/advisory/2022-05-17/
+          - url: /security/advisory/2022-05-17/
             title: 2022-05-17 security advisory
         message: |-
           Update bundled Script Security Plugin from 1.75 to v35f6a_0b_8207e
@@ -16286,7 +16286,7 @@
           - basil
         pr_title: Update bundled JUnit Plugin (+ tons more) after security advisory
         references:
-          - url: https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2760
+          - url: /security/advisory/2022-06-22/#SECURITY-2760
             title: 2022-06-22 security advisory
           - pull: 6582
         message: |-
@@ -17121,7 +17121,7 @@
             title: Jetty 10 and 11 blog post
           - url: https://github.com/jenkinsci/winstone/pull/232
             title: Remove ability to load pem cert for winstone
-          - url: https://www.jenkins.io/doc/book/installing/initial-settings/#https-with-an-existing-certificate
+          - url: /doc/book/installing/initial-settings/#https-with-an-existing-certificate
             title: Documentation
         message: |-
           Winstone 6.1: Upgrade Jetty from 9.4.46.v20220331 to 10.0.11.
@@ -18117,9 +18117,9 @@
           - timja
         pr_title: Update bundled script-security and workflow-support plugins
         references:
-          - url: https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2824%20(1)
+          - url: /security/advisory/2022-10-19/#SECURITY-2824%20(1)
             title: 2022-10-19 Security Advisory
-          - url: https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2881
+          - url: /security/advisory/2022-10-19/#SECURITY-2881
             title: 2022-10-19 Security Advisory
         message: |-
           Update bundled Script Security Plugin from 1172.v35f6a_0b_8207e to 1189.vb_a_b_7c8fd5fde.
@@ -19325,9 +19325,9 @@
         pr_title: Update plugins after 2023-02-15 security advisory
         references:
           - pull: 7651
-          - url: https://www.jenkins.io/security/advisory/2023-01-24/
+          - url: /security/advisory/2023-01-24/
             title: 2023-01-24 security advisory
-          - url: https://www.jenkins.io/security/advisory/2023-02-15/
+          - url: /security/advisory/2023-02-15/
             title: 2023-02-15 security advisory
         message: |-
           Update bundled plugins to include fixes announced in 20230124 and 20230215 Jenkins security advisories.

--- a/content/_data/logo/chatterbox.yml
+++ b/content/_data/logo/chatterbox.yml
@@ -6,4 +6,4 @@ vector:
 credit: 'Kseniia Nenasheva'
 credit_url: 'https://www.linkedin.com/in/knenasheva/'
 source: 'Jenkins Advocacy&Outreach SIG'
-source_url: 'https://jenkins.io/sigs/advocacy-and-outreach/'
+source_url: '/sigs/advocacy-and-outreach/'

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -87,7 +87,7 @@ categories:
     - name: Pipeline as YAML
       description: Official support for defining Jenkins Pipelines in YAML, without additional Pipeline libraries
       status: preview
-      link: https://jenkins.io/projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
+      link: /projects/gsoc/2020/project-ideas/pipeline-as-yaml-experiment/
       labels:
       - feature
     - name: Promotion support for Pipeline jobs
@@ -100,7 +100,7 @@ categories:
       status: future
       description: >
         Enhance the Jenkins Pipeline documentation generator to produce better documentation for thousands of Pipeline developers.
-      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/pipeline-step-documentation-generator/
+      link: /projects/gsoc/2020/project-ideas/pipeline-step-documentation-generator/
       labels:
       - documentation
   - name: Tool and Service integrations
@@ -110,14 +110,14 @@ categories:
     initiatives:
     - name: "Pipeline: GitHub App authentication"
       status: released
-      link: https://www.jenkins.io/blog/2020/04/16/github-app-authentication/
+      link: /blog/2020/04/16/github-app-authentication/
       labels:
       - feature
     - name: "Git Plugin Performance Improvements"
       status: released
       description: >
         Improve Jenkins git plugin performance by fixing known issues in performance critical areas
-      link: https://www.jenkins.io/projects/gsoc/2020/projects/git-plugin-performance/
+      link: /projects/gsoc/2020/projects/git-plugin-performance/
       labels:
       - feature
     - name: "GitHub Checks API integrations"
@@ -125,7 +125,7 @@ categories:
       description: >
         Create a new plugin API so that plugins can publish GitHub Checks statuses.
         Implement Checks API support in Warnings NG and Code Coverage API plugins.
-      link: https://www.jenkins.io/projects/gsoc/2020/projects/github-checks/
+      link: /projects/gsoc/2020/projects/github-checks/
       labels:
       - feature
     - name: Machine Learning Plugin for Data Science
@@ -133,21 +133,21 @@ categories:
       description: >
         Integrate Machine Learning workflow with Jenkins build tasks, including Data preprocessing, Model Training, Evaluation and Prediction.
         This plugin will be capable of executing code fragments via IPython kernel as currently supported by Jupyter.
-      link: https://www.jenkins.io/projects/gsoc/2020/projects/machine-learning/
+      link: /projects/gsoc/2020/projects/machine-learning/
       labels:
       - feature
     - name: OpenAPI for Jenkins core and plugins
       status: future
       description: >
         Expose Jenkins REST APIs as the OpenAPI Specification so that users could easily integrate with Jenkins and create clients for it.
-      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api/
+      link: /projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api/
       labels:
       - feature
     - name: "Docker: image changes polling and security scans"
       status: future
       description: >
         Create a new Jenkins plugin to automate polling of image changes and security scans.
-      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/docker-registries-polling-plugin/
+      link: /projects/gsoc/2020/project-ideas/docker-registries-polling-plugin/
       labels:
       - feature
       - security
@@ -158,7 +158,7 @@ categories:
     - name: "UI/UX: Look and Feel updates"
       status: current
       description: "Modernize the Jenkins Web interface styling and appearance"
-      link: https://jenkins.io/sigs/ux/#project-ui-look-and-feel
+      link: /sigs/ux/#project-ui-look-and-feel
       labels:
       - feature
     - name: "Dark Theme"
@@ -176,11 +176,11 @@ categories:
       labels:
       - feature
       - infrastructure
-      link: https://jenkins.io/sigs/ux/#project-plugin-management-ui-ux
+      link: /sigs/ux/#project-plugin-management-ui-ux
     - name: Plugin docs migration to GitHub
       description: Host plugin documentation on GitHub rather than the Jenkins Wiki
       status: current
-      link: https://jenkins.io/sigs/docs/#ongoing-projects
+      link: /sigs/docs/#ongoing-projects
       labels:
       - documentation
     - name: Docs migration to jenkins.io
@@ -198,7 +198,7 @@ categories:
     - name: "UI/UX: Accessibility"
       status: near-term
       description: Improve Jenkins navigation and layouts to make it more usable by as many user groups as possible.
-      link: https://jenkins.io/sigs/ux/#project-ui-accessibility
+      link: /sigs/ux/#project-ui-accessibility
       labels:
       - feature
     - name: "Configuration UI: Tables to Divs migration"
@@ -220,7 +220,7 @@ categories:
       - feature
     - name: "UI/UX: User interface rework"
       status: future
-      link: https://jenkins.io/sigs/ux/#project-ui-overhaul
+      link: /sigs/ux/#project-ui-overhaul
       labels:
       - feature
     - name: User Guide improvements
@@ -251,7 +251,7 @@ categories:
         We want to replace the deprecated terminology by new terms: “controller”, “agent”, “allowlist”, “denylist”, and “main” for branch names.
         Scope: documentation, Web UI, localizations, API, etc.
       status: current
-      link: https://www.jenkins.io/sigs/advocacy-and-outreach/#inclusive-naming
+      link: /sigs/advocacy-and-outreach/#inclusive-naming
       labels:
       - documentation
       - feature
@@ -289,7 +289,7 @@ categories:
       description: >
         Enhance Jenkins controller and agent service management on Windows by
         offering new configuration file formats and improving settings validation.
-      link: https://www.jenkins.io/projects/gsoc/2020/projects/winsw-yaml-configs/
+      link: /projects/gsoc/2020/projects/winsw-yaml-configs/
       labels:
       - feature
     - name: "Script Security: Improve approval management"
@@ -307,7 +307,7 @@ categories:
         Evolution of plugin management capabilities in the Jenkins core and Docker images.
         It includes adoption of the new Plugin Management Tool in distributions, and support of advanced plugin definition formats like YAML.
       status: near-term
-      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/plugin-installation-manager-tool/
+      link: /projects/gsoc/2020/project-ideas/plugin-installation-manager-tool/
       labels:
       - feature
     - name: "JCasC: Pluggable configuration sources"
@@ -328,7 +328,7 @@ categories:
       status: future
       description: >
         Support monitoring of Jenkins networking (controller to agent communications, etc.) with open source monitoring tools such as Prometheus, Grafana, etc.
-      link: https://www.jenkins.io/projects/gsoc/2020/project-ideas/remoting-monitoring/
+      link: /projects/gsoc/2020/project-ideas/remoting-monitoring/
       labels:
       - feature
 #  - name: Jenkins Security
@@ -348,7 +348,7 @@ categories:
          CloudEvents is a specification for describing event data in common, standardised formats.
          The CloudEvents plugin would enable Jenkins support for CloudEvents by allowing events to be emitted in Jenkins pipelines and triggering Jobs on certain events,
          bringing Jenkins one step closer to interoperability with other technologies in the cloud.
-      link: https://www.jenkins.io/projects/gsoc/2021/project-ideas/cloudevents-plugin/
+      link: /projects/gsoc/2021/project-ideas/cloudevents-plugin/
       labels:
       - feature
     - name: 'JEP-219: Jenkins Kubernetes Operator'
@@ -392,7 +392,7 @@ categories:
     - name: Document Jenkins on Kubernetes
       description: Describe the concepts, techniques, and choices available for Jenkins on Kubernetes
       status: near-term
-      link: https://jenkins.io/sigs/docs/#jenkins-on-kubernetes
+      link: /sigs/docs/#jenkins-on-kubernetes
       labels:
       - outreach-program
       - documentation
@@ -425,7 +425,7 @@ categories:
         Support for storing build results in an external storage or a databases.
         It includes build histories, metadata, and build actions which are stored in build.xml files.
       status: future
-      link: https://www.jenkins.io/sigs/cloud-native/pluggable-storage/#status-summary
+      link: /sigs/cloud-native/pluggable-storage/#status-summary
       labels:
       - feature
     - name: 'Pluggable Unit Test Results Storage'
@@ -450,7 +450,7 @@ categories:
         most notably build logs build results and reports, job configurations, etc.
         Particular initiatives might be split off this roadmap item.
       status: future
-      link: https://www.jenkins.io/sigs/cloud-native/pluggable-storage/
+      link: /sigs/cloud-native/pluggable-storage/
       labels:
       - feature
   - name: Packaging and platform support
@@ -459,7 +459,7 @@ categories:
     - name: Docker images for Windows agents
       description: Official Windows Docker images for Jenkins controllers and agents.
       status: released
-      link: https://www.jenkins.io/blog/2020/05/11/docker-windows-agents/
+      link: /blog/2020/05/11/docker-windows-agents/
       labels:
       - feature
     - name: Docker images for IBM s390x
@@ -484,14 +484,14 @@ categories:
         Rework of the Windows installer user experience.
         Java unbundling, account management and port setup.
       status: released
-      link: https://jenkins.io/blog/2020/08/12/windows-installers-upgrade/
+      link: /blog/2020/08/12/windows-installers-upgrade/
       labels:
       - feature
       - security
     - name: Windows support policy
       description: Currently Jenkins has no documented Windows Support policy. We want to add one and to deprecate/remove support for old platforms
       status: released
-      link: https://www.jenkins.io/doc/administration/requirements/windows/
+      link: /doc/administration/requirements/windows/
       labels:
       - documentation
       - policies
@@ -509,7 +509,7 @@ categories:
         with custom plugin sets and configurations included.
         This would be a self-hosted service initially.
       status: preview
-      link: https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
+      link: /projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
       labels:
       - feature
       - tools
@@ -517,7 +517,7 @@ categories:
       description: >
         Hosted versions of the Custom Jenkins distribution build service provided by the Jenkins project
       status: current
-      link: https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
+      link: /projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
       labels:
       - feature
       - infrastructure
@@ -535,7 +535,7 @@ categories:
         We would like to support future mainstream JVM versions (Java 17).
         Right now Jenkins runs well on Java 11, but we may need to do some changes towards the next LTS baseline.
       status: preview
-      link: https://jenkins.io/sigs/platform/#java-support
+      link: /sigs/platform/#java-support
       labels:
       - feature
     - name: Cloud native Java support
@@ -543,7 +543,7 @@ categories:
         We are interested to run Jenkins in cloud native environments.
         To do so, we would like to introduce support for perspective virtual machines like GraalVM or Quarkus.
       status: future
-      link: https://jenkins.io/sigs/platform/#java-support
+      link: /sigs/platform/#java-support
       labels:
       - feature
   - name: Jenkins developer tools and services
@@ -561,7 +561,7 @@ categories:
         This Bill of Materials lists libraries and versions supplied by the Jenkins core.
         It can be used by plugin developers to prevent risk of binary conflicts between plugins.
       status: released
-      link: https://jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-core-bom
+      link: /doc/developer/plugin-development/dependency-management/#jenkins-core-bom
       labels:
       - tools
     - name: Plugin POM 4.0
@@ -629,7 +629,7 @@ categories:
     initiatives:
     - name: Plugin adoption process revamp
       status: released
-      link: https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/
+      link: /doc/developer/plugin-governance/adopt-a-plugin/
       labels:
       - documentation
       - policies  
@@ -641,42 +641,42 @@ categories:
       - documentation
     - name: Google Summer of Code 2021
       status: released
-      link: https://jenkins.io/projects/gsoc/2021
+      link: /projects/gsoc/2021
       labels:
       - outreach-program
       - events
       - feature
     - name: Google Summer of Code 2020
       status: released
-      link: https://jenkins.io/projects/gsoc/2020
+      link: /projects/gsoc/2020
       labels:
       - outreach-program
       - events
       - feature
     - name: Google Season of Docs 2020
       status: released
-      link: https://www.jenkins.io/sigs/docs/gsod/2020/
+      link: /sigs/docs/gsod/2020/
       labels:
       - outreach-program
       - documentation
       - events
     - name: SheCodeAfrica Contributhon 2021
       status: released
-      link: https://www.jenkins.io/blog/2021/04/07/contributhon-participants/
+      link: /blog/2021/04/07/contributhon-participants/
       labels:
       - outreach-program
       - documentation
       - events
     - name: Community Bridge Mentorship
       status: future
-      link: https://jenkins.io/sigs/advocacy-and-outreach/outreach-programs/#community-bridge
+      link: /sigs/advocacy-and-outreach/outreach-programs/#community-bridge
       labels:
       - outreach-program
       - community
       - events
     - name: Hacktoberfest 2020
       status: released
-      link: https://jenkins.io/events/hacktoberfest/
+      link: /events/hacktoberfest/
       labels:
       - outreach-program
       - feature
@@ -685,7 +685,7 @@ categories:
       - events
     - name: Hacktoberfest 2021
       status: released
-      link: https://jenkins.io/events/hacktoberfest/
+      link: /events/hacktoberfest/
       labels:
       - outreach-program
       - feature
@@ -694,7 +694,7 @@ categories:
       - events
     - name: Hacktoberfest 2022
       status: released
-      link: https://jenkins.io/events/hacktoberfest/
+      link: /events/hacktoberfest/
       labels:
       - outreach-program
       - feature
@@ -709,14 +709,14 @@ categories:
       status: released
       description: >
         Jenkins Is The Way is a collection of experiences from all around the world showcasing how users are building, deploying, and automating great stuff with Jenkins. 
-      link: https://www.jenkins.io/blog/2020/04/30/jenkins-is-the-way/
+      link: /blog/2020/04/30/jenkins-is-the-way/
       labels:
       - outreach-program
     - name: New online meetup platform
       status: released
       description: >
         Make it possible to regularly host Jenkins online meetups and webinars.
-      link: https://www.jenkins.io/events/online-meetup/
+      link: /events/online-meetup/
       labels:
       - outreach-program
       - infrastructure
@@ -781,7 +781,7 @@ categories:
       description: >
         In late 2020 we plan to hold new Jenkins Governance Board and officer elections.
         We will re-elect at least one Governance Board member and all officers.
-      link: https://jenkins.io/blog/2020/12/03/election-results/
+      link: /blog/2020/12/03/election-results/
       labels:
       - events
     - name: Technical Steering Committee
@@ -795,7 +795,7 @@ categories:
       description: >
         Updating the Jenkins Code of Conduct to Contributor Covenant 2.0,
         alignment with the Continuous Delivery Foundation requirements.
-      link: https://www.jenkins.io/project/conduct/
+      link: /project/conduct/
       labels:
       - documentation
       - policies

--- a/content/blog/2017/04/2017-04-27-columbia.adoc
+++ b/content/blog/2017/04/2017-04-27-columbia.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/blog/2017/04/27/colombia/
+redirect_url: /blog/2017/04/27/colombia/
 ---
 

--- a/content/blog/2020/01/2020-01-29-gsoc-report.adoc
+++ b/content/blog/2020/01/2020-01-29-gsoc-report.adoc
@@ -67,7 +67,7 @@ During his project Abhyudaya also fixed the Jenkins Configuration-as-Code suppor
 * Final evaluation:  link:https://drive.google.com/file/d/1lAXDljWXypCq6noiqPHI-eZJqBqaSYue/view?usp=sharing[slides], link:https://youtu.be/g19o24uzy6c?t=1234[video]
 * Source code: link:https://github.com/jenkinsci/role-strategy-plugin[Role Strategy Plugin], link:https://github.com/jenkinsci/folder-auth-plugin[Folder Authorization Plugin]
 
-image:https://jenkins.io/images/post-images/role-strategy-performance/benchmarks2.png[Role strategy performance improvements, role=center]
+image:/images/post-images/role-strategy-performance/benchmarks2.png[Role strategy performance improvements, role=center]
 
 === Plugins Installation Manager CLI Tool/Library
 

--- a/content/projects/advocacy-and-outreach/outreach-programs.adoc
+++ b/content/projects/advocacy-and-outreach/outreach-programs.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url:  https://jenkins.io/sigs/advocacy-and-outreach/outreach-programs
+redirect_url: /sigs/advocacy-and-outreach/outreach-programs
 ---

--- a/content/projects/blueocean/roadmap/index.adoc
+++ b/content/projects/blueocean/roadmap/index.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://jenkins.io/projects/blueocean/contribute/
+redirect_url: /projects/blueocean/contribute/
 ---


### PR DESCRIPTION
Similar to https://github.com/jenkins-infra/jenkins.io/pull/6084, hard links are obsolete in the changelog and roadmap too.