### PR TITLE
Add refs to 2.466 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24104,7 +24104,7 @@
   - version: '2.465'
     date: 2024-07-02
     banner: >
-      This release build failed due to breaking changes in the Apache Maven release plugin.
+      This release failed due to breaking changes in the Maven Release plugin.
       Installers, native packages, and jenkins.war were not published.
     changes:
       - type: bug

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24147,8 +24147,8 @@
             title: parent pom PR 576
           - pull: 9430
         message: |-
+          Fix the release build that failed due to breaking changes in the Apache Maven Release plugin.
           Downgrade Apache Maven Release plugin from 3.1.0 to 3.0.1.
-          Apache Maven Release plugin 3.1.0 includes changes that break the release process of Jenkins core.
 
   # pull: 9427 (PR title: Update eslint monorepo to v9.6.0)
 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24104,7 +24104,7 @@
   - version: '2.465'
     date: 2024-07-02
     banner: >
-      This release build failed due to changes in the Apache Maven release plugin.
+      This release build failed due to breaking changes in the Apache Maven release plugin.
       Installers, native packages, and jenkins.war were not published.
     changes:
       - type: bug

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24147,8 +24147,8 @@
             title: parent pom PR 576
           - pull: 9430
         message: |-
-          Fix the release build that failed due to breaking changes in the Apache Maven Release plugin.
-          Downgrade Apache Maven Release plugin from 3.1.0 to 3.0.1.
+          Fix the release build that failed due to breaking changes in the Maven Release plugin.
+          Downgrade Maven Release plugin from 3.1.0 to 3.0.1.
 
   # pull: 9427 (PR title: Update eslint monorepo to v9.6.0)
 

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24104,7 +24104,7 @@
   - version: '2.465'
     date: 2024-07-02
     banner: >
-      This release build failed due to breaking changes in the Apache Maven release plugin.
+      This release build failed due to changes in the Apache Maven release plugin.
       Installers, native packages, and jenkins.war were not published.
     changes:
       - type: bug
@@ -24140,6 +24140,12 @@
           - dependabot[bot]
           - basil
         pr_title: Bump org.jenkins-ci:jenkins from 1.117 to 1.118
+        references:
+          - url: https://issues.apache.org/jira/browse/MRELEASE-1151
+            title: Maven Release Plugin MRELEASE-1151
+          - url: https://github.com/jenkinsci/pom/pull/576
+            title: parent pom PR 576
+          - pull: 9430
         message: |-
           Downgrade Apache Maven Release plugin from 3.1.0 to 3.0.1.
           Apache Maven Release plugin 3.1.0 includes changes that break the release process of Jenkins core.


### PR DESCRIPTION
Clarify that the breaking change failed the 2.465 build and the solution for 2.466 was to downgrade to the release without the breaking change.

Add references to the 2.466 changelog entry so that others can easily see the related issue and its pull requests.