### PR TITLE
Remove link to Google cloud build tutorial

### DIFF
--- a/content/doc/tutorials/tutorials-for-installing-jenkins-on-Google-Cloud.adoc
+++ b/content/doc/tutorials/tutorials-for-installing-jenkins-on-Google-Cloud.adoc
@@ -4,23 +4,12 @@ title: Jenkins on Google Cloud
 section: doc
 ---
 
-:toc:
-:toclevels: 3
 :imagesdir: ../../book/resources/
 
 You should have a Google Cloud account, otherwise you can https://cloud.google.com/gcp/getting-started[start here].
-At the end of every tutorial you will have a Jenkins up and running on the Google Cloud.
+At the end of the tutorial you will have a Jenkins up and running on the Google Cloud.
 
-## Tutorial 1 - Jenkins and GitOps approach
-
-This tutorial assumes you are familiar with the following software:
-
-* **Terraform** for managing infrastructure-as-code.
-* **Github** repository and associated tools for version-control management.
-
-Dive into https://cloud.google.com/solutions/managing-infrastructure-as-code-with-terraform-jenkins-and-gitops[this tutorial] for more detailed How-To explanation.
-
-## Tutorial 2 - Jenkins on Google Compute Engine
+## Jenkins on Google Compute Engine
 
 This tutorial assumes you are familiar with the following software:
 


### PR DESCRIPTION
https://cloud.google.com/solutions/managing-infrastructure-as-code-with-terraform-jenkins-and-gitops redirects to https://cloud.google.com/docs/terraform/resource-management/managing-infrastructure-as-code

We don't need to link to a Cloud Build tutorial.
