### PR TITLE
Remove pagination links from blog entry of same page

### DIFF
--- a/content/_partials/pagination.html.haml
+++ b/content/_partials/pagination.html.haml
@@ -33,7 +33,7 @@
         - if page_index == 0
           - if index == 0
             - # link to first page from first page
-            - link_url = '.'
+            -# - link_url = '.'
           - else
             - # link to other page from first page
             - link_url = "./page/#{index + 1}.html"
@@ -41,6 +41,8 @@
           - if index == 0
             - # link to first page from other page
             - link_url = '..'
+          - elsif index == page_index
+            -# This will remove Links from the current page
           - else
             - # link to other page from other page
             - link_url = "../page/#{index + 1}.html"

--- a/content/_partials/pagination.html.haml
+++ b/content/_partials/pagination.html.haml
@@ -31,19 +31,15 @@
         - # https://jenkins.io/node/page/4.html
         - # https://jenkins.io/node/tags/pipeline/page/4.html
         - if page_index == 0
-          - if index == 0
-            - # link to first page from first page
-            -# - link_url = '.'
-          - else
+          - if index != 0
             - # link to other page from first page
             - link_url = "./page/#{index + 1}.html"
         - else
           - if index == 0
             - # link to first page from other page
             - link_url = '..'
-          - elsif index == page_index
             -# This will remove Links from the current page
-          - else
+          - elsif index != page_index
             - # link to other page from other page
             - link_url = "../page/#{index + 1}.html"
 


### PR DESCRIPTION
Pagination improvement, to remove links from the current page, to avoid reloading the same page again

The implementation was just to change the condition 
```
  - if index != 0
   - # link to other page from first page
   - link_url = "./page/#{index + 1}.html"
   - else
     - if index == 0
       - # link to first page from other page
       - link_url = '..'
        -# This will remove Links from the current page
      - elsif index != page_index
         - # link to other page from other page
         - link_url = "../page/#{index + 1}.html"
```

#6190 This should close this issue 