### PR TITLE
Update GSoC project list with RPU

### DIFF
--- a/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
+++ b/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
@@ -16,6 +16,7 @@ skills:
 - GitHub user and team management
 mentors:
 - "notmyfault"
+- "gounthar"
 - "krisstern"
 student: "Alaurant"
 links:

--- a/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
+++ b/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
@@ -26,7 +26,7 @@ links:
 
 === Abstract
 
-To manage Artifactory permissions, distinguish between Jira and GitHub issues, and activate automatic releases, the jenkinsci organization uses a tool called the [repository permission updater (RPU)](https://github.com/jenkins-infra/repository-permissions-updater/).
+To manage Artifactory permissions, distinguish between Jira and GitHub issues, and activate automatic releases, the jenkinsci organization uses a tool called the link:https://github.com/jenkins-infra/repository-permissions-updater[repository permission updater (RPU)].
 
 Despite the name containing "repository permission", the RPU can't update or manage repository permission at all.
 Currently, all team modifications are done manually by the hosting team.

--- a/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
+++ b/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
@@ -1,0 +1,52 @@
+---
+layout: gsocproject2
+title: "Manage jenkinsci GitHub permissions as code"
+goal: "Automating the management of GitHub permissions for the jenkinsci organization"
+category: Tools
+year: 2024
+status: "Selected"
+sig: infra
+skills:
+- Java
+- Groovy
+- git
+- Maven
+- SnakeYAML
+- Data extraction from GitHub repositories
+- GitHub user and team management
+mentors:
+- "notmyfault"
+- "krisstern"
+student: "Alaurant"
+links:
+  gitter: gsoc2024-rpu:matrix.org
+  meetings: "/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization#office-hours"
+---
+
+=== Abstract
+
+To manage artifactory permission, diverge between Jira and GitHub issues, and activate automatic releases, the jenkinsci organization uses a tool called https://github.com/jenkins-infra/repository-permissions-updater/[repository permission updater (RPU)].
+
+Despite the name containing "repository permission", the RPU can't update or manage repository permission at all.
+Currently, all team modifications are done manually by the hosting team.
+
+The RPU is a critical component in the jenkinsci infrastructure and is used daily to onboard new plugins and update release permission.
+
+=== Rationale
+
+The project aims to build on top of the existing RPU logic and manage GitHub teams and individual users (for legacy reasons, we strive to use teams only), defined as a list in the pre-existing YAML file, which every repository within the jenkinsci GitHub organization has.
+
+Every YAML file within the RPU is expected to have a team defined with a list of users, where the RPU updates the team membership to match the list of users defined in the YAML file in the jenkinsci organization.
+
+Initially, we need to copy all teams and users added to every repository of the jenkinsci GitHub organization and add them to the permission files in the RPU.
+
+Hosting new plugins adds an entry automatically to the new YAML file.
+
+=== Implementation
+
+The project will be implemented in Java and Groovy, using the GitHub API to manage teams and users. The project will be built using Maven and will be integrated into the existing RPU project. The project will be tested using unit tests and integration tests. The project will be documented to ensure that future contributors can understand the codebase.
+
+=== Office hours
+
+* (General) Official weekly Jenkins office hours: Thursdays 13:00 UTC
+* (Project-based) Weekly project based office hours after Bonding Period: TBD

--- a/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
+++ b/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
@@ -26,7 +26,7 @@ links:
 
 === Abstract
 
-To manage artifactory permission, diverge between Jira and GitHub issues, and activate automatic releases, the jenkinsci organization uses a tool called https://github.com/jenkins-infra/repository-permissions-updater/[repository permission updater (RPU)].
+To manage Artifactory permissions, distinguish between Jira and GitHub issues, and activate automatic releases, the jenkinsci organization uses a tool called the [repository permission updater (RPU)](https://github.com/jenkins-infra/repository-permissions-updater/).
 
 Despite the name containing "repository permission", the RPU can't update or manage repository permission at all.
 Currently, all team modifications are done manually by the hosting team.
@@ -37,7 +37,7 @@ The RPU is a critical component in the jenkinsci infrastructure and is used dail
 
 The project aims to build on top of the existing RPU logic and manage GitHub teams and individual users (for legacy reasons, we strive to use teams only), defined as a list in the pre-existing YAML file, which every repository within the jenkinsci GitHub organization has.
 
-Every YAML file within the RPU is expected to have a team defined with a list of users, where the RPU updates the team membership to match the list of users defined in the YAML file in the jenkinsci organization.
+Every YAML file within the RPU is expected to have a team defined with a list of users, where the RPU updates the team membership to match the list of users defined in the YAML file for the corresponding repository in the jenkinsci organization.
 
 Initially, we need to copy all teams and users added to every repository of the jenkinsci GitHub organization and add them to the permission files in the RPU.
 
@@ -45,7 +45,9 @@ Hosting new plugins adds an entry automatically to the new YAML file.
 
 === Implementation
 
-The project will be implemented in Java and Groovy, using the GitHub API to manage teams and users. The project will be built using Maven and will be integrated into the existing RPU project. The project will be tested using unit tests and integration tests. The project will be documented to ensure that future contributors can understand the codebase.
+The project will be implemented in Java and Groovy, using the GitHub API to manage teams and users.
+The project will be built using Maven and integrated into the existing RPU project.
+The project will be tested using unit tests and integration tests, and it will be thoroughly documented to ensure that future contributors can easily understand the codebase.
 
 === Office hours
 

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -33,7 +33,7 @@ Google has accepted us as a mentoring organization in Google Summer of Code 2024
 
 The selected projects are:
 
-* Manage Jenkinsci GitHub Permissions as Code with link:https://github.com/Alaurant[Danyang Zhao] as the GSoC contributor.
+* link:/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization[Manage Jenkinsci GitHub Permissions as Code] with link:https://github.com/Alaurant[Danyang Zhao] as the GSoC contributor.
 
 * link:/projects/gsoc/2024/projects/using-openrewrite-recipes-for-plugin-modernization-or-automation-plugin-build-metadata-updates[Using OpenRewrite Recipes for Plugin Modernization] with link:https://github.com/sridamul[Sridhar Sivakumar] as the GSoC contributor.
 


### PR DESCRIPTION
Added GSoC 2024 Manage Jenkinsci GitHub Permissions as Code project page. 