### PR TITLE
Jenkins.io - add image guidelines to contributing.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -44,7 +44,7 @@ If you need any help, please ask in the xref:contacts[].
 [[contacts]]
 === Communication channels
 
-Jenkins website is largely maintained by the link:https://jenkins.io/sigs/docs/[Jenkins documentation] special interest group.
+The Jenkins website is largely maintained by the link:https://jenkins.io/sigs/docs/[Jenkins documentation] special interest group.
 This group has various communication channels which can be used to discuss contributing to the website:
 
 * link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Gitter chat]
@@ -53,40 +53,29 @@ This group has various communication channels which can be used to discuss contr
 [[forking]]
 === Creating a fork
 
-Creating a fork, aka link:https://guides.github.com/activities/forking/[forking],
-makes a personal copy of another repository.
-Any changes you make in your fork of the repository will not show up on the website
-until they are merged (via pull request) to the `master` branch of this repository.
-If you are unfamiliar with how to create a fork or how forks work, see the
-link:https://guides.github.com/activities/forking/[GitHub tutorial on forking].
+Creating a fork, aka link:https://guides.github.com/activities/forking/[forking], makes a personal copy of another repository.
+Any changes you make in your fork of the repository will not show up on the website until they are merged (via pull request) to the `master` branch of this repository.
+If you are unfamiliar with how to create a fork or how forks work, see the link:https://guides.github.com/activities/forking/[GitHub tutorial on forking].
 
 === Using GitHub to edit files
 
-GitHub makes it easy to add, edit, or delete individual files via their website's
-link:https://help.github.com/articles/editing-files-in-your-repository/[File Editor].
-The advantage of using the file editor is that GitHub will automatically fork (if needed),
-push the changes to a branch, and open a pull request for you.
+GitHub makes it easy to add, edit, or delete individual files via their website's link:https://help.github.com/articles/editing-files-in-your-repository/[File Editor].
+The advantage of using the file editor is that GitHub will automatically fork (if needed), push the changes to a branch, and open a pull request for you.
 It also means you don't need to have a local clone of your fork.
-The disadvantage is that you can't verify your changes locally before creating the PR,
-it only works on one file at a time, and your changes are lost if you close or navigate away from the page.
+The disadvantages are that you can't verify your changes locally before creating the PR, it only works on one file at a time, and your changes are lost if you close or navigate away from the page.
 
 === Using a local clone
 
-We generally recommend making changes in a
-link:https://help.github.com/articles/cloning-a-repository-from-github/[local clone] of your fork.
-This requires some additional tools and storage on your local machine,
-and you will need a bit more technical knowledge of how to use those tools.
+We generally recommend making changes in a link:https://help.github.com/articles/cloning-a-repository-from-github/[local clone] of your fork.
+This requires some additional tools and storage on your local machine, and you will need a bit more technical knowledge of how to use those tools.
 However, this will allow you to work on multiple files as part of a single set of changes.
 You'll save your changes in a local branch and then <<building, build and review>> them locally.
 When they are ready, you will push your changes to your fork and submit a pull request from there.
 
 == Building
 
-This project uses GNU/Make and Docker in order to generate the fully statically
-generated link:https://jenkins.io[jenkins.io] web site. The key tool for
-converting source code into the site is the
-link:https://github.com/awestruct/awestruct[Awestruct] static site generator,
-which is downloaded automatically as part of the build process.
+This project uses GNU/Make and Docker in order to generate the fully statically generated link:https://jenkins.io[jenkins.io] web site.
+The key tool for converting source code into the site is the link:https://github.com/awestruct/awestruct[Awestruct] static site generator, which is downloaded automatically as part of the build process.
 
 Ensure you have GNU/Make and Curl and Docker available on your machine:
 
@@ -99,43 +88,33 @@ Docker must be version 17.04 or greater.
 [[make-targets]]
 === `make` Targets
 
-Run `make` to run a full build, or `make <target>` using one of the targets below
-to achieve specific results.
+Run `make` to run a full build, or `make <target>` using one of the targets below to achieve specific results.
 
-* *all* (default target) will run a full build of the site, including
-  `prepare`, `generate`, and `archive`. This will also download and regenerate external resources.
+* *all* (default target) will run a full build of the site, including `prepare`, `generate`, and `archive`.
+This will also download and regenerate external resources.
 * *clean* will remove all build output and dependencies in preparation for a full rebuild.
-* *prepare* will download external dependencies and resources necessary to
-  build the site. As an optimization to make iterating on content locally more pleasant,
-  dependencies and resources will not be downloaded again unless the `clean` target is called first.
-  The exception being `all` which will download and regenerate external resources
-  (but not download dependencies which are more bandwidth intensive).
+* *prepare* will download external dependencies and resources necessary to build the site.
+As an optimization to make iterating on content locally more pleasant, dependencies and resources will not be downloaded again unless the `clean` target is called first.
+The exception being `all` which will download and regenerate external resources (but not download dependencies which are more bandwidth intensive).
 * *generate* will explicitly generate static website files.
-* *run* will run a live-reloading development server on
-  link:http://localhost:4242/[localhost:4242].
-* *check* will look for typos. It is advised to use  *check* to examine the documentation for typos and spelling mistakes before submitting a pull request.
-
-
+* *run* will run a live-reloading development server on link:http://localhost:4242/[localhost:4242].
+* *check* will look for typos.
+It is advised to use *check* to examine the documentation for typos and spelling mistakes before submitting a pull request.
 
 == Editing content
 
-The majority of what is considered "legacy" content is almost entirely under
-`content/blog`. These files represent the structure around the date the original
-stories were written in Drupal.
+The majority of what is considered "legacy" content is almost entirely under `content/blog`.
+These files represent the structure around the date the original stories were written in Drupal.
 
 Most content on this site is written up in the AsciiDoc markup language.
 
 
 ==== Why AsciiDoc?
 
-Generally speaking, all documentation should be written in
-link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc]. While most open
-source contributors are familiar with
-link:https://en.wikipedia.org/wiki/Markdown[Markdown], it has limitations which
-make writing in-depth documentation with it problematic. Markdown, as opposed to
-link:https://guides.github.com/features/mastering-markdown/[GitHub flavored
-Markdown], does not have support for denoting what language source code might be
-written in. AsciiDoc supports this natively with the "source code" block:
+Generally speaking, all documentation should be written in link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc].
+While most open source contributors are familiar with link:https://en.wikipedia.org/wiki/Markdown[Markdown], it has limitations which make writing in-depth documentation with it problematic.
+Markdown, as opposed to link:https://guides.github.com/features/mastering-markdown/[GitHub flavored Markdown], does not have support for denoting what language source code might be written in.
+AsciiDoc supports this natively with the "source code" block:
 
 [source, asciidoc]
 ----
@@ -145,10 +124,7 @@ This is where I would _cite_ some highlighted AsciiDoc code
 \----
 ----
 
-AsciiDoc has a number of other features which can make authoring of
-documentation easier, such as the
-"link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#admon-bl[admonition blocks]"
-which help call out specific sections, such as:
+AsciiDoc has a number of other features which can make authoring of documentation easier, such as "link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#admon-bl[admonition blocks]" which help call out specific sections, such as:
 
 [source, asciidoc]
 ----
@@ -164,19 +140,12 @@ NOTE: This is a notice that you should pay attention to!
 CAUTION: This is a common mistake!
 
 
-There are too many other helpful macros and formatting options to list here, so
-it is recommended that you refer to the
-link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[quick reference]
-to become more familiar with what is available.
+There are too many other helpful macros and formatting options to list here, so it is recommended that you refer to the link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[quick reference] to become more familiar with what is available.
 
 === Adding a blog post
 
