### PR TITLE
Remove unnecessary debug output

### DIFF
--- a/content/_ext/solutionpage.rb
+++ b/content/_ext/solutionpage.rb
@@ -7,12 +7,10 @@ require 'awestruct/page'
 class SolutionPage
   def execute(site)
     solutions = site.pages.select { |p| p.source_path =~ /solutions/ }
-    puts 'Loading solution pages'
 
     solutions.each do |solution|
       page = site.engine.load_page(solution.source_path)
       page.output_path = "/s/#{File.basename(solution.source_path, File.extname(solution.source_path))}/index.html"
-      puts " = Imported solution #{solution.source_path} as #{page.output_path}"
       site.pages << page
     end
   end

--- a/content/_ext/upgrade_guide.rb
+++ b/content/_ext/upgrade_guide.rb
@@ -11,7 +11,6 @@ class UpgradeGuide
       minor_versions.sort!.reverse!
       page = site.engine.find_and_load_site_page( "#{prefix}" )
       page.output_path = File.join( prefix, "#{major}/index.html" )
-      puts page.output_path
       page.version = major.to_s
       site.pages << page
     end


### PR DESCRIPTION
<details>
<summary>Before</summary>

```
$ make run
LISTEN=true ./scripts/awestruct --dev --bind 0.0.0.0 --source-dir=content --output-dir=build/_site
Using profile: development
Generating site: http://localhost:4242/
Executing pipeline...
Loading solution pages
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/android.adoc as /s/android/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/bitbucketserver.adoc as /s/bitbucketserver/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/c.adoc as /s/c/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/docker.adoc as /s/docker/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/embedded.adoc as /s/embedded/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/github.adoc as /s/github/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/index.html.haml as /s/index.html/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/java.adoc as /s/java/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/php.adoc as /s/php/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/pipeline.adoc as /s/pipeline/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/python.adoc as /s/python/index.html
 = Imported solution /Users/danielbeck/Repositories/github.com/daniel-beck/jenkins.io/content/solutions/ruby.adoc as /s/ruby/index.html
/doc/upgrade-guide/2.440/index.html
/doc/upgrade-guide/2.426/index.html
/doc/upgrade-guide/2.414/index.html
/doc/upgrade-guide/2.401/index.html
/doc/upgrade-guide/2.387/index.html
/doc/upgrade-guide/2.375/index.html
/doc/upgrade-guide/2.361/index.html
/doc/upgrade-guide/2.346/index.html
/doc/upgrade-guide/2.332/index.html
/doc/upgrade-guide/2.319/index.html
/doc/upgrade-guide/2.303/index.html
/doc/upgrade-guide/2.289/index.html
/doc/upgrade-guide/2.277/index.html
/doc/upgrade-guide/2.263/index.html
/doc/upgrade-guide/2.249/index.html
/doc/upgrade-guide/2.235/index.html
/doc/upgrade-guide/2.222/index.html
/doc/upgrade-guide/2.204/index.html
/doc/upgrade-guide/2.190/index.html
/doc/upgrade-guide/2.176/index.html
/doc/upgrade-guide/2.164/index.html
/doc/upgrade-guide/2.150/index.html
/doc/upgrade-guide/2.138/index.html
/doc/upgrade-guide/2.121/index.html
/doc/upgrade-guide/2.107/index.html
/doc/upgrade-guide/2.89/index.html
/doc/upgrade-guide/2.73/index.html
/doc/upgrade-guide/2.60/index.html
/doc/upgrade-guide/2.46/index.html
/doc/upgrade-guide/2.32/index.html
/doc/upgrade-guide/2.19/index.html
/doc/upgrade-guide/2.7/index.html
*************************************************************************
Starting preview server at http://0.0.0.0:4242 (Press Ctrl-C to shutdown)
*************************************************************************

16:40:32 - INFO - LiveReload is waiting for a browser to connect.
[2024-03-27 16:40:32] INFO  WEBrick 1.8.1
[2024-03-27 16:40:32] INFO  ruby 3.3.0 (2023-12-25) [aarch64-linux]
[2024-03-27 16:40:32] INFO  WEBrick::HTTPServer#start: pid=1 port=4242
```

</details>


<details>
<summary>After</summary>

```
$ make run
LISTEN=true ./scripts/awestruct --dev --bind 0.0.0.0 --source-dir=content --output-dir=build/_site
Using profile: development
Generating site: http://localhost:4242/
Executing pipeline...
*************************************************************************
Starting preview server at http://0.0.0.0:4242 (Press Ctrl-C to shutdown)
*************************************************************************

16:47:17 - INFO - LiveReload is waiting for a browser to connect.
[2024-03-27 16:47:17] INFO  WEBrick 1.8.1
[2024-03-27 16:47:17] INFO  ruby 3.3.0 (2023-12-25) [aarch64-linux]
[2024-03-27 16:47:17] INFO  WEBrick::HTTPServer#start: pid=1 port=4242
```

</details>