### PR TITLE
Update 'CVE pending' from 2019

### DIFF
--- a/content/security/advisory/2019-03-25.adoc
+++ b/content/security/advisory/2019-03-25.adoc
@@ -141,7 +141,6 @@ issues:
   reporter: Viktor Gazdag
   title: >
     Codebeamer Test Results Trend Updater Plugin stored password in plain text
-  cve: CVE pending
   cvss:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
@@ -160,7 +159,6 @@ issues:
     Daniel Beck, CloudBees, Inc.
   title: >
     Unprivileged users with Overall/Read access were able to enumerate credential IDs in Arxan MAM Publisher Plugin
-  cve: CVE pending
   cvss:
     severity: Medium
     vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N

--- a/content/security/advisory/2019-08-28.adoc
+++ b/content/security/advisory/2019-08-28.adoc
@@ -68,7 +68,7 @@ issues:
 - id: SECURITY-1512
   reporter: James Holderness, IB Boost
   title: PLUGIN_NAME showed plain text password in job configuration form fields
-  cve: CVE pending
+  cve: CVE-2019-10391
   cvss:
     severity: low
     vector: CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N


### PR DESCRIPTION
At the time, we did not assign CVEs for plugins with a very low install count. These should not have been marked "CVE pending" for that reason.

The other I just forgot to add to the advisory.