### PR TITLE
Add helm distribution to download page

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -96,6 +96,10 @@ title: Jenkins download and deployment
             %span.icon
             %span.title
               Docker
+          %a.list-group-item.list-group-item-action{:href=>'https://artifacthub.io/packages/helm/jenkinsci/jenkins'}
+            %span.icon
+            %span.title
+              Kubernetes
           %a.list-group-item.list-group-item-action{:href=>'https://pkg.jenkins.io/debian-stable/'}
             %span.icon
             %span.title


### PR DESCRIPTION
Let's add our official helm charts distribution to the download page.
This is based on https://github.com/jenkinsci/helm-charts fetching from our chart repo at https://charts.jenkins.io/

There are a plenty of Jenkins helm charts available. Therefore, I'd like to make it obvious from our end which one is the official repository.