### PR TITLE
Jenkins.io - 2.417 changelog adding entry from packaging

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -20898,7 +20898,6 @@
           Make tab panes accessible via keyboard.
       - type: rfe
         category: rfe
-        pull: 409
         authors:
           - philfry
         pr_title: "RPM: Remove System V initialization script"

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -20898,6 +20898,17 @@
           Make tab panes accessible via keyboard.
       - type: rfe
         category: rfe
+        pull: 409
+        authors:
+          - philfry
+        pr_title: "RPM: Remove System V initialization script"
+        references:
+          - url: https://github.com/jenkinsci/packaging/pull/409
+            title: RPM Remove System V initialization script
+        message: |-
+          RPM users with a custom log directory no longer have a <code>logrotate(8)</code> configuration out-of-the-box.
+      - type: rfe
+        category: rfe
         pull: 8273
         issue: 71366
         authors:


### PR DESCRIPTION
Per @basil's message in https://github.com/jenkinsci/packaging/pull/409#issuecomment-1652321738, I am adding an entry to the 2.417 changelog to include the RPM/System V removal.

I have added the text as provided, and have set up the entry to be as accurate as possible, although the `pull: 409` may be unnecessary as the pull request is used for the reference link as well.