### PR TITLE
Link from changelog to CVE-2023-44487

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9708,6 +9708,8 @@
         title: Jetty 10.0.16 changelog
       - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.17
         title: Jetty 10.0.17 changelog
+      - url: https://nvd.nist.gov/vuln/detail/CVE-2023-44487
+        title: CVE-2023-44487
     message: |-
       Upgrade Winstone from 6.12 to 6.14.
       This includes the upgrade of Jetty from 10.0.15 to 10.0.17.


### PR DESCRIPTION
## Link from changelog to CVE-2023-44487

Format the link to match other CVE references in the changelog.
