### PR TITLE
Add a banner in 2.426.1 LTS changelog about noticeable changes for the Windows images

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9738,6 +9738,8 @@
   banner: >
       Short container image tags (without "jdk" in them) such as <code>jenkins/jenkins:2.426.1</code> are now using Java 17.
       If you need to continue using Java 11, use tags like <code>jenkins/jenkins:2.426.1-jdk11</code>.
+      The Windows container images of this release switch from a windowsservercore-1809 Temurin base image to a windowsservercore-ltsc2019 Microsoft base image.
+      Note also that a proper set of tags is now published for these Windows images and they include "ltsc2019" instead of only "2019".
   lts_predecessor: "2.414.3"
   lts_baseline: "2.426"
   changes: # compared to lts_baseline 2.426 - extracted from the RC commit(s)


### PR DESCRIPTION
This PR adds a note about the change of base image and tag naming, similar to the notes added to the 2.432 weekly changelog and the controller image release: https://github.com/jenkinsci/docker/releases/tag/2.432

Ref:
- https://github.com/jenkinsci/docker/pull/1770
- https://github.com/jenkins-infra/jenkins.io/pull/6843