### PR TITLE
fix(updatecli): Manifest no longer reflects the status of the repository.

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -44,21 +44,13 @@ conditions:
       file: content/doc/book/pipeline/docker.adoc
       matchpattern: >-
         .*image.*\'maven:.*\'.*
-  testMavenKubernetesPlugin:
-    name: "Does the 'Effectively using Kubernetes plugin with Jenkins' blog post have a reference to the Maven alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/blog/2018/08/2018-08-30-speaker-blog-kubernetes-plugin.adoc
-      matchpattern: >-
-        .*image.*\'maven:.*\'.*
   testMavenAlpineImagePublished:
-    name: "Test maven:<latest_version>-eclipse-temurin-17-alpine docker image tag"
+    name: "Test maven:<latest_version>-eclipse-temurin-21-alpine docker image tag"
     kind: dockerimage
     disablesourceinput: true
     spec:
       image: "maven"
-      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine'
+      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine'
 
 targets:
   updateHelloWorldTutorialMavenPipeline:
@@ -70,7 +62,7 @@ targets:
       matchpattern: >-
         (.*agent.*docker.*image.*\')maven:(.*)(\'.*)
       replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
+        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine${3}
     scmid: default
   updateHelloWorldTutorialMavenScripted:
     name: "Update the value of the maven docker image for scripts in the 'Hello World!' tutorial"
@@ -81,7 +73,7 @@ targets:
       matchpattern: >-
         (.*docker.*image.*\')maven:(.*)(\'.*)
       replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
+        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine${3}
     scmid: default
   updateDockerTutorial:
     name: "Update the value of the maven docker image in the Docker tutorial"
@@ -92,7 +84,7 @@ targets:
       matchpattern: >-
         (.*image.*\')maven:(.*)(\'\).inside\(.*)
       replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
+        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine${3}
     scmid: default
   updateDockerTutorialWithoutComplexInside:
     name: "Update the value of the maven docker image in the Docker tutorial"
@@ -103,7 +95,7 @@ targets:
       matchpattern: >-
         (.*image.*\')maven:(.*)(\'\).inside.*)
       replacepattern: >-
-        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
+        ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine${3}
     scmid: default
   updateDockerTutorialDeclarative:
       name: "Update the value of the maven docker image in the Docker tutorial"
@@ -114,13 +106,13 @@ targets:
         matchpattern: >-
           (.*docker.*{.*image.*\')maven:(.*)(\'.*)
         replacepattern: >-
-          ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine${3}
+          ${1}maven:{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine${3}
       scmid: default
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: '[Tutorials] Bump maven alpine docker image version to {{ source "mavenLatestVersion" }}-eclipse-temurin-17-alpine'
+    title: '[Tutorials] Bump maven alpine docker image version to {{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine'
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -83,14 +83,6 @@ conditions:
       file: STYLEGUIDE.adoc
       matchpattern: >-
         .*docker.*image.*node:.*
-  testNodeInPipelineProjectCreationTutorial:
-    name: "Does the 'End-to-End Multibranch Pipeline Project Creation' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
-      matchpattern: >-
-        .*image.*node:.*
   testNodeInUsingDockerWithPipelineDocumentation:
     name: "Does the 'Using Docker with Pipeline' documentation have a reference to the Node alpine image?"
     kind: file
@@ -149,17 +141,6 @@ targets:
       file: STYLEGUIDE.adoc
       matchpattern: >-
         (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updatePipelineProjectCreationTutorial:
-    name: "Update the value of the node docker image in the 'End-to-End Multibranch Pipeline Project Creation' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
-      matchpattern: >-
-        (.*image.*\')node:(.*)(\'.*)
       replacepattern: >-
         ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default

--- a/updatecli/updatecli.d/python.yaml
+++ b/updatecli/updatecli.d/python.yaml
@@ -52,14 +52,6 @@ conditions:
       file: content/doc/pipeline/tour/hello-world.adoc
       matchpattern: >-
         .*agent.*docker.*image.*python:.*
-  testPythonInstallerAlpineArg:
-    name: "Does the 'build-a-python-app-with-pyinstaller.adoc' tutorial have a reference to the Python alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
-      matchpattern: >-
-        .*image.*python:.*
   testPythonAlpineImagePublished:
     name: "Test python:<latest_version>-alpine docker image tag"
     kind: dockerimage


### PR DESCRIPTION
As @MarkEWaite mentioned in #7364, some of the container references were no longer being updated.
This issue arose due to a refactoring of certain tutorial files, which involved removing Docker image references.
This PR aims to rectify the problem.

Mark also moved some image references to [JDK21](https://github.com/jenkins-infra/jenkins.io/pull/7364/files#diff-aa16972264f9707580a69bb0482bff4a81968c46ae2adaaf495c34e0986fb60cL59), so I'm following his path, and proposing to use JDK21 too in the `updatecli` manifests.