### PR TITLE
Remove outdated URL from hosting team page

### DIFF
--- a/content/project/teams/hosting.adoc
+++ b/content/project/teams/hosting.adoc
@@ -101,7 +101,6 @@ If needed, you can request a meeting in the developer mailing list.
 == Tools
 
 * link:/projects/infrastructure/ircbot/[Jenkins IRC Bot] - ChatOps tool for managing the hosting and ownership requests.
-* link:https://github.com/slide/jenkins-jira-checker[Jenkins Jira Checker] - Azure Function for checking hosting requests for Jenkins plugins
 
 == References
 


### PR DESCRIPTION
The repository linked does no longer exist.