### PR TITLE
 Improved Section Headline Clarity by Removing Italic Style

### DIFF
--- a/content/doc/book/security/access-control.adoc
+++ b/content/doc/book/security/access-control.adoc
@@ -34,12 +34,12 @@ A disadvantage is the lack of integration with Jenkins access controls and poten
 When configuring authentication and authorization in Jenkins, it is easy to accidentally allow far more access than intended.
 See link:/doc/book/security/access-control/permissions/#administer[the documentation on the access given to administrators] about the impact of unintentionally granting Administer permission.
 
-_Anyone can do anything_::
+Anyone can do anything::
 This authorization strategy is very rarely a good choice, as it allows even anonymous users to administer Jenkins.
 As a rule of thumb, it should not be used.
 Never rely on the Jenkins URL to not be known outside your team or organization alone for security.
 
-_Logged-in users can do anything_::
+Logged-in users can do anything::
 This authorization strategy can be a sensible choice as long as only fully trusted users have accounts to access Jenkins.
 This is the default with Jenkins's single admin user when setting up Jenkins with the setup wizard.
 +

--- a/content/doc/book/security/access-control.adoc
+++ b/content/doc/book/security/access-control.adoc
@@ -40,7 +40,7 @@ As a rule of thumb, it should not be used.
 Never rely on the Jenkins URL to not be known outside your team or organization alone for security.
 
 Logged-in users can do anything::
-This authorization strategy can be a sensible choice as long as only fully trusted users have accounts to access Jenkins.
+Using the *logged-in users can do anything* authorization strategy can be a sensible choice as long as only fully trusted users have accounts to access Jenkins.
 This is the default with Jenkins's single admin user when setting up Jenkins with the setup wizard.
 +
 Switching to an authentication realm that allows untrusted users to have an account later will result in those users getting administrative access to Jenkins if you keep this authorization strategy.

--- a/content/doc/book/security/access-control.adoc
+++ b/content/doc/book/security/access-control.adoc
@@ -35,7 +35,7 @@ When configuring authentication and authorization in Jenkins, it is easy to acci
 See link:/doc/book/security/access-control/permissions/#administer[the documentation on the access given to administrators] about the impact of unintentionally granting Administer permission.
 
 Anyone can do anything::
-This authorization strategy is very rarely a good choice, as it allows even anonymous users to administer Jenkins.
+The *anyone can do anything* authorization strategy is very rarely a good choice, as it allows even anonymous users to administer Jenkins.
 As a rule of thumb, it should not be used.
 Never rely on the Jenkins URL to not be known outside your team or organization alone for security.
 


### PR DESCRIPTION
**ISSUE**
Some headlines in the page are unnecessarily written in italic style.
See the issue at this link https://www.jenkins.io/doc/book/security/access-control/#common-configuration-mistakes

**WHY TO REMOVE ITALIC STYLE?**
To maintain uniformity in the documentation writing style. It will improve clarity and readability.

<img width="839" alt="Screenshot 2023-10-18 192253" src="https://github.com/jenkins-infra/jenkins.io/assets/102309095/0b872882-4e2a-4ebd-ba2a-063f01535650">
