### PR TITLE
chore: use `azcopy` in parallel to `blobxfer` for synchronisation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,11 +86,28 @@ node('docker&&linux') {
     /* The Jenkins which deploys doesn't use multibranch or GitHub Org Folders.
     */
     if (infra.isTrusted() && env.BRANCH_NAME == null) {
-        stage('Publish on Azure') {
+        stage('Publish on Azure with blobxfer on prodjenkinsio') {
             /* -> https://github.com/Azure/blobxfer
             Require credential 'BLOBXFER_STORAGEACCOUNTKEY' set to the storage account key */
             withCredentials([string(credentialsId: 'BLOBXFER_STORAGEACCOUNTKEY', variable: 'BLOBXFER_STORAGEACCOUNTKEY')]) {
                 sh './scripts/blobxfer upload --local-path /data/_site --storage-account-key $BLOBXFER_STORAGEACCOUNTKEY --storage-account prodjenkinsio --remote-path jenkinsio --recursive --mode file --skip-on-md5-match --file-md5 --delete'
+            }
+        }
+        stage('Publish on Azure with azcopy on jenkinsio') {
+            infra.withFileShareServicePrincipal([
+                servicePrincipalCredentialsId: 'trustedci_jenkinsio_fileshare_serviceprincipal_writer',
+                fileShare: 'jenkins-io',
+                fileShareStorageAccount: 'jenkinsio'
+            ]) {
+                sh '''
+                # Synchronize the File Share content
+                set +x
+                azcopy sync \
+                    --skip-version-check \
+                    --recursive=true\
+                    --delete-destination=true \
+                    ./data/_site/ "${FILESHARE_SIGNED_URL}"
+                '''
             }
         }
         stage('Purge cached CSS') {


### PR DESCRIPTION
This PR adds a step to use `azcopy` to synchronize content in a new Premium File Share in parallel of `blobxfer` (for now).

When all the process will be validated, `blobxfer` and related code and script will be removed in favor of `azcopy`.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414