### PR TITLE
Get the fallback release command closer to what the GH release action does

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -277,6 +277,8 @@ To cut a release:
 git checkout master
 git pull --ff-only
 mvn -Dset.changelist \
+  -Pquick-build \
+  -P-consume-incrementals \
   -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ \
   clean deploy
 ----


### PR DESCRIPTION
cf. https://github.com/jenkins-infra/jenkins-maven-cd-action/blob/master/run.sh#L8