### PR TITLE
preserve the aspect ratio of iframe on mobile #6869

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -4,20 +4,10 @@ section: blog
 ---
 
 :css
-  div.content {
-    position: relative;
-    overflow: hidden;
-    width: 100%;
-    padding-top: 56.25%; 
-  }
-  iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
+  div.content iframe {
+      aspect-ratio: 16 / 9;
+      max-width: 100%;
+      height: auto;
   }
 
 = partial('anchors.html.haml', :selector => '.app-post-page')

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -4,7 +4,7 @@ section: blog
 ---
 
 :css
-  div.content iframe {
+  .videoblock iframe {
       aspect-ratio: 16 / 9;
       max-width: 100%;
       height: auto;

--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -3,6 +3,23 @@ layout: default
 section: blog
 ---
 
+:css
+  div.content {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    padding-top: 56.25%; 
+  }
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+  }
+
 = partial('anchors.html.haml', :selector => '.app-post-page')
 
 %article.container.app-post-page


### PR DESCRIPTION
### Actual behavior - [issue 6869](https://github.com/jenkins-infra/jenkins.io/issues/6869)
The aspect ratio of iframes aren't preserved when browsing jenkins.io from a mobile:

![iframe aspect ratio](https://github.com/jenkins-infra/jenkins.io/assets/107404972/d7befb7a-3a80-4134-a172-3705a61878bc)


### After Changes

![iframe fixed](https://github.com/jenkins-infra/jenkins.io/assets/107404972/dfb3f578-2d6a-4b65-8a7f-4a34db7c1250)

Works perfectly on all pages with both mobile resolution and desktop resolution.

**Apologies for recreating the pull request, but I have adjusted the PR as per @zbynek  suggestions.[comment ](https://github.com/jenkins-infra/jenkins.io/pull/6870#issuecomment-1826833974)** 