### PR TITLE
Jenkins.io - draft suggestions for 2.428 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21722,6 +21722,21 @@
   - version: '2.428'
     date: 2023-10-16
     changes:
+      - type: major rfe
+        category: rfe
+        pull: 8586
+        issue: 72148
+        authors:
+          - jgreffe
+        pr_title: "[JENKINS-72148] Add missing fr properties in hudson directory"
+        references:
+          - pull: 8594
+          - pull: 8595
+          - pull: 8578
+          - pull: 8577
+        message: |-
+          Add missing <code>*_fr.properties</code> in win32errors and hudson, lib, and Jenkins resources.
+          Translate <code>hudson/Messages.properties</code>, <code>hudson/model/Messages.properties</code>, and <code>jenkins/model/Messages.properties</code> into French.
       - type: rfe
         category: rfe
         pull: 8596
@@ -21752,53 +21767,6 @@
         message: |-
           Upgrade Winstone from 6.12 to 6.14.
           This includes the upgrade of Jetty from 10.0.15 to 10.0.17.
-      - type: rfe
-        category: rfe
-        pull: 8586
-        issue: 72148
-        authors:
-          - jgreffe
-        pr_title: "[JENKINS-72148] Add missing fr properties in hudson directory"
-        message: |-
-          Add missing <code>*_fr.properties</code> in hudson and lib resources.
-      - type: rfe
-        category: rfe
-        pull: 8594
-        issue: 72148
-        authors:
-          - jgreffe
-        pr_title: "[JENKINS-72148] Add missing fr properties for win32errors"
-        message: |-
-          Add missing <code>*_fr.properties</code> for win32errors.
-      - type: rfe
-        category: rfe
-        pull: 8595
-        issue: 72148
-        authors:
-          - jgreffe
-          - timja
-        pr_title: "[JENKINS-72148] Add missing fr properties in package jenkins"
-        message: |-
-          Add missing <code>*_fr.properties</code> in Jenkins resources.
-      - type: rfe
-        category: rfe
-        pull: 8578
-        issue: 72143
-        authors:
-          - jgreffe
-        pr_title: "[JENKINS-72143] French translation"
-        message: |-
-          Translate <code>hudson/Messages.properties</code> into French.
-      - type: rfe
-        category: rfe
-        pull: 8577
-        issue: 72141
-        authors:
-          - jgreffe
-          - NotMyFault
-        pr_title: "[JENKINS-72141] French translation"
-        message: |-
-          Translate <code>hudson/model/Messages.properties</code> and <code>jenkins/model/Messages.properties</code> into French.
       - type: bug
         category: regression
         pull: 8602

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21719,6 +21719,144 @@
   # pull: 8575 (PR title: Update Yarn to v3.6.4)
   # pull: 8579 (PR title: Update dependency sass to v1.69.0)
 
