### PR TITLE
fix(updatecli): Fixes #7093.

### DIFF
--- a/updatecli/updatecli.d/docker-workflow.yaml
+++ b/updatecli/updatecli.d/docker-workflow.yaml
@@ -43,9 +43,9 @@ targets:
     spec:
       file: content/doc/book/installing/_docker-for-tutorials.adoc
       matchpattern: >-
-        (.*)jenkins-plugin-cli(.*)docker-workflow:(.*)\"
+        (.*)jenkins-plugin-cli(.*)docker-workflow:(.*) (.*)\"
       replacepattern: >-
-        ${1}jenkins-plugin-cli${2}docker-workflow:{{ source "dockerWorkflowLatestVersion" }}"
+        ${1}jenkins-plugin-cli${2}docker-workflow:{{ source "dockerWorkflowLatestVersion" }} ${4}"
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/docker-workflow.yaml
+++ b/updatecli/updatecli.d/docker-workflow.yaml
@@ -43,7 +43,7 @@ targets:
     spec:
       file: content/doc/book/installing/_docker-for-tutorials.adoc
       matchpattern: >-
-        (.*)jenkins-plugin-cli(.*)docker-workflow:(.*) (.*)\"
+        (.*)jenkins-plugin-cli(.*)docker-workflow:(.*?) (.*)\"
       replacepattern: >-
         ${1}jenkins-plugin-cli${2}docker-workflow:{{ source "dockerWorkflowLatestVersion" }} ${4}"
     scmid: default


### PR DESCRIPTION
The regex used in my updatecli manifest was quite off, and it was removing everything after docker-workflow:. This change should fix it (at least, it does on my machine 🤷 ).