### PR TITLE
Use correct link to GSoC project 5

### DIFF
--- a/content/blog/2024/05/2024-05-01-google-summer-of-code-congrats-and-welcome.adoc
+++ b/content/blog/2024/05/2024-05-01-google-summer-of-code-congrats-and-welcome.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Congrats and Welcome to Jenkins in Google Summer of Code 2024 Contributors"
-tags: 
+tags:
 - gsoc2024
 - community
 - events
@@ -10,7 +10,7 @@ description: "announcement for accepted GSoC 2024 contributors"
 opengraph:
   image: /images/post-images/2024/05/welcome-gsoc-2024-contributors.png
 ---
-image:/images/post-images/2024/05/welcome-gsoc-2024-contributors.png[Congratulations and welcome GSoc 2024 Contributors] 
+image:/images/post-images/2024/05/welcome-gsoc-2024-contributors.png[Congratulations and welcome GSoc 2024 Contributors]
 
 This year, we received numerous outstanding link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp[Google Summer of Code] (GSoC) proposals for Jenkins with just as many compelling ideas.
 Many thanks to all who submitted their proposal(s) previously.
@@ -23,7 +23,7 @@ We are excited to have them on board and can’t wait to see their progress!
 
 The 2024 Jenkins in GSoC projects are:
 
-1) link:/projects/gsoc/2024/project-ideas/automating-rpu-for-jenkinsci-organization/[Manage Jenkinsci GitHub Permissions as Code] - Automating the management of GitHub permissions for the Jenkinsci organization. 
+1) link:/projects/gsoc/2024/project-ideas/automating-rpu-for-jenkinsci-organization/[Manage Jenkinsci GitHub Permissions as Code] - Automating the management of GitHub permissions for the Jenkinsci organization.
 
 Mentors: author:notmyfault[Alexander Brandes], author:gounthar[Bruno Verachten]
 
@@ -47,7 +47,7 @@ Mentors: author:krisstern[Kris Stern], author:harsh-ps-2003[Harsh Pratap Singh],
 
 GSoC contributor: link:https://github.com/nouralmulhem[Nour Almulhem]
 
-5) link:/projects/gsoc/2024/project-ideas/automating-rpu-for-jenkinsci-organization/[Improve Maintainability for the Repository Permission Updater] - Automating the management of GitHub permissions to improve maintainability for the Repository Permission Updater for Jenkinsci. 
+5) link:/projects/gsoc/2024/projects/improving-maintainability-of-rpu/[Improve Maintainability for the Repository Permission Updater] - Automating the management of GitHub permissions to improve maintainability for the Repository Permission Updater for Jenkinsci.
 
 Mentors: author:notmyfault[Alexander Brandes], author:gounthar[Bruno Verachten], author:iamrajiv[Rajiv Singh]
 


### PR DESCRIPTION
## Use correct link to GSoC project 5

Incorrectly included the same link for GSoC project 1 and GSoC project 5.

Now uses the correct link for GSoC project 5.

Also removes trailing spaces from other lines in the blog post.
