### PR TITLE
Add Java 21 support to changelog and upgrade guide

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9877,6 +9877,17 @@
         title: 2023-07-26 security advisory
   - type: major rfe
     category: major rfe
+    authors:
+      - basil
+    pr_title: "Support Java 21"
+    references:
+      - issue: 71800
+      - url: https://www.jenkins.io/blog/2023/11/06/introducing-2-2-2-java-support-plan/
+        title: Java 21 supported in 2.426.1
+    message: |-
+      Support Java 21 in addition to Java 11 and Java 17.
+  - type: major rfe
+    category: major rfe
     pull: 7781
     authors:
       - timja

--- a/content/_data/upgrades/2-426-1.adoc
+++ b/content/_data/upgrades/2-426-1.adoc
@@ -1,3 +1,13 @@
+==== Java 21 supported
+
+Jenkins 2.426.1 supports Java 21.
+Java 21 is supported from `java -jar jenkins.war`, from the operating system specific installers, and from the container images.
+Container labels that previously included "-jdk21-preview" are now available with "-jdk21" for amd64 (Intel/AMD) and aarch64 (ARM) architectures.
+
+Refer to the specific link:https://hub.docker.com/r/jenkins/jenkins/tags?page=1&name=jdk21[Java 21 container images on hub.docker.com] for more details.
+
+A Java 21 preview is available for architectures where Eclipse Temurin has not yet released a general availability release of Java 21.
+
 ==== Prototype removed from Jenkins
 
 As of Jenkins 2.426.1, Prototype has been removed from Jenkins core.


### PR DESCRIPTION
## Add Java 21 support to changelog and upgrade guide

The [blog post](https://www.jenkins.io/blog/2023/11/06/introducing-2-2-2-java-support-plan/) announces the support and our social media feeds include it.  We should also include it in the changelog.
