### PR TITLE
add content for set maven settings.xml

### DIFF
--- a/content/doc/developer/plugin-development/dependency-management.adoc
+++ b/content/doc/developer/plugin-development/dependency-management.adoc
@@ -62,6 +62,8 @@ mvn versions:update-parent
 mvn clean verify
 ----
 
+If return `Project does not have a parent` error, please ensure set `~/.m2/settings.xml` correct.
+
 See the video below for a step by step guide to updating the parent pom.
 
 .Update the parent pom

--- a/content/doc/developer/plugin-development/dependency-management.adoc
+++ b/content/doc/developer/plugin-development/dependency-management.adoc
@@ -62,7 +62,7 @@ mvn versions:update-parent
 mvn clean verify
 ----
 
-If return `Project does not have a parent` error, please ensure set `~/.m2/settings.xml` correct.
+If the command reports an error that the `Project does not have a parent`, please configure `~/.m2/settings.xml` as noted in the link:/doc/developer/tutorial/prepare/[tutorial].
 
 See the video below for a step by step guide to updating the parent pom.
 

--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -56,6 +56,34 @@ This will let you invoke Maven using `mvn`.
 
 The rest of the tutorial assumes that Maven is on your `PATH` environment variable.
 
+Add the following to your `~/.m2/settings.xml` (Windows users will find them in `%USERPROFILE%\.m2\settings.xml`):
+
+[source,xml]
+----
+<settings>
+  <profiles>
+    <profile>
+      <id>jenkins</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>repo.jenkins-ci.org</id>
+          <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>repo.jenkins-ci.org</id>
+          <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>
+----
+
 To verify that Maven is installed, run the following command:
 
 [source,bash]


### PR DESCRIPTION
When not set `~/.m2/settings.xml`, will return `Project does not have a parent` error when execute `mvn versions:update-parent` command.
