### PR TITLE
Use latest bom-2.375.x in examples

### DIFF
--- a/content/doc/developer/plugin-development/dependency-management.adoc
+++ b/content/doc/developer/plugin-development/dependency-management.adoc
@@ -90,9 +90,9 @@ To use the Jenkins plugin BOM in your plugin:
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.303.x</artifactId>
+            <artifactId>bom-2.375.x</artifactId>
             <!-- Latest version goes here -->
-            <version>1117.v62a_f6a_01de98</version>
+            <version>1981.v17df70e84a_a_1</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
+++ b/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
@@ -42,9 +42,9 @@ The `git diff` might look like this:
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
 -        <artifactId>bom-2.319.x</artifactId>
-+        <artifactId>bom-2.361.x</artifactId>
++        <artifactId>bom-2.375.x</artifactId>
 -        <version>1466.v85a_616ea_b_87c</version>
-+        <version>1723.vcb_9fee52c9fc</version>
++        <version>1981.v17df70e84a_a_1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/content/doc/developer/tutorial-improve/use-plugin-bill-of-materials.adoc
+++ b/content/doc/developer/tutorial-improve/use-plugin-bill-of-materials.adoc
@@ -30,8 +30,8 @@ For example, the addition might look like:
   <dependencies>
     <dependency>
       <groupId>io.jenkins.tools.bom</groupId>
-      <artifactId>bom-2.361.x</artifactId>
-      <version>1723.vcb_9fee52c9fc</version>
+      <artifactId>bom-2.375.x</artifactId>
+      <version>1981.v17df70e84a_a_1</version>
       <scope>import</scope>
       <type>pom</type>
     </dependency>


### PR DESCRIPTION
## Use latest bom-2.375.x in examples

No reason to include outdated version numbers in the examples.  Eventually it would be nice to generate those version numbers and include the version number of the most recent release in the documentation set.
