### PR TITLE
Add (un)subscribe instructions for the jenkinsci-advisories list

### DIFF
--- a/content/security/for-administrators.adoc
+++ b/content/security/for-administrators.adoc
@@ -53,7 +53,7 @@ In the Jenkins project, we publish all security advisories link:/security/adviso
 // Copied from index.adoc
 We announce the publication of a new security advisory through multiple channels:
 
-* We send an email notification to the public link:https://groups.google.com/g/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory.
+* We send an email notification to the public link:https://groups.google.com/g/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory. Only Jenkins security team members can post. You can link:mailto:jenkinsci-advisories+subscribe@googlegroups.com[subscribe] and link:mailto:jenkinsci-advisories+unsubscribe@googlegroups.com[unsubscribe] via email.
 * We send an email notification to the link:https://oss-security.openwall.org/wiki/mailing-lists/oss-security[`oss-security`] mailing list with excerpts of the security advisory.
 * We publish an link:/security/advisories/rss.xml[RSS feed] for the Security Advisories page.
 

--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -18,7 +18,7 @@ You can find all past security advisories in our link:/security/advisories/[secu
 
 We announce the publication of a new security advisory through multiple channels:
 
-* We send an email notification to the public link:https://groups.google.com/g/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory.
+* We send an email notification to the public link:https://groups.google.com/g/jenkinsci-advisories[`jenkinsci-advisories`] Google group with a short overview of affected components and a link to the security advisory. Only Jenkins security team members can post. You can link:mailto:jenkinsci-advisories+subscribe@googlegroups.com[subscribe] and link:mailto:jenkinsci-advisories+unsubscribe@googlegroups.com[unsubscribe] via email.
 * We send an email notification to the link:https://oss-security.openwall.org/wiki/mailing-lists/oss-security[`oss-security`] mailing list with excerpts of the security advisory.
 * We publish an link:/security/advisories/rss.xml[RSS feed for the jenkins.io/security/advisories/] page.
 


### PR DESCRIPTION
This list is not a discussion group, so is not mentioned in https://www.jenkins.io/mailing-lists/ with the associated partial.

