### PR TITLE
2.401.1 changelog and upgrade guide

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -8965,6 +8965,18 @@
         title: Jenkins Security Advisory 2023-02-15
     message: |-
       Update bundled plugins to include fixes announced in 2023-01-24 and 2023-02-15 Jenkins security advisories.
+  - type: rfe
+    category: rfe
+    authors:
+      - dduportal
+      - markewaite
+      - smerle
+      - lemeurherve
+    references:
+      - url: https://github.com/jenkins-infra/release/pull/358
+        title: pull 358
+    message: |-
+      Sign WAR file and Windows installer with new code signing certificate.
 
 - version: "2.387.3"
   date: 2023-05-03
@@ -9005,6 +9017,277 @@
     pr_title: "[JENKINS-69129] Support escaped emoji characters in XML files"
     message: |-
       Support emojis in Job DSL scripts.
+
+- version: "2.401.1"
+  date: 2023-03-08
+  lts_predecessor: "2.387.3"
+  lts_baseline: "2.401"
+  changes: # compared to lts_baseline 2.401 - extracted from the RC commit(s)
+
+  - type: bug
+    category: regression
+    pull: 7924
+    issue: 71182
+    authors:
+      - jglick
+    pr_title: "[JENKINS-71182] Correct Unicode behavior of `XML_1_1`"
+    message: |-
+      Fix the writing of emojis to XML (regression in 2.403).
+
+  - type: bug
+    category: regression
+    pull: 7875
+    issue: 71139
+    authors:
+      - jglick
+    pr_title: "[JENKINS-71139] Fail fast when serializing invalid XML 1.1 data"
+    message: |-
+      Do not write NUL values to XML files.
+      A technically illegal <code>#x0</code> (NUL) could be written to Jenkins XML files but could no longer be read.
+      Now the write will fail as well (regression in 2.398).
+
+  - type: bug
+    category: regression
+    pull: 8052
+    issue: 71345
+    authors:
+      - MarkEWaite
+    pr_title: "[JENKINS-71345] Remove 'undefined' from system dropdown menu"
+    message: |-
+      Remove "undefined" trailing text from system dropdown menu.
+
+  - type: bug
+    category: bug
+    pull: 7891
+    issue: 71160
+    authors:
+      - flabrie
+      - NotMyFault
+    pr_title: '[JENKINS-71160] Fix "Tmp directories are hidden" alert icon'
+    message: |-
+      Fix the warning icon in the workspaces temporary directory message.
+
+  - type: bug
+    category: regression
+    pull: 7870
+    issue: 71115
+    authors:
+      - niralmaruda
+    pr_title: "[JENKINS-71115] Builds filter field doesn't use full width on sub\
+      \ 970px windows"
+    message: |-
+      Show full width filter field for builds on pages less than 970 pixels wide.
+
+  lts_changes: # compared to lts_predecessor 2.387.3 (selected by personal review)
+
+  - type: rfe
+    category: rfe
+    pull: 7661
+    authors:
+      - janfaracik
+      - timja
+    pr_title: Simplify settings names
+    message: |-
+      Simplify the names of the settings in Manage Jenkins.
+
+  - type: rfe
+    category: rfe
+    pull: 7581
+    authors:
+      - janfaracik
+      - NotMyFault
+    pr_title: Use a card layout instead of a table for the dashboard on mobile
+    message: |-
+      Use a card layout instead of a table for the dashboard on mobile.
+
+  - type: rfe
+    category: rfe
+    pull: 7748
+    authors:
+      - janfaracik
+    pr_title: Refresh the Build with Parameters interface
+    message: |-
+      Refresh the Build with Parameters interface.
+
+  - type: rfe
+    category: rfe
+    pull: 7718
+    authors:
+      - janfaracik
+      - timja
+    pr_title: Revamp icon legend as a modal
+    message: |-
+      Revamp icon legend as a modal.
+
+  - type: rfe
+    category: rfe
+    pull: 7712
+    authors:
+      - janfaracik
+    pr_title: Refresh the design of the About Jenkins page
+    message: |-
+      Refresh the design of the About Jenkins page.
+
+  - type: rfe
+    category: rfe
+    pull: 7614
+    authors:
+      - jglick
+      - daniel-beck
+    pr_title: "`t:progressiveText` should tolerate 5xx HTTP errors"
+    message: |-
+      Running pipeline build logs can now be displayed across controller restarts without reloading in some environments.
+
+  - type: rfe
+    category: rfe
+    pull: 7299
+    issue: 69853
+    authors:
+      - Wadeck
+      - NotMyFault
+      - timja
+    pr_title: "[JENKINS-69853] User experimental flags"
+    message: |-
+      Introduce user experimental flags.
+
+  - type: rfe
+    category: rfe
+    pull: 7625
+    authors:
+      - prathi-mani
+      - MarkEWaite
+      - NotMyFault
+      - janfaracik
+    pr_title: Added copy to clipboard button to agent launch snippets
+    references:
+      - pull: 7625
+      - pull: 7678
+      - pull: 7665
+      - issue: 21052
+    message: |-
+      Add a copy button for the code snippets that start agents and for the Jenkins home directory.
+      Warn user that copy button requires HTTPS.
+
+  - type: rfe
+    category: rfe
+    pull: 7605
+    authors:
+      - jglick
+    pr_title: Default CLI mode to `-webSocket`
+    message: |-
+      The default connection mode for the Java CLI client is now <code>webSocket</code>.
+      You can specify <code>http</code> to continue to use the former default (for example because you are running Jenkins in a servlet container other than the recommended builtin Jetty, or because you are running an unusual reverse proxy which does not support WebSocket).
+      You can also continue to specify <code>ssh</code> to use SSH transport (for example because you prefer to authenticate with a private key rather than an API token), or use a native SSH client.
+
+  - type: rfe
+    category: rfe
+    pull: 7827
+    authors:
+      - basil
+    pr_title: Remove dependency on `jenkins-js-modules`
+    message: |-
+      Simplify loading of JavaScript and CSS.
+      Users of OWASP DependencyTrack must upgrade to 4.3.1 or later, and users of ServiceNow CI/CD must upgrade to 2.1 or later.
+
+  - type: bug
+    category: bug
+    pull: 7701
+    issue: 70630
+    authors:
+      - carlos-mon-inm
+      - NotMyFault
+      - MarkEWaite
+    pr_title: "[JENKINS-70630] - Fix HTTP2 missing header"
+    message: |-
+      Fix null pointer exception on the "Manage Jenkins" page when HTTP/2 is enabled.
+
+  - type: bug
+    category: bug
+    pull: 7778
+    issue: 69129
+    authors:
+      - basil
+    pr_title: "[JENKINS-69129] Support escaped emoji characters in XML files"
+    message: |-
+      Support emoji in Job DSL scripts.
+
+  - type: bug
+    category: regression
+    pull: 7740
+    issue: 69489
+    authors:
+      - NotMyFault
+    pr_title: "[JENKINS-69489] - Hide restart checkbox if the controller doesn't\
+      \ support it"
+    message: |-
+      Hide the <strong>Restart Jenkins</strong> checkbox in the update center if the controller doesn't support it.
+
+  - type: bug
+    category: regression
+    pull: 7743
+    issue: 70820
+    authors:
+      - NotMyFault
+    pr_title: "[JENKINS-70820] - Restore 'New Node' button for users with node\
+      \ creation permission"
+    message: |-
+      Restore the <strong>New Node</strong> button in computer overview for users with node creation permission.
+
+  - type: bug
+    category: bug
+    pull: 7670
+    issue: 69955
+    authors:
+      - Dohbedoh
+      - timja
+      - NotMyFault
+    pr_title: "[JENKINS-69955] Make websocket connection idleTimeout configurable"
+    message: |-
+      Adjust websocket idle timeout to 60s seconds by default to avoid "WebSocketTimeoutException: Connection Idle Timeout" issues.
+      Idle timeout is configurable via <code>jenkins.websocket.idleTimeout=&lt;timeoutInSeconds&gt;</code>.
+
+  - type: bug
+    category: regression
+    pull: 7577
+    issue: 70394
+    authors:
+      - mPokornyETM
+      - timja
+    pr_title: "[JENKINS-70394] Move 'set node temporarily offline/online' buttons\
+      \ to app-bar"
+    message: |-
+      Move <code>set node temporarily offline/online</code> buttons to appbar.
+
+  - type: rfe
+    category: developer
+    pull: 7838
+    authors:
+      - dependabot[bot]
+    references:
+      - url: https://github.com/spring-projects/spring-framework/releases/tag/v5.3.27
+        title: Spring Framework 5.3.27 release notes
+    pr_title: Upgrade Spring Framework from 5.3.26 to 5.3.27
+    message: |-
+      Upgrade Spring Framework from 5.3.26 to 5.3.27.
+
+  - type: rfe
+    category: developer
+    pull: 7632
+    authors:
+      - jglick
+    pr_title: Upgrade Winstone from 6.7 to 6.10
+    references:
+      - pull: 7632
+      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.10
+        title: Winstone 6.10 changelog
+      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.9
+        title: Winstone 6.9 changelog
+      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.8
+        title: Winstone 6.8 changelog
+    message: |-
+      Upgrade bundled Winstone from 6.7 to 6.10.
+      Add the <code>excludeProtocols</code> option.
+      Improve logging during shutdown.
 
 # DO NOT EDIT THIS FILE DIRECTLY
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -19449,7 +19449,7 @@
         pr_title: "[JENKINS-69955] Make websocket connection idleTimeout configurable"
         message: |-
           Adjust websocket idle timeout to 60s seconds by default to avoid "WebSocketTimeoutException: Connection Idle Timeout" issues.
