### PR TITLE
Break new hard links

### DIFF
--- a/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
+++ b/content/blog/2019/02/2019-02-06-ssh-steps-for-jenkins-pipeline.adoc
@@ -17,7 +17,7 @@ image:pipeline/realworld-pipeline-flow.png[alt="Pipeline Flow",width=100%]
 
 ## Jenkins Pipelines
 
-https://jenkins.io/[Jenkins] is a well-known open source continuous integration and continuous deployment automation tool. With the latest 2.0 release, Jenkins introduced the Pipeline plugin that implements Pipeline-as-code. This plugin lets you define delivery pipelines using concise scripts which deal elegantly with jobs involving persistence and asynchrony. 
+link:/[Jenkins] is a well-known open source continuous integration and continuous deployment automation tool. With the latest 2.0 release, Jenkins introduced the Pipeline plugin that implements Pipeline-as-code. This plugin lets you define delivery pipelines using concise scripts which deal elegantly with jobs involving persistence and asynchrony.
 
 The Pipeline-as-code's script is also known as a _Jenkinsfile_. 
 

--- a/content/blog/2020/03/2020-03-02-pipeline-authoring-sig-update.adoc
+++ b/content/blog/2020/03/2020-03-02-pipeline-authoring-sig-update.adoc
@@ -49,7 +49,7 @@ maturity model can be found here: https://drive.google.com/file/d/1ByzWlPU0j1qM_
 We have been meeting regularly to define personas to help us better create the SIG roadmap. We meet twice a week,
 once on Thursday for the EMEA timezone and once on Friday for the US timezone. Meeting notes can be found here:
 https://docs.google.com/document/d/1EhWoBplGl4M8bHz0uuP-iOynPGuONjcz4enQm8sDyUE/edit# and the calendar, if you would
-like to attend, is here: https://jenkins.io/event-calendar/. The previous recording of the meetings are
+like to attend link:/event-calendar[here]. The previous recording of the meetings are
 located here: https://www.youtube.com/watch?v=pz_kPpb9C1w&list=PLN7ajX_VdyaOKKLBXek6iG8wTS24Ac7Y3
 
 === Next Steps

--- a/content/blog/2023/02/2023-02-28-build-msi-locally.adoc
+++ b/content/blog/2023/02/2023-02-28-build-msi-locally.adoc
@@ -23,7 +23,7 @@ Should you ever need to rebuild a Jenkins MSI on your Windows machine, here is a
 First, you should download the Jenkins war file that will be inside the MSI file.
 You can access it from the official Jenkins website or from https://updates.jenkins.io/[the Jenkins update center].
 
-Check the https://www.jenkins.io/download/[Jenkins download page] to download the latest weekly version of Jenkins for example.
+Check the link:/download/[Jenkins download page] to download the latest weekly version of Jenkins for example.
 You can always access https://updates.jenkins.io/latest/jenkins.war[the direct link] to get the latest weekly version, but you won't necessarily know which version number you are using.
 Just saying.
 

--- a/content/blog/2023/04/12/2023-04-12-jenkins-march-newsletter.adoc
+++ b/content/blog/2023/04/12/2023-04-12-jenkins-march-newsletter.adoc
@@ -57,9 +57,9 @@ Contributed by: author:kguerroudj[Kevin Guerroudj]
 
 Two security advisories have been published during the month of March:
 
-* One regarding link:https://www.jenkins.io/security/advisory/2023-03-21/[plugins]
+* One regarding link:/security/advisory/2023-03-21/[plugins]
 ** 13 plugins were impacted
-** 9 without fixes according to our link:https://www.jenkins.io/security/plugins/#unresolved[documentation]
+** 9 without fixes according to our link:/security/plugins/#unresolved[documentation]
 
 * One regarding link:https://www.jenkins.io/security/advisory/2023-03-08/[core and update-center2]
 ** The most critical being an XSS which we were able to confirm that there was no exploit.

