### PR TITLE
Don't append leading slash to GH URL

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -110,7 +110,7 @@
       :githubRepo => "jenkins-infra/jenkins.io",
       :githubBranch => "master",
       :reportAProblemTemplate => "4-bug.yml",
-      :sourcePath=> page.uneditable ? "" : "content/#{page.relative_source_path}"}
+      :sourcePath=> page.uneditable ? "" : "content#{page.relative_source_path}"}
 
     = google_analytics_universal
 


### PR DESCRIPTION
`relative_source_path` already contains a leading slash, as seen on footers such as https://www.jenkins.io/participate/ linking to https://github.com/jenkins-infra/jenkins.io/edit/master/content//participate/index.html.haml.

With the removal of the trailing slash from `content/`, URLs are no longer invalid: https://github.com/jenkins-infra/jenkins.io/edit/master/content/participate/index.html.haml