### PR TITLE
Update form-validation.adoc to include possibility to change variable

### DIFF
--- a/content/doc/developer/forms/form-validation.adoc
+++ b/content/doc/developer/forms/form-validation.adoc
@@ -33,7 +33,15 @@ The name of the method follows the convention `doCheckXyz` where `xyz` is the na
 ----
 
 
-The parameter name `value` is also significant. The `throws` clause isn't.
+The parameter name `value` is also significant. The `throws` clause isn't. If you want to use a different name as variable, e.g. `meaningfulName` you can do so, with:
+
+[source,java]
+----
+public FormValidation doCheckThreads(@QueryParameter("value") final String meaningfulName) throws IOException, ServletException {
+  // ...
+}
+----
+
 
 This naming convention is how Jenkins wires up your form validation method. The return type also must be FormValidation, which offers various static factory methods to create an instance. Form validation can be of 3 different kinds: `ok`, `warning` or `error`. Validation message can either be represented in plaintext or use HTML markup. Several validations of different kinds can be reported wrapping then into one using aggregate factory method.
 


### PR DESCRIPTION
I recently reworked an old plugin and there someone always used a more meaningful name for the variable as just `value`. I think this helps writing cleaner code.