### PR TITLE
Format Jenkins core entries consistent with others

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -134,11 +134,15 @@ notitle: true
 %ul
   - if page.core&.weekly&.previous
     %li
-      Jenkins weekly up to and including
+      %strong
+        Jenkins weekly
+      up to and including
       = page.core.weekly&.previous
   - if page.core&.lts&.previous
     %li
-      Jenkins LTS up to and including
+      %strong
+        Jenkins LTS
+      up to and including
       = page.core.lts&.previous
   - plugins.each do | plugin |
     %li
@@ -166,11 +170,15 @@ notitle: true
   %ul
     - if page.core&.weekly&.fixed
       %li
-        Jenkins weekly should be updated to version
+        %strong
+          Jenkins weekly
+        should be updated to version
         = page.core.weekly&.fixed
     - if page.core&.lts&.fixed
       %li
-        Jenkins LTS should be updated to version
+        %strong
+          Jenkins LTS
+        should be updated to version
         = page.core.lts&.fixed
     - fixed_plugins.each do | plugin |
       %li


### PR DESCRIPTION
Fixes this inconsistency in formatting:

> <img width="796" alt="Screenshot 2023-05-11 at 11 06 20" src="https://github.com/jenkins-infra/jenkins.io/assets/1831569/523781da-9e84-4ba7-a183-5258951156e2">

Untested.