### PR TITLE
Restrict internal workflows to 'jenkins-infra'

### DIFF
--- a/.github/workflows/label-conflicting-prs.yml
+++ b/.github/workflows/label-conflicting-prs.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   main:
-    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'jenkins-infra-changelog-generator'
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'jenkins-infra-changelog-generator' && github.repository_owner == 'jenkins-infra'
     runs-on: ubuntu-latest
     steps:
       - name: Label conflicting PRs

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'jenkins-infra'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Recently, GH disabled actions for new forks by default, however, this change does not affect existing contributors, causing workflows to run on your forks too, e.g. https://github.com/NotMyFault/jenkins.io/actions

If you don't opt-out email notifications, you end up with numerous mails notifying you that a workflow failed on your fork.

I'd propose to run our internal workflows in this repository only, given you don't need these on your fork when contributing.