### PR TITLE
fix(updatecli): Fixes #7086.

### DIFF
--- a/updatecli/updatecli.d/blueocean.yaml
+++ b/updatecli/updatecli.d/blueocean.yaml
@@ -46,9 +46,9 @@ targets:
     spec:
       file: content/doc/book/installing/_docker-for-tutorials.adoc
       matchpattern: >-
-        (.*)jenkins-plugin-cli(.*)blueocean:(.*) (.*)
+        (.*)jenkins-plugin-cli(.*)blueocean:(.*?) (.*)\"
       replacepattern: >-
-        ${1}jenkins-plugin-cli${2}blueocean:{{ source "blueoceanLatestVersion" }} ${4}
+        ${1}jenkins-plugin-cli${2}blueocean:{{ source "blueoceanLatestVersion" }} ${4}"
     scmid: default
 
 actions:


### PR DESCRIPTION
The regex used in my updatecli manifest was quite off, and it was removing everything after `blueocean:`:. This change should fix it (at least, it does on my machine 🤷 ).