### PR TITLE
Add a banner in weekly changelog about Java 17 by default for the Windows image

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21946,7 +21946,7 @@
   - version: '2.431'
     date: 2023-11-07
     banner: >
-      The Windows container image of this release is using Java 17 by default like the main Linux images.
+      The Windows container image of this release is using Java 17 by default like the Linux images.
     changes:
       - type: rfe
         category: rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21945,6 +21945,8 @@
 
   - version: '2.431'
     date: 2023-11-07
+    banner: >
+      The Windows container image of this release is using Java 17 by default like the main Linux images.
     changes:
       - type: rfe
         category: rfe


### PR DESCRIPTION
This PR adds a banner warning about the fact the Windows image is now using Java 17 by default. (No Java 11 for this release)

<img width="1150" alt="image" src="https://github.com/jenkins-infra/jenkins.io/assets/91831478/b979c78f-361a-4329-bac3-8c6c9ea541aa">
 
Follow-up of:
- https://github.com/jenkinsci/docker/pull/1773
