### PR TITLE
Remove reference to Python 2

### DIFF
--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -175,7 +175,7 @@ link:/doc/book/pipeline/syntax/#stage[`stage`] directive must specify its own
 `Build` that appears on the Jenkins UI.
 <3> This `image` parameter (of the link:/doc/book/pipeline/syntax#agent[`agent`]
 section's `docker` parameter) downloads the
-https://hub.docker.com/_/python/[`python:2-alpine` Docker image] (if it's not
+https://hub.docker.com/_/python/[python Docker image] (if it's not
 already available on your machine) and runs this image as a separate container.
 This means that:
 * You'll have separate Jenkins and Python containers running locally in Docker.


### PR DESCRIPTION
We use Python 3, not Python 2, since Python 2 is no longer supported.
