### PR TITLE
Remove proxy_buffering directive from nginx config

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -99,7 +99,6 @@ server {
       proxy_connect_timeout      90;
       proxy_send_timeout         90;
       proxy_read_timeout         90;
-      proxy_buffering            off;
       proxy_request_buffering    off; # Required for HTTP CLI commands
       proxy_set_header Connection ""; # Clear for keepalive
   }


### PR DESCRIPTION
The `proxy_buffering off` directive was migrated from the old Jenkins wiki here, so I'm not sure why it was enabled initially. However, its use is strongly discouraged by the nginx developers in most use cases. Remove its use from the suggested nginx configuration.

See [this nginx blog post](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering) for more details about why `proxy_buffering off` is discouraged from use. I ran across this because I attempted to set up caching of certain static files on our Jenkins server and the cache kept getting missed until I removed this.