### PR TITLE
Remove broken link to upgrading plugins

### DIFF
--- a/content/doc/book/platform-information/upgrade-java-to-17.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-17.adoc
@@ -32,7 +32,6 @@ If you need to upgrade Jenkins, as well as the JVM, we recommend you:
 TIP: We recommend that you use the package manager of your system (such as `apt` or `yum`).
 . Validate the upgrade to confirm that all plugins and jobs are loaded.
 . Upgrade the required plugins.
-Refer to <<Upgrading Plugins>> for further information.
 
 When upgrading the Java version for Jenkins and the JVM, it is important to upgrade all plugins that support Java 17.
 Plugin upgrades assure compatibility with the most recent Jenkins releases.


### PR DESCRIPTION
## Remove broken link to upgrading plugins

The Java 11 page includes a section that alerts the reader that they must install plugins that are compatible with Java 11.  We don't need the same warning with Java 17 (at least not yet).
