### PR TITLE
Removes alecharp from mentor list on GSOC 2024

### DIFF
--- a/content/projects/gsoc/2024/project-ideas/adding-additional-probes-to-plugin-health-score.adoc
+++ b/content/projects/gsoc/2024/project-ideas/adding-additional-probes-to-plugin-health-score.adoc
@@ -11,7 +11,6 @@ skills:
 - Data extraction from GitHub repositories
 - Data analysis applied to data representation
 mentors:
-- "alecharp"
 - "krisstern"
 - "jonesbusy"
 links:


### PR DESCRIPTION
I won't be able to mentor this year finally. 
I'll still be able to do code reviews as normally I should still have time to work on plugin-health-scoring.