### PR TITLE
feat(documentation): Adds a github-actions section in the dependabot sample file.

### DIFF
--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -33,7 +33,7 @@ version: 2
 updates:
 # Maintain dependencies for your plugin
 - package-ecosystem: maven
-  directory: "/"
+  directory: /
   schedule:
     interval: monthly
   open-pull-requests-limit: 10

--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -31,12 +31,20 @@ mkdir .github
 cat > .github/dependabot.yml <<END-OF-HERE-DOC
 version: 2
 updates:
+# Maintain dependencies for your plugin
 - package-ecosystem: maven
   directory: "/"
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
   target-branch: master
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  labels:
+  - skip-changelog
 END-OF-HERE-DOC
 ----
 

--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -43,8 +43,6 @@ updates:
   directory: /
   schedule:
     interval: monthly
-  labels:
-    - skip-changelog
 END-OF-HERE-DOC
 ----
 

--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -44,7 +44,7 @@ updates:
   schedule:
     interval: monthly
   labels:
-  - skip-changelog
+    - skip-changelog
 END-OF-HERE-DOC
 ----
 


### PR DESCRIPTION
I propose we add a section about GitHub Actions to the Dependabot configuration in our 'Improve a Plugin' tutorial.

This addition will provide a more comprehensive example for plugin maintainers on how to keep their plugins up-to-date.

The proposed section will cover the 'github-actions' package ecosystem in the 'dependabot.yml' file.

This is important to me because GitHub Actions are sometimes used in our repositories for various tasks.

These actions, like any other dependencies, need to be kept up-to-date to ensure we are using the most secure, efficient, and bug-free versions.
By incorporating this section, we will instruct Dependabot to check for updates to these actions on a regular basis (monthly). When Dependabot finds updates, it will automatically open pull requests to update the actions to the latest versions of GitHub Actions, like 'updatecli'.

I have to admit, though, that not that many plugins are using GitHub Actions except 'dependabot' or the actions that are played by the Jenkins infra itself.