### PR TITLE
Fix anchor in plugin site

### DIFF
--- a/content/_layouts/plugin.html.haml
+++ b/content/_layouts/plugin.html.haml
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+
+- unless page.noanchors
+  = partial("anchors.html.haml", :selector => '#grid-box')

--- a/content/plugins.html.haml
+++ b/content/plugins.html.haml
@@ -1,8 +1,9 @@
 ---
-layout: default
+layout: plugin
 title: "Jenkins Plugins"
 section: plugins
 uneditable: true
+noanchors: true
 ---
 
 - # This page is required by the plugins site at plugins.jenkins.io --

--- a/content/template.html.haml
+++ b/content/template.html.haml
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: plugin
 title: "{{ title }}"
 description: "{{ description }}"
 opengraph:
@@ -7,6 +7,7 @@ opengraph:
 section: plugins
 uneditable: true
 barebone: true
+noanchors: true
 ---
 
 - # This page is required by the plugins site at plugins.jenkins.io --


### PR DESCRIPTION
Closes [#1598](https://github.com/jenkins-infra/plugin-site/issues/1598)

### Problem:
Plugin wiki content uses https://github.com/jenkins-infra/jenkins.io/blob/master/content/template.html.haml which in default allows anchor to be displayed for all header, also github pages have inbuilt anchors. That's why there are two anchors displayed in any plugin page. 
### Approach:
To resolve this, we have disabled the anchor in the default template

Testing not done - I don't know a preferred way to test the plugins page from jenkins.io
