### PR TITLE
Add redirect to /security/advisory/ for URL editors

### DIFF
--- a/content/security/advisory/index.adoc
+++ b/content/security/advisory/index.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /security/advisories/
+---


### PR DESCRIPTION
https://www.jenkins.io/security/advisories/ is the nicer URL for this, but in case someone's a URL editor, this makes it easier to get there.