### PR TITLE
fix(redirect): The "End of life operating systems" redirect should point to the blog post.

### DIFF
--- a/content/redirect/operating-system-end-of-life.adoc
+++ b/content/redirect/operating-system-end-of-life.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: /doc/administration/requirements/linux/
+redirect_url: /blog/2023/05/30/operating-system-end-of-life/
 # https://github.com/jenkinsci/jenkins/pull/7913
 ---


### PR DESCRIPTION

During the latest Docs Office Hours meeting ([link](https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit#heading=h.gatcmisfay0r)), @MarkEWaite and I discussed the issue of redirection. The current link we are using is not bad, but for the upcoming weeks, we could consider using the link to the blog post, which is much better suited for the situation.