### PR TITLE
Fix README image dimensions and URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
-image::https://www.jenkins.io/images/jenkins-logo-title-dark.svg[jenkins.io]
+image::https://www.jenkins.io/images/jenkins-logo-title-dark.svg[link="https://www.jenkins.io/", 400]
+
 = jenkins.io
 
 image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://app.gitter.im/#/room/#jenkins/docs:matrix.org"]


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/pull/6715 added an image without proper scaling and using a wrong syntax attempting to link to jenkins.io, but linking to the image itself.

The change proposed corrects both issues.
