### PR TITLE
 Fix Throttle Concurrent Build plugins's link

### DIFF
--- a/content/doc/book/using/best-practices.adoc
+++ b/content/doc/book/using/best-practices.adoc
@@ -183,7 +183,7 @@ To prevent interference and ensure smooth execution, it is important to manage r
 For builds involving databases or networked services, it is crucial to implement measures that prevent conflicts.
 The plugin:lockable-resources[Lockable Resources plugin] offers fine-grained resource-locking capabilities for Jenkins jobs.
 By using this plugin, you can ensure that only one job has access to a specific resource at a time, avoiding conflicts and ensuring proper synchronization.
-In cases where resource locking with the lockable resources plugin is not sufficient, you can further control concurrent builds using the plugin:throttle-concurrent-builds[Throttle Concurrent Builds plugin].
+In cases where resource locking with the lockable resources plugin is not sufficient, you can further control concurrent builds using the plugin:throttle-concurrents[Throttle Concurrent Builds plugin].
 This plugin allows you to limit the number of builds that can run simultaneously, providing additional control and preventing overload on shared resources.
 
 By leveraging these plugins, you can manage resource conflicts and concurrency effectively, ensuring smooth and reliable execution of your Jenkins jobs.


### PR DESCRIPTION
The link of Throttle Concurrent Build Plugin was set wrong. Link was set to [here](https://plugins.jenkins.io/throttle-concurrent-builds)

I updated to proper [link](https://plugins.jenkins.io/throttle-concurrents/)


<img width="1266" alt="image" src="https://github.com/jenkins-infra/jenkins.io/assets/41505000/b71f818f-b509-43c9-b6db-af55eaa35c3d">
<img width="1363" alt="image" src="https://github.com/jenkins-infra/jenkins.io/assets/41505000/262f89c4-3c5f-4e68-a32d-d1deb19b67ba">