### PR TITLE
Remove mention of supply chain attacks

### DIFF
--- a/content/doc/book/security/controller-isolation.adoc
+++ b/content/doc/book/security/controller-isolation.adoc
@@ -16,7 +16,6 @@ What exactly happens during a build is often controlled by people less trusted t
 * Code authors (for example test code executed during a build)
 
 They all have some control over commands executed during a build.
-This does not even consider issues like supply chain attacks on build dependencies, whereby attackers take over control of NPM or Maven packages and insert malicious code.
 
 To ensure the stability of the Jenkins controller, builds should be executed on other nodes than the built-in node.
 This concept is called _distributed builds_ in Jenkins, and you can learn more about this link:/doc/book/scaling/architecting-for-scale/[here].


### PR DESCRIPTION
This seems out of place here. It's an important issue to consider, but mentioning here in this manner and then never picking it up again seems wrong.