### PR TITLE
Updating GSoC mentors

### DIFF
--- a/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score.adoc
@@ -15,7 +15,7 @@ mentors:
 - "dheerajodha"
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-add-probes-to-plugin-health-score/4838
-//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
+    gitter: "jenkinsci_GSoC-Plugin_Health_Score:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background

--- a/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
+++ b/content/projects/gsoc/2023/project-ideas/buiilding-android-app.adoc
@@ -13,8 +13,8 @@ skills:
 - Command line tools
 - Package management tool theory
 mentors:
-- "sbostandoust"
 - "gounthar"
+- "sbostandoust"
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-android-apps-with-jenkins/4798
 ---

--- a/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/project-ideas/docker-compose-build.adoc
@@ -12,6 +12,7 @@ skills:
 - Command line tools
 - Package management tool theory
 mentors:
+- "gounthar"
 - "berviantoleo"
 - "sbostandoust"
 links:

--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -11,7 +11,7 @@ skills:
 - Docker
 - GitLab
 mentors:
-- "basil"
+- "krisstern"
 - "markewaite"
 
 links:

--- a/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/project-ideas/gitlab-plugin-modernization.adoc
@@ -16,7 +16,7 @@ mentors:
 
 links:
     emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-active-modernization-of-gitlab-plugin/5039
-//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
+    gitter: "jenkinsci_gitlab-plugin:gitter.im"
 //   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
 ---
 === Background


### PR DESCRIPTION
This pull request cleans/updates the mentors for the 2023 GSoC project ideas.
Also adding the Gitter channel for some project ideas, when available.