### PR TITLE
Include 2.440.1 in list of releases with fix for 2024-01-24 core vulnerabilities

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -10262,7 +10262,7 @@
     message: Important security fixes.
     references:
       - url: /security/advisory/2024-01-24/
-        title: 2024-01-24 security advisory
+        title: security advisory
   - type: bug
     category: regression
     pull: 8814

--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -10262,7 +10262,7 @@
     message: Important security fixes.
     references:
       - url: /security/advisory/2024-01-24/
-        title: security advisory
+        title: 2024-01-24 security advisory
   - type: bug
     category: regression
     pull: 8814

--- a/content/security/advisory/2024-01-24.adoc
+++ b/content/security/advisory/2024-01-24.adoc
@@ -5,7 +5,7 @@ kind: core and plugins
 core:
   lts:
     previous: 2.426.2
-    fixed: 2.426.3
+    fixed: 2.426.3 or 2.440.1
   weekly:
     previous: '2.441'
     fixed: '2.442'
@@ -122,14 +122,14 @@ issues:
     ====
 
     **Fix Description:** +
-    Jenkins 2.442, LTS 2.426.3 disables the command parser feature that replaces an `@` character followed by a file path in an argument with the file's contents for CLI commands.
+    Jenkins 2.442, LTS 2.426.3, and LTS 2.440.1 disable the command parser feature that replaces an `@` character followed by a file path in an argument with the file's contents for CLI commands.
 
     In case of problems with this fix, disable this change by setting the link:/doc/book/managing/system-properties/#hudson-cli-clicommand-allowatsyntax[Java system property `hudson.cli.CLICommand.allowAtSyntax`] to `true`.
     Doing this is strongly discouraged on any network accessible by users who are not Jenkins administrators.
 
     **Workaround:** +
     Disabling access to the CLI is expected to prevent exploitation completely.
-    Doing so is strongly recommended to administrators unable to immediately update to Jenkins 2.442, LTS 2.426.3.
+    Doing so is strongly recommended to administrators unable to immediately update to Jenkins 2.442, LTS 2.426.3 or LTS 2.440.1.
     Applying this workaround does not require a Jenkins restart.
     For instructions, see the link:https://github.com/jenkinsci-cert/SECURITY-3314-3315/[documentation for this workaround].
 
@@ -177,12 +177,12 @@ issues:
       Attackers can execute the CLI commands that the victim's permissions allow using, up to and including Groovy scripting capabilities (`groovy` and `groovysh` commands) in case of a Jenkins administrator, resulting in arbitrary code execution.
 
     **Fix Description:** +
-    Jenkins 2.442, LTS 2.426.3 performs origin validation of requests made through the CLI WebSocket endpoint.
+    Jenkins 2.442, LTS 2.426.3, and LTS 2.440.1 perform origin validation of requests made through the CLI WebSocket endpoint.
 
     In case of problems with this fix, disable this change by setting the link:/doc/book/managing/system-properties/#hudson-cli-cliaction-allow_websocket[Java system property `hudson.cli.CLIAction.ALLOW_WEBSOCKET`] to `true`.
 
     **Workaround:** +
-    Some workarounds are available to mitigate some or all of the impact if you are unable to immediately upgrade to Jenkins 2.442, LTS 2.426.3:
+    Some workarounds are available to mitigate some or all of the impact if you are unable to immediately upgrade to Jenkins 2.442, LTS 2.426.3 or LTS 2.440.1:
 
     * **Disable CLI access** +
       Disabling access to the CLI will prevent exploitation completely and is the **recommended workaround** for administrators unable to immediately update.

--- a/content/security/advisory/2024-01-24.adoc
+++ b/content/security/advisory/2024-01-24.adoc
@@ -122,7 +122,7 @@ issues:
     ====
 
     **Fix Description:** +
-    Jenkins 2.442, LTS 2.426.3, and LTS 2.440.1 disable the command parser feature that replaces an `@` character followed by a file path in an argument with the file's contents for CLI commands.
+    Jenkins 2.442, LTS 2.426.3, and LTS 2.440.1 disables the command parser feature that replaces an `@` character followed by a file path in an argument with the file's contents for CLI commands.
 
     In case of problems with this fix, disable this change by setting the link:/doc/book/managing/system-properties/#hudson-cli-clicommand-allowatsyntax[Java system property `hudson.cli.CLICommand.allowAtSyntax`] to `true`.
     Doing this is strongly discouraged on any network accessible by users who are not Jenkins administrators.
@@ -177,7 +177,7 @@ issues:
       Attackers can execute the CLI commands that the victim's permissions allow using, up to and including Groovy scripting capabilities (`groovy` and `groovysh` commands) in case of a Jenkins administrator, resulting in arbitrary code execution.
 
     **Fix Description:** +
-    Jenkins 2.442, LTS 2.426.3, and LTS 2.440.1 perform origin validation of requests made through the CLI WebSocket endpoint.
+    Jenkins 2.442, LTS 2.426.3, and LTS 2.440.1 performs origin validation of requests made through the CLI WebSocket endpoint.
 
     In case of problems with this fix, disable this change by setting the link:/doc/book/managing/system-properties/#hudson-cli-cliaction-allow_websocket[Java system property `hudson.cli.CLIAction.ALLOW_WEBSOCKET`] to `true`.
 


### PR DESCRIPTION
Do not merge this PR before LTS 2.440.1 is published.