### PR TITLE
Link from LTS changelog to LTS upgrade guide, not blog post

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -8930,7 +8930,7 @@
   date: 2023-04-05
   banner: >
     A <strong>new GPG signing key</strong> is used for the Jenkins long term support package repositories.
-    Follow the instructions in the <a href="/blog/2023/03/27/repository-signing-keys-changing/">Linux repository signing blog post</a> to install the new public key on your computer.
+    Follow the instructions in the <a href="/doc/upgrade-guide/2.387/#upgrading-to-jenkins-lts-2-387-2">upgrade guide</a> to install the new public key on your computer.
   changes:
   - type: major bug
     category: bug

--- a/content/_data/upgrades/2-387-2.adoc
+++ b/content/_data/upgrades/2-387-2.adoc
@@ -10,9 +10,9 @@ Update Debian compatible operating systems (Debian, Ubuntu, etc.) with the comma
 .Debian/Ubuntu
 [source,bash]
 ----
-curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
+$ curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+$ echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 ----

--- a/content/_data/upgrades/2-387-2.adoc
+++ b/content/_data/upgrades/2-387-2.adoc
@@ -10,9 +10,9 @@ Update Debian compatible operating systems (Debian, Ubuntu, etc.) with the comma
 .Debian/Ubuntu
 [source,bash]
 ----
-$ curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee \
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-$ echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 ----


### PR DESCRIPTION
The LTS upgrade guide is specific to the LTS release and reduces the risk of LTS users inadvertently choosing the wrong text to cut and paste.

Thanks to @cybersa for detecting the problem in the blog post and fixing it there with 
* https://github.com/jenkins-infra/jenkins.io/pull/6249
