### PR TITLE
Add a banner in 2.432 weekly changelog about noticeable changes for the Windows images

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -22006,6 +22006,9 @@
 
   - version: '2.432'
     date: 2023-11-14
+    banner: >
+      The Windows container images of this release switch from a windowsservercore-1809 Temurin base image to a windowsservercore-ltsc2019 Microsoft base image.
+      Note also that a proper set of tags is now published, and they include "ltsc2019" instead of only "2019".
     changes:
       - type: rfe
         category: rfe


### PR DESCRIPTION
This PR adds a note about the change of base image and tag naming, similar to the notes added to the controller image release: https://github.com/jenkinsci/docker/releases/tag/2.432

Ref:
- https://github.com/jenkinsci/docker/pull/1770