### PR TITLE
Display anchor when hovering over the title

### DIFF
--- a/content/_partials/anchors.html.haml
+++ b/content/_partials/anchors.html.haml
@@ -1,22 +1,8 @@
 - selector = page.selector || '.container .row.body'
 :javascript
   window.addEventListener('DOMContentLoaded', function () {
-    anchors.options = {
-      class: 'hover-class',
-    }
-
     for (var i = 1 ; i <= 6 ; i ++) {
       anchors.add('#{selector} h' + i);
     }
+  })
 
-    const anchorIcons = document.querySelectorAll('.hover-class');
-    anchorIcons.forEach(icon => {
-      icon.style.opacity = '0';
-      icon.parentNode.addEventListener('mouseenter', () => {
-        icon.style.opacity = '1';
-      });
-      icon.parentNode.addEventListener('mouseleave', () => {
-        icon.style.opacity = '0';
-      });
-    });
-  });

--- a/content/_partials/anchors.html.haml
+++ b/content/_partials/anchors.html.haml
@@ -1,8 +1,22 @@
 - selector = page.selector || '.container .row.body'
 :javascript
   window.addEventListener('DOMContentLoaded', function () {
+    anchors.options = {
+      class: 'hover-class',
+    }
+
     for (var i = 1 ; i <= 6 ; i ++) {
       anchors.add('#{selector} h' + i);
     }
-  })
 
+    const anchorIcons = document.querySelectorAll('.hover-class');
+    anchorIcons.forEach(icon => {
+      icon.style.opacity = '0';
+      icon.parentNode.addEventListener('mouseenter', () => {
+        icon.style.opacity = '1';
+      });
+      icon.parentNode.addEventListener('mouseleave', () => {
+        icon.style.opacity = '0';
+      });
+    });
+  });

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -8,12 +8,6 @@ html {
   scroll-behavior: auto !important;
 }
 
-/* hide anchors unless they're hovered to offset the weird margin/padding
-   needed for anchored links to not hide the target behind the navigation bar */
-*:hover > .anchorjs-link {
-  opacity: 0;
-}
-
 img {
   max-width: 100%;
   object-fit: contain;
@@ -30,15 +24,6 @@ a:hover {
 
 .btn:hover {
   text-decoration: none;
-}
-
-.anchorjs-link:hover {
-  opacity: 1;
-}
-
-/* make anchor links easier to find */
-.anchorjs-link {
-  padding: 0.4em 0.3em 0.4em 0.5em !important;
 }
 
 .container.page {


### PR DESCRIPTION
Problem with:
Any documentation page
Eg. https://www.jenkins.io/doc/book/installing/

Existing Issue:
As mentioned by @lemeurherve in this [comment](https://github.com/jenkins-infra/jenkins.io/pull/7077#issuecomment-1947330743), the anchor only displays when hovered on the right side.

This PR offers a swift solution to address the issue and ensures the anchor is displayed when hovering over the title. However, it should have analyzed the underlying cause because I have tested it with various projects where the hover effect occurs without necessitating these alterations.