### PR TITLE
Remove date dependent phrase from governance agenda link

### DIFF
--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -28,8 +28,8 @@ The meetings calendar with links is available link:/event-calendar[here].
 
 === Agenda
 
-Starting from October 30, 2023, the governance meeting agenda is posted in link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[this HackMD note].
-Everyone is welcome to add a topic for one of the incoming meetings by suggesting a change in the mailing list.
+The next governance meeting agenda is posted in link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[a HackMD note].
+Everyone is welcome to add a topic for the incoming meeting by suggesting a change in the mailing list or in the link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[HackMD note].
 
 ++++
 <iframe src="https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA" width="100%" height="600px"></iframe>

--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -29,7 +29,7 @@ The meetings calendar with links is available link:/event-calendar[here].
 === Agenda
 
 The next governance meeting agenda is posted in link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[a HackMD note].
-Everyone is welcome to add a topic for the incoming meeting by suggesting a change in the mailing list or in the link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[HackMD note].
+Everyone is welcome to add a topic for the upcoming meeting by suggesting a change in the mailing list or in the link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[HackMD note].
 
 ++++
 <iframe src="https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA" width="100%" height="600px"></iframe>


### PR DESCRIPTION
## Remove date dependent phrase from governance agenda link

Readers that need the archived copies of the agenda should not look for them in HackMD.  We use HackMD as a real-time editing facility for markdown of the upcoming meeting.  During the meeting, we use it to take notes for the current meeting.  After the meeting, the notes are copied to the archive locations.

I think this may address a concern that was expressed by @daniel-beck.  Even if it fails to address that concern, I think this is a worthwhile change.
