### PR TITLE
Update index.adoc to fix URL

### DIFF
--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -119,7 +119,7 @@ During these time slots Jenkins GSoC org admins and mentors are available for an
 * Schedule: weekly 30 minutes meetings. Office hours will be held on Thursdays at 16:00 UTC.
   Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
 * link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
-* Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaO1f6bvkcSzW4PdWKkLktRG[here].
+* Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/@jenkinscicd/playlists
 
 This meeting will be used for Q&A with GSoC applicants/contributors and mentors before the announcement of accepted projects as well as during the GSoC program.
 You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].


### PR DESCRIPTION
While browsing [Jenkins GSoC](https://www.jenkins.io/projects/gsoc/) page for resources, found a link not working. Hence proposing a fix as following:

Fix non-working playlist link under 'Office Hours'. Existing link on-clicking redirects to YouTube with a message -> `The playlist does not exist.`

I have replaced it with [youtube.com/@jenkinscicd/playlists](https://www.youtube.com/@jenkinscicd/playlists). I hope I have identified the correct URL.