--- a/content/blog/2023/05/04/2023-05-04-gsoc2023-projects-announcement.adoc
+++ b/content/blog/2023/05/04/2023-05-04-gsoc2023-projects-announcement.adoc
@@ -45,7 +45,7 @@ _Mentors_: link:/blog/authors/alecharp[Adrien Lecharpentier], link:/blog/authors
 * **Building jenkins.io with alternative tools** -
 Using alternative tooling (i.e., Antora) to build the Jenkins static site and provide documentation per Jenkins version. +
 _Contributor_: link:https://github.com/Vandit1604[Vandit Singh] from India. +
-_Mentors_: link:/blog/authors/krisstern[Kris Stern], link:https://www.jenkins.io/blog/authors/iamrajiv[Rajiv Ranjan Singh], link:/blog/authors/yiminggong[Yiming Gong], and link:/blog/authors/markewaite[Mark Waite].
+_Mentors_: link:/blog/authors/krisstern[Kris Stern], link:/blog/authors/iamrajiv[Rajiv Ranjan Singh], link:/blog/authors/yiminggong[Yiming Gong], and link:/blog/authors/markewaite[Mark Waite].
 
 * **Docker-based Jenkins quickstart examples** -
 Provide examples, sample code, and documentation on how to start a local Jenkins instance. +

--- a/content/blog/2023/07/22/2023-07-22-gsoc-2023-midterm.adoc
+++ b/content/blog/2023/07/22/2023-07-22-gsoc-2023-midterm.adoc
@@ -23,7 +23,7 @@ Taking time to evaluate the progress and workflow of the project provides an opp
 Earlier this month, on the link:https://www.meetup.com/jenkins-online-meetup/[Jenkins Online Meetup], GSoC contributors presented midterm status and progress for their projects, below is a recap.
 Thank you Jagruti, Harsh, Vandit, and Ashutosh for your contributions to Jenkins!
 
-== link:https://www.jenkins.io/projects/gsoc/2023/projects/add-probes-to-plugin-health-score/[Add Probes to "Plugin Health Score"]
+== link:/projects/gsoc/2023/projects/add-probes-to-plugin-health-score/[Add Probes to "Plugin Health Score"]
 By link:https://github.com/Jagrutiti/[Jagruti Tiwari]
 
 A probe collects data about each plugin.

--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -412,7 +412,7 @@ This policy can be set on a job's configuration page.
 It is a best practice to take regular backups of your $JENKINS_HOME.
 A backup ensures that your Jenkins instance can be restored despite a misconfiguration,
 accidental job deletion, or data corruption. 
-See the link:https://www.jenkins.io/doc/book/system-administration/backing-up/[Backup policies] for more details.
+See the link:/doc/book/system-administration/backing-up/[Backup policies] for more details.
 
 === Finding your $JENKINS_HOME
 

--- a/content/merchandise.adoc
+++ b/content/merchandise.adoc
@@ -19,7 +19,7 @@ Cafepress hosts a link:https://www.cafepress.com/jenkinsci[Jenkins store] for va
 The link:https://www.shapeways.com/shops/jenkins[Jenkins 3D Shop] offers 3D printed figures of Mr. Jenkins.
 
 The model for these figures was created by link:https://www.fast-d.com/search/engineers/2798[akiki] and is licensed as CC-BY-SA.
-It can be be downloaded from the link:https://www.jenkins.io/artwork/[logo] page.
+It can be be downloaded from the link:/artwork/[logo] page.
 
 // link:/blog/2014/07/28/jenkins-figure-is-available-in-shapeways/[]
 
@@ -31,4 +31,4 @@ It can be be downloaded from the link:https://www.jenkins.io/artwork/[logo] page
 The link:https://www.heroforge.com/load_config%3D13211607/[Jenkins] is a share of a 3D print figurine of Mr. Jenkins.
 
 The model for these figures was created by link:https://www.linkedin.com/in/w-douglas-west-0856094/[D. West] and is licensed as CC-BY-SA.
-It can be be downloaded from the link:https://www.jenkins.io/artwork/[logo] page.
+It can be be downloaded from the link:/artwork/[logo] page.


### PR DESCRIPTION
The change proposed breaks new introduced hard links in the source files. Ideally, source files should use relative URLs inside the jenkins.io domain only, to not break linking in local development.