### PR TITLE
Make it more obvious that this is a new sentence

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -32,7 +32,7 @@ Don't push the changes directly to the default branch or merge the PR before the
 === Incrementals Enablement
 
 Verify that the plugin has already been link:../../plugin-development/incrementals[incrementalified].
-`pom.xml` should contain `<version>$\{revision}$\{changelist}</version>` and the files `.mvn/extensions.xml` and `.mvn/maven.config` should exist *before proceeding with subsequent steps*.
+The `pom.xml` should contain `<version>$\{revision}$\{changelist}</version>` and the files `.mvn/extensions.xml` and `.mvn/maven.config` should exist *before proceeding with subsequent steps*.
 
 NOTE: A new plugin created from the link:https://github.com/jenkinsci/archetypes/[archetypes] will already have this setup.
 

--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -32,7 +32,7 @@ Don't push the changes directly to the default branch or merge the PR before the
 === Incrementals Enablement
 
 Verify that the plugin has already been link:../../plugin-development/incrementals[incrementalified].
-The `pom.xml` should contain `<version>$\{revision}$\{changelist}</version>` and the files `.mvn/extensions.xml` and `.mvn/maven.config` should exist *before proceeding with subsequent steps*.
+The file `pom.xml` should contain `<version>$\{revision}$\{changelist}</version>` and the files `.mvn/extensions.xml` and `.mvn/maven.config` should exist *before proceeding with subsequent steps*.
 
 NOTE: A new plugin created from the link:https://github.com/jenkinsci/archetypes/[archetypes] will already have this setup.
 


### PR DESCRIPTION
I had a question from someone new to Jenkins why they could not see the `incrementalified.pom.xml`   The reason was obvious to me, but looking at the docs it was easy to see how this confusion arose.

This makes it more obvious that the `pom.xml` is in a different sentence by starting the sentence with a word