### PR TITLE
Remove reference to `globalMaskClasses`

### DIFF
--- a/content/doc/developer/plugin-development/dependencies-and-class-loading.adoc
+++ b/content/doc/developer/plugin-development/dependencies-and-class-loading.adoc
@@ -374,7 +374,6 @@ Thus it is best reserved to libraries used purely by internal implementation.
 A more limited flag is `maskClasses`, which blocks only selected classes or packages from the parent loader, rather than everything.
 You must manually verify that the masked classes are complete under the transitive closure of the Java linker:
 for example, masking one package but not another from a library bundled in core could make classes in the masked package unresolvable.
-There is a related flag `globalMaskClasses` which adjusts the behavior of _every loaded plugin_ to essentially override a component of the Java Platform.
 
 If you did not understand any part of this section, do not use these options. Even if you did, think twice.
 


### PR DESCRIPTION
I am removing this "feature" in https://github.com/jenkinsci/jenkins/pull/8785 and https://github.com/jenkinsci/maven-hpi-plugin/pull/563.