### PR TITLE
Simplify the governance meeting page

### DIFF
--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -15,16 +15,17 @@ If a decision cannot be made at the governance meeting, the project's link:/proj
 
 === How to join the meetings?
 
-The governance meeting commonly happens every two weeks on Mondays, see the link:/events[event calendar] for exact times and subscription.
+The governance meeting commonly happens every two weeks on Mondays.
+The link:/events[event calendar] provides exact times and other details.
 We hold the meeting as a recorded video call.
-The meetings calendar with links is available link:/event-calendar[here].
+Links to the video call are also available in the link:/event-calendar[Jenkins events calendar].
 
 === How to propose a topic?
 
 1. Start a discussion with your proposal in the link:https://groups.google.com/g/jenkinsci-dev[developer mailing list]
 2. Wait for initial feedback in the mailing list.
    If there is a strong consensus among community members and no formal approval needed, the mailing list thread might be enough.
-3. Suggest a change to the agenda document linked below.
+3. Suggest a change to the link:https://hackmd.io/6mgEkr1rS7Ca4j4a5YxZfA[next meeting agenda].
 
 === Agenda
 
@@ -37,20 +38,19 @@ Everyone is welcome to add a topic for the upcoming meeting by suggesting a chan
 
 === Archived Meetings
 
-Before using HackMD, we used Google Docs for the agenda.
-Previous notes are available in the old link:https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg[Google doc].
+Agendas, minutes, and other notes are archived in the link:https://github.com/jenkins-infra/governance-meetings-archives[Governance Meeting Archive 2011 - 2024].
 
-Agendas, minutes, and other notes are archived on these pages:
+// * link:./archives/2019[Governance Meeting Archive 2019]
+// * link:./archives/2018[Governance Meeting Archive 2018]
+// * link:./archives/2017[Governance Meeting Archive 2017]
+// * link:./archives/2016[Governance Meeting Archive 2016]
+// * link:./archives/2015[Governance Meeting Archive 2015]
+// * link:./archives/2014[Governance Meeting Archive 2014]
+// * link:./archives/2013[Governance Meeting Archive 2013]
+// * link:./archives/2012[Governance Meeting Archive 2012]
+// * link:./archives/2011[Governance Meeting Archive 2011]
 
-* link:https://github.com/jenkins-infra/governance-meetings-archives[Governance Meeting Archive 2011 - 2024]
-* link:./archives/2019[Governance Meeting Archive 2019]
-* link:./archives/2018[Governance Meeting Archive 2018]
-* link:./archives/2017[Governance Meeting Archive 2017]
-* link:./archives/2016[Governance Meeting Archive 2016]
-* link:./archives/2015[Governance Meeting Archive 2015]
-* link:./archives/2014[Governance Meeting Archive 2014]
-* link:./archives/2013[Governance Meeting Archive 2013]
-* link:./archives/2012[Governance Meeting Archive 2012]
-* link:./archives/2011[Governance Meeting Archive 2011]
+// Minutes and raw conversation history for older meetings can be found in full on link:http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
 
-Minutes and raw conversation history for older meetings can be found in full on link:http://meetings.jenkins-ci.org/[meetings.jenkins-ci.org].
+// Before using HackMD, we used Google Docs for the agenda.
+// Previous notes are available in the old link:https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg[Google doc].


### PR DESCRIPTION
Remove the links to older information that is now included in the GitHub
repository that includes the governance meeting archive.
