### PR TITLE
fix: correct RSS icon height in /changelog

### DIFF
--- a/content/_layouts/changelog.html.haml
+++ b/content/_layouts/changelog.html.haml
@@ -29,7 +29,7 @@ title: Changelog
 - if page.has_rss
   .w-100.text-right{:style => "margin: 10px 0;"}
     %a{:href => "rss.xml"}
-      %img{:src => "/images/changelog/feed-icon.svg", :height => "20px"}/
+      %img{:src => "/images/changelog/feed-icon.svg", :style => "height: 20px"}/
       RSS
 
 - if page.show_ratings


### PR DESCRIPTION
This PR sets the height as CSS style instead of HTML attribute.

Fixes #6951