### PR TITLE
chore: purge `stylesheets/styles.css` on publication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,10 @@ node('docker&&linux') {
             }
         }
         stage('Purge cached CSS') {
-            sh 'curl -X PURGE https://www.jenkins.io/css/jenkins.css'
+            sh '''
+            curl -X PURGE https://www.jenkins.io/css/jenkins.css
+            curl -x PURGE https://www.jenkins.io/stylesheets/styles.css
+            '''
         }
     }
 }


### PR DESCRIPTION
This PR adds another CSS to purge on publication.

Ref:
- https://github.com/jenkins-infra/jenkins.io/pull/7066#issuecomment-1943540449