### PR TITLE
Add installation notice for required declarative pipeline plugin

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -27,7 +27,7 @@ For an overview of available steps, please refer to the link:/doc/pipeline/steps
 [role=syntax]
 == Declarative Pipeline
 
-Declarative Pipeline presents a more simplified and opinionated syntax on top of the Pipeline sub-systems.
+Declarative Pipeline presents a more simplified and opinionated syntax on top of the Pipeline sub-systems. In order to use them, install the link:https://plugins.jenkins.io/pipeline-model-definition/[Pipeline: Declarative Plugin].
 
 All valid Declarative Pipelines must be enclosed within a `pipeline` block, for example:
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -27,7 +27,8 @@ For an overview of available steps, please refer to the link:/doc/pipeline/steps
 [role=syntax]
 == Declarative Pipeline
 
-Declarative Pipeline presents a more simplified and opinionated syntax on top of the Pipeline sub-systems. In order to use them, install the link:https://plugins.jenkins.io/pipeline-model-definition/[Pipeline: Declarative Plugin].
+Declarative Pipeline presents a more simplified and opinionated syntax on top of the Pipeline sub-systems.
+In order to use them, install the plugin:pipeline-model-definition[Pipeline: Declarative Plugin].
 
 All valid Declarative Pipelines must be enclosed within a `pipeline` block, for example:
 


### PR DESCRIPTION
Declarative pipelines need a plugin to actually run. Without it, they will seemingly succeed as there are no errors or warnings, but actually nothing happens and no pipeline code is executed. This results in a bad user experience:
> The evil part about it is that the job just runs silently without complaing about the DSL  – 
[Kutzi](https://stackoverflow.com/questions/71218985/jenkins-pipeline-script-not-running#comment130432822_71247427)

The only hint to this plugin I could find wasn't in the Jenkins docs but in [this StackOverflow answer](https://stackoverflow.com/a/71247427), so I added a notice.