### PR TITLE
:wrench: Fix avatar aspect ratio in mobile

### DIFF
--- a/content/_partials/avatar.html.haml
+++ b/content/_partials/avatar.html.haml
@@ -2,7 +2,7 @@
 - author.avatar = Dir.glob("content/images/avatars/#{page.authorId}.{bmp,gif,ico,jpg,jpeg,png,svg}").first
 - if author.avatar
   - author.avatar.sub!('content','')
-  %div.app-avatar{:style => "min-width: 64px; width: 25vw; max-width: 128px"}
+  %div.app-avatar{:style => "min-width: 64px; width: 25vw; max-width: 128px; min-height: 64px; max-height:128px"}
     %img.app-avatar__image{:src => expand_link(author.avatar), :alt => author.name, :loading => 'lazy', :onload => 'this.style.opacity = 1'}
 - else
   %div.app-avatar{:style => "min-width: 64px; width: 25vw; max-width: 128px"}

--- a/content/_partials/avatar.html.haml
+++ b/content/_partials/avatar.html.haml
@@ -2,7 +2,7 @@
 - author.avatar = Dir.glob("content/images/avatars/#{page.authorId}.{bmp,gif,ico,jpg,jpeg,png,svg}").first
 - if author.avatar
   - author.avatar.sub!('content','')
-  %div.app-avatar{:style => "min-width: 64px; width: 25vw; max-width: 128px; min-height: 64px; max-height:128px"}
+  %div.app-avatar{:class => "app-avatar-image"}
     %img.app-avatar__image{:src => expand_link(author.avatar), :alt => author.name, :loading => 'lazy', :onload => 'this.style.opacity = 1'}
 - else
   %div.app-avatar{:style => "min-width: 64px; width: 25vw; max-width: 128px"}

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1579,3 +1579,11 @@ ion-icon.report {
 .vendors{
   padding: 10px;
 }
+
+.app-avatar-image{
+  min-width: 64px;
+  width: 25vw; 
+  max-width: 128px; 
+  min-height: 64px; 
+  max-height:128px
+}


### PR DESCRIPTION
Fixing the avatar aspect ratio in mobile, just added a fixed height for min and max to make sure that images have a constant size all over the avatars. 

Closes #6316, closes #6317. 