### PR TITLE
Add the option to list all tags on the Jenkins blog

### DIFF
--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -7,6 +7,20 @@ section: blog
 :ruby
   page_count = page.posts ? page.posts.pages.size : 0
 
+:ruby
+  tags = []
+  site.pages.reverse_each do |page|
+    # Some pages don't have tags
+    next if page.tags.nil?
+    next if page.layout != 'post'
+    page.tags.each do |tag|
+      # tag is an Awestruct::Extensions::Tagger::TagStat
+      next unless !tags.include?(tag.to_s)
+      tags << tag.to_s
+    end
+  end
+  tags = tags.sort_by {|obj| obj.to_s.downcase}
+
 %div.app-blog-page
   - if page.author
     = partial("author.html.haml", :author => page.author, :blogroll => true)
@@ -19,6 +33,26 @@ section: blog
         %h1
           The Jenkins Blog
       %div.app-app-bar__controls.app-mobile-hide
+        %div{:class => page.selected_tag ? "app-button app-tags-picker app-tags-picker--active" : "app-button app-tags-picker"}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M435.25 48h-122.9a14.46 14.46 0 00-10.2 4.2L56.45 297.9a28.85 28.85 0 000 40.7l117 117a28.85 28.85 0 0040.7 0L459.75 210a14.46 14.46 0 004.2-10.2v-123a28.66 28.66 0 00-28.7-28.8z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="40"/><path d="M384 160a32 32 0 1132-32 32 32 0 01-32 32z" fill="currentColor" /></svg>
+          = page.selected_tag
+          %select{:id => 'tag-switcher'}
+            %option{:value => 'all', :selected => page.selected_tag == null ? true : null}
+              All
+            %optgroup{:label => 'Tags'}
+              - tags.each do |tag|
+                %option{:value => tag, :selected => page.selected_tag == tag.to_s ? true : null}
+                  = tag.to_s
+
+          :javascript
+            $(document).ready(function() {
+              const tagSwitcher = document.querySelector("#tag-switcher");
+              tagSwitcher.addEventListener('change', () => {
+                const value = tagSwitcher.value;
+                window.location.href = value === 'all' ? `/node/` : `/node/tags/${tagSwitcher.value}/`;
+              })
+            });
+
         %a{:href => "https://feeds.feedburner.com/ContinuousBlog/", :class => "app-button"}
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="460px" height="460px" viewBox="0 0 460 460" version="1.1"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(56.440081, 56.222063)" stroke="currentColor"><path d="M51.8355914,263.237609 C60.9709503,263.260732 69.2414786,266.967806 75.2384778,272.952922 C81.2358437,278.938404 84.9594026,287.202208 85.0001926,296.338927 C84.9725106,305.421743 81.2764727,313.639618 75.3166433,319.590173 C69.3466112,325.550914 61.1050301,329.236566 52.0036901,329.237536 C42.9023476,329.238505 34.6599806,325.554606 28.6886687,319.595137 C22.7173419,313.635654 19.017079,305.400589 18.9999666,296.299365 C18.9829135,287.198016 22.6522367,278.949119 28.6011501,272.967262 C34.5402452,266.995277 42.7514145,263.282855 51.8355914,263.237609 Z" stroke-width="38" fill-rule="nonzero"/><path d="M15.5639188,0 C189.695661,18.9886079 327.916779,157.508264 346.44594,331.777403" stroke-width="40" stroke-linecap="round"/><path d="M16.5639188,121.777403 C126.781388,133.796328 214.269067,221.472967 225.997183,331.777403" stroke-width="40" stroke-linecap="round"/></g></g></svg>
         %a{:href => "https://twitter.com/jenkinsci", :class => "app-button"}

--- a/content/node/index.html.haml
+++ b/content/node/index.html.haml
@@ -31,7 +31,8 @@ section: blog
     %div.app-app-bar
       %div.app-app-bar__content
         %h1
-          The Jenkins Blog
+          %a{:href => '/node/', :tabindex => -1}
+            The Jenkins Blog
       %div.app-app-bar__controls.app-mobile-hide
         %div{:class => page.selected_tag ? "app-button app-tags-picker app-tags-picker--active" : "app-button app-tags-picker"}
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M435.25 48h-122.9a14.46 14.46 0 00-10.2 4.2L56.45 297.9a28.85 28.85 0 000 40.7l117 117a28.85 28.85 0 0040.7 0L459.75 210a14.46 14.46 0 004.2-10.2v-123a28.66 28.66 0 00-28.7-28.8z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="40"/><path d="M384 160a32 32 0 1132-32 32 32 0 01-32 32z" fill="currentColor" /></svg>

--- a/content/stylesheets/pages/_blog.scss
+++ b/content/stylesheets/pages/_blog.scss
@@ -123,3 +123,28 @@
     }
   }
 }
+
+.app-tags-picker {
+  position: relative;
+  font-size: 0.9rem;
+  color: var(--color);
+  font-weight: 500;
+
+  svg {
+    translate: 0 1px;
+  }
+
+  select {
+    appearance: none;
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  &--active {
+    &::before {
+      opacity: 0.05;
+    }
+  }
+}

--- a/content/stylesheets/pages/_blog.scss
+++ b/content/stylesheets/pages/_blog.scss
@@ -24,6 +24,15 @@
     color: var(--color);
     font-family: "Georgia", serif;
 
+    a {
+      color: var(--color);
+      text-decoration-skip: auto;
+
+      &:active {
+        opacity: 0.7;
+      }
+    }
+
     @media screen and (max-width: $app-mobile-breakpoint) {
       font-size: 1.6rem;
     }


### PR DESCRIPTION
Small follow up to #6229. This PR introduces a new button in the top right of the blog which allows users to see the complete list of tags available. They can then click one to see all posts with that tag.

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/43062514/230774821-7a3dd274-10d8-416b-9daf-5473808d1e36.png">

<img width="372" alt="image" src="https://user-images.githubusercontent.com/43062514/230774826-0c46d28b-ba8e-40dc-b447-97990cdefa36.png">

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/43062514/230774837-c1b506d9-6e3c-46d7-9105-1919bd40c9ca.png">

**Changes**
* Adds a button to list all tags 
* If a user clicks on a tag it'll now show in the top right of the page
* The Jenkins Blog heading is now clickable to return to the blog