### PR TITLE
Revert "Fix aspect ratio of images"

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -16,8 +16,6 @@ html {
 
 img {
   max-width: 100%;
-  object-fit: contain;
-  height: auto;
 }
 
 a {


### PR DESCRIPTION
Reverts jenkins-infra/jenkins.io#6329 so that the changelog page returns to looking like this:

## Before the aspect ratio change

![before](https://user-images.githubusercontent.com/156685/235715874-1332d867-187a-4c0d-86ca-5ce7cc69be3b.png)

## After the aspect ratio change

![after](https://user-images.githubusercontent.com/156685/235715935-87274846-bc2c-43e2-981a-0858f1c7722b.png)
