### PR TITLE
Include fontconfig in Debian Linux install

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -97,11 +97,11 @@ Update the Debian apt repositories, install OpenJDK 17, and check the installati
 [source,bash]
 ----
 sudo apt update
-sudo apt install openjdk-17-jre
+sudo apt install fontconfig openjdk-17-jre
 java -version
-openjdk version "17.0.7" 2023-04-18
-OpenJDK Runtime Environment (build 17.0.7+7-Debian-1deb11u1)
-OpenJDK 64-Bit Server VM (build 17.0.7+7-Debian-1deb11u1, mixed mode, sharing)
+openjdk version "17.0.8" 2023-07-18
+OpenJDK Runtime Environment (build 17.0.8+7-Debian-1deb12u1)
+OpenJDK 64-Bit Server VM (build 17.0.8+7-Debian-1deb12u1, mixed mode, sharing)
 ----
 
 [NOTE]


### PR DESCRIPTION
## Include fontconfig in Debian Linux install

Avoid runtime warning messages from Jenkins core when Java attempts to access font definitions.

Increase consistency with the container images that install either `fontconfig`  or `libfontconfig1` in order to avoid warning messages from Jenkins core when Java attempts to access font definitions.

Increase consistency with the configuration tested in the Jenkins packaging repository.  The packaging repository tests with `fontconfig`.

Detected in https://github.com/jenkinsci/packaging/pull/431 code review by @basil.  Thanks @basil for detecting the error!
