### PR TITLE
draft: docs: Rename 'Manage Jenkins' references to 'Settings'

### DIFF
--- a/content/doc/book/installing/_setup-wizard.adoc
+++ b/content/doc/book/installing/_setup-wizard.adoc
@@ -68,7 +68,7 @@ NOTE: If you are not sure what plugins you need, choose **Install suggested
 plugins**.
 You can install (or remove) additional Jenkins plugins at a later point in time
 via the
-link:/doc/book/managing[**Manage Jenkins**] >
+link:/doc/book/managing[**Settings**] >
 link:/doc/book/managing/plugins/[**Plugins**] page in Jenkins.
 
 The setup wizard shows the progression of Jenkins being configured and your

--- a/content/doc/book/installing/war-file.adoc
+++ b/content/doc/book/installing/war-file.adoc
@@ -34,7 +34,7 @@ The Jenkins Web application ARchive (WAR) file can be started from the command l
 
 * This process does not automatically install any specific plugins.
   They need to installed separately via the
-  link:/doc/book/managing[**Manage Jenkins**] >
+  link:/doc/book/managing[**Settings**] >
   link:/doc/book/managing/plugins/[**Plugins**] page in Jenkins.
 * You can change the port by specifying the `--httpPort` option when you run the
   `java -jar jenkins.war` command. For example, to make Jenkins accessible

--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -230,7 +230,7 @@ NOTE: If you are not sure what plugins you need, choose **Install suggested
 plugins**.
 You can install (or remove) additional Jenkins plugins at a later point in time
 via the
-link:/doc/book/managing[**Manage Jenkins**] >
+link:/doc/book/managing[**Settings**] >
 link:/doc/book/managing/plugins/[**Plugins**] page in Jenkins.
 
 The setup wizard shows the progression of Jenkins being configured and your

--- a/content/doc/book/managing/about-jenkins.adoc
+++ b/content/doc/book/managing/about-jenkins.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 = About Jenkins
 
-The *Manage Jenkins >> About Jenkins* page shows
+The *Settings >> About Jenkins* page shows
 the current release of Jenkins on your system
 plus information about licenses for all components.
 The top of the display shows the release and version of Jenkins that is running.

--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -35,14 +35,14 @@ must be installed on the Jenkins controller
 that you will use to build out your JCasC configuration.
 If you do not see the *Configuration as Code* tile
 in the *System Configuration* section
-of the *Manage Jenkins* page on your dashboard,
+of the *Settings* page on your dashboard,
 you need to install the plugin.
 
 == Viewing the JCasC file
 
 When the Configuration as Code plugin is installed,
 you will see *Configuration as Code* in the *System Configuration* section
-of the *Manage Jenkins* page on your dashboard.
+of the *Settings* page on your dashboard.
 Click on this link,
 then click on *View Configuration*
 to view the YAML file.
@@ -64,17 +64,17 @@ The default JCasC YAML file has four sections:
 
 * `jenkins` section defines the root Jenkins object,
 with configurations that can be set with the
-*Manage Jenkins >> System*
-and *Manage Jenkins >> Configure Nodes and Clouds* screens.
+*Settings >> System*
+and *Settings >> Configure Nodes and Clouds* screens.
 
 * `tool` section defines build tools that can be set on the
-*Manage Jenkins >> Tools* screen.
+*Settings >> Tools* screen.
 
 * `unclassified` section defines all other configurations,
 including configuration for installed plugins.
 
 * `credentials` section defines credentials that can be set on the
-*Manage Jenkins >> Manage Credentials* screen.
+*Settings >> Manage Credentials* screen.
 You may want to delete this section from your YAML file;
 this is discussed in
 link:https://youtu.be/ANU7jkxbZSM?t=1673[How to Install Jenkins Using Ansible and JCasC].
@@ -123,7 +123,7 @@ before you make any modifications to the file.
 
 To modify the JCasC YAML file,
 use the text editor of your choice to edit the file
-that is listed on the *Manage Jenkins >> Configuration as Code* UI page.
+that is listed on the *Settings >> Configuration as Code* UI page.
 By default, this is _$JENKINS_HOME/jenkins.yaml_.
 
 For a simple exercise to work through the process,
@@ -161,7 +161,7 @@ To configure a plugin with JCasC:
 
 . Use the UI of the current system to install and configure the plugin
 . Click *Apply >> Save* to save the configuration
