### PR TITLE
feat: add rajiv as co-mentor for gsoc 2024 automating rpu project

### DIFF
--- a/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
+++ b/content/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization.adoc
@@ -18,6 +18,7 @@ mentors:
 - "notmyfault"
 - "gounthar"
 - "krisstern"
+- "iamrajiv"
 student: "Alaurant"
 links:
   gitter: gsoc2024-rpu:matrix.org


### PR DESCRIPTION
Added Rajiv Singh as co-mentor for the GSoC 2024 [Improve Maintainability for the Repository Permission Updater](https://www.jenkins.io/projects/gsoc/2024/projects/improving-maintainability-of-rpu) project. 

c.c. @NotMyFault 