### PR TITLE
Updating Installing documentation to remove use of "Jenkins instance"

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -320,7 +320,7 @@ kubectl get deployments -n jenkins
 
 === Grant access to Jenkins service
 
-We have a Jenkins instance deployed but it is still not accessible.
+We have a Jenkins controller deployed but it is still not accessible.
 The Jenkins Pod has been assigned an IP address that is internal to the Kubernetes cluster.
 It’s possible to log into the Kubernetes Node and access Jenkins from there but that’s not a very useful way to access the service.
 
@@ -373,7 +373,7 @@ minikube ip
 192.168.99.100
 ----
 
-Now we can access the Jenkins instance at http://192.168.99.100:32664/
+Now we can access the Jenkins controller at http://192.168.99.100:32664/
 
 To access Jenkins, you initially need to enter your credentials.
 The default username for new installations is admin.

--- a/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
+++ b/content/doc/book/installing/_setup-wizard-for-tutorials.adoc
@@ -17,7 +17,7 @@ to perform.
 
 ===== Unlocking Jenkins
 
-When you first access a new Jenkins instance, you are asked to unlock it using
+When you first access a new Jenkins controller, you are asked to unlock it using
 an automatically-generated password.
 
 . After the 2 sets of asterisks appear in the terminal/command prompt window,

--- a/content/doc/book/installing/_setup-wizard.adoc
+++ b/content/doc/book/installing/_setup-wizard.adoc
@@ -23,7 +23,7 @@ through which you can continue accessing Jenkins.
 
 === Unlocking Jenkins
 
-When you first access a new Jenkins instance, you are asked to unlock it using
+When you first access a new Jenkins controller, you are asked to unlock it using
 an automatically-generated password.
 
 . Browse to `\http://localhost:8080` (or whichever port you configured for

--- a/content/doc/book/installing/other.adoc
+++ b/content/doc/book/installing/other.adoc
@@ -135,7 +135,7 @@ Once Jenkins is running, consult the log
 administrator password for the initial set up of Jenkins, usually it will be
 found at `/var/lib/jenkins/home/secrets/initialAdminPassword`. Then navigate to
 link:http://localhost:8080[localhost:8080] to <<setup-wizard, complete configuration of the
-Jenkins instance>>.
+Jenkins controller>>.
 
 
 To change attributes of the service, such as environment variables like `JENKINS_HOME`


### PR DESCRIPTION
As part of the work to resolve https://github.com/jenkins-infra/jenkins.io/issues/7291, the areas where "Jenkins instance" was used has been updated to use a more accurate terminology (controller).

These are mostly small updates as the content/context does not change when updating from "instance" to "controller".