### PR TITLE
Explicitly note removal of System V init scripts

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -4472,7 +4472,7 @@
     references:
       - issue: 64212
       - url: "https://github.com/jenkinsci/packaging/pull/198"
-        title: pull 198
+        title: pull 198 (packaging)
     message: |-
       Fix Debian / Ubuntu Java version check for Java 11.0.9.1.
 
@@ -6987,7 +6987,7 @@
     references:
       - issue: 68170
       - url: https://github.com/jenkinsci/packaging/pull/306
-        title: pull 306
+        title: pull 306 (packaging)
     message: |-
       Show warning dialog if Java 8 is selected in Windows installer.
   - type: bug
@@ -7000,7 +7000,7 @@
     references:
       - issue: 68007
       - url: https://github.com/jenkinsci/packaging/pull/296
-        title: Packaging pull request 296
+        title: pull 296 (packaging)
     message: |-
       Prefer <code>--httpPort</code> from <code>JENKINS_ARGS</code> over <code>HTTP_PORT</code> when the two differ.
   - type: bug
@@ -7041,7 +7041,7 @@
     references:
       - issue: 68149
       - url: https://github.com/jenkinsci/packaging/pull/301
-        title: pull 301
+        title: pull 301 (packaging)
     message: |-
       Recover gracefully after incorrect merge of <code>/etc/sysconfig/jenkins</code> on Red Hat-based systems.
 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -20905,7 +20905,7 @@
           - url: https://github.com/jenkinsci/packaging/pull/409
             title: pull 409 (packaging)
           - url: https://www.jenkins.io/blog/2022/03/25/systemd-migration/
-            title: Linux install packages migrated from System V init to system
+            title: Linux install packages migrated from System V init to systemd
         message: |-
           Remove System V initialization scripts from RPM based installers.
           The System V initialization scripts were replaced in March 2022 with systemd initialization.

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -20903,8 +20903,12 @@
         pr_title: "RPM: Remove System V initialization script"
         references:
           - url: https://github.com/jenkinsci/packaging/pull/409
-            title: RPM Remove System V initialization script
+            title: pull 409 (packaging)
+          - url: https://www.jenkins.io/blog/2022/03/25/systemd-migration/
+            title: Linux install packages migrated from System V init to system
         message: |-
+          Remove System V initialization scripts from RPM based installers.
+          The System V initialization scripts were replaced in March 2022 with systemd initialization.
           RPM users with a custom log directory no longer have a <code>logrotate(8)</code> configuration out-of-the-box.
       - type: rfe
         category: rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -14181,7 +14181,7 @@
         references:
           - issue: 67724
           - url: https://github.com/jenkinsci/packaging/pull/278
-            title: pull 278
+            title: pull 278 (packaging)
         message: |-
           Allow Debian package to start when <code>JAVA_ARGS</code> contains spaces.
 
@@ -14710,7 +14710,7 @@
         pr_title: Fixes MSI Parameters Port and InstallDir
         references:
           - url: https://github.com/jenkinsci/packaging/pull/287
-            title: pull 287
+            title: pull 287 (packaging)
         message: |-
           Honor MSI installer parameter values for <code>PORT</code> and <code>INSTALLDIR</code>.
       - type: rfe
@@ -14803,7 +14803,7 @@
         references:
           - issue: 68007
           - url: https://github.com/jenkinsci/packaging/pull/296
-            title: Packaging pull request 296
+            title: pull 296 (packaging)
         message: |-
           Prefer <code>--httpPort</code> from <code>JENKINS_ARGS</code> over <code>HTTP_PORT</code> when the two differ.
       - type: bug
@@ -15072,7 +15072,7 @@
         references:
           - issue: 68170
           - url: https://github.com/jenkinsci/packaging/pull/306
-            title: pull 306
+            title: pull 306 (packaging)
         message: |-
           Show warning dialog if Java 8 is selected in Windows installer.
       - type: bug


### PR DESCRIPTION
## Explicitly note removal of System V init scripts

https://issues.jenkins.io/browse/JENKINS-71787 noted that the System V based initalization of Amazon Linux AMI (AL1) does not support systemd and thus cannot upgrade past Jenkins 2.416.

Amazon Linux AMI (AL1) reached end of regular support in 2020.  Extended maintenance support ends Dec 31, 2023.

- Format packaging changelog references consistently
- Explicitly note removal of System V init scripts
