### PR TITLE
GSoC 2024 - Update carousel for accepted proposal announcement 

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,13 +1,13 @@
 # jenkins accepted for GSoC 2024
-- :href: blog/2024/02/23/gsoc2024-announcement/
-  :title: Accepted for GSoC 2024!
-  :intro: We are happy to announce that the Jenkins project has been accepted as a Google Summer of Code (GSoC) 2024 Mentoring Organisation.
+- :href: blog/2024/05/01/google-summer-of-code-congrats-and-welcome/
+  :title: Welcome GSoC 2024 contributors!
+  :intro: We are happy to announce the projects that have been accepted for Google Summer of Code (GSoC) 2024.
   :image:
-    :src: images/gsoc/2024/GSoC2024-here-we-come.png
+    :src: images/post-images/2024/05/welcome-gsoc-2024-contributors.png
     :height: 320px
   :call_to_action:
     :text: More info
-    :href: blog/2024/02/23/gsoc2024-announcement/  
+    :href: blog/2024/05/01/google-summer-of-code-congrats-and-welcome/
 #
 - :href: https://devopsdozen.com/devops-dozen-2023-community-award-winners/
   :title: Jenkins wins DevOps Dozen award


### PR DESCRIPTION
This PR is to update the main page carousel so that the previous GSoC item is replaced with the accepted projects announcement. It utilizes the image used for the blog post's opengraph image.