### PR TITLE
Update GSoC main page for 2024

### DIFF
--- a/content/projects/gsoc/2024/application.adoc
+++ b/content/projects/gsoc/2024/application.adoc
@@ -1,0 +1,260 @@
+---
+layout: project
+title: "Jenkins GSoC Application 2022"
+description: "This page is Jenkins application form for Google Summer of Code"
+tags:
+- gsoc
+project: gsoc
+opengraph:
+    image: /images/gsoc/opengraph.png
+---
+
+//https://docs.google.com/document/d/1gVO2XT_7m8kf5aJJS00G05f5zBBf1eaFZPcoWl8W0m0/edit#heading=h.pj9miykzw86z
+
+{nbsp} +
+{nbsp} +
+
+
+**Organization Name**
+
+Jenkins
+
+{nbsp} +
+{nbsp} +
+ 
+
+**Is this organization an established Open Source project or organization that releases code under an OSI approved license ? An OSI License is required for program participation.**
+
+Yes
+
+{nbsp} +
+{nbsp} +
+
+
+**Has your organization participated in Google Summer of Code before?**
+
+Yes
+
+{nbsp} +
+{nbsp} +
+
+
+**Please select all years in which your organization participated prior to 2022.**
+
+2021, 2020, 2019, 2018, 2016
+
+{nbsp} +
+{nbsp} +
+
+
+**Agreements and Rules**
+
+_link:https://summerofcode.withgoogle.com/terms/org[Click the link] to review the organization agreement to continue._
+
+>> Accept
+
+{nbsp} +
+{nbsp} +
+
+
+=== Organization Profile
+
+* **Website url:** https://jenkins.io/
+* **Organization logo**
+
+<logo comes here>
+
+* **Tagline:** Open-source automation server for building great things at any scale
+
+* **Primary Open Source License:** MIT License is used for most of the components.
+
+* **What year was your project started:** 2006
+
+* **Link to your source code location:**
+** https://github.com/jenkinsci/,
+** https://github.com/jenkins-zh/,
+** https://github.com/jenkins-infra/
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== Organization Categories
+_Select which categories fit your organization best. You may select up to 2 categories. This helps GSoC contributors filter the large list of organizations by their interests._
+_Select at least 1_
+
+* Data (databases, analytics, visualization, AI/ML, etc)
+* **Development tools** (version control systems, CICD tools, text editors, issue managers, q/a tools, etc)
+* End user applications
+* Infrastructure and cloud (hardware, software defined infrastructure, cloud native tooling, orchestration and automation, etc)
+* Media (graphics, video, audio, VR, streaming, gaming, content management, etc)
+* Operating systems
+* **Programming languages** (libraries, package managers, testing tools, etc)
+* Science and medicine (healthcare, biotech, life sciences, academic research, etc)
+* Security (tools and frameworks)
+* Social and communications (Blog, chat, forums, wikis, etc)
+* Web (tools and frameworks)
+* Other
+
+=== Organization Technologies
+_Enter up to 5 keywords for the primary specific technologies your organization uses._
+
+* java
+* javascript
+* docker
+* kubernetes
+* go
+
+=== Organization Topics
+_Enter keywords for general topics that describe your organization. Examples: Robotics, Cloud,_
+
+* continuous integration
+* continuous delivery
+* developer tools
+* devops
+* automation
+
+
+{nbsp} +
+{nbsp} +
+ 
+
+=== Organization Description
+_Describe what it is your organization does. This information will also be included in the archive once the program has ended._
+
+{nbsp} +
+
+
+**Short description**
+
+Jenkins is a popular open source automation server which is used for building, testing, CI/CD, deployment and many other use-cases. Our motto is "Build great things at any scale".
+
+{nbsp} +
+
+**Long description (Markdown)**
+
+link:/[Jenkins], originally founded in 2006 as "Hudson", is one of the leading automation servers.
+Jenkins' motto is "Build great things at any scale".
+Using an extensible, plugin-based architecture developers have created hundreds of plugins to adapt Jenkins to a multitude of build, test, and deployment automation workloads.
+Jenkins is open-source, link:https://www.opensource.org/licenses/mit-license.php[MIT License] is used for most of the components.
+
+This year we invite potential GSoC contributors to join the Jenkins community and to work together to improve Jenkins.
+We have many strategic project ideas which are important to hundreds of thousands of Jenkins users.
+
+The project has over 600 active contributors working on Jenkins core, plugins, website, project infrastructure, localization activities, etc.
+In total we have more than 2,000 components including plugins, libraries, and various utilities.
+The main languages in the project are Java, Groovy and JavaScript, but we also have components written in other languages (Go, C/C++, C#, etc.).
+Jenkins project includes multiple sub-projects (including link:/projects/jcasc/[Configuration-as-Code], link:/projects/infrastructure/[Infrastructure] and link:/projects/remoting/[Remoting]) and link:/sigs/[special interest groups].
+These entities participate in GSoC as a part of the Jenkins project.
+
+The Jenkins project is a part of link:https://cd.foundation/[Continuous Delivery Foundation (CDF)].
+
+{nbsp} +
+{nbsp} +
+ 
+
+=== Contributor Guidance
+
+_Provide your potential contributors with a page containing tips on how to write a successful proposal for your organization. Let them know what you want included, how you want it structured, and how to best get in touch. link:https://developers.google.com/open-source/gsoc/help/contributor-guidance[Examples]._
+
+Welcome and thank you for your interest!
+To apply to the organization, please follow the link:https:/projects/gsoc/students/#student-application-process[guidelines on our website].
+
+Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/students/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
+If you have any questions about the application process, please feel free to contact us via link:https://community.jenkins.io/tag/gsoc[Jenkins GSoC Discourse] or in the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[jenkinsci/gsoc-sig Gitter] chat. We also have weekly meetings which are open to everyone.
+
+
+{nbsp} +
+{nbsp} +
+
+=== Communication Methods
+
+_How do you want potential contributors to interact with your organization? Select methods that your community uses daily as you will receive many inquiries if your org is selected._
+
+Jenkins GSoC communication channels: link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse], link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Gitter]
+
+
+{nbsp} +
+{nbsp} +
+
+
+== Organization Questionnaire
+
+=== Why does your organization want to participate in GSoC?
+
+In our community we are interested to have more contributors in both the Jenkins core and 1,800+ existing plugins. GSoC is an opportunity to find new contributors interested in software development automation (continuous integration and continuous delivery).
+It also helps to get existing contributors more involved in community work. We have previously participated in GSoC 2016-2021.
+We gained valuable experience, especially regarding the student selection process.
+We received significant contributions and are still using those contributions in the project.
+We are confident that we can host a successful Google Summer of Code 2022 in the Jenkins project.
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== What would your organization consider to be a successful GSoC program?
+
+A successful Jenkins GSoC program consists of:
+
+* A positive and enjoyable experience for both GSoC contributors and mentors, where the project’s goals provide a sense of challenge and rewarding learning experience.
+* Contributor’s code contributions play a part in the betterment of Jenkins resulting in benefit for Jenkins users
+* GSoC contributors are inspired to contribute to Jenkins after the program and return as a GSoC mentor in the future.
+
+{nbsp} +
+{nbsp} +
+
+=== How will you keep mentors engaged with their GSoC contributors?
+
+* We have explicit expectations from mentors, they are documented in our link:/projects/gsoc/mentors[mentor guidelines].
+  All mentors commit to these expectations during the project selection.
+* Each GSoC contributor will have at least 2 mentors AND an org admin advisor assigned to the project.
+* Mentors are expected to be accomplished Jenkins contributors, who are passionate about community/mentorship work.
+* Mentors are highly interested in the project they are mentoring
+* Mentors are directly involved in the GSoC contributor selection and interview processes so they will establish early connections with GSoC contributors
+* Org admins will be monitoring mentor/GSoC contributor interaction starting from the application phase and intervene if needed
+* There will be regular sync-ups between org admins and mentors
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== How will you keep your GSoC contributors on schedule to complete their projects?
+
+* During the Application phase and Community Bonding phase mentors will share their expertise to define realistic project plans.
+* The GSoC contributor project milestones will be discussed and confirmed between mentors and GSoC contributors. Milestones will be aligned with GSoC contributor evaluations and will have clear expectations defined.
+* Mentors will set up regular meetings with their GSoC contributor (at least weekly) in order to sync-up on projects.
+* Retrospectives with GSoC contributors will be held after each evaluation.
+* Mentors should be available for questions. They should also provide periodic feedback on the progress and on the performance of particular GSoC contributors (1x1).
+* Weekly public GSoC office-hours allow GSoC contributors, mentors, and organization administrators to meet, plan, and review. (or two meetings if time-zones require it) and private ones between mentors and org admins to sync-up
+* We will encourage frequent push to branches so that the GSoC contributors show progress and keep changes atomic.
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== How will you get your GSoC contributors involved in your community during GSoC?
+
+* GSoC contributors will cooperate with the Jenkins community during the project. Community Bonding will be a critical phase for us.
+* Projects will handled under an umbrella of SIGs or sub-projects so that non-mentor stakeholders and early adopters are included in the projects
+* GSoC contributors will be participating in sub-project/SIG meetings and presenting their work on a regular basis
+* Org Admins will provide an introductory training (community overview, code-of-conduct, etc.), then mentors will help GSoC contributors establish contacts with experts from the community
+* We expect GSoC contributors to be around in public chats and other communication channels during the “working days”
+* GSoC contributors will be involved in all standard processes in our community (pull requests, code reviews, chats and mailing lists, test automation, documentation, online meetups, etc.).
+* GSoC contributors will be encouraged to give updates to the wider community via the Jenkins blog and Jenkins online meetups
+
+
+{nbsp} +
+{nbsp} +
+
+
+=== Is your organization part of any government?
+
+No
+
+
+{nbsp} +
+{nbsp} +

