### PR TITLE
Restore 'Modularise more classes + increase usage of CSS variables (#5415)'

### DIFF
--- a/content/_partials/projectcarousel.html.haml
+++ b/content/_partials/projectcarousel.html.haml
@@ -6,11 +6,11 @@
 
 :css
   .carousel_#{carousel_id} {
+    --color: white;
     background-size: cover !important;
   }
   .carousel_#{carousel_id} a {
-    font-size: 16px;
-    color: #fff;
+    color: var(--color);
     text-decoration: none !important;
   }
   .carousel_#{carousel_id} img {

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -559,7 +559,7 @@ body .ji-dated-list>.post {
   position:absolute;
   height:1.1rem;
   width:10%;
-  box-shadow:inset #fff -3rem 0 2rem -2rem;
+  box-shadow:inset var(--background) -3rem 0 2rem -2rem;
   bottom:0; right:0;
 }
 .events .ji-item-list>.event>a .teaser{
@@ -575,7 +575,7 @@ body .ji-dated-list>.post {
   position:absolute;
   height:1.1rem;
   width:25%;
-  box-shadow:inset #fff -6rem 0 3rem -3rem;
+  box-shadow:inset var(--background) -6rem 0 3rem -3rem;
   bottom:0; right:0;
 }
 
@@ -600,7 +600,7 @@ body .ji-dated-list>.post {
 }
 
 .ji-blog-list>.post>.body>.teaser, .ji-dated-list>.post>.body>.teaser {
-  max-height: 6rem;
+  max-height: 6.64rem; /* 4x line height */
   overflow: hidden;
   position: relative;
   margin: 0 0 .5rem;
@@ -621,18 +621,12 @@ body .ji-dated-list>.post {
   {
   display: block;
   content: '';
-  box-shadow: inset -25rem 0 15rem -15rem #fff;
+  box-shadow: inset -25rem 0 15rem -15rem var(--background);
   height: 1.5rem;
   bottom: 0;
   right: 0;
   width: 30rem;
   position: absolute
-}
-.f9f9f9.section{
-  background:#f9f9f9;
-}
-z.f9f9f9.section .ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.body>.teaser:after{
-  box-shadow: inset -25rem 0 15rem -15rem #f9f9f9;
 }
 .ji-blog-list>.post>.body:hover, .ji-dated-list>.post>.body:hover {
   text-decoration: none;
@@ -737,7 +731,6 @@ z.f9f9f9.section .ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.
 .blog-posts .ji-blog-list .post
 {
     margin: .5rem -1.5rem 1rem;
-    background: #fff;
     padding: 1.5rem;
 }
 
@@ -852,7 +845,7 @@ z.f9f9f9.section .ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.
 }
 
 .ji-dated-list>.post>.article>.url {
-  color: #999;
+  color: var(--color--secondary);
   font-size: 75%
 }
 
@@ -1051,15 +1044,6 @@ ion-icon {
 #ji-download .btn:hover{box-shadow:none;}
 
 /*----plugin site----*/
-body {
-  font-family: system-ui, "Segoe UI" , roboto , "Noto Sans" , oxygen , ubuntu , cantarell , "Fira Sans" , "Droid Sans" , "Helvetica Neue" , arial , sans-serif , "Apple Color Emoji" , "Segoe UI Emoji" , "Segoe UI Symbol";
-  font-size: 1rem;
-  color: #4a5568;
-  line-height: 1.5;
-  margin: 0;
-  background-color: var(--background);
-}
-
 .jumbotron.plugins {
 /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#81b0c4+0,335061+100 */
 background: #81b0c4; /* Old browsers */
@@ -1191,10 +1175,6 @@ text-align: left;
     padding: .25rem 0 .25rem 5.5rem;
     width: auto;
     margin: .25rem 1rem .25rem .25rem;
-    border: 1px solid #ccc;
-    border-radius: 3px;
-    background:#fff;
-    box-shadow:rgba(0,0,0,.15) 0 2px 2px;
 }
 
 
@@ -1211,7 +1191,7 @@ table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inh
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color: var(--color--secondary)}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
 span.icon>.fa{cursor:default}
 .admonitionblock td.icon [class^="fa icon-"],.admonitionblock ion-icon{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
@@ -1506,6 +1486,7 @@ table.syntax > tbody > tr > th {
 
 .navbar-collapse{
   text-align: center;
+  line-height: 1.5;
 }
 
 .nav-link.dropdown-toggle {
@@ -1535,7 +1516,8 @@ table.syntax > tbody > tr > th {
   overflow: visible;
   width: 100%;
   height: 600px;
-  background: #F8F9FB;
+  background: var(--color);
+  opacity: 0.025;
   z-index: -1;
   -webkit-transform: skewY(-14deg);
   -moz-transform: skewY(-14deg);
@@ -1553,9 +1535,18 @@ table.syntax > tbody > tr > th {
       top: -350px;
       height: 1020px; } }
 
-
 .jumbotron {
-    background-color: #F8F9FB;
+  position: relative;
+  background: transparent;
+}
+
+.jumbotron::before {
+  position: absolute;
+  content: "";
+  inset: 0;
+  background: currentColor;
+  opacity: 0.05;
+  pointer-events: none;
 }
 
 .author-list {

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -512,7 +512,6 @@ body .ji-dated-list>.post {
   margin-bottom: .5rem
 }
 
-.ji-blog-list,
 .ji-dated-list,
 .ji-item-list,
 .ji-item-list>post,
@@ -584,57 +583,11 @@ body .ji-dated-list>.post {
   padding: 1.25rem 1rem 1rem 5rem;
   text-decoration: none;
 }
-
-.ji-blog-list>.post>.more {
-  position: absolute;
-  right: 0;
-  color: #79B1BE
-}
-
-.ji-blog-list>.post>.more:before {
-  content: '+';
-  display: block;
-  float: right;
-  margin-left: .5rem;
-  border: 1px solid
-}
-
-.ji-blog-list>.post>.body>.teaser, .ji-dated-list>.post>.body>.teaser {
-  max-height: 6.64rem; /* 4x line height */
-  overflow: hidden;
-  position: relative;
-  margin: 0 0 .5rem;
-  text-decoration: none;
-  color: #555
-}
-
-.ji-blog-list>.event>.body>.teaser {
-  max-height: 3.3rem !important
-}
 .fff.section{
   background:#fff;
   box-shadow:0 2px 3px rgba(0,0,0,.15);
   position:relative;
   z-index:2
-}
-.ji-blog-list>.post>.body>.teaser:after, .ji-dated-list>.post>.body>.teaser:after
-  {
-  display: block;
-  content: '';
-  box-shadow: inset -25rem 0 15rem -15rem var(--background);
-  height: 1.5rem;
-  bottom: 0;
-  right: 0;
-  width: 30rem;
-  position: absolute
-}
-.ji-blog-list>.post>.body:hover, .ji-dated-list>.post>.body:hover {
-  text-decoration: none;
-}
-
-.ji-blog-list>.post>.body:hover>.header>.title, .ji-dated-list>.post>.body:hover>.title
-  {
-  text-decoration: underline
 }
 
 .ji-dated-list>.post>.body>.teaser {
@@ -657,21 +610,6 @@ body .ji-dated-list>.post {
   font-size: 125%;
   margin: 0 0 .25rem;
   display: inline-block
-}
-
-.ji-blog-list>.post>.attrs>.tags, .ji-dated-list>.post>.attrs>.tags {
-  font-size: 75%;
-  opacity: .75
-}
-
-.ji-blog-list>.post>.attrs>.tags>li, .ji-dated-list>.post>.attrs>.tags>li
-  {
-  padding: 0;
-  display: inline-block
-}
-
-.ji-blog-list>.post>.attrs>.tags>li>a {
-  padding-right: .25rem
 }
 
 .ji-dated-list>.post>.attrs>.tags>li>a {
@@ -697,61 +635,8 @@ body .ji-dated-list>.post {
   line-height: 3rem
 }
 
-.ji-blog-list .date {
-  display: inline-block;
-  font-size: .75rem;
-  text-align: center;
-  line-height: 1.2em;
-  border: 1px solid;
-  margin: -.25rem .25rem 0 -2.75rem;
-  vertical-align: middle;
-  position: relative;
-}
-
-.ji-blog-list .header {
-  padding-left: 2.75rem;
-}
-
-.ji-blog-list .title {
-  display: inline-block;
-  vertical-align: middle
-}
-
-.ji-blog-list .date>.month {
-  padding: 0 .2rem;
-  border-bottom: 1px solid;
-  background: #168bb9;
-  color: #fff
-}
-
-.ji-item-list .post,
-.ji-blog-list .post {
+.ji-item-list .post {
   margin: .5rem 0 1.5rem
-}
-.blog-posts .ji-blog-list .post
-{
-    margin: .5rem -1.5rem 1rem;
-    padding: 1.5rem;
-}
-
-.ji-blog-list .header.time {
-  padding: 0 0 .33rem 2.15rem;
-  position: relative
-}
-
-.ji-blog-list .header.time .date {
-  left: 0;
-  top: 0;
-  margin: 0;
-  position: absolute;
-}
-
-.ji-blog-list .date-time .time {
-  font-size: .85rem;
-  color: #d53730;
-  position: relative;
-  margin-bottom: -.5rem;
-  top: -.33rem
 }
 
 .events>h5, .blog-posts>h4 {
@@ -794,10 +679,6 @@ body .ji-dated-list>.post {
   padding: 3em 0;
 
   background-image: linear-gradient(to bottom, transparent, white);
-}
-
-.events .ji-blog-list>.event>.body>.teaser:after {
-  height: 1.1rem
 }
 
 .docker-plugins-list {

--- a/content/solutions/index.html.haml
+++ b/content/solutions/index.html.haml
@@ -4,35 +4,11 @@ title: "Jenkins Use-cases"
 noanchors: true
 ---
 
-:css
-  .card h3 {
-    font-size: 1.3rem;
-    min-height: 3rem;
-  }
-  .card img {
-    height: 96px;
-    opacity: .54;
-    margin: auto;
-  }
-  a.card {
-    color: rgba(0, 0, 0, .9);
-  }
-  a.card.dark {
-    color: rgba(255, 255, 255, .9);
-  }
-  a.card.dark img {
-    filter: invert(1);
-  }
-  .grid-container.small {
-    grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
-  }
-
-.grid-container.small
+.app-use-cases
   - site.solutions.sort.each do |key, solution|
   - link = expand_link("solutions/#{key}")
   - cssClass = solution["dark"] ? "dark" : "light"
-    %a.card{:style => "background-color:#{solution["color"]}", :href => link, :class => cssClass}
-      .content.text-center
-        %h3
-          = solution["usecase"]
-        %img{:src => "/images/solution-images/#{key}.svg"}
+    %a.app-use-cases__card{:style => "background-color:#{solution["color"]}", :href => link, :class => cssClass}
+      %h3
+        = solution["usecase"]
+      %img{:src => "/images/solution-images/#{key}.svg"}

--- a/content/stylesheets/core/_all.scss
+++ b/content/stylesheets/core/_all.scss
@@ -1,1 +1,4 @@
+@import "base";
+@import "link";
+@import "headings";
 @import "link";

--- a/content/stylesheets/core/_base.scss
+++ b/content/stylesheets/core/_base.scss
@@ -1,0 +1,8 @@
+body {
+  font-family: system-ui, "Segoe UI", roboto, "Noto Sans", oxygen, ubuntu, cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 1rem;
+  color: var(--color);
+  line-height: 1.66;
+  margin: 0;
+  background-color: var(--background);
+}

--- a/content/stylesheets/core/_headings.scss
+++ b/content/stylesheets/core/_headings.scss
@@ -1,0 +1,19 @@
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+h3 {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+h4 {
+  font-size: 1.4rem;
+  font-weight: 700;
+}

--- a/content/stylesheets/pages/_all.scss
+++ b/content/stylesheets/pages/_all.scss
@@ -1,2 +1,3 @@
 @import "blog";
 @import "post";
+@import "use-cases";

--- a/content/stylesheets/pages/_use-cases.scss
+++ b/content/stylesheets/pages/_use-cases.scss
@@ -1,0 +1,36 @@
+.app-use-cases {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  &__card {
+    display: inline-flex;
+    align-items: center;
+    justify-items: center;
+    flex-direction: column;
+    border-radius: 0.66rem;
+    padding: 1rem;
+    color: rgba(0, 0, 0, .9) !important;
+
+    h3 {
+      font-size: 1.3rem;
+      min-height: 3rem;
+      text-align: center;
+    }
+
+    img {
+      height: 96px;
+      opacity: .55;
+      margin: auto;
+    }
+
+    &.dark {
+      color: rgba(255, 255, 255, .9) !important;
+
+      img {
+        filter: invert(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR restores the changes made in #5415 which intended to modularise the CSS classes and increase the usage of CSS variables in the codebase. 

See https://github.com/jenkins-infra/jenkins.io/pull/5415

---

The initial PR was rightfully reverted as it tweaked the heading sizes in a way which could confuse the hierarchy of the page. This PR fixes that regression by tweaking the sizings of the headings so that they're inline with the current jenkins.io design. The only changes you should see are mild colour tweaks and weight changes.

e.g.

Before
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/43062514/230929506-7540f97c-0247-4243-9637-5e6f81f53d01.png">

After
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/43062514/230929452-b10d5946-9195-4592-861c-4635ff1ea6d0.png">

Thanks

