### PR TITLE
feature(updatecli): Updates `nodejs` to the latest `LTS` version

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -44,14 +44,6 @@ conditions:
       file: content/doc/tutorials/build-a-java-app-with-maven.adoc
       matchpattern: >-
         .*image.*maven:.*
-  testMavenSimplePullRequestPlugin:
-    name: "Does the 'Pipeline as YAML' tutorial have a reference to the Maven alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
-      matchpattern: >-
-        .*dockerImage:.*maven:.*
   testMavenDockerTutorial:
     name: "Does the 'Pipeline as YAML' tutorial have a reference to the Maven alpine image?"
     kind: file
@@ -118,28 +110,6 @@ targets:
       file: content/doc/tutorials/build-a-java-app-with-maven.adoc
       matchpattern: >-
         (https.*\`)maven:(.*)(\`.*)
-      replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
-    scmid: default
-  updatePipelineAsYAML:
-    name: "Update the value of the maven docker image for scripts in the 'Pipeline as YAML' tutorial"
-    kind: file
-    sourceid: mavenLatestVersion
-    spec:
-      file: content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
-      matchpattern: >-
-        (.*dockerImage: +)maven:(.*)(.*)
-      replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
-    scmid: default
-  updatePipelineAsYAMLPipeline:
-    name: "Update the value of the maven docker image for scripts in the 'Pipeline as YAML' tutorial"
-    kind: file
-    sourceid: mavenLatestVersion
-    spec:
-      file: content/blog/2018/06/2018-06-15-simple-pull-request-plugin.adoc
-      matchpattern: >-
-        (.*image.*\')maven:(.*)(\'.*)
       replacepattern: >-
         ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
     scmid: default

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -23,6 +23,15 @@ sources:
       username: "{{ .github.username }}"
     transformers:
       - trimprefix: "v"
+  nodeLatestLTSVersionFromJson:
+    name: Get value from json
+    kind: json
+    spec:
+      file: https://nodejs.org/dist/index.json
+      key: .(lts!=false).version
+    transformers:
+      - trimprefix: "v"
+
   alpineLatestVersion:
     kind: githubrelease
     name: "Get the latest Alpine Linux version"
@@ -95,7 +104,7 @@ conditions:
     disablesourceinput: true
     spec:
       image: "node"
-      tag: '{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
+      tag: '{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}'
 
 targets:
   updateHelloWorldTutorialNodePipeline:
@@ -107,7 +116,7 @@ targets:
       matchpattern: >-
         (.*agent.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateHelloWorldTutorialNodeScripted:
     name: "Update the value of the node docker image for scripts in the 'Hello World!' tutorial"
@@ -118,7 +127,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateAgentsDocumentation:
     name: "Update the value of the node docker image in the 'Defining execution environments' documentation"
@@ -129,7 +138,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateStyleGuideDocumentation:
     name: "Update the value of the node docker image in the 'Jenkins Documentation Style Guide' documentation"
@@ -140,7 +149,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updatePipelineProjectCreationTutorial:
     name: "Update the value of the node docker image in the 'End-to-End Multibranch Pipeline Project Creation' tutorial"
@@ -151,7 +160,7 @@ targets:
       matchpattern: >-
         (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateBuildANodeJsAndReactAppWithNpmTutorial:
     name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
@@ -162,7 +171,7 @@ targets:
       matchpattern: >-
         (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateBuildANodeJsAndReactAppWithNpmDockerHubLinkTutorial:
     name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
@@ -173,7 +182,7 @@ targets:
       matchpattern: >-
         (https.*\`)node:(.*)(\`.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateUsingDockerWithPipelineDocumentation:
     name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
@@ -184,7 +193,7 @@ targets:
       matchpattern: >-
         (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateUsingDockerWithPipelineDocumentationDockerExample:
     name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
@@ -195,13 +204,13 @@ targets:
       matchpattern: >-
         (FROM )node:(.*)(.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: '[Tutorials and Agents Docs] Bump node alpine docker image version to {{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
+    title: '[Tutorials and Agents Docs] Bump node alpine docker image version to {{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}'
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -197,17 +197,6 @@ targets:
       replacepattern: >-
         ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
-  updateNodeVersion:
-    name: "Update the value of the node version in .nodeversion"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: .node-version
-      matchpattern: >-
-        .*
-      replacepattern: >-
-        {{ source "nodeLatestVersion" }}
-    scmid: default
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -14,15 +14,6 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  nodeLatestVersion:
-    kind: githubrelease
-    spec:
-      owner: "nodejs"
-      repository: "node"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-    transformers:
-      - trimprefix: "v"
   nodeLatestLTSVersionFromJson:
     name: Get value from json
     kind: json
@@ -32,6 +23,24 @@ sources:
     transformers:
       - trimprefix: "v"
 
+  # Using the githubrelease allows us to retrieve the changelog information
+  # It will fail if the version mentioned by appVersion does not have an equivalent published
+  # GitHub release
+  nodeLatestVersion:
+    kind: githubrelease
+    name: Get latest nodejs version
+    dependson:
+      - nodeLatestLTSVersionFromJson
+    spec:
+      owner: "nodejs"
+      repository: "node"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+        pattern: '{{ source "nodeLatestLTSVersionFromJson" }}'
+    transformers:
+      - trimprefix: "v"
   alpineLatestVersion:
     kind: githubrelease
     name: "Get the latest Alpine Linux version"
@@ -104,7 +113,7 @@ conditions:
     disablesourceinput: true
     spec:
       image: "node"
-      tag: '{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}'
+      tag: '{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
 
 targets:
   updateHelloWorldTutorialNodePipeline:
@@ -116,7 +125,7 @@ targets:
       matchpattern: >-
         (.*agent.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateHelloWorldTutorialNodeScripted:
     name: "Update the value of the node docker image for scripts in the 'Hello World!' tutorial"
@@ -127,7 +136,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateAgentsDocumentation:
     name: "Update the value of the node docker image in the 'Defining execution environments' documentation"
@@ -138,7 +147,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateStyleGuideDocumentation:
     name: "Update the value of the node docker image in the 'Jenkins Documentation Style Guide' documentation"
@@ -149,7 +158,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updatePipelineProjectCreationTutorial:
     name: "Update the value of the node docker image in the 'End-to-End Multibranch Pipeline Project Creation' tutorial"
@@ -160,7 +169,7 @@ targets:
       matchpattern: >-
         (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateBuildANodeJsAndReactAppWithNpmTutorial:
     name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
@@ -171,7 +180,7 @@ targets:
       matchpattern: >-
         (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateBuildANodeJsAndReactAppWithNpmDockerHubLinkTutorial:
     name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
@@ -182,7 +191,7 @@ targets:
       matchpattern: >-
         (https.*\`)node:(.*)(\`.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateUsingDockerWithPipelineDocumentation:
     name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
@@ -193,7 +202,7 @@ targets:
       matchpattern: >-
         (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
   updateUsingDockerWithPipelineDocumentationDockerExample:
     name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
@@ -204,13 +213,13 @@ targets:
       matchpattern: >-
         (FROM )node:(.*)(.*)
       replacepattern: >-
-        ${1}node:{{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}${3}
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: '[Tutorials and Agents Docs] Bump node LTS alpine docker image version to {{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}'
+    title: '[Tutorials and Agents Docs] Bump node LTS alpine docker image version to {{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -210,7 +210,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: '[Tutorials and Agents Docs] Bump node alpine docker image version to {{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}'
+    title: '[Tutorials and Agents Docs] Bump node LTS alpine docker image version to {{ source "nodeLatestLTSVersionFromJson" }}-alpine{{ source "alpineLatestVersion" }}'
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
[My previous PR](#6455) was updating `nodejs` to its latest version (current), which could represent way too much work for maintainers to test.
This PR fixes it by updating it to the latest `LTS`  version.
Please have a look at the [generated PR](https://github.com/gounthar/jenkins.io/pull/25) on my fork.