### PR TITLE
Exchange SUSE with openSUSE in linux support policy

### DIFF
--- a/content/doc/administration/requirements/linux.adoc
+++ b/content/doc/administration/requirements/linux.adoc
@@ -59,7 +59,7 @@ a|
 
 * link:https://wiki.debian.org/LTS[Debian Long Term Support]
 * link:https://access.redhat.com/support/policy/updates/errata[Red Hat Enterprise Linux Life Cycle]
-* link:https://www.suse.com/lifecycle/[SUSE Product Support Lifecycle]
+* link:https://en.opensuse.org/Lifetime[openSUSE Product Support Lifecycle]
 * link:https://ubuntu.com/about/release-cycle[Ubuntu lifecycle and release cadence]
 
 == Contributing


### PR DESCRIPTION
We test Jenkins against openSUSE 15.4. I propose to update the lifecycle link matching openSUSE's life cycle, instead of pointing to SUSE products and projects unrelated to what we guarantee Jenkins working on.