### PR TITLE
[JENKINS-72546] Include Amazon Linux 2 in RHEL 7 derivatives

### DIFF
--- a/content/blog/2023/05/30/2023-05-30-operating-system-end-of-life.adoc
+++ b/content/blog/2023/05/30/2023-05-30-operating-system-end-of-life.adoc
@@ -35,8 +35,12 @@ A link:https://www.redhat.com/en/blog/end-maintenance-red-hat-enterprise-linux-7
 Derivatives of Red Hat Enterprise Linux 7 like CentOS Linux 7, Scientific Linux 7, and Oracle Linux 7 will also no longer be supported after June 30, 2024.
 A link:https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/[CentOS project blog post] shares their announcement of end of life.
 
-The Jenkins project has decided to end its support of Red Hat Enterprise Linux 7 in late 2023 rather than waiting until 2024.
-After *Nov 16, 2023*, the Jenkins project will no longer support running Jenkins on Red Hat Enterprise Linux 7 or its derivatives.
+Amazon Linux 2 is also a derivative of Red Hat Enterprise Linux 7.
+It will no longer be supported by Amazon after June 30, 2025.
+The link:https://aws.amazon.com/amazon-linux-2/faqs/[Amazon Linux 2 FAQs] share more details on Amazon Linux 2 end of life.
+
+The Jenkins project has decided to end its support of Red Hat Enterprise Linux 7 and its derivatives in late 2023.
+After *Nov 16, 2023*, the Jenkins project will no longer support running Jenkins on Red Hat Enterprise Linux 7 or any of its derivatives.
 Jenkins container images based on CentOS 7 will no longer be supported after *Nov 16, 2023*.
 
 Users should replace their Red Hat Enterprise Linux 7 installations with another operating system.


### PR DESCRIPTION
[JENKINS-72546](https://issues.jenkins.io/browse/JENKINS-72546) is a recent request that shows OpenSSH versions before 7.6 are still being used.  Assure that readers know that Amazon Linux 2 is no longer supported because it is a derivative of Red Hat Enterprine Linux 7.

Usually we don't revise blog posts, but this blog post is frequently referenced.  I think it is better to revise the blog post than to post repeated additions to the phrasing of the blog post.
