### PR TITLE
fix(documentation): Misprint.

### DIFF
--- a/content/blog/2023/10/31/2023-10-31-marc-s-napkin-upgrade-guide.adoc
+++ b/content/blog/2023/10/31/2023-10-31-marc-s-napkin-upgrade-guide.adoc
@@ -23,7 +23,7 @@ I've included references that I found useful in my research, but keep in mind, y
 I hope this helps others in their journey.
 
 Yours in Jenkins,
-author::mwp565733[Marc]
+author:mwp565733[Marc]
 
 > “This is the way”
 


### PR DESCRIPTION
In the latest blog post that was published, there is an `author` link with a ":" that leads to a `404` error.