### PR TITLE
Add OpenIndiana Hipster to stable download

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -140,6 +140,12 @@ title: Jenkins download and deployment
             %span
               &nbsp;
             %ion-icon{:name=>"library-outline"}
+          %a.list-group-item.list-group-item-action{tooltip_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins-core-lts', third_party)}
+            %span.title
+              OpenIndiana Hipster
+            %span
+              &nbsp;
+            %ion-icon{:name=>"library-outline"}
 
     .col-md-6
       %strong
@@ -206,7 +212,7 @@ title: Jenkins download and deployment
           %span
             &nbsp;
           %ion-icon{:name=>"library-outline"}
-        %a.list-group-item.list-group-item-action{tooltip_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins', third_party)}
+        %a.list-group-item.list-group-item-action{tooltip_href('https://pkg.openindiana.org/hipster/en/search.shtml?token=jenkins-core-weekly', third_party)}
           %span.title
             OpenIndiana Hipster
           %span


### PR DESCRIPTION
They publish packages for stable versions of Jenkins too, let's add these to the "stable" column of the table.