-          Idle timeout is configurable via <code>jenkins.websocket.idleTimeout=<timeoutInSeconds></code>.
+          Idle timeout is configurable via <code>jenkins.websocket.idleTimeout=&lt;timeoutInSeconds&gt;</code>.
 
   # pull: 7643 (PR title: Minor updates to MAINTAINERS doc)
   # pull: 7682 (PR title: Update dependency node to v18.14.2)

--- a/content/_data/upgrades/2-401-1.adoc
+++ b/content/_data/upgrades/2-401-1.adoc
@@ -1,0 +1,14 @@
+==== Simplify loading of JavaScript and CSS
+
+A custom JavaScript library, `jenkins-js-modules` has been removed from Jenkins core.
+Users of the plugin:dependency-track[OWASP Dependency Track] plugin must upgrade to 4.3.1 or newer.
+Users of the plugin:servicenow-cicd[ServiceNow CI/CD] plugin must upgrade to 2.1 or newer.
+
+==== WebSocket is default command line interface mode
+
+The default connection mode for the Java link:/doc/book/managing/cli/[command line interface] client is now `-webSocket`.
+
+You can specify -http to continue to use the former default (for example because you are running Jenkins in a servlet container other than the recommended built-in Jetty, or because you are running an unusual reverse proxy which does not support WebSocket).
+You can also continue to specify -ssh to use SSH transport (for example because you prefer to authenticate with a private key rather than an API token), or use a native SSH client.
+
+If you use the Jenkins CLI but cannot make WebSocket connections to the Jenkins controller, you will now need to pass the -http or -ssh option if you were not already doing so.


### PR DESCRIPTION
## Jenkins 2.401.1 changelog and upgrade guide

Also fixes a markup error in the weekly changelog

## Changelog looks like this

![changelog](https://github.com/jenkins-infra/jenkins.io/assets/156685/50dc1ce5-4133-4add-bde8-e723a4927bd2)

## Upgrade guide looks like this

![upgrade-guide](https://github.com/jenkins-infra/jenkins.io/assets/156685/93235c17-66f3-4689-a0b3-032450b0902e)
