### PR TITLE
Jenkins.io - Update "Architecting for Manageability" with Java17

### DIFF
--- a/content/doc/book/scaling/architecting-for-manageability.adoc
+++ b/content/doc/book/scaling/architecting-for-manageability.adoc
@@ -163,7 +163,7 @@ control our _$JENKINS_HOME_ in a Github repository known as "demo-joc". The
 
 [source,bash]
 ----
-FROM eclipse-temurin:11-jdk-jammy
+FROM eclipse-temurin:17-jdk-jammy
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/content/doc/book/system-administration/systemd-services.adoc
+++ b/content/doc/book/system-administration/systemd-services.adoc
@@ -87,7 +87,7 @@ Environment="JAVA_OPTS=-Djava.awt.headless=true -XX:+UseStringDeduplication"
 
 # Arbitrary additional arguments to pass to Jenkins.
 # Full option list: java -jar jenkins.war --help
-Environment="JENKINS_OPTS=--prefix=/jenkins --javaHome=/opt/jdk-11"
+Environment="JENKINS_OPTS=--prefix=/jenkins --javaHome=/opt/jdk-17"
 
 # Configuration as code directory
 Environment="CASC_JENKINS_CONFIG=/var/lib/jenkins/configuration-as-code/"


### PR DESCRIPTION
This PR is to update the "Architecting for Manageability" page with a Java 17 supported image.

In the [configuring a test instance section ](https://www.jenkins.io/doc/book/scaling/architecting-for-manageability/#setting-up-a-test-instance), the current example uses eclipse-temurin:11-jdk-jammy.

I have updated this to use eclipse-temurin:17-jdk-jammy instead, to align with the transition to using Java 17. There are other versions such as [17.0.3_7](https://hub.docker.com/layers/library/eclipse-temurin/17.0.3_7-jdk-jammy/images/sha256-f7b969d455abeefb9cad0280477e067d8340c22a081347a94c6fe22d0c67d420), but wasn't certain that it should be this over the base 17 version.