-In order to add a new blog post, create a new file ending in **.adoc** (for
-link:https://asciidoctor.org[Asciidoctor]) in the appropriate
-`content/blog/<year>/<month>` directory with the full date and a *lowercase*
-title for your post. In effect, if you're writing a post that you want to title
-"Hello World" on January 1st, 1970, you would create the file:
-`content/blog/1970/01/1970-01-01-hello-world.adoc`.
+In order to add a new blog post, create a new file ending in **.adoc** (for link:https://asciidoctor.org[Asciidoctor]) in the appropriate `content/blog/<year>/<month>` directory with the full date and a *lowercase* title for your post.
+In effect, if you're writing a post that you want to title "Hello World" on January 1st, 1970, you would create the file: `content/blog/1970/01/1970-01-01-hello-world.adoc`.
 
 In that file you need to enter some meta-data in the following format:
 
@@ -197,21 +166,17 @@ note: "Here you can mention that this is a guest post" # optional
 ---
 ----
 
-This section is referred to as the
-link:https://jekyllrb.com/docs/frontmatter/[front matter]. The `layout`
-attribute tells the rendering engine to use the "post" layout.
+This section is referred to as the link:https://jekyllrb.com/docs/frontmatter/[front matter].
+The `layout` attribute tells the rendering engine to use the "post" layout.
 `title` will be the displayed title of the post.
 
 `tags` are descriptive terms for this post.
-They can be used to search for all posts for a specific subject,
-such as "tutorials" or "plugins".
+They can be used to search for all posts for a specific subject, such as "tutorials" or "plugins".
 Tags must contain only numbers and lowercase letters.
 Tags must not contain spaces.
 Tags should be short, generally one or two words.
-Tags containing multiple words should squash all the words together,
-as in "continuousdelivery" or "jenkinsworld2017".
-Dashes are allowed but should be avoided unless describing a topic that contains
-dashes, such as a plugin name that contains dashes.
+Tags containing multiple words should squash all the words together, as in "continuousdelivery" or "jenkinsworld2017".
+Dashes are allowed but should be avoided unless describing a topic that contains dashes, such as a plugin name that contains dashes.
 To see tags people have used before:
 
 [source,sh]
@@ -221,35 +186,26 @@ egrep -h '^- [^ ]+$' content/blog/*/*/*.adoc | sort | uniq -c
 
 The `author` attribute will map your GitHub name to author information which will be displayed in the blogpost.
 If this is your first time adding a blog post, please create an author file as documented in the section below.
-Once your author file is defined, you can return to your blog post file
-(`1970-01-01-hello-world.adoc`), finish creating the "front matter" and then
-write your blog post!
+Once your author file is defined, you can return to your blog post file (`1970-01-01-hello-world.adoc`), finish creating the "front matter" and then write your blog post!
 
 Images for blog posts should be placed in subdirectories of the `content/images/post-images/` directory.
 If a blog post is describing "feature-x" then the images might be in `content/images/post-images/feature-x/`.
 
-The `opengraph` section is optional. It allows you to define a preview of
-the article for social media. The `image` attribute should be a PNG or JPEG image
-with more than 200px in each dimension and preferred aspect ratio about 2:1. For
-more information, see the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook],
-and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
+The `opengraph` section is optional.
+It allows you to define a preview of the article for social media.
+The `image` attribute should be a PNG or JPEG image with more than 200px in each dimension and preferred aspect ratio about 2:1.
+For more information, see the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook], and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
 
-The `note` will be shown as a note at the top of the post,
-but will be omitted from the post summary on the blog front page. 
+The `note` will be shown as a note at the top of the post, but will be omitted from the post summary on the blog front page. 
 It is intended for identifying posts by guest authors and posts that were also published somewhere else.
 
-Once you have everything ready, you may
-link:https://help.github.com/articles/creating-a-pull-request/[create a pull
-request] containing your additions.
+Once you have everything ready, you may link:https://help.github.com/articles/creating-a-pull-request/[create a pull request] containing your additions.
 
-TIP: If you're unfamiliar with the AsciiDoc syntax, please consult this
-link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[handy quick
-reference guide].
+TIP: If you're unfamiliar with the AsciiDoc syntax, please consult this link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[handy quick reference guide].
 
 === Adding contributor/author info
 
-Contributor info might be needed for creating a blogpost,
-but it is also used in other locations to reference contributors (e.g. in GSoC projects or SIG pages).
+Contributor info might be needed for creating a blogpost, but it is also used in other locations to reference contributors such as GSoC projects or SIG pages.
 
 Please also create a "contributor" file in `content/_data/authors/` with the file named `yourgithubname.adoc`.
 The format of this file should be:
@@ -269,10 +225,8 @@ This is an *AsciiDoc* formatted bio, but it is completely optional!
 
 Only the `name:` and `github:` sections are mandatory.
 
-You may also add an avatar image file for yourself in `content/images/avatars/`
-with the file named `yourgithubname.jpg`.
-You can use an image file with one of the following extensions:
-`.bmp`, `.gif`, `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg`.
+You may also add an avatar image file for yourself in `content/images/avatars/` with the file named `yourgithubname.jpg`.
+You can use an image file with one of the following extensions: `.bmp`, `.gif`, `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg`.
 The image should be square (e.g. 400x400 pixels) to render properly.
 
 === Adding documentation
@@ -280,170 +234,109 @@ The image should be square (e.g. 400x400 pixels) to render properly.
 This repository holds the central documentation for the Jenkins project, which
 can be broken down into three categories:
 
-. *Jenkins User Documentation* - for people who want to _use_ Jenkins's existing
-  functionality and plugin features. The documentation model that the content is
-  based on is described in Michael Nicholson's blog post
-  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]". Refer to the
-  <<jenkins-user-documentation,Jenkins User Documentation>> section below for
-  details on how this content is structured.
-. *Extend Jenkins Documentation* - this documentation is for people who want to
-  _extend_ the functionality of Jenkins by developing their own Jenkins plugins.
-  Like the Jenkins User Documentation (above), the content is based on the same
-  link:https://www.divio.com/blog/beginners_guide_to_documentation/[documentation model]. The
-  content for this set of documentation is written up as a combination of
-  `.haml` and `.adoc` files located in the
-  link:content/doc/developer[`content/doc/developer/`]
-  directory. Read more about adding pages to this documentation in
-  <<adding-a-stand-alone-page,Adding a stand-alone-page>>.
-. *Solution pages* - topic-specific destination pages providing a high-level
-  overview of a topic with links into getting started guides, handbook chapters,
-  relevant plugins and multimedia related to the topic. Be aware that some of
-  this content might already be present in the Jenkins User / Extend Jenkins
-  Documentation.
+. *Jenkins User Documentation* - for people who want to _use_ Jenkins's existing functionality and plugin features.
+The documentation model that the content is based on is described in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]".
+Refer to the <<jenkins-user-documentation,Jenkins User Documentation>> section below for details on how this content is structured.
+. *Extend Jenkins Documentation* - this documentation is for people who want to _extend_ the functionality of Jenkins by developing their own Jenkins plugins.
+Like the Jenkins User Documentation (above), the content is based on the same link:https://www.divio.com/blog/beginners_guide_to_documentation/[documentation model].
+The content for this set of documentation is written up as a combination of `.haml` and `.adoc` files located in the link:content/doc/developer[`content/doc/developer/`] directory.
+Read more about adding pages to this documentation in <<adding-a-stand-alone-page,Adding a stand-alone-page>>.
+. *Solution pages* - topic-specific destination pages providing a high-level overview of a topic with links into getting started guides, handbook chapters, relevant plugins and multimedia related to the topic.
+Be aware that some of this content might already be present in the Jenkins User / Extend Jenkins Documentation.
 
-The documentation pages can use the same metadata (`title`, `description`, `opengraph:image`)
-as blog posts.
+The documentation pages can use the same metadata (`title`, `description`, `opengraph:image`) as blog posts.
+
+==== Adding images
+
+When adding screenshots or images to documentation, there are methods to ensure that the images are focused, clear, and useful to the reader:
+
+* *Use consistent screen dimensions* - Screenshots captured within a specific range of dimensions provide consistency for both quality and the user experience.
+Keep screenshots between 1024 x 768 - 1440 x 900 so that displays of any size can render these images properly. 
++
+Several browsers offer a native way to adjust screen size and zoom percentage:
++
+** link:https://developer.chrome.com/docs/devtools/device-mode/[Google Chrome]
+** link:https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/[Mozilla Firefox]
+** link:https://www.browserstack.com/guide/enable-responsive-design-mode-in-safari-and-firefox[Safari]
+
+* *Focus the screenshot's coverage* - Focusing the screenshot on the relevant content, and _necessary_ context, helps keep the screenshot relevant.
+If the image requires additional screen content to provide the proper context, be sure to include that information in the screenshot.
+
+* *Provide alt text for all images* - Alt text for images increases the accessibility of Jenkins documentation.
+link:https://docs.asciidoctor.org/asciidoc/latest/macros/images/[Asciidoc] can handle full sentence structure and formatting for alt text.
+Descriptive alt text is crucial for screen readers, as they provide as much clarity as possible.
 
 ==== Jenkins User Documentation
 
 The Jenkins User Documentation consists of the following parts:
 
