### PR TITLE
Hide subscribe buttons on governance board mailing list

### DIFF
--- a/content/_partials/mailing-lists/group.html.haml
+++ b/content/_partials/mailing-lists/group.html.haml
@@ -12,11 +12,12 @@
   - else
     = partial("mailing-lists/#{page.name}.adoc")
 
-.group-links 
-  %a{:href => archive_link} archive
-  |
-  %a{:href => subscribe_link} subscribe
-  |
-  %a{:href => unsubscribe_link} unsubscribe 
+- unless page.name == 'jenkinsci-board'
+  .group-links
+    %a{:href => archive_link} archive
+    |
+    %a{:href => subscribe_link} subscribe
+    |
+    %a{:href => unsubscribe_link} unsubscribe
 
 

--- a/content/_partials/mailing-lists/jenkinsci-board.adoc
+++ b/content/_partials/mailing-lists/jenkinsci-board.adoc
@@ -1,3 +1,3 @@
 Mailing list to contact https://www.jenkins.io/project/board/[Jenkins board members].
 
-NOTE: the subscription to this mailing list is reserved to Jenkins board members.
+NOTE: The subscription to this mailing list is reserved to Jenkins board members. Do not message this list for support with your Jenkins instance or plugins.

--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -10,14 +10,16 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkinsci-users")
 
-= partial(group, :name => "jenkinsci-board")
-
 = partial(group, :name => "jenkinsci-dev")
 
 = partial(group, :name => "jenkins-advocacy-and-outreach-sig",
   :description => "Mailing list for events, meet-ups, outreach programs, and fostering local communities.")
 
 = partial(group, :name => "jenkins-infra")
+
+%h2 Governance board mailing list
+
+= partial(group, :name => "jenkinsci-board")
 
 %h2 Read-only lists
 


### PR DESCRIPTION
Partly amends https://github.com/jenkins-infra/jenkins.io/pull/6493, but hiding the buttons for the governance board mailing list.

Additionally, this PR moves the entry to a dedicated category because the mailing list is not considered as an "English-language discussion list".