### PR TITLE
Updating Docs SIG page members and content to be current

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -104,9 +104,9 @@ There are no current plans to participate in Google Season of Docs, but if you a
 === Plugin documentation on GitHub
 
 Previously, the SIG link:/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github[migrated plugin documentation from the Jenkins Wiki to GitHub].
-Documentation in the plugin GitHub repository provides a good user experience for Jenkins users seeking documentation. 
-By performing this migration, plugin maintainers can now follow the documentation-as-code approach and make documentation changes a part of the pull requests. 
-It also creates an opportunity to review the documentation changes and add documentation contributor recognition, especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation]. 
+Documentation in the plugin GitHub repository provides a good user experience for Jenkins users seeking documentation.
+By performing this migration, plugin maintainers can now follow the documentation-as-code approach and make documentation changes a part of the pull requests.
+It also creates an opportunity to review the documentation changes and add documentation contributor recognition, especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation].
 
 As of November 2022, we have more than 1,000 plugins which already use GitHub as a documentation source, but there are still link:https://reports.jenkins.io/jenkins-plugin-migration.html[hundreds of plugins to migrate].
 We invite contributors to participate in the project and to help us with migrating the docs.
@@ -140,7 +140,7 @@ Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook]
 link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve user documentation.
 Common improvement themes include adding migration of the documentation from Wiki, pipeline examples with each of the pipeline steps, additional tutorials for new users, better searching, and navigation.
 
-Links: 
+Links:
 
 * link:https://github.com/jenkins-infra/jenkins.io/projects/1[GitHub Project]
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -16,8 +16,8 @@ leads:
 participants:
 - "gounthar"
 - "krisstern"
-- "stackscribe"
 - "vandit1604"
+- "stackscribe"
 
 links:
   gitter: "jenkins/docs:matrix.org"

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -12,12 +12,12 @@ tags:
   - documentation
 leads:
 - "markewaite"
+- "kmartens27"
 participants:
-- "oleg_nenashev"
-- "dheerajodha"
-- "kwhetstone"
+- "krisstern"
 - "stackscribe"
-- "zaycodes"
+- "vandit1604"
+
 links:
   gitter: "jenkins/docs:matrix.org"
   meetings: "https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit"
@@ -56,22 +56,22 @@ overview: >
 
 The SIG offers a venue for all kinds of documentation creation, improvement, and delivery.
 
-The group focuses on documentation for Jenkins, including:
+The group focuses on documentation for Jenkins including:
 
 * link:/doc/[User documentation] - Using Jenkins
 ** link:/doc/tutorials[Tutorials]
 ** link:/doc/book/[User Handbook]
-** References like link:/doc/book/pipeline/syntax/[Pipeline Syntax] and link:/doc/pipeline/steps/[Pipeline Steps]
+** References such as link:/doc/book/pipeline/syntax/[Pipeline Syntax] and link:/doc/pipeline/steps/[Pipeline Steps].
 ** link:/participate/how-to-guides/[How-to Guides]
 * link:/doc/developer/[Developer documentation] - Extending Jenkins
 ** link:/doc/developer/tutorial/[Tutorials]
 ** link:/doc/developer/book/[Developer Reference]
 ** link:/doc/developer/guides/[How-To Guides]
-* link:/solutions[Solution documentation] - using Jenkins with specific technologies (e.g. Java, PHP, or Docker).
-  Also, implementation solutions like link:/solutions/pipeline[Pipeline]
+* link:/solutions[Solution documentation] - using Jenkins with specific technologies such as Java, PHP, or Docker.
+This also includes implementation solutions like link:/solutions/pipeline[Pipeline].
 
-Documentation SIG may cooperate with other groups.
-For example, we cooperate with the link:/sigs/platform[Platform SIG] on platform topics.
+The Documentation SIG also collaborates with other groups.
+For example, we cooperate with the link:/sigs/platform[Platform SIG] on platform topics and the link:/sigs/advocacy-and-outreach[Advocacy and Outreach SIG] on community topics.
 
 == Topics
 
