### PR TITLE
Update declarative-linter HTTP API instructions for authenticated use

### DIFF
--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -53,11 +53,10 @@ ssh -p $JENKINS_PORT $JENKINS_HOST declarative-linter < Jenkinsfile
 [source,bash]
 ----
 # curl (REST API)
-# Assuming "anonymous read access" has been enabled on your Jenkins instance.
+# These instructions assume that the security realm of Jenkins is something other than "None" and you have an account.
 # JENKINS_URL=[root URL of Jenkins controller]
-# JENKINS_CRUMB is needed if your Jenkins controller has CRSF protection enabled as it should
-JENKINS_CRUMB=`curl "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)"`
-curl -X POST -H $JENKINS_CRUMB -F "jenkinsfile=<Jenkinsfile" $JENKINS_URL/pipeline-model-converter/validate
+# JENKINS_AUTH=[your Jenkins username and an API token in the following format: your_username:api_token]
+curl -X POST --user "$JENKINS_AUTH" -F "jenkinsfile=<Jenkinsfile" "$JENKINS_URL/pipeline-model-converter/validate"
 ----
 
 === Examples


### PR DESCRIPTION
The current instructions seemed to be written for a configuration we should not support by writing dedicated documentation for it.