### PR TITLE
Correctly encode other components in advisories RSS feed

### DIFF
--- a/content/security/advisories/rss.xml.haml
+++ b/content/security/advisories/rss.xml.haml
@@ -46,5 +46,5 @@
                   = "<li>Affects plugin: #{plugin.title || plugin.name}</li>".encode(xml: :text)
               - components = page.issues.collect { |issue| issue.components }.flatten.keep_if { |c| c }
               - components.each do | component |
-                = "<li>Affects #{component.title || component.name}</li>"
+                = "<li>Affects #{component.title || component.name}</li>".encode(xml: :text)
               = "</ul>".encode(xml: :text)


### PR DESCRIPTION
Untested.

This should take care of 

> [line 417](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fwww.jenkins.io%2Fsecurity%2Fadvisories%2Frss.xml#l417), column 0: Undefined description element: li (3 occurrences) [[help](https://validator.w3.org/feed/docs/error/UndefinedElement.html)]
> 
>        <li>Affects update-center2</li>

Addresses part of #7219.