### PR TITLE
jcasc: Fix Gitter broken format of JCasC on projects page

### DIFF
--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -54,7 +54,7 @@ The meeting takes place on Wednesdays, 9am (UTC+1) every two weeks.
 Meetings will be announced at link:/event-calendar/[*Event Calendar*]
 
 Hangouts On Air is used to host and stream the meeting on link:https://www.youtube.com/channel/UC5JBtmoz7ePk-33ZHimGiDQ[*Jenkins Youtube channel*].
-Link to the actual meeting is always shared a few minutes before the meeting at link:https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im[*configuration-as-code-plugin*] gitter channel
+Link to the actual meeting is always shared a few minutes before the meeting at link:++https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im++[*configuration-as-code-plugin*] gitter channel
 
 link:https://docs.google.com/document/d/1Hm07Q1egWL6VVAqNgu27bcMnqNZhYJmXKRvknVw4Y84/edit?usp=sharing[*Minutes of Meeting*] are available for everyone interested
 

--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -54,7 +54,7 @@ The meeting takes place on Wednesdays, 9am (UTC+1) every two weeks.
 Meetings will be announced at link:/event-calendar/[*Event Calendar*]
 
 Hangouts On Air is used to host and stream the meeting on link:https://www.youtube.com/channel/UC5JBtmoz7ePk-33ZHimGiDQ[*Jenkins Youtube channel*].
-Link to the actual meeting is always shared a few minutes before the meeting at link:++https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im++[*configuration-as-code-plugin*] gitter channel
+Link to the actual meeting is always shared a few minutes before the meeting in the link:++https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im++[*configuration-as-code-plugin*] gitter channel
 
 link:https://docs.google.com/document/d/1Hm07Q1egWL6VVAqNgu27bcMnqNZhYJmXKRvknVw4Y84/edit?usp=sharing[*Minutes of Meeting*] are available for everyone interested
 


### PR DESCRIPTION
This PR is to fix Gitter broken format of JCasC on projects page.  Might related to #3335 

**Page URL:** https://www.jenkins.io/projects/jcasc/#time-and-location

**Current format was broken:**
![image](https://github.com/jenkins-infra/jenkins.io/assets/85242618/e3c963ac-0973-48a9-ad2f-e883a9860c72)


**Resolution:**
- Adding `++` around the URL with special characters would help
- Asciidoctor Documentation: https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/#when-to-use-the-link-macro
- Something like: `link:++https://example.org/now_this__link_works.html++[]` 