### PR TITLE
Fix link to end of Java support changelog entry for 2.426.2

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -10231,7 +10231,7 @@
   changes:
   - type: rfe
     category: rfe
-    pull: 8503
+    pull: 8661
     authors:
       - MarkEWaite
     pr_title: "[JENKINS-72252] Warn 12 months and 3 months before end of Java support"


### PR DESCRIPTION
Fix link to end of Java support changelog entry for 2.426.2.  Was included in:

* https://github.com/jenkinsci/jenkins/pull/8661
