### PR TITLE
Include fontconfig in RHEL and Fedora Linux installs

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -128,7 +128,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install java-17-openjdk
+sudo dnf install fontconfig java-17-openjdk
 sudo dnf install jenkins
 sudo systemctl daemon-reload
 ----
@@ -145,7 +145,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install java-17-openjdk
+sudo dnf install fontconfig java-17-openjdk
 sudo dnf install jenkins
 ----
 
@@ -225,7 +225,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install java-17-openjdk
+sudo yum install fontconfig java-17-openjdk
 sudo yum install jenkins
 sudo systemctl daemon-reload
 ----
@@ -242,7 +242,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install java-17-openjdk
+sudo yum install fontconfig java-17-openjdk
 sudo yum install jenkins
 ----
 


### PR DESCRIPTION
## Include fontconfig in RHEL and Fedora Linux installs

Make the installation instructions more consistent with the packages that we include in the UBI 8, UBI 9, and AlmaLinux container images.

Make the installation instructions more consistent with the packages that are tested in the packaging repository.  https://github.com/search?q=repo%3Ajenkinsci%2Fpackaging%20fontconfig&type=code shows the current uses of fontconfig in the packaging repository.  It is used for RHEL and Debian and SUSE tests.
