### PR TITLE
Fix: Update meta tag name to property for description and og image

### DIFF
--- a/content/_layouts/frame.html.haml
+++ b/content/_layouts/frame.html.haml
@@ -50,9 +50,9 @@
     %meta{:content => page.title, :property => "og:title"}/
     %meta{:content => "article", :property => "og:type"}/
     %meta{:content => absolute_link(page.output_path), :property => "og:url"}/
-    %meta{:content => description, :name => "og:description"}/
+    %meta{:content => description, :property => "og:description"}/
     %meta{:content => page.title, :property => "og:site_name"}/
-    %meta{:content => opengraph_image, :name => "og:image"}/
+    %meta{:content => opengraph_image, :property => "og:image"}/
 
     - if page.css
       - for style in page.css


### PR DESCRIPTION
Fixes #6785. 

Updated the `meta` tag to have the proper `property` value instead of `name` value as in the example given in the LinkedIn recommended format at https://www.linkedin.com/help/linkedin/answer/a521928. 