### PR TITLE
chore: add a step to purge cached CSS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,6 +93,9 @@ node('docker&&linux') {
                 sh './scripts/blobxfer upload --local-path /data/_site --storage-account-key $BLOBXFER_STORAGEACCOUNTKEY --storage-account prodjenkinsio --remote-path jenkinsio --recursive --mode file --skip-on-md5-match --file-md5 --delete'
             }
         }
+        stage('Purge cached CSS') {
+            sh 'curl -X PURGE https://www.jenkins.io/css/jenkins.css'
+        }
     }
 }
 


### PR DESCRIPTION
As suggested by @zbynek in https://github.com/jenkins-infra/jenkins.io/issues/6316#issuecomment-1854576801, this PR adds a step to purge the cached CSS from Fastly.