### PR TITLE
Replace SPI reference in CLA instructions

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -61,9 +61,13 @@ This is not to be confused with proprietary plugins --- we recognize and encoura
 
 === Contributor License Agreement (CLA)
 
-To further clarify the intellectual property rights around the project, we require that core committers sign a contributor agreement. This CLA is the same as Apache's CLA with "Apache" replaced by "SPI". This agreement explicitly assigns a set of rights to SPI, such as the effective joint copyright ownership, patent grant, as well as acknowledging that you have the necessary rights to contribute changes.
+To further clarify the intellectual property rights around the project, we require that core committers sign a contributor agreement.
+The Jenkins project uses the EasyCLA service provided by the Linux Foundation.
+Refer to the link:https://github.com/jenkinsci/infra-cla/blob/master/README.md[infra-cla README] for contributor license agreement submission instructions.
+More details are available from the Linux Foundation for link:https://docs.linuxfoundation.org/lfx/easycla/v2-current/contributors/individual-contributor[individual contributors] and link:https://docs.linuxfoundation.org/lfx/easycla/v2-current/contributors/corporate-contributor[corporate contributors].
 
-The assignment of these rights to SPI helps Jenkins being neutral to any particular vendor, and it'll also make legal departments happy especially in large organizations who want to use Jenkins.
+EasyCLA is self service and requires no manual intervention by the board or any other Jenkins project member.
+It is a one-time process, valid for all link:/project/conduct/#community-spaces[Jenkins community spaces].
 
 CLAs come in two flavors. Every core contributor needs to sign an Individual CLA (ICLA), and in cases where you as an individual do not own the work you are contributing (such as when your company assigns you to work on Jenkins and therefore your company owns the hard work you produced), the corporation also needs to sign a Corporate CLA (CCLA). See link:https://www.apache.org/licenses/#clas[the discussion in Apache for more details]. The CLA forms can be obtained by following the documentation in the link:https://github.com/jenkinsci/infra-cla[infra-cla] repository.
 


### PR DESCRIPTION
## Replace SPI reference in CLA instructions

The Jenkins project uses EasyCLA for individual contributor license agreements and corporate contributor license agreements.  There is no need to refer to Software in the Public Interest.

https://github.com/jenkinsci/infra-cla/blob/master/README.md#how-to-submit-a-cla is the reference for this content with special thanks to @NotMyFault for his work to document EasyCLA in https://github.com/jenkinsci/infra-cla/pull/104
