### PR TITLE
Docs changes for jenkins-infra/repository-permissions-updater#3879

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -50,9 +50,9 @@ Enable the continuous delivery flag in link:https://github.com/jenkins-infra/rep
 ----
 cd:
   enabled: true
-  exclusive: true # <1>
 ----
-<1> Optionally enable https://github.com/jenkins-infra/repository-permissions-updater?tab=readme-ov-file#exclusively-using-jep-229-cd[exclusive JEP-229 CD], which does not grant the listed account upload permissions.
+
+By default, this enables https://github.com/jenkins-infra/repository-permissions-updater?tab=readme-ov-file#exclusively-using-jep-229-cd[exclusive JEP-229 CD], which does not grant the listed account upload permissions.
 
 In your PR towards the repository permission updater, include a link to the PR in your plugin, which contains all the necessary changes, like described above.
 
@@ -283,7 +283,7 @@ Do not forget to mark the PR with the label `breaking` (or `removed`) to get an 
 
 == Fallback
 
-Unless the component is configured for https://github.com/jenkins-infra/repository-permissions-updater?tab=readme-ov-file#exclusively-using-jep-229-cd[exclusive JEP-229 CD], you can also release manually if you have configured your machine for link:../releasing-manually[manual release].
+If https://github.com/jenkins-infra/repository-permissions-updater?tab=readme-ov-file#exclusively-using-jep-229-cd[exclusive JEP-229 CD] is disabled for your component, you can also release manually if you have configured your machine for link:../releasing-manually[manual release].
 To cut a release:
 
 [source,shell]


### PR DESCRIPTION
Companion PR to https://github.com/jenkins-infra/repository-permissions-updater/pull/3879, which should only be merged after that PR is merged.