### PR TITLE
Remove WMI Windows Agent reference

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -187,9 +187,8 @@ This approach is convenient for an execution as a daemon on Unix.
   that the script runs the java program as a _java -jar agent.jar_ on the
   agent.
 
-Windows agent set-up can either follow the standard SSH and JNLP approach  or
-use a more Windows-specific configuration approach. Windows agents have the
-following options:
+Windows agent set-up can follow the standard SSH and inbound agent approaches.
+Windows agents have the following options:
 
 * *SSH-connector approach with Putty*
 * *SSH-connector approach with Cygwin and OpenSSH*:
@@ -198,13 +197,7 @@ following options:
 * *SSH-connector approach with Microsoft OpenSSH*:
   The link:https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse[Microsoft OpenSSH server] works well for Microsoft operating systems that support the server.
   Refer to installation instructions in the link:https://github.com/jenkinsci/ssh-slaves-plugin/blob/master/doc/CONFIGURE.md#launch-windows-agents-using-microsoft-openssh[ssh build agents configuration guide].
-* *Remote management facilities (WMI + DCOM)*: With this approach, which
-  utilizes the
-  plugin:windows-slaves[WMI Windows Agents Plugin]), the Jenkins controller will register the agent on the
-  windows agent machine creating a Windows service. The Jenkins controller can
-  control the agents, issuing stops/restarts/updates of the same. However this
-  is difficult to configure and not recommended.
-* *JNLP-connector approach*: With
+* *Inbound agent approach*: With
   https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+as+a+Windows+service[this approach]
    it is possible to manually register the agent as Windows service,
   but it will not be possible to centrally manage it from the controller. Each


### PR DESCRIPTION
The WMI Windows Agent plugin no longer works and is deprecated.  It does not help users to mention a technique that cannot work.
