### PR TITLE
Document how to create a poll in CIVS

### DIFF
--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -50,7 +50,8 @@ The election committee is responsible for preparing and running the election pro
 
 ==== Discourse
 
-The election committee creates the `election-voter-20XX` group in the link:https://community.jenkins.io/[Jenkins community forum]. As template, the group from the past year can be used, to set permissions and the group profile.
+The election committee creates the `election-voter-20XX` group in the link:https://community.jenkins.io/[Jenkins community forum].
+As template, the group from the past year can be used, to set permissions and the group profile.
 
 The election committee from the previous year adds the new election committee members to the link:https://community.jenkins.io/g/election-committee[election-committee] as group owner, and removes themselves from the group.
 
@@ -64,13 +65,16 @@ The group's email address is used to create and manage the poll(s) in CIVS.
 Include the officer role in the poll name, if there is more than one candidate for the role, like `Jenkins Election 20XX - Infrastructure Officer`.
 Otherwise, omit the part after the year, if there is not more than one candidate for an office and the role is a position on the board.
 
-The name of the supervisor includes both names of the election committee members, like `John Doe and Jane Doe`. This information is shown publicly to voters and used in emails.
+The name of the supervisor includes both names of the election committee members, like `John Doe and Jane Doe`.
+This information is shown publicly to voters and used in emails.
 
 The description of the poll contains a link to the election announcement page, listing all candidates and their statements for the annual election.
 
-The names of candidates are entered in alphabetical order. Tick `Present choices on voting page in exactly the given order.` at the bottom of the poll to preserve the order.
+The names of candidates are entered in alphabetical order.
+Tick `Present choices on voting page in exactly the given order.` at the bottom of the poll to preserve the order.
 
-The radio button `Private` is selected. The list of email addresses of eligible voters from the `election-voter-20XX` discourse group is supplied in the next step, after poll creation and activation.
+The radio button `Private` is selected.
+The list of email addresses of eligible voters from the `election-voter-20XX` discourse group is supplied in the next step, after poll creation and activation.
 
 === Nominations
 

--- a/content/project/board-election-process.adoc
+++ b/content/project/board-election-process.adoc
@@ -2,8 +2,6 @@
 layout: simplepage
 title: "Board and Officer election process"
 section: project
-opengraph:
-  image: /images/governance/elections/2020/opengraph.png
 description: >
   This page describes the election process for Jenkins Governance Board and Officer roles.
 ---
@@ -25,38 +23,6 @@ A board comprised fully of write-in candidates runs the risk of being overweighe
 . Make sure that the board reflects the balance of different viewpoints and needs of users, committers, organizations of any size, and commercial interests.
 . Maintain stability and avoid sudden direction changes.
 
-== 2021 Elections
-
-NOTE: Jenkins 2021 Elections are over, thanks to all participants!
-Please see the link:/blog/2021/12/03/election-results[results announcement].
-
-During the 2021 elections, we elected two governing board members and five officers, namely:
-link:/project/team-leads/#security[Security], link:/project/team-leads/#events[Events], link:/project/team-leads/#release[Release], link:/project/team-leads/#infrastructure[Infrastructure], and link:/project/team-leads/#documentation[Documentation].
-The terms of office for these elected positions are:
-
-* Officer positions (one year): December 03, 2021 to December 2, 2022
-* Governing board member (two years): December 03, 2021 to December 2, 2023
-
-=== References
-
-* link:/blog/2021/12/03/election-results[Election results]
-* link:/blog/2021/10/25/jenkins-elections/[Voter registration]
-* link:/blog/2021/09/20/election-period-opened/[Election announcement]
-
-=== Key dates
-
-* *October 20* - Nominations open
-* *October 20* - Voting registration begins
-** During the registration period, the election committee will monitor the sign-ups and update the list of voters.
-* *November 10* - Nominations deadline
-** After the deadline, the election committee will process nominations and notify the candidates.
-* *November 17* - Voting registration is closed
-* *November 17* - Election candidates and personal statements published
-* *November 17* - Voting begins
-** Email is distributed to all registered voters through link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
-* *December 02* - Voting ends, 11PM UTC
-* *December 07* - Results are announced
-
 === Elections Committee
 
 The elections are coordinated by the Jenkins Governance Board members who are not up for re-election this year.
@@ -76,7 +42,35 @@ If link:/blog/authors/kohsuke[Kohsuke] decides to resign, all five members will 
 The board will meet in private to select final candidates
 * The number of elected board members affiliated with one company must be 50% or less.
 * If a board member gets employed by a company and the limitation gets violated, somebody must step down and the board will follow the link:/project/board-election-process/#interim-procedures[#Interim Procedures]
-. Use the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service] as the method to elect multiple people in one vote.
+. Use the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service (CIVS)] as the method to elect multiple people in one vote.
+
+=== Preparation
+
+The election committee is responsible for preparing and running the election process. This includes various preparation steps within the CIVS and discourse.
+
+==== Discourse
+
+The election committee creates the `election-voter-20XX` group in the link:https://community.jenkins.io/[Jenkins community forum]. As template, the group from the past year can be used, to set permissions and the group profile.
+
+The election committee from the previous year adds the new election committee members to the link:https://community.jenkins.io/g/election-committee[election-committee] as group owner, and removes themselves from the group.
+
+==== CIVS
+
+The poll is created using a designated email address, all election committee members have access to.
+The election committee from the previous year adds the new election committee members to link:https://groups.google.com/g/jenkinsci-elections[the Google group] as group manager, and removes themselves from the group afterwards.
+
+The group's email address is used to create and manage the poll(s) in CIVS.
+
+Include the officer role in the poll name, if there is more than one candidate for the role, like `Jenkins Election 20XX - Infrastructure Officer`.
+Otherwise, omit the part after the year, if there is not more than one candidate for an office and the role is a position on the board.
+
+The name of the supervisor includes both names of the election committee members, like `John Doe and Jane Doe`. This information is shown publicly to voters and used in emails.
+
+The description of the poll contains a link to the election announcement page, listing all candidates and their statements for the annual election.
+
+The names of candidates are entered in alphabetical order. Tick `Present choices on voting page in exactly the given order.` at the bottom of the poll to preserve the order.
+
+The radio button `Private` is selected. The list of email addresses of eligible voters from the `election-voter-20XX` discourse group is supplied in the next step, after poll creation and activation.
 
 === Nominations
 
