### PR TITLE
Fix minor blog post error

### DIFF
--- a/content/blog/2023/09/06/2023-09-06-artifactory-bandwidth-reduction.adoc
+++ b/content/blog/2023/09/06/2023-09-06-artifactory-bandwidth-reduction.adoc
@@ -89,7 +89,7 @@ Mark implemented a central cache in his home lab in an attempt to prevent the is
 
 **Cache your __dependencies__**
 
-Use local drives and local servers to cache your dependencies so that the can be downloaded faster.
+Use local drives and local servers to cache your dependencies so that they can be downloaded faster.
 
 === Summary
 


### PR DESCRIPTION
## Fix minor error in blog post

Replace "the" with "they" in one location
