### PR TITLE
Update durability wording

### DIFF
--- a/content/doc/book/pipeline/scaling-pipeline.adoc
+++ b/content/doc/book/pipeline/scaling-pipeline.adoc
@@ -71,7 +71,7 @@ A dirty shutdown can also happen due to catastrophic operating system failures, 
 
 * Performance-optimized mode ("PERFORMANCE_OPTIMIZED") - *Greatly* reduces disk I/O.  If Pipelines do not finish AND Jenkins is not shut down gracefully, they may lose data and behave like Freestyle projects -- see details above.
 
-* Maximum durability ("MAX_SURVIVABILITY") - behaves just like Pipeline did before, slowest option.  Use this for running your most critical Pipelines.
+* Maximum survivability/durability ("MAX_SURVIVABILITY") - behaves just like Pipeline did before, slowest option.  Use this for running your most critical Pipelines.
 
 * Less durable, a bit faster ("SURVIVABLE_NONATOMIC") - Writes data with every step but avoids atomic writes. This is faster than maximum durability mode, especially on networked filesystems.  It carries a small extra risk (details above under "What Am I Giving Up: Atomic Writes").
 


### PR DESCRIPTION
I have made a change [here](https://github.com/jenkinsci/workflow-api-plugin/pull/343) to adapt the wording of the durability setting to make it clearer to users. This PR is to keep the documentation aligned with that.

Keeping this pull request in draft until https://github.com/jenkinsci/workflow-api-plugin/pull/343 has been reviewed and merged :slightly_smiling_face: 