### PR TITLE
blog - contributor summit update

### DIFF
--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -39,5 +39,5 @@ This will lead us to 16h30/17h00 (4:30/5:00 PM) for the end of the presentations
 Until 18h30 (6:30 PM), we will have one or several (concurrent) coding “workshops”/discussions/demonstrations (still to be discussed and organized with Basil Crow). 
 People not interested in these sessions can either network or head to their respective hotels for a quick break.
 
-At 18h30 (6:30 PM), we will head for the restaurant (link:https://maps.app.goo.gl/CS5i53NCTTaYxZvc7[“Restaurant Rubens”], *Rue de l’Escadron 21, 1040 Bruxelles, Belgium* ) that is a 12 minute walk from the co-work. 
+At 18h30 (6:30 PM), we will head for the restaurant (link:https://maps.app.goo.gl/CS5i53NCTTaYxZvc7[“Restaurant Rubens”], *Rue de l’Escadron 21, 1040 Bruxelles, Belgium*) that is a 12 minute walk from the co-work. 
 At 19h00 (7:00 PM) we will have dinner.

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -1,0 +1,41 @@
+---
+layout: post
+title: "2024 Jenkins Contributor Summit - Update"
+tags:
+- events
+- community
+- contribute
+author: jmMeessen
+discourse: true
+opengraph:
+  image: /images/post-images/2023/11/ContribSummit/Contributor_summit_2024.png
+description: >
+  We are looking forward to meet you during the  Jenkins Contributor Summit in Brussels prior to FOSDEM.
+---
+
+The Jenkins Contributor Summit in Brussels (February 2nd) is now quickly approaching. We are looking forward to meeting you.
+
+If you plan to join us and didn’t let us know yet, don’t forget to register by dropping us a note. The list of registered attendees can be found in this document: link:https://docs.google.com/spreadsheets/d/1fatDxa39U-yHW6iTpMQZuW_pMf8G9jhO6yczfoqcY08/edit?usp=sharing[Contributor Summit 24 - Attendees].
+
+The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in room "AZZAR"
+
+Find hereafter a quick overview of the day’s planning:
+
+* We will welcome attendees from 9h30 (9:30 AM) on
+* The Summit will start at 10h00 (10:00 AM)
+* During the morning we will listen to the introduction by the various Jenkins Officers. 
+  Each one will present, for his domain of responsibility, the year’s projects and goals, the challenges, as well as the topics that could/should be discussed during the Summit.
+* At 12h00 (12:00 AM) we will have a one hour lunch break where people can go grab some food (sandwiches) at a nearby shop.
+* At 13h00 (1:00 PM), we start the afternoon sessions and discussions:
+** Changes made to Jenkins to support the new CB HA solution (Vincent L.)
+** Impact and challenges of removing Blue Ocean of the base Jenkins distribution (Alexander B. & Damien D.)
+** User experience evolution
+* Initiatives and roadmap discussion (as built during the morning sessions)
+
+This will lead us to 16h30/17h00 (4:30/5:00 PM) for the end of the presentations and discussions.
+
+Until 18h30 (6:30 PM), we will have one or several (concurrent) coding “workshop”/discussions/demonstrations (still to be discussed and organized with Basil Crow). 
+People not interested in these sessions, can either network or head for hotels for a quick break.
+
+At 18h30 (6:30 PM), we will head for the restaurant (link:https://maps.app.goo.gl/CS5i53NCTTaYxZvc7[“Restaurant Rubens”], *Rue de l’Escadron 21, 1040 Bruxelles, Belgium* ) that is a 12 minute walk from the co-work. 
+At 19h00 (7:00 PM) we will have dinner.

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -23,16 +23,16 @@ The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], 
 
 Find hereafter a quick overview of the day’s planning:
 
-* We will welcome attendees from 9h30 (9:30 AM) on
-* The Summit will start at 10h00 (10:00 AM)
-* During the morning we will listen to the introduction by the various Jenkins Officers. 
-  Each one will present, for his domain of responsibility, the year’s projects and goals, the challenges, as well as the topics that could/should be discussed during the Summit.
-* At 12h00 (12:00 AM) we will have a one hour lunch break where people can go grab some food (sandwiches) at a nearby shop.
+* We will welcome attendees from 9h30 (9:30 AM) on.
+* The Summit will start at 10h00 (10:00 AM).
+* During the morning, we will listen to the introduction presented by the various Jenkins Officers.
+Each one will present, for their domain of responsibility, the year’s projects and goals, the challenges, as well as the topics that could/should be discussed during the Summit.
+* At 12h00 (12:00 AM) we will have a one hour lunch break, where people can go grab some food (sandwiches) at a nearby shop.
 * At 13h00 (1:00 PM), we start the afternoon sessions and discussions:
 ** Changes made to Jenkins to support the new CB HA solution (Vincent L.)
 ** Impact and challenges of removing Blue Ocean of the base Jenkins distribution (Alexander B. & Damien D.)
 ** User experience evolution
-* Initiatives and roadmap discussion (as built during the morning sessions)
+** Initiatives and roadmap discussion (as built during the morning sessions).
 
 This will lead us to 16h30/17h00 (4:30/5:00 PM) for the end of the presentations and discussions.
 

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -19,7 +19,7 @@ We are looking forward to meeting you.
 If you plan to join us and didn’t let us know yet, don’t forget to register by dropping us a note.
 The list of registered attendees can be found in this document: link:https://docs.google.com/spreadsheets/d/1fatDxa39U-yHW6iTpMQZuW_pMf8G9jhO6yczfoqcY08/edit?usp=sharing[Contributor Summit 24 - Attendees].
 
-The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in room "AZZAR"
+The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in the "AZZAR" room.
 
 Find hereafter a quick overview of the day’s planning:
 

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -16,7 +16,8 @@ description: >
 The Jenkins Contributor Summit, being held in Brussels on February 2nd, is now quickly approaching.
 We are looking forward to meeting you.
 
-If you plan to join us and didn’t let us know yet, don’t forget to register by dropping us a note. The list of registered attendees can be found in this document: link:https://docs.google.com/spreadsheets/d/1fatDxa39U-yHW6iTpMQZuW_pMf8G9jhO6yczfoqcY08/edit?usp=sharing[Contributor Summit 24 - Attendees].
+If you plan to join us and didn’t let us know yet, don’t forget to register by dropping us a note.
+The list of registered attendees can be found in this document: link:https://docs.google.com/spreadsheets/d/1fatDxa39U-yHW6iTpMQZuW_pMf8G9jhO6yczfoqcY08/edit?usp=sharing[Contributor Summit 24 - Attendees].
 
 The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in room "AZZAR"
 

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -21,7 +21,7 @@ The list of registered attendees can be found in this document: link:https://doc
 
 The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in the "*AZZAR*" room.
 
-Find hereafter a quick overview of the day’s planning:
+The following list provides a quick overview of the day’s planning:
 
 * We will welcome attendees from 9h30 (9:30 AM) on.
 * The Summit will start at 10h00 (10:00 AM).

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -29,7 +29,7 @@ Find hereafter a quick overview of the day’s planning:
 Each one will present, for their domain of responsibility, the year’s projects and goals, the challenges, as well as the topics that could/should be discussed during the Summit.
 * At 12h00 (12:00 AM) we will have a one hour lunch break, where people can go grab some food (sandwiches) at a nearby shop.
 * At 13h00 (1:00 PM), we start the afternoon sessions and discussions:
-** Changes made to Jenkins to support the new CB HA solution (Vincent L.)
+** Changes made to Jenkins to support the new CloudBees high availability solution (Vincent L.)
 ** Impact and challenges of removing Blue Ocean of the base Jenkins distribution (Alexander B. & Damien D.)
 ** User experience evolution
 ** Initiatives and roadmap discussion (as built during the morning sessions).

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -19,7 +19,7 @@ We are looking forward to meeting you.
 If you plan to join us and didn’t let us know yet, don’t forget to register by dropping us a note.
 The list of registered attendees can be found in this document: link:https://docs.google.com/spreadsheets/d/1fatDxa39U-yHW6iTpMQZuW_pMf8G9jhO6yczfoqcY08/edit?usp=sharing[Contributor Summit 24 - Attendees].
 
-The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in the "AZZAR" room.
+The Summit will take place at link:https://www.betacowork.com/[**Betacowork**], located at *4 Rue des Pères Blancs, 1040 Brussels, Belgium* (link:https://maps.app.goo.gl/S8VrWsrErmLMXqza7[Betacowork] on Google Maps) in the "*AZZAR*" room.
 
 Find hereafter a quick overview of the day’s planning:
 

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -13,7 +13,8 @@ description: >
   We are looking forward to meet you during the  Jenkins Contributor Summit in Brussels prior to FOSDEM.
 ---
 
-The Jenkins Contributor Summit in Brussels (February 2nd) is now quickly approaching. We are looking forward to meeting you.
+The Jenkins Contributor Summit, being held in Brussels on February 2nd, is now quickly approaching.
+We are looking forward to meeting you.
 
 If you plan to join us and didn’t let us know yet, don’t forget to register by dropping us a note. The list of registered attendees can be found in this document: link:https://docs.google.com/spreadsheets/d/1fatDxa39U-yHW6iTpMQZuW_pMf8G9jhO6yczfoqcY08/edit?usp=sharing[Contributor Summit 24 - Attendees].
 

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -37,7 +37,7 @@ Each one will present, for their domain of responsibility, the year’s projects
 This will lead us to 16h30/17h00 (4:30/5:00 PM) for the end of the presentations and discussions.
 
 Until 18h30 (6:30 PM), we will have one or several (concurrent) coding “workshops”/discussions/demonstrations (still to be discussed and organized with Basil Crow). 
-People not interested in these sessions, can either network or head for hotels for a quick break.
+People not interested in these sessions can either network or head to their respective hotels for a quick break.
 
 At 18h30 (6:30 PM), we will head for the restaurant (link:https://maps.app.goo.gl/CS5i53NCTTaYxZvc7[“Restaurant Rubens”], *Rue de l’Escadron 21, 1040 Bruxelles, Belgium* ) that is a 12 minute walk from the co-work. 
 At 19h00 (7:00 PM) we will have dinner.

--- a/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
+++ b/content/blog/2024/01/2024-01-17-jenkins-contributor-summit-update.adoc
@@ -36,7 +36,7 @@ Each one will present, for their domain of responsibility, the year’s projects
 
 This will lead us to 16h30/17h00 (4:30/5:00 PM) for the end of the presentations and discussions.
 
-Until 18h30 (6:30 PM), we will have one or several (concurrent) coding “workshop”/discussions/demonstrations (still to be discussed and organized with Basil Crow). 
+Until 18h30 (6:30 PM), we will have one or several (concurrent) coding “workshops”/discussions/demonstrations (still to be discussed and organized with Basil Crow). 
 People not interested in these sessions, can either network or head for hotels for a quick break.
 
 At 18h30 (6:30 PM), we will head for the restaurant (link:https://maps.app.goo.gl/CS5i53NCTTaYxZvc7[“Restaurant Rubens”], *Rue de l’Escadron 21, 1040 Bruxelles, Belgium* ) that is a 12 minute walk from the co-work. 


### PR DESCRIPTION
This proposed blog post gives additional details about the coming Jenkins Contributor Summit.