### PR TITLE
Update Linux installation for Java 17

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -25,6 +25,9 @@ include::doc/book/installing/_installation_requirements.adoc[]
 
 On Debian and Debian-based distributions like Ubuntu you can install Jenkins through `apt`.
 
+NOTE: With the release of link:https://www.debian.org/News/2023/20230610[Debian 12], OpenJDK 11 is *no longer* included.
+It has been replaced with link:https://openjdk.org/projects/jdk/17/[OpenJDK 17], which is reflected in the instructions below.
+
 === Long Term Support release
 
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
@@ -86,17 +89,18 @@ Here, "8081" was chosen but you can put another port available.
 
 Jenkins requires Java in order to run, yet certain distributions don't include this by default and  link:/doc/administration/requirements/java/[some Java versions are incompatible] with Jenkins.
 
-There are multiple Java implementations which you can use. link:https://openjdk.java.net/[OpenJDK] is the most popular one at the moment, we will use it in this guide.
+There are multiple Java implementations which you can use.
+link:https://openjdk.java.net/[OpenJDK] is the most popular one at the moment, we will use it in this guide.
 
-Update the Debian apt repositories, install OpenJDK 11, and check the installation with the commands:
+Update the Debian apt repositories, install OpenJDK 17, and check the installation with the commands:
 [source,bash]
 ----
 sudo apt update
-sudo apt install openjdk-11-jre
+sudo apt install openjdk-17-jre
 java -version
-openjdk version "11.0.12" 2021-07-20
-OpenJDK Runtime Environment (build 11.0.12+7-post-Debian-2)
-OpenJDK 64-Bit Server VM (build 11.0.12+7-post-Debian-2, mixed mode, sharing)
+openjdk version "17.0.7" 2023-04-18
+OpenJDK Runtime Environment (build 17.0.7+7-Debian-1deb11u1)
+OpenJDK 64-Bit Server VM (build 17.0.7+7-Debian-1deb11u1, mixed mode, sharing)
 ----
 
 [NOTE]
@@ -123,7 +127,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install java-11-openjdk
+sudo dnf install java-17-openjdk
 sudo dnf install jenkins
 sudo systemctl daemon-reload
 ----
@@ -140,7 +144,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install java-11-openjdk
+sudo dnf install java-17-openjdk
 sudo dnf install jenkins
 ----
 
@@ -220,7 +224,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install java-11-openjdk
+sudo yum install java-17-openjdk
 sudo yum install jenkins
 sudo systemctl daemon-reload
 ----
@@ -237,7 +241,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install java-11-openjdk
+sudo yum install java-17-openjdk
 sudo yum install jenkins
 ----
 
@@ -269,7 +273,7 @@ If everything has been set up correctly, you should see an output like this:
 [source,bash]
 ----
 Loaded: loaded (/lib/systemd/system/jenkins.service; enabled; vendor preset: enabled)
-Active: active (running) since Tue 2018-11-13 16:19:01 +03; 4min 57s ago
+Active: active (running) since Tue 2023-06-22 16:19:01 +03; 4min 57s ago
 ...
 ----
 


### PR DESCRIPTION
This pull request is to update the installation guide for Jenkins on Linux. With the recent release of Debian 12, OpenJDK 11 is no longer delivered, so the instructions we have must be updated for OpenJDK 17.

I have tested these instructions using Parallels on my Mac, and everything appears to work properly when changing the `openjdk-11-jre` to `openjdk-17-jre`

I've also added a note at the top of the page, under the "Debian/Ubuntu" header, indicating that with the Bookworm release, this is the change/why this has changed.