### PR TITLE
Fixing “JEP 229” link

### DIFF
--- a/content/_data/upgrades/2-375-1.adoc
+++ b/content/_data/upgrades/2-375-1.adoc
@@ -11,7 +11,7 @@ Support for OpenSSL-style PEM-encoded RSA private keys has been removed when run
 Specifically, the `--httpsPrivateKey` and `--httpsCertificate` flags have been removed in favor of the `--httpsKeyStore` flag.
 The removed flags have printed deprecation warnings since 2016 and were implemented with non-standard APIs that have since been removed from Java 17. +
 The recommendation is to migrate to the `--httpsKeyStore` option, which takes a keystore as described in the documentation. +
-As of link:https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc[JEP 229], PKCS12 is the recommended keystore type.
+As of link:https://openjdk.org/jeps/229[JEP 229], link:https://en.wikipedia.org/wiki/PKCS_12[PKCS12] is the recommended keystore type.
 
 Additionally, the `--toolsJar` and `--useJasper` flags have been removed, because they no longer serve a purpose with Java 11 or newer. +
 `--ajp13Port` and `--ajp13ListenAddress` have been removed, they are obsolete since Jetty 9, which has been released 6 years ago. +


### PR DESCRIPTION
#5370 got this right, but somehow #5721 mangled it. Unfortunately both OpenJDK and Jenkins use the _JEP_ acronym, leading to this sort of confusion. CC @kmartens27 