### PR TITLE
Update datatables to 1.13.4

### DIFF
--- a/content/doc/developer/publishing/source-code-hosting.adoc
+++ b/content/doc/developer/publishing/source-code-hosting.adoc
@@ -19,9 +19,9 @@ Starting Chrome with the arguments --disable-web-security --user-data-dir=<some 
 ////
 ++++
     <style type="text/css">
-    @import url(https://cdn.datatables.net/1.10.21/css/jquery.dataTables.min.css);
+    @import url(https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css);
     </style>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.21/datatables.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript">
 $(document).ready(function() {
     $('#permissions').DataTable( {

--- a/content/doc/developer/publishing/source-code-hosting/forks.adoc
+++ b/content/doc/developer/publishing/source-code-hosting/forks.adoc
@@ -15,9 +15,9 @@ Starting Chrome with the arguments --disable-web-security --user-data-dir=<some 
 ////
 ++++
     <style type="text/css">
-    @import url(https://cdn.datatables.net/1.10.21/css/jquery.dataTables.min.css);
+    @import url(https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css);
     </style>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.21/datatables.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript">
 $(document).ready(function() {
     $('#forks').DataTable( {


### PR DESCRIPTION
Updates datatables and switches to the new repository, from where it's distributed.