### PR TITLE
perserve the aspect ratio of images on mobile (issue #6316)

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -15,8 +15,8 @@ html {
 }
 
 img {
-  display: block;
-  width: 100%;
+  max-width: 100%;
+  width: auto;
   height: auto;
 }
 

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -10,12 +10,14 @@ html {
 
 /* hide anchors unless they're hovered to offset the weird margin/padding
    needed for anchored links to not hide the target behind the navigation bar */
-*:hover > .anchorjs-link {
+*:hover>.anchorjs-link {
   opacity: 0;
 }
 
 img {
-  max-width: 100%;
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 a {
@@ -42,10 +44,12 @@ a:hover {
 .container.page {
   position: relative
 }
-body .no-margin{
-  margin:0;
-  padding:0;
+
+body .no-margin {
+  margin: 0;
+  padding: 0;
 }
+
 #ji-hover-layer {
   position: relative;
   z-index: 999
@@ -94,10 +98,12 @@ body h1.page-title .in-tag {
 .sub-heading {
   margin: -.5rem 0 1rem;
 }
-.fixed.top{
-  position:fixed;
-  top:0; width:100%;
-  z-index:10;
+
+.fixed.top {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10;
 }
 
 .text-right {
@@ -147,32 +153,33 @@ body h1.page-title .in-tag {
 }
 
 /* for same font-size in popups*/
-.dropdown-menu p{
+.dropdown-menu p {
 
-      font-size: .875rem !important;
+  font-size: .875rem !important;
 
 }
+
 /* fix for windows chrome which renders size of dropdown button 1px less because of round-off */
-@media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm)
-{
-    .chromeOnly{
+@media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm) {
+  .chromeOnly {
 
-       height: 36px;
+    height: 36px;
 
-    }
+  }
 }
 
 #ji-download {
- top: 18rem;
- right: 0;
- left: 0;
- position: absolute;
- z-index: 9;
- text-align: center;
- min-width: 620px
+  top: 18rem;
+  right: 0;
+  left: 0;
+  position: absolute;
+  z-index: 9;
+  text-align: center;
+  min-width: 620px
 }
 
-.authors, .authors>.auth {
+.authors,
+.authors>.auth {
   display: inline-block;
   padding-bottom: 5px;
   margin: 0;
@@ -202,7 +209,7 @@ div .authors {
 }
 
 .no-margin .row {
-  margin:0;
+  margin: 0;
 }
 
 
@@ -279,7 +286,8 @@ img.desaturate {
   top: -5px
 }
 
-.media-row, .step-by-step {
+.media-row,
+.step-by-step {
   text-align: center;
   padding: 2rem 1rem 3rem;
   white-space: nowrap;
@@ -290,87 +298,98 @@ img.desaturate {
 }
 
 .media-row {
-    display: flex;
-    flex-wrap: wrap;
-    background-color: #fff;
+  display: flex;
+  flex-wrap: wrap;
+  background-color: #fff;
 }
 
-.media-row>.header, .step-by-step>.container>.header {
+.media-row>.header,
+.step-by-step>.container>.header {
   margin-bottom: 1.75rem;
 }
 
-.media-row>.media, .step-by-step>.container.step {
+.media-row>.media,
+.step-by-step>.container.step {
   vertical-align: top;
   cursor: pointer;
-  font-size:.9rem;
+  font-size: .9rem;
 }
+
 .date-time,
 .step-by-step>.container .step .card-title {
-    display: inline-block;
-    text-align:center;
-    width: 4.75em;
-    height: 4.75em;
-    padding: .5em;
-    background: #168bb9;
-    color: #fff;
-    border-radius: 50%;
-    position: relative;
-    overflow: hidden;
-    font-size: 1rem;
+  display: inline-block;
+  text-align: center;
+  width: 4.75em;
+  height: 4.75em;
+  padding: .5em;
+  background: #168bb9;
+  color: #fff;
+  border-radius: 50%;
+  position: relative;
+  overflow: hidden;
+  font-size: 1rem;
 }
+
 .date-time>.date,
 .step-by-step>.container .step .card-title>.tag {
-    font-size: .75em;
-    font-weight: normal;
-    position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    padding: .5em 0 .25em;
-    background: rgba(180,40,40,.85);
-    box-shadow: 0 1px 5px rgba(0,0,0,.15);
-    border-top-left-radius: .5em;
-    border-top-right-radius: .5em;
+  font-size: .75em;
+  font-weight: normal;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  padding: .5em 0 .25em;
+  background: rgba(180, 40, 40, .85);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, .15);
+  border-top-left-radius: .5em;
+  border-top-right-radius: .5em;
 }
-.date-time > .date .small {
+
+.date-time>.date .small {
   font-size: .5em;
 }
 
-body .date-time{
-  border-radius:.5em;
-  height:5.3em;
-  width:5.3em;
+body .date-time {
+  border-radius: .5em;
+  height: 5.3em;
+  width: 5.3em;
 }
-.date-time>.date>*{
-  display:inline;
+
+.date-time>.date>* {
+  display: inline;
 }
-.date-time>.date>.dow{
-    display: block;
-    position: absolute;
-    bottom: -1.1em;
-    left: -1em;
-    right: -1.15em;
-    font-size: 6em;
-    font-family: 'arial narrow';
-    font-weight: bolder;
-    color: rgba(0,0,0,.15);
-    text-align: center;
+
+.date-time>.date>.dow {
+  display: block;
+  position: absolute;
+  bottom: -1.1em;
+  left: -1em;
+  right: -1.15em;
+  font-size: 6em;
+  font-family: 'arial narrow';
+  font-weight: bolder;
+  color: rgba(0, 0, 0, .15);
+  text-align: center;
 }
-.date-time>.time{
-    font-size: 1.1em;
-    line-height: .67em;
-    position: relative;
-    margin: 2em -1em 0;
+
+.date-time>.time {
+  font-size: 1.1em;
+  line-height: .67em;
+  position: relative;
+  margin: 2em -1em 0;
 }
+
 .step-by-step>.container .step .card-title>.num {
-    font-size: 2em;
-    line-height: 1em;
-    margin-top: .67em;
+  font-size: 2em;
+  line-height: 1em;
+  margin-top: .67em;
 }
+
 .step-by-step>.container .step .title {
-  font-size:1.1rem;
-  white-space:nowrap
+  font-size: 1.1rem;
+  white-space: nowrap
 }
+
 .step-by-step>.container .step .short {
   font-size: .75rem;
   line-height: 1.5em;
@@ -379,8 +398,9 @@ body .date-time{
   margin: 0 .5rem .5rem;
   overflow: hidden
 }
+
 /* default padding removed so that text dont get cropped */
-.card-block{
+.card-block {
   padding-bottom: 0
 }
 
@@ -455,7 +475,8 @@ body .date-time{
   font-size: 75%
 }
 
-#welcome, body #sidebar ul.resources {
+#welcome,
+body #sidebar ul.resources {
   padding-bottom: 3rem;
   position: relative;
   border-top: 1px solid #ccc;
@@ -493,8 +514,9 @@ body .date-time{
   height: auto
 }
 
-#sidebar ul.resources, #sidebar ul.resources>li, #sidebar ul.resources>li>a
-  {
+#sidebar ul.resources,
+#sidebar ul.resources>li,
+#sidebar ul.resources>li>a {
   display: block;
   list-style: none;
   margin: 0;
@@ -522,72 +544,82 @@ body .ji-dated-list>.post {
   padding: 0;
   margin: 0;
   list-style: none;
-  font-size:1rem;
+  font-size: 1rem;
 }
-.events .ji-item-list{
+
+.events .ji-item-list {
   text-align: center;
   white-space: nowrap;
   overflow: visible;
   overflow-x: auto;
   overflow-y: visible;
-  border-bottom:1px solid #ccc;
-  vertical-align:top;
+  border-bottom: 1px solid #ccc;
+  vertical-align: top;
 }
 
-.events .ji-item-list>.event{
-  display:inline-block;
-  margin:0;
-  vertical-align:top;
+.events .ji-item-list>.event {
+  display: inline-block;
+  margin: 0;
+  vertical-align: top;
 }
-.events .ji-item-list>.event>a{
-  width:16rem;
-  padding:.75rem;
-  margin:1rem .25rem .25rem;
-  white-space:normal;
-  text-decoration:none;
+
+.events .ji-item-list>.event>a {
+  width: 16rem;
+  padding: .75rem;
+  margin: 1rem .25rem .25rem;
+  white-space: normal;
+  text-decoration: none;
 }
-.events .ji-item-list>.event>a .title{
-  margin:.75rem 0 .25rem;
-  height:1.1rem;
-  overflow:hidden;
-  position:relative;
+
+.events .ji-item-list>.event>a .title {
+  margin: .75rem 0 .25rem;
+  height: 1.1rem;
+  overflow: hidden;
+  position: relative;
 }
-.events .ji-item-list>.event>a .title:after{
-  content:' ';
-  display:block;
-  position:absolute;
-  height:1.1rem;
-  width:10%;
-  box-shadow:inset var(--background) -3rem 0 2rem -2rem;
-  bottom:0; right:0;
+
+.events .ji-item-list>.event>a .title:after {
+  content: ' ';
+  display: block;
+  position: absolute;
+  height: 1.1rem;
+  width: 10%;
+  box-shadow: inset var(--background) -3rem 0 2rem -2rem;
+  bottom: 0;
+  right: 0;
 }
-.events .ji-item-list>.event>a .teaser{
-  color:#4a5568;
-  font-size:.85rem;
-  height:3.3rem;
-  overflow:hidden;
-  position:relative;
+
+.events .ji-item-list>.event>a .teaser {
+  color: #4a5568;
+  font-size: .85rem;
+  height: 3.3rem;
+  overflow: hidden;
+  position: relative;
 }
-.events .ji-item-list>.event>a .teaser:after{
-  content:' ';
-  display:block;
-  position:absolute;
-  height:1.1rem;
-  width:25%;
-  box-shadow:inset var(--background) -6rem 0 3rem -3rem;
-  bottom:0; right:0;
+
+.events .ji-item-list>.event>a .teaser:after {
+  content: ' ';
+  display: block;
+  position: absolute;
+  height: 1.1rem;
+  width: 25%;
+  box-shadow: inset var(--background) -6rem 0 3rem -3rem;
+  bottom: 0;
+  right: 0;
 }
 
 
-.ji-dated-list>.post>.attrs, .ji-dated-list>.post>.body {
+.ji-dated-list>.post>.attrs,
+.ji-dated-list>.post>.body {
   padding: 1.25rem 1rem 1rem 5rem;
   text-decoration: none;
 }
-.fff.section{
-  background:#fff;
-  box-shadow:0 2px 3px rgba(0,0,0,.15);
-  position:relative;
-  z-index:2
+
+.fff.section {
+  background: #fff;
+  box-shadow: 0 2px 3px rgba(0, 0, 0, .15);
+  position: relative;
+  z-index: 2
 }
 
 .ji-dated-list>.post>.body>.teaser {
@@ -639,7 +671,8 @@ body .ji-dated-list>.post {
   margin: .5rem 0 1.5rem
 }
 
-.events>h5, .blog-posts>h4 {
+.events>h5,
+.blog-posts>h4 {
   min-height: 2rem;
   margin: 0 0 1rem;
   border-bottom: 1px solid #ccc
@@ -807,7 +840,7 @@ body .ji-dated-list>.post {
 }
 
 .segment {
-    padding-top:3rem;
+  padding-top: 3rem;
 }
 
 .cols-3 {
@@ -823,80 +856,83 @@ body .ji-dated-list>.post {
 }
 
 ion-icon {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 .features.uniform-height>div {
   padding-left: 0
 }
 
-.uniform-height  .box {
-    padding: .67rem .75rem 0 4rem;
-    position: relative;
-    border-radius: 5px;
-    min-height: 10rem;
+.uniform-height .box {
+  padding: .67rem .75rem 0 4rem;
+  position: relative;
+  border-radius: 5px;
+  min-height: 10rem;
 }
 
 .uniform-height ion-icon {
-    content: ' ';
-    display: block;
-    position: absolute;
-    left: 0rem;
-    top: .75rem;
-    width: 2.25rem;
-    height: 2.25rem;
-    padding: .5rem;
-    line-height: 3.25rem;
-    background: #168bb9;
-    border-radius: 50%;
-    text-align: center;
-    color: #fff;
-    font-size: 1.75rem;
+  content: ' ';
+  display: block;
+  position: absolute;
+  left: 0rem;
+  top: .75rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: .5rem;
+  line-height: 3.25rem;
+  background: #168bb9;
+  border-radius: 50%;
+  text-align: center;
+  color: #fff;
+  font-size: 1.75rem;
 }
 
-.uniform-height  .box>p {
+.uniform-height .box>p {
   line-height: 1.5em;
   font-size: .8rem;
   overflow: hidden
 }
 
-.uniform-height  .box>h5 {
+.uniform-height .box>h5 {
   line-height: 1.3em;
   font-size: 1.1rem;
   margin-bottom: .33rem;
 }
 
-@media ( max-width : 768px) {
-  html, body {
+@media (max-width : 768px) {
+
+  html,
+  body {
     max-width: 100%;
     overflow-x: hidden;
   }
+
   .segment {
     padding-top: 1rem
   }
-  .uniform-height  .box {
+
+  .uniform-height .box {
     min-height: 4rem;
     padding-bottom: .5rem;
     margin-bottom: .5rem;
   }
 }
 
-@media ( min-width : 992px ) and ( max-width : 1200px ) {
-  .uniform-height  .box {
+@media (min-width : 992px) and (max-width : 1200px) {
+  .uniform-height .box {
     min-height: 12rem;
   }
 }
 
 #ji-download .btn {
-    position: relative;
-    border-radius: 3px;
-    box-shadow: 0 3px 3px -1px rgba(0, 0, 0, .25);
+  position: relative;
+  border-radius: 3px;
+  box-shadow: 0 3px 3px -1px rgba(0, 0, 0, .25);
 }
 
 #ji-download .btn .brick-tops {
-  display:none;
-  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #358
-    12px, #07d 22px, #358 32px);
+  display: none;
+  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #358 12px, #07d 22px, #358 32px);
   position: absolute;
   top: 0;
   left: 0;
@@ -904,51 +940,73 @@ ion-icon {
 }
 
 .brick-tops.footer {
-  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #234
-    12px, #357 22px, #234 32px);
+  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #234 12px, #357 22px, #234 32px);
   border-bottom: 2px solid rgba(255, 255, 255, .1)
 }
 
 #ji-download .btn:hover .brick-tops {
-  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #136
-    12px, #05a 22px, #136 32px);
+  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #136 12px, #05a 22px, #136 32px);
 }
 
 #ji-download .btn:hover {
   box-shadow: none;
 }
 
-.brick-tops.footer {background:repeating-linear-gradient( 90deg, transparent, transparent 12px, #234 12px, #357 22px, #234 32px ); border-bottom:2px solid rgba(255,255,255,.1)}
-#ji-download .btn:hover .brick-tops{
- background: repeating-linear-gradient( 90deg, transparent, transparent 12px, #136 12px, #05a 22px, #136 32px );
+.brick-tops.footer {
+  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #234 12px, #357 22px, #234 32px);
+  border-bottom: 2px solid rgba(255, 255, 255, .1)
 }
-#ji-download .btn:hover{box-shadow:none;}
+
+#ji-download .btn:hover .brick-tops {
+  background: repeating-linear-gradient(90deg, transparent, transparent 12px, #136 12px, #05a 22px, #136 32px);
+}
+
+#ji-download .btn:hover {
+  box-shadow: none;
+}
 
 .jumbotron.plugins {
-/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#81b0c4+0,335061+100 */
-background: #81b0c4; /* Old browsers */
-background: -moz-linear-gradient(left,  #81b0c4 0%, #335061 100%); /* FF3.6-15 */
-background: -webkit-linear-gradient(left,  #81b0c4 0%,#335061 100%); /* Chrome10-25,Safari5.1-6 */
-background: linear-gradient(to right,  #81b0c4 0%,#335061 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#81b0c4', endColorstr='#335061',GradientType=1 ); /* IE6-9 */
-  border-radius:0;
-  color:#fff}
-.overview {padding-top:1.5rem}
-.overview p {font-size:1.1rem}
+  /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#81b0c4+0,335061+100 */
+  background: #81b0c4;
+  /* Old browsers */
+  background: -moz-linear-gradient(left, #81b0c4 0%, #335061 100%);
+  /* FF3.6-15 */
+  background: -webkit-linear-gradient(left, #81b0c4 0%, #335061 100%);
+  /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(to right, #81b0c4 0%, #335061 100%);
+  /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#81b0c4', endColorstr='#335061', GradientType=1);
+  /* IE6-9 */
+  border-radius: 0;
+  color: #fff
+}
+
+.overview {
+  padding-top: 1.5rem
+}
+
+.overview p {
+  font-size: 1.1rem
+}
 
 .btn-primary {
   background: #d24939;
   border: 0px;
 }
-.btn-primary:focus, .btn-primary:hover, .btn-primary:active {
-  background:#335061;
+
+.btn-primary:focus,
+.btn-primary:hover,
+.btn-primary:active {
+  background: #335061;
   border: 0px;
 }
+
 nav .nav-item {
-  cursor:pointer;
+  cursor: pointer;
 }
+
 nav .nav-item.active {
-  box-shadow:inset #D33833 0 -2px;
+  box-shadow: inset #D33833 0 -2px;
 }
 
 #toc-blog {
@@ -965,100 +1023,108 @@ nav .nav-item.active {
 }
 
 .quoteblock {
-    padding-bottom: 1rem;
+  padding-bottom: 1rem;
 }
 
 blockquote {
-    padding: 1rem 1rem 1rem 2rem;
-    border-left: 5px solid #ddd;
-    margin: 1rem 0 2rem;
-    font-style: italic;
+  padding: 1rem 1rem 1rem 2rem;
+  border-left: 5px solid #ddd;
+  margin: 1rem 0 2rem;
+  font-style: italic;
 }
 
 .quoteblock blockquote {
-    padding: 1rem 1rem 1rem 3rem;
-    margin: 1rem 0 0 0;
-    position: relative;
-    background: #fff;
+  padding: 1rem 1rem 1rem 3rem;
+  margin: 1rem 0 0 0;
+  position: relative;
+  background: #fff;
 }
 
 .quoteblock .attribution {
-    margin-left: 1.5rem;
-    font-style: italic;
+  margin-left: 1.5rem;
+  font-style: italic;
 }
 
 .quoteblock blockquote:before {
-    content: '\201C';
-    font-size: 4rem;
-    color: #ddd;
-    display: block;
-    position: absolute;
-    left: 0rem;
-    top: .5rem;
-    width: 3rem;
-    text-align: center;
-    line-height: 1em;
+  content: '\201C';
+  font-size: 4rem;
+  color: #ddd;
+  display: block;
+  position: absolute;
+  left: 0rem;
+  top: .5rem;
+  width: 3rem;
+  text-align: center;
+  line-height: 1em;
 }
 
 .toc {
-    margin-bottom: 1rem;
-    background-color: #f9f9f9;
-    border-left: 1px solid #c9c9c9;
-    float: right;
-    width: 20rem;
-    margin-left: 15px;
-    padding: 10px;
-    clear: right;
+  margin-bottom: 1rem;
+  background-color: #f9f9f9;
+  border-left: 1px solid #c9c9c9;
+  float: right;
+  width: 20rem;
+  margin-left: 15px;
+  padding: 10px;
+  clear: right;
 }
 
 .toc li li {
-    padding-left: 1rem;
+  padding-left: 1rem;
 }
-.toc ul, .toc li, .toc li > a {
-    display: block;
-    font-size: 0.9rem;
-    line-height: 1.35rem;
-    padding: 0px;
-    margin: 0px;
-    list-style: none;
+
+.toc ul,
+.toc li,
+.toc li>a {
+  display: block;
+  font-size: 0.9rem;
+  line-height: 1.35rem;
+  padding: 0px;
+  margin: 0px;
+  list-style: none;
 }
-.toc ul.root > li > a {
-    font-size: 0.85rem;
-    color: rgb(153, 17, 17);
+
+.toc ul.root>li>a {
+  font-size: 0.85rem;
+  color: rgb(153, 17, 17);
 }
-.container.blog-post #sidebar
-{
-    position: fixed;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    padding-top: 5rem;
-    overflow-y: auto;
-    background: #f9f9f9;
-    border-left: 1px solid #ccc;
-    box-shadow: inset 10px 0 10px -15px;
+
+.container.blog-post #sidebar {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  padding-top: 5rem;
+  overflow-y: auto;
+  background: #f9f9f9;
+  border-left: 1px solid #ccc;
+  box-shadow: inset 10px 0 10px -15px;
 }
-.container.blog-post
-{
-  flex:1;
+
+.container.blog-post {
+  flex: 1;
 }
+
 .vertical.events .ji-item-list>.event {
-  display:block;
+  display: block;
 }
-.container.blog-post .events .ji-item-list{
-  white-space:normal;
-  border:none;
+
+.container.blog-post .events .ji-item-list {
+  white-space: normal;
+  border: none;
 }
-.container.blog-post .time .date-time{
-font-size: .75rem;
-    position: absolute;
-    left: 1rem;
+
+.container.blog-post .time .date-time {
+  font-size: .75rem;
+  position: absolute;
+  left: 1rem;
 }
+
 .container.blog-post .events .ji-item-list>.event>a {
-text-align: left;
-    padding: .25rem 0 .25rem 5.5rem;
-    width: auto;
-    margin: .25rem 1rem .25rem .25rem;
+  text-align: left;
+  padding: .25rem 0 .25rem 5.5rem;
+  width: auto;
+  margin: .25rem 1rem .25rem .25rem;
 }
 
 
@@ -1067,34 +1133,130 @@ text-align: left;
   text-shadow: none;
 }
 
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
-.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%; margin: 10px;}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color: var(--color--secondary)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-span.icon>.fa{cursor:default}
-.admonitionblock td.icon [class^="fa icon-"],.admonitionblock ion-icon{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
-.admonitionblock ion-icon.important{color:#bf0000}
+.admonitionblock td.content>.title,
+.audioblock>.title,
+.exampleblock>.title,
+.imageblock>.title,
+.listingblock>.title,
+.literalblock>.title,
+.stemblock>.title,
+.openblock>.title,
+.paragraph>.title,
+.quoteblock>.title,
+table.tableblock>.title,
+.verseblock>.title,
+.videoblock>.title,
+.dlist>.title,
+.olist>.title,
+.ulist>.title,
+.qlist>.title,
+.hdlist>.title {
+  text-rendering: optimizeLegibility;
+  text-align: left;
+  font-family: "Noto Serif", "DejaVu Serif", serif;
+  font-size: 1rem;
+  font-style: italic
+}
+
+table.tableblock>caption.title {
+  white-space: nowrap;
+  overflow: visible;
+  max-width: 0
+}
+
+.paragraph.lead>p,
+#preamble>.sectionbody>.paragraph:first-of-type p {
+  color: rgba(0, 0, 0, .85)
+}
+
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p {
+  font-size: inherit
+}
+
+.admonitionblock>table {
+  border-collapse: separate;
+  border: 0;
+  background: none;
+  width: 100%;
+  margin: 10px;
+}
+
+.admonitionblock>table td.icon {
+  text-align: center;
+  width: 80px
+}
+
+.admonitionblock>table td.icon img {
+  max-width: none
+}
+
+.admonitionblock>table td.icon .title {
+  font-weight: bold;
+  font-family: "Open Sans", "DejaVu Sans", sans-serif;
+  text-transform: uppercase
+}
+
+.admonitionblock>table td.content {
+  padding-left: 1.125em;
+  padding-right: 1.25em;
+  border-left: 1px solid #ddddd8;
+  color: var(--color--secondary)
+}
+
+.admonitionblock>table td.content>:last-child>:last-child {
+  margin-bottom: 0
+}
+
+span.icon>.fa {
+  cursor: default
+}
+
+.admonitionblock td.icon [class^="fa icon-"],
+.admonitionblock ion-icon {
+  font-size: 2.5em;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
+  cursor: default
+}
+
+.admonitionblock td.icon .icon-note:before {
+  content: "\f05a";
+  color: #19407c
+}
+
+.admonitionblock td.icon .icon-tip:before {
+  content: "\f0eb";
+  text-shadow: 1px 1px 2px rgba(155, 155, 0, .8);
+  color: #111
+}
+
+.admonitionblock td.icon .icon-warning:before {
+  content: "\f071";
+  color: #bf6900
+}
+
+.admonitionblock td.icon .icon-caution:before {
+  content: "\f06d";
+  color: #bf3400
+}
+
+.admonitionblock td.icon .icon-important:before {
+  content: "\f06a";
+  color: #bf0000
+}
+
+.admonitionblock ion-icon.important {
+  color: #bf0000
+}
 
 .fa {
-    display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
-    /* font-family is needed to override some settings in font-icons.css */
-    font-family: FontAwesome !important;
-    font-size: inherit;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  /* font-family is needed to override some settings in font-icons.css */
+  font-family: FontAwesome !important;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 p.details {
@@ -1112,7 +1274,8 @@ p.details {
   padding: 1rem 2rem;
 }
 
-#sponsorsblock ul, #sponsorsblock p {
+#sponsorsblock ul,
+#sponsorsblock p {
   list-style-type: none;
   padding: 0;
   text-align: center;
@@ -1135,25 +1298,26 @@ p.details {
   font-weight: bold;
 }
 
-.div-mar{
+.div-mar {
   margin-right: 2rem;
-  border-top:solid 2px white;
+  border-top: solid 2px white;
 }
 
-.div-mar,.area{
+.div-mar,
+.area {
   padding: 1rem 0;
 }
 
-.links{
+.links {
   padding: 0;
 }
 
-.footer-left{
+.footer-left {
   padding-left: 0;
 }
 
-@media screen and (max-width: 991px){
-  .footer-left{
+@media screen and (max-width: 991px) {
+  .footer-left {
     margin-top: 1rem;
   }
 }
@@ -1168,11 +1332,14 @@ li>p {
  * container properly
  */
 .image.center>img {
-    max-width: 100%;
-    max-height: 100%;
+  max-width: 100%;
+  max-height: 100%;
 }
 
-.skip, .current-page, .next-link, .previous-link {
+.skip,
+.current-page,
+.next-link,
+.previous-link {
   position: relative;
   float: left;
   padding: 0.5rem 0.75rem;
@@ -1184,7 +1351,10 @@ li>p {
   border: 1px solid #DDD;
 }
 
-.next-link:focus, .next-link:hover, .previous-link:focus, .previous-link:hover {
+.next-link:focus,
+.next-link:hover,
+.previous-link:focus,
+.previous-link:hover {
   color: #014C8C;
   background-color: #ECEEEF;
   border-color: #DDD;
@@ -1202,23 +1372,64 @@ li.card.step {
   border: none;
 }
 
-.card.step > .card-block > p {
+.card.step>.card-block>p {
   white-space: normal;
 }
 
 /* Ensure that source code block numbering looks pretty (e.g. :https://asciidoctor.org/docs/user-manual/#source-code-blocks) */
 
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
-.colist>table tr>td:last-of-type{padding:.25em 0}
+.conum[data-value] {
+  display: inline-block;
+  color: #fff !important;
+  background-color: rgba(0, 0, 0, .8);
+  -webkit-border-radius: 100px;
+  border-radius: 100px;
+  text-align: center;
+  font-size: .75em;
+  width: 1.67em;
+  height: 1.67em;
+  line-height: 1.67em;
+  font-family: "Open Sans", "DejaVu Sans", sans-serif;
+  font-style: normal;
+  font-weight: bold
+}
+
+.conum[data-value] * {
+  color: #fff !important
+}
+
+.conum[data-value]+b {
+  display: none
+}
+
+.conum[data-value]:after {
+  content: attr(data-value)
+}
+
+pre .conum[data-value] {
+  position: relative;
+  top: -.125em
+}
+
+b.conum * {
+  color: inherit !important
+}
+
+.conum:not([data-value]):empty {
+  display: none
+}
+
+.colist>table tr>td:first-of-type {
+  padding: 0 .75em;
+  line-height: 1
+}
+
+.colist>table tr>td:last-of-type {
+  padding: .25em 0
+}
+
 table {
-    margin-bottom: 1.25rem;
+  margin-bottom: 1.25rem;
 }
 
 /* Making the sidebar scroll independently */
@@ -1250,19 +1461,19 @@ table {
 
 /** docbook section navigation **/
 .doc-page-link {
-    margin-left: auto;
-    margin-right: auto;
-    text-align: center;
-    display: block;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  display: block;
 }
 
 
 .pipeline-block {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 .pipeline-script-expand {
-    font-size: 0.7rem;
+  font-size: 0.7rem;
 }
 
 
@@ -1270,38 +1481,44 @@ table {
  * sections of documentation
  **/
 .scripted-pipeline {
-    border-left: 2px solid #ddd;
-    border-top: 1px solid #ddd;
-    padding: 5px;
+  border-left: 2px solid #ddd;
+  border-top: 1px solid #ddd;
+  padding: 5px;
 }
+
 /** Some specific styles for styling Pipeline syntax reference pages **/
 
 .syntax h2 {
-    border-bottom: 3px solid #ddd;
+  border-bottom: 3px solid #ddd;
 }
+
 .syntax h3 {
-    border-bottom: 2px solid #ddd;
+  border-bottom: 2px solid #ddd;
 }
+
 .syntax h4 {
-    border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
 }
 
 table.syntax {
-    font-size: 0.8rem;
-    margin: 1rem;
-    border: 1px solid #FAFAFA;
+  font-size: 0.8rem;
+  margin: 1rem;
+  border: 1px solid #FAFAFA;
 }
+
 table.syntax p {
-    padding: 5px;
-    margin: 0;
+  padding: 5px;
+  margin: 0;
 }
-table.syntax > tbody > tr > td {
-    border: 1px solid #FAFAFA;
+
+table.syntax>tbody>tr>td {
+  border: 1px solid #FAFAFA;
 }
-table.syntax > tbody > tr > th {
-    background-color: #FAFAFA;
-    border: 1px solid #FAFAFA;
-    font-weight: bold;
+
+table.syntax>tbody>tr>th {
+  background-color: #FAFAFA;
+  border: 1px solid #FAFAFA;
+  font-weight: bold;
 }
 
 
@@ -1334,62 +1551,90 @@ table.syntax > tbody > tr > th {
 .row {
   --bs-gutter-x: 30px;
 }
+
 /** pilfered from blueocean-style.css **/
 .navbar.navbar-expand-lg {
   padding: 0.5rem 1rem;
-  font-size: 0.875rem; }
-  .navbar.navbar-expand-lg.bg-dark {
-    background-color: #212529!important; }
-  .navbar.navbar-expand-lg .navbar-brand {
-    font-family: Georgia,Times,Times New Roman,serif;
-    font-weight: 600;
-    font-size: 20px;
-    padding: 2px 0; }
-  .navbar.navbar-expand-lg .btn {
-    font-size: 0.875rem;
-    margin-left: 8px;
-    margin-top: 1px; }
-    .navbar.navbar-expand-lg .btn.dropdown-toggle::after {
-      margin: 0 0 0 8px; }
-    .navbar.navbar-expand-lg .btn.btn-outline-secondary.active, .navbar.navbar-expand-lg .btn.btn-outline-secondary.focus, .navbar.navbar-expand-lg .btn.btn-outline-secondary:active, .navbar.navbar-expand-lg .btn.btn-outline-secondary:focus,
-    .navbar.navbar-expand-lg .btn .btn-outline-secondary.active,
-    .navbar.navbar-expand-lg .btn .btn-outline-secondary:active {
-      background-color: rgba(255, 255, 255, 0.15); }
-    .navbar.navbar-expand-lg .btn.btn-outline-secondary:hover, .navbar.navbar-expand-lg .navbar-toggler:hover {
-      background-color: rgba(255, 255, 255, 0.1); }
-  .navbar.navbar-expand-lg .show > .btn-outline-secondary.dropdown-toggle {
-    background-color: rgba(255, 255, 255, 0.15); }
-  .navbar.navbar-expand-lg .nav-link.btn {
-    color: rgba(255, 255, 255, 0.75); }
-  .navbar.navbar-expand-lg .dropdown-menu {
-    font-size: 0.875rem; 
-    max-height: 80vh;
-    overflow-y: auto; }
-  .navbar-toggler-icon {
-    font-size: 0.8em; }
+  font-size: 0.875rem;
+}
 
-.navbar-collapse{
+.navbar.navbar-expand-lg.bg-dark {
+  background-color: #212529 !important;
+}
+
+.navbar.navbar-expand-lg .navbar-brand {
+  font-family: Georgia, Times, Times New Roman, serif;
+  font-weight: 600;
+  font-size: 20px;
+  padding: 2px 0;
+}
+
+.navbar.navbar-expand-lg .btn {
+  font-size: 0.875rem;
+  margin-left: 8px;
+  margin-top: 1px;
+}
+
+.navbar.navbar-expand-lg .btn.dropdown-toggle::after {
+  margin: 0 0 0 8px;
+}
+
+.navbar.navbar-expand-lg .btn.btn-outline-secondary.active,
+.navbar.navbar-expand-lg .btn.btn-outline-secondary.focus,
+.navbar.navbar-expand-lg .btn.btn-outline-secondary:active,
+.navbar.navbar-expand-lg .btn.btn-outline-secondary:focus,
+.navbar.navbar-expand-lg .btn .btn-outline-secondary.active,
+.navbar.navbar-expand-lg .btn .btn-outline-secondary:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.navbar.navbar-expand-lg .btn.btn-outline-secondary:hover,
+.navbar.navbar-expand-lg .navbar-toggler:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.navbar.navbar-expand-lg .show>.btn-outline-secondary.dropdown-toggle {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.navbar.navbar-expand-lg .nav-link.btn {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.navbar.navbar-expand-lg .dropdown-menu {
+  font-size: 0.875rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.navbar-toggler-icon {
+  font-size: 0.8em;
+}
+
+.navbar-collapse {
   text-align: center;
   line-height: 1.5;
 }
 
 .nav-link.dropdown-toggle {
-    border: 0;
-    background-color: transparent;
-    font-size: inherit;
-    line-height: inherit;
-    font-family: inherit;
-    margin: 0 auto
+  border: 0;
+  background-color: transparent;
+  font-size: inherit;
+  line-height: inherit;
+  font-family: inherit;
+  margin: 0 auto
 }
 
-.navbar .navbar-brand:focus, .navbar .nav-link:focus{
-    outline-width: 1px;
-    outline-style: auto;
-    outline-color: rgba(255,255,255,0.5);
+.navbar .navbar-brand:focus,
+.navbar .nav-link:focus {
+  outline-width: 1px;
+  outline-style: auto;
+  outline-color: rgba(255, 255, 255, 0.5);
 }
 
-.no-outline .navbar .navbar-brand:focus, .no-outline .navbar .nav-link:focus {
-    outline-width: 0;
+.no-outline .navbar .navbar-brand:focus,
+.no-outline .navbar .nav-link:focus {
+  outline-width: 0;
 }
 
 .banner-container .skew:before {
@@ -1409,15 +1654,22 @@ table.syntax > tbody > tr > th {
   -o-transform: skewY(-14deg);
   transform: skewY(-14deg);
   -webkit-backface-visibility: hidden;
-  backface-visibility: initial; }
-  @media (min-width: 767px) {
-    .header .skew:before {
-      top: -350px;
-      height: 900px; } }
-  @media (min-width: 992px) {
-    .header .skew:before {
-      top: -350px;
-      height: 1020px; } }
+  backface-visibility: initial;
+}
+
+@media (min-width: 767px) {
+  .header .skew:before {
+    top: -350px;
+    height: 900px;
+  }
+}
+
+@media (min-width: 992px) {
+  .header .skew:before {
+    top: -350px;
+    height: 1020px;
+  }
+}
 
 .jumbotron {
   position: relative;
@@ -1460,7 +1712,7 @@ table.syntax > tbody > tr > th {
   cursor: pointer;
 }
 
-.author-card .author.logo{
+.author-card .author.logo {
   display: block;
 }
 
@@ -1510,13 +1762,15 @@ table.syntax > tbody > tr > th {
 }
 
 /* add border to tables */
-.grid-all, .grid-all th, .grid-all td {
+.grid-all,
+.grid-all th,
+.grid-all td {
   border: 1px solid #dee2e6;
   padding: .75rem;
 }
 
 .grid-all thead th {
-    border-bottom-width: 2px;
+  border-bottom-width: 2px;
 }
 
 .nav-item.searchbox {
@@ -1532,6 +1786,7 @@ table.syntax > tbody > tr > th {
     max-height: 70vh;
     overflow-y: auto;
   }
+
   /* search box container */
   .nav-item.searchbox {
     width: 100%;
@@ -1540,7 +1795,7 @@ table.syntax > tbody > tr > th {
     margin-left: 0;
   }
 
-  .nav-item.searchbox input.form-control.searchbox{
+  .nav-item.searchbox input.form-control.searchbox {
     width: 100%;
   }
 
@@ -1569,21 +1824,21 @@ ion-icon.report {
   margin-right: 5px;
 }
 
-.vendors-list{
+.vendors-list {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
   justify-content: space-between;
 }
 
-.vendors{
+.vendors {
   padding: 10px;
 }
 
-.app-avatar-image{
+.app-avatar-image {
   min-width: 64px;
-  width: 25vw; 
-  max-width: 128px; 
-  min-height: 64px; 
+  width: 25vw;
+  max-width: 128px;
+  min-height: 64px;
   max-height: 128px
 }


### PR DESCRIPTION
**Actual behavior**
The aspect ratio of large images isn't preserved when browsing jenkins.io from a mobile:
![Screenshot 2023-11-26 113129](https://github.com/jenkins-infra/jenkins.io/assets/107404972/9f508ce2-f4ba-4a08-a73f-8c764f587aed)
**After Changes**
![new](https://github.com/jenkins-infra/jenkins.io/assets/107404972/d5fbed3f-15a1-48ae-bdf5-500db803cd43)

Works perfectly on all pages with both mobile resolution and desktop resolution.