-* *Tutorials* - these are step-by-step guides that teach users, relatively new to
-  Continuous Integration (CI) / Continuous Delivery (CD), concepts about how to
-  implement their project (of a particular tech stack) in Jenkins. A tutorial's
-  content is based on the "tutorial" description in Michael Nicholson's blog post
-  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]". Read more about
-  <<adding-a-tutorial-page,Adding a Tutorial page>>.
-* *How-to guides* - these are short guides consisting of procedures to get the
-  reader started with specific/common use-case scenarios. They could also be
-  guides that assist with overcoming commonly encountered issues - thereby
-  behaving as a form of knowledgebase article. A how-to guide's content goes
-  beyond the more general scope of a topic in the User Handbook, but these
-  guides do not hand-hold or teach the reader using very specific scenarios
-  (e.g. forking a given repo), as the *Tutorials* do. A how-to guide's content
-  is based on the "how-to guide" description in Michael Nicholson's blog post
-  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]". While there are currently no "how-to guides" yet, this
-  section will be added when good candidate guides arise.
-* *User Handbook* - rich and in-depth documentation, separated into chapters,
-  each of which covers a given topic/feature of Jenkins. This is conceptually
-  and structurally similar to the
-  link:https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/[FreeBSD
-  Handbook]. The User Handbook covers the fundamentals on how to use Jenkins as
-  well as content which is not explained in the *Tutorials* or *How-to Guides*
-  (above). This content is based predominantly on the "technical reference" description in
-  Michael Nicholson's blog post
-  "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]" blog post, with appropriate "discussion"- (i.e.
-  background/overview material) and general "how-to guide"- (i.e. specific to
-  the chapter/topic in question) like material. Read more about
-  <<adding-user-handbook-content,Adding User Handbook content>>.
+* *Tutorials* - these are step-by-step guides that teach users, relatively new to Continuous Integration (CI) / Continuous Delivery (CD), concepts about how to implement their project (of a particular tech stack) in Jenkins.
+A tutorial's content is based on the "tutorial" description in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]".
+Read more about <<adding-a-tutorial-page,Adding a Tutorial page>>.
+* *How-to guides* - these are short guides consisting of procedures to get the reader started with specific/common use-case scenarios.
+They could also be guides that assist with overcoming commonly encountered issues - thereby behaving as a form of knowledgebase article.
+A how-to guide's content goes beyond the more general scope of a topic in the User Handbook, but these guides do not hand-hold or teach the reader using very specific scenarios, such as forking a given repo, as the *Tutorials* do.
+A how-to guide's content is based on the "how-to guide" description in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]".
+While there are currently no "how-to guides", this section will be added when good candidate guides arise.
+* *User Handbook* - rich and in-depth documentation, separated into chapters, each of which covers a given topic/feature of Jenkins.
+This is conceptually and structurally similar to the link:https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/[FreeBSD Handbook].
+The User Handbook covers the fundamentals on how to use Jenkins, as well as content which is not explained in the *Tutorials* or *How-to Guides*.
+This content is based predominantly on the "technical reference" description in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]", with appropriate "discussion" (background/overview material) and general "how-to guide" (specific to the chapter/topic in question) material.
+Read more about <<adding-user-handbook-content,Adding User Handbook content>>.
 * *Resources*:
-** The Pipeline Syntax Reference is a link to the published
-   link:content/doc/book/pipeline/syntax.adoc[syntax.adoc]
-   reference page in the *User Handbook*.
-** The Pipeline Steps Reference consists of Asciidoc files which are
-   auto-generated from content within the relevant Pipeline plugin source code.
-   Therefore, to contribute to this content, you need to edit the relevant
-   plugin's source code.
-* *Recent Tutorial Blog Posts* - these are a list of the most recently
-  published blog posts presented as tutorials (and tagged with the *tutorial*
-  tag).
-* *Guided Tour* (Deprecated) - This part of the documentation is
-  being decommissioned in favor of the *Tutorials* and *How-to guides*
-  parts, both of which focus more on teaching people how to use Jenkins
-  or helping people with specific use-cases. Once all the
-  content from the *Guided Tour* is sufficiently captured in
-  those other parts, this part will be removed. +
-  Unless existing content in the *Guided Tour* needs to be updated
-  because it is incorrect or misleading (perhaps as a result of a Jenkins
-  update), avoid making additional contributions to this part.
-
+** The Pipeline Syntax Reference is a link to the published link:content/doc/book/pipeline/syntax.adoc[syntax.adoc] reference page in the *User Handbook*.
+** The Pipeline Steps Reference consists of Asciidoc files which are auto-generated from content within the relevant Pipeline plugin source code.
+Therefore, to contribute to this content, you need to edit the relevant plugin's source code.
+* *Recent Tutorial Blog Posts* - these are a list of the most recently published blog posts presented as tutorials (and tagged with the *tutorial* tag).
+* *Guided Tour* (Deprecated) - This part of the documentation is being decommissioned in favor of the *Tutorials* and *How-to guides* parts, both of which focus more on teaching people how to use Jenkins or helping people with specific use-cases.
+Once all the content from the *Guided Tour* is sufficiently captured in those other parts, this part will be removed.
+Unless existing content in the *Guided Tour* needs to be updated because it is incorrect or misleading (perhaps as a result of a Jenkins update), avoid making additional contributions to this part.
 
 ==== Adding a Tutorial page
 
-A tutorial is presented on its own page, each of which is written up as an
-`.adoc` file located in the link:content/doc/tutorials[`content/doc/tutorials/`]
-directory. If an `.adoc` file name begins with a underscore (e.g.
-link:content/doc/tutorials/_prerequisites.adoc[`content/doc/tutorials/_prerequisites.adoc`]),
-this means that the content is used as an
-link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[Asciidoc
-inclusion] on another page.
+A tutorial is presented on its own page, each of which is written up as an `.adoc` file located in the link:content/doc/tutorials[`content/doc/tutorials/`] directory.
+If an `.adoc` file name begins with a underscore (e.g. link:content/doc/tutorials/_prerequisites.adoc[`content/doc/tutorials/_prerequisites.adoc`]), this means that the content is used as an link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[Asciidoc inclusion] on another page.
 
 
 ==== Adding a How-to guide page
 
-This section will be completed when the first (or first set of) "how-to guides"
-are written.
+This section will be completed when the first (or first set of) "how-to guides" are written.
 
 
 ==== Adding User Handbook content
 
-The different chapters for the Handbook are located in the
-link:content/doc/book[`content/doc/book/`] directory.
+The different chapters for the Handbook are located in the link:content/doc/book[`content/doc/book/`] directory.
 
 To add a chapter:
 
-. Add a new subdirectory (within this directory) whose name reflects your
-  chapter title.
-. Specify this subdirectory's name as a new entry in the
-  link:content/doc/book/_book.yml[`content/doc/book/_book.yml`] file. The
-  position of the entry in this file determines the order in which the chapter
-  appears in the User Handbook.
-. Create an `index.adoc` file within the subdirectory you created above. Feel
-  free to copy another chapter's `index.adoc` content as a template/starting
-  point. The content on this page should be an overview (i.e. "discussion"
-  material) about the subject of this chapter (e.g. some big new Jenkins
-  feature). +
-  Once you do this, the chapters will automatically surface on the User Handbook
-  home page
-  (provided by
-  link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]),
-  which will automatically appear https://jenkins.io/doc/book/[here] (and in the
-  TOC on the left of this page) when accepted. +
-  Once you do add some topics to this chapter page as well as additional pages
-  of topics within a chapter (see below), it's recommended that you link to
-  these topics from within the overview (to help readers find this information).
+. Add a new subdirectory (within this directory) whose name reflects your chapter title.
+. Specify this subdirectory's name as a new entry in the link:content/doc/book/_book.yml[`content/doc/book/_book.yml`] file.
+The position of the entry in this file determines the order in which the chapter appears in the User Handbook.
+. Create an `index.adoc` file within the subdirectory you created above.
+Feel free to copy another chapter's `index.adoc` content as a template/starting point.
+The content on this page should be an overview ("discussion" material) about the subject of this chapter, such as some big new Jenkins feature. +
+Once you do this, the chapters will automatically surface on the User Handbook home page (provided by link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]), which will automatically appear https://jenkins.io/doc/book/[here] and in the TOC on the left of this page when accepted. +
+Once you do add some topics to this chapter page, as well as additional pages of topics within a chapter as described below, it's recommended that you link to these topics from within the overview to help readers find this information.
 
 To add a page (i.e. "section") within a chapter:
 
