### PR TITLE
feat: Replace gsoc redirection with actual contents for 2023

### DIFF
--- a/content/projects/gsoc/2023/index.adoc
+++ b/content/projects/gsoc/2023/index.adoc
@@ -1,4 +1,148 @@
 ---
-layout: redirect
-redirect_url: /projects/gsoc
+layout: project
+title: "Google Summer of Code in Jenkins"
+description: "Landing page for the Google Summer of Code program in the Jenkins project"
+section: projects
+tags:
+- gsoc2023
+sig: gsoc
+opengraph:
+  image: /images/gsoc/opengraph.png
+links:
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
+  meetings: "/projects/gsoc/#office-hours"
 ---
+
+// image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=left]
+link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
+(GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 10-22 weeks programming project under the guidance of mentors.
+
+GSoC contributors accepted into the program receive a stipend and are sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
+In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
+
+image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
+
+== GSoC 2023
+
+We have been accepted as a Google Summer of Code mentoring org for 2023. +
+See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
+
+// Uncomment when application is worked on and submitted (Feb 2024)
+//(link:./2024/application[Jenkins GSoC Organisation Application Form])
+
+The selected projects are
+
+* link:/projects/gsoc/2023/projects/gitlab-plugin-modernization[GitLab Plugin Modernization] with link:https://github.com/harsh-ps-2003[Harsh Pratap Singh] as GSoC contributor.
+* link:/projects/gsoc/2023/projects/add-probes-to-plugin-health-score[Add probes to "Plugin Health Score"] with link:https://github.com/Jagrutiti[Jagruti Tiwari] as GSoC contributor.
+* link:/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool[Building Jenkins.io with alternative tools] with link:/blog/authors/vandit1604/[Vandit Singh] as GSoC contributor.
+* link:/projects/gsoc/2023/projects/docker-compose-build[Docker-based Jenkins quickstart examples] with link:/blog/authors/ash-sxn/[Ashutosh Saxena] as GSoC contributor.
+
+They were proposed and selected from these link:./2023/project-ideas[project ideas].
+
+NOTE: Every year, there are changes in how GSoC is organized.
+Jenkins GSoC documentation may be outdated in some places,
+please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.
+Our documentation will be updated over time to reflect the changes in the GSoC program,
+please report any issues you discover.
+
+== GSoC Contributors
+
+* link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
+* Online Meetup: Introduction to Jenkins in GSoC
+(link:https://bit.ly/3pbJFuC[slides],
+link:https://youtu.be/GDRTgEvIVBc[video])
+* link:https://summerofcode.withgoogle.com/programs/2023/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
+* link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
+
+== Mentors
+
+* link:/projects/gsoc/mentors[Information for mentors]
+* link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
+* link:/projects/gsoc/roles-and-responsibilities[Roles and Responsibilities]
+* link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
+* link:https://community.jenkins.io/c/contributing/gsoc-mentors/25[Mentor's Dedicated Discourse group]
+
+== Org Admins
+
+Org Admins are the people managing the GSoC program for the Jenkins Organization.
+For 2023, Org Admins are:
+
+* Alyssa Tong
+* Jean-Marc Meessen
+* Kris Stern
+* Bruno Verachten
+
+The following checklists and documents describe the role.
+
+* link:https://docs.google.com/document/d/1tShnTyka5fdBxaE0c93ptu-J_XTlSf3tKwJemhx5_nA/edit?usp=sharing[Org Admin runbook for the Jenkins project]
+* link:https://developers.google.com/open-source/gsoc/help/oa-tips[Org Admin tips by Google]
+
+== Contacts
+
+* We use the link:/sigs/gsoc[GSoC SIG] for communications about GSoC.
+Projects may also have their own mailing lists, chats and meetings.
+See details on project pages.
+* We use link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse] for discussions.
+This is the **recommended** channel for communications
+* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications,
+but it is better to use Discourse to request technical feedback or to have long discussions
+* For private matters such as communication difficulties with mentors, GSoC contributors, or Org Admins,
+please use the mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
+
+=== GSoC Discourse
+
+Public communication channel: link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse].
+
+The purpose of GSoC Discourse is for all public communications on GSoC such as new mentor and new GSoC contributor introductions,
+project proposal questions and discussions, process and timeline related questions.
+
+=== Chats
+
+* link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
+* Project-specific chats, see project and project idea pages
+* link:/chat/[Common developer chats] for technical topics
+
+=== Office hours
+
+Although we use Discourse as the main communication channel,
+we also have regular "office hours" video calls.
+During these time slots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
+
+* Schedule: weekly 30 minutes meetings. Office hours will be held on Thursdays at 16:00 UTC.
+Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
+* link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
+* Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
+
+This meeting will be used for Q&A with GSoC applicants/contributors and mentors before the announcement of accepted projects as well as during the GSoC program.
+You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
+More slots may be added on-demand, e.g. for project-specific discussions.
+
+In addition to these organization-wide meetings,
+each GSoC project has regular meetings during community bonding and coding phases.
+See the project pages for the schedule.
+
+== Previous years
+
+* link:/projects/gsoc/2022[GSoC 2022] - 4 student projects
+* link:/projects/gsoc/2021[GSoC 2021] - 5 student projects
+* link:/projects/gsoc/2020[GSoC 2020] - 7 student projects
+* link:/projects/gsoc/2019[GSoC 2019] - 7 student projects
+* link:/projects/gsoc/2018[GSoC 2018] - 3 student projects
+* link:/projects/gsoc/gsoc2017[GSoC 2017] - not accepted
+* link:/projects/gsoc/gsoc2016[GSoC 2016] - 5 student projects
+* link:https://wiki.jenkins.io/display/JENKINS/Google+Summer+of+Code+2009[GSoC 2009] - as Hudson, not accepted
+
+== References, 2023
+
+* link:./2023/project-ideas[GSoC 2023 project ideas]
+//* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins page on the GSoC website]
+* link:/blog/2022/11/16/gsoc-2023/[Jenkins GSoC 2023 announcement]
+* link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2023 announcement blog]
+
+== References
+
+You can find more information about GSoC in Jenkins below.
+
+* link:/sigs/gsoc[Jenkins GSoC Special Interest Group]
+* link:/sigs/advocacy-and-outreach/outreach-programs/[Other outreach programs in Jenkins]
+* link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]

