### PR TITLE
Update jelly-form-controls.adoc to link to design-library-plugin

### DIFF
--- a/content/doc/developer/forms/jelly-form-controls.adoc
+++ b/content/doc/developer/forms/jelly-form-controls.adoc
@@ -2,15 +2,15 @@
 title: Jelly form controls
 layout: developersection
 references:
-- url: https://github.com/jenkinsci/ui-samples-plugin
-  title: ui-samples-plugin
+- url: https://github.com/jenkinsci/design-library-plugin
+  title: design-library-plugin
 ---
 
 Most of the the jelly files in the Jenkins source have embedded documentation. See link:/doc/developer/development-environment/ide-configuration[IDE Configuration] for details on how to get this setup so you can click through to it in your IDE. 
 
 For example you can see the embedded documentation of link:https://github.com/jenkinsci/jenkins/blob/63f80114e99f6692812c3039407652592bdf36fe/core/src/main/resources/lib/form/form.jelly[ the <form> tag ].
 
-You can also have a look at the referenced **ui-samples-plugin**, this repository contains executable examples of user interface elements, including forms.
+You can also have a look at the referenced **design-library-plugin**, this repository contains executable examples of user interface elements, including forms. You can also check the live version in link:https://weekly.ci.jenkins.io/design-library/[weekly.ci.jenkins.io/design-library]
 
 == Validation Button
 
@@ -57,7 +57,7 @@ public FormValidation doTestConnection(@QueryParameter("accessId") final String 
 }
 ----
 
-The doTestConnection method contains the validation logic. In the end, this method has to call either `FormValidation.ok`, `.warning`, or .error method. Depending on which method you use, the appropriate HTML will be rendered on the client side to indicate the status to the user.
+The `doTestConnection` method contains the validation logic. In the end, this method has to call either `FormValidation.ok`, `.warning`, or `.error` method. Depending on which method you use, the appropriate HTML will be rendered on the client side to indicate the status to the user.
 
 == Advanced
 


### PR DESCRIPTION
Update `jelly-form-controls.adoc` to link to design-library-plugin. It anyhow redirects there, but I guess mentioning the deployed version on weekly might also be useful for others.