### PR TITLE
Improve layout of list in docker install instruction

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -59,6 +59,7 @@ This is useful for executing `docker` commands on the host machine to control th
 Download this image before running, by using the command: `docker image pull docker:dind`.
 <12> The storage driver for the Docker volume.
 Refer to the link:https://docs.docker.com/storage/storagedriver/select-storage-driver[Docker storage drivers] documentation for supported options.
+
 +
 NOTE: If you have problems copying and pasting the above command snippet, use the annotation-free version below:
 +

--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -143,6 +143,7 @@ NOTE: If you change the source volume or directory for this, the volume from the
 <9> Maps the `/certs/client` directory to the previously created `jenkins-docker-certs` volume.
 The client TLS certificates required to connect to the Docker daemon are now available in the path specified by the `DOCKER_CERT_PATH` environment variable.
 <10> The name of the Docker image, which you built in the previous step.
+
 +
 NOTE: If you have problems copying and pasting the command snippet, use the annotation-free version below:
 +


### PR DESCRIPTION
Fix the ordering of the list in the docker install instructions, previously the note was displayed under the 12th bullet point which is not intended behaviour (i assume)

before:
<img width="1510" alt="Screenshot 2024-04-04 at 5 15 16 PM" src="https://github.com/jenkins-infra/jenkins.io/assets/48334675/4183bd79-ab61-4724-8081-e82f25dfa96f">
after:
<img width="1510" alt="Screenshot 2024-04-04 at 5 15 23 PM" src="https://github.com/jenkins-infra/jenkins.io/assets/48334675/e67a4200-4edf-442a-aae8-b46f513b1786">
