### PR TITLE
Remove 2020 tables to divs disclaimer

### DIFF
--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -32,26 +32,6 @@ Inline help is available on most *Manage Jenkins* pages:
 * To access the help, select the `?` icon to the right of each field.
 * Click the `?` icon again to hide the help text.
 
-[NOTE]
-====
-The *Manage Jenkins* screens were modernized in 2020
-to provide a more attractive user interface for all users
-and a much better experience for users on narrow devices such as tablets and phones.
-The main changes made were:
-
-* Configuration screens now use HTML `div` tags
-rather than the HTML `table` tags that were used in older releases.
-* The screens linked from this page are grouped somewhat logically,
-whereas older versions presented a long list of tasks in somewhat random order.
-* Some configuration fields were moved or added.
-
-For more information about these and other changes that have been implemented, see:
-
-* link:/changelog-stable/#v2.277.1[2.277.1 LTS Changelog]
-* link:/blog/2020/11/10/major-changes-in-weekly-releases/[Jenkins 2.264+: Major changes in the weekly release line]
-* link:/doc/upgrade-guide/[Jenkins LTS Upgrade Guide]
-====
-
 Other system administration topics are discussed in
 <<system-administration#,Jenkins System Administration>>.
 


### PR DESCRIPTION
We're now in 2023 and the transition from table tags to div tags is far behind us.  No need to describe that change in this page any longer.

# Before this change

Before the change, the page has a large disruptive gap that precedes the note about the table to div transition.  That makes the page hard to read.

![before](https://github.com/jenkins-infra/jenkins.io/assets/156685/6c2b8d8e-4fc1-4a41-8486-d5f914190dad)


# After this change

After the change, the page no longer has a large disruptive gap.  That makes the page easier to read.



![after](https://github.com/jenkins-infra/jenkins.io/assets/156685/70e421b5-dc95-41b9-a44d-f294a7ca51ab)
