### PR TITLE
Remove spinup.com as a sponsor

### DIFF
--- a/content/_data/indexpage/supporters.yml
+++ b/content/_data/indexpage/supporters.yml
@@ -37,8 +37,6 @@
   url: https://pagerduty.com
 - name: Sentry
   url: https://sentry.io
-- name: SpinUp
-  url: https://spinup.com/
 - name: Tsinghua University
   url: https://www.tsinghua.edu.cn
 - name: XMission


### PR DESCRIPTION
## Remove spinup.com as a sponsor

No response from the https://spinup.com/ URL that is linked for this sponsor.

No mention of spinup.com in any of the meeting notes that I searched.

Not in https://github.com/jenkins-infra/governance-meetings-archives governance meeting archive.

Not in https://github.com/jenkins-infra/docker-confluence-data wiki data.

Not in https://github.com/jenkins-infra/helpdesk help desk tickets.

https://www.prnewswire.com/news-releases/introducing-spinup-a-simple-cloud-that-grows-with-you-301004549.html announced their existence and @olblak added them as a sponsor in April 2020

https://www.prnewswire.com/news-releases/spinup-commits-20-million-in-hosting-capacity-for-remote-learning-amid-covid-19-outbreak-301026950.html was another press release from them.
