### PR TITLE
Reword image compression paragraph to fix page layout

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -262,7 +262,7 @@ Several browsers offer a native way to adjust screen size and zoom percentage:
 * *Focus the screenshot's coverage:* Focusing the screenshot on the relevant content, and _necessary_ context, helps keep the screenshot relevant.
 If the image requires additional screen content to provide the proper context, be sure to include that information in the screenshot.
 
-* *Compress the image:* Before adding the image, you must compress the image using something like link:https://compressor.io/[compressor.io] or link:https://www.toptal.com/developers/pngcrush/[PNG Crush].
+* *Compress all images:* Before adding the image, you must compress the image using something like link:https://compressor.io/[compressor.io] or link:https://www.toptal.com/developers/pngcrush/[PNG Crush].
 Compressing the image is important, as this reduces the size of the image while retaining quality.
 
 * *Provide alt text for all images:* Alt text for images increases the accessibility of Jenkins documentation.


### PR DESCRIPTION
Follow up to https://github.com/jenkins-infra/jenkins.io/pull/6253

`image:` is a keyword in asciidoc. The current usage breaks the entire page layout below the paragraph:
![Screenshot 2023-04-07 at 19 22 29](https://user-images.githubusercontent.com/13383509/230650758-6f9e4c79-e585-4a2f-933c-920180f9d565.png)

How does my proposal of words sound to you? Should warrant the context while restoring the layout.