### PR TITLE
Restore note on hostname, fix formatting

### DIFF
--- a/content/doc/developer/publishing/releasing-manually.adoc
+++ b/content/doc/developer/publishing/releasing-manually.adoc
@@ -26,19 +26,20 @@ curl -u your_user_name:your_password https://repo.jenkins-ci.org/setup/settings.
 
 This will print the configuration you need to your terminal. You should see something similar to this:
 
-[source,bash]
+[source,xml]
 ----
-curl -u mr_jenkins:j3nkinsr0ck5 https://repo.jenkins-ci.org/setup/settings.xml
+$ curl -u mr_jenkins:j3nkinsr0ck5 https://repo.jenkins-ci.org/setup/settings.xml
 <settings xmlns="https://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>maven.jenkins-ci.org</id>
+      <id>maven.jenkins-ci.org</id> // <1>
       <username>mr_jenkins</username>
       <password>APrj80t4398w8fnytd498nft4dt8so</password>
     </server>
   </servers>
 </settings>
 ----
+<1> This is not a valid host name anymore, but still the ID used by default in the Jenkins plugin parent POM.
 
 Store the output as `~/.m2/settings.xml` (`~` representing your user home directory, e.g. `/home/yourname` or `C:\Users\yourname`), creating the file if it doesn't exist yet.
 If you already have this file, merge the `server` block provided in the output with your existing `servers` section, if any, and otherwise add the provided `servers` section to your file.


### PR DESCRIPTION
Restore a note explaining the host name that was deleted as part of #6396 (only appeared in the block removed there).

Revert improper change to sample output from #6398.

Untested.