### PR TITLE
adding myself as potential mentor for GSoC 2024

### DIFF
--- a/content/_data/authors/harsh-ps-2003.adoc
+++ b/content/_data/authors/harsh-ps-2003.adoc
@@ -7,5 +7,5 @@ linkedin: harsh-pratap-singh-787485255
 Harsh is currently an undergrad at the Indian Institute of Technology, Kanpur, whose interests lies in rapidly evolving Computer Science fields like Linux Performance, DevOps, GenAI and more. He is an avid open-source contributor and is inspired by the idea of developing useful open-source software for the masses to use. 
 Other than software development, his interest lies in economics, philosophy, and psychology.
 He was a Jenkins Google Summer of Code (GSoC) contributor in 2023, participating in the link:https://github.com/jenkinsci/gitlab-plugin[GitLab Plugin Modernization] project.
-He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin Modernization]n.
+He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin Modernization].
 

--- a/content/_data/authors/harsh-ps-2003.adoc
+++ b/content/_data/authors/harsh-ps-2003.adoc
@@ -7,5 +7,5 @@ linkedin: harsh-pratap-singh-787485255
 Harsh is currently an undergrad at the Indian Institute of Technology, Kanpur, whose interests lies in rapidly evolving Computer Science fields like Linux Performance, DevOps, GenAI and more. He is an avid open-source contributor and is inspired by the idea of developing useful open-source software for the masses to use. 
 Other than software development, his interest lies in economics, philosophy, and psychology.
 He was a Jenkins Google Summer of Code (GSoC) contributor in 2023, participating in the link:https://github.com/jenkinsci/gitlab-plugin[GitLab Plugin Modernization] project.
-He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin Modernization].
+He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin].
 

--- a/content/_data/authors/harsh-ps-2003.adoc
+++ b/content/_data/authors/harsh-ps-2003.adoc
@@ -4,8 +4,8 @@ github: harsh-ps-2003
 twitter: harsh_ps2003
 linkedin: harsh-pratap-singh-787485255
 ---
-Harsh is currently a Freshman at the Indian Institute of Technology, Kanpur, whose interests lies in rapidly evolving Computer Science fields like DevSecOps, Blockchain and more. He is an avid open-source contributor and is inspired by the idea of developing useful open-source software for the masses to use. 
+Harsh is currently an undergrad at the Indian Institute of Technology, Kanpur, whose interests lies in rapidly evolving Computer Science fields like Linux Performance, DevOps, GenAI and more. He is an avid open-source contributor and is inspired by the idea of developing useful open-source software for the masses to use. 
 Other than software development, his interest lies in economics, philosophy, and psychology.
-He is a Jenkins Google Summer of Code (GSoC) contributor in 2023, participating in the link:https://github.com/jenkinsci/gitlab-plugin[GitLab Plugin Modernization] project.
-He started his journey of contributing to Jenkins in February 2023 and got hooked since.
+He was a Jenkins Google Summer of Code (GSoC) contributor in 2023, participating in the link:https://github.com/jenkinsci/gitlab-plugin[GitLab Plugin Modernization] project.
+He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin Modernization]n.
 

--- a/content/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc
+++ b/content/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc
@@ -14,6 +14,7 @@ skills:
 - UI
 mentors:
 - "krisstern"
+- "harsh-ps-2003"
 links:
   meetings: /projects/gsoc/#office-hours
 ---

--- a/content/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io.adoc
+++ b/content/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io.adoc
@@ -14,6 +14,7 @@ mentors:
 - "markewaite"
 - "krisstern"
 - "berviantoleo"
+- "harsh-ps-2003"
 links:
   meetings: /projects/gsoc/#office-hours
 ---


### PR DESCRIPTION
Hey,
I would also like to be the mentor for GSoC 2024 for the following projects:

1. [enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge 2](https://www.jenkins.io/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge/)
2. [using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io 1](https://www.jenkins.io/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io/)

I believe my Jenkins plugin development and Infrastructure knowledge can be a valuable addition to the projects!

Thanking you in Anticipation
Warm Regards