### PR TITLE
Remove "archive site" stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,14 +83,6 @@ node('docker&&linux') {
         }
     }
 
-    stage('Archive site') {
-        /* The `archive` task inside the Gradle build should be creating a zip file
-        * which we can use for the deployment of the site. This stage will archive
-        * that artifact so we can pick it up later
-        */
-        archiveArtifacts artifacts: 'build/**/*.zip', fingerprint: true
-    }
-
     /* The Jenkins which deploys doesn't use multibranch or GitHub Org Folders.
     */
     if (infra.isTrusted() && env.BRANCH_NAME == null) {


### PR DESCRIPTION
7 years ago this archive was used for the deployment via FTP. This isn't the case since a long time ago.

These archives currently occupy ~36GB on `ci.jenkins.io` for nothing as there are now PR previews on Netlify.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3492