### PR TITLE
Fix: Make some GSoC 2024-related changes

### DIFF
--- a/content/blog/2018/02/2018-02-19-gsoc2018-announcement.adoc
+++ b/content/blog/2018/02/2018-02-19-gsoc2018-announcement.adoc
@@ -27,7 +27,7 @@ All information about the Jenkins GSoC is available on its link:/projects/gsoc/[
 
 == I am a student. How do I apply?
 
-See link:/projects/gsoc/students[Information for students] for application guidelines.
+See link:/projects/gsoc/contributors[Information for students] for application guidelines.
 
 First step is to join discussions in the mailing lists in order to introduce yourself, establish connections with the community and potential mentors.
 The application period starts on March 12 and ends on March 27, but don't let it misguide you!

--- a/content/blog/2019/03/2019-03-04-gsoc2019-announcement.adoc
+++ b/content/blog/2019/03/2019-03-04-gsoc2019-announcement.adoc
@@ -38,7 +38,7 @@ All information about the Jenkins GSoC is available on its link:/projects/gsoc/[
 
 == I am a student. How do I apply?
 
-See the link:/projects/gsoc/students[Information for students] page for full application guidelines.
+See the link:/projects/gsoc/contributors[Information for students] page for full application guidelines.
 
 We encourage interested students to reach out to the Jenkins community early and to start exploring project ideas.
 All project ideas have chats and mailing lists referenced on their pages.

--- a/content/blog/2020/01/2020-01-29-gsoc-report.adoc
+++ b/content/blog/2020/01/2020-01-29-gsoc-report.adoc
@@ -172,7 +172,7 @@ including the number of hours that are expected from mentors,
 and we even have a section on preventing link:/projects/gsoc/mentors/#conflict-of-interest-prevention[conflict of interest].
 When we recruit mentors, we point them to the mentor information page.
 
-We also updated the link:/projects/gsoc/students/[student information page].
+We also updated the link:/projects/gsoc/contributors/[student information page].
 We find this is a huge time saver as every student contacting us has the same questions about joining and participating in the program.
 Instead of re-explaining the program each time, we send them a link to those pages.
 
@@ -287,4 +287,4 @@ Jenkins GSoC pages have been already updated towards the next year, and we invit
 * link:/projects/gsoc/[Main page with all contacts] 
 * link:/projects/gsoc/2020/project-ideas/[GSoC 2020 Project Ideas]
 * link:/blog/2019/12/20/call-for-mentors/[GSoC 2020 Call for Mentors and Project Ideas]
-* Information for link:/projects/gsoc/students/[students] and link:/projects/gsoc/mentors/[mentors] 
+* Information for link:/projects/gsoc/contributors/[students] and link:/projects/gsoc/mentors/[mentors]

--- a/content/blog/2021/03/2021-03-17-gsoc2021-announcement.adoc
+++ b/content/blog/2021/03/2021-03-17-gsoc2021-announcement.adoc
@@ -40,7 +40,7 @@ All information about the Jenkins GSoC is available on its link:/projects/gsoc/[
 
 == I am a student. How do I apply?
 
-See the link:/projects/gsoc/students[Information for students] page for full application guidelines.
+See the link:/projects/gsoc/contributors[Information for students] page for full application guidelines.
 
 We encourage interested students to reach out to the Jenkins community early and to start exploring project ideas.
 All project ideas have chats and mailing lists referenced on their pages.

--- a/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
+++ b/content/blog/2022/03/2022-03-08-gsoc2022-announcement.adoc
@@ -53,7 +53,7 @@ All information about the Jenkins GSoC is available on its link:/projects/gsoc/[
 
 == How do I apply?
 
-See the link:/projects/gsoc/students[Information for students] page for full application guidelines.
+See the link:/projects/gsoc/contributors[Information for students] page for full application guidelines.
 
 We encourage interested participants to reach out to the Jenkins community early and to start exploring project ideas.
 We also encourage participants to join the weekly link:https://docs.google.com/document/d/1OpvMWpzBKtKnYBAkhtQ1dK5zQix3D7RY5g3vDJXkSnc/edit?usp=sharing[Jenkins GSoC office hours], these meetings are set up for participants to meet org admins and mentors and to ask questions.

--- a/content/blog/2022/11/2022-11-23-get-prepared-for-gsoc.adoc
+++ b/content/blog/2022/11/2022-11-23-get-prepared-for-gsoc.adoc
@@ -55,7 +55,7 @@ To move forward, use the documentation available on link:/doc/developer/[jenkins
 
 Another way to get experience is to follow the suggestions of the link:/doc/developer/tutorial-improve/[**"Improve a Plugin Tutorial"**].
 
-And of course read the rules and general advice specific to Google Summer of Code: link:/projects/gsoc/students/[GSoC studends] and https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html.
+And of course read the rules and general advice specific to Google Summer of Code: link:/projects/gsoc/contributors/[GSoC studends] and https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html.
 Also a useful reading are link:/projects/gsoc/#previous-years[previous year's submission] and recorded meetings.
 
 Remember it is always a good idea to let others know about your contributions to the community especially via IRC conversations, GitHub issues, as well as pull requests. 

--- a/content/blog/2023/02/2023-02-01-gsoc-update.adoc
+++ b/content/blog/2023/02/2023-02-01-gsoc-update.adoc
@@ -35,7 +35,7 @@ The proposals are based on the link:/projects/gsoc/2023/project-ideas/[2023 proj
 The phase will culminate with the selection of the students/contributors participating in in this year's GSoC. 
 The deadline for the application is April 4.
 
-Please carefully review the guidelines for a successful application on the link:/projects/gsoc/students/[Information for GSoC Contributors] page.
+Please carefully review the guidelines for a successful application on the link:/projects/gsoc/contributors/[Information for GSoC Contributors] page.
 
 In a nutshell, select a project idea and begin thinking about how you will build a proposal to convince the mentors that you are the best candidate to bring the project to a successful end.
 

--- a/content/blog/2023/02/2023-02-23-gsoc2023-announcement.adoc
+++ b/content/blog/2023/02/2023-02-23-gsoc2023-announcement.adoc
@@ -50,7 +50,7 @@ All information about the Jenkins GSoC is available on its link:/projects/gsoc/[
 
 == How do I apply?
 
-Refer to the link:/projects/gsoc/students[Information for students] page for full application guidelines.
+Refer to the link:/projects/gsoc/contributors[Information for students] page for full application guidelines.
 
 We encourage interested participants to reach out to the Jenkins community early and to start exploring project ideas.
 We also encourage participants to join the weekly link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Jenkins GSoC office hours].

--- a/content/blog/2024/02/2024-02-23-gsoc2024-announcement.adoc
+++ b/content/blog/2024/02/2024-02-23-gsoc2024-announcement.adoc
@@ -47,7 +47,7 @@ All information about the Jenkins GSoC is available on its link:/projects/gsoc/[
 
 == How do I apply?
 
-Refer to the link:/projects/gsoc/students[information for contributors] page for full application guidelines.
+Refer to the link:/projects/gsoc/contributors[information for contributors] page for full application guidelines.
 
 We encourage interested participants to reach out to the Jenkins community early and start exploring project ideas.
 We also encourage participants to join the weekly link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Jenkins GSoC office hours].

--- a/content/projects/gsoc/2022/application.adoc
+++ b/content/projects/gsoc/2022/application.adoc
@@ -161,7 +161,7 @@ _Provide your potential contributors with a page containing tips on how to write
 Welcome and thank you for your interest!
 To apply to the organization, please follow the link:https:/projects/gsoc/students/#student-application-process[guidelines on our website].
 
-Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/students/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
+Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/contributors/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
 If you have any questions about the application process, please feel free to contact us via link:https://community.jenkins.io/tag/gsoc[Jenkins GSoC Discourse] or in the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[jenkinsci/gsoc-sig Gitter] chat. We also have weekly meetings which are open to everyone.
 
 

--- a/content/projects/gsoc/2022/index.adoc
+++ b/content/projects/gsoc/2022/index.adoc
@@ -45,7 +45,7 @@ please report any issues you discover.
 
 == GSoC Contributors
 
-* link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
+* link:/projects/gsoc/contributors[Information and application guidelines for GSoC contributors]
 * Online Meetup: Introduction to Jenkins in GSoC
 (link:https://bit.ly/3pbJFuC[slides],
 link:https://youtu.be/GDRTgEvIVBc[video])

--- a/content/projects/gsoc/2023/index.adoc
+++ b/content/projects/gsoc/2023/index.adoc
@@ -49,7 +49,7 @@ please report any issues you discover.
 
 == GSoC Contributors
 
-* link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
+* link:/projects/gsoc/contributors[Information and application guidelines for GSoC contributors]
 * Online Meetup: Introduction to Jenkins in GSoC
 (link:https://bit.ly/3pbJFuC[slides],
 link:https://youtu.be/GDRTgEvIVBc[video])

--- a/content/projects/gsoc/2024/application.adoc
+++ b/content/projects/gsoc/2024/application.adoc
@@ -161,7 +161,7 @@ _Provide your potential contributors with a page containing tips on how to write
 Welcome and thank you for your interest!
 To apply to the organization, please follow the link:https:/projects/gsoc/students/#student-application-process[guidelines on our website].
 
-Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/students/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
+Before submitting please go through the link:https://google.github.io/gsocguides/student/[GSoC contributor guide] and the link:/projects/gsoc/contributors/[Jenkins GSoC contributor guide] which documents Jenkins specific requirements. Participating in Google Summer of Code requires 15-20 hours commitment a week over several months. If it may overlap with your study, internship, work or other commitments, we recommend you plan accordingly.
 If you have any questions about the application process, please feel free to contact us via link:https://community.jenkins.io/tag/gsoc[Jenkins GSoC Discourse] or in the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[jenkinsci/gsoc-sig Gitter] chat. We also have weekly meetings which are open to everyone.
 
 

--- a/content/projects/gsoc/2024/project-ideas/cloudevents-plugin.adoc
+++ b/content/projects/gsoc/2024/project-ideas/cloudevents-plugin.adoc
@@ -10,6 +10,7 @@ skills:
 - Java
 - Go
 - CloudEvents SDK
+- CDEvents SDK
 - Networking
 mentors:
 - "krisstern"
@@ -21,16 +22,20 @@ links:
 ---
 
 === Background
-As the CI/CD world is moving more towards interoperability between multiple platforms, Jenkins should also be compatible with the same interoperability standards. Some of these standards with respect to communication between different CI/CD platforms are put forth by the CloudEvents specification. This spec outlines the structure of CloudEvents, which are produced or consumed by entities which support it, hence making those entities compatible with other CI/CD platforms which also support them allowing them to work together.
+As the CI/CD world is moving more towards interoperability between multiple platforms, Jenkins should also be compatible with the emergent interoperability standards. Some of these standards with respect to communication between different CI/CD platforms are put forth by the CloudEvents and CDEvents specifications. This spec outlines the structure of CloudEvents, which are produced or consumed by entities which support it, hence making those entities compatible with other CI/CD platforms which also support them allowing them to work together.
 
-Jenkins currently does not support CloudEvents, making it hard for users to use it with other platforms which support them.
+Jenkins currently supports CloudEvents via a link:../../2021/projects/cloudevents-plugin.adoc[former GSoC project from 2021], however, it does not support CDEvents, making it hard for users to use it with other platforms which support both.
 
-The link:/projects/gsoc/2021/projects/cloudevents-plugin[previous CloudEvents plugin project] in Google Summer of Code  was a predecessor to the CDEvents project, that is currently running in the Continuous Delivery Foundation.
-To provide some context, the CDEvents project is an incubating project at the Continuous Delivery Foundation.
+The link:/projects/gsoc/2021/projects/cloudevents-plugin[previous CloudEvents plugin project] in Google Summer of Code 2021 was a predecessor to the CDEvents project, that is currently running in the Continuous Delivery Foundation, this is such that this older project could not support CDEvents since it existed before CDEvents' inception.
+For CDEvents only, we have an link:https://plugins.jenkins.io/cdevents/[existing plugin] that is able to listen to and emit CDEvents, but does not support CloudEvents.
+This project aims to extend Jenkins support to both the CloudEvents and CDEvents.
 More information about that project is available at link:https://cdevents.dev/[].
 For this new project, we will enable Jenkins to support CDEvents.
 That may involve extending or adjusting the CloudEvents plugin so that it supports CDEvents.
 The most likely scenario is that we will start a new plugin for this project.
+
+For a context, we expect the selected contributor to harness both the link:https://github.com/cloudevents/sdk-java[CloudEvents Java SDK] and the link:https://github.com/cdevents/sdk-java[CDEvents Java SDK] to create and read events by the proposed new plugin for Jenkins.
+The contributor will also need to understand how to Jenkins plugin development life-cycle works and gain hands-on experience in plugin architecture design.
 
 
 ==== Project Details

--- a/content/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc
+++ b/content/projects/gsoc/2024/project-ideas/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc
@@ -8,9 +8,12 @@ status: published
 sig: infra
 skills:
 - Python
+- React.js
 - LLM
 - AI/ML
 - Jenkins
+- Ollama
+- LangChain
 - UI
 mentors:
 - "krisstern"
@@ -23,8 +26,10 @@ links:
 
 === Background
 
-This full-stack project focuses on a proof-of-concept (PoC) to fine-tune an existing open-source LLM model Llama 2 with domain-specific Jenkins data to be compiled, wrangled, and processed by the contributor as a part of an application to be developed, with a minimalistic UI to interact with the user.
+This full-stack project focuses on a proof-of-concept (PoC) idea to fine-tune an existing open-source LLM model (such as Llama 2) with domain-specific Jenkins data to be compiled, wrangled, and processed by the contributor as a part of an AI-driven application, with the goal to develop a minimalistic UI for the user to interact with the LLM as a complete end-to-end product.
+This product is to be installed and run locally on the user's laptop, with tools such as link:https://ollama.com/[Ollama] for setting up and running LLM's locally, and link:https://www.langchain.com/[LangChain] to be used as a framework to construct the LLM-powered app.
 The contributor will get to be involved in every step of the application development process, from data collection, wrangling, and processing to fine-tuning the model and developing the UI.
+They may also get exposed to how to package a software to be distributed as a standalone application to be consumed by the end user.
 
 
 === Project Size
@@ -38,3 +43,4 @@ Intermediate to Advanced
 === Links
 
 * link:https://www.datacamp.com/tutorial/fine-tuning-llama-2[DataCamp tutorial on how to fine-tune Llama 2]
+* link:https://www.datacamp.com/tutorial/how-to-build-llm-applications-with-langchain[How to Build LLM Applications with LangChain Tutorial]

--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -1,6 +1,6 @@
 ---
 layout: project
-title: "Google Summer of Code. Information for GSoC Contributors"
+title: "Google Summer of Code: Information for GSoC Contributors"
 description: "This page aggregates links to internal and external resources for Google Summer of Code contributors"
 tags:
 - gsoc

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -54,7 +54,7 @@ Our documentation will be updated over time to reflect the changes in the GSoC p
 
 == GSoC Contributors
 
-* link:/projects/gsoc/students[Information and application guidelines for GSoC contributors]
+* link:/projects/gsoc/contributors[Information and application guidelines for GSoC contributors]
 // * Online Meetup: Introduction to Jenkins in GSoC
 // (link:https://bit.ly/3pbJFuC[slides],
 // link:https://youtu.be/GDRTgEvIVBc[video])

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -12,7 +12,7 @@ opengraph:
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]
 
 This page aggregates links to internal and external resources for Google Summer of Code **mentors**.
-GSoC Contributor resources can be found link:/projects/gsoc/students[here].
+GSoC Contributor resources can be found link:/projects/gsoc/contributors[here].
 
 :toc:
 

--- a/content/projects/gsoc/roles-and-responsibilities.adoc
+++ b/content/projects/gsoc/roles-and-responsibilities.adoc
@@ -72,7 +72,7 @@ A technical advisor is one type of subject matter expert.
 
 GSoC contributors are the active learners and coders.
 
-To learn more about their role, please see link:/projects/gsoc/students/[information for GSoC contributors]
+To learn more about their role, please see link:/projects/gsoc/contributors/[information for GSoC contributors]
 
 ## Org Admin
 

--- a/content/projects/gsoc/students.adoc
+++ b/content/projects/gsoc/students.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /projects/gsoc/contributors
+---


### PR DESCRIPTION
Fixes #7157

1. Corrected / expanded content of some GSoC 2024 project idea pages.
2. Updated the URL for contributor-dedicated contents. 