--- a/content/projects/gsoc/2024/index.adoc
+++ b/content/projects/gsoc/2024/index.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /projects/gsoc
+---

--- a/content/projects/gsoc/2024/project-ideas.html.haml
+++ b/content/projects/gsoc/2024/project-ideas.html.haml
@@ -50,7 +50,7 @@ opengraph:
   Accepted ideas
 
 %p
-  In the following list, you can refer to the list of project ideas that fully match the Jenkins' project idea standard.
+  In the following list, you will find the project ideas that fully match the Jenkins' project idea standard.
   The scope of these ideas is understood and we don't normally expect deep changes.
   All ideas have quick start guidelines and newbie-friendly issues referenced.
   We welcome contributors to join the mentor teams, and we invite GSoC contributors to submit project proposal applications in relation to these ideas.

--- a/content/projects/gsoc/2024/project-ideas.html.haml
+++ b/content/projects/gsoc/2024/project-ideas.html.haml
@@ -34,13 +34,13 @@ opengraph:
     This page aggregates project ideas for Google Summer of Code
     = page.year
   = succeed '.' do
-    See more information about this project and applications
+    Refer to the Jenkins Google Summer of Code page
     %a{:href => expand_link("/projects/gsoc/")}
-      on the Jenkins Google Summer of Code page
+         for more information about this project and applications.
 %p
   Below you can find project ideas which have been proposed for this year.
