### PR TITLE
Announce 2024 elections

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,3 +1,15 @@
+# Jenkins 2024 board and officer elections
+- :href: /blog/2023/09/18/board-officer-election-announcement/
+  :title: Jenkins Elections 2024 Announcement
+  :intro: Nominations for board and officer positions are now open.
+    Sign up and nominate someone today to shape the future of Jenkins!
+  :image:
+    :src: /images/governance/elections/2024/2024-announcement-opengraph.svg
+    :height: 320px
+  :call_to_action:
+    :text: Sign up & Nominate someone today!
+    :href: /blog/2024/08/01/board-officer-election-announcement/
+
 # jenkins accepted for GSoC 2024
 - :href: blog/2024/05/01/google-summer-of-code-congrats-and-welcome/
   :title: Welcome GSoC 2024 contributors!
@@ -11,7 +23,7 @@
 #
 - :href: https://devopsdozen.com/devops-dozen-2023-community-award-winners/
   :title: Jenkins wins DevOps Dozen award
-  :intro: Jenkins has been awarded the  
+  :intro: Jenkins has been awarded the
     "Most innovative DevOps Open Source project" distinction
     by DevOps Dozen.
   :image:
@@ -22,7 +34,7 @@
     :href: https://devopsdozen.com/devops-dozen-2023-community-award-winners/
 - :href: https://contributors.jenkins.io/
   :title: Meet the driving forces
-  :intro: behind Jenkins 
+  :intro: behind Jenkins
     as we showcase the top contributors shaping the
     future of continuous integration and delivery.
   :image:

--- a/content/blog/2024/08/01/2024-08-01-board-officer-election-announcement.adoc
+++ b/content/blog/2024/08/01/2024-08-01-board-officer-election-announcement.adoc
@@ -19,7 +19,7 @@ opengraph:
 
 == Nominations
 
