### PR TITLE
Add new layout for GSoC projects

### DIFF
--- a/content/_layouts/gsocproject3.html.haml
+++ b/content/_layouts/gsocproject3.html.haml
@@ -1,0 +1,53 @@
+---
+layout: project
+project: gsoc
+---
+
+%p
+  %b
+    Goal:
+  = page.goal
+%p
+  %b
+    Status:
+  = page.status
+      
+    
+
+%h3.title
+  Team
+%ul
+  %li
+    Contributor:
+    = display_user(page.student)
+  %li
+    Mentor(s):
+    - i = 0
+    - page.mentors.each do |mentor|
+      = display_user_optional(mentor)
+      - i = i+1
+      -if i != page.mentors.length
+        = ", "
+  -if page.advisors
+    %li
+      Advisor(s):
+      - i = 0
+      - page.advisors.each do |mentor|
+        = display_user_optional(mentor)
+        - i = i+1
+        -if i != page.advisors.length
+          = ", "
+
+%h2.title
+  Details
+- if page.showGoogleDoc
+  %p
+    This project is published as a Google doc for now.
+    You are welcome to comment on the proposal or to suggest changes in the draft embedded below
+    (
+    %a{:href => page.links.draft, :target => "_blank", :rel => "noreferrer noopener"}
+      Google Doc
+    )
+  %iframe{:src => "#{page.links.draft}?embedded=true", :width => "100%", :height => "600px"}
+- else
+  = content

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -41,6 +41,6 @@ By using Docker Compose to define and run a multi-container Docker application f
 === Links
 * General office hours meeting can be attended link:https://zoom.us/j/93082176149[here]
 * Project specific office hours can be attended link:https://zoom.us/j/92846964984[here]
-* project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]
+* Project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]
 * Recodings of these weekly project meetings can be found on the Discourse post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
 * Gitter channel dedicated to this project can be joined link:https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org[here]

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -39,4 +39,11 @@ By using Docker Compose to define and run a multi-container Docker application f
 
 
 === Links
-* Weekly project specific office hours link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[Meeting Notes]
+
+
+=== Links
+* General office hours meeting can be attended link:https://zoom.us/j/93082176149[here]
+* Project specific office hours can be attended link:https://zoom.us/j/92846964984[here]
+* project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]
+* Recodings of these office hours can be found on community blog post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
+* Gitter channel used project can be joined link:https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org[here]

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -1,5 +1,5 @@
 ---
-layout: gsocproject2
+layout: gsocproject3
 title: "Docker-based Jenkins quickstart examples"
 goal: "Provide examples, sample code, and documentation on how to start a local Jenkins instance."
 category: Tools

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -42,5 +42,5 @@ By using Docker Compose to define and run a multi-container Docker application f
 * General office hours meeting can be attended link:https://zoom.us/j/93082176149[here]
 * Project specific office hours can be attended link:https://zoom.us/j/92846964984[here]
 * project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]
-* Recodings of these office hours can be found on community blog post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
+* Recodings of these weekly project meetings can be found on the Discourse post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
 * Gitter channel dedicated to this project can be joined link:https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org[here]

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -42,5 +42,5 @@ By using Docker Compose to define and run a multi-container Docker application f
 * General office hours meeting can be attended link:https://zoom.us/j/93082176149[here]
 * Project specific office hours can be attended link:https://zoom.us/j/92846964984[here]
 * Project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]
-* Recodings of these weekly project meetings can be found on the Discourse post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
+* Recordings of these weekly project meetings can be found on the Discourse post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
 * Gitter channel dedicated to this project can be joined link:https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org[here]

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -43,4 +43,4 @@ By using Docker Compose to define and run a multi-container Docker application f
 * Project specific office hours can be attended link:https://zoom.us/j/92846964984[here]
 * project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]
 * Recodings of these office hours can be found on community blog post link:https://community.jenkins.io/t/docker-quick-start-examples-gsoc-2023/7479[here]
-* Gitter channel used project can be joined link:https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org[here]
+* Gitter channel dedicated to this project can be joined link:https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org[here]

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -39,9 +39,6 @@ By using Docker Compose to define and run a multi-container Docker application f
 
 
 === Links
-
-
-=== Links
 * General office hours meeting can be attended link:https://zoom.us/j/93082176149[here]
 * Project specific office hours can be attended link:https://zoom.us/j/92846964984[here]
 * project specific office hours meeting notes can be found link:https://docs.google.com/document/d/1yij9OvM2_92My3vqjn6u8ABHjXcyy0a7O6oM30b6ctM/edit[here]


### PR DESCRIPTION
I have added a new layout `gsocproject3` to use instead of `gsocproject2` since the links in `gsocproject2` were not easily editable. 

I don't know much about how `.haml` files work yet, so I have just removed the links section from the end of `gsocproject2` and tested it on a Gitpod instance. 

![Screenshot from 2023-05-22 19-50-49](https://github.com/jenkins-infra/jenkins.io/assets/98499313/22507501-df30-4176-979f-0f887755bf60)

