### PR TITLE
Add cdCon and Hacktoberfest events

### DIFF
--- a/content/_data/events/2023-05-08-cdcon.adoc
+++ b/content/_data/events/2023-05-08-cdcon.adoc
@@ -1,0 +1,12 @@
+---
+
+title: "cdCon"
+location: "Vancouver, BC, Canada"
+date: "2023-05-08T09:00:00-07:00"
+endDate: "2023-05-09T18:00:00-07:00"
+link: "https://events.linuxfoundation.org/cdcon-gitopscon/"
+
+---
+
+Jenkins will be represented at cdCon organized by the Continuous Delivery Foundation.
+There will be multiple talks related to Jenkins and a panel discussion of CDF member projects.

--- a/content/_data/events/2023-10-01-hacktoberfest.adoc
+++ b/content/_data/events/2023-10-01-hacktoberfest.adoc
@@ -1,0 +1,10 @@
+---
+title: "Hacktoberfest"
+location: "Virtual"
+date: "2023-10-01T00:00:00"
+endDate: "2023-10-31T00:00:00"
+link: "/events/hacktoberfest/"
+---
+
+Month-long worldwide event to support open source software.
+Jenkins participates in it!


### PR DESCRIPTION
## Add cdCon and Hacktoberfest events

cdCon includes link to the web site.

Hacktoberfest 2023 has not been announced yet, but DigitalOcean has been consistent for many years.
