### PR TITLE
Document post-host process

### DIFF
--- a/content/doc/developer/publishing/requesting-hosting.adoc
+++ b/content/doc/developer/publishing/requesting-hosting.adoc
@@ -49,8 +49,9 @@ The Jenkins project hosts a Jenkins instance to perform continuous integration b
 We recommend you set up CI builds for your plugin in the `jenkinsci` GitHub organization by creating a `Jenkinsfile` in your plugin's GitHub repository.
 See link:../continuous-integration[the documentation for CI builds] for details how to do this.
 
+== After the hosting acceptance
 
-== Request Upload Permissions
+=== Request Upload Permissions
 
 After your plugin source code has been forked into the `jenkinsci` organization, a pull request will be created for you that adds release permissions, if this doesn't happen you may need to create the request yourself.
 link:https://github.com/jenkins-infra/repository-permissions-updater/[Follow the instructions in the README of this repository] to do that.
@@ -62,12 +63,42 @@ Alternately, you can configure your plugin to be released automatically whenever
 In this case you only need write permission to GitHub; you never need local credentials.
 Follow link:/redirect/continuous-delivery-of-plugins[this guide] for details.
 
-== Categorize the Plugin
+=== Automate your GitHub repository
+
+==== Activate GitHub actions
+
+During the hosting process, you have included a shared workflow to generate changelogs automatically. Publishing changelogs as GitHub release notes is a good practice to keep your users informed about the changes in your plugin.
+
+To activate the workflow, you need to go to the `Actions` tab of your GitHub repository and click on the `I understand my workflows, go ahead and enable them` button.
+Follow the next section to create the necessary labels for your pull requests.
+
+==== Create the default labels
+
+Use the following script to create the default labels for your GitHub repository, used to categorize issues and pull requests and generate changelogs automatically:
+
+The script makes use of `gh`, you may need to install and link:[authenticate](https://cli.github.com/manual/gh_auth_login) first, if you haven't already.
+
+```sh
+https://gist.github.com/NotMyFault/b036718b73f1ad2a96faca315fc8ca68/raw
+```
+Enter the repository name of your plugin when prompted.
+
+NOTE: Bear in mind, that the script is intended to overwrite existing labels, to make sure you don't have any outdated labels with different descriptions or colors.
+
+==== Activate dependabot
+
+Dependabot is a GitHub feature that automatically creates pull requests to update dependencies in your repository. It is a good practice to keep your dependencies up to date, as it helps to avoid security vulnerabilities and compatibility issues.
+
+To activate dependabot, you need to go to the `Settings` tab, followed by `Code security and analysis` tab of your GitHub repository and click on the `Enable` button next to `Dependabot version updates` and `Dependency graph`.
+
+Alternatively, you can use link:[renovate](https://www.mend.io/renovate/) too, which is used by plugin maintainers, if you prefer.
+
+=== Categorize the Plugin
 
 Jenkins shows plugins in categories in the plugin manager and on the link:https://plugins.jenkins.io/[plugins site].
 The link:../documentation[plugin documentation guide] includes instructions for link:../documentation#documenting-plugins[documenting], categorizing, and link:../documentation#labeling-plugins[labeling] plugins.
 
-== Integrate with Jira
+=== Integrate with Jira
 
 If your chosen issue tracker is Jira, you can setup autolink references, to link from commits directly to the Jenkins Jira issue.
 All you need to do is heading to the `Settings` tab of your GitHub repository and add the following configuration to the `Autolink references` section:
@@ -79,7 +110,7 @@ Target URL: https://issues.jenkins.io/browse/JENKINS-<num>
 Commits prefixed with `JENKINS-<num>` will now be linked to the corresponding Jira issue:
 image:/images/developer/plugin-development/hosting/jira-auto-reference.png[]
 
-== Join the community
+=== Join the community
 
 As a new plugin author, its highly recommended that you join the link:/mailing-lists/[mailing list] to interact with the community and to stay up to date with the latest Jenkins news.
 


### PR DESCRIPTION
GitHub has changed a few settings for forks, therefore not all settings and tools are automatically available to hosted plugins.

The change proposed ensures, people are aware of what they can enable to spend less time on dependency updates e.g.