### PR TITLE
Jenkins.io blog - fix outreach label on FOSDEM post

### DIFF
--- a/content/blog/2023/02/2023-02-21-thoughts-on-FOSDEM-2023.adoc
+++ b/content/blog/2023/02/2023-02-21-thoughts-on-FOSDEM-2023.adoc
@@ -8,7 +8,7 @@ tags:
 - fosdem
 - gsoc
 - open-source
-- outreachy
+- outreach
 authors:
 - alyssat
 - notmyfault


### PR DESCRIPTION
This is to update the "outreachy" label on the FOSDEM 2023 recap post, and correct it to "outreach"