### PR TITLE
Update GSoC weekly project meeting time

### DIFF
--- a/content/_layouts/gsocproject.html.haml
+++ b/content/_layouts/gsocproject.html.haml
@@ -11,8 +11,6 @@ project: gsoc
   %b
     Status:
   = page.status
-      
-    
 
 %h3.title
   Team

--- a/content/_layouts/gsocproject2.html.haml
+++ b/content/_layouts/gsocproject2.html.haml
@@ -11,8 +11,6 @@ project: gsoc
   %b
     Status:
   = page.status
-      
-    
 
 %h3.title
   Team

--- a/content/_partials/connect-links.html.haml
+++ b/content/_partials/connect-links.html.haml
@@ -56,7 +56,7 @@
 - elsif matrix
   %li
     %a{:href => "https://matrix.to/#/##{matrix}", :target => "_blank", :rel => "noreferrer noopener"}
-      %img{:title => "Matrix", :src => "https://img.shields.io/badge/matrix-join%20chat-blue"}
+      %img{:title => "Matrix", :src => "https://img.shields.io/badge/matrix-join%20chat-blue?style=flat&logo=matrix"}
 - elsif chat
   %li
     %a{:href => (chat.start_with? "http") ? chat : expand_link(chat), :target => "_blank", :rel => "noreferrer noopener"}

--- a/content/_partials/connect-links.html.haml
+++ b/content/_partials/connect-links.html.haml
@@ -36,6 +36,8 @@
 - ####
 - if page.links && page.links.gitter
   - gitter = page.links.gitter
+- elsif page.links && page.links.matrix
+  - matrix = page.links.matrix
 - elsif page.links && page.links.chat
   - chat = page.links.chat
 - elsif project && project.links && project.links.gitter
@@ -51,6 +53,10 @@
   %li
     %a{:href => "https://app.gitter.im/#/room/##{gitter}", :target => "_blank", :rel => "noreferrer noopener"}
       %img{:title => "Gitter", :src => "https://badges.gitter.im/#{gitter}.svg"}
+- elsif matrix
+  %li
+    %a{:href => "https://matrix.to/#/##{matrix}", :target => "_blank", :rel => "noreferrer noopener"}
+      %img{:title => "Matrix", :src => "https://img.shields.io/badge/matrix-join%20chat-blue"}
 - elsif chat
   %li
     %a{:href => (chat.start_with? "http") ? chat : expand_link(chat), :target => "_blank", :rel => "noreferrer noopener"}

--- a/content/projects/gsoc/2023/projects/add-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2023/projects/add-probes-to-plugin-health-score.adoc
@@ -18,7 +18,7 @@ links:
     idea: /projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score
     gitter: jenkinsci_GSoC-Plugin_Health_Score:gitter.im
     draft: https://drive.google.com/file/d/1VEd-RDpJglWMMZApkQ0cn3Xujfj4sXW6/view
-    meetings: /projects/gsoc/2023/projects/add-probes-to-plugin-health-score/#office-hours```
+    meetings: /projects/gsoc/#office-hours
 ---
 === Abstract
 

--- a/content/projects/gsoc/2023/projects/add-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2023/projects/add-probes-to-plugin-health-score.adoc
@@ -16,7 +16,7 @@ mentors:
 - "mostafaashraf"
 links:
     idea: /projects/gsoc/2023/project-ideas/add-probes-to-plugin-health-score
-    gitter: https://app.element.io/\#/room/\#jenkinsci_GSoC-Plugin_Health_Score:gitter.im
+    gitter: jenkinsci_GSoC-Plugin_Health_Score:gitter.im
     draft: https://drive.google.com/file/d/1VEd-RDpJglWMMZApkQ0cn3Xujfj4sXW6/view
     meetings: /projects/gsoc/2023/projects/add-probes-to-plugin-health-score/#office-hours```
 ---

--- a/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
@@ -19,7 +19,7 @@ links:
     idea: /projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool
     matrix: jenkinsci_gsoc-2023-building-jenkinsio:matrix.org
     draft: https://docs.google.com/document/d/1RS7-NO9shIaF2xZzYnAXTbSvpRNxoZMI7cJ5q5bc-h8/edit?usp=sharing
-    meeting: https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing
+    meetings: https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing
 ---
 
 === Abstract

--- a/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
@@ -56,5 +56,5 @@ At last Blogs using Gatsby will be set up.
 === Office hours
 
 * (General) Official weekly Jenkins office hours: Thursdays 15:00 UTC
-* (Project-based) Weekly project based office hours: Fridays 13:30 UTC
+* (Project-based) Weekly project based office hours: Saturdays 14:30 UTC
 Details regarding the Weekly project-specific office hours can be found inside our link:https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing[Meeting Document], along with important links.

--- a/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
@@ -17,7 +17,7 @@ mentors:
 - "markewaite"
 links:
     idea: /projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool
-    gitter: https://matrix.to/#/#jenkinsci_gsoc-2023-building-jenkinsio:matrix.org
+    matrix: jenkinsci_gsoc-2023-building-jenkinsio:matrix.org
     draft: https://docs.google.com/document/d/1RS7-NO9shIaF2xZzYnAXTbSvpRNxoZMI7cJ5q5bc-h8/edit?usp=sharing
     meeting: https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing
 ---

