### PR TITLE
Delete content/redirects directory

### DIFF
--- a/content/redirects/distributed-builds.adoc
+++ b/content/redirects/distributed-builds.adoc
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect_url: https://wiki.jenkins.io/display/JENKINS/Distributed+builds
----


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/jenkins.io/pull/3075 from 3 years ago, this folder containing a single redirection was added temporarily.

This PR deletes it, keeping only one folder for them: https://github.com/jenkins-infra/jenkins.io/tree/master/content/redirect