### PR TITLE
Remove detailed theme compatibility recommendation

### DIFF
--- a/content/doc/book/managing/ui-themes.adoc
+++ b/content/doc/book/managing/ui-themes.adoc
@@ -95,12 +95,6 @@ and we would be happy to consider enhancements from them for a default Jenkins t
 To improve the user experience,
 please consider the following recommendations:
 
-* Explicitly document compatibility for themes.
-** Compatibility documentation should include: required theme plugins and versions,
-   target Jenkins core version,
-   plugin requirements and versions if applicable (UI/CSS are overridden), and
-   browser compatibility.
-** Examples of such documentation: link:https://github.com/djonsson/jenkins-atlassian-theme#compatibility[Jenkins Atlassian Theme], link:https://github.com/TobiX/jenkins-neo2-theme#compatibility[Neo2]
 * Version themes with tags on Git and to maintain changelogs with explicit references to changes in the supported versions (e.g. see our release drafter documentation as one of the ways to automate changelogs).
 * Explicitly define an link:https://opensource.org/licenses[OSI-approved open source license] so that users can freely modify and redistribute them.
 ** This is also a prerequisite for hosting themes in Jenkins GitHub organizations and, in the future, theme marketplaces or other similar promotion engines.


### PR DESCRIPTION
Actively maintained themes are linked in the top section of the page and do not provide detailed compatibility statements.  They work because they are actively maintained, not because someone reads a compatibility statement.
