### PR TITLE
Link to GSoC 2024 ideas

### DIFF
--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -33,7 +33,7 @@ We cannot make any exception. Please:
 
 === Application steps
 
-. Check out the link:/projects/gsoc/2023/project-ideas[GSoC 2023 Project ideas]
+. Check out the link:/projects/gsoc/2024/project-ideas[GSoC 2024 Project ideas]
 . Select an interesting project idea or draft your own proposal.
 . Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
@@ -155,7 +155,7 @@ It is required to use this channel for the initial review and feedback collectio
 
 === First begin a communication in link:https://community.jenkins.io/c/contributing/gsoc/[Discourse]
 
-* Please use the _[GSOC 2023 PROPOSAL] Your Name and Project Title_ subject in discussion.
+* Please use the _[GSOC 2024 PROPOSAL] Your Name and Project Title_ subject in discussion.
 ** If another contributor is interested in the same project idea, you can contribute to their thread, or start your own thread.
 * Contents. In the first communication we would be interested to see the following information:
 ** A short self-introduction: your area of study, interests, background


### PR DESCRIPTION
## Link to GSoC 2024 project ideas

The 2023 ideas are good reference material as well, but those project ideas that are still viable from 2023 should be copied into the 2024 project ideas.
