### PR TITLE
Jenkins.io - Remove number ordering on "Books" page

### DIFF
--- a/content/books.html.haml
+++ b/content/books.html.haml
@@ -17,7 +17,6 @@ title: Jenkins Related Books
   %div{:style => 'margin-bottom: 2rem'}
     %h4
       %span
-        = (index + 1).to_s + '.'
         - if book['url']
           %a{:href => book['url'], :target => '_blank'}
             = book['title']


### PR DESCRIPTION
Currently, the jenkins.io/books page has numbered ordering, which can appear as though we are recommending books in a specific order/ranking. We want to make sure that everything is impartial and that the perception is any of these books could be number 1, depending on what the user needs/is looking for.

<img width="637" alt="Screenshot 2023-03-16 at 9 49 23 AM" src="https://user-images.githubusercontent.com/99040580/225637714-04debc4b-1871-444f-9969-22b18232477c.png">

This suggestion is to remove the index+1 line in the file so that there is no numbered ordering.