### PR TITLE
Link from plugin build process doc to tutorial

### DIFF
--- a/content/doc/developer/plugin-development/build-process.adoc
+++ b/content/doc/developer/plugin-development/build-process.adoc
@@ -28,3 +28,5 @@ It is generally recommended to frequently update to a recent plugin parent POM f
 // TODO Need a good reference for that before including it as example:
 // For example, plugins depending on the plugins parent POM 1.637 (with maven-hpi-plugin 1.110) or newer will need to specify the <code>escape-by-default</code> in all Jelly files for the InjectedTest to pass. Plugins depending on older releases may have hidden XSS vulnerabilities.
 * Recent versions of the tools (inherited from the parent plugins POM) allow developers to use more advanced tools like the https://github.com/jenkinsci/plugin-compat-tester[plugin compatibility tester] to determine whether their plugin is compatible with newest Jenkins releases.
+
+The link:/doc/developer/tutorial-improve/["Improve a plugin" tutorial] includes a step to link:/doc/developer/tutorial-improve/update-parent-pom/[update the plugin parent pom], along with an associated link:https://youtu.be/Fev8KfFsPZE[video].


### PR DESCRIPTION
Since the build process document is describing an update to the parent pom, let's include a link to the "Improve a plugin" tutorial topic that addresses it.  Some readers might benefot from seeiong the steps in text and others might benefit from the tutorial video.
