### PR TITLE
Outline which CD format is the standard

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -123,7 +123,7 @@ Merge this PR activating CD.
 Be sure to apply one of the link:https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50[predefined labels]
 to this and every subsequent PR before merging so that Release Drafter can properly categorize changes.
 
-Fully automated versioning (optional)::
+Fully automated versioning (recommended)::
 For a regular component whose version number is not that meaningful, let the version number be automatically determined by setting a top-level `<version>+++${changelist}+++</version>` and having an entry `<changelist>999999-SNAPSHOT</changelist>` in the `<properties>` section, removing `<revision>`:
 +
 [source,diff]
@@ -199,7 +199,7 @@ because version numbers going forward must be mathematically larger than any cur
 IMPORTANT: It is _not recommended_ to implement actual semantic versioning with automated releases performed by CD, as that requires great care in always changing the `revision` as part of the changes that semantically would require a `revision` change for the next release.
 Otherwise, automated releases may have version numbers that semantically would not make sense.
 
-Versioning with wrapped components::
+Versioning with wrapped components (optional)::
 Similar to the previous option, for a component whose version number ought to reflect a release version of some wrapped component, use a hyphen (`-`) as the separator between the prefix corresponding to the wrapped component's version and the CD-generated suffix:
 +
 [source,diff]


### PR DESCRIPTION
Outlines that the first syntax is our default syntax for CD.