### PR TITLE
Revert "chore(Jenkinsfile) increase DockerHub rate limit with authentication"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,24 +64,21 @@ node('docker&&linux') {
         * something is very wrong
         */
         timeout(60) {
-            // Need to authenticate on DockerHub with a read-only account to avoid rate limit
-            infra.withDockerCredentials {
-                sh '''#!/usr/bin/env bash
-                    set -o errexit
-                    set -o nounset
-                    set -o pipefail
-                    set -o xtrace
-    
-                    make all
-    
-                    illegal_filename="$( find . -name '*[<>]*' )"
-                    if [[ -n "$illegal_filename" ]] ; then
-                        echo "Failing build due to illegal filename:" >&2
-                        echo "$illegal_filename" >&2
-                        exit 1
-                    fi
-                    '''
-            }
+            sh '''#!/usr/bin/env bash
+                set -o errexit
+                set -o nounset
+                set -o pipefail
+                set -o xtrace
+
+                make all
+
+                illegal_filename="$( find . -name '*[<>]*' )"
+                if [[ -n "$illegal_filename" ]] ; then
+                    echo "Failing build due to illegal filename:" >&2
+                    echo "$illegal_filename" >&2
+                    exit 1
+                fi
+                '''
         }
     }
 


### PR DESCRIPTION
Reverts jenkins-infra/jenkins.io#7421 as per https://github.com/jenkins-infra/helpdesk/issues/4192#issuecomment-2270821972 since we now have a DockerHub mirror inside the infrastructure