### PR TITLE
Remove quotation marks in archetype filters

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -26,7 +26,7 @@ See link:https://wiki.jenkins.io/display/JENKINS/Before+starting+a+new+plugin[th
 Open a command prompt, navigate to the directory you want to store your new Jenkins plugin in, and run the following command:
 
 [source]
-mvn -U archetype:generate -Dfilter="io.jenkins.archetypes:"
+mvn -U archetype:generate -Dfilter=io.jenkins.archetypes:
 
 This command will let you generate one of several project archetypes related to Jenkins.
 In this tutorial we're going to use the `hello-world` archetype, version 1.5, so select that:
@@ -34,7 +34,7 @@ In this tutorial we're going to use the `hello-world` archetype, version 1.5, so
 // https://asciidoctor.org/docs/user-manual/#applying-substitutions
 [source,subs="verbatim,quotes"]
 ----
-mvn -U archetype:generate -Dfilter="io.jenkins.archetypes:"
+mvn -U archetype:generate -Dfilter=io.jenkins.archetypes:
 …
 Choose archetype:
 1: remote -> io.jenkins.archetypes:empty-plugin (Skeleton of a Jenkins plugin with a POM and an empty source tree.)


### PR DESCRIPTION
I found that the quotation marks in the samples do not work in some cases (e.g. IntelliJ "Run Anything" tries to escape them) 
The result is no archetype being found:
```
[INFO] --- archetype:3.2.1:generate (default-cli) @ my-jenkins-plugin ---
[INFO] Generating project in Interactive mode
[INFO] Your filter doesn't match any archetype, so try again with another value.
````
There is no harm in removing them, the Troubleshooting section does not use them either. 