### PR TITLE
fix(documentation): corebaseline is also used for other versions than LTS.

### DIFF
--- a/content/_layouts/corebaseline.html.haml
+++ b/content/_layouts/corebaseline.html.haml
@@ -1,0 +1,22 @@
+---
+layout: developersection
+---
+
+:ruby
+    oldest_weekly = site._generated[:core_tiers].weeklyCores[0]
+
+    # For this file, assume that the the entries are in increasing order and get the second column (which is the last pre-split version)
+    # TODO Figure out a way to obtain this content differently, this is terrible
+    split_versions = URI.open('https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/resources/jenkins/split-plugins.txt').read.lines.select { |l| l.strip.length > 0 && !(l.strip =~ /^#/) }.map { |l| l.split(' ')[1] }
+    latest_split = split_versions[-1]
+
+    lts = site._generated[:core_tiers].stableCores
+    oldest_lts = lts[0]
+    all_lts = site._generated[:lts_releases].results.map { |v| v.version }
+
+    next_lts_1 = all_lts.select { |v| v =~ /[.]1$/ }[0]
+    # We assume that lts will contain at least one release of the previous LTS line, which is reasonable.
+    # Surely there's going to be at least one plugin depending on the old .1 by the time the next .1 is available.
+    previous_lts_highs = lts.map { |v| v[0...-1] }.uniq[0...-1].map { |l| all_lts.select { |v| v.start_with?(l) }[0] }
+
+= page.content.gsub('PLACEHOLDER_NEWER_LTS_POINT_ONE', next_lts_1).gsub('PLACEHOLDER_RECENT_LTS_POINT_HIGHS', previous_lts_highs[-2...].join(' and ')).gsub('PLACEHOLDER_OLDEST_LTS', oldest_lts).gsub('PLACEHOLDER_OLDEST_WEEKLY', oldest_weekly).gsub('PLACEHOLDER_LATEST_SPLIT', latest_split).gsub('PLACEHOLDER_RECENT_LTS_POINT_HIGH', previous_lts_highs[-1])


### PR DESCRIPTION
Attempting to rectify the errors I introduced recently.

When I introduced the use of updatecli in #6717, I also removed `content/_layouts/corebaseline.html.haml`. This `Ruby` script calculates the various LTS versions that we can find in different parts of the documentation. It's also responsible for determining various weekly versions mentioned in other sections of the documentation, which I regrettably overlooked. 🤦

This is why we need to retain it until we address the other usages with `updatecli`.

@MarkEWaite spotted my mistake in #6749 and corrected it in #6751. However, because the `Ruby` script was still missing, it didn't work.

Consequently, I'm proposing this PR to reintegrate the original script so that the website can once again generate references for Jenkins weekly versions correctly. Next week, I'll suggest a way to automate this with `updatecli`.