### PR TITLE
Redirect distributed-builds to "Architecting for Scale"

### DIFF
--- a/content/doc/book/security/controller-isolation.adoc
+++ b/content/doc/book/security/controller-isolation.adoc
@@ -19,7 +19,7 @@ They all have some control over commands executed during a build.
 This does not even consider issues like supply chain attacks on build dependencies, whereby attackers take over control of NPM or Maven packages and insert malicious code.
 
 To ensure the stability of the Jenkins controller, builds should be executed on other nodes than the built-in node.
-This concept is called _distributed builds_ in Jenkins, and you can learn more about this https://wiki.jenkins.io/display/JENKINS/Distributed+builds[here].
+This concept is called _distributed builds_ in Jenkins, and you can learn more about this https://www.jenkins.io/doc/book/scaling/architecting-for-scale/[here].
 Setting up distributed builds in Jenkins is a great start for protecting the Jenkins controller from malicious (or just broken) build scripts, but care needs to be taken for protections to be effective.
 
 [CAUTION]

--- a/content/redirect/distributed-builds.adoc
+++ b/content/redirect/distributed-builds.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Distributed+builds
+redirect_url: https://www.jenkins.io/doc/book/scaling/architecting-for-scale/#distributed-builds-architecture
 ---

--- a/content/redirects/distributed-builds.adoc
+++ b/content/redirects/distributed-builds.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Distributed+builds
+redirect_url: https://www.jenkins.io/doc/book/scaling/architecting-for-scale/#distributed-builds-architecture
 ---


### PR DESCRIPTION
Don't lead users to <https://wiki.jenkins.io/display/JENKINS/Distributed+builds> in the deprecated wiki. But leave the following unchanged:

- content/blog/\*/\*.adoc because those are historical.
- content/redirect/troubleshooting/windows-agent-restart.adoc because the "Architecting for Scale" page does not describe how to solve this problem.