### PR TITLE
Jenkins.io - updating "Using Agents" for Java 17

### DIFF
--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -148,7 +148,7 @@ Here we will use the link:https://github.com/jenkinsci/docker-ssh-agent[docker-s
 ----
 docker run -d --rm --name=agent1 --network jenkins -p 22:22 `
   -e "JENKINS_AGENT_SSH_PUBKEY=[your-public-key]" `
-  jenkins/ssh-agent:jdk11
+  jenkins/ssh-agent:jdk17
 ----
 +
 [NOTE]


### PR DESCRIPTION
This PR is to update the usage of Java 11 on the "[Using Agents](https://www.jenkins.io/doc/book/using/using-agents/)" documentation.

In the Windows code example pt 1, it is using `jenkins/ssh-agent:jdk11`, so it has been updated to `jenkins/ssh-agent:jdk17`.

This is the only updated needed in the page from what I have reviewed.