--- a/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
@@ -17,15 +17,15 @@ mentors:
 - "markewaite"
 links:
     idea: /projects/gsoc/2023/project-ideas/alternative-jenkinsio-build-tool
-//   matrix: https://matrix.to/#/#jenkinsci_gsoc-2023-building-jenkinsio:matrix.org
-//   draft: https://docs.google.com/document/d/1RS7-NO9shIaF2xZzYnAXTbSvpRNxoZMI7cJ5q5bc-h8/edit?usp=sharing
-//   meeting: "/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool/#office-hours"
+    gitter: https://matrix.to/#/#jenkinsci_gsoc-2023-building-jenkinsio:matrix.org
+    draft: https://docs.google.com/document/d/1RS7-NO9shIaF2xZzYnAXTbSvpRNxoZMI7cJ5q5bc-h8/edit?usp=sharing
+    meeting: https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing
 ---
 
 === Abstract
 
 The goal of this project is to build the Jenkins.io static site with alternative tools such as Antora and Gatsby.
-We will divide the current site into sections.
+We will divide the current site into the following broad sections:
 
 - Blogs
 - Documentation (both user and developer)
@@ -37,9 +37,8 @@ The preferred tools for the blogs, changelogs and roadmaps is Gatsby while Antor
 
 One of the drawbacks of the current build method is that the technical documentation is not product version bound. 
 It is thus not possible to view the documentation for a given Jenkins version. 
-Only the latest can be viewed. 
-This can lead to unnecessary confusion and affects the overall User Experience.
-
+Only the latest version can be viewed.
+This can lead to unnecessary confusion and affects the overall user experience.
 Another reason is that Awestruct hasn't released a newer version in more than two years.
 It doesn't seem useful to rely on it continuously.
 
@@ -52,10 +51,9 @@ The most urgent milestone would be Jenkins-style versioned documentation.
 Following that, developer documentation that does not need to be versioned would be set up.
 At last Blogs using Gatsby will be set up.
 
-
 === Office hours
 
-* (General) Official weekly Jenkins office hours: Thursdays 15:00 UTC
-* (Project-based) Weekly project based office hours: Saturdays 14:30 UTC
+* (General) Official weekly Jenkins office hours: Thursdays 15:00 UTC.
+* (Project-based) Weekly project based office hours: Saturdays 14:30 UTC.
 
-Details regarding the Weekly project-specific office hours can be found inside our link:https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing[Meeting Document], along with important links.
+Details regarding the weekly project-specific office hours can be found via the "Meetings" link below.

--- a/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
+++ b/content/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool.adoc
@@ -57,4 +57,5 @@ At last Blogs using Gatsby will be set up.
 
 * (General) Official weekly Jenkins office hours: Thursdays 15:00 UTC
 * (Project-based) Weekly project based office hours: Saturdays 14:30 UTC
+
 Details regarding the Weekly project-specific office hours can be found inside our link:https://docs.google.com/document/d/1ZLauV_lKQFB5SJn--TJqVftKwhzeepB-dUfhS0ldfa8/edit?usp=sharing[Meeting Document], along with important links.

--- a/content/projects/gsoc/2023/projects/docker-compose-build.adoc
+++ b/content/projects/gsoc/2023/projects/docker-compose-build.adoc
@@ -19,7 +19,7 @@ links:
     idea: "/projects/gsoc/2023/project-ideas/docker-compose-build/"
     Gitter: "https://matrix.to/#/#gsoc-2023-docker-quickstart:matrix.org"
     draft: https://docs.google.com/document/d/1ZpPihadYqpAvR20rxZkTD2SVpf34E6YMzg6opU6yHAg/edit?usp=sharing
-    meeting: /projects/gsoc/2023/projects/docker-compose-build.adoc#office-hours
+    meeting: /projects/gsoc/#office-hours
 ---
 
 === Abstract

--- a/content/projects/gsoc/2023/projects/gitlab-plugin-modernization.adoc
+++ b/content/projects/gsoc/2023/projects/gitlab-plugin-modernization.adoc
@@ -18,7 +18,7 @@ links:
   idea: /projects/gsoc/2023/project-ideas/gitlab-plugin-modernization
   gitter: jenkinsci_gitlab-plugin:gitter.im
   draft: https://docs.google.com/document/d/1fRTWTV2zwLnhWmylavKgQ30apHamrHRfJkK5s_acw7c/edit?usp=sharing
-  meetings: "/projects/gsoc/2023/projects/gitlab-plugin-modernization/#office-hours"
+  meetings: https://docs.google.com/document/d/18JrgxI9TucuqbKDycXBdVCWvBAvdqY5RgpY-UUKNc-4/edit?usp=sharing
 ---
 
 === Abstract
@@ -46,4 +46,4 @@ Existing code will be exercised against a real GitLab installation, then the por
 === Office hours
 
 * (General) Official weekly Jenkins office hours: Thursdays 15:00 UTC
-* (Project-based) Details regarding the Weekly project-specific office hours can be found inside our link:https://docs.google.com/document/d/18JrgxI9TucuqbKDycXBdVCWvBAvdqY5RgpY-UUKNc-4/edit#heading=h.iiyb3sq4n3xo[Meeting Document], along with important links.
+* (Project-based) Details regarding the Weekly project-specific office hours can be found inside our Meeting Document along with important links via the Meetings link below.


### PR DESCRIPTION
Updated GSoC weekly project meeting time on "Building jenkins.io with alternative tools" project page. 