### PR TITLE
docker compose down fix

### DIFF
--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -310,7 +310,7 @@ To learn more about what Jenkins can do, check out:
 * The link:/doc/book[User Handbook] for more detailed information about using Jenkins, such as link:/doc/book/pipeline[Pipelines] (in particular link:/doc/book/pipeline/syntax[Pipeline syntax]) and the link:/doc/book/blueocean[Blue Ocean] interface.
 * The link:/node[Jenkins blog] for the latest events, other tutorials and updates.
 
-If you want to clean up your environment, you can stop the containers with `docker compose down -v --remove-orphans`.
+If you want to clean up your environment, you can stop the containers with `docker compose --profile maven down -v --remove-orphans`.
 
 [[appendix]]
 


### PR DESCRIPTION
Line 313:  The command 'docker compose down -v --remove-orphans' will not shut down all the running containers. Noticed this bug and proposed a fix with the replaced command 'docker compose --profile maven down -v --remove-orphans' .