### PR TITLE
Governance meeting happens every 4 weeks

### DIFF
--- a/content/project/governance-meeting/index.adoc
+++ b/content/project/governance-meeting/index.adoc
@@ -15,7 +15,7 @@ If a decision cannot be made at the governance meeting, the project's link:/proj
 
 === How to join the meetings?
 
-The governance meeting commonly happens every two weeks on Mondays.
+The governance meeting commonly happens every four weeks on Mondays.
 The link:/events[event calendar] provides exact times and other details.
 We hold the meeting as a recorded video call.
 Links to the video call are also available in the link:/event-calendar[Jenkins events calendar].

--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -203,7 +203,7 @@ and we invite all interested parties to join us and to contribute towards the ro
 [[meeting]]
 == Decision making
 
-The Jenkins project uses link:/project/governance-meeting[biweekly project meetings] as the primary forum of decision making for matters that need consensus.
+The Jenkins project uses link:/project/governance-meeting[regularly scheduled project meetings] as the primary forum of decision making for matters that need consensus.
 The meeting is conducted using a video call or link:/chat/#meeting[IRC].
 These meetings are open to anyone, and everyone is welcome to provide their feedback and vote on decisions at the meeting.
 Agenda items can be added by anyone by simply adding your topic to link:/project/governance-meeting[the Governance Meeting Agenda].


### PR DESCRIPTION
## Governance meeting happens every 4 weeks

As agreed in governance meeting today.  Switch to the meeting pace that we use in the UX SIG, every four weeks, with the option to meet more often whenever needed.

