### PR TITLE
Update the download verification instructions

### DIFF
--- a/content/download/verify.adoc
+++ b/content/download/verify.adoc
@@ -17,7 +17,7 @@ Expected output of `jarsigner -verify -verbose jenkins.war`:
 ----
 - Signed by "CN="CDF Binary Project a Series of LF Projects, LLC", O="CDF Binary Project a Series of LF Projects, LLC", L=Wilmington, ST=Delaware, C=US"
     Digest algorithm: SHA-256
-    Signature algorithm: SHA256withRSA, 4096-bit key
+    Signature algorithm: SHA384withRSA, 4096-bit key
 ----
 
 Earlier releases were created and signed by Kohsuke Kawaguchi.
@@ -61,5 +61,9 @@ The weekly Linux package repositories for link:https://pkg.jenkins.io/debian/[De
 
 NOTE: Jenkins automatically verifies the integrity of plugins it downloads from update centers. These instructions apply to manual downloads.
 
-To manually download plugin releases, visit the plugin's page on the https://plugins.jenkins.io/[plugin site] and select "Archives".
-That page will list all releases available for download as well as their SHA-1 and SHA-256 checksums.
+To manually download plugin releases, visit the plugin's page on the https://plugins.jenkins.io/[plugin site] and select "Releases".
+That page lists all releases available for download.
+Click the version number to download that release of the plugin.
+
+The SHA-1 and SHA-256 checksums of the plugin downloads are available from the https://updates.jenkins.io/download/plugins/[update center plugin pages].
+Click the plugin in the list and the resulting page will show the checksums and other information about all its releases.

--- a/content/download/verify.adoc
+++ b/content/download/verify.adoc
@@ -61,9 +61,9 @@ The weekly Linux package repositories for link:https://pkg.jenkins.io/debian/[De
 
 NOTE: Jenkins automatically verifies the integrity of plugins it downloads from update centers. These instructions apply to manual downloads.
 
-To manually download plugin releases, visit the plugin's page on the https://plugins.jenkins.io/[plugin site] and select "Releases".
+To manually download plugin releases, visit the plugin's page on the link:https://plugins.jenkins.io/[plugin site] and select "Releases".
 That page lists all releases available for download.
 Click the version number to download that release of the plugin.
 
-The SHA-1 and SHA-256 checksums of the plugin downloads are available from the https://updates.jenkins.io/download/plugins/[update center plugin pages].
+The SHA-1 and SHA-256 checksums of the plugin downloads are available from the link:https://updates.jenkins.io/download/plugins/[update center plugin pages].
 Click the plugin in the list and the resulting page will show the checksums and other information about all its releases.


### PR DESCRIPTION
## Update the download verification instructions

The signature algorithm used for the Jenkins war file has been strengthened with the most recent update of the Jenkins war signing ceritifcate.  Use the current string in the sample output.

The plugins site no longer has a tab called "Archives".  It is now the "Releases" tab and does not include the checksums for the plugin releases.  Link to the update center page that includes the checksums for plugins.
