### PR TITLE
fix(tutorials): Improve cleanup instructions and add explanation for --remove-orphans option

### DIFF
--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -310,7 +310,24 @@ To learn more about what Jenkins can do, check out:
 * The link:/doc/book[User Handbook] for more detailed information about using Jenkins, such as link:/doc/book/pipeline[Pipelines] (in particular link:/doc/book/pipeline/syntax[Pipeline syntax]) and the link:/doc/book/blueocean[Blue Ocean] interface.
 * The link:/node[Jenkins blog] for the latest events, other tutorials and updates.
 
-If you want to clean up your environment, you can stop the containers with `docker compose --profile maven down -v --remove-orphans`.
+=== Cleaning Up Your Environment
+
+After completing the tutorial, it's important to clean up your environment to prevent interference with other tutorials you might try later.
+
+To stop the containers and remove associated volumes:
+
+[source,bash]
+----
+docker compose --profile maven down -v --remove-orphans
+----
+
+This command ensures a clean slate for your next project.
+
+[NOTE]
+====
+The `--remove-orphans` option instructs Docker Compose to remove any containers that are not defined in the `docker-compose.yml` file but are labeled as belonging to the project.
+This helps in cleaning up any services that might have been started independently but are considered part of the project.
+====
 
 [[appendix]]
 

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -553,6 +553,24 @@ To learn more about what Jenkins can do, check out:
 * The link:/doc/book[User Handbook] for more detailed information about using Jenkins, such as link:/doc/book/pipeline[Pipelines] (in particular link:/doc/book/pipeline/syntax[Pipeline syntax]) and the link:/doc/book/blueocean[Blue Ocean] interface.
 * The link:/node[Jenkins blog] for the latest events, other tutorials and updates.
 
+=== Cleaning Up Your Environment
+
+After completing the tutorial, it's important to clean up your environment to prevent interference with other tutorials you might try later.
+
+To stop the containers and remove associated volumes:
+
+[source,bash]
+----
+docker compose --profile multi down -v --remove-orphans
+----
+
+This command ensures a clean slate for your next project.
+
+[NOTE]
+====
+The `--remove-orphans` option instructs Docker Compose to remove any containers that are not defined in the `docker-compose.yml` file but are labeled as belonging to the project.
+This helps in cleaning up any services that might have been started independently but are considered part of the project.
+====
 
 '''
 ++++

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -375,6 +375,24 @@ To learn more about what Jenkins can do, check out:
 * The link:/node[Jenkins blog] for the latest events, other tutorials and
   updates.
 
+=== Cleaning Up Your Environment
+
+After completing the tutorial, it's important to clean up your environment to prevent interference with other tutorials you might try later.
+
+To stop the containers and remove associated volumes:
+
+[source,bash]
+----
+docker compose --profile node down -v --remove-orphans
+----
+
+This command ensures a clean slate for your next project.
+
+[NOTE]
+====
+The `--remove-orphans` option instructs Docker Compose to remove any containers that are not defined in the `docker-compose.yml` file but are labeled as belonging to the project.
+This helps in cleaning up any services that might have been started independently but are considered part of the project.
+====
 
 '''
 ++++

--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -403,7 +403,25 @@ To learn more about what Jenkins can do, check out:
 * The link:/node[Jenkins blog] for the latest events, other tutorials and
   updates.
 
-If you want to clean up your environment, you can stop the containers with `docker compose down -v --remove-orphans`.
+
+=== Cleaning Up Your Environment
+
+After completing the tutorial, it's important to clean up your environment to prevent interference with other tutorials you might try later.
+
+To stop the containers and remove associated volumes:
+
+[source,bash]
+----
+docker compose --profile python down -v --remove-orphans
+----
+
+This command ensures a clean slate for your next project.
+
+[NOTE]
+====
+The `--remove-orphans` option instructs Docker Compose to remove any containers that are not defined in the `docker-compose.yml` file but are labeled as belonging to the project.
+This helps in cleaning up any services that might have been started independently but are considered part of the project.
+====
 
 '''
 ++++


### PR DESCRIPTION
This PR is a follow-up to the fix provided by Jay in #7335.

## Motivation

Another user [encountered issues](https://github.com/jenkins-docs/quickstart-tutorials/issues/454) last week, highlighting the need for a comprehensive solution to prevent problems when users chain tutorials together.

## Changes

- Enhanced cleanup instructions to ensure a clean environment between tutorials
- Added an explanation for the `--remove-orphans` option
- Provided clear guidance to prevent issues with lingering containers or volumes

These improvements should effectively prevent deployment problems in subsequent tutorials caused by remnants from previous setups.