### PR TITLE
Remove UX SIG mailing list entry from table to div page

### DIFF
--- a/content/doc/developer/blueocean-plugin-development/index.adoc
+++ b/content/doc/developer/blueocean-plugin-development/index.adoc
@@ -25,7 +25,6 @@ As Blue Ocean is still new, the extensibility aspects of JavaScript development 
 If you wish to make a plugin for blue ocean, some starting points: 
 
 * Introduce yourself to the https://app.gitter.im/#/room/#jenkinsci_blueocean-plugin:gitter.im[gitter chat room]. This is often the best place to start. There are many people there to help you get going.
-* Contact the https://groups.google.com/forum/#!forum/jenkinsci-ux[jenkins-ux mailing list] (things move fast, ask someone for help)
 * Read the https://github.com/jenkinsci/blueocean-plugin#building-plugins-for-blue-ocean[README] with pointers on plugin development
 * Get familiar with regular Jenkins plugin development (at least a very simple plugin)
 * Read up a little on https://facebook.github.io/react/tutorial/tutorial.html[ReactJS] (not necessary but doesn't hurt)

--- a/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
+++ b/content/doc/developer/views/icon-path-to-icon-class-migration.adoc
@@ -64,5 +64,5 @@ More information about Jelly tags provided by core to display icons can be found
 
 == I still need more help?
 
-Contact the link:/sigs/ux[UX sig] on link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[mailing list].
+Contact the link:/sigs/ux[UX sig] on link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter].
 

--- a/content/doc/developer/views/table-to-div-migration.adoc
+++ b/content/doc/developer/views/table-to-div-migration.adoc
@@ -134,4 +134,4 @@ def blockWrapper(Closure closure) {
 
 == I still need more help?
 
-Contact the link:/sigs/ux[UX sig] on link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter] or on the link:https://groups.google.com/forum/#!forum/jenkinsci-ux[mailing list].
+Contact the link:/sigs/ux[UX sig] on link:https://app.gitter.im/#/room/#jenkinsci/ux-sig:matrix.org[Gitter].


### PR DESCRIPTION
We don't use any mailing list. I removed it from the blue ocean page too, let's not guide people here.