### PR TITLE
The hudson.model.DirectoryBrowserSupport.allowAbsolutePath escape hatch is obsolete

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -357,14 +357,13 @@ properties:
 
 - name: hudson.model.DirectoryBrowserSupport.allowAbsolutePath
   tags:
-  - security
-  - escape hatch
+  - obsolete
   def: |
     `false`
   since: 2.315 and 2.303.2
   description: |
-    Escape hatch for link:/security/advisory/2021-10-06/#SECURITY-2481[SECURITY-2481].
-    Set this to `true` to allow browsing to absolute paths.
+    Deprecated: Escape hatch for link:/security/advisory/2021-10-06/#SECURITY-2481[SECURITY-2481].
+    Has no effect since 2.463, as the escape hatch has been removed.
 
 - name: hudson.model.DirectoryBrowserSupport.allowSymlinkEscape
   tags:


### PR DESCRIPTION
## The hudson.model.DirectoryBrowserSupport.allowAbsolutePath is obsolete

`hudson.model.DirectoryBrowserSupport.allowAbsolutePath` will be obsolete in the first weekly release after the merge of:

* https://github.com/jenkinsci/jenkins/pull/9387

Was not sure if this is the correct pattern to record a property that is no longer available.  I tried to follow the pattern used by others in the file.  Happy to adjust to whatever format or style is preferred.
