### PR TITLE
Fixed adoc syntax in Add GSoC 2023 contributor introductory blog for Plugin Health Scoring System project blog

### DIFF
--- a/content/blog/2023/05/22/2023-05-22-jagruti-introduction-blog-post.adoc
+++ b/content/blog/2023/05/22/2023-05-22-jagruti-introduction-blog-post.adoc
@@ -45,7 +45,8 @@ My project is titled “Adding Probes to Plugin Health Score”. As the title su
 
 === What are `probes`?
 Probes are nothing but data that compute the health score of the plugin. The score is computed based on the data collected by the probe. Based on this score, the future contributors and maintainers, adopters decide which plugin they want to invest their time in.
-== What will I do during this GSoC period?
+
+g== What will I do during this GSoC period?
 
 . Designing the probes
 .. Identify the key features and functionality of the plugins.

--- a/content/blog/2023/05/22/2023-05-22-jagruti-introduction-blog-post.adoc
+++ b/content/blog/2023/05/22/2023-05-22-jagruti-introduction-blog-post.adoc
@@ -46,7 +46,7 @@ My project is titled “Adding Probes to Plugin Health Score”. As the title su
 === What are `probes`?
 Probes are nothing but data that compute the health score of the plugin. The score is computed based on the data collected by the probe. Based on this score, the future contributors and maintainers, adopters decide which plugin they want to invest their time in.
 
-g== What will I do during this GSoC period?
+== What will I do during this GSoC period?
 
 . Designing the probes
 .. Identify the key features and functionality of the plugins.


### PR DESCRIPTION
Fixed `adoc`  syntax for subheading "What will I do during this GSoC period?"

![image](https://github.com/jenkins-infra/jenkins.io/assets/28809492/4c436411-02f3-4d19-9921-743d41dc8797)
