### PR TITLE
Fix 2.428 release date in changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -21720,7 +21720,7 @@
   # pull: 8579 (PR title: Update dependency sass to v1.69.0)
 
   - version: '2.428'
-    date: 2023-10-16
+    date: 2023-10-17
     changes:
       - type: security
         message: Important security fix.


### PR DESCRIPTION
## Fix 2.428 release date in changelog

Found while working through a history question
