### PR TITLE
fix: correct typo in year of blog title for gsoc 2024

### DIFF
--- a/content/blog/2024/04/2024-04-04-gsoc-2024-contributor-application-period-concludes.adoc
+++ b/content/blog/2024/04/2024-04-04-gsoc-2024-contributor-application-period-concludes.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "GSoC 22024 contributor application ended. What happens next?"
+title: "GSoC 2024 contributor application ended. What happens next?"
 tags:
 - gsoc
 - gsoc2024


### PR DESCRIPTION
Updated year in blog post title from "22024" to "2024"