### PR TITLE
Jenkins.io - Update "Viewing Logs" to use java 17

### DIFF
--- a/content/doc/book/system-administration/viewing-logs.adoc
+++ b/content/doc/book/system-administration/viewing-logs.adoc
@@ -15,17 +15,14 @@ endif::[]
 
 == Logs on the system
 
-When running `jenkins.war` manually with `java -jar jenkins.war`,
-all logging information by default is output to standard out. Many
-Jenkins native packages modify this behavior to ensure logging
-information is output in a more conventional location for the platform.
+When running `jenkins.war` manually with `java -jar jenkins.war`, all logging information by default is output to standard out.
+Many Jenkins native packages modify this behavior to ensure logging information is output in a more conventional location for the platform.
 
 === Linux (rpm and deb)
 
 By default logs can be viewed by running `journalctl -u jenkins.service`.
 
-To customize the log location,
-run `systemctl edit jenkins` and add the following:
+To customize the log location, run `systemctl edit jenkins` and add the following:
 
 [source]
 ----
@@ -35,7 +32,7 @@ Environment="JENKINS_LOG=%L/jenkins/jenkins.log"
 
 === Windows (msi)
 
-By default logs should be at `%JENKINS_HOME%/jenkins.out` and `%JENKINS_HOME%/jenkins.err`, unless customized in `%JENKINS_HOME%/jenkins.xml`
+By default, logs should be at `%JENKINS_HOME%/jenkins.out` and `%JENKINS_HOME%/jenkins.err`, unless customized in `%JENKINS_HOME%/jenkins.xml`.
 
 === macOS
 
@@ -46,15 +43,14 @@ Log files should be at `+/var/log/jenkins/jenkins.log+`, unless customized in `o
 When Jenkins is started from a command line with `+java -jar jenkins.war+`, the log file will be written to the `+JENKINS_HOME+` directory.
 If no value is assigned to the `+JENKINS_HOME+` environment variable, the log file will be written to the `+.jenkins/log+` directory.
 
-
 === Docker
 
 If you run Jenkins inside Docker as a detached container, you can use `docker logs <containerId>` to view the Jenkins logs.
 
 == Logs in Jenkins
 
-Jenkins uses `java.util.logging` for logging. The `java.util.logging` system by
-default sends every log above `INFO` to stdout.
+Jenkins uses `java.util.logging` for logging.
+The `java.util.logging` system by default sends every log above `INFO` to stdout.
 
 Jenkins is equipped with a GUI for configuring/collecting/reporting log records of your choosing. 
 This page shows you how to do this.
@@ -63,8 +59,7 @@ First, select the "System Log" from the "Manage Jenkins" page:
 
 image::logging-manage-screen.png["Manage Jenkins"]
 
-From there, you can create a custom log recorder, which helps you group
-relevant logs together while filtering out the noise.
+From there, you can create a custom log recorder, which helps you group relevant logs together while filtering out the noise.
 
 image::logging-log-recorders.png["Log Recorders"]
 
@@ -72,38 +67,35 @@ Choose a name that makes sense to you.
 
 image::logging-enter-name.png["Enter log recorder name"]
 
-You'll be then asked to configure loggers and their levels whose output
-you'd like to collect. Depending on which part of Jenkins you monitor,
-you'll need to specify different loggers. Tell us the symptom of your
-problem in the users list and we should be able to tell you where you
-need to look. Also, this is really just a wrapper around the
-java.util.logging package, so if you program in Java, you might be able
-to guess where to look.
+You'll be then asked to configure loggers and their levels whose output you'd like to collect.
+Depending on which part of Jenkins you monitor, you'll need to specify different loggers.
+Tell us the symptom of your problem in the users list and we should be able to tell you where you need to look.
+Also, this is really just a wrapper around the java.util.logging package, so if you program in Java, you might be able to guess where to look.
 
 image::logging-logger-config.png["Specify loggers"]
 
-Once the set up is complete, Jenkins will start collecting data. The
-collected logs are available from the web UI.
+Once the set up is complete, Jenkins will start collecting data.
+The collected logs are available from the web UI.
 
 == Making custom logs available outside of the web UI
 
-The simplest solution is to install the link:https://plugins.jenkins.io/support-core[Support Core Plugin], 
-which causes custom logs to be written to disk automatically.
+The simplest solution is to install the link:https://plugins.jenkins.io/support-core[Support Core Plugin], which causes custom logs to be written to disk automatically.
 
 == Debug logging in Jenkins
 
-1. Create a file `logging.properties`
-2. Define the logging levels and a `ConsoleHandler`
-3. Pass this file to the JVM by adding the system property `-Djava.util.logging.config.file=<pathTo>/logging.properties`.
+1. Create a file `logging.properties`
+2. Define the logging levels and a `ConsoleHandler`
+3. Pass this file to the JVM by adding the system property `-Djava.util.logging.config.file=<pathTo>/logging.properties`.
 
 An example *logging.properties* is included below.
-Note that for a normal production environment the default level is INFO, it is not advised to have debug log in production.
+
+NOTE: For a normal production environment the default level is INFO, it is not advised to have debug log in production.
 
 [source]
 ----
 handlers = java.util.logging.ConsoleHandler
 
-# see https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/SimpleFormatter.html
+# see https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/SimpleFormatter.html
 java.util.logging.SimpleFormatter.format = [%1$tF %1$tT][%4$-6s][%2$s] %5$s %6$s %n
 
 # Keep this level to ALL or FINEST or it will be filtered before applying other levels


### PR DESCRIPTION
This PR is to update the link used in the code block at the bottom of the page, as it is currently using Java 11. It has been updated to use 17 and the updated link has been tested and verified.

Additionally some updates to formatting and syntax.