### PR TITLE
Move Guice 6.x Upgrade to 2.401.2

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9524,14 +9524,6 @@
       Switch the double-launch checker to a regular administrative monitor.
   - type: rfe
     category: rfe
-    pull: 8065
-    authors:
-    - basil
-    pr_title: "Move from javax.inject to jakarta.inject"
-    message: |-
-      Add support for <code>jakarta.inject</code> annotations.
-  - type: rfe
-    category: rfe
     pull: 7998
     authors:
     - jglick
@@ -9546,17 +9538,6 @@
     pr_title: "Refinements to AssociatedConverterImpl.cache"
     message: |-
       Refinements to class loading behavior looking up special formatters for XML configuration files.
-  - type: rfe
-    category: rfe
-    pull: 7990
-    authors:
-    - NotMyFault
-    pr_title: "Upgrade from Guice 5.1.0 to 6.0.0"
-    references:
-      - url: https://github.com/google/guice/wiki/Guice600#changes-since-guice-510
-        title: Guice 6.0.0 changelog
-    message: |-
-      Upgrade from Guice 5 to 6.
   - type: rfe
     category: rfe
     pull: 7948
@@ -9639,6 +9620,27 @@
     pr_title: "[JENKINS-71479] Do not use SCSS lighten function directly to avoid invalid CSS"
     message: |-
       Fix invalid CSS which caused some buttons to become invisible on hover (regression in 2.402).
+  lts_changes:
+  - type: rfe
+    category: rfe
+    pull: 8065
+    authors:
+    - basil
+    pr_title: "Move from javax.inject to jakarta.inject"
+    message: |-
+      Add support for <code>jakarta.inject</code> annotations.
+  - type: rfe
+    category: rfe
+    pull: 7990
+    authors:
+    - NotMyFault
+    pr_title: "Upgrade from Guice 5.1.0 to 6.0.0"
+    references:
+    - url: https://github.com/google/guice/wiki/Guice600#changes-since-guice-510
+      title: Guice 6.0.0 changelog
+    - pull: 8121
+    message: |-
+      Upgrade from Guice 5 to 6.
 
 - version: "2.414.3"
   date: 2023-10-18

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9278,6 +9278,26 @@
     pr_title: "Backport end of life warning to stable-2.401"
     message: |-
       Warn administrators when their Linux operating system is approaching end of life.
+  - type: rfe
+    category: rfe
+    pull: 8065
+    authors:
+    - basil
+    pr_title: "Move from javax.inject to jakarta.inject"
+    message: |-
+      Add support for <code>jakarta.inject</code> annotations.
+  - type: rfe
+    category: rfe
+    pull: 7990
+    authors:
+    - NotMyFault
+    pr_title: "Upgrade from Guice 5.1.0 to 6.0.0"
+    references:
+    - url: https://github.com/google/guice/wiki/Guice600#changes-since-guice-510
+      title: Guice 6.0.0 changelog
+    - pull: 8121
+    message: |-
+      Upgrade from Guice 5 to 6.
 
 - version: "2.401.3"
   date: 2023-07-26
@@ -9620,26 +9640,6 @@
     pr_title: "[JENKINS-71479] Do not use SCSS lighten function directly to avoid invalid CSS"
     message: |-
       Fix invalid CSS which caused some buttons to become invisible on hover (regression in 2.402).
-  - type: rfe
-    category: rfe
-    pull: 8065
-    authors:
-    - basil
-    pr_title: "Move from javax.inject to jakarta.inject"
-    message: |-
-      Add support for <code>jakarta.inject</code> annotations.
-  - type: rfe
-    category: rfe
-    pull: 7990
-    authors:
-    - NotMyFault
-    pr_title: "Upgrade from Guice 5.1.0 to 6.0.0"
-    references:
-    - url: https://github.com/google/guice/wiki/Guice600#changes-since-guice-510
-      title: Guice 6.0.0 changelog
-    - pull: 8121
-    message: |-
-      Upgrade from Guice 5 to 6.
 
 - version: "2.414.3"
   date: 2023-10-18

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9620,7 +9620,6 @@
     pr_title: "[JENKINS-71479] Do not use SCSS lighten function directly to avoid invalid CSS"
     message: |-
       Fix invalid CSS which caused some buttons to become invisible on hover (regression in 2.402).
-  lts_changes:
   - type: rfe
     category: rfe
     pull: 8065


### PR DESCRIPTION
Hi,

I noticed looking at the changelog-lts that the first mention of Guice 6.x (and `jakarta.inject`) was in Jenkins 2.414.1.

The first LTS release using Guice 6.x was in 2.401.2 (https://github.com/jenkinsci/jenkins/pull/8121 | [discussion](https://groups.google.com/g/jenkinsci-dev/c/jPh07uaqv1o/m/sVhT7GCpAgAJ)).

Interested in updating this because I'd like to link to it while sending PRs from the OpenRewrite Jenkins modernization recipe: https://github.com/openrewrite/rewrite-jenkins/pull/53