### PR TITLE
Remove extra entry from 2.426.1 changelog

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -10170,15 +10170,6 @@
       Hide administrative monitors icons/popup in the header of <strong>Manage Jenkins</strong>, as they're shown directly on the page.
   - type: bug
     category: bug
-    pull: 8378
-    issue: 61452
-    authors:
-      - jglick
-    pr_title: "[JENKINS-61452] Tolerate corrupt Base64 in `PlainTextConsoleOutputStream`"
-    message: |-
-      The plain text console log will still be printed even if some console annotations are corrupt.
-  - type: bug
-    category: bug
     pull: 8387
     issue: 71833
     authors:


### PR DESCRIPTION
## Remove [JENKINS-61452](https://issues.jenkins.io/browse/JENKINS-61452) from 2.426.1 changelog, was fixed in 2.414.2

[Illegal base64 character](https://issues.jenkins.io/browse/JENKINS-61452) was fixed in 2.414.2, remove it from the 2.426.1 changelog
