### PR TITLE
Update instructions for new contributors

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -31,13 +31,14 @@ The documentation below describes common cases for contributors.
 If you have any questions, please do not hesitate to ask in link:https://app.gitter.im/#/room/#jenkinsci_newcomer-contributors:gitter.im[newcomers] or link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Documentation SIG] Gitter chats.
 If you have any feedback about your contributor experience, please also share it with us in these channels so that we can improve our guidelines.
 
-You can also find some newbie-friendly issues in our task trackers:
+You can also find some newbie-friendly issues in our task tracker:
 
 * link:https://github.com/jenkins-infra/jenkins.io/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Good First Issues on GitHub]
-* link:https://issues.jenkins.io/issues/?filter=18650&jql=project%20%3D%20WEBSITE%20AND%20labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Jenkins Jira query]
 
 If you found an issue that you would like to work on, you are welcome to go ahead and start contributing.
 Please don't ask to be assigned to an issue, we don't assign individuals to issues, just go ahead and start working on it.
+If you want to avoid having other people work on the same issue, feel free to add a comment to the issue stating that you're working on it.
+If the last comment on the issue is older than a week and there is no pull request linked to the issue, you can assume nobody is working on it.
 If you need any help, please ask in the xref:contacts[].
 
 [[contacts]]


### PR DESCRIPTION
* the Jira link resulted in empty page
* it would be good to have a bit more clear policy for (not) assigning issues, so I proposed some additions