### PR TITLE
Jenkins LTS 2.440.3 - update Spring changelog entry for accuracy

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -10765,8 +10765,8 @@
     pull: 9047
     issue: 72900
     authors:
-      - daniel-beck
-    pr_title: "Update bundled trilead-api to 2.84.86.vf9c960e9b_458"
+      - dependabot
+    pr_title: "Bump org.springframework.security:spring-security-bom from 5.8.10 to 5.8.11"
     references:
       - pull: 9042
       - url: https://github.com/spring-projects/spring-security/releases/tag/5.8.11


### PR DESCRIPTION
As pointed out by @alecharp, the Spring Security/Framework entry has the same `pr_title` and `author` values as the Trilead API plugin entry.

This PR is to update the values so that the Spring Security/Framework entry has the correct author and PR associated with it. 