### PR TITLE
Jenkins.io - Update weekly.yml entries for 2.419

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21021,24 +21021,6 @@
   - version: '2.419'
     date: 2023-08-14
     changes:
-      - type: TODO
-        category: developer
-        pull: 8374
-        authors:
-          - dependabot[bot]
-        pr_title: Bump org.jenkins-ci.plugins:matrix-project from 802.v8013b_40c7edc
-          to 808.v5a_b_5f56d6966
-        message: |-
-          (No proposed changelog)
-      - type: TODO
-        category: developer
-        pull: 8359
-        authors:
-          - dependabot[bot]
-        pr_title: Bump org.jenkins-ci.plugins:cloudbees-folder from 6.815.v0dd5a_cb_40e0e
-          to 6.846.v23698686f0f6
-        message: |-
-          (No proposed changelog)
       - type: bug
         category: bug
         pull: 8089


### PR DESCRIPTION
This PR is to adjust the weekly changelog so that the unnecessary entries are removed.