### PR TITLE
chore(changelog): add a note about the addition of short `-jdk17` LTS Docker image tags

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9645,6 +9645,7 @@
   banner: >
       Short tags (without "jdk" in them) such as <code>jenkins/jenkins:2.414.3-alpine</code> are using Java 17 and not Java 11 like previously.
       If you need to keep using Java 11, use tags like <code>jenkins/jenkins:2.414.3-jdk11</code>.
+      Also note that two new tags (2.414.3-alpine-jdk17 & 2.414.3-slim-jdk17) have been published without any content change a week later than the original ones.
   changes:
   - type: security
     message: Important security fix.

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21836,8 +21836,6 @@
 
   - version: '2.429'
     date: 2023-10-24
-    banner: >
-        Note that two new tags (2.429-alpine-jdk17 & 2.429-slim-jdk17) have been published without any content change a week later than the original ones.
     changes:
       - type: rfe
         category: rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21836,6 +21836,8 @@
 
   - version: '2.429'
     date: 2023-10-24
+    banner: >
+        Note that two new tags (2.429-alpine-jdk17 & 2.429-slim-jdk17) have been published without any content change a week later than the original ones.
     changes:
       - type: rfe
         category: rfe


### PR DESCRIPTION
This PR adds a banner note to the LTS changelog about the new short `-jdk17` Docker image tags which don't contain any change but have a datetime creation a week later than the one of the initial set of tags.

Ref:
- https://github.com/jenkinsci/docker/issues/1754#issuecomment-1777733751