### PR TITLE
Restore placeholder calculation for version selection page

### DIFF
--- a/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+++ b/content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
@@ -1,5 +1,5 @@
 ---
-layout: developersection
+layout: corebaseline
 title: Choosing a Jenkins version to build against
 ---
 // This file contains placeholders that are replaced in the Ruby script that's part of the 'corebaseline' layout.


### PR DESCRIPTION
## Compute placeholder text in version selection page

Removing the placeholder processing left placeholder text in the final page.

Fixes #6748
