### PR TITLE
Jenkins weekly 2.452 - add reference for new People View plugin

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23191,6 +23191,9 @@
         authors:
           - daniel-beck
         pr_title: "[JENKINS-18884] Remove 'People' view"
+        references:
+          - url: https://plugins.jenkins.io/people-view/
+            title: People View plugin
         message: |-
           Remove <strong>People</strong> view.
           Administrators can install the new People View plugin to restore this functionality.


### PR DESCRIPTION
As the plugin had not been released prior to the changelog being merged, I held off from including this, opting to get confirmation from @daniel-beck on its status.

Now that weekly 2.452 has completed its build phase, the plugin release is imminent and a reference has been added to the weekly changelog to direct users to the plugin page.