### PR TITLE
Advise users to test their SSH connection before performing a release

### DIFF
--- a/content/doc/developer/publishing/releasing-manually.adoc
+++ b/content/doc/developer/publishing/releasing-manually.adoc
@@ -87,6 +87,14 @@ See the link:https://help.github.com/articles/connecting-to-github-with-ssh/[Git
 
 == Performing the release
 
+Always test your SSH connection before performing a release:
+
+[source,bash]
+----
+$ ssh -T git@github.com
+# Attempts to ssh to GitHub
+----
+
 With GitHub and Maven credentials set up, performing a release should be as easy as running the following command:
 
 ----


### PR DESCRIPTION
Fail fast in a common (at least for me) error condition.