### PR TITLE
Fix scaling of JCasC on projects page

### DIFF
--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -133,7 +133,7 @@ link:remoting[*Learn more*]
 
 == Jenkins Configuration as Code
 
-image:/images/logos/JCasC/JCasC.svg["Jenkins Configuration as Code", role=right, height=180]
+image:/images/logos/JCasC/JCasC.svg["Jenkins Configuration as Code", role=right, width=180]
 
 Setting up Jenkins is a complex process, as both Jenkins and its plugins require some tuning and configuration,
 with dozens of parameters to set within the web UI manage section.


### PR DESCRIPTION
The change proposed fixes the JCasC logo scaling on https://www.jenkins.io/projects/. The variable to set should be the width and not the height.

Before:

![Screenshot 2024-02-09 at 10 42 34](https://github.com/jenkins-infra/jenkins.io/assets/13383509/75552f41-0f0b-4b33-96e1-595e8f748942)

After:
![Screenshot 2024-02-09 at 10 42 51](https://github.com/jenkins-infra/jenkins.io/assets/13383509/3816902e-71a9-4695-b397-c20b312c1839)
