### PR TITLE
Add a note to LTS 2.414.3 changelog to warn about short tags and Java 17

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9642,6 +9642,9 @@
 
 - version: "2.414.3"
   date: 2023-10-18
+  banner: >
+      Short tags (without "jdk" in them) like 'jenkins/jenkins:2.414.3-alpine' (for example) are using Java 17 and not Java 11 like previously.
+      If you need to keep using Java 11 use tags like 'jenkins/jenkins:2.414.3-jdk11'.
   changes:
   - type: security
     message: Important security fix.
@@ -9658,8 +9661,6 @@
         title: Docker pull request 1724
     message: |-
       Use Java 17 as the default Java version in container images that do not specify a Java version in the container label.
-      Short tags (without "jdk" in them) like 'jenkins/jenkins:2.414.3-alpine' (for ex) are using Java 17 and not Java 11 like previously.
-      If you need to keep using Java 11 use tags like 'jenkins/jenkins:2.414.3-jdk11'.
   - type: major rfe
     category: rfe
     pull: 8478

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9658,6 +9658,9 @@
         title: Docker pull request 1724
     message: |-
       Use Java 17 as the default Java version in container images that do not specify a Java version in the container label.
+
+      Please note that images with short tags (without "jdk" in them) like `jenkins/jenkins:2.414.3` or `jenkins/jenkins:2.414.3-alpine` amongst other are using Java 17 and not Java 11 like in previous version.
+      If you need to keep using Java 11, you'll have to use (for example) the tags `jenkins/jenkins:2.414.3-jdk11` or `jenkins/jenkins:2.414.3-alpine-jdk11`.
   - type: major rfe
     category: rfe
     pull: 8478

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9658,9 +9658,8 @@
         title: Docker pull request 1724
     message: |-
       Use Java 17 as the default Java version in container images that do not specify a Java version in the container label.
-
-      Please note that images with short tags (without "jdk" in them) like `jenkins/jenkins:2.414.3` or `jenkins/jenkins:2.414.3-alpine` amongst other are using Java 17 and not Java 11 like in previous version.
-      If you need to keep using Java 11, you'll have to use (for example) the tags `jenkins/jenkins:2.414.3-jdk11` or `jenkins/jenkins:2.414.3-alpine-jdk11`.
+      Short tags (without "jdk" in them) like 'jenkins/jenkins:2.414.3-alpine' (for ex) are using Java 17 and not Java 11 like previously.
+      If you need to keep using Java 11 use tags like 'jenkins/jenkins:2.414.3-jdk11'.
   - type: major rfe
     category: rfe
     pull: 8478

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9643,8 +9643,8 @@
 - version: "2.414.3"
   date: 2023-10-18
   banner: >
-      Short tags (without "jdk" in them) like for example <code>jenkins/jenkins:2.414.3-alpine</code> are using Java 17 and not Java 11 like previously.
-      If you need to keep using Java 11 use tags like <code>jenkins/jenkins:2.414.3-jdk11</code>.
+      Short tags (without "jdk" in them) such as <code>jenkins/jenkins:2.414.3-alpine</code> are using Java 17 and not Java 11 like previously.
+      If you need to keep using Java 11, use tags like <code>jenkins/jenkins:2.414.3-jdk11</code>.
   changes:
   - type: security
     message: Important security fix.

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9643,8 +9643,8 @@
 - version: "2.414.3"
   date: 2023-10-18
   banner: >
-      Short tags (without "jdk" in them) like 'jenkins/jenkins:2.414.3-alpine' (for example) are using Java 17 and not Java 11 like previously.
-      If you need to keep using Java 11 use tags like 'jenkins/jenkins:2.414.3-jdk11'.
+      Short tags (without "jdk" in them) like for example <code>jenkins/jenkins:2.414.3-alpine</code> are using Java 17 and not Java 11 like previously.
+      If you need to keep using Java 11 use tags like <code>jenkins/jenkins:2.414.3-jdk11</code>.
   changes:
   - type: security
     message: Important security fix.


### PR DESCRIPTION
This PR adds a note to https://www.jenkins.io/changelog-stable/ to warn users that short tags (without "jdk" in them) are Java 17 ones now, not Java 11, and that they have to add "jdk11" to continue using Java 11.

Related: https://github.com/jenkinsci/docker/issues/1754#issuecomment-1776772387