### PR TITLE
Use `Jenkins.get()` instead of deprecated method

### DIFF
--- a/content/doc/developer/plugin-development/optional-dependencies.adoc
+++ b/content/doc/developer/plugin-development/optional-dependencies.adoc
@@ -43,7 +43,7 @@ To determine if an optional dependency is installed, the Jenkins.getPlugin(Strin
 
 [source,java]
 ----
-if (Jenkins.getInstance().getPlugin("javanet-uploader") != null) {
+if (Jenkins.get().getPlugin("javanet-uploader") != null) {
     // use classes in the "javanet-uploader" plugin
 }
 ----


### PR DESCRIPTION
Use `Jenkins.get()` instead of deprecated `getInstance()` method