### PR TITLE
Footnote to GitHub branch source, not deprecated plugin

### DIFF
--- a/content/doc/book/pipeline/index.adoc
+++ b/content/doc/book/pipeline/index.adoc
@@ -135,7 +135,7 @@ video::IOUm1lw7F58[youtube,width=800,height=420]
 Building on the core Jenkins value of extensibility, Pipeline is also extensible
 both by users with link:shared-libraries[Pipeline Shared Libraries] and by
 plugin developers.
-footnote:ghof[plugin:github-organization-folder[GitHub Organization Folder plugin]]
+footnote:ghof[plugin:github-branch-source[GitHub Branch Source plugin]]
 
 The flowchart below is an example of one CD scenario easily modeled in Jenkins
 Pipeline:


### PR DESCRIPTION
## Footnote to GitHub branch source, not deprecated plugin

Thanks to a report in the [docs feedback form](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) noting that the previous link points to a deprecated plugin.  Organization folders have been implemented in the GitHub branch source plugin for many years.
