### PR TITLE
feat(sponsors): Create donors.json

### DIFF
--- a/content/_data/donors/donors.json
+++ b/content/_data/donors/donors.json
@@ -1,0 +1,150 @@
+[
+  {
+    "type": "donation",
+    "id": "bf2847c5-2a1f-404e-b530-a0ac3c77fcc6",
+    "name": "Chan Young Jeong",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/chanyoung.1711173787260",
+    "category": "mentorship",
+    "createdOn": "2024-03-23T06:04:45Z"
+  },
+  {
+    "type": "donation",
+    "id": "17be10f3-cb17-4664-926a-c74d5faafaed",
+    "name": "Verachten Bruno",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/gounthar.1651215884869",
+    "category": "mentorship",
+    "createdOn": "2024-02-07T10:15:03Z"
+  },
+  {
+    "type": "donation",
+    "id": "419d5896-cbf4-48f5-88e5-b644a0fd979e",
+    "name": "Linux Foundation",
+    "avatarUrl": "https://s.gravatar.com/avatar/ac55c2bf8e6b064ddb2e670d37b68c72?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Flf.png",
+    "category": "Donation",
+    "createdOn": "2023-11-27T11:13:32Z",
+    "organization": {
+      "organizationId": "1c7953a6-6bed-4eb2-9a54-e03f68ee87cc",
+      "name": "Google",
+      "avatarUrl": "https://lff-prod-uploads.s3.amazonaws.com/2dd1bf9b-8bc7-46a5-9fb5-fafa9b8aa35b"
+    }
+  },
+  {
+    "type": "donation",
+    "id": "97966e71-af91-4df1-9db0-437cecd45fba",
+    "name": "Byron Johnson",
+    "avatarUrl": "https://s.gravatar.com/avatar/feb9b10d1c804e6cf7014739e40ec7bb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fbj.png",
+    "category": "mentorship",
+    "createdOn": "2023-11-18T02:01:14Z"
+  },
+  {
+    "type": "donation",
+    "id": "63fe742a-8ef4-4c90-a1f2-2ffaea473948",
+    "name": "Geoff Griffiths",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/geoffcoding.1685138384492",
+    "category": "mentorship",
+    "createdOn": "2023-05-26T22:01:20Z"
+  },
+  {
+    "type": "donation",
+    "id": "dc7a0ae6-336b-43a5-a7f7-88b3efde1ccf",
+    "name": "jufeng.2006",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/jufeng.1682661522385",
+    "category": "mentorship",
+    "createdOn": "2023-04-28T06:00:59Z"
+  },
+  {
+    "type": "donation",
+    "id": "28b5e2b1-3995-4b1e-819d-e90237e6fb3b",
+    "name": "Mark Waite",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/mark.waite.1612554815587.png",
+    "category": "mentorship",
+    "createdOn": "2023-04-17T18:20:21Z"
+  },
+  {
+    "type": "donation",
+    "id": "540e489d-b531-46a5-b4fc-41d96b35d89b",
+    "name": "Márcio André Castelo Branco Zampiron",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/marciocastelobranco3.1644752620701.png",
+    "category": "mentorship",
+    "createdOn": "2023-03-21T00:57:57Z"
+  },
+  {
+    "type": "donation",
+    "id": "077489ac-c4f8-458d-a11a-101a424c1759",
+    "name": "wwamba.pro",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/wwambapro.1677440966849",
+    "category": "mentorship",
+    "createdOn": "2023-02-26T19:51:46Z"
+  },
+  {
+    "type": "donation",
+    "id": "5785d50c-d23f-42d7-a46f-75d7dd92018a",
+    "name": "Keri Heutmaker",
+    "avatarUrl": "https://s.gravatar.com/avatar/06bfe68c44386175dc46fae1e0aaf078?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fkh.png",
+    "category": "mentorship",
+    "createdOn": "2023-02-23T15:14:25Z"
+  },
+  {
+    "type": "donation",
+    "id": "8d04ba5f-2cfb-4571-8982-c31bde763e94",
+    "name": "Verachten Bruno",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/gounthar.1651215884869",
+    "category": "mentorship",
+    "createdOn": "2023-02-10T10:28:12Z"
+  },
+  {
+    "type": "donation",
+    "id": "ad8bb25f-b114-49f2-8235-d6f33f1297e5",
+    "name": "Cyprien Devillez",
+    "avatarUrl": "https://s.gravatar.com/avatar/5e1dec95a3b1f1a7de76714e493c914b?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fcd.png",
+    "category": "mentorship",
+    "createdOn": "2022-12-28T16:49:20Z",
+    "organization": {
+      "organizationId": "d218a045-b784-4bef-a0ec-1beb876c02b3",
+      "name": "Ethersys",
+      "avatarUrl": "https://lff-prod-uploads.s3.amazonaws.com/6d0ac1e6-590a-497a-9f2e-9fe05c3986b7"
+    }
+  },
+  {
+    "type": "donation",
+    "id": "107bfe6e-1b04-4c6c-92fc-1380cdc4d0fb",
+    "name": "Byron Johnson",
+    "avatarUrl": "https://s.gravatar.com/avatar/feb9b10d1c804e6cf7014739e40ec7bb?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fbj.png",
+    "category": "mentorship",
+    "createdOn": "2022-12-04T05:59:33Z"
+  },
+  {
+    "type": "donation",
+    "id": "d0966495-a481-41e9-9b2a-fbb9f56a02a6",
+    "name": "Linux Foundation",
+    "avatarUrl": "https://s.gravatar.com/avatar/ac55c2bf8e6b064ddb2e670d37b68c72?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Flf.png",
+    "category": "Mentorship",
+    "createdOn": "2022-10-05T20:09:29Z",
+    "organization": {
+      "organizationId": "1c7953a6-6bed-4eb2-9a54-e03f68ee87cc",
+      "name": "Google",
+      "avatarUrl": "https://lff-prod-uploads.s3.amazonaws.com/2dd1bf9b-8bc7-46a5-9fb5-fafa9b8aa35b"
+    }
+  },
+  {
+    "type": "donation",
+    "id": "73fe1dca-cbee-4d69-b210-e23263aa97c6",
+    "name": "Linux Foundation",
+    "avatarUrl": "https://s.gravatar.com/avatar/ac55c2bf8e6b064ddb2e670d37b68c72?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Flf.png",
+    "category": "Donation",
+    "createdOn": "2022-08-30T10:37:55Z",
+    "organization": {
+      "organizationId": "1c7953a6-6bed-4eb2-9a54-e03f68ee87cc",
+      "name": "Google",
+      "avatarUrl": "https://lff-prod-uploads.s3.amazonaws.com/2dd1bf9b-8bc7-46a5-9fb5-fafa9b8aa35b"
+    }
+  },
+  {
+    "type": "donation",
+    "id": "7a31f6df-ff35-4364-92df-ca2ffc7c1fe7",
+    "name": "Anup Jaltade",
+    "avatarUrl": "https://platform-logos-myprofile-api-prod.s3.us-east-2.amazonaws.com/fflier.1650291301660",
+    "category": "mentorship",
+    "createdOn": "2022-07-14T02:34:38Z"
+  }
+]


