### PR TITLE
Add index of all published security issues

### DIFF
--- a/content/_ext/pipeline.rb
+++ b/content/_ext/pipeline.rb
@@ -41,6 +41,7 @@ Awestruct::Extensions::Pipeline.new do
   extension Releases.new
 
   extension UpgradeGuide.new
+  extension SecurityIssues.new
 
   extension AuthorList.new(:posts,
                         '/node/index',

--- a/content/_ext/security_issue.html.haml
+++ b/content/_ext/security_issue.html.haml
@@ -1,0 +1,2 @@
+---
+layout: redirect

--- a/content/_ext/security_issues.rb
+++ b/content/_ext/security_issues.rb
@@ -1,0 +1,37 @@
+require 'awestruct/page'
+
+class SecurityIssues
+  def execute(site)
+    advisories = site.pages.select { |p| p.source_path =~ /security\/advisory\// }
+
+    template = Pathname.new(::Awestruct::Engine.instance.site.config.dir).join('_ext/security_issue.html.haml')
+
+    all_issues = Array.new
+
+    advisories.each do |advisory|
+      advisory_yaml = YAML.load(File.read(advisory.source_path))
+      if advisory_yaml['issues']
+        advisory_yaml['issues'].each do |issue|
+          advisory_entry = issue['id']
+
+          if advisory_entry =~ / \([2-9]\)/
+            # If one issue has two advisory entries, skip duplicate pages and ensure we link to the first entry
+            next
+          end
+
+          issue_id = advisory_entry.gsub(/ .*/, '')
+          numeric_id = issue_id.gsub(/SECURITY-/, '')
+
+          all_issues << { :id => numeric_id.to_i, :redirect_id => issue_id, :entry => issue_id }
+
+          page = site.engine.load_page(template)
+          page.output_path = "/security/issue/#{issue_id}/index.html"
+          page.redirect_url = advisory.output_path + "##{advisory_entry}"
+          site.pages << page
+        end
+      end
+    end
+
+    site.send('security_issues=', all_issues)
+  end
+end

--- a/content/_ext/security_issues.rb
+++ b/content/_ext/security_issues.rb
@@ -22,7 +22,7 @@ class SecurityIssues
           issue_id = advisory_entry.gsub(/ .*/, '')
           numeric_id = issue_id.gsub(/SECURITY-/, '')
 
-          all_issues << { :id => numeric_id.to_i, :redirect_id => issue_id, :entry => issue_id }
+          all_issues << { :id => numeric_id.to_i, :redirect_id => issue_id }
 
           page = site.engine.load_page(template)
           page.output_path = "/security/issue/#{issue_id}/index.html"

--- a/content/_layouts/security.html.haml
+++ b/content/_layouts/security.html.haml
@@ -19,6 +19,8 @@ section: security
           %li
             = active_href('security/advisories', 'Security Advisories')
           %li
+            = active_href('security/issues', 'Security Issues')
+          %li
             = active_href('security/scheduling', 'Advisory Schedule')
           %li
             = active_href('security/plugins', 'Vulnerabilities in Plugins')

--- a/content/security/issues/index.html.haml
+++ b/content/security/issues/index.html.haml
@@ -16,4 +16,4 @@ section: security
           - site.security_issues.sort_by { |x| x[:id] }.reverse.each do |issue|
             %li
               %a{:href => "../issue/#{issue[:redirect_id]}"}
-                = issue[:entry]
+                = issue[:redirect_id]

--- a/content/security/issues/index.html.haml
+++ b/content/security/issues/index.html.haml
@@ -1,0 +1,19 @@
+---
+layout: security
+title: All published security issues
+section: security
+---
+
+.container
+  .row
+    %p
+      This page lists all security issues that have been published in security advisories since ca. 2018.
+
+  .row
+    .container
+      .row
+        %ul
+          - site.security_issues.sort_by { |x| x[:id] }.reverse.each do |issue|
+            %li
+              %a{:href => "../issue/#{issue[:redirect_id]}"}
+                = issue[:entry]


### PR DESCRIPTION
This will also allow [autolinks from GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources).

## Demo Deployment

See https://deploy-preview-6693--jenkins-io-site-pr.netlify.app/security/issues/ for the index.

It links to permalinkable URLs like https://deploy-preview-6693--jenkins-io-site-pr.netlify.app/security/issue/SECURITY-3228 that redirect to the corresponding advisory entry.

Issues that are split into two advisory entries, like https://deploy-preview-6693--jenkins-io-site-pr.netlify.app/security/issue/SECURITY-2772, link to the first (the second usually follows immediately after).

(Ideally we could do the same with CVEs, but we don't have those as cleanly in the current metadata.)