-  New ideas may be proposed by interested mentors or GSoC contributors (e.g. new features in the core, "write a plugin for MY_TOOL_OR_SERVICE", etc.).
-  Project ideas without potential mentors will be considered though applicants may need to work with the community and GSoC org admins to find mentors.
+  New ideas may be proposed by interested mentors or GSoC contributors, such as new features in the core or "write a plugin for MY_TOOL_OR_SERVICE".
+  Project ideas without potential mentors will be considered, though applicants may need to work with the community and GSoC org admins to find mentors.
   To add a new project idea, see:
   = succeed '.' do
     %a{:href => expand_link("/projects/gsoc/proposing-project-ideas/")}
@@ -50,8 +50,8 @@ opengraph:
   Accepted ideas
 
 %p
-  Below you can see the list of project ideas that fully match the Jenkins' project idea standard.
-  The scope of these ideas is well known and we don't normally expect deep changes.
+  In the following list, you can refer to the list of project ideas that fully match the Jenkins' project idea standard.
+  The scope of these ideas is understood and we don't normally expect deep changes.
   All ideas have quick start guidelines and newbie-friendly issues referenced.
   We welcome contributors to join the mentor teams, and we invite GSoC contributors to submit project proposal applications in relation to these ideas.
 
@@ -91,10 +91,10 @@ opengraph:
   Draft project ideas
 
 %p
-  Below you can see draft project ideas, which are currently under review.
+  In the following list, you can refer to draft project ideas, which are currently under review.
   The scope of such ideas may change during the discussions, but the idea is accepted in principle.
-  You are welcome to comment on the draft and to join the project as a mentor.
-  If you are a GSoC contributor, it is also fine to explore and to apply to the draft project ideas.
+  You are welcome to comment on the draft and join the project as a mentor.
+  If you are a GSoC contributor, it is also fine to explore and apply to the draft project ideas.
 
 %table.pi_table.grid-all
   %thead
@@ -134,9 +134,9 @@ opengraph:
     Ongoing discussion
 
   %p.markdown
-    These are proposals in the mailing lists which have not been published as project ideas yet.
+    These proposals are suggestions from the mailing list, which have not been published as project ideas yet.
     The feasibility is yet to be defined, and the idea may be dismissed depending on the feedback.
-    Everyone is welcome to participate in the discussion and to join as a potential mentor.
+    Everyone is welcome to participate in the discussion and join as a potential mentor.
 
   %table.pi_table.grid-all
     %thead

--- a/content/projects/gsoc/2024/project-ideas.html.haml
+++ b/content/projects/gsoc/2024/project-ideas.html.haml
@@ -36,7 +36,7 @@ opengraph:
   = succeed '.' do
     Refer to the Jenkins Google Summer of Code page
     %a{:href => expand_link("/projects/gsoc/")}
-         for more information about this project and applications.
+    for more information about this project and applications.
 %p
   Below you can find project ideas which have been proposed for this year.
   New ideas may be proposed by interested mentors or GSoC contributors, such as new features in the core or "write a plugin for MY_TOOL_OR_SERVICE".

