### PR TITLE
Fix RSS error, it's `pubDate` and not `date`

### DIFF
--- a/content/security/advisories/rss.xml.haml
+++ b/content/security/advisories/rss.xml.haml
@@ -26,7 +26,7 @@
       %item
         %title
           = page.title
-        %date
+        %pubDate
           #{(DateTime.strptime(page.title,"Jenkins Security Advisory %Y-%m-%d") + 0.5).rfc822}
         %link
           = "https://www.jenkins.io#{ expand_link(page.url) }"


### PR DESCRIPTION
Untested.

This should take care of

> [line 20](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fwww.jenkins.io%2Fsecurity%2Fadvisories%2Frss.xml#l20), column 0: Undefined item element: date (74 occurrences) [[help](https://validator.w3.org/feed/docs/error/UndefinedElement.html)]
>
>     <date>

Addresses part of https://github.com/jenkins-infra/jenkins.io/issues/7219.

How this even happened in the first place? No clue. Tolerant RSS readers?