### PR TITLE
chore(dependencies): Now finds the latest baseline.

### DIFF
--- a/updatecli/scripts/jenkins-lts-baseline.sh
+++ b/updatecli/scripts/jenkins-lts-baseline.sh
@@ -10,7 +10,7 @@ set -eu -o pipefail
 # This argument specifies which version to get, starting from 0 for the latest version.
 backward=${1:-0}
 
-# Subtract 1 from backward to start from 0.
+# Add 1 to backward to start from 1.
 backward=$((backward + 1))
 
 # Uses the wget command to download the RSS feed of the Jenkins changelog and outputs it to the standard output (-O -).

--- a/updatecli/scripts/jenkins-lts-baseline.sh
+++ b/updatecli/scripts/jenkins-lts-baseline.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script fetches the Jenkins release data, extracts the LTS version numbers, sorts them, and then outputs a specific version based on a "backward" argument.
+
+# -e  causes the script to exit immediately if any command fails.
+# -u  treats unset variables as an error and exits the script.
+set -eu -o pipefail
+
+# Get the "backward" argument, default to 0 if not provided.
+# This argument specifies which version to get, starting from 0 for the latest version.
+backward=${1:-0}
+
+# Subtract 1 from backward to start from 0.
+backward=$((backward + 1))
+
+# Uses the wget command to download the RSS feed of the Jenkins changelog and outputs it to the standard output (-O -).
+wget -q -O - https://www.jenkins.io/changelog-stable/rss.xml | \
+# Uses awk to extract the LTS (Long-Term Support) version numbers from the downloaded RSS feed.
+# It searches for lines containing <title>Jenkins, splits the third field based on spaces, and prints the second element of the resulting array.
+awk -F'[<>]' '/<title>Jenkins /{split($3,a," "); print a[2]}' | \
+# Sorts the version numbers in ascending order.
+# It uses the sort command with the delimiter set to dot (-t.) and sorts numerically (-n) based on the first, second, and third fields (-k1,1n -k2,2n -k3,3n).
+sort -t. -k1,1n -k2,2n -k3,3n | \
+# Uses awk to get the first version of each unique base version.
+# It creates an associative array x with the first and second fields as the key and the whole version number as the value.
+# If the key is not already in the array, it stores the version number.
+# In the END block, it iterates over the array and prints the values.
+awk -F. '{if (!($1"."$2 in x)) x[$1"."$2]=$0} END {for (i in x) print x[i]}' | \
+# Sorts the versions again in ascending order.
+sort -t. -k1,1n -k2,2n -k3,3n | \
+# Uses the tail command to get the "backward" version.
+# It gets the last n lines, where n is the "backward" argument.
+# Then it uses the head command to get the first line of the result, which is the desired version.
+tail -n $backward | head -n 1

--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -19,6 +19,11 @@ sources:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/jenkins-lts.sh 0 # source input value passed as argument
+  JenkinsLatestLTSBaseline:
+    name: Get the latest Jenkins LTS baseline version
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/jenkins-lts-baseline.sh 0 # source input value passed as argument
   JenkinsPreviousLTS:
     name: Get the previous Jenkins LTS version
     kind: shell
@@ -72,6 +77,10 @@ conditions:
   jenkinsLatestLTSVersion:
     kind: jenkins
     sourceid: JenkinsLatestLTS
+  # Test that the latest LTS Jenkins baseline version exists
+  jenkinsLatestLTSBaselineVersion:
+    kind: jenkins
+    sourceid: JenkinsLatestLTSBaseline
   # Test that the previous LTS Jenkins version exists
   jenkinsPreviousLTSVersion:
     kind: jenkins
@@ -90,7 +99,7 @@ targets:
       matchpattern: >-
         (.*You could also consider \*)(.*)(\* if there are specific reasons.*)
       replacepattern: >-
-        ${1}{{ source "JenkinsLatestLTS" }}${3}
+        ${1}{{ source "JenkinsLatestLTSBaseline" }}${3}
     scmid: default
   setJenkinsLTSVersionInMinimumRecommendedVersion:
     kind: file


### PR DESCRIPTION
In #6945, [@MarkEWaite pointed out](https://github.com/jenkins-infra/jenkins.io/pull/6945#pullrequestreview-1780165327) that the change proposed by my updatecli manifest was incorrect.

> In this case, we want to recommend the initial release of the most recent LTS baseline (for example, 2.426.1) , not the most recent release of the most recent LTS baseline (for example 2.426.2 or 2.426.3). We rarely allow backporting of a new feature to later releases of an LTS line.

My initial implementation was naive, and I hadn't captured the full complexity of variations within LTS versions for Jenkins.

I am now proposing this change, which adds another Jenkins source (the latest baseline) and incorporates it into the `content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc` file.