### PR TITLE
Remove more references to inactive SIGs

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -63,7 +63,7 @@ labels:
 categories:
   - name: Pipeline authoring and development tools
     description: Initiatives focused on improving Jenkins Pipeline and experience of Pipeline developers
-    link: /sigs/pipeline-authoring
+    link: /doc/developer/tutorial-improve/improve-pipeline-documentation/
     initiatives:
     - name: Jenkins Templating Engine 2.0 
       description: "JTE enables the creation of tool-agnostic pipeline templates that can be shared across teams. Version 2.0 will have improved integration with the underlying pipeline engine and incorporate many of the community's top feature requests." 
@@ -339,7 +339,7 @@ categories:
       Initiatives focused on making Jenkins easy to deploy and run in cloud environments,
       including Kubernetes and various cloud providers.
       It also includes integrations with cloud storage providers.
-    link: /sigs/cloud-native
+    link: /sigs/cloud-native/pluggable-storage/
     initiatives:
     - name: CloudEvents support
       status: current

--- a/content/blog/2018/07/2018-07-25-contributor-summit.adoc
+++ b/content/blog/2018/07/2018-07-25-contributor-summit.adoc
@@ -25,7 +25,6 @@ We will also have updates on the 'Big 5' projects in active development:
 * link:https://jenkins-x.io[Jenkins X]
 * link:https://www.praqma.com/stories/jenkins-configuration-as-code[Configuration as Code]
 * link:/doc/book/pipeline[Jenkins Pipeline]
-* link:/sigs/cloud-native[Cloud Native Jenkins Architecture]
 
 Plus we will feature a link:/projects/gsoc[Google Summer of Code] update, and more!
 

--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -310,17 +310,5 @@ See link:/events/hacktoberfest/faq[Hacktoberfest in Jenkins FAQ].
   link:https://issues.jenkins.io/issues/?jql=labels%20%3D%20newbie-friendly%20and%20component%20in%20(gitlab-plugin%2C%20gitlab-api-plugin%2C%20gitlab-branch-source-plugin)%20and%20status%20in%20(Open%2C%20Reopened%2C%20%22To%20Do%22)[Newbie-friendly issues in Jira],
   link:https://github.com/jenkinsci/gitlab-plugin/issues?q=is%3Aissue+is%3Aopen+label%3Anewbie-friendly[GitHub issues for the Gitlab plugin]
 
-| link:/sigs/chinese-localization/[Chinese Localization SIG]
-| Documentation, +
-  Asciidoc, +
-  Java
-| Contribute to the new link:https://github.com/jenkins-infra/cn.jenkins.io[Website] and
-  the link:https://github.com/jenkinsci/localization-zh-cn-plugin[Simplified Chinese Localization plugin].
-
-| link:https://github.com/jenkins-zh/jenkins-cli/[Jenkins CLI written in Go]
-| Go, +
-  REST API
-| Try to supplement the documents or start from the link:https://github.com/jenkins-zh/jenkins-cli/issues?q=is%3Aissue+is%3Aopen+label%3Anewbie[newbie-friendly issues].
-
 // End of need confirmation from maintainers before we add them to featured projects
 ////

--- a/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
+++ b/content/projects/gsoc/2020/project-ideas/jenkins-distribution-customize-service.adoc
@@ -62,4 +62,3 @@ Below you can find a list of existing plugins and libraries which can be used fo
 
 * link:https://github.com/jenkinsci/custom-war-packager[Custom WAR Packager for Jenkins]
 * link:https://github.com/jenkinsci/configuration-as-code-plugin[Jenkins Configuration as Code Plugin]
-* link:/sigs/cloud-native/pluggable-storage/[Pluggable Storage]

--- a/content/projects/infrastructure/index.adoc
+++ b/content/projects/infrastructure/index.adoc
@@ -138,7 +138,6 @@ Jenkins infrastructure also hosts some services for sub-projects and special int
 [%header]
 |===
 | Service | Owner Sub-project/SIG | Issue tracker component(s) | Repository
-| link:/zh/[Website in Chinese] | link:/sigs/chinese-localization/[Chinese Localization] | https://github.com/jenkins-infra/helpdesk/labels/cn.jenkins.io[cn.jenkins.io]    | https://github.com/jenkins-infra/cn.jenkins.io[Code]
 | link:/download/verify/[Code and Repository Signing] | link:/project/team-leads/#release[Release Team] | https://github.com/jenkins-infra/helpdesk/labels/release[release] | https://www.digicert.com/[DigiCert]
 |===
 

--- a/content/sigs/cloud-native/pluggable-storage.adoc
+++ b/content/sigs/cloud-native/pluggable-storage.adoc
@@ -22,8 +22,6 @@ We believe that by using cloud provided services the overall usability, performa
 
 You can find more information about Pluggable Storage and priorities
 in link:/blog/2018/07/30/introducing-cloud-native-sig/[this blogpost].
-Full list of Jenkins Enhancement Proposals is provided on the
-link:/sigs/cloud-native[Cloud Native SIG Page].
 
 === Status summary
 
@@ -91,7 +89,7 @@ Jenkins core:
   Related JEPs: jep:213[]
 | N/A
 
-| **Test Results** + 
+| **Test Results** +
   **(Available)**
 | API is available in plugin:junit[JUnit Plugin].
 | plugin:junit-sql-storage[Junit SQL Storage]
@@ -240,9 +238,3 @@ Status:
 * Related JEP: jep:226[External Fingerprint Storage]
 * link:https://github.com/jenkinsci/jenkins/pull/4731[Prototype API]
 * Reference Implementation: link:https://github.com/jenkinsci/redis-fingerprint-storage-plugin[Redis Fingerprint Storage Plugin]
-
-=== Other Pluggable storage stories
-
-This page summarizes statuses of the ongoing work only.
-There are other Pluggable Storage stories we consider in the Cloud Native SIG.
-See the link:/sigs/cloud-native[SIG's page] for more details and links.

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -71,10 +71,7 @@ The group focuses on documentation for Jenkins, including:
   Also, implementation solutions like link:/solutions/pipeline[Pipeline]
 
 Documentation SIG may cooperate with other groups.
-For example, we will be cooperating with the link:/sigs/cloud-native[Cloud-Native Jenkins SIG]
-on topics related to Cloud-Native documentation efforts and
-with the link:/sigs/platform[Platform SIG].
-on platform topics.
+For example, we cooperate with the link:/sigs/platform[Platform SIG] on platform topics.
 
 == Topics
 


### PR DESCRIPTION
Inactive SIG links will redirect to the SIG parent page.  That won't help users that click a link to reach a page specific to a SIG.  Remove or replace links so that they lead to reasonable locations