### PR TITLE
Be more restrictive about the allowed terms in the typo check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -55,9 +55,11 @@ check-filename = false
 "loLSNdCv6K4" = "loLSNdCv6K4"
 "ND" = "ND"
 "nd" = "nd"
+"HashiCorp" = "HashiCorp"
+# false positive "ede" > "edge" in jenkins-test-harness versions from ./content/_data/changelogs/weekly.yml
+"vcb_b_ede610d76" = "vcb_b_ede610d76"
 
 [default.extend-words]
-"Jenkins CNA" = "Jenkins CNA"
 "ACI" = "ACI"
 "AKS" = "AKS"
 "Varian" = "Varian"
@@ -69,7 +71,3 @@ check-filename = false
 # content/security/advisory/2022-06-30.adoc
 "testng" = "testng"
 "Referer" = "Referer" # false positive, the HTTP request header is misspelled on purpose
-# content/security/advisory/2023-04-12.adoc -- HashiCorp
-"Hashi" = "Hashi"
-# false positive "ede" > "edge" in jenkins-test-harness versions from ./content/_data/changelogs/weekly.yml
-"ede" = "ede"


### PR DESCRIPTION
Amends #6486.

This is more restrictive in what it allows, allowing `ede` everywhere seems risky.

Also, remove "Jenkins CNA" given "CNA" is allowed, and move "Hashi" to "HashiCorp".

`make check` passes locally for me with these changes.