### PR TITLE
Use consistent page titles for GSoC summaries

### DIFF
--- a/content/projects/gsoc/2022/index.adoc
+++ b/content/projects/gsoc/2022/index.adoc
@@ -1,7 +1,7 @@
 ---
 layout: project
-title: "Google Summer of Code in Jenkins 2022"
-description: "Landing page for the Google Summer of Code program in the Jenkins project"
+title: "Jenkins in Google Summer of Code 2022"
+description: "Google Summer of Code 2022 in the Jenkins project"
 section: projects
 tags:
 - gsoc2022

--- a/content/projects/gsoc/2023/index.adoc
+++ b/content/projects/gsoc/2023/index.adoc
@@ -1,6 +1,6 @@
 ---
 layout: project
-title: "Google Summer of Code in Jenkins"
+title: "Jenkins in Google Summer of Code 2023"
 description: "Google Summer of Code 2023 in the Jenkins project"
 section: projects
 tags:


### PR DESCRIPTION
## Use consistent page titles for GSoC summaries

Prior to 2022, the page titles for the GSoC summaries were using a slightly different form than the most recent two page titles.  Adjust the page titles to match the previous years.

Adjust the page descriptions to include the year of the GSoC project.
