### PR TITLE
Correct spotless issue during release

### DIFF
--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -264,7 +264,7 @@ It's a good practice to run `mvn clean verify` now, even when there are no merge
 For Maven-based plugins that are usually released manually using `mvn release:prepare release:perform`, use the following command to stage the plugin release.
 `REPONAME` is a placeholder for the name of the Maven staging repository that is provided by the Jenkins security team.
 
-`mvn -DstagingRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/REPONAME -DpushChanges=false -DlocalCheckout=true org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare org.apache.maven.plugins:maven-release-plugin:2.5.3:stage`
+`mvn -DstagingRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/REPONAME -DpushChanges=false -DlocalCheckout=true org.apache.maven.plugins:maven-release-plugin:3.0.0:prepare org.apache.maven.plugins:maven-release-plugin:3.0.0:stage`
 
 WARNING: The staging repository name (`REPONAME`) is _never_ a GitHub URL or GitHub repository name.
 


### PR DESCRIPTION
By using 3.0.0, we include https://github.com/apache/maven-release/pull/62 which improve the end of line support for the pom.xml.

This could be necessary for (at least) Windows developpers when their plugin has configured spotless (perhaps also depending on their git checkout setup). In my case the pom.xml got its end of line rewritten as /r/n while I had /n due to core.autocrlf=input. As the default is "source", it should work for everyone without any changes.

<details><summary>Example of stacktrace related to this problem</summary>

```
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  7.315 s
[INFO] [INFO] Finished at: 2023-05-06T16:46:28+02:00
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.36.0:check (default) on project
 strict-crumb-issuer: The following files had format violations:
[INFO] [ERROR]     pom.xml
[INFO] [ERROR]         @@ -1,76 +1,76 @@
[INFO] [ERROR]         -<?xml version="1.0" encoding="UTF-8"?>\r\n
[INFO] [ERROR]         -<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSch
ema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">\r\n 
[INFO] [ERROR]         -  <modelVersion>4.0.0</modelVersion>\r\n
[INFO] [ERROR]         -\r\n
[INFO] [ERROR]         -  <parent>\r\n
[INFO] [ERROR]         -    <groupId>org.jenkins-ci.plugins</groupId>\r\n
[INFO] [ERROR]         -    <artifactId>plugin</artifactId>\r\n
[INFO] [ERROR]         -    <version>4.62</version>\r\n
[INFO] [ERROR]         -    <relativePath />\r\n
[INFO] [ERROR]         -  </parent>\r\n
[INFO] [ERROR]         -  <artifactId>strict-crumb-issuer</artifactId>\r\n
[INFO] [ERROR]         -  <version>2.1.2_jca_test1</version>\r\n
[INFO] [ERROR]         -  <packaging>hpi</packaging>\r\n
[...]
```

</details>