### PR TITLE
Update default branch checkout for manual CD

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -286,9 +286,9 @@ To cut a release:
 
 [source,shell]
 ----
-# Checkout the primary branch of the repository if you are on a UN*X system:
+# Checkout the primary branch of the repository if you are on a Unix system:
 git checkout $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-# Windows users are adviced to use the following command in CMD:
+# Windows users are advised to use the following command in CMD:
 # for /f "tokens=4 delims=/" %i in ('git symbolic-ref refs/remotes/origin/HEAD') do git checkout %i
 git pull --ff-only
 mvn -Dset.changelist \

--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -286,6 +286,7 @@ To cut a release:
 
 [source,shell]
 ----
+# Checkout the primary branch of the repository
 git checkout $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
 git pull --ff-only
 mvn -Dset.changelist \

--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -286,8 +286,10 @@ To cut a release:
 
 [source,shell]
 ----
-# Checkout the primary branch of the repository
+# Checkout the primary branch of the repository if you are on a UN*X system:
 git checkout $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+# Windows users are adviced to use the following command in CMD:
+# for /f "tokens=4 delims=/" %i in ('git symbolic-ref refs/remotes/origin/HEAD') do git checkout %i
 git pull --ff-only
 mvn -Dset.changelist \
   -Pquick-build \

--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -286,7 +286,7 @@ To cut a release:
 
 [source,shell]
 ----
-git checkout master
+git checkout $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
 git pull --ff-only
 mvn -Dset.changelist \
   -Pquick-build \


### PR DESCRIPTION
The change proposed updates the default branch matching your defined default branch, when copy/pasting the sample to cut a manual release, in case it's not `master`.