### PR TITLE
Add reference to system property docs to CSP page

### DIFF
--- a/content/doc/book/security/configuring-content-security-policy.adoc
+++ b/content/doc/book/security/configuring-content-security-policy.adoc
@@ -61,7 +61,7 @@ If neither is true, and all users with the ability to change files in workspaces
 
 === Implementation
 
-The CSP header sent by Jenkins can be modified by setting the system property `hudson.model.DirectoryBrowserSupport.CSP`:
+The CSP header sent by Jenkins can be modified by link:/doc/book/managing/system-properties/[setting the Java system property] `hudson.model.DirectoryBrowserSupport.CSP`:
 
 If its value is the *empty string*, e.g. `java -Dhudson.model.DirectoryBrowserSupport.CSP= -jar jenkins.war` then the header will not be sent at all.
 


### PR DESCRIPTION
Seems to work fine on https://deploy-preview-6544--jenkins-io-site-pr.netlify.app/doc/book/security/configuring-content-security-policy/