### PR TITLE
Removing GSoC 2023 announcement from carousel/jumbotron

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -8,16 +8,6 @@
   :call_to_action:
     :text: Sign up & Nominate someone today!
     :href: /blog/2023/09/18/board-officer-election-announcement/
-# selected projects for GSoC 2023
-- :href: /blog/2023/05/04/gsoc2023-projects-announcement/
-  :title: Welcome to GSoC 2023!
-  :intro: Google Summer of Code 2023 includes 4 Jenkins projects. Congratulations to the selected GSoC contributors.
-  :image:
-    :src: /images/gsoc/gsoc_projects_contributors_selected.png
-    :height: 320px
-  :call_to_action:
-    :text: More info
-    :href: /blog/2023/05/04/gsoc2023-projects-announcement/
 # Case Studies
 - :href: https://stories.jenkins.io/
   :title: Jenkins Stories!


### PR DESCRIPTION
GSoC 2023 is reaching its final days. Time to remove the annoucement from the main page carousel (aka Jumbotron)