### PR TITLE
Use same Jenkins version in sample diff as in body text

### DIFF
--- a/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
+++ b/content/doc/developer/tutorial-improve/update-base-jenkins-version.adoc
@@ -42,7 +42,7 @@ The `git diff` might look like this:
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
 -        <artifactId>bom-2.346.x</artifactId>
-+        <artifactId>bom-2.414.x</artifactId>
++        <artifactId>bom-2.426.x</artifactId>
 -        <version>1757.vf3c66da_b_7492</version>
 +        <version>2961.v1f472390972e</version>
         <type>pom</type>


### PR DESCRIPTION
The Jenkins version is maintained by the updatecli scripts but this diff seems to have become outdated.  Make it match the text in the body of the document.
