### PR TITLE
Updating bom version in tutorial-improve to current latest version

### DIFF
--- a/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
+++ b/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
@@ -42,9 +42,9 @@ The `git diff` might look like this:
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
 -        <artifactId>bom-2.319.x</artifactId>
-+        <artifactId>bom-2.375.x</artifactId>
++        <artifactId>bom-2.387.x</artifactId>
 -        <version>1466.v85a_616ea_b_87c</version>
-+        <version>1981.v17df70e84a_a_1</version>
++        <version>2179.v0884e842b_859</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Hello folks :wave:

While following the [Improve a Plugin Tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/) guidance, in the [Update Jenkins version](https://www.jenkins.io/doc/developer/tutorial-improve/update-base-jenkins-version/) I noticed a small inconsistency:

![image](https://github.com/jenkins-infra/jenkins.io/assets/311677/688a1c9a-f0ac-485e-8c2f-757538e59da3)

The `jenkins.version` that is suggested is `2.387.3`, but the bom version is `bom-2.375.x` which is inconsistent.

This small PR proposes to recommend the `bom-2.387.x` instead, with the latest version available at the time of submitting the PR.

Let me know if that makes sense to you.

Have a great day!