### PR TITLE
feat: update GSoC 2024 home page after org list published

### DIFF
--- a/content/projects/gsoc/2024/project-ideas/automatic-specification-generator-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2024/project-ideas/automatic-specification-generator-for-jenkins-rest-api.adoc
@@ -4,7 +4,7 @@ title: "Automatic Specification Generator for Jenkins REST API"
 goal: "Find and implement the extraction of the REST APIs from the sources and generate and publish the REST APIs respective documentation"
 category: Plugins
 year: 2024
-status: published
+status: draft
 sig: docs
 skills:
 - Java

--- a/content/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io.adoc
+++ b/content/projects/gsoc/2024/project-ideas/using-opentelemetry-for-jenkins-jobs-on-ci_jenkins_io.adoc
@@ -4,7 +4,7 @@ title: "Using OpenTelemetry for Jenkins Jobs on ci.jenkins.io"
 goal: "To help enhance observability of Jenkins jobs on ci.jenkins.io via the introduction of the use of OpenTelemetry"
 category: Tools
 year: 2024
-status: published
+status: draft
 sig: infra
 skills:
 - OpenTelemetry

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -15,7 +15,7 @@ links:
 
 // image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=left]
 link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
-(GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 10-22 weeks programming project under the guidance of mentors.
+(GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ weeks-long programming project under the guidance of dedicated mentors.
 
 GSoC contributors accepted into the program receive a stipend and are sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
 In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
@@ -26,7 +26,7 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 We are participating in Google Summer of Code in 2024. +
 // See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
-We are applying to be a mentoring organization in Google Summer of Code 2024.
+We have been accepted by Google to be a mentoring organization in Google Summer of Code 2024.
 
 // Uncomment when application is worked on and submitted (Feb 2024)
 //(link:./2024/application[Jenkins GSoC Organisation Application Form])
@@ -40,10 +40,10 @@ We are applying to be a mentoring organization in Google Summer of Code 2024.
 
 // They were proposed and selected from these link:./2024/project-ideas[project ideas].
 
-We are currently collecting project ideas.
-Add your ideas by submitting an ad-hoc pull request as explained in our previous link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
+We have finalised a list of 9 project ideas.
+// Add your ideas by submitting an ad-hoc pull request as explained in our previous link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
 
-The 2024 GSoC project ideas can be found link:./2024/project-ideas[here].
+The 2024 GSoC project ideas link:./2024/project-ideas[can be found here].
 
 //Uncomment when further in the selection process
 // They were proposed and selected from these link:./2022/project-ideas[project ideas].
@@ -58,7 +58,7 @@ Our documentation will be updated over time to reflect the changes in the GSoC p
 // * Online Meetup: Introduction to Jenkins in GSoC
 // (link:https://bit.ly/3pbJFuC[slides],
 // link:https://youtu.be/GDRTgEvIVBc[video])
-// * link:https://summerofcode.withgoogle.com/programs/2023/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
+* link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
 
 == Mentors
@@ -91,11 +91,11 @@ The following checklists and documents describe the role:
 == Contacts
 
 * We use the link:/sigs/gsoc[GSoC SIG] for communications about GSoC.
-Projects may also have their own mailing lists, chats and meetings.
-See details on project pages.
+Projects may also have their own mailing lists, chats, and meetings.
+Please see the details on each of the project pages.
 * We use link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse] for discussions.
   This is the **recommended** channel for communications.
-* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications, but it is better to use Discourse to request technical feedback or to have long discussions.
+* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications, but it is better to use Discourse to request technical feedback or to have long-form discussions.
 * For private matters such as communication difficulties with mentors, GSoC contributors, or Org Admins,
   please use this mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
 
@@ -116,7 +116,7 @@ The purpose of GSoC Discourse is for all public communications on GSoC such as n
 Although we use Discourse as the main communication channel, we also have regular "office hours" video calls.
 During these time slots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
 
-* Schedule: weekly 30 minutes meetings. Office hours will be held on Thursdays at 16:00 UTC.
+* Schedule: Weekly 30 minutes meetings. Office hours will be held on Thursdays at 16:00 UTC.
   Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
 * link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
 * Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaODwGnSZzxjV6-6mqRfcoBe[here].
@@ -125,9 +125,8 @@ This meeting will be used for Q&A with GSoC applicants/contributors and mentors 
 You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
 More slots may be added on-demand, e.g. for project-specific discussions.
 
-In addition to these organization-wide meetings,
-each GSoC project has regular meetings during community bonding and coding phases.
-See the project pages for the schedule.
+In addition to these organization-wide meetings, each GSoC project has regular meetings during community bonding and coding phases.
+Please see the project pages for the schedule.
 
 == Previous years
 


### PR DESCRIPTION
Updated the GSoC 2024 home page to get the good news ready to be announced publicly