### PR TITLE
fixup: correct local path passed to `azcopy`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ node('docker&&linux') {
                         --skip-version-check \
                         --recursive=true\
                         --delete-destination=true \
-                        ./data/_site/ "${FILESHARE_SIGNED_URL}"
+                        ./build/_site/ "${FILESHARE_SIGNED_URL}"
                     '''
                 }
             }


### PR DESCRIPTION
This PR uses the correct `./build/_site` local path cf https://github.com/jenkins-infra/jenkins.io/blob/2cf0d355d01da358cfe0b836e69695160ca2ccbd/scripts/blobxfer#L24

Tested via a replay of the primary branch job on trusted.ci.jenkins.io

Fixup of:
- #7123 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414