### PR TITLE
Jenkins.io - Update "Managing systemd services" to use java17

### DIFF
--- a/content/doc/book/system-administration/systemd-services.adoc
+++ b/content/doc/book/system-administration/systemd-services.adoc
@@ -87,7 +87,7 @@ Environment="JAVA_OPTS=-Djava.awt.headless=true -XX:+UseStringDeduplication"
 
 # Arbitrary additional arguments to pass to Jenkins.
 # Full option list: java -jar jenkins.war --help
-Environment="JENKINS_OPTS=--prefix=/jenkins --javaHome=/opt/jdk-11"
+Environment="JENKINS_OPTS=--prefix=/jenkins --javaHome=/opt/jdk-17"
 
 # Configuration as code directory
 Environment="CASC_JENKINS_CONFIG=/var/lib/jenkins/configuration-as-code/"


### PR DESCRIPTION
This PR is to update the "Managing systemd services page" so that it is using Java 17, to be in line with the rest of the Jenkins documentation.

The only mention that I found on this page, is in the ["Overriding service configurations"](https://www.jenkins.io/doc/book/system-administration/systemd-services/#overriding-service-configurations) section where jdk-11 is used.

This has been updated to jdk-17 accordingly.