### PR TITLE
Fix 2.467 changelog date

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24153,7 +24153,7 @@
   # pull: 9427 (PR title: Update eslint monorepo to v9.6.0)
 
   - version: '2.467'
-    date: 2024-07-08
+    date: 2024-07-09
     changes:
       - type: rfe
         category: rfe


### PR DESCRIPTION
## Fix 2.467 changelog date

Release was today, 9 Jul 2024, not yesterday 8 Jul 2024
