### PR TITLE
Update architecting-for-scale.adoc. Fix typo

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -385,7 +385,7 @@ different approaches to expandable storage:
   spanned volume later.
 * *Logical Volume Manager for Linux* - LVM manages disk drives and allows
   logical volumes to be resized on the fly. Many distributions of Linux use LVM
-  when they are installed, but Jenkins should have its our LVM setup.
+  when they are installed, but Jenkins should have its own LVM setup.
 * *ZFS for Solaris* - ZFS is even more flexible than LVM and spanned volumes
   and just requires that the _$JENKINS_HOME_ be on its own filesystem. This
   makes it easier to create snapshots, backups, etc.


### PR DESCRIPTION
Original: Jenkins should have its "our" LVM setup
New: Jenkins should have its own LVM setup