### PR TITLE
Fix 'Back to blog' link redirecting to `/node`

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -14,7 +14,7 @@ section: blog
 
 %article.container.app-post-page
   %div{:class => "app-!-display-flex"}
-    %a.app-back-link{:href => expand_link("node")}
+    %a.app-back-link{:href => expand_link("blog")}
       Back to blog
 
   %h1


### PR DESCRIPTION
Small fix following https://github.com/jenkins-infra/jenkins.io/pull/7173. Currently clicking the 'Back to blog' link redirects to `/node` which results in a redirect page, this PR fixes that by taking the user directly to `/blog`.