### PR TITLE
hotfix(LTS upgrade notes for 2.440.1) fixup of #7064 to add all occurences of 'jenkins_home' and 'agent_name' as "Asciidoctor passtrough".

### DIFF
--- a/content/_data/upgrades/2-440-1.adoc
+++ b/content/_data/upgrades/2-440-1.adoc
@@ -1,6 +1,6 @@
 ==== Upgrade to the latest version of Remoting
 
-The `-jnlpUrl ${JENKINS_URL}/computer/${AGENT_NAME}/jenkins-agent.jnlp` argument to the agent JAR has been deprecated; use `-url ${JENKINS_URL}` and `-name ${AGENT_NAME}` instead, potentially also passing in `-webSocket`, `-tunnel`, and/or work directory options as needed.
+The `+-jnlpUrl ${JENKINS_URL}/computer/${AGENT_NAME}/jenkins-agent.jnlp+` argument to the agent JAR has been deprecated; use `+-url ${JENKINS_URL}+` and `+-name ${AGENT_NAME}+` instead, potentially also passing in `-webSocket`, `-tunnel`, and/or work directory options as needed.
 Make sure you reset all inbound launcher options to defaults, and follow new guidance for command-line options for agent.jar.
 The official Docker images are already using the new calling convention.
 


### PR DESCRIPTION
…

Removes the error message

```
11:37:37  set_urls
11:37:37  build_page_index
11:37:39  Generating pages...
11:37:39  Using the following options from site.generation: {}
11:39:36  Failing build due to warnings in log output:
11:39:36  asciidoctor: WARNING: skipping reference to missing attribute: agent_name
11:39:36  asciidoctor: WARNING: skipping reference to missing attribute: jenkins_url
11:39:36
11:39:36  NOTE for 'Missing attribute error':
11:39:36      This means there is a some text that looks like '{some_name}',
11:39:36      but asciidoctor could not find an attribute called 'some_name'.
11:39:36      If you expected there to be an attribute for substitution,
11:39:36      check the spelling.
11:39:36
11:39:36      To display some literal text such as ${ENV_VAR_NAME}
11:39:36      you will need to make it a passthrough: +${ENV_VAR_NAME}+.
11:39:36      To get monospace and passthrough, you must use
11:39:36      backtick and plus: `+${ENV_VAR_NAME}+`
 ````