### PR TITLE
Contributing guide - small change to make the date formatting more obvious

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -148,11 +148,11 @@ There are too many other helpful macros and formatting options to list here, so 
 === Adding a blog post
 
 To add a new blog post, create a new file ending in **.adoc** (for link:https://asciidoctor.org[Asciidoctor]) in the appropriate `content/blog/<year>/<month>` directory with the full date and a *lowercase* title for your post.
-For example, if you're writing a post that you want to title "Hello World" on January 1st, 1970, you would create the file: `content/blog/1970/01/1970-01-01-hello-world.adoc`.
+For example, if you're writing a post that you want to title "Hello World" on January 15th, 1970, you would create the file: `content/blog/1970/01/1970-01-15-hello-world.adoc`.
 
 In that file you need to enter some meta-data in the following format:
 
-.1970-01-01-hello-world.adoc
+.1970-01-15-hello-world.adoc
 [source,yaml]
 ----
 ---
@@ -189,7 +189,7 @@ egrep -h '^- [^ ]+$' content/blog/*/*/*.adoc | sort | uniq -c
 
 The `author` attribute will map your GitHub name to author information which will be displayed in the blogpost.
 If this is your first time adding a blog post, please create an author file as documented in the section below.
-Once your author file is defined, you can return to your blog post file (`1970-01-01-hello-world.adoc`), finish creating the "front matter" and then write your blog post!
+Once your author file is defined, you can return to your blog post file (`1970-01-15-hello-world.adoc`), finish creating the "front matter" and then write your blog post!
 
 Images for blog posts should be placed in subdirectories of the `content/images/post-images/` directory.
 If a blog post is describing "feature-x" then the images might be in `content/images/post-images/feature-x/`.


### PR DESCRIPTION
When reviewing the blog posting guidelines in the contributing guide, the date of January 1st 1970 could appear a bit misleading when formatted as `1970-01-01`. Since EU and US dates are formatted differently, this 01/01 does not portray a clear usage, so the suggested change to `1970-01-15` is so that it is clear which is the month and which is the day.