-. Within the relevant chapter subdirectory, create a new `.adoc` file whose name
-  reflects your page title. Feel free to copy another section's `.adoc` content
-  as a template/starting point.
-. Specify this `.adoc` file's name as a new entry in a `_chapter.yml` file
-  within this directory. Feel free to copy an empty `_chapter.yml` file from
-  another subdirectory/chapter (e.g. from the `glossary` directory). The
-  position of the entry in this file determines the order in which the page
-  appears within the chapter. +
-  Once you do this, the pages will automatically surface on the User Handbook
-  home page
-  (provided by
-  link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]),
-  which will automatically appear https://jenkins.io/doc/book/[here] (and the
-  TOC on the left of this page) when accepted. +
-  The content on this page should be predominantly "reference" material about
-  the subject of page (e.g. more detailed information about a specific aspect
-  of the big new feature). These pages may contain appropriate "discussion"- and
-  "how-to guide"-like material (i.e. overviews and procedures) relevant to the
-  subject to make the content more useful.
-
+. Within the relevant chapter subdirectory, create a new `.adoc` file whose name reflects your page title. Feel free to copy another section's `.adoc` content as a template/starting point.
+. Specify this `.adoc` file's name as a new entry in a `_chapter.yml` file within this directory. Feel free to copy an empty `_chapter.yml` file from another subdirectory/chapter (e.g. from the `glossary` directory).
+The position of the entry in this file determines the order in which the page appears within the chapter. +
+Once you do this, the pages will automatically surface on the User Handbook home page (provided by link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]), which will automatically appear https://jenkins.io/doc/book/[here] (and the TOC on the left of this page) when accepted. +
+The content on this page should be predominantly "reference" material about the subject of page (e.g. more detailed information about a specific aspect of the big new feature).
+These pages may contain appropriate "discussion"- and "how-to guide"-like material (i.e. overviews and procedures) relevant to the subject to make the content more useful.
 
 ==== Adding a Solution page
 
-Solution pages are somewhat *special* insofar that they are not generally
-AsciiDoc files, but rather link:http://haml.info[Haml] templates. All the
-solution pages are located in the link:content/solutions[`content/solutions/`]
-directory hierarchy, with some data provided for the solution pages in
-link:content/_data/solutions[`content/_data/solutions/`].
+Solution pages are somewhat *special* insofar that they are not generally AsciiDoc files, but rather link:http://haml.info[Haml] templates. All the solution pages are located in the link:content/solutions[`content/solutions/`] directory hierarchy, with some data provided for the solution pages in link:content/_data/solutions[`content/_data/solutions/`].
 
-IMPORTANT: The naming of a solution page template (`pipeline.html.haml`) must
-match the data file in `content/_data/solutions`, e.g. `pipeline.yml`
+IMPORTANT: The naming of a solution page template (`pipeline.html.haml`) must match the data file in `content/_data/solutions`, e.g. `pipeline.yml`
 
-New solution pages should help guide a reader to documentation and resources
-about a very specific topic, or use-case, on Jenkins. How specific/niche the
-solution pages should be requires a bit of judgement, for example "Jenkins for
-Visual C++" is probably too niche to fill out a page with a rich set of plugins,
-presentations and links to documentation.  A page "Jenkins for C/C++" would
-still be relatively specific, and could easily include a section for Visual
-C++/Windows specific content.
+New solution pages should help guide a reader to documentation and resources about a very specific topic, or use-case, on Jenkins.
+How specific/niche the solution pages should be requires a bit of judgement.
+For example, "Jenkins for Visual {cpp}" is probably too niche to fill out a page with a rich set of plugins, presentations and links to documentation.
+However, a "Jenkins for C/{cpp}" page would still be relatively specific, but could easily include a section for Visual {cpp}/Windows specific content.
 
 ==== Adding a Redirect page
 
@@ -468,12 +361,9 @@ Oleg Nenashev has provided a link:https://youtu.be/-cGeb2wtg4I[brief video tutor
 
 === Adding an event
 
-To add an event to the Jenkins event calendar, create a file in the
-`https://github.com/jenkins-infra/jenkins.io/tree/master/content/_data/events[content/_data/events/]`
-folder of this repo.
+To add an event to the Jenkins event calendar, create a file in the `https://github.com/jenkins-infra/jenkins.io/tree/master/content/_data/events[content/_data/events/]` folder of this repo.
 
-To create a file in this folder using the GitHub web editor,
-link:https://github.com/jenkins-infra/jenkins.io/new/master/content/_data/events[open this page in a new tab].
+To create a file in this folder using the GitHub web editor, link:https://github.com/jenkins-infra/jenkins.io/new/master/content/_data/events[open this page in a new tab].
 
 Name the file using the pattern `<DATE>-<CITY><OPTIONAL_ID>.adoc`:
 
@@ -505,26 +395,21 @@ link: "<LINK>"
 ----
 
 * EVENT_NAME - The name of the event.  
-  Note, this is not the _subject_ of the event, but the _name_. Examples: "Seattle JAM", "DevOps World 2022".
-  Basically, take a look at the events list on 
-  link:https://jenkins.io/events/[] as though you were trying to choose events you would go to. 
-  "August JAM" is not specific enough, but "DevOps World 2022" is.
+Note, this is not the _subject_ of the event, but the _name_. Examples: "Seattle JAM", "DevOps World 2022".
+Basically, take a look at the events list on link:https://jenkins.io/events/[] as though you were trying to choose events you would go to. 
+"August JAM" is not specific enough, but "DevOps World 2022" is.
 * LOCATION - Location of the meetup. The recommended format is `CITY, COUNTRY`, e.g. "Seattle, USA" or "Paris, France".
-  States may be specified if needed.
-  Use "Online" for online events like link:https://www.meetup.com/Jenkins-online-meetup/[Jenkins Online Meetup]
+States may be specified if needed.
+Use "Online" for online events like link:https://www.meetup.com/Jenkins-online-meetup/[Jenkins Online Meetup].
 * DATE_TIME - The date and time of the event in the format: `YYYY-MM-DDTHH:MM:00`.
-  The time should be when the event occurs in the local time zone and always using 24-hour format.
-  For online JAMs, use Pacific Time.
+The time should be when the event occurs in the local time zone and always using 24-hour format.
+For online JAMs, use Pacific Time.
 * LINK - a link to a page with more event information.
 * DESCRIPTION - A description of the event in Asciidoc format.
-  This may include the name and bio of the speakers, the subjects to be presented,
-  links to related content, or any other information that seems relevant.
+This may include the name and bio of the speakers, the subjects to be presented, links to related content, or any other information that seems relevant.
 +
-The description may be written in a local language for the event,
-  and using any unicode characters desired.
-  If not written in a language understood by the submitter of the event,
-  the submitter must do due diligence to make sure that what is being posted is appropriate content -
-  either by asking someone for help or using translation software.
+The description may be written in a local language for the event, and using any unicode characters desired.
+If not written in a language understood by the submitter of the event, the submitter must do due diligence to make sure that what is being posted is appropriate content - either by asking someone for help or using translation software.
 
 Examples:
 
@@ -554,56 +439,44 @@ Zero to Continuous Delivery with Jenkins Blue Ocean
 Presenter: Kohsuke Kawaguchi
 ----
 
-If using the GitHub UI to create this file,
-commit the file using the "Create a new branch for this commit and start a pull request" option.
+If using the GitHub UI to create this file, commit the file using the "Create a new branch for this commit and start a pull request" option.
 If working via a local clone, commit the change, push to a branch, and start a PR as usual.
 
 === Adding a stand-alone page
 
 Encouraged formats:
 
