### PR TITLE
Provide OS end of life redirect

### DIFF
--- a/content/redirect/operating-system-end-of-life.adoc
+++ b/content/redirect/operating-system-end-of-life.adoc
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_url: /doc/administration/requirements/linux/
+# https://github.com/jenkinsci/jenkins/pull/7913
+---


### PR DESCRIPTION
## Add operating system end of life redirect

https://github.com/jenkinsci/jenkins/pull/7913 proposes operating system end of life administrative monitors and proposes an early end of life for RHEL 7, CentOS 7, Scientific Linux 7, and Oracle Linux 7.

This redirect is used in that code to provide administrators with more details about the Linux support policy of the Jenkins project/files.
