### PR TITLE
AWS-tutorial spelling correction

### DIFF
--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -241,7 +241,7 @@ Warning: Permanently added 'ec2-198-51-100-1.compute1.amazonaws.com' (RSA) to th
 Completing the previous steps enables you to download and install Jenkins on AWS.
 To download and install Jenkins:
 
-. Ensure that your software packages are up to date on your instance by uing the following command to perform a quick software update:
+. Ensure that your software packages are up to date on your instance by using the following command to perform a quick software update:
 +
 [source,bash]
 ----


### PR DESCRIPTION
corrected the spelling in `tutorial-for-installing-jenkins-on-AWS` file , in  `Downloading and installing Jenkins` section