### PR TITLE
fix(documentation): Emphasizes on the necessity to create a branch before contributing

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -10,13 +10,14 @@ toc::[]
 
 == Getting Started
 
-To contribute to this repository you will
-link:https://guides.github.com/activities/forking/[fork this repository],
-push changes to a branch in your fork, and then
-link:https://help.github.com/articles/creating-a-pull-request-from-a-fork/[create a pull request(PR)]
-from that branch to the `master` branch of this repository.
-Forking only needs to be done once, after which you can push changes to your fork
-using the GitHub website file editor or from a local clone, as described below.
+To contribute to this repository, follow these steps:
+
+1. link:https://guides.github.com/activities/forking/[Fork this repository] and ensure that you keep only the `master` branch.
+2. Create a new branch from your `master` branch and perform your work on this new branch, avoiding direct changes to the `master` branch.
+3. Once your work is completed and committed to your branch, push the changes to your forked repository.
+4. link:https://help.github.com/articles/creating-a-pull-request-from-a-fork/[Create a pull request (PR)] from your branch to the `master` branch of this repository.
+
+Note that forking needs to be done only once. After forking, you can keep your fork up to date thanks to *Sync fork* or make further changes to your forked repository using the GitHub website file editor or by working on a local clone, as described below.
 
 You can also open this project as a https://www.gitpod.io/[Gitpod workspace] which comes pre-configured with all the tools you will need.
 

--- a/content/redirect/operating-system-end-of-life.adoc
+++ b/content/redirect/operating-system-end-of-life.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: /doc/administration/requirements/linux/
+redirect_url: /blog/2023/05/30/operating-system-end-of-life/
 # https://github.com/jenkinsci/jenkins/pull/7913
 ---

--- a/content/redirect/operating-system-end-of-life.adoc
+++ b/content/redirect/operating-system-end-of-life.adoc
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_url: /blog/2023/05/30/operating-system-end-of-life/
+redirect_url: /doc/administration/requirements/linux/
 # https://github.com/jenkinsci/jenkins/pull/7913
 ---


### PR DESCRIPTION
We regularly have PRs from the fork's master to Jenkins' master.
The last one is #6409 .
This can be handled easily, but isn't it better to create PRs from another branch?