### PR TITLE
Correct link to Frontside

### DIFF
--- a/content/artwork/index.html.haml
+++ b/content/artwork/index.html.haml
@@ -15,7 +15,7 @@ title: Jenkins Artwork
 
       %p
         The original Jenkins logo was created by our friends at
-        %a{:href => 'https://frontside.io/'}
+        %a{:href => 'https://frontside.com'}
           Frontside.
         Special thanks to
         %a{:href => 'https://github.com/cowboyd'}


### PR DESCRIPTION
Corrected link on the Jenkins Artwork page that credits Frontside for artwork of original Jenkins logo.