@@ -97,21 +91,24 @@ This information is published by the election committee before the voting starts
 Any Jenkins project and/or community contributor is eligible to vote in the election if there is a contribution made before September 01 of the election year.
 Contributing does not only mean a _code contribution_, as link:/participate[contributions] could be:
 
-* Documentation updates or creation
-* Code reviews
-* Issue reporting
-* Translating resources
-* Connecting with or assisting the community
-* Code testing
+* link:/participate/connect/[Connecting with the community]
+* link:/participate/meet/[Joining or organizing a meetup]
+* link:/participate/code/[Contributing code to Jenkins]
+* link:/participate/help/[Helping Jenkins users]
+* link:/doc/developer/internationalization/[Translating Jenkins resources]
+* link:/participate/test/[Testing Jenkins core and plugins]
+* link:/participate/document/[Contributing to Jenkins documentation]
+* link:/participate/design/[Creating art or updating the Jenkins UI]
+* link:/participate/review-changes/[Reviewing open pull requests]
+* link:/donate/[Donating to Jenkins]
 
 As long as you are contributing to the Jenkins project or community, you are eligible to register for voting. 
 
 Voter registration is announced through the Jenkins mailing lists, blog, and social media accounts.
-Users can register to vote in the election by joining the link:https://community.jenkins.io/g/election-voter-2022[2022 election voter group].
-Previous elections utilized their own groups, so joining the link:https://community.jenkins.io/g/election-voter-2022[2022 group] is required for participation.
+Users can register to vote in the election by joining the annual election voting group.
 
 To register, you must have an account on link:https://community.jenkins.io[community.jenkins.io].
-You can use your existing Github account, or create a new account specifically for link:https://community.jenkins.io[Jenkins community discussion].
+You can use your existing GitHub account, or create a new account specifically for link:https://community.jenkins.io[Jenkins community discussion].
 
 Once voter registration is over, the election committee will process the form submissions and prepare a list of the registered voters.
 In the case of rejection, one of the election committee members will send a rejection email.
@@ -120,7 +117,7 @@ In the case of rejection, one of the election committee members will send a reje
 
 Voting happens through the link:https://civs.cs.cornell.edu/[Condorcet Internet Voting Service].
 Once the voting period begins, all voters will receive a notification to the email used for your link:https://community.jenkins.io[Jenkins community account].
-There will be separate emails for each role (board members and each officer) with more than 1 candidate.
+There will be separate emails and polls for each role (board members and each officer) with more than 1 candidate.
 If you have not received an email within 24 hours from the voting start date, please contact the link:https://community.jenkins.io/g/election-committee[Jenkins Election Committee].
 Every contributor can vote only once, and multiple intentional votes will be considered a violation and serious misbehavior, subject to the link:/conduct[Jenkins Code of Conduct].
 
@@ -141,6 +138,13 @@ The transition process is to be defined by former and newly elected contributors
 with an expectation that the transition concludes within one month after the results announcement.
 
 The election committee is responsible to hold a retrospective for the elections and to make the results of it public.
+
+=== Publicity
+
+The election committee is encouraged to post about phase changes (nomination phase, voting phase, etc.) on the Jenkins blog and social media accounts.
+The LinkedIn and Twitter posts from the past years can be used as a template.
+
+Additionally, posts on the mailing lists (jenkinsci-dev, jenkinsci-users), link:https://community.jenkins.io/[community forums], and places seen by many people, such as link:https://github.com/jenkinsci/.github/tree/master/profile[GitHub organization profiles], are encouraged
 
 == Interim Procedures
 
@@ -175,6 +179,9 @@ At the same time, we wanted to preserve stability by limiting voting rights to o
 
 == Previous elections
 
+* 2022 - link:/blog/2022/10/20/jenkins-election-announcement/[announcement]
+** No results available. The candidates up for election have been selected without a vote, as there was only one candidate per seat and role.
+
 * 2021 - link:/blog/2021/12/03/election-results[results], link:/blog/2021/09/20/election-period-opened[announcement]
 
 * 2020 -
@@ -184,6 +191,12 @@ link:/blog/2020/12/03/election-results[results], link:/blog/2020/10/28/election-
 link:/blog/2019/12/16/board-election-results/[results], link:/blog/2019/09/25/board-elections/[announcement], link:https://docs.google.com/document/d/1Htgjq2Gnojz6a-FE62kgjIq6AVR8ctPcARbd-m2KctQ/edit?usp=sharing[retrospective], link:https://groups.google.com/forum/#!msg/jenkinsci-dev/vKi9JpxTQxY/2KgDsKUeAQAJ[dev list discussion]
 
 == Change History
+
+=== 2023-07-25
+
+* Outline how to create a poll in CIVS.
+* Document how to create an election group in Discourse.
+* Add a link to the elections from 2022.
 
 === 2020-09-24
 


### PR DESCRIPTION
The change proposed documents how to create a poll in CIVS and how to create a discourse group.

Additionally, it adds the results to the 2022 election and makes contributions clickable.

I chose to remove the dates from the 2021 election without replacement, to reference this document in every year's election announcement, without the need to duplicate data.