-Nominations can be submitted for link:/project/board/[governance board] positions, and all link:/project/team-leads/[officer] positions (link:/project/team-leads/#security[Security], link:/project/team-leads/#events[Events], link:/project/team-leads/#release[Release], link:/project/team-leads/#infrastructure[Infrastructure], and link:/project/team-leads/#documentation[Documentation]).
+Nominations can be submitted for link:/project/board/[governance board] positions and all link:/project/team-leads/[officer] positions (link:/project/team-leads/#security[Security], link:/project/team-leads/#events[Events], link:/project/team-leads/#release[Release], link:/project/team-leads/#infrastructure[Infrastructure], and link:/project/team-leads/#documentation[Documentation]).
 
 During the registration period, we invite community members to nominate candidates by sending a message to the link:https://community.jenkins.io/g/election-committee[election-committee] group.
 In your message, please include the name of the nominee, the specific position and your reasons for nominating that person.

--- a/content/blog/2024/08/01/2024-08-01-board-officer-election-announcement.adoc
+++ b/content/blog/2024/08/01/2024-08-01-board-officer-election-announcement.adoc
@@ -1,0 +1,120 @@
+---
+:layout: post
+:title: "Jenkins Board and Officer Elections 2024 - Nominations Open"
+:tags:
+- community
+- governance
+- governance-board
+- elections
+authors:
+- markewaite
+- basil
+description: >
+  Nomination are open for Jenkins Board and Officer elections.
+opengraph:
+  image: /images/governance/elections/2024/2024-announcement-opengraph.svg
+---
+
+**We are excited to announce the 2024 Jenkins Governance Board and Officer elections!**
+
+== Nominations
+
+Nominations can be submitted for link:/project/board/[governance board] positions, and all link:/project/team-leads/[officer] positions (link:/project/team-leads/#security[Security], link:/project/team-leads/#events[Events], link:/project/team-leads/#release[Release], link:/project/team-leads/#infrastructure[Infrastructure], and link:/project/team-leads/#documentation[Documentation]).
+
+During the registration period, we invite community members to nominate candidates by sending a message to the link:https://community.jenkins.io/g/election-committee[election-committee] group.
+In your message, please include the name of the nominee, the specific position and your reasons for nominating that person.
+A tutorial is available that shows the steps to link:/project/election-walkthrough/#nominate-a-candidate[nominate a candidate].
+
+The nomination period ends on *September 15*.
+Nominees will be notified and asked to confirm that they are interested in running as a candidate.
+The list of candidates will be announced on September 16.
+
+**Anyone can nominate anyone as a candidate!**
+
+Many thanks to link:/blog/authors/uhafner/[Dr. Ullrich Hafner] and link:/blog/authors/notmyfault/[Alexander Brandes] for serving on the link:/project/board/[Jenkins Governance Board].
+We also want to thank link:/blog/authors/dduportal/[Damien Duportal] as link:/project/team-leads/#infrastructure[Infrastructure Officer], link:/blog/authors/wadeck/[Wadeck Follonier] as link:/project/team-leads/#security[Security Officer], link:/blog/authors/alyssat/[Alyssa Tong] as link:/project/team-leads/#events[Events Officer], link:/blog/authors/timja/[Tim Jacomb] as link:/project/team-leads/#release[Release Officer], and link:/blog/authors/kmartens27/[Kevin Martens] as link:/project/team-leads/#documentation[Documentation Officer] for all of their work over the last term.
+
+== The election consists of 4 phases:
+
+* Nomination of candidates (August 1 - September 15)
+* Voter registration (September 16 - October 31)
+* Voting (November 1 - November 30)
+* Results announcement (December 1)
+
+=== Voting
+
+Participation in the election process requires registering an account on the link:https://community.jenkins.io[Jenkins community forums] and at least one contribution made before September 1, 2024.
+When registering, you can use an existing GitHub account or create a new account specifically for link:https://community.jenkins.io[Jenkins community forums].
+We ask all community members who are interested in voting and meet the requirements to join the link:https://community.jenkins.io/g/election-voter-2024[election-voter-2024] group during the registration period.
+Previous elections utilized their own groups, so joining the link:https://community.jenkins.io/g/election-voter-2024[election-voter-2024] group is required for participation.
+
+We have made the decision to trust participants and not require that you provide evidence of contribution as part of your voter registration.
+We reserve the right to ban any account from the election process if we identify abuse.
+Once registration is over, a list of email addresses will be sent to the link:https://civs1.civs.us/[Condorcet Internet Voting Service (CIVS)].
+
+=== Contributing
+
+As shown on the link:/participate/[Participate and Contribute] page, there are many different ways to contribute to Jenkins. You can contribute by:
+
+* link:/participate/connect/[Connecting with the community]
+* link:/participate/meet/[Joining or organizing a meetup]
+* link:/participate/code/[Contributing code to Jenkins]
+* link:/participate/help/[Helping Jenkins users]
+* link:/doc/developer/internationalization/[Translating Jenkins resources]
+* link:/participate/test/[Testing Jenkins core and plugins]
+* link:/participate/document/[Contributing to Jenkins documentation]
+* link:/participate/design/[Creating art or updating the Jenkins UI]
+* link:/participate/review-changes/[Reviewing open pull requests]
+* link:/donate/[Donating to Jenkins]
+
+All contributions to Jenkins and its community are welcome
+
+== Election
+
+Candidates will be announced September 16.
+Voter registration closes on October 31.
+Voting begins November 1.
+Registered voters will be notified by email to participate using the link:https://civs1.civs.us/[Condorcet Internet Voting System].
+All votes must be submitted by end of day November 30.
+
+== Results
+
+Election results will be published December 1.
+The new term starts on December 1, when the newly elected members will transition to their roles.
+
+== Important Dates
+
+[cols="1,1"]
+|===
+|Important Dates |Time
+
+|Nomination of candidates open
+|August 1
+
+|Nomination of candidates closes
+|September 15
+
+|Voter registration opens and candidates announced
+|September 16
+
+|Voter registration closes
+|October 31
+
+|Voting starts
+|November 1
+
+|Voting closes
+|November 30
+
+|Results announced
+|December 1
+|===
+
+== Troubleshooting
+
+If you are new to Jenkins elections, unfamiliar with the Condorcet Internet Voting Service (CIVS) or the community forums, or feel overwhelmed with the process, don't worry, we've got you covered.
+We published a link:/project/election-walkthrough/[step-by-step guide], outlining how to to join the link:https://community.jenkins.io/g/election-voter-2024[election-voter-2024], activate your CIVS account and cast your vote.
+
+If you encounter issues still or need assistance, don't hesitate to contact the link:https://community.jenkins.io/g/election-committee[election committee].
+
+Thank you, as always, and don't forget to register to vote by October 31!

--- a/content/images/governance/elections/2024/2024-announcement-opengraph.svg
+++ b/content/images/governance/elections/2024/2024-announcement-opengraph.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+    <defs>
+        <linearGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" style="stop-color:#F6C3D0;" />
+            <stop offset="100%" style="stop-color:#FFECB8;" />
+        </linearGradient>
+        <linearGradient id="gradient2" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" style="stop-color:#A0E7E5;" />
+            <stop offset="100%" style="stop-color:#B6E0F5;" />
+        </linearGradient>
+    </defs>
+    <rect width="100%" height="100%" fill="url(#gradient1)" />
+    <text x="50%" y="20%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="80" fill="#000">
+        Jenkins Election 2024
+    </text>
+    <text x="50%" y="35%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="40" fill="#000">
+        Nominations opened
+    </text>
+    <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="40" fill="#000">
+        3 Governance Board Positions available
+    </text>
+    <text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="40" fill="#000">
+        5 Officer Positions available
+    </text>
+    <text x="50%" y="75%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="60" fill="#000">
+        Nominate someone today!
+    </text>
+</svg>

--- a/content/images/governance/elections/2024/2024-announcement-opengraph.svg
+++ b/content/images/governance/elections/2024/2024-announcement-opengraph.svg
@@ -17,10 +17,10 @@
         Nominations opened
     </text>
     <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="40" fill="#000">
-        3 Governance Board Positions available
+        Governance board positions available
     </text>
     <text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="40" fill="#000">
-        5 Officer Positions available
+        Officer positions available
     </text>
     <text x="50%" y="75%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="60" fill="#000">
         Nominate someone today!


### PR DESCRIPTION
## Announce 2024 elections

Nominating for positions on the governing board and for officers.

https://www.jenkins.io/project/election-walkthrough/ provides the detailed calendar and steps I used to modify last year's election announcement:

* https://github.com/jenkins-infra/jenkins.io/pull/6663
