### PR TITLE
jenkins.io - suggestions for 2.420 weekly changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21079,6 +21079,128 @@
   # pull: 8369 (PR title: Update jenkins/ath Docker tag to v5695)
   # pull: 8373 (PR title: Update dependency eslint to v8.47.0)
 
+  - version: '2.420'
+    date: 2023-08-22
+    changes:
+      - type: rfe
+        category: rfe
+        pull: 8376
+        authors:
+          - janfaracik
+        pr_title: Move app bar for plugins
+        message: |-
+          Move plugins page title into sidebar so that plugins app bar is at the top of the page.
+      - type: rfe
+        category: rfe
+        pull: 8370
+        issue: 71514
+        authors:
+          - yaroslavafenkin
+        pr_title: "[JENKINS-71514] Remove `eval` call in hudson-behavior.js"
+        message: |-
+          Remove <code>eval</code> call in <code>hudsonbehavior.js</code>.
+      - type: rfe
+        category: rfe
+        pull: 8368
+        authors:
+          - mustafau
+        pr_title: Turkish localization fixes for the job configuration page
+        message: |-
+          Update Turkish localizations for the job configuration page.
+      - type: rfe
+        category: rfe
+        pull: 8375
+        authors:
+          - janfaracik
+          - NotMyFault
+        pr_title: Update link design
+        message: |-
+          Refresh link design.
+      - type: rfe
+        category: rfe
+        pull: 8208
+        authors:
+          - janfaracik
+          - NotMyFault
+          - timja
+        pr_title: Display a notice when there are plugins installed or updates available
+        message: |-
+          Display a notice when plugin updates are available or when there are no plugins installed.
+      - type: rfe
+        category: rfe
+        pull: 8363
+        authors:
+          - janfaracik
+          - timja
+        pr_title: Update the design of the content blocks
+        message: |-
+          Update the design of the content blocks.
+      - type: rfe
+        category: rfe
+        pull: 8355
+        authors:
+          - janfaracik
+        pr_title: Remove the addition of the 'has-help' class from `hudson-behaviour.js`
+        message: |-
+          Remove the unnecessary <code>hashelp</code> class additions from <code>hudsonbehaviour.js</code>.
+      - type: bug
+        category: regression
+        pull: 8388
+        issue: 71848
+        authors:
+          - daniel-beck
+        pr_title: "[JENKINS-71848] Remove admin monitors popup from `/manage/` again"
+        message: |-
+          Hide administrative monitors icons/popup in the header of Manage Jenkins, as they're shown directly on the page.
+      - type: bug
+        category: bug
+        pull: 8378
+        issue: 61452
+        authors:
+          - jglick
+        pr_title: "[JENKINS-61452] Tolerate corrupt Base64 in `PlainTextConsoleOutputStream`"
+        message: |-
+          The plain text console log will still be printed even if some console annotations are corrupt.
+      - type: bug
+        category: bug
+        pull: 8387
+        issue: 71833
+        authors:
+          - daniel-beck
+        pr_title: "[JENKINS-71833] Fix link to job in slow trigger admin monitor"
+        message: |-
+          Fix link to job in the message informing administrators of trigger computations that run for an unusually long time.
+      - type: rfe
+        category: developer
+        pull: 8357
+        authors:
+          - janfaracik
+        pr_title: Deprecate `findAncestor` and `findAncestorClass`
+        message: |-
+          Deprecate <code>findAncestor</code> and <code>findAncestorClass</code> in <code>hudsonbehaviour.js</code>.
+
+  # pull: 8340 (PR title: Replace hetero-list YUI button and menu with new style button and tippy.js menu)
+  # pull: 8354 (PR title: Remove unused CSS variables)
+  # pull: 8372 (PR title: Remove unused CSS classes)
+  # pull: 8377 (PR title: Update jenkins/ath Docker tag to v5699)
+  # pull: 8382 (PR title: Many French translations for plugin panels)
+  # pull: 8383 (PR title: Bump org.jenkins-ci.plugins:cloudbees-folder from 6.846.v23698686f0f6 to 6.848.ve3b_fd7839a_81)
+  # pull: 8384 (PR title: Bump org.jenkins-ci.plugins:script-security from 1264.vecf66020eb_7d to 1269.v639888f5e366)
+  # pull: 8389 (PR title: Bump org.jenkins-ci.plugins:structs from 324.va_f5d6774f3a_d to 325.vcb_307d2a_2782)
+  # pull: 8391 (PR title: Remove 'track-mouse' JS)
+  # pull: 8396 (PR title: Update dependency prettier to v3.0.2)
+  # pull: 8397 (PR title: Bump org.jenkins-ci.plugins:display-url-api from 2.3.8 to 2.3.9)
+  # pull: 8398 (PR title: Update dependency postcss to v8.4.28)
+  # pull: 8400 (PR title: Update dependency postcss-scss to v4.0.7)
+  # pull: 8401 (PR title: Update Yarn to v3.6.2)
+  # pull: 8402 (PR title: Update dependency sass to v1.66.0)
+  # pull: 8405 (PR title: Bump org.apache.ant:ant from 1.10.13 to 1.10.14)
+  # pull: 8407 (PR title: Bump org.springframework.security:spring-security-bom from 5.8.5 to 5.8.6)
+  # pull: 8408 (PR title: Bump org.jenkins-ci.plugins:script-security from 1269.v639888f5e366 to 1271.vdede89739a_81)
+  # pull: 8409 (PR title: Bump org.jenkins-ci.main:jenkins-test-harness from 2053.v0ea_6fc5d99b_f to 2058.va_7b_41a_286207)
+  # pull: 8411 (PR title: Update dependency sass to v1.66.1)
+  # pull: 8412 (PR title: Revert "Replace hetero-list YUI button and menu with new style button and tippy.js menu")
+
 # DO NOT EDIT THIS FILE DIRECTLY ON GITHUB IF YOU HAVE COMMIT ACCESS
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS
 # MALFORMED FILE CONTENTS WILL BREAK THE SITE BUILD


### PR DESCRIPTION
This PR is for the weekly 2.420 changelog suggestions.

At this time, the only change is moving a developer entry to the end of the list. Other than that, the entries appear to be all set!