-. Use *Manage Jenkins >> Configuration as Code >> View Configuration*
+. Use *Settings >> Configuration as Code >> View Configuration*
 to view the JCasC file with the plugin configured
 . Click on *Download Configuration*  to save the modified configuration file locally
 . Edit the JCasC YAML file to modify the configuration, if necessary
@@ -252,7 +252,7 @@ They should understand that JCasC will overwrite changes they make on the UI.
 
 === General information
 
-* link:https://www.youtube.com/watch?v=47D3H1BZi4o[Look Ma! No Hands! -- Manage Jenkins Configuration as Code]
+* link:https://www.youtube.com/watch?v=47D3H1BZi4o[Look Ma! No Hands! -- Settings Configuration as Code]
 is a video of the 2018 DevOps World presentation
 that introduced the JCasC feature.
 

--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -65,7 +65,7 @@ The default JCasC YAML file has four sections:
 * `jenkins` section defines the root Jenkins object,
 with configurations that can be set with the
 *Settings >> System*
-and *Settings >> Configure Nodes and Clouds* screens.
+and *Settings >> Nodes and Clouds* screens.
 
 * `tool` section defines build tools that can be set on the
 *Settings >> Tools* screen.

--- a/content/doc/book/managing/change-system-timezone.adoc
+++ b/content/doc/book/managing/change-system-timezone.adoc
@@ -16,7 +16,7 @@ endif::[]
 = Change System Time Zone
 
 The system time zone configuration is the default time zone displayed by Jenkins.
-The "Manage Jenkins" => "System Information" page shows the value of the system properties that define the time zone for the Jenkins controller.
+The "Settings" => "System Information" page shows the value of the system properties that define the time zone for the Jenkins controller.
 
 Refer to the following video for tips on changing the time zone
 

--- a/content/doc/book/managing/cli.adoc
+++ b/content/doc/book/managing/cli.adoc
@@ -343,7 +343,7 @@ To solve the problem, ensure your users exist in your configured security realm.
 
 To get more information about the authentication process:
 
-. Go into *Manage Jenkins* > *System Log* > *Add new log recorder*.
+. Go into *Settings* > *System Log* > *Add new log recorder*.
 . Enter any name you want and click on *Ok*.
 . Click on *Add*
 . Type `org.jenkinsci.main.modules.sshd.PublicKeyAuthenticatorImpl` (or type `PublicKeyAuth` and then select the full name)

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -15,26 +15,26 @@ endif::[]
 = Managing Jenkins
 
 Most standard administrative tasks can be performed from the screens
-in the *Manage Jenkins* section of the dashboard.
+in the *Settings* section of the dashboard.
 In this chapter, we look at these screens and explain how to use them.
 
-The tiles displayed on the *Manage Jenkins* page are grouped logically.
+The tiles displayed on the *Settings* page are grouped logically.
 Here we discuss the pages that are part of the standard installation.
 Plugins may add pages to this screen.
 
-The top of the *Manage Jenkins* screen may contain "Monitors"
+The top of the *Settings* screen may contain "Monitors"
 that alert you when a new version
 of the Jenkins software or a security update is available.
 Each monitor includes a description of the issue it is reporting and links to additional information about the issue
 
-Inline help is available on most *Manage Jenkins* pages:
+Inline help is available on most *Settings* pages:
 
 * To access the help, select the `?` icon to the right of each field.
 * Click the `?` icon again to hide the help text.
 
 [NOTE]
 ====
-The *Manage Jenkins* screens were modernized in 2020
+The *Settings* screens were modernized in 2020
 to provide a more attractive user interface for all users
 and a much better experience for users on narrow devices such as tablets and phones.
 The main changes made were:

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -61,7 +61,7 @@ successfully.
 === From the web UI
 
 The simplest and most common way of installing plugins is through the
-*Manage Jenkins* > *Plugins* view, available to administrators of a
+*Settings* > *Plugins* view, available to administrators of a
 Jenkins environment.
 
 Under the *Available* tab, plugins available for download from the configured
@@ -128,7 +128,7 @@ If an administrator manually copies a plugin archive into the `plugins` director
 Assuming a `.hpi` file has been downloaded, a logged-in Jenkins administrator
 may upload the file from within the web UI:
 
