### PR TITLE
fix avatar img on safari browser for GSoC project ideas page

### DIFF
--- a/content/stylesheets/components/_avatar.scss
+++ b/content/stylesheets/components/_avatar.scss
@@ -14,7 +14,7 @@
     overflow: hidden;
     flex-shrink: 0;
     width: 100%;
-    height: 100%;
+    max-height: 100%;
     object-fit: cover;
     object-position: center;
     opacity: 0;


### PR DESCRIPTION
Fixes #7082

Updated CSS so that the images for avatars work in safari.