### PR TITLE
Minor updated to the CoC

### DIFF
--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -22,7 +22,7 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
+nationality, personal appearance, race, caste, color, religion, or sexual identity
 and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
@@ -232,15 +232,18 @@ The ban will include but is not limited to:
 
 == Attribution
 
-This Code of Conduct is adapted from the Contributor Covenant,
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the link:https://www.contributor-covenant.org/[Contributor Covenant],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by link:https://github.com/mozilla/diversity[Mozilla's code of conduct
 enforcement ladder].
 
+For answers to common questions about the adapted code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+
 == Version history
 
+* **Aug 23, 2023** - Minor update of the Code of Conduct adding translations to the footer and incorporating the link:https://github.com/EthicalSource/contributor_covenant/releases/tag/2.1[2.1] update.
 * **Jul 02, 2020** - Major update of the Code of Conduct.
   It was approved the project governance meeting on Jul 01
   (link:https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit#heading=h.6rx5y09hwmti[meeting notes],


### PR DESCRIPTION
This PR is a small updated for our CoC, adapting version 2.1's changes to add several more words to the preamble: https://github.com/EthicalSource/contributor_covenant/releases/tag/2.1

Additionally, I have added a link to translations of the Contributor Covenant part.