### PR TITLE
Align LTS javadoc list with baseline recommendations

### DIFF
--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -26,7 +26,7 @@ title: Javadoc
 
 %ul
   - previous = ''
-  -# No more than 15 LTS releases because update center does not generally extend beyond 12 months
+  -# No more than 9 LTS releases because LTS baseline recommends most recent baseline and two baselines prior
   - site._generated[:lts_releases].results[0..8].each do | entry |
     - version = entry.version
     -# Show the javadoc for the most recent release of each LTS baseline

--- a/content/doc/developer/javadoc.html.haml
+++ b/content/doc/developer/javadoc.html.haml
@@ -27,7 +27,7 @@ title: Javadoc
 %ul
   - previous = ''
   -# No more than 15 LTS releases because update center does not generally extend beyond 12 months
-  - site._generated[:lts_releases].results[0..14].each do | entry |
+  - site._generated[:lts_releases].results[0..8].each do | entry |
     - version = entry.version
     -# Show the javadoc for the most recent release of each LTS baseline
     -# Assumes releases have form x.y.z as in 2.346.2


### PR DESCRIPTION
Minor change to align the number of items in the bullet list of LTS javadocs with the baseline recommendations.  The baseline recommendation presents the most recent LTS baseline and two baselines before it.  This change causes the Javadoc list to show the most recent LTS baseline and two baselines before it.