### PR TITLE
Replace embedded google doc with hackmd in governance meeting page

### DIFF
--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -28,14 +28,17 @@ The meetings calendar with links is available link:/event-calendar[here].
 
 === Agenda
 
-Starting from 12.12.2019, the governance meeting agenda is posted in link:http://bit.ly/jenkins-governance-meeting[this Google Document].
-Everyone is welcome to add a topic for one of the incoming meetings by suggesting a change in this Google document.
+Starting from October the 30th, 2023, the governance meeting agenda is posted in link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[this HackMD note].
+Everyone is welcome to add a topic for one of the incoming meetings by suggesting a change in the mailing list.
 
 ++++
-<iframe src="https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg?embedded=true" width="100%" height="600px"></iframe>
+<iframe src="https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA" width="100%" height="600px"></iframe>
 ++++
 
 === Archived Meetings
+
+Before using HackMD, we used to use Google Docs for the agenda.
+Previous notes are available in the old link:https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg[Google doc].
 
 Older agendas, minutes and IRC logs are archived on these pages:
 


### PR DESCRIPTION
The change proposed replaces the embedded google doc with hackmd, what we are using now to take notes.