### PR TITLE
Update release date for 2.427

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21628,7 +21628,7 @@
   # pull: 8553 (PR title: Tweak changelog guidance in PR template)
 
   - version: '2.427'
-    date: 2023-10-09
+    date: 2023-10-10
     changes:
       - type: bug
         category: regression


### PR DESCRIPTION
When viewing the Weekly release changelog, I noticed that the date is currently set as  (2023-10-09) when it should be (2023-10-10).

This PR is to update the date and correct it to today (10/10)