### PR TITLE
Revert "Use non-deprecated property for ping interval"

### DIFF
--- a/content/doc/book/system-administration/monitoring.adoc
+++ b/content/doc/book/system-administration/monitoring.adoc
@@ -69,7 +69,7 @@ https://issues.jenkins.io/browse/JENKINS-25695[JENKINS-25695].
 Sometimes, for example https://wiki.jenkins.io/display/JENKINS/Remoting+issue[to diagnose the agent connection loss
 problem], you may want to disable the ping thread.  This needs to be done in two places.
 
-To disable the controller from pinging agents, the system property `+hudson.slaves.ChannelPinger.pingIntervalSeconds+` should
+To disable the controller from pinging agents, the system property `+hudson.slaves.ChannelPinger.pingInterval+` should
 be set on the controller JVM to -1. You can also change the value in memory for a running Jenkins, if you don't want to
 restart Jenkins *(Deprecated since 2.37)*:
 


### PR DESCRIPTION
Reverts jenkins-infra/jenkins.io#6098