### PR TITLE
Add a note about the subscription to jenkinsci-board mailing list reserved to Jenkins board members

### DIFF
--- a/content/_partials/mailing-lists/jenkinsci-board.adoc
+++ b/content/_partials/mailing-lists/jenkinsci-board.adoc
@@ -1,0 +1,3 @@
+Mailing list to contact https://www.jenkins.io/project/board/[Jenkins board members].
+
+NOTE: the subscription to this mailing list is reserved to Jenkins board members.

--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -10,8 +10,7 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkinsci-users")
 
-= partial(group, :name => "jenkinsci-board",
-  :description => "Mailing list to contact Jenkins board members. Note: the subscription to this mailing list is reserved to Jenkins board members.")
+= partial(group, :name => "jenkinsci-board")
 
 = partial(group, :name => "jenkinsci-dev")
 

--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -11,7 +11,7 @@ title: Mailing Lists
 = partial(group, :name => "jenkinsci-users")
 
 = partial(group, :name => "jenkinsci-board",
-  :description => "Mailing list to contact Jenkins board members")
+  :description => "Mailing list to contact Jenkins board members. Note: the subscription to this mailing list is reserved to Jenkins board members.")
 
 = partial(group, :name => "jenkinsci-dev")
 


### PR DESCRIPTION
This PR adds a note for jenkinsci-board mailing list on https://www.jenkins.io/mailing-lists/ and a link to the Jenkins board members page.

Here is an extract of the mail response received when trying to subscribe to this mailing list:
> jenkinsci-board requires owner approval for join requests.