### PR TITLE
fix(updatecli): No more blog nor `.node-version` update 

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -44,14 +44,6 @@ conditions:
       file: content/doc/tutorials/build-a-java-app-with-maven.adoc
       matchpattern: >-
         .*image.*maven:.*
-  testMavenSimplePullRequestPlugin:
-    name: "Does the 'Pipeline as YAML' tutorial have a reference to the Maven alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
-      matchpattern: >-
-        .*dockerImage:.*maven:.*
   testMavenDockerTutorial:
     name: "Does the 'Pipeline as YAML' tutorial have a reference to the Maven alpine image?"
     kind: file
@@ -118,28 +110,6 @@ targets:
       file: content/doc/tutorials/build-a-java-app-with-maven.adoc
       matchpattern: >-
         (https.*\`)maven:(.*)(\`.*)
-      replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
-    scmid: default
-  updatePipelineAsYAML:
-    name: "Update the value of the maven docker image for scripts in the 'Pipeline as YAML' tutorial"
-    kind: file
-    sourceid: mavenLatestVersion
-    spec:
-      file: content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
-      matchpattern: >-
-        (.*dockerImage: +)maven:(.*)(.*)
-      replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
-    scmid: default
-  updatePipelineAsYAMLPipeline:
-    name: "Update the value of the maven docker image for scripts in the 'Pipeline as YAML' tutorial"
-    kind: file
-    sourceid: mavenLatestVersion
-    spec:
-      file: content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
-      matchpattern: >-
-        (.*image.*\')maven:(.*)(\'.*)
       replacepattern: >-
         ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
     scmid: default

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -197,17 +197,6 @@ targets:
       replacepattern: >-
         ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
-  updateNodeVersion:
-    name: "Update the value of the node version in .nodeversion"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: .node-version
-      matchpattern: >-
-        .*
-      replacepattern: >-
-        {{ source "nodeLatestVersion" }}
-    scmid: default
 actions:
   default:
     kind: github/pullrequest


### PR DESCRIPTION
Apologies for the first generated PR by updatecli (#6577 and #6576).
The errors were only my fault, not the tool's fault.