### PR TITLE
Fix CODEOWNERS scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,3 @@ content/security/ @jenkins-infra/security
 # GSoC
 content/projects/gsoc/ @jenkins-infra/gsoc
 *gsoc* @jenkins-infra/gsoc
-
-# Hacktoberfest
-*hacktoberfest* @jenkins-infra/hacktoberfest


### PR DESCRIPTION
The CODEOWNERS file doesn't work for people or teams without write permissions. The `jenkins-infra/hacktoberfest` team has no individual write permissions on this repository. Hence, the file errors every time you open it.
I recommend dropping the clause, given it didn't work in the first place. The team members are still welcome to review PRs affecting their area <3

![Screenshot 2023-04-07 at 19 33 20](https://user-images.githubusercontent.com/13383509/230652121-c22a00ad-a1ce-4ad3-b2b8-7bae2d6bbcfc.png)