### PR TITLE
Re-order cd releasing page

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -42,23 +42,6 @@ Here are some PR examples for various plugins to enable CD:
 - link:https://github.com/jenkinsci/kubernetes-plugin/pull/1139/files[kubernetes-plugin]
 - link:https://github.com/jenkinsci/plain-credentials-plugin/pull/31/files[plain-credentials-plugin]
 
-=== Enable CD Permissions
-
-Enable the continuous delivery flag in link:https://github.com/jenkins-infra/repository-permissions-updater/[repository permission updater] (RPU) for your plugin by filing a pull request adding to `permissions/plugin-xxx.yml`:
-
-[source,yaml]
-----
-cd:
-  enabled: true
-----
-
-By default, this enables https://github.com/jenkins-infra/repository-permissions-updater?tab=readme-ov-file#exclusively-using-jep-229-cd[exclusive JEP-229 CD], which does not grant the listed account upload permissions.
-
-In your PR towards the repository permission updater, include a link to the PR in your plugin, which contains all the necessary changes, like described above.
-
-Once that has been merged, start checking `https://github.com/jenkinsci/your-plugin/settings/secrets/actions`
-until you see `MAVEN_TOKEN` and `MAVEN_USERNAME` appear under *Repository secrets*.
-
 === Configure CD Workflow
 
 Create the CD workflow as a copy of the template:
@@ -241,6 +224,23 @@ Use the `revision` property for the `<dependency>` declaration to ensure they al
     <version>${revision}</version>
 </dependency>
 ----
+
+=== Enable CD Permissions
+
+Enable the continuous delivery flag in link:https://github.com/jenkins-infra/repository-permissions-updater/[repository permission updater] (RPU) for your plugin by filing a pull request adding to `permissions/plugin-xxx.yml`:
+
+[source,yaml]
+----
+cd:
+  enabled: true
+----
+
+By default, this enables https://github.com/jenkins-infra/repository-permissions-updater?tab=readme-ov-file#exclusively-using-jep-229-cd[exclusive JEP-229 CD], which does not grant the listed account upload permissions.
+
+In your PR towards the repository permission updater, include a link to the PR in your plugin, which contains all the necessary changes, like described above.
+
+Once that has been merged, start checking `https://github.com/jenkinsci/your-plugin/settings/secrets/actions`
+until you see `MAVEN_TOKEN` and `MAVEN_USERNAME` appear under *Repository secrets*.
 
 == Releasing
 


### PR DESCRIPTION
see https://github.com/jenkins-infra/repository-permissions-updater/pull/3970#issuecomment-2163312089

It asks you to create it before you've done the plugin changes, I think that has tripped a couple of people up recently