### PR TITLE
Turn down renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:base",
     ":semanticCommitsDisabled",
-    "schedule:earlyMondays"
+    "schedule:monthly"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
We don't need to run renovate that frequently, monthly is totally fine for our dependencies.