### PR TITLE
Remove 3 incorrect entries from 2.401.1 changelog

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9240,19 +9240,6 @@
       Restore the <strong>New Node</strong> button in computer overview for users with node creation permission.
 
   - type: bug
-    category: bug
-    pull: 7670
-    issue: 69955
-    authors:
-      - Dohbedoh
-      - timja
-      - NotMyFault
-    pr_title: "[JENKINS-69955] Make websocket connection idleTimeout configurable"
-    message: |-
-      Adjust websocket idle timeout to 60s seconds by default to avoid "WebSocketTimeoutException: Connection Idle Timeout" issues.
-      Idle timeout is configurable via <code>jenkins.websocket.idleTimeout=&lt;timeoutInSeconds&gt;</code>.
-
-  - type: bug
     category: regression
     pull: 7577
     issue: 70394

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9230,17 +9230,6 @@
 
   - type: bug
     category: regression
-    pull: 7743
-    issue: 70820
-    authors:
-      - NotMyFault
-    pr_title: "[JENKINS-70820] - Restore 'New Node' button for users with node\
-      \ creation permission"
-    message: |-
-      Restore the <strong>New Node</strong> button in computer overview for users with node creation permission.
-
-  - type: bug
-    category: regression
     pull: 7577
     issue: 70394
     authors:

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9208,16 +9208,6 @@
       Fix null pointer exception on the "Manage Jenkins" page when HTTP/2 is enabled.
 
   - type: bug
-    category: bug
-    pull: 7778
-    issue: 69129
-    authors:
-      - basil
-    pr_title: "[JENKINS-69129] Support escaped emoji characters in XML files"
-    message: |-
-      Support emoji in Job DSL scripts.
-
-  - type: bug
     category: regression
     pull: 7740
     issue: 69489


### PR DESCRIPTION
## Remove 3 incorrect entries

Detected during the 2.401.1 live stream with Darrin Pope that several entries in the 2.401.1 changelog had already been included in previous Jenkins LTS releases.

Each of the changes that are being removed from 2.401.1 were already included in a previous LTS release.

Removals include:

* Support emoji in Job DSL scripts.
* Restore the <strong>New Node</strong> button in computer overview for users with node creation permission.
* Configurable timeout for websocket
