### PR TITLE
Preserve the aspect ratio of both images and iframes on mobile (Issue 6316 & 6869)

### DIFF
--- a/content/doc/developer/publishing/releasing-manually.adoc
+++ b/content/doc/developer/publishing/releasing-manually.adoc
@@ -58,8 +58,15 @@ Always test your SSH connection before performing a release:
 [source,bash]
 ----
 ssh -T git@github.com
-# Attempts to ssh to GitHub
 ----
+
+If you have been authenticated correctly, you see a message similar to the following example in your terminal:
+
+```txt
+Hi yourGitHubUsername! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+`yourGitHubUsername` is a placeholder representing your GitHub username.
 
 With GitHub and Maven credentials set up, performing a release should be as easy as running the following command:
 


### PR DESCRIPTION
### Actual behavior - [issue 6316](https://github.com/jenkins-infra/jenkins.io/issues/6316)
The aspect ratio of large images isn't preserved when browsing jenkins.io from a mobile:

![Screenshot 2023-11-26 113129](https://github.com/jenkins-infra/jenkins.io/assets/107404972/04a14dd5-cdd1-492f-b088-fc3203f58d26)

### After Changes

![new](https://github.com/jenkins-infra/jenkins.io/assets/107404972/77668a55-92cb-44b5-be33-fab085d25212)


### Actual behavior  - [issue 6869](https://github.com/jenkins-infra/jenkins.io/issues/6869)
The aspect ratio of iframes aren't preserved when browsing jenkins.io from a mobile:

![iframe aspect ratio](https://github.com/jenkins-infra/jenkins.io/assets/107404972/8c3a641c-0c7d-471c-856c-fb1f2d8776af)

### After Changes

![iframe fixed](https://github.com/jenkins-infra/jenkins.io/assets/107404972/d60b3497-f771-4406-8572-9f9a9eadfd2d)

**Works perfectly on all pages with both mobile resolution and desktop resolution.**

