### PR TITLE
Fix typo in today's security advisory

### DIFF
--- a/content/security/advisory/2023-03-21.adoc
+++ b/content/security/advisory/2023-03-21.adoc
@@ -160,7 +160,7 @@ issues:
   description: |-
     PLUGIN_NAME 1.0 and earlier uses basic string concatenation to convert Freestyle projects' Build Environment, Build Steps, and Post-build Actions to the equivalent Pipeline step invocations.
 
-    This allows attackers able to configure Freestyle projects to prepare a crafted configuration that injects Pipeline script code into the (unsandboxed) Pipeline resulting from a convertion by PLUGIN_NAME.
+    This allows attackers able to configure Freestyle projects to prepare a crafted configuration that injects Pipeline script code into the (unsandboxed) Pipeline resulting from a conversion by PLUGIN_NAME.
     If an administrator converts the Freestyle project to a Pipeline, the script will be pre-approved.
 
     As of publication of this advisory, there is no fix.


### PR DESCRIPTION
`convert -> conversion` is supposed to be meant here, I assume.