### PR TITLE
Fix dates in operating system end of life blog post

### DIFF
--- a/content/blog/2023/05/30/2023-05-30-operating-system-end-of-life.adoc
+++ b/content/blog/2023/05/30/2023-05-30-operating-system-end-of-life.adoc
@@ -14,8 +14,7 @@ opengraph:
 
 = End of life operating systems
 
-Beginning with Jenkins 2.407, May 30, 2023, Jenkins administrators running a Jenkins weekly release will be warned if they are running Jenkins on an operating system that is within 6 months of its link:https://endoflife.date/[end of life date].
-The same warning will be visible to Jenkins administrators running a Jenkins long term support (LTS) release with the next LTS baseline after Jenkins 2.401.x, beginning August 23, 2023.
+Beginning with Jenkins 2.407, May 30, 2023 and Jenkins 2.401.2, June 28, 2023, Jenkins administrators will be warned if they are running Jenkins on an operating system that is within 6 months of its link:https://endoflife.date/[end of life date].
 
 The warning includes the date when Jenkins will no longer be supported on that operating system version.
 It advises the administrator to upgrade to a newer version of the operating system.


### PR DESCRIPTION
We accelerated the release of the end of life administrative monitor into 2.401.2 so that administrators would be alerted 8 weeks earlier than if we waited for the release of the next LTS baseline.

Thanks to Darin Pope for catching the correction.
