### PR TITLE
Fix references in JENKINS-18884 entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23186,12 +23186,12 @@
     changes:
       - type: rfe
         category: rfe
-        pull: 9060
-        issue: 18884
         authors:
           - daniel-beck
         pr_title: "[JENKINS-18884] Remove 'People' view"
         references:
+          - issue: 18884
+          - pull: 9060
           - url: https://plugins.jenkins.io/people-view/
             title: People View plugin
         message: |-


### PR DESCRIPTION
`references` does not add to existing automatic links, it replaces any implicit links.

Untested.