### PR TITLE
Minor improvements to governance docs

### DIFF
--- a/content/project/governance.adoc
+++ b/content/project/governance.adoc
@@ -204,17 +204,19 @@ and we invite all interested parties to join us and to contribute towards the ro
 == Decision making
 
 The Jenkins project uses link:/project/governance-meeting[regularly scheduled project meetings] as the primary forum of decision making for matters that need consensus.
-The meeting is conducted using a video call or link:/chat/#meeting[IRC].
-These meetings are open to anyone, and everyone is welcome to provide their feedback and vote on decisions at the meeting.
-Agenda items can be added by anyone by simply adding your topic to link:/project/governance-meeting[the Governance Meeting Agenda].
+The meeting is conducted using a video call.
+These meetings are open to anyone.
+Everyone is welcome to provide their feedback and vote on decisions at the meeting.
+Agenda items can be added by anyone by simply adding your topic to the link:/project/governance-meeting[Governance meeting agenda].
 
 The meeting minutes are public:
 
-* link:/project/governance-meeting[Governance Meeting Agenda] for meetings held in as video calls
-* link:http://meetings.jenkins-ci.org/jenkins-meeting/[September 2015 to today]
-* link:http://meetings.jenkins-ci.org/jenkins/[2011 to September 2015]
+* link:/project/governance-meeting[Governance meeting agenda] for meetings
+* link:https://github.com/jenkins-infra/governance-meetings-archives[Meeting notes GitHub repository]
+* link:https://community.jenkins.io/tag/governance[Governance meeting archive on community.jenkins.io]
+* link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaMsOs5pRWGByvIcuJOpHpC6[Governance meeting YouTube playlist]
 
-The board serves as the ultimate decision-making body in case the project meeting fails to reach a consensus on a particular topic.
+The board serves as the ultimate decision-making body in case the meeting fails to reach a consensus on a particular topic.
 
 //TODO(oleg_nenashev): This section is dated and not really relevant to the project governance
 // IMO we should move it elsewhere and leave only Governance-related parts like ownership, teams, consensus building, etc.


### PR DESCRIPTION
## Minor improvements to governance docs

Governance meeting is only a video call, not an IRC meet as in the past.

Governance meeting is the same as the project meeting.  Remove the references to project meeting.

Link to community.jenkins.io and the GitHub repository and the YouTube playlist.
