### PR TITLE
Remove Jenkins Community Awards from carousel

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -8,16 +8,6 @@
   :call_to_action:
     :text: More info
     :href: blog/2023/03/27/repository-signing-keys-changing/
-# jenkins community award
-- :href: blog/2023/02/23/cdf-awards/
-  :title: Jenkins Community Awards
-  :intro: Voting for the Jenkins Contributor 2023 Awards is now open (until March 28). 
-  :image:
-    :src: images/post-images/2023/02/23/2023-02-23-cdf-awards/community_awards_2023_jenkins.png 
-    :height: 320px
-  :call_to_action:
-    :text: Vote
-    :href: https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform
 # jenkins accepted for GSoC 2023
 - :href: blog/2023/02/23/gsoc2023-announcement/
   :title: Accepted for GSoC 2023!


### PR DESCRIPTION
The vote is closed, no need to display it in the carousel anymore.