### PR TITLE
Update reference to `pipeline-github-lib`

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -119,9 +119,9 @@ sandbox just like typical Pipelines.
 ===  Automatic Shared Libraries
 
 Other plugins may add ways of defining libraries on the fly.  For example, the
-plugin:github-branch-source[GitHub Branch Source] plugin provides a "GitHub
-Organization Folder" item which allows a script to use an untrusted library
-such as `github.com/someorg/somerepo` without any additional configuration.  In
+plugin:pipeline-github-lib[Pipeline: GitHub Groovy Libraries] plugin
+allows a script to use an untrusted library
+named like `github.com/someorg/somerepo` without any additional configuration.  In
 this case, the specified GitHub repository would be loaded, from the `master`
 branch, using an anonymous checkout.
 


### PR DESCRIPTION
The reference to `github-branch-source` was misleading since that is not a prerequisite for using `pipeline-github-lib` to load an untrusted library from a public GitHub repository. Perhaps the intent was to say that if you are doing Pipeline-as-code generally, you can minimize the amount of configuration in Jenkins to a simple org folder definition by using this trick, but even that does not make much sense since you _would_ still need to define the org folder (and you could if you wished define untrusted libraries with any SCM including authentication on that folder).

https://github.com/fabric8io/kubernetes-client/blob/231aafb89340f901eb2619bb4c646f1b200b7e12/Jenkinsfile#L17 is an example but I was reluctant to put that here since it would really belong below under **Using libraries**.