### PR TITLE
Platform Information - add line for Java 17 requirement in weekly to support table

### DIFF
--- a/content/doc/book/platform-information/support-policy-java.adoc
+++ b/content/doc/book/platform-information/support-policy-java.adoc
@@ -12,6 +12,7 @@ The following Java versions are required to run Jenkins:
 |===
 |Supported Java versions|Long term support (LTS) release|Weekly release
 
+|Java 17 or Java 21|N/A |2.463 (June 2024)
 |Java 11, Java 17, or Java 21|2.426.1 (November 2023) |2.419 (August 2023)
 |Java 11 or Java 17|2.361.1 (September 2022)|2.357 (June 2022)
 |Java 8, Java 11, or Java 17|2.346.1 (June 2022)|2.340 (March 2022)


### PR DESCRIPTION
This PR is to add another line to the Java Support policy documentation that includes the upcoming requirement for Java 17. Since this will be part of the weekly release for 2.463, the LTS piece was filled in with N/A for now, but can always be updated. If that should be changed to October 2024 (based on Basil's blog post information), that can be done so that it is more clearly outlined ahead of time.