### PR TITLE
Announce that jenkins award voting is now open

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,13 +1,13 @@
 # jenkins community award
 - :href: blog/2023/02/23/cdf-awards/
   :title: Jenkins Community Awards
-  :intro: The nominations for the Jenkins Contributor 2023 Awards are now open. 
+  :intro: Voting for the Jenkins Contributor 2023 Awards is now open (until March 28). 
   :image:
     :src: images/post-images/2023/02/23/2023-02-23-cdf-awards/community_awards_2023_jenkins.png 
     :height: 320px
   :call_to_action:
-    :text: More info
-    :href: blog/2023/02/23/cdf-awards/
+    :text: Vote
+    :href: https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform
 # jenkins accepted for GSoC 2023
 - :href: blog/2023/02/23/gsoc2023-announcement/
   :title: Accepted for GSoC 2023!


### PR DESCRIPTION
This pull request updates the jenkins.io carousel (aka Jumbotron) to announce that voting for the Jenkins Contributor 2023 Awards is now open.