-* link:https://asciidoctor.org[Asciidoctor] (basic content creation)
-  (link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc
-  syntax quick reference])
-* link:http://haml.info[Haml] (more advanced/custom page)
-  (link:http://haml.info/docs/yardoc/file.REFERENCE.html[Haml syntax reference])
+* link:https://asciidoctor.org[Asciidoctor] (basic content creation) (link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc syntax quick reference])
+* link:http://haml.info[Haml] (more advanced/custom page) (link:http://haml.info/docs/yardoc/file.REFERENCE.html[Haml syntax reference])
 
-Adding a new page is as easy as adding a new file to the
-link:content/[`content/`] directory. It is important to keep in mind that the
-filename you choose *will be the URL of your page*, so ensure you have a
-*lowercase* and useful filename.
+Adding a new page is as easy as adding a new file to the link:content/[`content/`] directory.
+It is important to keep in mind that the filename you choose *will be the URL of your page*, so ensure you have a *lowercase* and useful filename.
 
-
-The link:content/index.html.haml[`content/index.html.haml`] page is one such
-example of a special-case, standalone page.
-
+The link:content/index.html.haml[`content/index.html.haml`] page is one such example of a special-case, standalone page.
 
 ==== Clean URLs
 
-In order to have a clean URL, e.g. "https://jenkins.io/my-clean-url", you would
-need to create a directory with your content in it. Using the above example, I
-would create the directory `content/my-clean-url` and if I were creating an
-Asciidoc file, I would then create the file `content/my-clean-url/index.adoc`.
+In order to have a clean URL, e.g. "https://jenkins.io/my-clean-url", you would need to create a directory with your content in it.
+Using the above example, I would create the directory `content/my-clean-url` and if I were creating an Asciidoc file, I would then create the file `content/my-clean-url/index.adoc`.
 (Advanced Haml users would create `content/my-clean-url/index.html.haml`).
 
 === Adding a Logo
 
-In order to add a new logo, please submit a pull request, 
-adding a new metadata `.yml` file in `content/_data/logo` and a 
-new directory containing the logo assets into `content/images/logos/`.
+In order to add a new logo, please submit a pull request, adding a new metadata `.yml` file in `content/_data/logo` and a new directory containing the logo assets into `content/images/logos/`.
 
-Requirements to the images:
+Requirements for logos:
 
-* All submitted images are licensed under the link:https://creativecommons.org/licenses/by-sa/3.0/[Creative Commons Attribution-ShareAlike 3.0 Unported License]
-* At least 2 images are needed: full-size PNG and another PNG which has a 256px height
+* All submitted images are licensed under the link:https://creativecommons.org/licenses/by-sa/3.0/[Creative Commons Attribution-ShareAlike 3.0 Unported License].
+* At least 2 images are needed: full-size PNG and another PNG which has a 256px height.
 ** Images should not contain the "Jenkins" or other text in the bottom like you may see on stickers.
-   We publish only logos on the site, text can be added in credits
-** It is recommended to add PNGs without background
-** PNGs should be losslessly optimized using special tools for that, e.g. link:https://pmt.sourceforge.io/pngcrush/[pngcrush]
-* SVG or other vector formats can be added to the image 
+We publish only logos on the site, text can be added in credits.
+** It is recommended to add PNGs without background.
+** PNGs should be losslessly optimized using special tools for that, such as link:https://pmt.sourceforge.io/pngcrush/[pngcrush].
+* SVG or other vector formats can be added to the image. 
 
-Each logo is identified by a unique ID (e.g. `imageId`), all images should be stored in a `content/images/logos/${imageId}`.
-Metadata file for the image would be `content/_data/logo/${imageId}`.
+Each logo is identified by a unique ID, such as `imageId`.
+All images should be stored in a `content/images/logos/${imageId}`.
+The metadata file for the image would be `content/_data/logo/${imageId}`.
 An example of such a metadata file is:
 
 ```yaml
@@ -647,15 +520,13 @@ Both teams operate under the umbrella of link:https://www.jenkins.io/sigs/docs/[
 
 === Joining the teams
 
-If you are interested to join the Triage or Copy Editors team, 
-you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list] or in the link:https://www.jenkins.io/sigs/docs/[Documentation SIG channels].
+If you are interested to join the Triage or Copy Editors team, you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list] or in the link:https://www.jenkins.io/sigs/docs/[Documentation SIG channels].
 The request will be processed and discussed by the community, and then the link:https://www.jenkins.io/project/team-leads/#documentation[documentation officer] will make a decision.
 
 Eligibility requirements:
 
 * Membership in both teams requires a track of contributions to the Jenkins website and/or documentation.
-  _Triage_ team is effectively an onboarding team for contributors interested in becoming copy editors,
-  and this team has a low entry bar.
+_Triage_ team is effectively an onboarding team for contributors interested in becoming copy editors, and this team has a low entry bar.
 * Applicants to the _Copy Editors_ team should have a signed link:https://github.com/jenkinsci/infra-cla[Contributor License Agreement].
 
 [[reviewing]]
@@ -668,10 +539,9 @@ Reviews may take some time depending on availability of contributors.
 Some tips for contributors:
 
 * Pull requests are open to public, and any GitHub user can review changes and provide feedback.
-  If you are interested to review changes, please just do so (and thanks in advance!). 
-  No special permissions needed
-* If you need help with reviews for documentation changes,
-  you can ask in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Documentation SIG Gitter channel].
+If you are interested to review changes, please just do so (and thanks in advance!). 
+No special permissions are needed.
+* If you need help with reviews for documentation changes, you can ask in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Documentation SIG Gitter channel].
 
 [[merging-common]]
 === Merging changes in common areas

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -13,7 +13,7 @@ toc::[]
 To contribute to this repository you will
 link:https://guides.github.com/activities/forking/[fork this repository],
 push changes to a branch in your fork, and then
-link:https://help.github.com/articles/creating-a-pull-request-from-a-fork/[create a pull request]
+link:https://help.github.com/articles/creating-a-pull-request-from-a-fork/[create a pull request(PR)]
 from that branch to the `master` branch of this repository.
 Forking only needs to be done once, after which you can push changes to your fork
 using the GitHub website file editor or from a local clone, as described below.
@@ -38,7 +38,7 @@ You can also find some newbie-friendly issues in our task tracker:
 If you found an issue that you would like to work on, you are welcome to go ahead and start contributing.
 Please don't ask to be assigned to an issue, we don't assign individuals to issues, just go ahead and start working on it.
 If you want to avoid having other people work on the same issue, feel free to add a comment to the issue stating that you're working on it.
-If the last comment on the issue is older than a week and there is no pull request linked to the issue, you can assume nobody is working on it.
+If the last comment on the issue is older than a week and there is no PR linked to the issue, you can assume nobody is working on it.
 If you need any help, please ask in the xref:contacts[].
 
 [[contacts]]
@@ -54,13 +54,13 @@ This group has various communication channels which can be used to discuss contr
 === Creating a fork
 
 Creating a fork, aka link:https://guides.github.com/activities/forking/[forking], makes a personal copy of another repository.
-Any changes you make in your fork of the repository will not show up on the website until they are merged (via pull request) to the `master` branch of this repository.
-If you are unfamiliar with how to create a fork or how forks work, see the link:https://guides.github.com/activities/forking/[GitHub tutorial on forking].
+Changes you make in your fork do not show up on the website until they are merged (via PR) to the `master` branch of the repository.
+If you are unfamiliar with how to create a fork or how forks work, refer to the link:https://guides.github.com/activities/forking/[GitHub tutorial on forking].
 
 === Using GitHub to edit files
 
 GitHub makes it easy to add, edit, or delete individual files via their website's link:https://help.github.com/articles/editing-files-in-your-repository/[File Editor].
-The advantage of using the file editor is that GitHub will automatically fork (if needed), push the changes to a branch, and open a pull request for you.
+The advantage of using the file editor is that GitHub will automatically fork (if needed), push the changes to a branch, and open a PR for you.
 It also means you don't need to have a local clone of your fork.
 The disadvantages are that you can't verify your changes locally before creating the PR, it only works on one file at a time, and your changes are lost if you close or navigate away from the page.
 
@@ -70,12 +70,12 @@ We generally recommend making changes in a link:https://help.github.com/articles
 This requires some additional tools and storage on your local machine, and you will need a bit more technical knowledge of how to use those tools.
 However, this will allow you to work on multiple files as part of a single set of changes.
 You'll save your changes in a local branch and then <<building, build and review>> them locally.
-When they are ready, you will push your changes to your fork and submit a pull request from there.
+When they are ready, you will push your changes to your fork and submit a PR from there.
 
 == Building
 
-This project uses GNU/Make and Docker in order to generate the fully statically generated link:https://jenkins.io[jenkins.io] web site.
-The key tool for converting source code into the site is the link:https://github.com/awestruct/awestruct[Awestruct] static site generator, which is downloaded automatically as part of the build process.
+This project uses GNU/Make and Docker to generate the fully statically link:https://jenkins.io[jenkins.io] web site.
+The key tool to convert source code into the site is the link:https://github.com/awestruct/awestruct[Awestruct] static site generator, which is downloaded automatically as part of the build process.
 
 Ensure you have GNU/Make and Curl and Docker available on your machine:
 
@@ -91,15 +91,15 @@ Docker must be version 17.04 or greater.
 Run `make` to run a full build, or `make <target>` using one of the targets below to achieve specific results.
 
 * *all* (default target) will run a full build of the site, including `prepare`, `generate`, and `archive`.
-This will also download and regenerate external resources.
+This also downloads and regenerates external resources.
 * *clean* will remove all build output and dependencies in preparation for a full rebuild.
 * *prepare* will download external dependencies and resources necessary to build the site.
-As an optimization to make iterating on content locally more pleasant, dependencies and resources will not be downloaded again unless the `clean` target is called first.
-The exception being `all` which will download and regenerate external resources (but not download dependencies which are more bandwidth intensive).
+As an optimization to make iterating on content locally more pleasant, dependencies and resources are not downloaded again unless the `clean` target is called first.
+The exception being `all`, which downloads and regenerates external resources (but not download dependencies because they are more bandwidth intensive).
 * *generate* will explicitly generate static website files.
-* *run* will run a live-reloading development server on link:http://localhost:4242/[localhost:4242].
-* *check* will look for typos.
-It is advised to use *check* to examine the documentation for typos and spelling mistakes before submitting a pull request.
+* *run* runs a live-reloading development server on link:http://localhost:4242/[localhost:4242].
+* *check* looks for typos.
+It is advised to use *check* to examine the documentation for typos and spelling mistakes before you submit a PR.
 
 == Editing content
 
@@ -112,7 +112,7 @@ Most content on this site is written up in the AsciiDoc markup language.
 ==== Why AsciiDoc?
 
 Generally speaking, all documentation should be written in link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc].
-While most open source contributors are familiar with link:https://en.wikipedia.org/wiki/Markdown[Markdown], it has limitations which make writing in-depth documentation with it problematic.
+While most open source contributors are familiar with link:https://en.wikipedia.org/wiki/Markdown[Markdown], it has limitations that make writing in-depth documentation with it problematic.
 Markdown, as opposed to link:https://guides.github.com/features/mastering-markdown/[GitHub flavored Markdown], does not have support for denoting what language source code might be written in.
 AsciiDoc supports this natively with the "source code" block:
 
@@ -124,7 +124,7 @@ This is where I would _cite_ some highlighted AsciiDoc code
 \----
 ----
 
-AsciiDoc has a number of other features which can make authoring of documentation easier, such as "link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#admon-bl[admonition blocks]" which help call out specific sections, such as:
+AsciiDoc has a number of other features that make authoring documentation easier, such as "link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#admon-bl[admonition blocks]", which help call out specific sections, including:
 
 [source, asciidoc]
 ----
@@ -140,12 +140,12 @@ NOTE: This is a notice that you should pay attention to!
 CAUTION: This is a common mistake!
 
 
-There are too many other helpful macros and formatting options to list here, so it is recommended that you refer to the link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[quick reference] to become more familiar with what is available.
+There are too many other helpful macros and formatting options to list here, so we recommended that you refer to the link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[quick reference] to become more familiar with what is available.
 
 === Adding a blog post
 
-In order to add a new blog post, create a new file ending in **.adoc** (for link:https://asciidoctor.org[Asciidoctor]) in the appropriate `content/blog/<year>/<month>` directory with the full date and a *lowercase* title for your post.
-In effect, if you're writing a post that you want to title "Hello World" on January 1st, 1970, you would create the file: `content/blog/1970/01/1970-01-01-hello-world.adoc`.
+To add a new blog post, create a new file ending in **.adoc** (for link:https://asciidoctor.org[Asciidoctor]) in the appropriate `content/blog/<year>/<month>` directory with the full date and a *lowercase* title for your post.
+For example, if you're writing a post that you want to title "Hello World" on January 1st, 1970, you would create the file: `content/blog/1970/01/1970-01-01-hello-world.adoc`.
 
 In that file you need to enter some meta-data in the following format:
 
@@ -194,18 +194,18 @@ If a blog post is describing "feature-x" then the images might be in `content/im
 The `opengraph` section is optional.
 It allows you to define a preview of the article for social media.
 The `image` attribute should be a PNG or JPEG image with more than 200px in each dimension and preferred aspect ratio about 2:1.
-For more information, see the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook], and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
+For more information, refer to the documentation for link:https://developers.facebook.com/docs/sharing/webmasters/images/[Facebook], and link:https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html[Twitter].
 
