### PR TITLE
Jenkins.io - Remove Red Hat as a sponsor

### DIFF
--- a/content/_data/indexpage/supporters.yml
+++ b/content/_data/indexpage/supporters.yml
@@ -7,9 +7,6 @@
 - logo: cdf.png
   name: Continuous Delivery Foundation
   url: https://cd.foundation/
-- logo: redhat.png
-  name: Red Hat, Inc.
-  url: https://redhat.com
 - logo: aws.png
   name: AWS
   url: https://aws.amazon.com/


### PR DESCRIPTION
Due to recent changes in the Continuous Delivery Foundation, Red Hat is no longer a member of the foundation, and therefore would not be considered a sponsor of Jenkins.

This PR is to remove the logo & link from the supporters carousel at the bottom of the top level page, so that there is no misinformation being shared.