### PR TITLE
Jenkins weekly 2.451 - add entry for Debian 10 & Ubuntu 20.04 requirement

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23143,12 +23143,11 @@
         references:
           - url: https://github.com/jenkinsci/packaging/pull/456
             title: pull 456 (packaging)
-          - url: https://www.debian.org/releases/buster/releasenotes
-            title: Debian 10 Release Notes
-          - url: https://wiki.ubuntu.com/FocalFossa/ReleaseNotes
-            title: Ubuntu 20.04 Release Notes
+          - url: https://github.com/jenkinsci/packaging/issues/455
+            title: Packaging issue 455
         message: |-
-          Require Debian 10 and Ubuntu 20.04 as the minimum supported versions.
+          Add specific temporary files to the Debian package for better support of Unix domain sockets.
+          Require Debian 10 and Ubuntu 20.04 as the minimum supported versions for Debian packages.
       - type: rfe
         category: rfe
         pull: 9067

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23137,6 +23137,20 @@
     changes:
       - type: rfe
         category: rfe
+        authors:
+          - TobiX
+        pr_title: "Require Debian 10 / Ubuntu 20.04 or newer, include jenkins.tmpfiles"
+        references:
+          - url: https://github.com/jenkinsci/packaging/pull/456
+            title: pull 456 (packaging)
+          - url: https://www.debian.org/releases/buster/releasenotes
+            title: Debian 10 Release Notes
+          - url: https://wiki.ubuntu.com/FocalFossa/ReleaseNotes
+            title: Ubuntu 20.04 Release Notes
+        message: |-
+          Require Debian 10 and Ubuntu 20.04 as the minumum supported versions.
+      - type: rfe
+        category: rfe
         pull: 9067
         authors:
           - mustafau

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23135,7 +23135,7 @@
   - version: '2.451'
     date: 2024-03-26
     changes:
-      - type: rfe
+      - type: major rfe
         category: rfe
         authors:
           - TobiX

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23148,7 +23148,7 @@
           - url: https://wiki.ubuntu.com/FocalFossa/ReleaseNotes
             title: Ubuntu 20.04 Release Notes
         message: |-
-          Require Debian 10 and Ubuntu 20.04 as the minumum supported versions.
+          Require Debian 10 and Ubuntu 20.04 as the minimum supported versions.
       - type: rfe
         category: rfe
         pull: 9067


### PR DESCRIPTION
This PR is to add an entry to the 2.451 changelog stating that Debian 10 and Ubuntu 20.04 are the new minimum required versions. I have included the packaging pull request as expected, and added the Debian 10/Ubuntu 20.04 release notes as additional resources for the changelog.
![Screenshot 2024-03-26 at 5 11 33 PM](https://github.com/jenkins-infra/jenkins.io/assets/99040580/5a49f8e7-14f1-4d10-9580-995b90223059)

