### PR TITLE
Add gitpod badge to PRs and install AsciiDoc plugin for IJ

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,19 @@ ports:
   - port: 4242
     onOpen: open-preview
 
+github:
+  prebuilds:
+    pullRequestsFromForks: true
+    addBadge: true
+
 vscode:
   extensions:
     - asciidoctor.asciidoctor-vscode
     - streetsidesoftware.code-spell-checker
+
+jetbrains:
+  intellij:
+    plugins:
+      - org.asciidoctor.intellij.asciidoc
+    prebuilds:
+      version: stable


### PR DESCRIPTION
Install the AsciiDoc plugin if you open the repository through GitPod in IJ and adds a badge to PRs, similar to core, to allow checking out PRs.