### PR TITLE
Vulnerabilities need to be exploitable on recent versions of Jenkins

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -47,7 +47,6 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
   We still recommend reporting such vulnerabilities in private so that they can be reviewed by the security team, in case the vulnerable code is also used for features accessible by regular users.
 * Web methods that lack permission checks or CSRF protection, and cause Jenkins to access a URL, that is not controlled by an attacker, without disclosing configuration information from Jenkins or returning sensitive information.
   This behavior is commonly the case in plugins integrating with a hosted service (e.g., some connection tests) and while permissions beyond Overall/Read should be required to cause Jenkins to send a request, the impact is negligible.
-* Cross-site scripting (XSS) vulnerabilities due to lack of `escape-by-default` XML processing instruction, as these are only exploitable on Jenkins before 2.146 and 2.138.2.
 * Vulnerabilities in dependencies without a plausible or demonstrated exploit will not be treated as vulnerabilities.
   While we inform maintainers about the need to update their dependencies, and may track progress in the SECURITY Jira project, no security advisory will be published for these.
 * Cookies not set to `Secure` due to misconfiguration of Jenkins.
@@ -57,9 +56,13 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
   This is a feature.
 * Jobs started by a specific user can run on agents where the user lacks Agent/Build permission and can themselves trigger builds of jobs where the user lacks Job/Build permission.
   link:/doc/book/security/build-authorization/[See the documentation on Access Control for Builds].
-* `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check` (no longer exploitable since 2.319 and LTS 2.303.3).
-  link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
 * Ability for unauthenticated users to trigger SCM polling via webhooks without directly initiating a build or other resource-intensive computations.
+* Any issues in plugins whose exploitation has been prevented through changes in Jenkins core or other plugins for at least 13 months. Some examples:
+  * Cross-site scripting (XSS) vulnerabilities due to lack of `escape-by-default` XML processing instruction are no longer exploitable since Jenkins 2.146 and 2.138.2 (published 2018-10-10).
+  * Cross-site scripting (XSS) vulnerabilities through user-provided content in `Cause#getShortDescription` without a custom `description.jelly` are no longer exploitable since Jenkins 2.315 and LTS 2.303.2 (published 2021-10-06).
+  link:/doc/developer/security/xss-prevention/Cause-getShortDescription/[See the documentation on the redefinition of Cause#getShortDescription].
+  * `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check` is no longer exploitable since Jenkins 2.319 and LTS 2.303.3 (published 2021-11-04).
+  link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
 
 == Issue Handling Process
 


### PR DESCRIPTION
13 months takes care even of people who only update Jenkins once a year. That seems like a reasonable cutoff.

As of today, 2023-07-04, this would exclude anything not exploitable anymore on:

* 2.332.3 (released 2022-05-04) was the current release on 2022-06-04 (superseded only on 2022-06-22)
* 2.350 (released 2022-06-01) was the current release on 2022-06-04 (superseded 2022-06-07)

Per usage stats, around two thirds of known instances are those releases or newer.

This is a similar cutoff as we use for update-center2 tiers (400 days is slightly more than 13 months).