### PR TITLE
Add an example how to test shared pipeline library changes

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,7 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your pipeline library is hosted on GitHub.  
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your pipeline library is hosted on GitHub. +
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, BitBucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,7 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub. +
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub. +
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, Bitbucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,7 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub and the SCM configuration for the pipeline library uses GitHub. +
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of a library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub and the SCM configuration for the pipeline library uses GitHub. +
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, Bitbucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which has its source code stored at https://github.com/jenkins-infra/pipeline-library/.

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -706,7 +706,7 @@ execute a second one, your build will fail as a result.
 By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub. +
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, Bitbucket, Gitea, GitLab, and Tuleap.
 
-Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.
+Take, for example, a change to the global ci.jenkins.io shared pipeline, which has its source code stored at https://github.com/jenkins-infra/pipeline-library/.
 
 Let's say you're writing a new feature and opened a pull request on the pipeline library, number `123`.
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -700,3 +700,28 @@ Only entire ``pipeline``s can be defined in shared libraries as of this time.
 This can only be done in `vars/*.groovy`, and only in a `call` method. Only one
 Declarative Pipeline can be executed in a single build, and if you attempt to
 execute a second one, your build will fail as a result.
+
+=== Testing library pull request changes
+
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_.
+
+Taking for example a change to the global ci.jenkins.io shared pipeline which source code is stored at https://github.com/jenkins-infra/pipeline-library/.
+
+Let's say you're writing a new functionality and opened a pull request on the pipeline library, number `123`.
+
+By opening a pull request on https://github.com/jenkins-infra/jenkins-infra-test-plugin/[the dedicated `jenkins-infra-test-plugin` test repository] with the following content, you'll be able to check your changes on ci.jenkins.io:
+
+[source,diff]
+----
+--- jenkins-infra-test-plugin/Jenkinsfile
++++ jenkins-infra-test-plugin/Jenkinsfile
+@@ -1,3 +1,4 @@
++ @Library('pipeline-library@pull/123/head') _
+  buildPlugin(
+    useContainerAgent: true,
+    configurations: [
+      [platform: 'linux', jdk: 17],
+      [platform: 'windows', jdk: 11],
+  ])
+----
+

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,7 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your Pipeline library is hosted on GitHub.
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your pipeline library is hosted on GitHub.  
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, BitBucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -708,7 +708,7 @@ Refer to the pull request or merge request branch naming convention for other pr
 
 Taking for example a change to the global ci.jenkins.io shared pipeline which source code is stored at https://github.com/jenkins-infra/pipeline-library/.
 
-Let's say you're writing a new functionality and opened a pull request on the pipeline library, number `123`.
+Let's say you're writing a new feature and opened a pull request on the pipeline library, number `123`.
 
 By opening a pull request on https://github.com/jenkins-infra/jenkins-infra-test-plugin/[the dedicated `jenkins-infra-test-plugin` test repository] with the following content, you'll be able to check your changes on ci.jenkins.io:
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -706,7 +706,7 @@ execute a second one, your build will fail as a result.
 By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your Pipeline library is hosted on GitHub.
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, BitBucket, Gitea, GitLab, and Tuleap.
 
-Taking for example a change to the global ci.jenkins.io shared pipeline which source code is stored at https://github.com/jenkins-infra/pipeline-library/.
+Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.
 
 Let's say you're writing a new feature and opened a pull request on the pipeline library, number `123`.
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,7 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub. +
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub and the SCM configuration for the pipeline library uses GitHub. +
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, Bitbucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which has its source code stored at https://github.com/jenkins-infra/pipeline-library/.

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,7 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your pipeline library is hosted on GitHub. +
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes __in situ__ if your pipeline library is hosted on GitHub. +
 Refer to the pull request or merge request branch naming convention for other providers like Assembla, Bitbucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -710,7 +710,7 @@ Take, for example, a change to the global ci.jenkins.io shared pipeline, which h
 
 Let's say you're writing a new feature and opened a pull request on the pipeline library, number `123`.
 
-By opening a pull request on https://github.com/jenkins-infra/jenkins-infra-test-plugin/[the dedicated `jenkins-infra-test-plugin` test repository] with the following content, you'll be able to check your changes on ci.jenkins.io:
+By opening a pull request on https://github.com/jenkinsci/jenkins-infra-test-plugin/[the dedicated `jenkins-infra-test-plugin` test repository] with the following content, you'll be able to check your changes on ci.jenkins.io:
 
 [source,diff]
 ----

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -704,7 +704,7 @@ execute a second one, your build will fail as a result.
 === Testing library pull request changes
 
 By adding `@Library('my-shared-library@pull/<your-pr-number>/head') \_` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your pipeline library is hosted on GitHub. +
-Refer to the pull request or merge request branch naming convention for other providers like Assembla, BitBucket, Gitea, GitLab, and Tuleap.
+Refer to the pull request or merge request branch naming convention for other providers like Assembla, Bitbucket, Gitea, GitLab, and Tuleap.
 
 Take, for example, a change to the global ci.jenkins.io shared pipeline, which stores its source code at https://github.com/jenkins-infra/pipeline-library/.
 

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -703,7 +703,8 @@ execute a second one, your build will fail as a result.
 
 === Testing library pull request changes
 
-By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_.
+By adding `@Library('my-shared-library@pull/<your-pr-number>/head') _` at the top of the library consumer Jenkinsfile, you can test your pipeline library pull request changes _in situ_ if your Pipeline library is hosted on GitHub.
+Refer to the pull request or merge request branch naming convention for other providers like Assembla, BitBucket, Gitea, GitLab, and Tuleap.
 
 Taking for example a change to the global ci.jenkins.io shared pipeline which source code is stored at https://github.com/jenkins-infra/pipeline-library/.
 


### PR DESCRIPTION
This PR adds an explicit example how to test in situ a shared pipeline library change.

Follow-up of https://github.com/jenkins-infra/pipeline-library/pull/718