@@ -85,33 +85,30 @@ For example, we cooperate with the link:/sigs/platform[Platform SIG] on platform
 
 == Contributing
 
-See link:/participate/document[this page] for information about contributing to Jenkins documentation.
+Our link:/participate/document[Documentation participation page] has further information about contributing to Jenkins documentation.
 It contains links for newcomers and seasoned contributors.
 If you have any questions or ideas, please feel free to reach out to us using the channels listed on the right panel.
 
-[[ongoing-projects]]
-== Projects
+[[past-projects]]
+== Past projects
 
-This section lists some of the projects working under the direction of this SIG.
-See the link:https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
+This section lists some of the past projects completed under the direction of this SIG.
+Refer to the link:https://docs.google.com/document/d/1ygRZnVtoIvuEKpwNeF_oVRVCV5NKcZD1_HMtWlUZguo/edit?usp=sharing[SIG meeting notes] for more information about ongoing projects.
 
 === Google Season of Docs
 
 Google Season of Docs brings together open source communities and technical writers for the benefit of both.
 The program raises awareness of open source, of documentation, and of technical writing.
-
-See our link:/sigs/docs/gsod[Google Season of Docs status page] for documentation project ideas, contact information, and more.
+There are no current plans to participate in Google Season of Docs, but if you are curious, refer to our link:/sigs/docs/gsod[Google Season of Docs page] for past documentation project ideas and other information.
 
 === Plugin documentation on GitHub
 
-Currently the SIG is link:/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github[migrating plugin documentation from Jenkins Wiki to GitHub].
+Previously, the SIG link:/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github[migrated plugin documentation from the Jenkins Wiki to GitHub].
 Documentation in the plugin GitHub repository provides a good user experience for Jenkins users seeking documentation. 
-At the same time, plugin maintainers now can follow the documentation-as-code approach and make documentation changes a part of the pull requests. 
-It also gives an opportunity to review the documentation changes and to add documentation contributor recognition, 
-especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation]. 
+By performing this migration, plugin maintainers can now follow the documentation-as-code approach and make documentation changes a part of the pull requests. 
+It also creates an opportunity to review the documentation changes and add documentation contributor recognition, especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation]. 
 
-As of November 2022 we have more than 900 plugins which already use GitHub as a documentation source,
-but there are still hundreds of plugins to migrate.
+As of November 2022, we have more than 1,000 plugins which already use GitHub as a documentation source, but there are still link:https://reports.jenkins.io/jenkins-plugin-migration.html[hundreds of plugins to migrate].
 We invite contributors to participate in the project and to help us with migrating the docs.
 It is also a great opportunity to update and copy-edit the documentation.
 
@@ -124,15 +121,15 @@ Useful links:
 
 === Plugin site integration with GitHub
 
-link:https://plugins.jenkins.io/[Jenkins Plugin Site] currently uses GitHub to get plugin documentation (see above) and tags (using GitHub topics).
+The link:https://plugins.jenkins.io/[Jenkins Plugin site] currently uses GitHub to get plugin documentation (see above) and tags (using GitHub topics).
 Release information is also pulled from GitHub releases.
 There are still some areas for improvement, such as parsing of CHANGELOG.md files to get release information for plugins that don't use GitHub releases.
-This project is tracked in the jira:WEBSITE-637[] EPIC.
+This project was tracked in the jira:WEBSITE-637[] EPIC.
 
 Useful links:
 
-* link:/doc/developer/publishing/documentation/[Publishing Plugin Documentation]
-* link:https://github.com/jenkins-infra/plugin-site[Plugin Site Frontend]
+* link:/doc/developer/publishing/documentation/[Publishing plugin documentation]
+* link:https://github.com/jenkins-infra/plugin-site[Plugin site frontend]
 * link:https://github.com/jenkins-infra/update-center2[Jenkins Update Center] (serves plugin metadata)
 * link:https://github.com/jenkins-infra/plugin-site/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Newbie-friendly issues for the plugin site]
 
