### PR TITLE
List members of the hosting team

### DIFF
--- a/content/project/teams/hosting.adoc
+++ b/content/project/teams/hosting.adoc
@@ -49,6 +49,14 @@ How to start contributing?
 
 === Joining the main hosting team
 
+==== Members of the hosting team:
+* Adrien Lecharpentier (link:https://github.com/alecharp[@alecharp])
+* Alex Earl (link:https://github.com/slide[@slide])
+* Alexander Brandes (link:https://github.com/NotMyFault[@NotMyFault])
+* Baptiste Mathus (link:https://github.com/batmat[@batmat])
+* Oleg Nenashev (link:https://github.com/oleg-nenashev[@oleg-nenashev])
+* Tim Jacomb (link:https://github.com/timja[@timja])
+
 ==== Requesting membership
 
 If you are interested in joining the team, 


### PR DESCRIPTION
Given, teams are accessible to organization members only, this PR improves on that topic, by shining more transparency on the individuals involved in the hosting process, for non-organization members and everyone interested.