### PR TITLE
Fix typos in jenkins-button

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -20387,7 +20387,7 @@
           - timja
         pr_title: Use jenkins-button for Repeatable buttons
         message: |-
-          Use jenkinsbutton for repeatable buttons.
+          Use jenkins-button for repeatable buttons.
       - type: bug
         category: bug
         pull: 8082
@@ -20647,7 +20647,7 @@
         pr_title: Update appearance of buttons for password and secretTextarea matching
           'jenkins-button's
         message: |-
-          Update appearance of buttons for password and secretTextarea matching 'jenkinsbutton's.
+          Update appearance of buttons for password and secretTextarea matching 'jenkins-button's.
       - type: rfe
         category: rfe
         pull: 8186


### PR DESCRIPTION
It's named `jenkins-button`, actually.