### PR TITLE
Get GSoC 2024 projects ready for org application

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc
@@ -3,6 +3,7 @@ This file is only meant to be included as a snippet in other documents.
 It is used in reverse proxy document to describe the Jenkins context path.
 ////
 
+[#context-path]
 == Context path
 
 The context path is the prefix of a URL path.

--- a/content/projects/gsoc/2024/project-ideas/adding-additional-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2024/project-ideas/adding-additional-probes-to-plugin-health-score.adoc
@@ -4,7 +4,7 @@ title: "Improving \"Plugin Health Score\" scoring abilities"
 goal: "To add additional probes and review scorings to the \"Plugin Health Score\" project."
 category: Tools
 year: 2024
-status: draft
+status: published
 sig: infra
 skills:
 - Java
@@ -12,7 +12,6 @@ skills:
 - Data analysis applied to data representation
 mentors:
 - "alecharp"
-- "markewaite"
 - "krisstern"
 - "jonesbusy"
 links:
@@ -52,6 +51,7 @@ Bottom line: we need more probes…
 
 With those new probes, in addition of the existing ones, we can improve the score representation of the plugin.
 
+
 === Quick Start
 
 A presentation of the "Plugin Health Score" project was made during the link:https://community.jenkins.io/t/gsoc-office-hours-emea/1471[10-Feb-2022 GSoC Office Hour].
@@ -61,6 +61,7 @@ video::i7Y0FM1tms4[youtube,width=800,height=420,start=488]
 A presentation of the status of the "Plugin Health Score" project at the end of GSoC 2022 was made during the link:https://community.jenkins.io/t/jom-jenkins-gsoc-project-2022-final-edition/3826[05-Oct-2022 GSoC Final Edition].
 
 video::fM2SMbppRxw[youtube,width=800,height=420,start=328]
+
 
 === Some simple probe ideas
 
@@ -73,19 +74,23 @@ video::fM2SMbppRxw[youtube,width=800,height=420,start=328]
 
 Existing probes are listed at link:https://plugin-health.jenkins.io/probes[Plugin Health Scoring +::+ Probes]
 
+
 === Skills to Study and Improve
 
 * Java
 * Data extraction from GitHub repositories
 * Data analysis applied to data representation
 
+
 === Project Difficulty Level
 
 Beginner to Intermediate
 
+
 === Project Size
 
 175 hours
+
 
 === Expected outcomes
 

--- a/content/projects/gsoc/2024/project-ideas/automatic-specification-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2024/project-ideas/automatic-specification-generator-for-jenkins-rest-api.adoc
@@ -4,7 +4,7 @@ title: "Automatic Specification Generator for Jenkins REST API"
 goal: "Find and implement the extraction of the REST APIs from the sources and generate and publish the REST APIs respective documentation"
 category: Plugins
 year: 2024
-status: draft
+status: published
 sig: docs
 skills:
 - Java
@@ -55,6 +55,14 @@ Jenkins users should be easily able to see the REST APIs available for their ins
 For Jenkins core, this could be done with a URL like:  `http://localhost/rest/api/1.0`.
 The plugins would have their own REST API path with a version number like: `http://localhost/plugin/rest/api/1.0`.
 Plugins and the core would thus have their own version number, and an additional REST API version number.  Automated API documentation using the OpenAPI 3.0 specification is part of identifying the API specs.
+
+
+=== Project Size
+This project is of medium size and is expected to be completed in ~175 hours.
+
+
+=== Project Difficulty
+Intermediate
 
 
 === Links

--- a/content/projects/gsoc/2024/project-ideas/automating-rpu-for-jenkinsci-organization.adoc
+++ b/content/projects/gsoc/2024/project-ideas/automating-rpu-for-jenkinsci-organization.adoc
@@ -4,7 +4,7 @@ title: "Manage jenkinsci GitHub permissions as code"
 goal: "Automating the management of GitHub permissions for the jenkinsci organization"
 category: Tools
 year: 2024
-status: draft
+status: published
 sig: infra
 skills:
 - Java
@@ -16,6 +16,7 @@ skills:
 - GitHub user and team management
 mentors:
 - "notmyfault"
+- "krisstern"
 links:
   emailThread: https://community.jenkins.io/t/gsoc-2024-project-idea-manage-jenkinsci-github-permissions-as-code/11186
   gitter: gsoc2024-rpu:matrix.org

--- a/content/projects/gsoc/2024/project-ideas/cloudevents-plugin.adoc
+++ b/content/projects/gsoc/2024/project-ideas/cloudevents-plugin.adoc
@@ -4,7 +4,7 @@ title: "CloudEvents plugin for Jenkins"
 goal: "Build a plugin able to listen to and emit CloudEvents from Jenkins"
 category: Plugins
 year: 2024
-status: draft
+status: published
 sig: cloud-native
 skills:
 - Java
@@ -32,6 +32,14 @@ This project idea proposes to implement a Jenkins plugin which extends the Jenki
 The project requires the student to start with plugin development from scratch and then work with understanding how to use the CloudEvents Java SDK to create and read events.
 
 In the beginning, the student can work on understanding the Jenkins plugin development by writing code for creating a simple Build Step which creates a CloudEvent, and from there we can move to the GlobalPluginConfiguration on how Jenkins should listen to the CloudEvents.
+
+
+=== Project Size
+This project is of medium size and is expected to be completed in ~175 hours.
+
+
+=== Project Difficulty
+Intermediate to Advanced
 
 
 === Links

--- a/content/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc
+++ b/content/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc
@@ -4,7 +4,7 @@ title: "Enhancing an Existing LLM Model with Domain-specific Jenkins knowledge"
 goal: "To develop an app using an existing open-source LLM model with data collected for domain-specific Jenkins knowledge one can fine-tune locally and set up with a proper UI for the user to interact with"
 category: AI/ML
 year: 2024
-status: draft
+status: published
 sig: infra
 skills:
 - Python
@@ -23,6 +23,14 @@ links:
 
 This full-stack project focuses on a proof-of-concept (PoC) to fine-tune an existing open-source LLM model Llama 2 with domain-specific Jenkins data to be compiled, wrangled, and processed by the contributor as a part of an application to be developed, with a minimalistic UI to interact with the user.
 The contributor will get to be involved in every step of the application development process, from data collection, wrangling, and processing to fine-tuning the model and developing the UI.
+
+
+=== Project Size
+This project is of medium size and is expected to be completed in ~175 hours.
+
+
+=== Project Difficulty
+Intermediate to Advanced
 
 
 === Links

--- a/content/projects/gsoc/2024/project-ideas/fixing-backend-extension-indexer-tool.adoc
+++ b/content/projects/gsoc/2024/project-ideas/fixing-backend-extension-indexer-tool.adoc
@@ -1,0 +1,34 @@
+---
+layout: gsocprojectidea
+title: "Fixing the Backend Extension Indexer Tool"
+goal: "The goal of this project is to fix the backend extension indexer tool so that all plugins can be displayed using it."
+category: Tools
+year: 2024
+status: published
+sig: infra
+skills:
+- Bug fixing
+- Java
+- Jenkins
+mentors:
+- "markewaite"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+The Backend Extension Indexer Tool currently used to display all plugins at link:https://www.jenkins.io/doc/developer/extensions/[https://www.jenkins.io/doc/developer/extensions/] is not working as expected. The tool is not able to display all the plugins. And this project involves identifying the underlying issues and fixing them. We currently know that if the plugin has been modernised, then they would no longer be fetched by the tool.
+
+
+=== Project Size
+This project is of the small size and is expected to be completed in ~90 hours.
+
+
+=== Project Difficulty
+Beginner to Intermediate
+
+
+=== Skills to improve/study
+* Java
+* Jenkins
+* Bug investigation and fixing

--- a/content/projects/gsoc/2024/project-ideas/implementing-ui-for-jenkins-infra-statistics.adoc
+++ b/content/projects/gsoc/2024/project-ideas/implementing-ui-for-jenkins-infra-statistics.adoc
@@ -4,7 +4,7 @@ title: "Implementing UI for Jenkins Infra Statistics"
 goal: "To build upon the current GitHub Pages based UI into a user-friendly and full-featured website for showcasing Jenkins Infra Statistics"
 category: UI/UX
 year: 2024
-status: draft
+status: published
 sig: infra
 skills:
 - Javascript/Typescript
@@ -46,6 +46,14 @@ The current GitHub Pages site at https://stats.jenkins.io/ is fairly basic. The 
 The contributor will get to design the look and feel of the website, and implement the UI using a frontend framework they would agree to explore.
 The contributor will also get to explore the interplay between data and its presentation.
 We aim for a final product that is both visually pleasing and informative.
+
+
+=== Project Size
+This project is of the medium size and is expected to be completed in ~175 hours.
+
+
+=== Project Difficulty
+Intermediate
 
 
 == Links

--- a/content/projects/gsoc/2024/project-ideas/plugin-installation-manager-tool.adoc
+++ b/content/projects/gsoc/2024/project-ideas/plugin-installation-manager-tool.adoc
@@ -4,7 +4,7 @@ title: "Plugin Installation Manager Tool Improvements"
 goal: "Introduce new features and improvements in the plugin installation manager"
 category: Tools
 year: 2024
-status: draft
+status: published
 sig: platform
 skills:
 - Java
@@ -14,6 +14,7 @@ skills:
 mentors:
 - "markewaite"
 - "jonesbusy"
+- "krisstern"
 links:
   gitter: "jenkinsci_plugin-installation-manager-cli-tool:gitter.im"
   draft: https://docs.google.com/document/d/1s-dLUfU1OK-88bCj-GKaNuFfJQlQNLTWtacKkVMVmHc

--- a/content/projects/gsoc/2024/project-ideas/screenshot-automation.adoc
+++ b/content/projects/gsoc/2024/project-ideas/screenshot-automation.adoc
@@ -2,7 +2,7 @@
 layout: gsocprojectidea
 title: "Screenshot Automation for Jenkins Docs"
 goal: "To automate screenshot capture process for Jenkins docs"
-category: Dev Tools
+category: Tools
 year: 2024
 status: draft
 sig: docs

--- a/content/projects/gsoc/2024/project-ideas/using-bearer-token-authentication-for-the-git-plugin-and-git-client-plugin.adoc
+++ b/content/projects/gsoc/2024/project-ideas/using-bearer-token-authentication-for-the-git-plugin-and-git-client-plugin.adoc
@@ -4,7 +4,7 @@ title: "Using Bearer Token Authentication for the Git plugin and Git Client Plug
 goal: "To introduce a new authentication technique for both the Git plugin and Git Client plugin"
 category: Plugins
 year: 2024
-status: draft
+status: published
 sig: platform
 skills:
 - Java
@@ -20,7 +20,15 @@ links:
 
 === Background
 
-Currently neither the Jenkins Git plugin nor the Jenkins Git Client plugin support the use of bearer token authentication. This project would add support for bearer token authentication to both plugins.
+Currently, neither the Jenkins Git plugin nor the Jenkins Git Client plugin support the use of bearer token authentication. This project would add support for bearer token authentication to both plugins. One of the issue is to investigate the use cases of this feature and to design the implementation to support those use cases.
+
+
+=== Project Size
+This project is of medium size and is expected to be completed in ~175 hours.
+
+
+=== Project Difficulty
+Intermediate
 
 
 === Links

--- a/content/projects/gsoc/2024/project-ideas/using-openrewrite-recipes-for-plugin-modernization-or-automation-plugin-build-metadata-updates.adoc
+++ b/content/projects/gsoc/2024/project-ideas/using-openrewrite-recipes-for-plugin-modernization-or-automation-plugin-build-metadata-updates.adoc
@@ -4,16 +4,15 @@ title: "Using OpenRewrite Recipes for Plugin Modernization or Automation Plugin 
 goal: "Explore ways OpenRewrite recipes can be used for Jenkins plugin modernization or automation of plugin build metadata updates"
 category: Tools
 year: 2024
-status: draft
+status: published
 sig: infra
 skills:
 - OpenRewrite
 - Java
 - Plugin hygiene and migration
 mentors:
-- "sghill"
-- "rahulsom"
 - "jonesbusy"
+- "krisstern"
 links:
   emailThread: https://community.jenkins.io/t/google-summer-of-code-gsoc-2022-call-for-organizers-mentors-and-project-ideas/1010/8
   meetings: /projects/gsoc/#office-hours

--- a/content/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io.adoc
+++ b/content/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io.adoc
@@ -4,7 +4,7 @@ title: "Using OpenTelemetry for Jenkins Jobs on ci.jenkins.io"
 goal: "To help enhance observability of Jenkins jobs on ci.jenkins.io via the introduction of the use of OpenTelemetry"
 category: Tools
 year: 2024
-status: draft
+status: published
 sig: infra
 skills:
 - OpenTelemetry
@@ -12,7 +12,6 @@ skills:
 - DevOps
 mentors:
 - "markewaite"
-- "krisstern"
 - "berviantoleo"
 - "harsh-ps-2003"
 - "vandit1604"
@@ -28,6 +27,14 @@ Infra team would like to to perform deeper monitoring of specific jobs on ci.jen
 The introduction of OpenTelemetry would allow us to do this.
 OpenTelemetry is a collection of APIs, SDKs, and tools used to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) to help analyzing software performance and behavior.
 With proper design and orchestration of the different moving parts of OpenTelemetry, we hope that the contributor completing the project will be able to gain invaluable experience in implementing observability tooling to the Jenkins project.
+
+
+=== Project Size
+This project is of medium size and is expected to be completed in ~175 hours.
+
+
+=== Project Difficulty
+Intermediate
 
 
 === Links


### PR DESCRIPTION
Moving some projects from "draft" to "published" in preparation for the GSoC 2024 org applications to take place over the next few days, as well as adding details such as project size and difficulty, and adding a new project idea for the backend-extension-indexer as @MarkEWaite suggested. 