### PR TITLE
Jenkins.io - weekly 2.419 changelog adding entries based on github release notes

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21021,6 +21021,30 @@
   - version: '2.419'
     date: 2023-08-14
     changes:
+      - type: rfe
+        category: rfe
+        pull: 8355
+        authors:
+          - janfaracik
+        pr_title: Remove the addition of the 'has-help' class from hudson-behaviour.js
+        message: |-
+          Remove the addition of the 'has-help' class from <code>hudson-behaviour.js</code>.
+      - type: rfe
+        category: rfe
+        pull: 8208
+        authors:
+          - janfaracik
+        pr_title: Display a notice when there are plugins installed or updates available
+        message: |-
+          Display a notice when there are plugins installed or updates available.
+      - type: rfe
+        category: rfe
+        pull: 8363
+        authors:
+          - janfaracik
+        pr_title: Update the design of the content blocks
+        message: |-
+          Update the design of the content blocks.
       - type: bug
         category: bug
         pull: 8089
@@ -21029,6 +21053,15 @@
         pr_title: Use standard size node icon even with long node names
         message: |-
           Use standard size node icon even with long node names.
+      - type: rfe
+        category: developer
+        pull: 8357
+        authors:
+          - janfaracik
+        pr_title: Deprecate findAncestor and findAncestorClass
+        message: |-
+          Deprecate <code>findAncestor</code> and <code>findAncestorClass</code> in <code>hudson-behaviour.js</code>.
+
 
   # pull: 8319 (PR title: Replace MD5 digest with SHA256 while logging payload in Mock class called from tests)
   # pull: 8347 (PR title: Update dependency postcss-preset-env to v9.1.1)


### PR DESCRIPTION
Based on the [github release notes](https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.419), the changelog on jenkins.io is missing several entries. For some reason, these were not captured by the automated changelog generator, and need to be added.

@NotMyFault brought this to my attention [here](https://github.com/jenkins-infra/jenkins.io/pull/6614#issuecomment-1679179031), so I am adding these to align the changelog/release notes.