### PR TITLE
Update links to Google Cloud and Oracle Cloud on home page

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -266,10 +266,10 @@ title: Jenkins download and deployment
       Using Jenkins for distributed builds on Compute Engine
 
   %div.vendors
-    %a{:href=>'https://docs.oracle.com/en/solutions/jenkins-master-agent-mode/'}
+    %a{:href=>'https://docs.oracle.com/en/solutions/cicd-pipeline/'}
       %img{:src=>'/images/oracle_cloud_infrastructure.png', :width=>'320'}
     %p{:style=>'margin-bottom:1cm;margin-top:.2cm;width: 300px;'}
-      Jenkins Reference Architecture and one-click deployment on Oracle Cloud Infrastructure
+      Set up a CI/CD pipeline for cloud deployments with Jenkins
 
   %div.vendors
     %a{:href=>'https://github.com/civo/kubernetes-marketplace/tree/master/jenkins'}

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -260,10 +260,10 @@ title: Jenkins download and deployment
       Jenkins quickstarts, tutorials, samples, and resources for Azure
 
   %div.vendors
-    %a{:href=>'https://cloud.google.com/jenkins'}
+    %a{:href=>'https://cloud.google.com/architecture/using-jenkins-for-distributed-builds-on-compute-engine'}
       %img{:src=>'/images/google_cloud.png', :width=>'320'}
     %p{:style=>'margin-bottom:1cm;margin-top:.2cm;width: 300px;'}
-      Jenkins at scale on Google Kubernetes Engine
+      Using Jenkins for distributed builds on Compute Engine
 
   %div.vendors
     %a{:href=>'https://docs.oracle.com/en/solutions/jenkins-master-agent-mode/'}


### PR DESCRIPTION

## Update home page links to Google Cloud and Oracle Cloud

Point to a Google Cloud page that is not archived.  The archived page has a scary warning that it may harm the kubernetes cluster.  The new page describes current techniques.

Use more recent Oracle Cloud destination link.  The previous page is an implementation guide, while the new link describes the architecture and provides some implementation.
