### PR TITLE
Update lts.yml: fix typo in 2.440.2

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -10694,7 +10694,7 @@
       Reduce the likelihood of thread creation errors on agents.
 
 - version: "2.440.2"
-  date: 2023-03-20
+  date: 2024-03-20
   changes:
   - type: security
     message: Important security fix.


### PR DESCRIPTION
Just a small typo in the date (always a challenge remembering the new year, isn't it? :) )