### PR TITLE
Minor rephrase on press contacts page

### DIFF
--- a/content/press.adoc
+++ b/content/press.adoc
@@ -91,10 +91,10 @@ Its mission is to grow and sustain projects that are part of the broad and growi
 
 == Press Contact
 
-A single point of contact can be reached out to for comment, clarification
+A single point of contact is available for comment, clarification
 or questions about the Jenkins project. Please bear in mind that many are
 volunteers so availability and time may be limited.
-Please post your inquiries in the link:https://community.jenkins.io/c/press/24[Press] category on the Jenkins Community forums.
+Please post your inquiries in the link:https://community.jenkins.io/c/press/24[Press] category on the Jenkins community forums.
 
 === Security related contacts
 


### PR DESCRIPTION
## Minor rephrase on press contacts page

A little easier to read when the verb is a single word instead of using two words, like "reach out".
