### PR TITLE
Document `REQUIRES_DIR_FSYNC` escape hatch

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1215,6 +1215,17 @@ properties:
     Disables the forced flushing when calling `#close()`.
     Not expected to be used.
 
+- name: hudson.util.AtomicFileWriter.REQUIRES_DIR_FSYNC
+  tags:
+  - escape hatch
+  def: |
+    `true` on Unix, `false` on Windows
+  since: 2.440
+  description: |
+    Whether or not to flush the parent directory to disk after flushing the file to disk,
+    which is needed to ensure crash consistency in several Unix filesystems.
+    Prior to 2.440, the parent directory was never flushed to disk.
+
 - name: hudson.util.CharacterEncodingFilter.disableFilter
   tags:
   - escape hatch


### PR DESCRIPTION
Document the escape hatch introduced in jenkinsci/jenkins#8815.