### PR TITLE
Define the level of logs containing secrets considered vulnerable

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -63,7 +63,7 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
 link:/doc/developer/security/xss-prevention/Cause-getShortDescription/[See the documentation on the redefinition of Cause#getShortDescription].
 ** `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check` is no longer exploitable since Jenkins 2.319 and LTS 2.303.3 (published 2021-11-04).
 link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
-* Log messages containing secrets at levels lower than `INFO` (i.e., `CONFIG`, `FINE`, `FINER`, `FINEST`), implying that they are not recorded in the default Jenkins log.
+* Log messages containing secrets at levels lower than `INFO` (i.e., `CONFIG`, `FINE`, `FINER`, `FINEST`), implying that they are not recorded in the default Jenkins log recorder.
 
 == Issue Handling Process
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -63,7 +63,7 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
 link:/doc/developer/security/xss-prevention/Cause-getShortDescription/[See the documentation on the redefinition of Cause#getShortDescription].
 ** `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check` is no longer exploitable since Jenkins 2.319 and LTS 2.303.3 (published 2021-11-04).
 link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
-* Log messages containing secrets at levels lower than `INFO` (i.e., `CONFIG`, `FINE`, `FINER`, `FINEST`), implying that they are not recorded in the default Jenkins log recorder.
+* Log messages containing secrets at levels more verbose than `INFO` (i.e., `CONFIG`, `FINE`, `FINER`, `FINEST`), implying that they are not recorded in the default Jenkins log recorder.
 
 == Issue Handling Process
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -63,6 +63,7 @@ We do not consider the following issues to be vulnerabilities in Jenkins (core +
 link:/doc/developer/security/xss-prevention/Cause-getShortDescription/[See the documentation on the redefinition of Cause#getShortDescription].
 ** `Callable` implementations providing an implementation of `#checkRoles(RoleChecker)` that neither throws an exception nor calls `RoleChecker#check` is no longer exploitable since Jenkins 2.319 and LTS 2.303.3 (published 2021-11-04).
 link:/doc/developer/security/remoting-callables/[See the documentation on Remoting Callables].
+* Log messages containing secrets at levels lower than `INFO` (i.e., `CONFIG`, `FINE`, `FINER`, `FINEST`), implying that they are not recorded in the default Jenkins log.
 
 == Issue Handling Process
 


### PR DESCRIPTION
New clarification to define more precisely what the Jenkins Security team considers a vulnerability.

Secrets present in logs should not appear in the default Jenkins log recorders, but could appear in specifically configured log recorders for debugging purposes.

The log recorder description has also been adapted to be more explicit with this definition, see https://github.com/jenkinsci/jenkins/pull/8509