### PR TITLE
Remove incorrect reference to SPI

### DIFF
--- a/content/press.adoc
+++ b/content/press.adoc
@@ -30,14 +30,11 @@ Board], which is the group with acting executive authority. While board members
 are available for comment, we encourage you to reach out to our <<Press Contact>>
 as an initial point of contact for press inquiries.
 
+=== Trademark
+
 The name "Jenkins" is a registered trademark in the USA to protect the project and users from confusing use of the term: 
 link:https://trademarks.justia.com/854/47/jenkins-85447465.html[#4664929],
 held by LF CHARITIES, Inc. (a 501(c)(3) nonprofit charity associated with the Linux Foundation).
-
-=== Trademark
-
-The name "Jenkins" is a registered trademark in the USA (link:https://trademarks.justia.com/854/47/jenkins-85447465.html[#4664929],
-held by link:https://spi-inc.org[Software in the Public Interest, Inc.]) in order to protect the project and users from confusing use of the term.
 For more info about trademark and its usage see the link:/project/governance/#trademark[Trademark] and link:/project/governance/#trademark-attribution[Trademark Attribution] sections of the Governance document.
 
 === Branding


### PR DESCRIPTION
## Remove incorrect reference to SPI

The correct text had been inserted into the press page but it was above the "Trademark" heading with the incorrect SPI text under the heading.

Corrected by deleting the SPI text and moving the "Trademark" heading above the correct text that was already in the page.
