### PR TITLE
Don't consider empty checkRoles as a vulnerability

### DIFF
--- a/content/doc/developer/security/remoting-callables.adoc
+++ b/content/doc/developer/security/remoting-callables.adoc
@@ -51,7 +51,7 @@ class MyCallable implements Callable<ReturnType,ExceptionType> {
         return Some.code().operatesOn(this.parameter);
     }
 
-    public void checkRules(RoleChecker checker) {
+    public void checkRoles(RoleChecker checker) {
         // this is an empty block // <1>
     }
 }
@@ -93,7 +93,7 @@ This is mostly equivalent to implementing `checkRoles` as follows:
 
 [source,java]
 ----
-    public void checkRules(RoleChecker checker) {
+    public void checkRoles(RoleChecker checker) {
         checker.check(this,Roles.SLAVE);
     }
 }
@@ -101,11 +101,11 @@ This is mostly equivalent to implementing `checkRoles` as follows:
 
 In very care cases, the agent-side of a connection will send a `Callable` to the controller for execution there.
 This is tricky to do safely and it's generally recommended plugins are restructured so this isn't needed.
-If this isn't possible, plugins can implement `SlaveToMasterCallable` or `SlaveToMasterFileCallable`, or implement `#checkRules` as follows:
+If this isn't possible, plugins can implement `SlaveToMasterCallable` or `SlaveToMasterFileCallable`, or implement `#checkRoles` as follows:
 
 [source,java]
 ----
-    public void checkRules(RoleChecker checker) {
+    public void checkRoles(RoleChecker checker) {
         checker.check(this,Roles.MASTER);
     }
 }

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -57,6 +57,8 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
   This is a feature.
 * Jobs started by a specific user can run on agents where the user lacks Agent/Build permission and can themselves trigger builds of jobs where the user lacks Job/Build permission.
   link:/doc/book/security/build-authorization/[See the documentation on Access Control for Builds].
+* `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check`.
+  link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
 
 == Issue Handling Process
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -57,7 +57,7 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
   This is a feature.
 * Jobs started by a specific user can run on agents where the user lacks Agent/Build permission and can themselves trigger builds of jobs where the user lacks Job/Build permission.
   link:/doc/book/security/build-authorization/[See the documentation on Access Control for Builds].
-* `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check`.
+* `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check` (no longer exploitable since 2.319 and LTS 2.303.3).
   link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
 
 == Issue Handling Process


### PR DESCRIPTION
Since Jenkins 2.319 and LTS 2.303.3 empty roles checks are not a danger.

We've decided to not treat them as a vulnerability anymore