### PR TITLE
Test with Java 17 and Java 21

### DIFF
--- a/content/doc/developer/tutorial-improve/add-a-jenkinsfile.adoc
+++ b/content/doc/developer/tutorial-improve/add-a-jenkinsfile.adoc
@@ -25,8 +25,8 @@ Create a file named `Jenkinsfile` with the content:
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])
 ```
 Be sure the configuration platform is set correctly.


### PR DESCRIPTION
## Test with Java 17 and Java 21

The [create a plugin tutorial](https://www.jenkins.io/doc/developer/publishing/new-plugin/) uses the plugin archetype to generate a Jenkinsfile that tests with Java 21 on Linux and Java 17 on Windows.  A discussion
of the reasons for that configuration is available in https://github.com/jenkinsci/archetypes/pull/651

Let's have the documentation use the same technique as is used in the plugin archetype.
