### PR TITLE
Updated jenkinsfile.adoc, incorrect referral fixed

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -1294,7 +1294,7 @@ cleaner parallel syntax is supported for Declarative Pipeline. Right now
 stuff.
 ////
 
-The example in the <<using-multiple-nodes,section above>> runs tests across two
+The example in the <<using-multiple-agents,section above>> runs tests across two
 different platforms in a linear series. In practice, if the `make check`
 execution takes 30 minutes to complete, the "Test" stage would now take 60
 minutes to complete!


### PR DESCRIPTION
Hi!

The existing wiki page uses a non-existent reference in the "Parallel Execution" section, which refers to a "node" instead of an "agent" when describing the usage of multiple agents in one pipeline. I'm guessing some changes were made to this document, and the wording was changed from node to an agent which is why this reference is not working at the moment.