### PR TITLE
Remove references to archived `executable-war` GitHub repository

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -39,7 +39,7 @@ properties:
   tags:
   - packaging
   description: |
-    This is the path to `jenkins.war` and set by the `executable-war` wrapper when invoked using `java -jar jenkins.war`.
+    This is the path to `jenkins.war` and set by `executable.Main` when invoked using `java -jar jenkins.war`.
     This allows Jenkins to find its own `.war` file and e.g. replace it to apply an update.
     If undefined, Jenkins will not e.g. offer to update itself.
 

--- a/content/doc/developer/initialization/embedded-container.adoc
+++ b/content/doc/developer/initialization/embedded-container.adoc
@@ -2,11 +2,9 @@
 layout: developersection
 summary: Why java -jar jenkins.war works
 references:
-- url: "https://github.com/jenkinsci/extras-executable-war/"
-  title: "Executable WAR repository on GitHub"
 - url: "https://github.com/jenkinsci/winstone/"
   title: "Winstone-Jetty on GitHub"
 wip: true
 ---
 
-= Embedded Winstone and `executable-war`
+= Embedded Winstone

--- a/content/doc/developer/initialization/index.adoc
+++ b/content/doc/developer/initialization/index.adoc
@@ -5,5 +5,5 @@ wip: true
 references:
 - url: https://wiki.jenkins.io/display/JENKINS/Jenkins+Pieces+in+GitHub
   title: >
-    Jenkins wiki: On Winstone and executable-war
+    Jenkins wiki: On Winstone
 ---


### PR DESCRIPTION
This repository was archived about a year ago and inlined into Jenkins core.