### PR TITLE
Revise brew installation

### DIFF
--- a/content/_partials/osx-brew-installer.html.haml
+++ b/content/_partials/osx-brew-installer.html.haml
@@ -21,11 +21,7 @@ Sample commands:
   %li
     = "Install the latest #{page.type} version:"
     %code
-      = "brew install #{page.tag}" 
-  %li
-    = "Install a specific #{page.type} version:"
-    %code
-      = "brew install #{page.tag}@YOUR_VERSION" 
+      = "brew install #{page.tag}"
   %li
     = "Start the Jenkins service:"
     %code

--- a/content/blog/2019/11/2019-11-25-macos-native-installer-deprecation.adoc
+++ b/content/blog/2019/11/2019-11-25-macos-native-installer-deprecation.adoc
@@ -65,7 +65,6 @@ We do not provide an official migration guide, but it is possible to find some g
 Sample commands:
 
 * Install the latest Weekly version: `brew install jenkins`
-* Install a specific Weekly version: `brew install jenkins@YOUR_VERSION`
 * Start the Jenkins service: `brew services start jenkins`
 * Restart the Jenkins service: `brew services restart jenkins`
 * Update the Jenkins version: `brew upgrade jenkins`


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/jenkins.io/issues/6540

The formula maintainers chose to support the latest version only, and don't maintain an archive of pinned versions, disallowing selective installations using the `@version` syntax.
If you want to use an outdated version, you'll have to package it yourself, modifying the homebrew formula.