### PR TITLE
Don't warn about conflicts in changelog PRs

### DIFF
--- a/.github/workflows/label-conflicting-prs.yml
+++ b/.github/workflows/label-conflicting-prs.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   main:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'jenkins-infra-changelog-generator[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Label conflicting PRs


### PR DESCRIPTION
Comments like https://github.com/jenkins-infra/jenkins.io/pull/6449#issuecomment-1579306692 just clutter the notifications, the bot will resolve conflicts on next run anyway.