### PR TITLE
Jenkins.io - adding compression guideline

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -250,7 +250,7 @@ The documentation pages can use the same metadata (`title`, `description`, `open
 
 When you add screenshots or images to documentation, there are methods to ensure that the images are focused, clear, and useful to the reader:
 
-* *Use consistent screen dimensions* - Screenshots captured within a specific range of dimensions provide consistency for both quality and the user experience.
+* *Use consistent screen dimensions:* Screenshots captured within a specific range of dimensions provide consistency for both quality and the user experience.
 Keep screenshots between 1024 x 768 - 1440 x 900 so that displays of any size render images properly. 
 +
 Several browsers offer a native way to adjust screen size and zoom percentage:
@@ -261,6 +261,9 @@ Several browsers offer a native way to adjust screen size and zoom percentage:
 
 * *Focus the screenshot's coverage:* Focusing the screenshot on the relevant content, and _necessary_ context, helps keep the screenshot relevant.
 If the image requires additional screen content to provide the proper context, be sure to include that information in the screenshot.
+
+* *Compress the image:* Before adding the image, you must compress the image using something like link:https://compressor.io/[compressor.io] or link:https://www.toptal.com/developers/pngcrush/[PNG Crush].
+Compressing the image is important, as this reduces the size of the image while retaining quality.
 
 * *Provide alt text for all images:* Alt text for images increases the accessibility of Jenkins documentation.
 link:https://docs.asciidoctor.org/asciidoc/latest/macros/images/[Asciidoc] can handle full sentence structure and formatting for alt text.


### PR DESCRIPTION
This is a pull request to add another guideline to the image section just implemented in the contributing guide.

Compression is integral to the image process, as this helps reduce the size/page load.