-The `note` will be shown as a note at the top of the post, but will be omitted from the post summary on the blog front page. 
+The `note` is shown as a note at the top of the post, but is omitted from the post summary on the blog front page.
 It is intended for identifying posts by guest authors and posts that were also published somewhere else.
 
-Once you have everything ready, you may link:https://help.github.com/articles/creating-a-pull-request/[create a pull request] containing your additions.
+Once you have everything ready, you may link:https://help.github.com/articles/creating-a-pull-request/[create a PR] containing your additions.
 
-TIP: If you're unfamiliar with the AsciiDoc syntax, please consult this link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[handy quick reference guide].
+TIP: If you're unfamiliar with the AsciiDoc syntax, refer to this link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[handy quick reference guide].
 
 === Adding contributor/author info
 
-Contributor info might be needed for creating a blogpost, but it is also used in other locations to reference contributors such as GSoC projects or SIG pages.
+Contributor info may be needed to create a blogpost, but it is also used in other locations to reference contributors, such as GSoC projects or SIG pages.
 
 Please also create a "contributor" file in `content/_data/authors/` with the file named `yourgithubname.adoc`.
 The format of this file should be:
@@ -234,24 +234,24 @@ The image should be square (e.g. 400x400 pixels) to render properly.
 This repository holds the central documentation for the Jenkins project, which
 can be broken down into three categories:
 
-. *Jenkins User Documentation* - for people who want to _use_ Jenkins's existing functionality and plugin features.
+. *Jenkins User Documentation:* For people who want to _use_ Jenkins's existing functionality and plugin features.
 The documentation model that the content is based on is described in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]".
 Refer to the <<jenkins-user-documentation,Jenkins User Documentation>> section below for details on how this content is structured.
-. *Extend Jenkins Documentation* - this documentation is for people who want to _extend_ the functionality of Jenkins by developing their own Jenkins plugins.
+. *Extend Jenkins Documentation:* This documentation is for people who want to _extend_ the functionality of Jenkins by developing their own Jenkins plugins.
 Like the Jenkins User Documentation (above), the content is based on the same link:https://www.divio.com/blog/beginners_guide_to_documentation/[documentation model].
 The content for this set of documentation is written up as a combination of `.haml` and `.adoc` files located in the link:content/doc/developer[`content/doc/developer/`] directory.
 Read more about adding pages to this documentation in <<adding-a-stand-alone-page,Adding a stand-alone-page>>.
-. *Solution pages* - topic-specific destination pages providing a high-level overview of a topic with links into getting started guides, handbook chapters, relevant plugins and multimedia related to the topic.
+. *Solution pages:* Topic-specific destination pages providing a high-level overview of a topic with links into getting started guides, handbook chapters, relevant plugins, and multimedia related to the topic.
 Be aware that some of this content might already be present in the Jenkins User / Extend Jenkins Documentation.
 
 The documentation pages can use the same metadata (`title`, `description`, `opengraph:image`) as blog posts.
 
 ==== Adding images
 
-When adding screenshots or images to documentation, there are methods to ensure that the images are focused, clear, and useful to the reader:
+When you add screenshots or images to documentation, there are methods to ensure that the images are focused, clear, and useful to the reader:
 
 * *Use consistent screen dimensions* - Screenshots captured within a specific range of dimensions provide consistency for both quality and the user experience.
-Keep screenshots between 1024 x 768 - 1440 x 900 so that displays of any size can render these images properly. 
+Keep screenshots between 1024 x 768 - 1440 x 900 so that displays of any size render images properly. 
 +
 Several browsers offer a native way to adjust screen size and zoom percentage:
 +
@@ -259,10 +259,10 @@ Several browsers offer a native way to adjust screen size and zoom percentage:
 ** link:https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/[Mozilla Firefox]
 ** link:https://www.browserstack.com/guide/enable-responsive-design-mode-in-safari-and-firefox[Safari]
 
-* *Focus the screenshot's coverage* - Focusing the screenshot on the relevant content, and _necessary_ context, helps keep the screenshot relevant.
+* *Focus the screenshot's coverage:* Focusing the screenshot on the relevant content, and _necessary_ context, helps keep the screenshot relevant.
 If the image requires additional screen content to provide the proper context, be sure to include that information in the screenshot.
 
-* *Provide alt text for all images* - Alt text for images increases the accessibility of Jenkins documentation.
+* *Provide alt text for all images:* Alt text for images increases the accessibility of Jenkins documentation.
 link:https://docs.asciidoctor.org/asciidoc/latest/macros/images/[Asciidoc] can handle full sentence structure and formatting for alt text.
 Descriptive alt text is crucial for screen readers, as they provide as much clarity as possible.
 
@@ -270,26 +270,26 @@ Descriptive alt text is crucial for screen readers, as they provide as much clar
 
 The Jenkins User Documentation consists of the following parts:
 
-* *Tutorials* - these are step-by-step guides that teach users, relatively new to Continuous Integration (CI) / Continuous Delivery (CD), concepts about how to implement their project (of a particular tech stack) in Jenkins.
+* *Tutorials:* These are step-by-step guides that teach users, relatively new to Continuous Integration (CI) / Continuous Delivery (CD), concepts about how to implement their project (of a particular tech stack) in Jenkins.
 A tutorial's content is based on the "tutorial" description in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]".
 Read more about <<adding-a-tutorial-page,Adding a Tutorial page>>.
