### PR TITLE
Jenkins.io - LTS 2.414.3 add winstone & jetty upgrade entry

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9692,6 +9692,26 @@
     pr_title: "Add telemetry for security-related settings"
     message: |-
       Add telemetry collecting basic information about the security configuration.
+  - type: rfe
+    category: rfe
+    pull: 8592
+    issue: 72156
+    authors:
+    - olamy
+    pr_title: "[JENKINS-72156] Backport Upgrade to Winstone 6.14 which contains an upgrade to Jetty 10.0.17"
+    references:
+      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.13
+        title: Winstone 6.13 changelog
+      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.14
+        title: Winstone 6.14 changelog
+      - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.16
+        title: Jetty 10.0.16 changelog
+      - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.17
+        title: Jetty 10.0.17 changelog
+    message: |-
+      Upgrade Winstone from 6.12 to 6.14.
+      This includes the upgrade of Jetty from 10.0.15 to 10.0.17.
+      The Jetty upgrade includes fixes for several CVEs.
   - type: bug
     category: regression
     pull: 8485


### PR DESCRIPTION
This PR is to add an entry to the 2.414.3 changelog for the upgrade of Winstone from 6.12 to 6.14 & Jetty from 10.0.15 to 10.0.17.

This is related to https://github.com/jenkinsci/jenkins/pull/8592 as this upgrade is being backported for the next LTS release (2.414.3)