### PR TITLE
Fix/add links and edit CloudEvents plugin project idea page

### DIFF
--- a/content/projects/gsoc/2023/index.adoc
+++ b/content/projects/gsoc/2023/index.adoc
@@ -136,9 +136,9 @@ See the project pages for the schedule.
 
 == References, 2023
 
-* link:./2023/project-ideas[GSoC 2023 project ideas]
-//* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins page on the GSoC website]
-* link:/blog/2022/11/16/gsoc-2023/[Jenkins GSoC 2023 announcement]
+* link:./project-ideas[GSoC 2023 project ideas]
+* link:https://summerofcode.withgoogle.com/programs/2023/organizations/jenkins-wp/[Jenkins page on the GSoC website]
+* link:/blog/2023/02/23/gsoc2023-announcement/[Jenkins GSoC 2023 announcement]
 * link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2023 announcement blog]
 
 == References

--- a/content/projects/gsoc/2024/project-ideas/cloudevents-plugin.adoc
+++ b/content/projects/gsoc/2024/project-ideas/cloudevents-plugin.adoc
@@ -24,8 +24,9 @@ links:
 As the CI/CD world is moving more towards interoperability between multiple platforms, Jenkins should also be compatible with the same interoperability standards. Some of these standards with respect to communication between different CI/CD platforms are put forth by the CloudEvents specification. This spec outlines the structure of CloudEvents, which are produced or consumed by entities which support it, hence making those entities compatible with other CI/CD platforms which also support them allowing them to work together.
 
 Jenkins currently does not support CloudEvents, making it hard for users to use it with other platforms which support them.
+
 The link:/projects/gsoc/2021/projects/cloudevents-plugin[previous CloudEvents plugin project] in Google Summer of Code  was a predecessor to the CDEvents project, that is currently running in the Continuous Delivery Foundation.
-The CDEvents project is an incubating projects at the Continuous Delivery Foundation. 
+To provide some context, the CDEvents project is an incubating project at the Continuous Delivery Foundation.
 More information about that project is available at link:https://cdevents.dev/[].
 For this new project, we will enable Jenkins to support CDEvents.
 That may involve extending or adjusting the CloudEvents plugin so that it supports CDEvents.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -140,12 +140,12 @@ Please take a look at the project pages for the schedule.
 * link:/projects/gsoc/gsoc2016[GSoC 2016] - 5 student projects
 * link:https://wiki.jenkins.io/display/JENKINS/Google+Summer+of+Code+2009[GSoC 2009] - as Hudson, not accepted
 
-// == References, 2023
-//
-// * link:./2023/project-ideas[GSoC 2023 project ideas]
-// //* link:https://summerofcode.withgoogle.com/programs/2022/organizations/jenkins-wp/[Jenkins page on the GSoC website]
-// * link:/blog/2022/11/16/gsoc-2023/[Jenkins GSoC 2023 announcement]
-// * link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2023 announcement blog]
+== References, 2024
+
+* link:./2024/project-ideas[GSoC 2024 project ideas]
+* link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp/[Jenkins page on the GSoC website]
+* link:/blog/2024/02/23/gsoc2024-announcement/[Jenkins GSoC 2024 announcement]
+* link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2024 announcement blog]
 
 == References
 


### PR DESCRIPTION
1. Added some new reference links for GSoC 2024
2. Fixed / added some reference links for GSoC 2023
3. Edited the GSoC 2024 CloudEvents plugin project idea page