### PR TITLE
doc: book: pipeline: syntax: Fix 'when' directive list formatting

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -1089,10 +1089,11 @@ Nesting conditions may be nested to any arbitrary depth.
 branch:: Execute the stage when the branch being built matches the branch pattern (ANT style path glob) given, for example: `when { branch 'master' }`. Note that this only works on a multibranch Pipeline.
 +
 The optional parameter `comparator` may be added after an attribute to specify how any patterns are evaluated for a match:
+
 * `EQUALS` for a simple string comparison
 * `GLOB` (the default) for an ANT style path glob (same as for example `changeset`)
 * `REGEXP` for regular expression matching
-+
+
 For example: `when { branch pattern: "release-\\d+", comparator: "REGEXP"}`
 
 buildingTag:: Execute the stage when the build is building a tag.
@@ -1104,10 +1105,11 @@ changeset:: Execute the stage if the build's SCM changeset contains one or more 
 Example: `+when { changeset "**/*.js" }+`
 +
 The optional parameter `comparator` may be added after an attribute to specify how any patterns are evaluated for a match:
+
 * `EQUALS` for a simple string comparison
 * `GLOB` (the default) for an ANT style path glob case insensitive (this can be turned off with the `caseSensitive` parameter).
 * `REGEXP` for regular expression matching
-+
+
 For example: `when { changeset pattern: ".*TEST\\.java", comparator: "REGEXP" }` or `when { changeset pattern: "**/*TEST.java", caseSensitive: true }`
 
 changeRequest:: Executes the stage if the current build is for a "change request" (a.k.a. Pull Request on GitHub and Bitbucket, Merge Request on GitLab, Change in Gerrit, etc.).
@@ -1118,10 +1120,11 @@ Possible attributes are `id`, `target`, `branch`, `fork`, `url`, `title`, `autho
 Each of these corresponds to a `CHANGE_*` environment variable, for example: `when { changeRequest target: 'master' }`.
 +
 The optional parameter `comparator` may be added after an attribute to specify how any patterns are evaluated for a match:
+
 * `EQUALS` for a simple string comparison (the default)
 * `GLOB` for an ANT style path glob (same as for example `changeset`)
 * `REGEXP` for regular expression matching
-+
+
 Example: `when { changeRequest authorEmail: "[\\w_-.]+@example.com", comparator: 'REGEXP' }`
 
 environment:: Execute the stage when the specified environment variable is set to the given value, for example: `when { environment name: 'DEPLOY_TO', value: 'production' }`.
@@ -1137,9 +1140,11 @@ For example: `when { tag "release-*" }`
 If an empty pattern is provided the stage will execute if the `TAG_NAME` variable exists (same as `buildingTag()`).
 +
 The optional parameter `comparator` may be added after an attribute to specify how any patterns are evaluated for a match:
+
 * `EQUALS` for a simple string comparison,
 * `GLOB` (the default) for an ANT style path glob (same as for example `changeset`), or
 * `REGEXP` for regular expression matching.
+
 For example: `when { tag pattern: "release-\\d+", comparator: "REGEXP"}`
 
 not:: Execute the stage when the nested condition is false.


### PR DESCRIPTION
AsciiDoc list formatting is broken - lists should have empty lines before and after them;
Not having them causes lists not be rendered correctly.
Fix that.