### PR TITLE
Add voting deadline to Community Awards blog post

### DIFF
--- a/content/blog/2024/01/2024-01-29-nominate-someone-2024-jenkins-contributor-awards.adoc
+++ b/content/blog/2024/01/2024-01-29-nominate-someone-2024-jenkins-contributor-awards.adoc
@@ -18,7 +18,7 @@ Jenkins Contributor Awards for 2024 are being run by the Continuous Delivery Fou
 The nominations are open and are being accepted using GitHub issues to make the process transparent.
 Any contributor is eligible!
 The deadline to nominate someone is February 19, 2024.
-Voting will open on February 22.
+Voting will open on February 22 and close on Friday, March 22.
 
 Nominate contributors or vote with reactions/comments for all three Jenkins awards:
 


### PR DESCRIPTION
This PR is to add the voting deadline to the 2024 Community Awards post. @lemeurherve rightfully noticed and shared, so that this can be adjusted accordingly.