### PR TITLE
Reword backporting eligibility

### DIFF
--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -94,7 +94,7 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 
 Any user can propose that an issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
 For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface. +
-Backporting candidates have to be delivered in a weekly release to be tested by the community before shipping in LTS lines.
+Backporting candidates should be delivered in a weekly release before shipping in an LTS release.
 Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 

--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -92,8 +92,9 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 
 ## Backporting Process
 
-Any user can propose that a issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
-For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface.
+Any user can propose that an issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
+For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface. +
+Backporting candidates have to be delivered in a weekly release to be tested by the community before shipping in LTS lines.
 Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.
 

--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -93,7 +93,7 @@ See the link:/content/event-calendar[event calendar] for the specific LTS RC/rel
 ## Backporting Process
 
 Any user can propose that an issue is backported to LTS by labeling with link:https://issues.jenkins.io/secure/IssueNavigator.jspa?reset=true&jqlQuery=labels+%3D+lts-candidate[lts-candidate].
-For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface. +
+For an issue to be eligible for backporting it should be a small, safe-looking, uncontroversial fix for an important bug with no change to API surface.
 Backporting candidates should be delivered in a weekly release before shipping in an LTS release.
 Additionally library updates can also be considered if the library contains a public CVE that does not affect Jenkins (if Jenkins is vulnerable via a library then the link:/security[security] process applies).
 Backporters use link:https://issues.jenkins.io/issues/?filter=12146[this query] to list up issues that need to be attended once resolved.


### PR DESCRIPTION
A small wording change to note that backporting candidates should be tested on weeklys before landing in LTS lines.
This principle isn't new and already complied by in recent LTS lines, this PR just documents it.