### PR TITLE
Increase anchor distance to menu bar

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1,6 +1,6 @@
 /* Make all anchors on the page slightly lower so they don't get clipped by the header */
 *[id] {
-  scroll-margin-top: 55px;
+  scroll-margin-top: 65px;
 }
 
 /* Turns off smooth scrolling */


### PR DESCRIPTION
This increases the distance to the top slightly when jumping to an anchor, so that the text is not directly below the menu bar.

Example: https://www.jenkins.io/security/#advisories

## Before
<img width="500" alt="Screenshot 2024-02-20 at 08 50 19" src="https://github.com/jenkins-infra/jenkins.io/assets/1831569/05d3a230-d801-499f-8631-02a5c79061ec">

## After
<img width="495" alt="Screenshot 2024-02-20 at 08 50 13" src="https://github.com/jenkins-infra/jenkins.io/assets/1831569/b197c164-767f-44e9-9887-fd77866bdab0">
