### PR TITLE
Link to the OpenJDK upgrade issue in Jira

### DIFF
--- a/content/_data/upgrades/2-440-2.adoc
+++ b/content/_data/upgrades/2-440-2.adoc
@@ -3,8 +3,10 @@ NOTE: These upgrade are not specific to the 2.440.2 release, but are crucial for
 ==== OpenJDK Upgrade
 
 Due to a recent change in the upstream OpenJDK, users may encounter a breaking change if they do not upgrade and restart their Java processes.
-When upgrading the Java runtime to OpenJDK 11.0.22 and later or 17.0.10 and later, you must restart the Java process.
+When upgrading the Java runtime to OpenJDK 11.0.22 and later or 17.0.10 and later, you **must** restart the Java process.
 This practice applies to both controllers and agents: when upgrading the Java runtime on the controller, restart the Java process on the controller; when upgrading the Java runtime on the agent, restart the Java process on the agent.
+
+Details of the issue are available in link:https://issues.jenkins.io/browse/JENKINS-72665[JENKINS-72665].
 
 ==== Jakarta Plugin Upgrades
 


### PR DESCRIPTION
[JENKINS-72665](https://issues.jenkins.io/browse/JENKINS-72665) has more details for readers that need to better understand the root of the issue and the reason that they must restart the Java process when the Java runtime is upgraded.

Segmentation violation or segfault is reported by Java when Java tries to spawn a new process after an upgrade from a Java 11 version before 11.0.22 to a Java 11 version 11.0.22 or later.  Same failure when they upgrade Java from a Java 17 version before 17.0.10 to a Java version 17.0.10 or later.

The segfault is only reported when the previous version of the JDK is trying to use the spawnhelper of the new version.  If the user stops the Java process and restarts it, the problem will not occur.

Reported by Daniel Beck in:

* https://github.com/jenkins-infra/jenkins.io/pull/7162#issuecomment-2244447288