### PR TITLE
Added link to LTS release line on LTS upgrade guide and LTS changelog

### DIFF
--- a/content/changelog-stable/index.html.haml
+++ b/content/changelog-stable/index.html.haml
@@ -11,6 +11,12 @@ has_rss: true
     LTS upgrade guide
   for advice on upgrading Jenkins.
 
+%div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+  See the
+  %a{:href => '/download/lts'}
+    LTS Release Line
+  for more information on Jenkins LTS.
+
 .ratings
   - # source: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/lts.yml
   - site.changelogs[:lts].reverse_each do | release |

--- a/content/doc/upgrade-guide.html.haml
+++ b/content/doc/upgrade-guide.html.haml
@@ -25,7 +25,8 @@ title: "Jenkins LTS Upgrade Guide"
 - else
   %p
     This section highlights important changes for administrators upgrading
-    Jenkins LTS. Each section covers the upgrade from the previous LTS release,
+    %a{:href => "/download/lts"} Jenkins LTS.
+    Each section covers the upgrade from the previous LTS release,
     sections on versions x.y.1 cover the upgrade from the last release of the
     previous LTS line. if you are skipping LTS releases when upgrading, it is
     recommended to read the sections for all releases in between.


### PR DESCRIPTION
Add a link to the [Jenkins LTS Release Line](https://www.jenkins.io/download/lts/) page on the [Jenkins LTS Upgrade Guide](https://www.jenkins.io/doc/upgrade-guide/) and the [LTS Changelog](https://www.jenkins.io/changelog-stable/).

Fixes issue #6401 