### PR TITLE
Make use of UTF-8 in localization example

### DIFF
--- a/content/doc/developer/internationalization/i18n-source-code.adoc
+++ b/content/doc/developer/internationalization/i18n-source-code.adoc
@@ -25,9 +25,9 @@ Example.Description = A simple example for localization
 
 `src/main/resources/org/example/package/Messages_de.properties`:
 [source]
-Example.Description = Ein einfaches Beispiel f\u00fcr Lokalisierung
+Example.Description = Ein einfaches Beispiel für Lokalisierung
 
-The first file is the default localization for the _key_ `description` (used unless a more specific localization is available), while the second file provides the German localization.
+The first file is the default localization for the _key_ `description` (used unless a more specific localization is available), while the second file provides the German localization. Notice that UTF-8 is fully supported since Jenkins 2.361.1 (Java 11).
 
 Localizer will generate a class that looks similar to the following from these resource files:
 

--- a/content/doc/developer/internationalization/i18n-source-code.adoc
+++ b/content/doc/developer/internationalization/i18n-source-code.adoc
@@ -27,7 +27,7 @@ Example.Description = A simple example for localization
 [source]
 Example.Description = Ein einfaches Beispiel für Lokalisierung
 
-The first file is the default localization for the _key_ `description` (used unless a more specific localization is available), while the second file provides the German localization. Notice that UTF-8 is fully supported since Jenkins 2.361.1 (Java 11).
+The first file is the default localization for the _key_ `description` (used unless a more specific localization is available), while the second file provides the German localization. UTF-8 is supported since Jenkins 2.361.1 (Java 11).
 
 Localizer will generate a class that looks similar to the following from these resource files:
 


### PR DESCRIPTION
Make use of UTF-8 in example. We shouldn't encourage the escaped variant any longer.