-. Navigate to the *Manage Jenkins* > *Plugins* page in the web UI.
+. Navigate to the *Settings* > *Plugins* page in the web UI.
 . Click on the *Advanced* tab.
 . Choose the `.hpi` file from your system or enter a URL to the archive file under the *Deploy Plugin* section.
 . *Deploy* the plugin file.
@@ -214,7 +214,7 @@ re-installing the plugin will result in those configuration values reappearing.
 ==== Removing old data
 
 Jenkins provides a facility for purging configuration left behind by
-uninstalled plugins. Navigate to *Manage Jenkins* and then click on *Manage
+uninstalled plugins. Navigate to *Settings* and then click on *Manage
 Old Data* to review and remove old data.
 
 === Disabling a plugin

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -29,7 +29,7 @@ these plugins execute user-provided scripts in a <<groovy-sandbox>>
 that limits the internal APIs that are accessible.
 This protection is provided by the plugin:script-security[Script Security plugin].
 As soon as an unsafe method is used in any of the scripts, the administrator can use
-the "In-process Script Approval" action appears in *Manage Jenkins*
+the "In-process Script Approval" action appears in *Settings*
 to allow the unsafe method.
 Unsafe methods should not be enabled without careful consideration of the impact.
 

--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -66,12 +66,12 @@ agents.
 
 === Running Script Console on the controller
 
-This feature can be accessed from _"Manage Jenkins" > "Script Console"_. 
+This feature can be accessed from _"Settings" > "Script Console"_. 
 Or by visiting the sub-URL `/script` on your Jenkins instance.
 
 === Running Script Console on agents
 
-Visit _"Manage Jenkins" > "Manage Nodes"_.  Select any node to view the status
+Visit _"Settings" > "Manage Nodes"_.  Select any node to view the status
 page.  In the menu on the left, a menu item is available to open a "Script
 Console" on that specific agent.
 

--- a/content/doc/book/managing/system-info.adoc
+++ b/content/doc/book/managing/system-info.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 = System Information
 
-The *Manage Jenkins >> System Information* page provides detailed information
+The *Settings >> System Information* page provides detailed information
 about what is available on this Jenkins instance:
 
 * *System Properties* that can be used as arguments

--- a/content/doc/book/managing/ui-themes.adoc
+++ b/content/doc/book/managing/ui-themes.adoc
@@ -29,7 +29,7 @@ There are several plugins that provide built-in themes, the most popular are
   provides Solarized (light and dark) themes.
 
 Installing any of these will also install their common dependency: the plugin:theme-manager[Theme Manager Plugin].
-This plugin allows administrators to set the default theme for a Jenkins installation via _Manage Jenkins > System > Built-in Themes_
+This plugin allows administrators to set the default theme for a Jenkins installation via _Settings > System > Built-in Themes_
 and users can set their preferred theme in their personal settings.
 You can also configure this plugin using plugin:configuration-as-code[Configuration-as-Code Plugin].
 See the plugin documentation for more details.
@@ -40,7 +40,7 @@ To be able to fully customize Jenkins appearance you can install the plugin:simp
 It allows customizing the Jenkins UI by providing custom CSS and Javascript files.
 It also supports replacing the Favicon.
 
-To configure a theme, you can go to _Manage Jenkins > System > Theme_ and enter the URL of your stylesheet and/or Javascript file.
+To configure a theme, you can go to _Settings > System > Theme_ and enter the URL of your stylesheet and/or Javascript file.
 You can also configure this plugin using plugin:configuration-as-code[Configuration-as-Code Plugin].
 See the plugin documentation for the detailed usage guidelines and links to sample themes.
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -280,7 +280,7 @@ By default, Pipeline assumes that _any_ configured
 link:../../glossary/#agent[agent] is capable of running Docker-based Pipelines.
 For Jenkins environments which have macOS, Windows, or other agents, which are
 unable to run the Docker daemon, this default setting may be problematic.
