### PR TITLE
Prevent symbol substitution

### DIFF
--- a/content/doc/developer/architecture/remoting.adoc
+++ b/content/doc/developer/architecture/remoting.adoc
@@ -4,6 +4,6 @@ layout: developer
 ---
 
 Jenkins remoting is an executable JAR, which implements the communication layer in Jenkins.
-It's used for controller <=> agent and controller <=> CLI communications.
+It's used for controller \<\=> agent and controller \<\=> CLI communications.
 
 The documentation is hosted in the https://github.com/jenkinsci/remoting/blob/master/README.md[dedicated library repository]


### PR DESCRIPTION
The adoc has formatted the symbols and substituted the < = > to include arrows, so currently this text is harder to follow. I have removed the symbol substitution. (See how it is rendered [here](https://www.jenkins.io/doc/developer/architecture/remoting/))

See https://github.com/jenkinsci/remoting for original text, and https://docs.asciidoctor.org/asciidoc/latest/subs/prevent/ for adoc editing.