### PR TITLE
Update prepare.adoc

### DIFF
--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -95,14 +95,6 @@ It should indicate a _17_ version of Java, and list the path to where Java is lo
 If you don't see this information, see <<Troubleshooting>>.
 
 == Setting up a productive environment with your IDE
-===   NetBeans
-
-NetBeans users can use the IDE's Maven support to open the project directly.
-
-As you navigate through the code, you can tell NetBeans to attach source code JAR files by clicking the "Attach" button that appears in the top of the main content window. This allows you to read the Jenkins core source code as you develop plugins. (Or just select Download Sources on the Dependencies node.)
-
-You are advised to use the link:https://github.com/stapler/netbeans-stapler-plugin[NetBeans plugin for Jenkins/Stapler development]. This offers many Jenkins-specific features. Most visibly, create a new plugin using New Project » Maven » Jenkins Plugin, and use Run project to test it.
-
 === IntelliJ IDEA
 
 IntelliJ users just need to open the project and all should work out of the box.
@@ -114,6 +106,14 @@ Create a new Maven project using **Create from archetype** and **Add an Archetyp
 Select the GroupId and ArtifactId as above, and choose RELEASE as version.
 On the next screen, select io.jenkins.plugins as groupID and choose an artifactId (Project name) and Version to your liking.
 This will automatically create a maven project based on the specified artifact (for example, `empty-plugin`).
+
+=== NetBeans
+
+NetBeans users can use the IDE's Maven support to open the project directly.
+
+As you navigate through the code, you can tell NetBeans to attach source code JAR files by clicking the "Attach" button that appears in the top of the main content window. This allows you to read the Jenkins core source code as you develop plugins. (Or just select Download Sources on the Dependencies node.)
+
+You are advised to use the link:https://github.com/stapler/netbeans-stapler-plugin[NetBeans plugin for Jenkins/Stapler development]. This offers many Jenkins-specific features. Most visibly, create a new plugin using New Project » Maven » Jenkins Plugin, and use Run project to test it.
 
 === Eclipse
 


### PR DESCRIPTION
In section "Setting up a productive environment with your IDE", I moved NetBeans under IntelliJ IDEA.

The Jenkins plugin development with NetBeans seems not to be maintained anymore, since https://plugins.netbeans.apache.org/ does not list any "Jenkins" or "Stapler" plugin. And the last commit to the linked GitHub repo for the "Jenkins/Stapler" plugin was updated 4 years ago.

More background:
As I am rarely coding Java, I had no IDE installed, but I just wanted to learn how to write a Jenkins Plugin.
I assumed that the top mentioned IDE is the best choice to get started with. But then, after installing NetBeans, realizing that it is not really supported anymore (in terms of Jenkins Plugin development).