### PR TITLE
Mention Jira x GitHub distinction in issue reporting

### DIFF
--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -18,7 +18,8 @@ If you need assistance or have general questions, visit us link:/chat/[in chat],
 
 First, *identify the location of the issue*.
 Are you reporting an issue in Jenkins itself or one of its plugins? 
-We document all the issues in Jenkins on link:https://issues.jenkins.io/[JIRA] and plugin issues are on Github.
+We document all the issues in Jenkins on link:https://issues.jenkins.io/[JIRA].
+Plugins may use JIRA or Github for issue tracking, see <<Howtoreportanissue-Creatingtheissue,Creating the Issue>> for details.
 If you are reporting an issue with the jenkins.io site, please create an issue in our link:https://github.com/jenkins-infra/jenkins.io/issues[GitHub issue tracker].
 
 After that, determine what kind of issue it is. There are three main types:


### PR DESCRIPTION
The document has all the information bout Jira and GitHub issues, but the first mention of plugin issues only mentions GitHub which is confusing (see #7337)

Preview: https://deploy-preview-7338--jenkins-io-site-pr.netlify.app/participate/report-issue/#Howtoreportanissue-Beforecreatinganissue