### PR TITLE
Fix some elements in dark mode

### DIFF
--- a/content/_layouts/changelog.html.haml
+++ b/content/_layouts/changelog.html.haml
@@ -28,8 +28,8 @@ title: Changelog
       %li.storm required rollback
 - if page.has_rss
   .w-100.text-right{:style => "margin: 10px 0;"}
-    %a{:href => "rss.xml"}
-      %img{:src => "/images/changelog/feed-icon.svg", :style => "height: 20px"}/
+    %a{:href => "rss.xml", :class => "app-button app-button--tertiary"}
+      = File.read("content/images/symbols/rss.svg")
       RSS
 
 - if page.show_ratings

--- a/content/_layouts/gsocprojectidea.html.haml
+++ b/content/_layouts/gsocprojectidea.html.haml
@@ -16,7 +16,7 @@ project: gsoc
     = page.skills.join(", ")
 
 - if page.status == "draft"
-  %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+  %div{:class => 'app-banner'}
     %b
       NOTE:
     This idea is published as a draft under active discussion, but it is confirmed in principle.
@@ -36,10 +36,10 @@ project: gsoc
           Google Doc
         )
     - else
-      %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+      %div{:class => 'app-banner'}
         ERROR: The project idea draft link is missing, please report an error to GSoC org admins
   - else
-    %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+    %div{:class => 'app-banner'}
       ERROR: The project links are not defined in the document, please report an error to GSoC org admins
 - else
   %h2.title

--- a/content/_partials/changelog-old.html
+++ b/content/_partials/changelog-old.html
@@ -1297,7 +1297,7 @@
 
 
 <h3 id=v2.0>What's new in 2.0 (2016/04/20)</h3>
-<div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
+<div class="app-banner">
   <strong>More detailed information about the new features in Jenkins 2.0 <a href="/2.0/">on the overview page</a>.</strong>
 </div>
 

--- a/content/_partials/changelog-stable.html
+++ b/content/_partials/changelog-stable.html
@@ -78,7 +78,7 @@ title: LTS Changelog
 
 <h3 id=v2.19.3>What's new in 2.19.3 (2016-11-16)</h3>
 
-<div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
+<div class="app-banner">
   This is an out-of-schedule release addressing <a href="/blog/2016/11/12/addressing-remote-vulnerabilities-in-cli/">the zero day vulnerability published on November 11, 2016</a>. It does not contain the usual LTS bug fixes, but only addresses the security vulnerability. There will be another LTS release in the 2.19.x line containing bug fixes as regularly scheduled.
 </div>
 
@@ -315,7 +315,7 @@ title: LTS Changelog
 
 <div><strong>Notable changes since 1.651.3:</strong></div>
 
-<div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
+<div class="app-banner">
   <strong>More detailed information about the new features in Jenkins 2 <a href="/2.0/">on the overview page</a>.
     Note that AJP support has been removed, if your service script enables it, Jenkins will fail to start.</strong>
 </div>
@@ -724,7 +724,7 @@ title: LTS Changelog
 
     <h3 id=v1.625.1>What's new in 1.625.1 (2015/10/14)</h3>
 
-<div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
+<div class="app-banner">
 <strong>1.625.1 is the first Jenkins LTS release that requires Java 7 to run.</strong>
 If you're using the Maven Project type, please note that it needs to use a JDK capable of running Jenkins, i.e. JDK 7 or up.
 If you configure an older JDK in a Maven Project, Jenkins will attempt to find a newer JDK and use that automatically.

--- a/content/_partials/release-header.html.haml
+++ b/content/_partials/release-header.html.haml
@@ -3,5 +3,5 @@
   - if page.release.date
     = "(#{page.release.date})"
 - if page.release.banner
-  %div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+  %div{:class => 'app-banner'}
     = page.release.banner

--- a/content/changelog-old/index.html.haml
+++ b/content/changelog-old/index.html.haml
@@ -4,7 +4,7 @@ title: Changelog Archive
 show_ratings: false
 ---
 
-%div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+%div{:class => 'app-banner'}
   %b
     This is the changelog archive.
   Recent changelogs can be found

--- a/content/changelog-stable/index.html.haml
+++ b/content/changelog-stable/index.html.haml
@@ -5,13 +5,13 @@ show_ratings: true
 has_rss: true
 ---
 
-%div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+%div{:class => 'app-banner'}
   See the
   %a{:href => '/doc/upgrade-guide/'}
     LTS upgrade guide
   for advice on upgrading Jenkins.
 
-%div{:style => 'margin: 10px; padding: 10px; background-color: #FFFFCE;'}
+%div{:class => 'app-banner'}
   See the
   %a{:href => '/download/lts'}
     LTS Release Line

--- a/content/stylesheets/components/_all.scss
+++ b/content/stylesheets/components/_all.scss
@@ -2,6 +2,7 @@
 @import "author";
 @import "avatar";
 @import "back-link";
+@import "banner";
 @import "button";
 @import "cards";
 @import "chips";

--- a/content/stylesheets/components/_banner.scss
+++ b/content/stylesheets/components/_banner.scss
@@ -1,6 +1,7 @@
 .app-banner {
   margin: 10px 0;
   padding: 10px 15px;
-  background-color: color-mix(in srgb, currentColor 5%, transparent);
+  background-color: color-mix(in srgb, var(--accent-color) 7.5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 5%, transparent);
   border-radius: 10px;
 }

--- a/content/stylesheets/components/_banner.scss
+++ b/content/stylesheets/components/_banner.scss
@@ -1,0 +1,6 @@
+.app-banner {
+  margin: 10px 0;
+  padding: 10px 15px;
+  background-color: color-mix(in srgb, currentColor 5%, transparent);
+  border-radius: 10px;
+}


### PR DESCRIPTION
Small one to fix some elements in dark mode, namely the banner and the RSS icon.

[![View comparison](https://raw.githubusercontent.com/janfaracik/janfaracik.github.io/add9a80914c0342ea13e4f8c409c953cd9c6f105/comparison/compare.svg)](https://janfaracik.github.io/comparison?before=https://github.com/user-attachments/assets/67c88d78-65a6-44dd-b2d9-e4f8cecc07e7&after=https://github.com/user-attachments/assets/5c514ba5-bc14-40e7-ae2c-080f05c839f1&github=https://github.com/jenkins-infra/jenkins.io/pull/7457)

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/67c88d78-65a6-44dd-b2d9-e4f8cecc07e7">

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5c514ba5-bc14-40e7-ae2c-080f05c839f1">