-Pipeline provides a global option in the **Manage Jenkins** page, and on
+Pipeline provides a global option in the **Settings** page, and on
 the
 link:../../glossary/#folder[Folder]
 level, for specifying which agents (by

--- a/content/doc/book/pipeline/scaling-pipeline.adoc
+++ b/content/doc/book/pipeline/scaling-pipeline.adoc
@@ -24,7 +24,7 @@ Because these settings include a trade-off of speed vs. durability, they are ini
 == How Do I Set Speed/Durability Settings?
 There are 3 ways to configure the durability setting:
 
-. *Globally*, you can choose a global default durability setting under "Manage Jenkins" > "System", labelled "Pipeline Speed/Durability Settings".  You can override these with the more specific settings below.
+. *Globally*, you can choose a global default durability setting under "Settings" > "System", labelled "Pipeline Speed/Durability Settings".  You can override these with the more specific settings below.
 
 . *Per pipeline job:* at the top of the job configuration, labelled "Custom Pipeline Speed/Durability Level" - this overrides the global setting.  Or, use a "properties" step - the setting will apply to the NEXT run after the step is executed (same result).
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -91,7 +91,7 @@ Other directories under the root are reserved for future enhancements.
 === Global Shared Libraries
 
 There are several places where Shared Libraries can be defined, depending on
-the use-case. _Manage Jenkins » System » Global Pipeline Libraries_
+the use-case. _Settings » System » Global Pipeline Libraries_
 as many libraries as necessary can be configured.
 
 image::pipeline/add-global-pipeline-libraries.png["Add a Global Pipeline Library", role=center]

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1114,7 +1114,7 @@ pipeline {
     }
 }
 ----
-<1> The tool name must be pre-configured in Jenkins under *Manage Jenkins* ->
+<1> The tool name must be pre-configured in Jenkins under *Settings* ->
 *Tools*.
 =====
 

--- a/content/doc/book/scaling/architecting-for-manageability.adoc
+++ b/content/doc/book/scaling/architecting-for-manageability.adoc
@@ -141,7 +141,7 @@ complete the migration, whether through scripts or through a drag-and-drop
 process.
 
 Once this is done, you will need to restart the new test Jenkins
