### PR TITLE
Update container images versions in hello-world tutorial

### DIFF
--- a/content/doc/pipeline/tour/hello-world.adoc
+++ b/content/doc/pipeline/tour/hello-world.adoc
@@ -56,7 +56,7 @@ various languages.
 // Declarative //
 /* Requires the Docker Pipeline plugin */
 pipeline {
-    agent { docker { image 'maven:3.9.7-eclipse-temurin-17-alpine' } }
+    agent { docker { image 'maven:3.9.7-eclipse-temurin-21-alpine' } }
     stages {
         stage('build') {
             steps {
@@ -69,7 +69,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('maven:3.9.7-eclipse-temurin-17-alpine').inside {
+        docker.image('maven:3.9.7-eclipse-temurin-21-alpine').inside {
             sh 'mvn --version'
         }
     }
@@ -83,7 +83,7 @@ node {
 // Declarative //
 /* Requires the Docker Pipeline plugin */
 pipeline {
-    agent { docker { image 'node:20.11.1-alpine3.19' } }
+    agent { docker { image 'node:20.14.0-alpine3.20' } }
     stages {
         stage('build') {
             steps {
@@ -96,7 +96,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('node:20.11.1-alpine3.19').inside {
+        docker.image('node:20.14.0-alpine3.20').inside {
             sh 'node --version'
         }
     }
@@ -137,7 +137,7 @@ node {
 // Declarative //
 /* Requires the Docker Pipeline plugin */
 pipeline {
-    agent { docker { image 'python:3.12.1-alpine3.19' } }
+    agent { docker { image 'python:3.12.4-alpine3.20' } }
     stages {
         stage('build') {
             steps {
@@ -150,7 +150,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('python:3.12.1-alpine3.19').inside {
+        docker.image('python:3.12.4-alpine3.20').inside {
             sh 'python --version'
         }
     }
@@ -177,7 +177,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('php:8.1.11-alpine').inside {
+        docker.image('php:8.3.8-alpine3.20').inside {
             sh 'php --version'
         }
     }
@@ -204,7 +204,7 @@ pipeline {
 /* Requires the Docker Pipeline plugin */
 node {
     stage('Build') {
-        docker.image('golang:1.19.1-alpine').inside {
+        docker.image('golang:1.22.4-alpine3.20').inside {
             sh 'go version'
         }
     }


### PR DESCRIPTION
It is not clear to me why the updatecli process did not propose changes for these containers.  It is especially curious that some cases remained very far out of date on older Alpine versions and at least one case had an update in the declarative Pipeline example that was not matched in the scripted Pipeline example.

Switches the Maven example to use Java 21.
