### PR TITLE
Fix minor typos in weekly changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -22956,7 +22956,7 @@
           - jglick
         pr_title: Use `ABORTED` from `Run.reload`
         message: |-
-          NonPipeline builds interrupted by a controller restart will now be marked as aborted rather than failed.
+          Non-Pipeline builds interrupted by a controller restart will now be marked as aborted rather than failed.
       - type: rfe
         category: rfe
         pull: 8990

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23074,7 +23074,7 @@
           - timja
         pr_title: "[JENKINS-72796] stable context classloader for Computer.threadPoolForRemoting"
         message: |-
-          Ensure threads in the <code>Computer.threadPoolForRemoting</code>executor service always have the Jenkins webapp <code>ClassLoader</code> set as the context <code>ClassLoader</code> to prevent random class loading issues when code is running in this <code>ExecutorService</code>.
+          Ensure threads in the <code>Computer.threadPoolForRemoting</code> executor service always have the Jenkins webapp <code>ClassLoader</code> set as the context <code>ClassLoader</code> to prevent random class loading issues when code is running in this <code>ExecutorService</code>.
       - type: rfe
         category: developer
         pull: 8979

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -22801,7 +22801,7 @@
           - daniel-beck
         pr_title: "[JENKINS-72637] Make Cloud permission scope inherit from Jenkins"
         message: |-
-          Make the Agent/Provision permission available in the global Security configuration when using matrixbased authorization strategies.
+          Make the Agent/Provision permission available in the global Security configuration when using matrix-based authorization strategies.
       - type: rfe
         category: rfe
         pull: 8938


### PR DESCRIPTION
- **Fix typo in 2.445 changelog** -- "matrixbased" -> "matrix-based"
- **Fix typo in 2.448 changelog** -- "NonPipeline" -> "Non-Pipeline"
- **Insert missing space in 2.449 changelog**
