### PR TITLE
Remove link to private topic in community

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -133,7 +133,6 @@ a| Improve coverage of French localization of the Jenkins web interface, includi
 The same is possible for other languages, let us know if you are interested!
 
   * Some proposal are listed in link:https://issues.jenkins.io/browse/JENKINS-66658[a dedicated Epic].
-  * A topic is opened in the link:https://community.jenkins.io/t/topic-traduction-fr-pour-hacktoberfest-2021-sentez-vous-libre-de-me-rejoindre/405[French category of discourse].
   * Use and improve if needed link:/doc/book/using/using-local-language/[the language selection documentation]
   * Use and improve if needed link:/doc/developer/internationalization/[the internationalization documentation]
   * If you want to participate to other language than French you are welcome ! However it would be great if you can find some other person speaking the target language for reviews.


### PR DESCRIPTION
## Remove link to private topic in the community forum

The organizers of the 2021 Hacktoberfest project to localize in French are not participating in HAcktoberfest 2023 in Jenkins.  The thread in community.jenkins.io was made private at the end of the 2021 effort.

The remaining links are useful and the French localization effort is still a good effort to continue.
