### PR TITLE
Reverse proxy configuration - adjust link macro usage

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -108,7 +108,7 @@ server {
 This assumes that you run Jenkins on port 8080.
 Remember to create the folder /var/log/nginx/jenkins.
 
-Make sure you do not end the `proxy_pass` value with a slash, as it will cause problems like in this [issue](https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16).
+Make sure you do not end the `proxy_pass` value with a slash, as it will cause problems like those described in link:https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16[this discussion].
 
 include::doc/book/system-administration/reverse-proxy-configuration-with-jenkins/_context_path.adoc[]
 


### PR DESCRIPTION
This was something that I caught just before the previous PR was merged, and wasn't quick enough to fix it prior. Just a small adjustment to fix the link formatting/rendering.