### PR TITLE
Fix broken URLs on GSoC blog post

### DIFF
--- a/content/blog/2023/05/04/2023-05-04-gsoc2023-projects-announcement.adoc
+++ b/content/blog/2023/05/04/2023-05-04-gsoc2023-projects-announcement.adoc
@@ -21,7 +21,7 @@ image:/images/gsoc/gsoc_projects_contributors_selected.png[Jenkins GSoC, role=ce
 
 
 On behalf of the Jenkins GSoC org admin team and mentors,
-We would like to welcome
+we would like to welcome
 link:https://github.com/harsh-ps-2003[Harsh Pratap Singh],
 link:https://github.com/Jagrutiti[Jagruti Tiwari],
 link:https://github.com/Vandit1604[Vandit Singh], and
@@ -54,7 +54,7 @@ _Mentors_: link:/blog/authors/gounthar[Bruno Verachten], link:/blog/authors/berv
 
 As part of the "GSoC Community Bonding Period" over the next few weeks, project teams will be reaching out to potential stakeholders.
 The purpose is to establish connections with the community to get comments regarding their project designs.
-If you are interested in the projects, please join discussions in the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG] and link:https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im[project] Gitter channels, the link:https://groups.google.com/forum/#!forum/jenkinsci-dev[Developer mailing lists], and project meetings once they get scheduled.
+If you are interested in the projects, please join discussions in the link:https://app.gitter.im/\#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC SIG] and link:https://app.gitter.im/\#/room/#jenkinsci_jenkins:gitter.im[project] Gitter channels, the link:https://groups.google.com/g/jenkinsci-dev[Developer mailing lists], and project meetings once they get scheduled.
 Also, expect more detailed blogposts about the projects soon.
 
 If you are interested to know more about GSoC in Jenkins, you can find information, timelines, and communication channels link:/projects/gsoc/[here].


### PR DESCRIPTION
The change proposed escapes the hashtags in the URLs to make the URLs valid.

![Screenshot 2023-05-04 at 21 56 12](https://user-images.githubusercontent.com/13383509/236315452-c6df9bd9-b550-4672-82cb-e112a0813eca.png)

It is unclear to me why they are broken on this page, given they work on other pages.
But for now, let's fix them.