### PR TITLE
Add note about including the ssh-XXX prefix

### DIFF
--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -132,6 +132,8 @@ jenkins/ssh-agent:alpine-jdk17
 ====
 * Remember to replace the tag [your-public-key] for your own SSH *public* key.
 * Your public key value in this example could be found by issuing : `cat ~/.ssh/jenkins_agent_key.pub` on the machine your created it. Do not add the square brackets `[]` around the key value
+* The value of [your-public-key] MUST include the full contents of your .pub file, including the `ssh-XXXX` prefix.
+** Ex: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQCo9+BpMRYQ/dL3DS2CyJxRF+j6ctbT3/Qp84+KeFhnii7NT7fELilKUSnxS30WAvQCCo2yU1orfgqr41mM70MB`
 * [[ssh-anchor]] If your machine already has a ssh server running on the `22` port (if you logged onto this machine thanks to the `ssh` command, that's the case), you should use another port for the `docker` command, such as `-p 4444:22`
 
 ====


### PR DESCRIPTION
I've worked with a few people to debug docker ssh agents, one of the main issues they have had is not including the full public SSH key information. They often leave off the ssh-XXX prefix and just have the key data itself. This adds a note to make sure people understand what information to include.