### PR TITLE
fallback needs to include profile de-activation

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -276,7 +276,8 @@ To cut a release:
 ----
 git checkout master
 git pull --ff-only
-mvn -Dset.changelist \
+mvn -P\!consume-incrementals \
+  -Dset.changelist \
   -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ \
   clean deploy
 ----


### PR DESCRIPTION
without the profile deactivation a release can be published that consumes incrementals.

This is baaadddd.

update the docs to specifically deactive the `consume-incremental` profile