--- a/content/projects/gsoc/2024/project-ideas.html.haml
+++ b/content/projects/gsoc/2024/project-ideas.html.haml
@@ -1,0 +1,161 @@
+---
+layout: simplepage
+title: "GSoC 2024 Project Ideas"
+year: 2024
+tags:
+- gsoc
+- gsoc2024
+project: gsoc
+opengraph:
+  image: /images/gsoc/opengraph.png
+---
+
+//The individual page's layout is located at /content/_layouts/gsocprojectidea.html.haml
+
+:css
+  .pi_table {
+    width: 100%;
+  }
+  .pi_table_header {
+    text-align: center;
+  }
+  .pi_table_category {
+    width: 100px;
+  }
+  .pi_table_skills {
+    width: 175px;
+  }
+
+%img{:title => "Jenkins GSoC", :src => expand_link("/images/gsoc/jenkins-gsoc-logo_small.png"), :style => "float:right", :width => "128"}
+
+
+%p
+  = succeed '.' do
+    This page aggregates project ideas for Google Summer of Code
+    = page.year
+  = succeed '.' do
+    See more information about this project and applications
+    %a{:href => expand_link("/projects/gsoc/")}
+      on the Jenkins Google Summer of Code page
+%p
+  Below you can find project ideas which have been proposed for this year.
+  New ideas may be proposed by interested mentors or GSoC contributors (e.g. new features in the core, "write a plugin for MY_TOOL_OR_SERVICE", etc.).
+  Project ideas without potential mentors will be considered though applicants may need to work with the community and GSoC org admins to find mentors.
+  To add a new project idea, see:
+  = succeed '.' do
+    %a{:href => expand_link("/projects/gsoc/proposing-project-ideas/")}
+      proposing project ideas
+
+%h3
+  Accepted ideas
+
+%p
+  Below you can see the list of project ideas that fully match the Jenkins' project idea standard.
+  The scope of these ideas is well known and we don't normally expect deep changes.
+  All ideas have quick start guidelines and newbie-friendly issues referenced.
+  We welcome contributors to join the mentor teams, and we invite GSoC contributors to submit project proposal applications in relation to these ideas.
+
+%table.pi_table.grid-all
+  %thead
+    %tr.pi_table_header
+      %th Project
+      %th Category
+      %th Skills to study/improve
+  %tbody
+    // TODO: parameterize year
+    - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2024\/project-ideas\/[^\/]+.adoc/ }
+    - ideas.each do |item|
+      - if item.status == "published"
+        %tr
+          %td
+            %a{:href => item.url}
+              %strong
+                = item.title
+            %br
+            = succeed '.' do
+              = item.goal
+            %br
+            %b
+              Potential Mentor(s):
+            - item.mentors.each do |mentor|
+              = display_user_optional(mentor)
+          %td.pi_table_category
+            - if item.category
+              = item.category
+            - else
+              Undefined
+          %td.pi_table_skills
+            = item.skills.join(", ")
+
+%h3
+  Draft project ideas
+
+%p
+  Below you can see draft project ideas, which are currently under review.
+  The scope of such ideas may change during the discussions, but the idea is accepted in principle.
+  You are welcome to comment on the draft and to join the project as a mentor.
+  If you are a GSoC contributor, it is also fine to explore and to apply to the draft project ideas.
+
+%table.pi_table.grid-all
+  %thead
+    %tr.pi_table_header
+      %th Project
+      %th Category
+      %th Skills to study/improve
+  %tbody
+    // TODO: parameterize year
+    - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2024\/project-ideas\/[^\/]+.adoc/ }
+    - ideas.each do |item|
+      - if item.status == "draft"
+        %tr
+          %td
+            %a{:href => item.url}
+              %strong
+                = item.title
+            %br
+              = succeed '.' do
+                = item.goal
+            %b
+              Potential Mentor(s):
+            - item.mentors.each do |mentor|
+              = display_user_optional(mentor)
+          %td.pi_table_category
+            - if item.category
+              = item.category
+            - else
+              Undefined
+          %td.pi_table_skills
+            = item.skills.join(", ")
+
+// TODO parameterize year
+- ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2024\/project-ideas\/[^\/]+.adoc/ }
+- if ideas.length > 1
+  %h3
+    Ongoing discussion
+
+  %p.markdown
+    These are proposals in the mailing lists which have not been published as project ideas yet.
+    The feasibility is yet to be defined, and the idea may be dismissed depending on the feedback.
+    Everyone is welcome to participate in the discussion and to join as a potential mentor.
+
+  %table.pi_table.grid-all
+    %thead
+      %tr.pi_table_header
+        %th Project
+        %th Category
+    %tbody
+      - ideas.each do |item|
+        - if item.status == "discussion"
+          %tr
+            %td
+              %a{:href => item.links.emailThread}
+                %strong
+                  = item.title
+              %br
+                = succeed '.' do
+                  = item.goal
+            %td.pi_table_category
+              - if item.category
+                = item.category
+              - else
+                Undefined

