### PR TITLE
Mark JENKINS-63286 as released

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -499,7 +499,7 @@ categories:
       description: >
         Currently Jenkins uses OpenJDK in the most of official Docker packages.
         We would like to migrate to Eclipse Temurin which offers wider range of supported platforms.
-      status: current
+      status: released
       link: https://issues.jenkins.io/browse/JENKINS-63286
       labels:
       - feature


### PR DESCRIPTION
[JENKINS-63286](https://issues.jenkins.io/browse/JENKINS-63286) was completed in February but never marked as released in the public roadmap.