-* *How-to guides* - these are short guides consisting of procedures to get the reader started with specific/common use-case scenarios.
+* *How-to guides:* These are short guides consisting of procedures to get the reader started with specific/common use-case scenarios.
 They could also be guides that assist with overcoming commonly encountered issues - thereby behaving as a form of knowledgebase article.
 A how-to guide's content goes beyond the more general scope of a topic in the User Handbook, but these guides do not hand-hold or teach the reader using very specific scenarios, such as forking a given repo, as the *Tutorials* do.
 A how-to guide's content is based on the "how-to guide" description in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]".
 While there are currently no "how-to guides", this section will be added when good candidate guides arise.
-* *User Handbook* - rich and in-depth documentation, separated into chapters, each of which covers a given topic/feature of Jenkins.
+* *User Handbook:* Rich and in-depth documentation, separated into chapters, each of which covers a given topic/feature of Jenkins.
 This is conceptually and structurally similar to the link:https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/[FreeBSD Handbook].
 The User Handbook covers the fundamentals on how to use Jenkins, as well as content which is not explained in the *Tutorials* or *How-to Guides*.
 This content is based predominantly on the "technical reference" description in Michael Nicholson's blog post "link:https://www.divio.com/blog/beginners_guide_to_documentation/[Beginner's Guide to Documentation: Here's What You Need to Know]", with appropriate "discussion" (background/overview material) and general "how-to guide" (specific to the chapter/topic in question) material.
 Read more about <<adding-user-handbook-content,Adding User Handbook content>>.
-* *Resources*:
+* *Resources:*
 ** The Pipeline Syntax Reference is a link to the published link:content/doc/book/pipeline/syntax.adoc[syntax.adoc] reference page in the *User Handbook*.
 ** The Pipeline Steps Reference consists of Asciidoc files which are auto-generated from content within the relevant Pipeline plugin source code.
-Therefore, to contribute to this content, you need to edit the relevant plugin's source code.
-* *Recent Tutorial Blog Posts* - these are a list of the most recently published blog posts presented as tutorials (and tagged with the *tutorial* tag).
-* *Guided Tour* (Deprecated) - This part of the documentation is being decommissioned in favor of the *Tutorials* and *How-to guides* parts, both of which focus more on teaching people how to use Jenkins or helping people with specific use-cases.
-Once all the content from the *Guided Tour* is sufficiently captured in those other parts, this part will be removed.
+Therefore, to contribute to this content, you must edit the relevant plugin's source code.
+* *Recent Tutorial Blog Posts:* These are a list of the most recently published blog posts presented as tutorials (and tagged with the *tutorial* tag).
+* *Guided Tour (Deprecated):* This part of the documentation is being decommissioned in favor of the *Tutorials* and *How-to guides* parts, both of which focus more on teaching how to use Jenkins or helping with specific use-cases.
+** Once all the content from the *Guided Tour* is sufficiently captured in those other parts, this part will be removed.
 Unless existing content in the *Guided Tour* needs to be updated because it is incorrect or misleading (perhaps as a result of a Jenkins update), avoid making additional contributions to this part.
 
 ==== Adding a Tutorial page
@@ -302,34 +302,38 @@ If an `.adoc` file name begins with a underscore (e.g. link:content/doc/tutorial
 
 This section will be completed when the first (or first set of) "how-to guides" are written.
 
-
 ==== Adding User Handbook content
 
 The different chapters for the Handbook are located in the link:content/doc/book[`content/doc/book/`] directory.
 
 To add a chapter:
 
-. Add a new subdirectory (within this directory) whose name reflects your chapter title.
+. Add a new subdirectory, within this directory, whose name reflects your chapter title.
 . Specify this subdirectory's name as a new entry in the link:content/doc/book/_book.yml[`content/doc/book/_book.yml`] file.
 The position of the entry in this file determines the order in which the chapter appears in the User Handbook.
 . Create an `index.adoc` file within the subdirectory you created above.
 Feel free to copy another chapter's `index.adoc` content as a template/starting point.
-The content on this page should be an overview ("discussion" material) about the subject of this chapter, such as some big new Jenkins feature. +
-Once you do this, the chapters will automatically surface on the User Handbook home page (provided by link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]), which will automatically appear https://jenkins.io/doc/book/[here] and in the TOC on the left of this page when accepted. +
-Once you do add some topics to this chapter page, as well as additional pages of topics within a chapter as described below, it's recommended that you link to these topics from within the overview to help readers find this information.
+The content on this page should be an overview ("discussion" material) about the subject of this chapter, such as some big new Jenkins feature. 
+* Once you do this, the chapters will automatically surface on the User Handbook home page (provided by link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]), which will automatically appear link:https://jenkins.io/doc/book/[on the handbook index page] and in the TOC on the left of this page when accepted. 
 
-To add a page (i.e. "section") within a chapter:
+After you add some topics to this chapter page, as well as additional pages of topics within a chapter as described below, we recommend that you link to these topics from within the overview to help readers find this information.
 
-. Within the relevant chapter subdirectory, create a new `.adoc` file whose name reflects your page title. Feel free to copy another section's `.adoc` content as a template/starting point.
-. Specify this `.adoc` file's name as a new entry in a `_chapter.yml` file within this directory. Feel free to copy an empty `_chapter.yml` file from another subdirectory/chapter (e.g. from the `glossary` directory).
-The position of the entry in this file determines the order in which the page appears within the chapter. +
-Once you do this, the pages will automatically surface on the User Handbook home page (provided by link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]), which will automatically appear https://jenkins.io/doc/book/[here] (and the TOC on the left of this page) when accepted. +
-The content on this page should be predominantly "reference" material about the subject of page (e.g. more detailed information about a specific aspect of the big new feature).
-These pages may contain appropriate "discussion"- and "how-to guide"-like material (i.e. overviews and procedures) relevant to the subject to make the content more useful.
+To add a page ("section") within a chapter:
+
+. Within the relevant chapter subdirectory, create a new `.adoc` file whose name reflects your page title.
+You can copy another section's `.adoc` content as a template/starting point.
+. Specify this `.adoc` file's name as a new entry in a `_chapter.yml` file within this directory.
+You can copy an empty `_chapter.yml` file from another subdirectory/chapter such as the `glossary` directory.
+The position of the entry in this file determines the order in which the page appears within the chapter.
+* Once you do this, the pages automatically surface on the User Handbook home page (provided by link:content/doc/book/index.html.haml[`content/doc/book/index.html.haml`]), which will automatically appear link:https://jenkins.io/doc/book/[on the handbook index page], and the TOC on the left of this page when accepted.
+
+The content on this page should be predominantly "reference" material about the subject, such as more detailed information about a specific aspect of the big new feature.
+These pages may contain appropriate "discussion" - and "how-to guide"- like material, such as overviews and procedures, relevant to the subject to make the content more useful.
 
 ==== Adding a Solution page
 
-Solution pages are somewhat *special* insofar that they are not generally AsciiDoc files, but rather link:http://haml.info[Haml] templates. All the solution pages are located in the link:content/solutions[`content/solutions/`] directory hierarchy, with some data provided for the solution pages in link:content/_data/solutions[`content/_data/solutions/`].
+Solution pages are somewhat *special* because they are generally not AsciiDoc files, but rather link:http://haml.info[Haml] templates.
+All the solution pages are located in the link:content/solutions[`content/solutions/`] directory hierarchy, with some data provided for the solution pages in link:content/_data/solutions[`content/_data/solutions/`].
 
 IMPORTANT: The naming of a solution page template (`pipeline.html.haml`) must match the data file in `content/_data/solutions`, e.g. `pipeline.yml`
 
@@ -354,7 +358,7 @@ When the user opens the moved page, the redirect automatically opens the new loc
 When the user opens a removed page, the redirect can take them to a different location or to the `/404/index.html` "not found" page
 
 Redirects are implemented with a `layout: redirect` and the property `redirect_url` assigned the URL to the destination of the redirect.
-Redirects can be placed in any of the content locations (like `projects/` and `docs/`).
+Redirects can be placed in any of the content locations, like `projects/` or `docs/`.
 Redirects that need a shorter link are created by convention in the `content/redirect/` folder
 
 Oleg Nenashev has provided a link:https://youtu.be/-cGeb2wtg4I[brief video tutorial] that shows how to create and test a redirect with `jenkins.io`.
@@ -367,14 +371,14 @@ To create a file in this folder using the GitHub web editor, link:https://github
 
 Name the file using the pattern `<DATE>-<CITY><OPTIONAL_ID>.adoc`:
 
-* DATE -
+* *DATE:*
   The date of the event written as `YYYY-MM-DD`.
   For a multi-day event, use the starting day.