+  - version: '2.428'
+    date: 2023-10-16
+    changes:
+      - type: rfe
+        category: rfe
+        pull: 8596
+        authors:
+          - daniel-beck
+        pr_title: Add telemetry for Jenkins uptime
+        message: |-
+          Add telemetry for Jenkins uptime.
+      - type: rfe
+        category: rfe
+        pull: 8587
+        issue: 72156
+        authors:
+          - olamy
+        pr_title: "[JENKINS-72156] Upgrade to Winstone 6.14 which contains an upgrade\
+          \ to Jetty 10.0.17"
+        references:
+          - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.13
+            title: Winstone 6.13 changelog
+          - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.14
+            title: Winstone 6.14 changelog
+          - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.16
+            title: Jetty 10.0.16 changelog
+          - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.17
+            title: Jetty 10.0.17 changelog
+          - url: https://nvd.nist.gov/vuln/detail/CVE-2023-44487
+            title: CVE-2023-44487
+        message: |-
+          Upgrade Winstone from 6.12 to 6.14.
+          This includes the upgrade of Jetty from 10.0.15 to 10.0.17.
+      - type: rfe
+        category: rfe
+        pull: 8586
+        issue: 72148
+        authors:
+          - jgreffe
+        pr_title: "[JENKINS-72148] Add missing fr properties in hudson directory"
+        message: |-
+          Add missing <code>*_fr.properties</code> in hudson and lib resources.
+      - type: rfe
+        category: rfe
+        pull: 8594
+        issue: 72148
+        authors:
+          - jgreffe
+        pr_title: "[JENKINS-72148] Add missing fr properties for win32errors"
+        message: |-
+          Add missing <code>*_fr.properties</code> for win32errors.
+      - type: rfe
+        category: rfe
+        pull: 8595
+        issue: 72148
+        authors:
+          - jgreffe
+          - timja
+        pr_title: "[JENKINS-72148] Add missing fr properties in package jenkins"
+        message: |-
+          Add missing <code>*_fr.properties</code> in Jenkins resources.
+      - type: rfe
+        category: rfe
+        pull: 8578
+        issue: 72143
+        authors:
+          - jgreffe
+        pr_title: "[JENKINS-72143] French translation"
+        message: |-
+          Translate <code>hudson/Messages.properties</code> into French.
+      - type: rfe
+        category: rfe
+        pull: 8577
+        issue: 72141
+        authors:
+          - jgreffe
+          - NotMyFault
+        pr_title: "[JENKINS-72141] French translation"
+        message: |-
+          Translate <code>hudson/model/Messages.properties</code> and <code>jenkins/model/Messages.properties</code> into French.
+      - type: bug
+        category: regression
+        pull: 8602
+        issue: 72170
+        authors:
+          - mawinter69
+        pr_title: "[JENKINS-72170] fix nested hetero-list entries with mixture of\
+          \ inputs and buttons"
+        message: |-
+          Fix multibranch Pipeline "Add source" and other uses that mix inputs and buttons (regression in 2.422).
+      - type: bug
+        category: regression
+        pull: 8492
+        issue: 72020
+        authors:
+          - Vlatombe
+        pr_title: "[JENKINS-72020] Restore ability to reorder clouds"
+        message: |-
+          Allow clouds to be reordered.
+          This was previously possible, but disappeared when the cloud management was moved to a separate page (regression in 2.403).
+      - type: rfe
+        category: rfe
+        pull: 8544
+        issue: 72107
+        authors:
+          - Vlatombe
+        pr_title: "[JENKINS-72107] Introduce `Loadable` interface"
+        message: |-
+          Developer: Formalize an interface for objects that can be loaded from disk.
+      - type: rfe
+        category: rfe
+        pull: 8589
+        issue: 72111
+        authors:
+          - jglick
+        pr_title: "[JENKINS-72111] Allow `Lifecycle` to load implementations from\
+          \ plugins"
+        message: |-
+          Developer: Allow plugins to define a custom <code>Lifecycle</code>.
+
+  # pull: 8565 (PR title: [JENKINS-72028] replace deprecated `URL()` at  `core/src/main/java/hudson/`)
+  # pull: 8568 (PR title: [JENKINS-72028] replace deprecated `URL()` at  `core/src/main/java/jenkins/`)
+  # pull: 8569 (PR title: [JENKINS-72028] at ` test/src/test/java/hudson/` replace deprecated `URL()`  )
+  # pull: 8570 (PR title: [JENKINS-72028] at `test/src/test/java/jenkins/` replace deprecated `URL()`  )
+  # pull: 8584 (PR title: Update dependency eslint to v8.51.0)
+  # pull: 8585 (PR title: Bump org.jenkins-ci.main:jenkins-test-harness from 2085.va_c531db_287b_d to 2090.v6d1706e434a_b_)
+  # pull: 8588 (PR title: Restrict helper classes in `ScriptListener` for internal use)
+  # pull: 8591 (PR title: Bump stapler.version from 1814.vdc9dd5217ee2 to 1819.v4a_093e9c82f9)
+  # pull: 8597 (PR title: Bump com.google.guava:guava from 32.1.2-jre to 32.1.3-jre)
+  # pull: 8599 (PR title: Update dependency postcss-preset-env to v9.2.0)
+  # pull: 8600 (PR title: Bump org.jenkins-ci.main:remoting from 3148.v532a_7e715ee3 to 3160.vd76b_9ddd10cc)
+  # pull: 8603 (PR title: Remove unnecessary `<dependencyManagement>` entry)
+  # pull: 8604 (PR title: Update dependency sass to v1.69.1)
+  # pull: 8605 (PR title: Update dependency lit to v3)
+  # pull: 8609 (PR title: Update dependency sass to v1.69.2)
+  # pull: 8610 (PR title: Update babel monorepo to v7.23.2)
+  # pull: 8611 (PR title: Update dependency sass to v1.69.3)
+
 # DO NOT EDIT THIS FILE DIRECTLY ON GITHUB IF YOU HAVE COMMIT ACCESS
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS
 # MALFORMED FILE CONTENTS WILL BREAK THE SITE BUILD


### PR DESCRIPTION
This PR is a draft for the suggested changes for the 2.428 changelog.

There are several entries for the translation/inclusion of `*_fr.properties` in various areas, and the Winstone upgrade entry has been borrowed from the LTS changelog since it has been backported there already.

The entries have been re-arranged to be more relevant to each other as well.