### PR TITLE
reverse-proxy-configuration proxy_pass warning

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -108,6 +108,8 @@ server {
 This assumes that you run Jenkins on port 8080.
 Remember to create the folder /var/log/nginx/jenkins.
 
+Make sure you do not end `proxy_pass` value with slash, as it will cause problems like in this [issue](https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16).
+
 include::doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc[]
 
 If you are having problems with some paths (eg folders) with *Blue

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -108,7 +108,7 @@ server {
 This assumes that you run Jenkins on port 8080.
 Remember to create the folder /var/log/nginx/jenkins.
 
-Make sure you do not end `proxy_pass` value with slash, as it will cause problems like in this [issue](https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16).
+Make sure you do not end the `proxy_pass` value with a slash, as it will cause problems like in this [issue](https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16).
 
 include::doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc[]
 


### PR DESCRIPTION
Tricky issue to resolve, mentioned here: 
https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16