### PR TITLE
Linkify 'osi-approved'

### DIFF
--- a/content/doc/developer/publishing/preparation.adoc
+++ b/content/doc/developer/publishing/preparation.adoc
@@ -21,7 +21,7 @@ All plugins distributed by the Jenkins project need to be free and open source s
 This applies to the plugin source code as well as all its dependencies.
 Make sure to specify the license both in the `pom.xml` file, as well as a `LICENSE` file in your repository.
 
-We recommend use of the MIT license which is used for Jenkins core and most plugins and libraries, but any OSI-approved open source license will do.
+We recommend use of the MIT license which is used for Jenkins core and most plugins and libraries, but any link:https://opensource.org/licenses/[OSI-approved] open source license will do.
 
 == Documentation
 

--- a/content/doc/developer/publishing/source-code-hosting.adoc
+++ b/content/doc/developer/publishing/source-code-hosting.adoc
@@ -3,7 +3,7 @@ title: Source Code Hosting
 layout: developersection
 ---
 
-The Jenkins project only publishes free and open source plugins distributed under an OSI-approved license.
+The Jenkins project only publishes free and open source plugins distributed under an link:https://opensource.org/licenses/[OSI-approved] license.
 
 The canonical source code repository is in the `jenkinsci` GitHub organization to ensure source code access and project continuity in case previous maintainers move on.
 Some plugins we distribute are currently maintained outside the `jenkinsci` GitHub organization for historical reasons, but this is discouraged.

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -53,7 +53,7 @@ This not only frees our time to do more creative work, but it also helps reduce 
 
 The Jenkins project uses the link:https://opensource.org/licenses/MIT[MIT License] as the primary license of choice, for the code that we develop. Unless otherwise stated, all the code is under the MIT license.
 
-The link:https://github.com/jenkinsci/jenkins[core of Jenkins] is entirely under the MIT license, as is the majority of our link:https://github.com/jenkins-infra[infrastructure code] (that runs the project itself), as well as many plugins. We encourage hosted plugins to use the same MIT license, to simplify the story for users, but plugins are free to choose their own licenses, so long as it’s an OSI-approved open-source license.
+The link:https://github.com/jenkinsci/jenkins[core of Jenkins] is entirely under the MIT license, as is the majority of our link:https://github.com/jenkins-infra[infrastructure code] (that runs the project itself), as well as many plugins. We encourage hosted plugins to use the same MIT license, to simplify the story for users, but plugins are free to choose their own licenses, so long as it’s an link:https://opensource.org/licenses/[OSI-approved] open-source license.
 
 This is not to be confused with proprietary plugins --- we recognize and encourage plugins that people write on their own for their internal use, without necessarily making the source code available. But no such plugins will be hosted by the Jenkins project.
 


### PR DESCRIPTION
In case the term is unclear, and regarding ongoing tasks, I propose to add links to the OSI listing all approved licenses, to avoid any possible confusion. 