--- a/content/projects/gsoc/2023/index.adoc
+++ b/content/projects/gsoc/2023/index.adoc
@@ -1,7 +1,7 @@
 ---
 layout: project
 title: "Google Summer of Code in Jenkins"
-description: "Landing page for the Google Summer of Code program in the Jenkins project"
+description: "Google Summer of Code 2023 in the Jenkins project"
 section: projects
 tags:
 - gsoc2023
@@ -15,16 +15,18 @@ links:
 
 // image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=left]
 link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
-(GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 10-22 weeks programming project under the guidance of mentors.
+(GSoC) is a global, online program focused on bringing students and new contributors into open source software development.
+GSoC contributors work with an open source organization on a 10-22 week programming project under the guidance of mentors.
 
-GSoC contributors accepted into the program receive a stipend and are sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
-In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
+GSoC contributors accepted into the program receive a stipend and are sponsored by Google to work on well-defined projects to improve or enhance the Jenkins project.
+In exchange, numerous Jenkins community members volunteer as mentors for the selected GSoC contributors.
+Mentors help the contributors integrate into the open source community and help them succeed in completing their projects.
 
 image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 == GSoC 2023
 
-We have been accepted as a Google Summer of Code mentoring org for 2023. +
+We have been accepted as a Google Summer of Code mentoring org for 2023.
 See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
 
 // Uncomment when application is worked on and submitted (Feb 2024)


### PR DESCRIPTION
Fixed a link on the current /gsoc/index page for the year 2023. 
Retained contents from 2023. 