@@ -141,7 +138,7 @@ Useful links:
 
 Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
 link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve user documentation.
-Common improvement themes include adding migration of the documentation from Wiki, pipeline examples with each of the pipeline steps, additional tutorials for new users, better search and navigation.
+Common improvement themes include adding migration of the documentation from Wiki, pipeline examples with each of the pipeline steps, additional tutorials for new users, better searching, and navigation.
 
 Links: 
 
@@ -151,43 +148,40 @@ Links:
 === Administrator Guide
 
 Jenkins administration topics are included in the current link:/doc/book[Jenkins Handbook].
-Navigation can be improved for administrators by separating the administration topics into a separate volume.
-This project will create a separate Jenkins Administrator Guide with content specific for administrators.
-This project is tracked in the jira:WEBSITE-738[] EPIC.
+Since these topics are already included, we are not separating the administration topics into a separate volume.
+Upon reviewing other project documentation, very few, if any, have separate administrator guides.
+Due to this, we are keeping the User Handbook as it is now, where administration topics are part of the overall documentation.
 
 [[solution-pages]]
 === Solution Pages
 
 Jenkins link:/solutions/[solution pages] highlight specific use cases for Jenkins users.
-Those solutions include SCM provider solutions (link:/solutions/github[GitHub], link:/solutions/bitbucketserver[Bitbucket]),
-programming language solutions (link:/solutions/python[Python], link:/solutions/ruby[Ruby], link:/solutions/c[C/C++], link:/solutions/java[Java], and link:/solutions/php[PHP]),
-and execution environment solutions (link:/solutions/python[Pipeline], link:/solutions/docker[Docker], link:/solutions/embedded[Embedded], and link:/solutions/android[Android]).
+Those solutions include SCM provider solutions (link:/solutions/github[GitHub], link:/solutions/bitbucketserver[Bitbucket]), programming language solutions (link:/solutions/python[Python], link:/solutions/ruby[Ruby], link:/solutions/c[C/C++], link:/solutions/java[Java], and link:/solutions/php[PHP]), and execution environment solutions (link:/solutions/python[Pipeline], link:/solutions/docker[Docker], link:/solutions/embedded[Embedded], and link:/solutions/android[Android]).
 An excellent link:/solutions/[opening page] has been provided by link:https://github.com/zbynek[Zbynek Konecny].
 Additional use cases and user stories are being collected by link:https://github.com/alyssat[Alyssa Tong].
 
-The appearance and navigation of those solution pages needs improvement.
-The existing pages should be revisited and improved so that users of specific solutions can find what they need on jenkins.io.
-This project is tracked in the jira:WEBSITE-742[] EPIC.
+The appearance and navigation of those solution pages has been improved since originally starting this project.
+The existing pages have been revisited and improved so that users of specific solutions can find what they need on jenkins.io.
+This project was tracked in the jira:WEBSITE-742[] EPIC.
 
-=== Documentation Reviews
+== Documentation Reviews
 
 * Reviewing Jenkins documentation link:https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=18640[bug reports]
 * Identifying link:https://issues.jenkins.io/issues/?jql=project%20%3D%20%22Jenkins%20Website%22%20and%20status%20!%3D%20done%20and%20labels%20%3D%20newbie-friendly%20ORDER%20BY%20%20%20type%20asc%2C%20status%2C%20updatedDate[newbie-friendly documentation bug reports]
 * Reviewing Jenkins documentation link:https://github.com/jenkins-infra/jenkins.io/pulls[pull requests]
-* Reviewing Jenkins X documentation link:https://github.com/jenkins-x/jx-docs/pulls[pull requests]
 * link:https://plugins.jenkins.io/[Plugins site] improvements
 
 == Office Hours
 
-Documentation office hours are held each Thursday at *18:00 UTC* (Europe and US East) and each Friday at *01:30 UTC* (Asia and US West).
+Documentation office hours are held each Thursday at *17:00 UTC* (Europe and US East) and each Friday at *01:30 UTC* (Asia and US West).
 Office hours are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
-Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] before the meeting starts.
 
 == Meetings
 
 The Documentation SIG meetings are part of the documentation office hours.
 Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
-Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] 10 minutes before the meeting starts.
+Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] before the meeting starts.
 
 === Meeting Agendas
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -156,7 +156,7 @@ Due to this, we are keeping the User Handbook as it is now, where administration
 === Solution Pages
 
 Jenkins link:/solutions/[solution pages] highlight specific use cases for Jenkins users.
-Those solutions include SCM provider solutions (link:/solutions/github[GitHub], link:/solutions/bitbucketserver[Bitbucket]), programming language solutions (link:/solutions/python[Python], link:/solutions/ruby[Ruby], link:/solutions/c[C/C++], link:/solutions/java[Java], and link:/solutions/php[PHP]), and execution environment solutions (link:/solutions/python[Pipeline], link:/solutions/docker[Docker], link:/solutions/embedded[Embedded], and link:/solutions/android[Android]).
+Those solutions include SCM provider solutions (link:/solutions/github[GitHub], link:/solutions/bitbucketserver[Bitbucket]), programming language solutions (link:/solutions/python[Python], link:/solutions/ruby[Ruby], link:/solutions/c[C/C++], link:/solutions/java[Java], and link:/solutions/php[PHP]), and execution environment solutions (link:/solutions/pipeline[Pipeline], link:/solutions/docker[Docker], link:/solutions/embedded[Embedded], and link:/solutions/android[Android]).
 An excellent link:/solutions/[opening page] has been provided by link:https://github.com/zbynek[Zbynek Konecny].
 Additional use cases and user stories are being collected by link:https://github.com/alyssat[Alyssa Tong].
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -11,8 +11,8 @@ tags:
   - docs_sig
   - documentation
 leads:
-- "markewaite"
 - "kmartens27"
+- "markewaite"
 participants:
 - "krisstern"
 - "stackscribe"

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -14,6 +14,7 @@ leads:
 - "kmartens27"
 - "markewaite"
 participants:
+- "gounthar"
 - "krisstern"
 - "stackscribe"
 - "vandit1604"

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -108,7 +108,7 @@ Documentation in the plugin GitHub repository provides a good user experience fo
 By performing this migration, plugin maintainers can now follow the documentation-as-code approach and make documentation changes a part of the pull requests.
 It also creates an opportunity to review the documentation changes and add documentation contributor recognition, especially if the story is combined with link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[changelog automation].
 
-As of November 2022, we have more than 1,000 plugins which already use GitHub as a documentation source, but there are still link:https://reports.jenkins.io/jenkins-plugin-migration.html[hundreds of plugins to migrate].
+As of March 2024, we have more than 1,000 plugins which already use GitHub as a documentation source, but there are still link:https://reports.jenkins.io/jenkins-plugin-migration.html[hundreds of plugins to migrate].
 We invite contributors to participate in the project and to help us with migrating the docs.
 It is also a great opportunity to update and copy-edit the documentation.
 


### PR DESCRIPTION
As pointed out by @halkeye in the [docs gitter channel](https://matrix.to/#/!MWIrtxEAtbSRBOpnfE:matrix.org/$CkyxbzCAed89DpAYIVyGypEzrO6ID9GRXmTNHIDthjY?via=g4v.dev&via=gitter.im&via=matrix.org), the existing Docs SIG page is a bit out of date. The members do not reflect current activity and the projects listed are presented as current, where most of them have been completed in one sense or another.

This PR is to update the Docs SIG members, format some of the headers, add syntax/content where needed to clarify that projects are either completed or not being done anymore.

For example, we are not currently participating in Google Season of Docs, and do not have plans to apply any time soon, so we should not be presenting it as though it is a possibility. Similarly, we are no longer looking to separate out the administrator topics from the rest of the user handbook, so the phrasing has been added to reflect this.