### PR TITLE
Render footnote correctly

### DIFF
--- a/content/doc/developer/plugin-development/build-process.adoc
+++ b/content/doc/developer/plugin-development/build-process.adoc
@@ -15,7 +15,7 @@ They typically use the link:https://github.com/jenkinsci/plugin-pom/[Jenkins plu
 The link:https://github.com/jenkinsci/maven-hpi-plugin/[Maven HPI plugin] is one of the plugins configured there.
 It does the heavy lifting, such as bundling plugins in the HPI/JPI archive format used for Jenkins plugins, or allowing developers to run a debug Jenkins instance with the plugin.
 
-Since version 2.0 of the plugin POM, it's possible to specify the core version dependency of the parent POM independent of its version.footnote:1.x[Up to Jenkins 1.645, the plugin POM was kept in sync with Jenkins releases, so that the minimum required Jenkins version for a plugin determined the versions of the tools used to build the plugin. These versions should no longer be used.]
+Since version 2.0 of the plugin POM, it's possible to specify the core version dependency of the parent POM independent of its version.footnote:[Up to Jenkins 1.645, the plugin POM was kept in sync with Jenkins releases, so that the minimum required Jenkins version for a plugin determined the versions of the tools used to build the plugin. These versions should no longer be used.]
 This allows plugins compatible with older Jenkins releases to benefit from fixes and improvements in the parent POM.
 The link:https://github.com/jenkinsci/plugin-pom/releases[plugin POM changelog] provides more details.
 


### PR DESCRIPTION
Asciidoc documentation says that the footnote macro should be immediately after the item it is annotating, just as this footnote is.  I assume that means the footnote text was the problem because it contains a punctuation character.  When I remove that punctuation character, the footnote renders correctly.

Fixes #6940
