### PR TITLE
Update system-properties.adoc

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1521,9 +1521,9 @@ properties:
   - tuning
   def: 2x of CPU
   description: |
-    During start of Jenkins, loading of jobs in parallel have a fixed number of threads by default (twice the CPU).
+    During the start of Jenkins, the loading of jobs in parallel have a fixed number of threads by default (twice the CPU).
     To make Jenkins load time 8x faster (assuming sufficient IO), increase it to 8x.
-    For example, 24 CPU Jenkins controller host use this: `-Dhudson.InitReactorRunner.concurrency=192`
+    For example, 24 CPU Jenkins controller host use this: `-Djenkins.InitReactorRunner.concurrency=192`
 
 - name: jenkins.install.runSetupWizard
   tags:


### PR DESCRIPTION
Address inconsistency in the `jenkins.InitReactorRunner.concurrency` documentation.