### PR TITLE
Restore javax.inject to jakarta.inject to 2.414.1

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9280,14 +9280,6 @@
       Warn administrators when their Linux operating system is approaching end of life.
   - type: rfe
     category: rfe
-    pull: 8065
-    authors:
-    - basil
-    pr_title: "Move from javax.inject to jakarta.inject"
-    message: |-
-      Add support for <code>jakarta.inject</code> annotations.
-  - type: rfe
-    category: rfe
     pull: 7990
     authors:
     - NotMyFault
@@ -9542,6 +9534,14 @@
     pr_title: "Clean up DoubleLaunchChecker"
     message: |-
       Switch the double-launch checker to a regular administrative monitor.
+  - type: rfe
+    category: rfe
+    pull: 8065
+    authors:
+    - basil
+    pr_title: "Move from javax.inject to jakarta.inject"
+    message: |-
+      Add support for <code>jakarta.inject</code> annotations.
   - type: rfe
     category: rfe
     pull: 7998


### PR DESCRIPTION
## Restore javax.inject to jakarta.inject to 2.414.1

https://github.com/jenkinsci/jenkins/pull/8065 was first included in 2.408 and was not backported to any of the 2.401.x releases.

https://github.com/jenkinsci/jenkins/pull/8121 was backported to 2.401.2.
