### PR TITLE
Add Pomerium reverse proxy guide

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_section.yml
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_section.yml
@@ -3,6 +3,7 @@ subsections:
   - reverse-proxy-configuration-apache
   - reverse-proxy-configuration-nginx
   - reverse-proxy-configuration-haproxy
+  - reverse-proxy-configuration-pomerium
   - reverse-proxy-configuration-squid
   - reverse-proxy-configuration-iis
   - reverse-proxy-configuration-iptables

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/index.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/index.adoc
@@ -82,6 +82,7 @@ This section provides examples for specific reverse proxies, though much of the 
 * link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-apache[Running Jenkins with Apache]
 * link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx[Running Jenkins with Nginx]
 * link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-haproxy[Running Jenkins with HAProxy]
+* link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium[Running Jenkins with Pomerium]
 * link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-squid[Running Jenkins with Squid]
 * link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iis[Running Jenkins with IIS]
 * link:../reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables[Running Jenkins with iptables]

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
@@ -14,16 +14,16 @@ endif::[]
 
 = Reverse proxy - Pomerium
 
-You can secure your Jenkins application with JWT authentication and custom claims behind link:https://pomerium.com[Pomerium proxy]. 
+You can secure your Jenkins application with JWT authentication and custom claims behind link:https://pomerium.com[Pomerium proxy].
 
 = Why use Pomerium with Jenkins?
 
-You can set up role-based permissions in Jenkins to control a user’s privileges with Jenkins’ built-in authorization matrix. 
+You can set up role-based permissions in Jenkins to control a user’s privileges with Jenkins’ built-in authorization matrix.
 However, this method requires a username and password to sign in and relies on Jenkins’ user database to store credentials.
 
 JWT authentication is a more secure method of identity verification that authenticates and authorizes users against an identity provider, eliminating the need to store or share credentials to access your Jenkins application.
 
-However, Jenkins doesn’t support JWT authentication out of the box. 
+However, Jenkins doesn’t support JWT authentication out of the box.
 With Pomerium, you can implement JWT authentication and apply claims to your route’s authorization policy to determine a user’s role and privileges before granting a user access to Jenkins.
 
 Once you’ve configured JWT authentication, you can assign permissions within Jenkins for a specific user, any authenticated user, anonymous users, or a user group.
@@ -31,5 +31,3 @@ Once you’ve configured JWT authentication, you can assign permissions within J
 == Secure Jenkins with Pomerium proxy
 
 Please refer to Pomerium's link:https://www.pomerium.com/docs/guides/jenkins[guide on securing Jenkins].
-
-

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
@@ -1,0 +1,35 @@
+---
+layout: subsection
+---
+
+ifdef::backend-html5[]
+ifndef::env-github[:imagesdir: ../../../resources/managing]
+:notitle:
+:description:
+:author:
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+endif::[]
+
+= Reverse proxy - Pomerium
+
+You can secure your Jenkins application with JWT authentication and custom claims behind link:https://pomerium.com[Pomerium proxy]. 
+
+= Why use Pomerium with Jenkins?
+
+You can set up role-based permissions in Jenkins to control a user’s privileges with Jenkins’ built-in authorization matrix. 
+However, this method requires a username and password to sign in and relies on Jenkins’ user database to store credentials.
+
+JWT authentication is a more secure method of identity verification that authenticates and authorizes users against an identity provider, eliminating the need to store or share credentials to access your Jenkins application.
+
+However, Jenkins doesn’t support JWT authentication out of the box. 
+With Pomerium, you can implement JWT authentication and apply claims to your route’s authorization policy to determine a user’s role and privileges before granting a user access to Jenkins.
+
+Once you’ve configured JWT authentication, you can assign permissions within Jenkins for a specific user, any authenticated user, anonymous users, or a user group.
+
+== Secure Jenkins with Pomerium proxy
+
+Please refer to Pomerium's link:https://www.pomerium.com/docs/guides/jenkins[guide on securing Jenkins].
+
+

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 You can secure your Jenkins application with JWT authentication and custom claims behind link:https://pomerium.com[Pomerium proxy].
 
-= Why use Pomerium with Jenkins?
+== Why use Pomerium with Jenkins?
 
 You can set up role-based permissions in Jenkins to control a user’s privileges with Jenkins’ built-in authorization matrix.
 However, this method requires a username and password to sign in and relies on Jenkins’ user database to store credentials.


### PR DESCRIPTION
Adding a link to Pomerium proxy's guide on securing Jenkins. Let me know if the guide should be fully imported instead and I will make further changes, but this will eventually result in two guides needing updates.