### PR TITLE
Download the Debian/Ubuntu repository signature with wget, not curl

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -35,8 +35,8 @@ It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-
 
 [source,bash]
 ----
-curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
-  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
+  https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
 echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
@@ -51,8 +51,8 @@ It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt re
 
 [source,bash]
 ----
-curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee \
-  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
+  https://pkg.jenkins.io/debian/jenkins.io-2023.key
 echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
   https://pkg.jenkins.io/debian binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null


### PR DESCRIPTION
When I set up a new Ubuntu container and install Jenkins, the installation instructions so far don't work directly because you still have to install `curl` (in addition to Java), which is unnecessary since `wget` is already pre-installed. So the command is now similar to the Fedora script.