### PR TITLE
Update back link icon in dark mode

### DIFF
--- a/content/stylesheets/components/_back-link.scss
+++ b/content/stylesheets/components/_back-link.scss
@@ -3,20 +3,17 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
   font-weight: 500;
 
   &::before {
     content: "";
     position: relative;
     display: inline-block;
-    width: 1.4rem;
-    height: 1.4rem;
+    width: 1.375rem;
+    height: 1.375rem;
     background-color: currentColor;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 550 512'%3E%3Cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='60' d='M328 112L184 256l144 144'/%3E%3C/svg%3E%0A");
-    background-size: 1rem;
-    background-position: center;
-    background-repeat: no-repeat;
-    border-radius: 100vmax;
+    mask-image: url("data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 0C4.92487 0 0 4.92487 0 11C0 17.0751 4.92487 22 11 22C17.0751 22 22 17.0751 22 11C22 4.92487 17.0751 0 11 0ZM13.2416 7.41278C13.5861 7.08959 13.5861 6.56559 13.2416 6.24239C12.897 5.9192 12.3383 5.9192 11.9937 6.24239L7.75844 10.2148C7.41386 10.538 7.41386 11.062 7.75844 11.3852L11.9937 15.3576C12.3383 15.6808 12.897 15.6808 13.2416 15.3576C13.5861 15.0344 13.5861 14.5104 13.2416 14.1872L9.63019 10.8L13.2416 7.41278Z' fill='white'/%3E%3C/svg%3E%0A");
+    mask-size: contain;
   }
 }


### PR DESCRIPTION
Small one to fix the back link icon in dark mode, previously the chevron was white now it follows the background colour + some minor size changes to round to pixels.

**Before**
<img width="145" alt="image" src="https://github.com/user-attachments/assets/d01348c6-292c-4ec7-8fea-21438dc57d1e">

**After**
<img width="140" alt="image" src="https://github.com/user-attachments/assets/26b6ac25-9257-45e7-aecd-d5030b876f1a">
