### PR TITLE
fix: typo on webpage running-pipelines

### DIFF
--- a/content/doc/book/pipeline/running-pipelines.adoc
+++ b/content/doc/book/pipeline/running-pipelines.adoc
@@ -85,7 +85,7 @@ Pipeline run that created them, this has not created any limitations on usage. B
 you may want to be able to `unstash` artifacts from a stage which ran before the stage you're restarting from.
 
 To enable this, there is a job property that allows you to configure a maximum number of completed runs whose
-`stash` artifacts should be preserved for reuse in a restarted run. You can specify anywhere from 1 to 5 as the
+`stash` artifacts should be preserved for reuse in a restarted run. You can specify anywhere from 1 to 50 as the
 number of runs to preserve.
 
 This job property can be configured in your Declarative Pipeline's `options` section, as below:
@@ -99,7 +99,7 @@ options {
 }
 ----
 <1> The default number of runs to preserve is 1, just the most recent completed build.
-<2> If a number for `buildCount` outside of the range of 1 to 5 is specified, the Pipeline will fail with a
+<2> If a number for `buildCount` outside of the range of 1 to 50 is specified, the Pipeline will fail with a
 validation error.
 
 When a Pipeline completes, it will check to see if any previously completed runs should have their `stash` artifacts

--- a/content/doc/book/pipeline/running-pipelines.adoc
+++ b/content/doc/book/pipeline/running-pipelines.adoc
@@ -85,7 +85,7 @@ Pipeline run that created them, this has not created any limitations on usage. B
 you may want to be able to `unstash` artifacts from a stage which ran before the stage you're restarting from.
 
 To enable this, there is a job property that allows you to configure a maximum number of completed runs whose
-`stash` artifacts should be preserved for reuse in a restarted run. You can specify anywhere from 1 to 50 as the
+`stash` artifacts should be preserved for reuse in a restarted run. You can specify anywhere from 1 to 5 as the
 number of runs to preserve.
 
 This job property can be configured in your Declarative Pipeline's `options` section, as below:


### PR DESCRIPTION
There was an ambiguity regarding the maximum number of build stashes allowed, eighter 50 or 5. I changed it to 5