### PR DESCRIPTION
# Recognizing Financial Contributions

## Current Situation
- Major sponsors are listed on the jenkins.io home page.
- Recent discussions in [Advocacy and Outreach meetings](https://docs.google.com/document/d/1K5dTSqe56chFhDSGNfg_MCy-LmseUs_S3ys_tg60sTs) with @krisstern and @alyssat highlighted a lack of information about financial contributions to the Jenkins project.
- There have been discussions, [PRs](https://github.com/jenkins-infra/jenkins.io/pull/6882), and [issues](https://github.com/jenkins-infra/jenkins.io/issues/6861) about new ways to recognize various types of contributions.

## Proposal
We suggest adding information about financial contributions:
1. Display this information on the sponsors' page.
2. Keep it up to date regularly.

Note: This PR is not intended to implement the full solution, but rather to host the initial list of known donors.

## Technical Implementation
1. I've created a JSON file containing the current list of cash donors (minus one) through the Linux Foundation donations page.
2. Proposal: Store this file in the jenkins.io repository.
3. Future plan: Keep it updated using `updatecli` (to be addressed in a separate PR).
   - [The code](https://github.com/gounthar/jenkins.io/blob/donors/updatecli/updatecli.d/find-donors.yaml) for this update process already exists and is functional.

## Future Steps
This file could be used to generate a donor page when building the website.

We welcome your thoughts and feedback on this approach.