-service or reload its configuration from the Jenkins UI ("Manage Jenkins" >>
+service or reload its configuration from the Jenkins UI ("Settings" >>
 "Reload Configuration").
 
 *With GitHub + Docker (Linux-only)*
@@ -257,7 +257,7 @@ If you discover that a plugin update is causing conflict within the test
 controller, you can rollback in several ways:
 
 * For bad plugins, you can rollback the plugin from the UI by going to the
-  plugin manager ("Manage Jenkins" >> "Plugins") and going to the
+  plugin manager ("Settings" >> "Plugins") and going to the
   "Available" tab. Jenkins will show a "downgrade" button next to any plugins
   that can be downgraded.
 

--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -424,7 +424,7 @@ a service and the default _$JENKINS_HOME_ will be "C:\Program Files
 (x86)\jenkins".
 
 You can edit the location of your _$JENKINS_HOME_ by opening the jenkins.xml
-file and editing the _$JENKINS_HOME_ variable, or going to the "Manage Jenkins"
+file and editing the _$JENKINS_HOME_ variable, or going to the "Settings"
 screen, clicking on the "Install as Windows Service" option in the menu, and
 then editing the "Installation Directory" field to point to another existing
 directory.

--- a/content/doc/book/scaling/scaling-jenkins-on-kubernetes.adoc
+++ b/content/doc/book/scaling/scaling-jenkins-on-kubernetes.adoc
@@ -189,7 +189,7 @@ IP:             172.17.0.4
 
 === Kubernetes Plugin Configuration
 
-Now, we are ready to fill in the Kubernetes plugin configuration. In order to do that, open the Jenkins UI and navigate to “Manage Jenkins -> Nodes and Clouds -> Clouds -> Add a new cloud -> Kubernetes and fill in the `Kubernetes URL` and `Jenkins URL` appropriately, by using the values which we have just collected in the previous step.
+Now, we are ready to fill in the Kubernetes plugin configuration. In order to do that, open the Jenkins UI and navigate to “Settings -> Nodes and Clouds -> Clouds -> Add a new cloud -> Kubernetes and fill in the `Kubernetes URL` and `Jenkins URL` appropriately, by using the values which we have just collected in the previous step.
 
 image::kubernetes-plugin-configuration.png[kubernetes-plugin-configuration]
 

--- a/content/doc/book/security/controller-isolation.adoc
+++ b/content/doc/book/security/controller-isolation.adoc
@@ -38,7 +38,7 @@ It is therefore highly advisable to not run any builds on the built-in node, ins
 
 // TODO Fix this once https://github.com/jenkinsci/jenkins/pull/5425 is merged and released:
 
-To prevent builds from running on the built-in node directly, navigate to _Manage Jenkins » Nodes and Clouds_.
+To prevent builds from running on the built-in node directly, navigate to _Settings » Nodes and Clouds_.
 Select _Built-In Node_ in the list, then select _Configure_ in the menu.
 Set the number of executors to 0 and save.
 Make sure to also set up clouds or build agents to run builds on, otherwise builds won't be able to start.

--- a/content/doc/book/security/csrf-protection.adoc
+++ b/content/doc/book/security/csrf-protection.adoc
@@ -24,7 +24,7 @@ NOTE: The documentation on this page applies to Jenkins 2.222 or newer.
 
 ## Configuring CSRF Protection
 
-In _Manage Jenkins » Security » CSRF Protection_, administrators can configure CSRF Protection.
+In _Settings » Security » CSRF Protection_, administrators can configure CSRF Protection.
 
 image::security/configure-global-security-prevent-csrf.png["CSRF Protection in Security", role=center]
 

--- a/content/doc/book/security/markup-formatter.adoc
+++ b/content/doc/book/security/markup-formatter.adoc
@@ -12,7 +12,7 @@ They serve two purposes:
 
 == Configuring the Markup Formatter
 
-The markup formatter can be configured in _Manage Jenkins » Security » Markup Formatter_.
+The markup formatter can be configured in _Settings » Security » Markup Formatter_.
 
 The default markup formatter _Plain text_ renders all descriptions as entered:
 Unsafe HTML metacharacters like `<` and `&` are escaped, and line breaks are rendered as `<br/>` HTML tags.

--- a/content/doc/book/security/services.adoc
+++ b/content/doc/book/security/services.adoc
@@ -20,7 +20,7 @@ For an overview of the URLs accessible to users without any permissions in Jenki
 == TCP Agent Listener Port
 
 Jenkins can expose a TCP port that allows inbound agents to connect to it.
-It can be enabled, disabled, and configured in _Manage Jenkins » Security_.
+It can be enabled, disabled, and configured in _Settings » Security_.
 
 // TODO Screenshot
 

--- a/content/doc/book/security/user-content.adoc
+++ b/content/doc/book/security/user-content.adoc
@@ -27,7 +27,7 @@ This is often a difficult tradeoff between functionality and security, so should
 == Resource Root URL
 
 As an alternative to relaxing `Content-Security-Policy`, administrators can configure Jenkins to serve files from potentially less trusted sources from a different domain.
-This option can be configured in _Manage Jenkins » System_ in the section _Serve resource files from another domain_.
+This option can be configured in _Settings » System_ in the section _Serve resource files from another domain_.
 
 // TODO Screenshot
 

--- a/content/doc/book/system-administration/backing-up.adoc
+++ b/content/doc/book/system-administration/backing-up.adoc
@@ -53,7 +53,7 @@ They are supported by:
 === Plugins for backup
 
 Several plugins are available for backup.
-From the main menu select _Manage Jenkins_, then go to _Plugins>Available_ and search for **backup**.
+From the main menu select _Settings_, then go to _Plugins>Available_ and search for **backup**.
 Note that only the link:https://plugins.jenkins.io/thinBackup/[thinBackup Plugin] of the open source plugins is currently being maintained.
 You can try the other plugins but you may have problems with them.
 

--- a/content/doc/book/system-administration/reverse-proxy-configuration-troubleshooting.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-troubleshooting.adoc
@@ -17,7 +17,7 @@ endif::[]
 [[jenkins-says-my-reverse-proxy-setup-is-broken]]
 == Symptoms
 
-An error message is displayed in the "Manage Jenkins" page
+An error message is displayed in the "Settings" page
 
 `+It appears that your reverse proxy setup is broken+`
 

--- a/content/doc/book/system-administration/viewing-logs.adoc
+++ b/content/doc/book/system-administration/viewing-logs.adoc
@@ -59,9 +59,9 @@ default sends every log above `INFO` to stdout.
 Jenkins is equipped with a GUI for configuring/collecting/reporting log records of your choosing. 
 This page shows you how to do this.
 
-First, select the "System Log" from the "Manage Jenkins" page:
+First, select the "System Log" from the "Settings" page:
 
-image::logging-manage-screen.png["Manage Jenkins"]
+image::logging-manage-screen.png["Settings"]
 
 From there, you can create a custom log recorder, which helps you group
 relevant logs together while filtering out the noise.

--- a/content/doc/book/troubleshooting/diagnosing-errors.adoc
+++ b/content/doc/book/troubleshooting/diagnosing-errors.adoc
@@ -68,7 +68,7 @@ Under *References*, right-click `this` and select *Show Nearest GC Root*. Right-
 
 == How to Report a Bug
 
-For easier bug reporting, you can get the full list of plugins with this Groovy script that you can run in **Jenkins > Manage Jenkins > Script Console**:
+For easier bug reporting, you can get the full list of plugins with this Groovy script that you can run in **Jenkins > Settings > Script Console**:
 ```
 println("Jenkins: ${Jenkins.instance.getVersion()}")
 println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")

--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -164,7 +164,7 @@ Additionally, the command `docker container inspect agent1 | Select-String -Patt
 
 1. Go to your Jenkins dashboard;
 2. Go to `Settings` option in main menu;
-3. Go to `Manage Nodes and clouds` item;
+3. Go to `Nodes and clouds` item;
 +
 image:node/node-1.png[Manage node menu,700]
 

--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -96,7 +96,7 @@ The key's randomart image is:
 ==== Create a Jenkins SSH credential
 
 1. Go to your Jenkins dashboard;
-2. Go to `Manage Jenkins` option in main menu and click on the `Manage Credentials` button;
+2. Go to `Settings` option in main menu and click on the `Manage Credentials` button;
 +
 image:node/credentials-1.png[credentials menu,700]
 
@@ -163,7 +163,7 @@ Additionally, the command `docker container inspect agent1 | Select-String -Patt
 === Setup up the agent1 on jenkins.
 
 1. Go to your Jenkins dashboard;
-2. Go to `Manage Jenkins` option in main menu;
+2. Go to `Settings` option in main menu;
 3. Go to `Manage Nodes and clouds` item;
 +
 image:node/node-1.png[Manage node menu,700]

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -93,7 +93,7 @@ To add new global credentials to your Jenkins instance:
 . If required, ensure you are logged in to Jenkins (as a user with the
   *Credentials > Create* permission).
 . From the Jenkins home page (i.e. the Dashboard of the Jenkins classic UI),
-  click *Manage Jenkins > Manage Credentials*.
+  click *Settings > Manage Credentials*.
 +
 image:../../../images/using/manage.png[image,title="Manage_credentials"]
 

--- a/content/doc/book/using/using-jmeter-with-jenkins.adoc
+++ b/content/doc/book/using/using-jmeter-with-jenkins.adoc
@@ -50,7 +50,7 @@ To integrate JMeter with Jenkins, we will use the plugin:performance[Performance
 
 Follow these steps to install it:
 
-. From your Jenkins dashboard page, go to: *Manage Jenkins*.
+. From your Jenkins dashboard page, go to: *Settings*.
 . Go to the *Plugins* page.
 . Select *Available*, and enter 'performance' in the search field.
 . Mark the installation checkbox, and select *Install without restart*.

--- a/content/doc/developer/security/csp.adoc
+++ b/content/doc/developer/security/csp.adoc
@@ -51,7 +51,7 @@ Both modes can be useful with identifying broken functionality.
 ==== Report Only
 When set to only report issues but not enforce, the UI can be used as usual while letting the browser report violations, allowing to quickly gather a number of findings while not being blocked by broken functionality.
 Afterwards, the reported violations can be reviewed and affected functionality identified this way.
-Navigate to _Manage Jenkins » Content-Security-Policy Report_ and review the violations there.
+Navigate to _Settings » Content-Security-Policy Report_ and review the violations there.
 
 NOTE: As of Jenkins 2.372, functionality violating the plugin's default rule set is readily available in Jenkins, even without considering plugins, so the list should very rarely be empty.
 If the list of violations remains empty after navigating several pages of the Jenkins UI, review your browser's console for errors related to reporting CSP violations.

--- a/content/doc/developer/tutorial/run.adoc
+++ b/content/doc/developer/tutorial/run.adoc
@@ -54,7 +54,7 @@ Finished: SUCCESS
 <1> The Greeting added by the build step
 
 // TODO This is not present in version 1.2 of the archetype
-//Additionally, the build step has global configuration options. Go to _Manage Jenkins » System_ and you'll see this:
+//Additionally, the build step has global configuration options. Go to _Settings » System_ and you'll see this:
 //
 //image::developer/tutorial/system-config.png[System configuration]
 

--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -28,7 +28,7 @@ Handbook.
 
 To get started quickly with Pipeline:
 
-. Install the link:https://plugins.jenkins.io/docker-workflow/[*Docker Pipeline plugin*] through the *Manage Jenkins > Plugins* page
+. Install the link:https://plugins.jenkins.io/docker-workflow/[*Docker Pipeline plugin*] through the *Settings > Plugins* page
 . After installing the plugin, restart Jenkins so that the plugin is ready to use
 . Copy one of the <<examples, examples below>> into your repository and name it `Jenkinsfile`
 . Click the *New Item* menu within Jenkins

--- a/content/doc/tutorials/build-a-labview-app.adoc
+++ b/content/doc/tutorials/build-a-labview-app.adoc
@@ -180,7 +180,7 @@ image:tutorials/labview-14-create-first-user.png[alt="create first user",width=1
 
 Environment variables can be accessed across Jenkins jobs. We will want certain values accessible when Jenkins tries to build, test and diff your application. Since the GitHub organization name, access token, and picture repository will likely be the same across Jenkins jobs, we will set them in our Jenkins configuration.
 
-. From the Jenkins dashboard, navigate to the system configuration page: *Manage Jenkins >> System*
+. From the Jenkins dashboard, navigate to the system configuration page: *Settings >> System*
 . Navigate to the _Global properties_ section.
 . Check the *Environment* variables box to display the List of variables.
 . Click *Add* to add a new environment variable. Fill out the Name as shown below (BUILD_SYSTEM_REPO), and enter myBuildSystem in the Value field:
@@ -200,7 +200,7 @@ image:tutorials/labview-17-github-secret-text.png[alt="add github secret text",w
 
 The Global Library contains the script files and other components that will be used each time Jenkins tries to build. In this example, we are hosting them in the myBuildSystem repository. We will link Jenkins to that repository so it can use those files for each job.
 
-. On the main Jenkins dashboard: *Manage Jenkins >> System*
+. On the main Jenkins dashboard: *Settings >> System*
 
 . Under the _Global Pipeline Libraries section_, click *Add* and fill out the credentials for the myBuildSystem repository. Make sure to check the *Load implicitly* checkbox. Your options should look like this:
 [.boxshadow]

--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -347,7 +347,7 @@ image::tutorials/AWS/configure_cloud.png[Jenkins Dashboard showing configure a c
 +
 image::tutorials/AWS/manage-jenkins.png[Jenkins dashboard if there are existing clouds.]
 
-.. After navigating to *Settings*, select *Configure Nodes and Clouds* from the left hand side of the page.
+.. After navigating to *Settings*, select *Nodes and Clouds* from the left hand side of the page.
 +
 image::tutorials/AWS/manage-nodes-and-clouds.png[Manage nodes and clouds option from Settings page]
 .. From here, select *Clouds*.

--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -330,7 +330,7 @@ Enter your information, and then select *Save and Continue*.
 +
 image::tutorials/AWS/create_admin_user.png[Create your first admin user.]
 
-. On the left-hand side, select *Manage Jenkins*, and then select *Manage
+. On the left-hand side, select *Settings*, and then select *Manage
 Plugins*.
 . Select the *Available* tab, and then enter *Amazon EC2 plugin* at the top
 right.
@@ -343,13 +343,13 @@ image::tutorials/AWS/install_ec2_plugin.png[Jenkins Plugin Manager showing avail
 . Select *Configure a cloud* if there are no existing nodes or clouds.
 +
 image::tutorials/AWS/configure_cloud.png[Jenkins Dashboard showing configure a cloud.]
-. If you already have other nodes or clouds set up, select *Manage Jenkins*.
+. If you already have other nodes or clouds set up, select *Settings*.
 +
 image::tutorials/AWS/manage-jenkins.png[Jenkins dashboard if there are existing clouds.]
 
-.. After navigating to *Manage Jenkins*, select *Configure Nodes and Clouds* from the left hand side of the page.
+.. After navigating to *Settings*, select *Configure Nodes and Clouds* from the left hand side of the page.
 +
-image::tutorials/AWS/manage-nodes-and-clouds.png[Manage nodes and clouds option from Manage Jenkins page]
+image::tutorials/AWS/manage-nodes-and-clouds.png[Manage nodes and clouds option from Settings page]
 .. From here, select *Clouds*.
 +
 image::tutorials/AWS/manage-jenkins-configure-clouds.png[Configure clouds option in navigation.]

--- a/content/doc/tutorials/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
+++ b/content/doc/tutorials/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
@@ -251,7 +251,7 @@ with:
 
 For additional information, refer to the link:https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples] provided by the plugin:configuration-as-code[Configuration as Code] plugin, and learn how to configure the Jenkins instance without using the UI page. 
 Some plugins do not have concrete examples, but you can debug and find their JCasC in the UI page. 
-You can check the configuration in *Manage Jenkins* -> *Configuration as Code* -> *View Configuration*. 
+You can check the configuration in *Settings* -> *Configuration as Code* -> *View Configuration*.
 Then, you can copy the parts you need to the JCasC file.
 
 === Add and configure plugins (optional)

--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -64,7 +64,7 @@ fail, make sure the network is reliable.
 newer versions of the affected component.
 For Jenkins itself, review the link:/changelog-stable/[long term support changelog], the link:/doc/upgrade-guide/[LTS upgrade guide], and the link:/changelog/[weekly changelog].
 If you believe the problem to be in a plugin, review the changelog for the specific plugin on the link:https://plugins.jenkins.io/[plugins site].  The plugin documentation can also be reached
-directly by clicking the plugin name in _Manage Jenkins_ » _Plugins_ » _Installed_.
+directly by clicking the plugin name in _Settings_ » _Plugins_ » _Installed_.
 If you're still unable to resolve the problem and cannot find existing
 issue reports or related fixes in newer versions of Jenkins or the
 If you're still unable to resolve the problem, and cannot find existing issue reports or related fixes in newer versions of Jenkins or the plugins, file a *bug*.
@@ -153,7 +153,7 @@ all systems involved (your client's, the Jenkins server's, all agent
 nodes'),
 * All relevant *JRE/JDK vendors and versions* (e.g. Oracle JRE, OpenJDK,
 ...) and the parameters set.
-* *Jenkins and plugin versions*, use the below snippet in **Jenkins > Manage Jenkins > Script Console**:
+* *Jenkins and plugin versions*, use the below snippet in **Jenkins > Settings > Script Console**:
 ```
 println("Jenkins: ${Jenkins.instance.getVersion()}")
 println("OS: ${System.getProperty('os.name')} - ${System.getProperty('os.version')}")

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -67,7 +67,7 @@ To run pipelines, you need to have a Jenkins instance that is set up with the ap
 
 The Pipeline plugin is installed in the same way as other Jenkins plugins. Installing the Pipeline plugin also installs the suite of related plugins on which it depends:
 Open Jenkins in your web browser.
-On the Manage Jenkins page for your installation, navigate to Plugins.
+On the Settings page for your installation, navigate to Plugins.
 Find plugin:workflow-aggregator[Pipeline Plugin] from among the plugins listed on the Available tab.
  (You can do this by scrolling through the plugin list or by using “Pipeline” as a term to filter results)
 Select the checkbox for Pipeline Plugin.

--- a/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
+++ b/content/projects/gsoc/2020/projects/external-fingerprint-storage.adoc
@@ -202,7 +202,7 @@ The plugin can be installed using the Jenkins Update Center.
 
 Follow along the following steps after running Jenkins to download and install the plugin:
 
-. Select `Manage Jenkins`
+. Select `Settings`
 
 . Select `Plugins`
 
@@ -218,7 +218,7 @@ The plugin should now be installed on your system.
 
 Once the plugin has been installed, you can configure the Redis server details by following the steps below:
 
-. Select `Manage Jenkins`
+. Select `Settings`
 
 . Select `System`
 


### PR DESCRIPTION
Updates jenkins.io to align with the changes introduced in https://github.com/jenkinsci/jenkins/pull/7741

Only merge once/if 7741 is merged, thanks :)