### PR TITLE
Jenkins 2.457 - adjust message for changelog entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -23501,7 +23501,7 @@
           - mawinter69
         pr_title: "[JENKINS-72744] remove tooltip when widget is refreshed"
         message: |-
-          JENKINS72744, remove tooltip when widget is refreshed
+          Remove tooltip when a widget is refreshed.
       - type: bug
         category: bug
         pull: 9224


### PR DESCRIPTION
This PR is to adjust the message for the changelog entry regarding tooltips. The current message includes the JIRA ticket number and does not have correct punctuation.