### PR TITLE
#6259 Improve link title

### DIFF
--- a/content/doc/book/index.html.haml
+++ b/content/doc/book/index.html.haml
@@ -22,4 +22,4 @@ title: "Jenkins Handbook"
 
 .page-link
   %a{:href => '/doc'}
-    Up to all documentation
+    > Back to User Documentation Home


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/jenkins.io/issues/6259

Title of the link changed from _Up to all documentation_ into `> Back to User Documentation Home`. 
_Up_ keyword was not correctly used previously, as user is sent to different page and not on top of the page.

`>` sign in front differentiates title from the table of contents and aligns with what is on top of the left side menu.

