### PR TITLE
Removing character from weekly 2.447 changelog entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -22932,7 +22932,7 @@
           - url: https://github.com/jenkinsci/stapler/releases/tag/1839.ved17667b_a_eb_5
             title: Stapler 1839.ved17667b_a_eb_5 Release Notes
         message: |-
-          * Developer: Update Stapler from 1822.v120278426e1c to 1839.ved17667b_a_eb_5 to no longer generate line JavaScript with Stapler bound objects to improve compatibility with ContentSecurityPolicy Plugin.
+          Developer: Update Stapler from 1822.v120278426e1c to 1839.ved17667b_a_eb_5 to no longer generate line JavaScript with Stapler bound objects to improve compatibility with ContentSecurityPolicy Plugin.
 
   # pull: 8980 (PR title: Update dependency webpack to v5.90.3)
   # pull: 8981 (PR title: Update dependency sass-loader to v14.1.1)


### PR DESCRIPTION
The weekly changelog contains a developer entry, but I forgot to remove the extra * at the beginning of the Developer text.

This is to remove the extra character