--- a/content/projects/gsoc/2024/project-ideas/buiilding-android-app.adoc
+++ b/content/projects/gsoc/2024/project-ideas/buiilding-android-app.adoc
@@ -1,0 +1,64 @@
+---
+layout: gsocprojectidea
+title: "Building Android Apps with Jenkins"
+goal: "Describe best practices and provide architectural templates for building Android applications with Jenkins"
+category: Tools
+year: 2024
+status: draft
+sig: platform
+skills:
+- Java
+- YAML
+- Android development
+- Command line tools
+- Package management tool theory
+mentors:
+- "gounthar"
+links:
+    emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-android-apps-with-jenkins/4798
+---
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
+//   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+
+=== Background
+
+Applying CI principles when building IOS applications brings its own challenges, different from those of more classical applications.
+How to proceed, what are the successful patterns, what are the pitfalls is poorly documented. 
+It very often requires potential user and Jenkins Administrator to "reinvent the wheel".
+
+Some experiments are link:https://github.com/gounthar/MyFirstAndroidAppBuiltByJenkins[available] and were link:https://www.youtube.com/watch?v=fmTdT4Y-uCw&ab_channel=JeanQuinze[presented publicly].
+
+The proof of concept could be the docker-compose based. It would works under Windows, Linux, Vagrant, macOS (x86 and ARM), and mostly on Gitpod.
+It should be easily transposable to a production environment.
+The demo/proof-of-concept would be composed of a Jenkins controller (configured with JCasc), an Android agent, a generic Docker agent, an Android emulator, and an Android device farm (link:https://github.com/DeviceFarmer[STF]).
+
+The idea is to have a more precise status of what can be done now with Jenkins. We could then amend the existing link:/solutions/android/[documentation] and describe architectures for:
+
+* Standalone Android projects
+* Android apps building farms
+* Android distro building (customized AOSP)
+
+//
+// === Quick Start
+// TBD
+//
+=== Skills to Study and Improve
+
+- Jenkins technical architecture
+- Android application development
+- CI principle and practice
+- Docker
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+=== Project Size
+
+175 hours
+
+=== Expected outcomes
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase. 
+
+// === Newbie Friendly Issues

--- a/content/projects/gsoc/2024/project-ideas/buiilding-android-app.adoc
+++ b/content/projects/gsoc/2024/project-ideas/buiilding-android-app.adoc
@@ -23,16 +23,18 @@ links:
 === Background
 
 Applying CI principles when building IOS applications brings its own challenges, different from those of more classical applications.
-How to proceed, what are the successful patterns, what are the pitfalls is poorly documented. 
-It very often requires potential user and Jenkins Administrator to "reinvent the wheel".
+Topics such as _how to proceed_, _what are the successful patterns_, and _what are the pitfalls_ are poorly documented. 
+It very often requires potential users and Jenkins Administrators to "reinvent the wheel".
 
 Some experiments are link:https://github.com/gounthar/MyFirstAndroidAppBuiltByJenkins[available] and were link:https://www.youtube.com/watch?v=fmTdT4Y-uCw&ab_channel=JeanQuinze[presented publicly].
 
-The proof of concept could be the docker-compose based. It would works under Windows, Linux, Vagrant, macOS (x86 and ARM), and mostly on Gitpod.
+The proof of concept could be docker-compose based.
+It would work under Windows, Linux, Vagrant, macOS (x86 and ARM), and _mostly_ on Gitpod.
 It should be easily transposable to a production environment.
 The demo/proof-of-concept would be composed of a Jenkins controller (configured with JCasc), an Android agent, a generic Docker agent, an Android emulator, and an Android device farm (link:https://github.com/DeviceFarmer[STF]).
 
-The idea is to have a more precise status of what can be done now with Jenkins. We could then amend the existing link:/solutions/android/[documentation] and describe architectures for:
+The idea is to have a more precise status of what can be done now with Jenkins.
+We could then amend the existing link:/solutions/android/[Android documentation] and describe architectures for:
 
 * Standalone Android projects
 * Android apps building farms

--- a/content/projects/gsoc/2024/project-ideas/buiilding-ios-app.adoc
+++ b/content/projects/gsoc/2024/project-ideas/buiilding-ios-app.adoc
@@ -1,0 +1,60 @@
+---
+layout: gsocprojectidea
+title: "Building iOS Apps with Jenkins"
+goal: "Describe best practices and provide architectural templates for building iOS applications with Jenkins"
+category: Tools
+year: 2024
+status: draft
+sig: platform
+skills:
+- Java
+- YAML
+- iOS development
+- Command line tools
+- Package management tool theory
+mentors:
+- "gounthar"
+links:
+    emailThread: https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799
+---
+//   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
+//   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+
+=== Background
+
+Applying CI principles when building iOS applications brings its own challenges, different from those of more classical applications.
+How to proceed, what are the successful patterns, what are the pitfalls is poorly documented. 
+It very often requires potential user and Jenkins Administrator to "reinvent the wheel".
+
+The project idea is to have a clear status of what can be done with Jenkins for iOS app builds now.
+There are only a few articles here and there about iOS.
+
+//
+// === Quick Start
+// TBD
+//
+=== Skills to Study and Improve
+
+- Jenkins technical architecture
+- iOS application development
+- CI principle and practice
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+=== Project Size
+
+175 hours
+
+=== Expected outcomes
+
+* A working iOS application CI build with Jenkins from a public GitHub public repository (Proof of Concept).
+* A proposed architecture that would work for almost anyone (so Docker whenever it’s possible, or virtual machines) using a public GitHub repo.
+* The required additional tooling to make it all work.
+* At least one blog post explaining how to replicate the POC, preferably a full documentation to be integrated in Jenkins.io
+
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase. 
+// 
+// === Newbie Friendly Issues

--- a/content/projects/gsoc/2024/project-ideas/buiilding-ios-app.adoc
+++ b/content/projects/gsoc/2024/project-ideas/buiilding-ios-app.adoc
@@ -22,9 +22,8 @@ links:
 
 === Background
 
-Applying CI principles when building iOS applications brings its own challenges, different from those of more classical applications.
-How to proceed, what are the successful patterns, what are the pitfalls is poorly documented. 
-It very often requires potential user and Jenkins Administrator to "reinvent the wheel".
+Topics such as _how to proceed_, _what are the successful patterns_, and _what are the pitfalls_ are poorly documented. 
+It very often requires potential users and Jenkins Administrators to "reinvent the wheel".
 
 The project idea is to have a clear status of what can be done with Jenkins for iOS app builds now.
 There are only a few articles here and there about iOS.

--- a/content/projects/gsoc/2024/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2024/project-ideas/plugin-installation-manager-tool.adoc
@@ -1,0 +1,90 @@
+---
+layout: gsocprojectidea
+title: "Plugin Installation Manager Tool Improvements"
+goal: "Introduce new features and improvements in the plugin installation manager"
+category: Tools
+year: 2024
+status: draft
+sig: platform
+skills:
+- Java
+- YAML
+- Command line tools
+- Package management tool theory
+mentors:
+- "markewaite"
+links:
+  gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
+  draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc
+---
+=== Background
+
+In 2019 there was a Jenkins link:/projects/gsoc/2019/plugin-installation-manager-tool-cli/[Google Summer of Code project] to create a tool to link:https://github.com/jenkinsci/plugin-installation-manager-tool/#readme[automatically install plugins] from the command line based on a provided input.
+This is meant to help with creating reproducible environments and other places where you would want to install a certain set of plugins.
+The project was successful in creating a useable tool to install plugins with a 1.0 release.
+Over time, the plugin installation manager was improved and added to other components like official link:https://github.com/jenkinsci/docker#preinstalling-plugins[Jenkins container images].
+
+As a part of this project,
+contributors are invited to introduce new features and improvements in the plugin installation manager.
+The list of enhancements is a subject for discovery as a part of the application process.
+Some of the ideas are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues[project tracker].
+
+Additional background information may be found in a video recording from 2021.
+
+video::QJcwcLnHjRw[youtube, width=640, height=360, align="center"]
+
+=== Quick Start
+
+Visit the link:https://github.com/jenkinsci/plugin-installation-manager-tool[project page] for more details.
+
+1. Clone the project
+2. Run the tests; there are several different lists of plugins
+3. Run the Plugin Installation Manager for various combinations of plugins with a real Jenkins instance.
+   See how the downloads and caching work.
+4. Try out some edge cases to see what could be improved.
+
+=== Skills to Study and Improve
+
+* Java
+* YAML/data structures/package management tools
+* Writing command line interfaces
+* How the Jenkins Docker image and Configuration as Code (CasC) work
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+=== Project Size
+
+175 hours
+
+=== Expected outcomes
+
+Improvements to existing tool
+
+Key improvements for the plugin installation manager tool will be identified, prioritized, and planned.
+Google Summer of Code contributor will propose the areas for improvement and work with mentors to plan those improvements.
+
+Some candidate ideas from the mentors include:
+
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/237[Add subcommands to the command line arguments] requires a definition and design of the subcommands and their behavior
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/488[Generate plugins.txt file from existing directory]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/432[Optionally show progress bar during download]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/446[Retain comments when creating new file from existing file]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/428[List skipped plugins when broken downloads are skipped]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/321[Report the mirror URL and original URL on download failure]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/312[Improve plugin-versions caching for container builds]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/270[Only download a plugin once per session (test if still an issue)]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/267[Allow security warnings report for only specified plugins]
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/264[Read hpi files from maven cache if found there] (and link:https://issues.jenkins.io/browse/JENKINS-58217[JENKINS-58217])
+* link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues/263[Allow logging to be increased for debug and diagnosis]
+* link:https://issues.jenkins.io/browse/JENKINS-65298[Allow plugin versions from the plugin bill of materials to be preferred over latest version]
+* link:https://issues.jenkins.io/browse/JENKINS-65297[Provide an optional flag that returns an error if a plugin dependency is not in the list of plugins to be installed]
+* link:https://issues.jenkins.io/browse/JENKINS-58129[Add command line option to ignore errors if plugin download fails]
+* link:https://issues.jenkins.io/browse/JENKINS-60654[Document the handling of bundled plugins more clearly]
+* link:https://issues.jenkins.io/browse/JENKINS-59066[Cache downloaded plugin files in the Maven cache]
+
+=== Newbie Friendly Issues
+
+Some good first issues are available in the link:https://github.com/jenkinsci/plugin-installation-manager-tool/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[issue tracker].
+For information about how to contribute to and what to work on, please use the link:https://app.gitter.im/#/room/#jenkinsci_plugin-installation-manager-cli-tool:gitter.im[gitter channel].

--- a/content/projects/gsoc/2024/project-ideas/prj-idea-template.adoc_text
+++ b/content/projects/gsoc/2024/project-ideas/prj-idea-template.adoc_text
@@ -1,0 +1,52 @@
+---
+layout: gsocprojectidea
+title: "a title"
+goal: "Goal"
+category: Tools
+year: 2023
+status: discussion
+sig: platform
+skills:
+- Java
+- YAML
+- Command line tools
+- Package management tool theory
+mentors:
+// TODO: enter mentors as jenkins.io authors ( see content/_data/authors)
+// Note: renderer will fail if mentor does not exist
+- "gsoc"
+
+// TODO: Uncomment and update links to the project idea discussion on community.jenkins.io, the gitter channel, and the draft document 
+// links:
+//   emailThread:  Link to the Discourse thread. (*** FOR EXAMPLE *** → https://community.jenkins.io/t/gsoc-2023-project-idea-building-ios-apps-with-jenkins/4799)
+//   gitter: Link to the gitter channel (*** FOR EXAMPLE *** → "jenkinsci/plugin-installation-manager-cli-tool")
+//   draft: Link to the draft detailed project idea ( *** FOR EXAMPLE *** → https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc)
+---
+
+// TODO: Fill the project idea details following bellow template.
+// When uncommented, the following sections will only be rendered when the project idea is promoted to "draft" or "accepted" status.
+
+// === Background
+// TBD
+//
+// === Quick Start
+// TBD
+//
+// === Skills to Study and Improve
+// * TBD
+//
+// === Project Difficulty Level
+// 
+// Beginner to Intermediate
+// 
+// === Project Size
+// 
+// (*** FOR EXAMPLE *** → 175 hours)
+// 
+// === Expected outcomes
+// 
+// New feature
+// 
+// Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase. 
+// 
+// === Newbie Friendly Issues

--- a/content/projects/gsoc/2024/project-ideas/screenshot-automation.adoc
+++ b/content/projects/gsoc/2024/project-ideas/screenshot-automation.adoc
@@ -1,0 +1,72 @@
+---
+layout: gsocprojectidea
+title: "Screenshot Automation for Jenkins Docs"
+goal: "To automate screenshot capture process for Jenkins docs"
+category: Dev Tools
+year: 2024
+status: draft
+sig: docs
+skills:
+- Web Browser Automation
+- Image Comparison
+mentors:
+- "markewaite"
+links:
+  emailThread: https://community.jenkins.io/t/she-code-africa-contributhon-2022/253/3
+---
+
+=== Background
+
+* Browser automation is a known thing and is an interesting idea to explore for the Jenkins project
+* Basic idea is to convert the steps from a human-readable format to a set of computer operations
+* This idea is relatively light-weight and is expected to require no more than a few months' time to complete
+* Could be in almost any language, it is a separate dev tool
+
+=== Project details
+
+* May be extended to render a series of screenshots assembled as gif or mp4
+* How would we define the steps needed?
+    - A YAML format to describe the steps
+    - Capybara in Ruby expresses UI automation in English phrasing
+* How to reduce images to the relevant portion could also be considered
+    - Focusing on an element is a known Javascript technique
+    - Reducing image size is a more complicated procedure, but feasible
+
+=== Links
+
+* https://www.selenium.dev/documentation/
+* https://github.com/teamcapybara/capybara/
+* https://developers.google.com/web/tools/puppeteer
+* https://www.cypress.io/
+
+=== Newbie-friendly issues
+
+Any relevant issue to acquire the GSoC contributor with the way documentation is handled in the Jenkins ecosystem, especially the ones in link:https://github.com/jenkins-infra/jenkins.io/issues/[the jenkins.io repo].
+
+=== Tools available in this space
+
+* Selenium (for web browser automation)
+* Capybara (for web browser automation)
+* Puppeteer (for webdriver web browser automation)
+* Cypress (for webdriver web browser automation)
+* Zika (for image comparison)
+
+=== Skills to improve/study
+
+* Web browser automation
+* Automatic image comparison
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+=== Project Size
+
+175 hours
+
+=== Expected outcomes
+
+New tool to maintain documentation screenshots
+
+Documentation screenshots will be updated automatically based on steps defined as code.
+The steps will be a small domain-specific language that describe common Jenkins UI operations in a way that documentation writers understand.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -17,7 +17,7 @@ links:
 link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
 (GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 10-22 weeks programming project under the guidance of mentors.
 
-GSoC contributors accepted into the program receive a stipend, sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
+GSoC contributors accepted into the program receive a stipend and are sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
 In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
 
 image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -17,44 +17,55 @@ links:
 link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
 (GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 10-22 weeks programming project under the guidance of mentors.
 
-GSoC contributors accepted into the program receive a stipend,
-paid by Google, to work well-defined projects to improve or enhance the Jenkins project.
-In exchange, numerous Jenkins community members volunteer as "mentors"
-for GSoC contributors to help integrate them into the open source community and succeed
-in completing their projects.
+GSoC contributors accepted into the program receive a stipend, sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
+In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
 
 image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
-== GSoC 2023
+== GSoC 2024
 
-We have been accepted as a Google Summer of Code mentoring org for 2023. +
-See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
+We are participating in Google Summer of Code in 2024. +
+// See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
+We are applying to be a mentoring organization in Google Summer of Code 2024.
 
-The selected projects are
+// Uncomment when application is worked on and submitted (Feb 2024)
+//(link:./2024/application[Jenkins GSoC Organisation Application Form])
 
-* link:/projects/gsoc/2023/projects/gitlab-plugin-modernization[GitLab Plugin Modernization] with link:https://github.com/harsh-ps-2003[Harsh Pratap Singh] as GSoC contributor.
-* link:/projects/gsoc/2023/projects/add-probes-to-plugin-health-score[Add probes to "Plugin Health Score"] with link:https://github.com/Jagrutiti[Jagruti Tiwari] as GSoC contributor.
-* link:/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool[Building Jenkins.io with alternative tools] with link:/blog/authors/vandit1604/[Vandit Singh] as GSoC contributor.
-* link:/projects/gsoc/2023/projects/docker-compose-build[Docker-based Jenkins quickstart examples] with link:/blog/authors/ash-sxn/[Ashutosh Saxena] as GSoC contributor.
+// The selected projects are
+//
+// * link:/projects/gsoc/2023/projects/gitlab-plugin-modernization[GitLab Plugin Modernization] with link:https://github.com/harsh-ps-2003[Harsh Pratap Singh] as GSoC contributor.
+// * link:/projects/gsoc/2023/projects/add-probes-to-plugin-health-score[Add probes to "Plugin Health Score"] with link:https://github.com/Jagrutiti[Jagruti Tiwari] as GSoC contributor.
+// * link:/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool[Building Jenkins.io with alternative tools] with link:/blog/authors/vandit1604/[Vandit Singh] as GSoC contributor.
+// * link:/projects/gsoc/2023/projects/docker-compose-build[Docker-based Jenkins quickstart examples] with link:/blog/authors/ash-sxn/[Ashutosh Saxena] as GSoC contributor.
 
-They were proposed and selected from these link:./2023/project-ideas[project ideas].
+// They were proposed and selected from these link:./2024/project-ideas[project ideas].
+
+We are currently collecting project ideas.
+Add your ideas by submitting an ad-hoc pull request as explained in our previous link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
+
+The 2024 GSoC project ideas can be found link:./2024/project-ideas[here].
+
+//Uncomment when further in the selection process
+// They were proposed and selected from these link:./2022/project-ideas[project ideas].
 
 NOTE: Every year, there are changes in how GSoC is organized.
-Jenkins GSoC documentation may be outdated in some places,
-please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.
-Our documentation will be updated over time to reflect the changes in the GSoC program,
-please report any issues you discover.
+Jenkins GSoC documentation may be outdated in some places, please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.
+Our documentation will be updated over time to reflect the changes in the GSoC program, please report any issues you encounter via our GitHub issue tracker.
 
 == GSoC Contributors
 
 * link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
-* Online Meetup: Introduction to Jenkins in GSoC
-(link:https://bit.ly/3pbJFuC[slides],
-link:https://youtu.be/GDRTgEvIVBc[video])
-* link:https://summerofcode.withgoogle.com/programs/2023/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
+// * Online Meetup: Introduction to Jenkins in GSoC
+// (link:https://bit.ly/3pbJFuC[slides],
+// link:https://youtu.be/GDRTgEvIVBc[video])
+// * link:https://summerofcode.withgoogle.com/programs/2023/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
 
 == Mentors
+
+Mentors are volunteers who help GSoC contributors to succeed in their projects.
+If you are interested in contributing to GSoC as a mentor, and have had either some GSoC contributor experience or have done mentoring before, please do not hesitate to reach out to us.
+We are always looking for new mentors to help us with the program.
 
 * link:/projects/gsoc/mentors[Information for mentors]
 * link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
@@ -65,14 +76,14 @@ link:https://youtu.be/GDRTgEvIVBc[video])
 == Org Admins
 
 Org Admins are the people managing the GSoC program for the Jenkins Organization.
-For 2023, Org Admins are:
+For 2024, our Org Admins are:
 
 * Alyssa Tong
-* Jean-Marc Meessen
 * Kris Stern
 * Bruno Verachten
+* Jean-Marc Meessen
 
-The following checklists and documents describe the role.
+The following checklists and documents describe the role:
 
 * link:https://docs.google.com/document/d/1tShnTyka5fdBxaE0c93ptu-J_XTlSf3tKwJemhx5_nA/edit?usp=sharing[Org Admin runbook for the Jenkins project]
 * link:https://developers.google.com/open-source/gsoc/help/oa-tips[Org Admin tips by Google]
@@ -83,18 +94,16 @@ The following checklists and documents describe the role.
 Projects may also have their own mailing lists, chats and meetings.
 See details on project pages.
 * We use link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse] for discussions.
-  This is the **recommended** channel for communications
-* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications,
-  but it is better to use Discourse to request technical feedback or to have long discussions
+  This is the **recommended** channel for communications.
+* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications, but it is better to use Discourse to request technical feedback or to have long discussions.
 * For private matters such as communication difficulties with mentors, GSoC contributors, or Org Admins,
-  please use the this mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
+  please use this mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
 
 === GSoC Discourse
 
 Public communication channel: link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse].
 
-The purpose of GSoC Discourse is for all public communications on GSoC such as new mentor and new GSoC contributor introductions,
-project proposal questions and discussions, process and timeline related questions.
+The purpose of GSoC Discourse is for all public communications on GSoC such as new mentor and new GSoC contributor introductions, project proposal questions and discussions, process and timeline related questions.
 
 === Chats
 
@@ -104,11 +113,10 @@ project proposal questions and discussions, process and timeline related questio
 
 === Office hours
 
-Although we use Discourse as the main communication channel,
-we also have regular "office hours" video calls.
+Although we use Discourse as the main communication channel, we also have regular "office hours" video calls.
 During these time slots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
 
-* Schedule: weekly 30 minutes meeting. Office hours will be held on Thursdays at 16:00 UTC.
+* Schedule: weekly 30 minutes meetings. Office hours will be held on Thursdays at 16:00 UTC.
   Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
 * link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
 * Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
@@ -123,6 +131,7 @@ See the project pages for the schedule.
 
 == Previous years
 
+* link:/projects/gsoc/2023[GSoC 2023] - 4 student projects
 * link:/projects/gsoc/2022[GSoC 2022] - 4 student projects
 * link:/projects/gsoc/2021[GSoC 2021] - 5 student projects
 * link:/projects/gsoc/2020[GSoC 2020] - 7 student projects
@@ -132,12 +141,12 @@ See the project pages for the schedule.
 * link:/projects/gsoc/gsoc2016[GSoC 2016] - 5 student projects
 * link:https://wiki.jenkins.io/display/JENKINS/Google+Summer+of+Code+2009[GSoC 2009] - as Hudson, not accepted
 
-== References, 2023
-
-* link:./2023/project-ideas[GSoC 2023 project ideas]
-//* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins page on the GSoC website]
-* link:/blog/2022/11/16/gsoc-2023/[Jenkins GSoC 2023 announcement]
-* link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2023 announcement blog]
+// == References, 2023
+//
+// * link:./2023/project-ideas[GSoC 2023 project ideas]
+// //* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins page on the GSoC website]
+// * link:/blog/2022/11/16/gsoc-2023/[Jenkins GSoC 2023 announcement]
+// * link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2023 announcement blog]
 
 == References
 


### PR DESCRIPTION
This PR proposes the changes to the main GSoC page for 2024 that are required to start a new iteration in the new year.