-* CITY -
+* *CITY:*
   The name of the city in lowercase letters without modifiers/accents
   (only the characters "a-z") and using dashes instead of spaces.
   For an online JAM, the city name should be "online".
-* OPTIONAL_ID -
+* *OPTIONAL_ID:*
   If there is more than one event in the same city on a specific day,
   add an OPTIONAL_ID as a dash and a number (1-9).
 
@@ -394,21 +398,20 @@ link: "<LINK>"
 <DESCRIPTION>
 ----
 
-* EVENT_NAME - The name of the event.  
+* *EVENT_NAME:* The name of the event.  
 Note, this is not the _subject_ of the event, but the _name_. Examples: "Seattle JAM", "DevOps World 2022".
 Basically, take a look at the events list on link:https://jenkins.io/events/[] as though you were trying to choose events you would go to. 
 "August JAM" is not specific enough, but "DevOps World 2022" is.
-* LOCATION - Location of the meetup. The recommended format is `CITY, COUNTRY`, e.g. "Seattle, USA" or "Paris, France".
+* *LOCATION:* Location of the meetup. The recommended format is `CITY, COUNTRY`, e.g. "Seattle, USA" or "Paris, France".
 States may be specified if needed.
 Use "Online" for online events like link:https://www.meetup.com/Jenkins-online-meetup/[Jenkins Online Meetup].
-* DATE_TIME - The date and time of the event in the format: `YYYY-MM-DDTHH:MM:00`.
+* *DATE_TIME:* The date and time of the event in the format: `YYYY-MM-DDTHH:MM:00`.
 The time should be when the event occurs in the local time zone and always using 24-hour format.
-For online JAMs, use Pacific Time.
-* LINK - a link to a page with more event information.
-* DESCRIPTION - A description of the event in Asciidoc format.
+For online JAMs, use Pacific time.
+* *LINK:* A link to a page with more event information.
+* *DESCRIPTION:* A description of the event in Asciidoc format.
 This may include the name and bio of the speakers, the subjects to be presented, links to related content, or any other information that seems relevant.
-+
-The description may be written in a local language for the event, and using any unicode characters desired.
+** The description may be written in a local language for the event, and using any unicode characters desired.
 If not written in a language understood by the submitter of the event, the submitter must do due diligence to make sure that what is being posted is appropriate content - either by asking someone for help or using translation software.
 
 Examples:
@@ -439,35 +442,37 @@ Zero to Continuous Delivery with Jenkins Blue Ocean
 Presenter: Kohsuke Kawaguchi
 ----
 
-If using the GitHub UI to create this file, commit the file using the "Create a new branch for this commit and start a pull request" option.
+If using the GitHub UI to create this file, commit the file using the *Create a new branch for this commit and start a pull request* option.
 If working via a local clone, commit the change, push to a branch, and start a PR as usual.
 
 === Adding a stand-alone page
 
 Encouraged formats:
 
-* link:https://asciidoctor.org[Asciidoctor] (basic content creation) (link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc syntax quick reference])
-* link:http://haml.info[Haml] (more advanced/custom page) (link:http://haml.info/docs/yardoc/file.REFERENCE.html[Haml syntax reference])
+* link:https://asciidoctor.org[Asciidoctor] for basic content creation.
+** link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc syntax quick reference]
+* link:http://haml.info[Haml] for more advanced/custom page creation.
+** link:http://haml.info/docs/yardoc/file.REFERENCE.html[Haml syntax reference]
 
 Adding a new page is as easy as adding a new file to the link:content/[`content/`] directory.
-It is important to keep in mind that the filename you choose *will be the URL of your page*, so ensure you have a *lowercase* and useful filename.
+Remember that the filename you choose *will be the URL of your page*, so ensure you have a *lowercase* and useful filename.
 
 The link:content/index.html.haml[`content/index.html.haml`] page is one such example of a special-case, standalone page.
 
 ==== Clean URLs
 
-In order to have a clean URL, e.g. "https://jenkins.io/my-clean-url", you would need to create a directory with your content in it.
+To have a clean URL such as "https://jenkins.io/my-clean-url", you would need to create a directory with your content in it.
 Using the above example, I would create the directory `content/my-clean-url` and if I were creating an Asciidoc file, I would then create the file `content/my-clean-url/index.adoc`.
 (Advanced Haml users would create `content/my-clean-url/index.html.haml`).
 
 === Adding a Logo
 
-In order to add a new logo, please submit a pull request, adding a new metadata `.yml` file in `content/_data/logo` and a new directory containing the logo assets into `content/images/logos/`.
+To add a new logo, submit a PR, adding a new metadata `.yml` file in `content/_data/logo` and a new directory containing the logo assets into `content/images/logos/`.
 
-Requirements for logos:
+Logo requirements:
 
 * All submitted images are licensed under the link:https://creativecommons.org/licenses/by-sa/3.0/[Creative Commons Attribution-ShareAlike 3.0 Unported License].
-* At least 2 images are needed: full-size PNG and another PNG which has a 256px height.
+* At least two images are needed: full-size PNG and another PNG that has a 256px height.
 ** Images should not contain the "Jenkins" or other text in the bottom like you may see on stickers.
 We publish only logos on the site, text can be added in credits.
 ** It is recommended to add PNGs without background.
@@ -513,14 +518,14 @@ Areas not in this file are considered as _common areas_ and maintained by teams 
 
 There are 2 teams which maintain the majority of the website content except special areas:
 
-* link:https://github.com/orgs/jenkins-infra/teams/jenkins-io-triage[Triage] team which performs triage and reviews the submitted issues and pull requests.
+* link:https://github.com/orgs/jenkins-infra/teams/jenkins-io-triage[Triage] team which performs triage and reviews the submitted issues and PRs.
 * link:https://github.com/orgs/jenkins-infra/teams/copy-editors[Copy Editors] team which, in addition to reviews and triage, has permissions to copy-edit and merge submitted changes.
 
 Both teams operate under the umbrella of link:https://www.jenkins.io/sigs/docs/[Jenkins Documentation Special Interest Group] led by the link:https://www.jenkins.io/project/team-leads/#documentation[Documentation Officer].
 
 === Joining the teams
 
-If you are interested to join the Triage or Copy Editors team, you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list] or in the link:https://www.jenkins.io/sigs/docs/[Documentation SIG channels].
+If you are interested in joining the Triage or Copy Editors team, you can request membership in the link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer mailing list] or in the link:https://www.jenkins.io/sigs/docs/[Documentation SIG channels].
 The request will be processed and discussed by the community, and then the link:https://www.jenkins.io/project/team-leads/#documentation[documentation officer] will make a decision.
 
 Eligibility requirements:
@@ -532,13 +537,13 @@ _Triage_ team is effectively an onboarding team for contributors interested in b
 [[reviewing]]
 === Reviewing changes
 
-There are many pull requests being submitted to jenkins.io every week.
+There are many PRs being submitted to jenkins.io every week.
 Reviews are driven by the community, and any contributions are always welcome.
 Reviews may take some time depending on availability of contributors.
 
 Some tips for contributors:
 
-* Pull requests are open to public, and any GitHub user can review changes and provide feedback.
+* PRs are open to public, and any GitHub user can review changes and provide feedback.
 If you are interested to review changes, please just do so (and thanks in advance!). 
 No special permissions are needed.
 * If you need help with reviews for documentation changes, you can ask in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[Documentation SIG Gitter channel].
@@ -547,9 +552,9 @@ No special permissions are needed.
 === Merging changes in common areas
 
 Common area process applies when there is no special ownership or process defined.
-Pull requests to common areas can be merged by any _Copy Editor_ once all of the following apply:
+PRs to common areas can be merged by any _Copy Editor_ once all of the following apply:
 
-* Conversations in the pull request are completed OR it is explicit that a reviewer does not block the change (often indicated by line comments attached to an approving PR review, or by using the term "nit", from "nit-picking")
+* Conversations in the PR are completed OR it is explicit that a reviewer does not block the change (often indicated by line comments attached to an approving PR review, or by using the term "nit", from "nit-picking")
 * There are enough approvals
 ** For trivial changes (typo fixes, minor improvements) - 1 approval from a _Copy Editor_
 ** For major changes - at least 2 approvals from reviewers.


### PR DESCRIPTION
This pull request is to add some image guidelines for contributing to Jenkins. These are some general ideas meant to help clarify how screenshots/images can be used and added to the documentation. It also provides guidelines on adding alt text, to improve the SEO score and provide further accessibility for users.

I have also updated a fair amount of the sentence/page formatting to use single sentence per line (in a lot of areas). I know this is not complete throughout the documentation, but plan on making further edits when adding additional guideline suggestions (documentation formatting and book submissions).