### PR TITLE
jenkins.io - add packaging entry to weekly 2.434 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -22129,6 +22129,16 @@
         pr_title: Refuse to load the Jenkins test harness in production
         message: |-
           Fail fast when attempting to load a broken plugin that contains the Jenkins test harness in production.
+      - type: rfe
+        category: rfe
+        authors:
+          - minfrin
+        pr_title: "Add packaging support for unix domain sockets"
+        references:
+          - url: https://github.com/jenkinsci/packaging/pull/442
+            title: pull 442 (packaging)
+        message: |-
+          Add support for Unix domain sockets.
 
   # pull: 8701 (PR title: improve dialog form handling)
   # pull: 8704 (PR title: Avoid scrollbar in dropdown popups (page footer, log recorder))


### PR DESCRIPTION
There was a [PR from the packaging repo](https://github.com/jenkinsci/packaging/pull/442#event-11080547837) that was merged earlier today that should have been included in the weekly changelog.

This pull request is to add the entry to the changelog so that it is properly represented.
