### PR TITLE
cleanup(roadmap): remove `customize.jenkins.io` and "Custom Jenkins distribution build service"

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -503,24 +503,6 @@ categories:
       link: https://issues.jenkins.io/browse/JENKINS-63286
       labels:
       - feature
-    - name: Custom Jenkins distribution build service
-      description: >
-        A new service which would allow users to configure and build their own Jenkins distributions,
-        with custom plugin sets and configurations included.
-        This would be a self-hosted service initially.
-      status: preview
-      link: /projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
-      labels:
-      - feature
-      - tools
-    - name: "customize.jenkins.io"
-      description: >
-        Hosted versions of the Custom Jenkins distribution build service provided by the Jenkins project
-      status: current
-      link: /projects/gsoc/2020/projects/custom-jenkins-distribution-build-service
-      labels:
-      - feature
-      - infrastructure
     - name: Custom WAR/Docker Packager 2.0
       description: >
         New edition of Custom WAR Packager with a new configuration YAML format.


### PR DESCRIPTION
This project is discontinued.

Related: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1591316525