### PR TITLE
Inline text in darkmode logo to support several styles

### DIFF
--- a/content/images/jenkins-logo-title-dark.svg
+++ b/content/images/jenkins-logo-title-dark.svg
@@ -77,8 +77,30 @@
                 <path d="m 119.717,99.934 c 0,-1.0121 -0.821,-1.8328 -1.834,-1.8328 -1.012,0 -1.833,0.8207 -1.833,1.8328 0,1.012 0.821,1.834 1.833,1.834 1.013,0 1.834,-0.822 1.834,-1.834" style="fill:#1d1919;fill-opacity:1;fill-rule:evenodd;stroke:none" id="path134" inkscape:connector-curvature="0" />
                 <path d="m 121.55,91.434 c 0,-1.0121 -0.821,-1.8328 -1.834,-1.8328 -1.012,0 -1.833,0.8207 -1.833,1.8328 0,1.0121 0.821,1.834 1.833,1.834 1.013,0 1.834,-0.8219 1.834,-1.834" style="fill:#1d1919;fill-opacity:1;fill-rule:evenodd;stroke:none" id="path136" inkscape:connector-curvature="0" />
 			</g>
-        <text xml:space="preserve" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Georgia" x="231.70523" y="-71.714066" id="text5675" sodipodi:linespacing="100%" transform="scale(1,-1)">
-				<tspan sodipodi:role="line" fill="#c9d1d9" id="tspan5677" x="231.70523" y="-71.714066" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Georgia">Jenkins</tspan>
+        <style>
+            .text {
+            fill: #ffffff;
+            font-size: 144px;
+            font-family: Georgia-Bold, Georgia;
+            font-weight: 700;
+            font-style: normal;
+            font-variant: normal;
+            font-weight: bold;
+            font-stretch: normal;
+            text-align: start;
+            line-height: 100%;
+            writing-mode: lr-tb;
+            text-anchor: start;
+            }
+        }
+        @media (prefers-color-scheme: dark) {
+            .text {
+            fill: #c9d1d9;
+            }
+        }
+        </style>
+        <text class="text" xml:space="preserve" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Georgia" x="231.70523" y="-71.714066" id="text5675" sodipodi:linespacing="100%" transform="scale(1,-1)">
+				<tspan sodipodi:role="line" fill="#c9d1d9" id="tspan5677" x="231.70523" y="-71.714066" class="text">Jenkins</tspan>
 			</text>
 		</g>
 </svg>

--- a/content/images/jenkins-logo-title-dark.svg
+++ b/content/images/jenkins-logo-title-dark.svg
@@ -79,7 +79,7 @@
 			</g>
         <style>
             .text {
-            fill: #ffffff;
+            fill: #000000;
             font-size: 144px;
             font-family: Georgia-Bold, Georgia;
             font-weight: 700;
@@ -92,14 +92,13 @@
             writing-mode: lr-tb;
             text-anchor: start;
             }
-        }
         @media (prefers-color-scheme: dark) {
             .text {
             fill: #c9d1d9;
             }
         }
         </style>
-        <text class="text" xml:space="preserve" style="font-size:144px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Georgia" x="231.70523" y="-71.714066" id="text5675" sodipodi:linespacing="100%" transform="scale(1,-1)">
+        <text class="text" xml:space="preserve" x="231.70523" y="-71.714066" id="text5675" sodipodi:linespacing="100%" transform="scale(1,-1)">
 				<tspan sodipodi:role="line" fill="#c9d1d9" id="tspan5677" x="231.70523" y="-71.714066" class="text">Jenkins</tspan>
 			</text>
 		</g>


### PR DESCRIPTION
When I added this logo some time ago, I made it "darkmode only". The change proposed alters the logic to a theme-agnostic version allowing me to use it on more occasions without handling darkmode logic, given this logic is now handled right inside the SVG via `prefers-color-scheme`.