### PR TITLE
Fix README, Awestruct points to website instead of Awestruct Git repo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://app.gitter.im/#/room/#jenkins/docs:matrix.org"]
 
 This repository powers the link:https://jenkins.io/[Jenkins website].
-This uses link:https://github.com/awestruct/awestruct[Awestruct]
+This uses link:https://awestruct.github.io/[Awestruct]
 with link:https://asciidoctor.org[Asciidoctor] under the hood to provide a very
 useful and compelling web presence for the link:https://jenkins.io/[Jenkins automation server].
 


### PR DESCRIPTION
The Awestruct link inside README was pointing to the Awestruct Repository page, now it points to the homepage as mentioned in the Awestruct README.