### PR TITLE
Add instructions for Amazon Linux 2023

### DIFF
--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -268,11 +268,18 @@ To download and install Jenkins:
 [ec2-user ~]$ sudo yum upgrade
 ----
 
-. Install Java:
+. Install Java (Amazon Linux 2):
 +
 [source,bash]
 ----
 [ec2-user ~]$ sudo amazon-linux-extras install java-openjdk11 -y
+----
+
+. Install Java (Amazon Linux 2023):
++
+[source,bash]
+----
+[ec2-user ~]$ sudo yum install java-11-amazon-corretto-headless -y
 ----
 
 . Install Jenkins:

--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -279,7 +279,7 @@ To download and install Jenkins:
 +
 [source,bash]
 ----
-[ec2-user ~]$ sudo yum install java-11-amazon-corretto-headless -y
+[ec2-user ~]$ sudo dnf install java-11-amazon-corretto-headless -y
 ----
 
 . Install Jenkins:

--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -279,7 +279,7 @@ To download and install Jenkins:
 +
 [source,bash]
 ----
-[ec2-user ~]$ sudo dnf install java-11-amazon-corretto-headless -y
+[ec2-user ~]$ sudo dnf install java-11-amazon-corretto -y
 ----
 
 . Install Jenkins:


### PR DESCRIPTION
Amazon Linux 2023 no longer includes an OpenJDK 11 package, so recommend Corretto instead. Tested as part of https://github.com/jenkinsci/packaging/pull/388.