### PR TITLE
Advise to use numeric autolink references

### DIFF
--- a/content/blog/2023/05/25/2023-05-25-github-sponsors-jenkinsci-org.adoc
+++ b/content/blog/2023/05/25/2023-05-25-github-sponsors-jenkinsci-org.adoc
@@ -25,7 +25,7 @@ If you are a Jenkins plugin maintainer, you can now use autolink references to l
 All you need to do is heading to the "Settings" tab of your GitHub repository and add the following configuration to the "Autolink references" section:
 
 ```
-Alphanumeric
+Numeric
 Reference prefix: JENKINS-
 Target URL: https://issues.jenkins.io/browse/JENKINS-<num>
 ```

--- a/content/doc/developer/publishing/requesting-hosting.adoc
+++ b/content/doc/developer/publishing/requesting-hosting.adoc
@@ -72,7 +72,7 @@ The link:../documentation[plugin documentation guide] includes instructions for 
 If your chosen issue tracker is Jira, you can setup autolink references, to link from commits directly to the Jenkins Jira issue.
 All you need to do is heading to the `Settings` tab of your GitHub repository and add the following configuration to the `Autolink references` section:
 ```txt
-Alphanumeric
+Numeric
 Reference prefix: JENKINS-
 Target URL: https://issues.jenkins.io/browse/JENKINS-<num>
 ```


### PR DESCRIPTION
Given the unlikely case, your commit message contains the string `jenkins-` without further numbers, you get a link to Jira, even if you don't want one.

The change proposed advises to use numeric references, to get a Jira link only if `jenkins-` is followed by numbers.