### PR TITLE
Updating Managing documentation to remove usage of "Jenkins instance"

### DIFF
--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -12,7 +12,7 @@ The configuration can then be modified by editing this file and then applying it
 ====
 Traditionally, experienced Jenkins administrators
 created Apache Groovy `init` scripts
-to automate the configuration for their Jenkins instances.
+to automate the configuration for their Jenkins controllers.
 This works but requires in-depth understanding of Jenkins APIs
 and the ability to write Groovy scripts.
 Such scripts are powerful and can do almost anything,

--- a/content/doc/book/managing/index.adoc
+++ b/content/doc/book/managing/index.adoc
@@ -37,10 +37,10 @@ Other system administration topics are discussed in
 
 == System Configuration group
 
-Screens for configuring resources for your Jenkins instance.
+Screens for configuring resources for your Jenkins controller.
 
 link:system-configuration[System]::
-Configure global settings and paths for the Jenkins instance
+Configure global settings and paths for the Jenkins controller
 
 link:tools[Tools]::
 Configure tools, their locations, and automatic installers
@@ -53,18 +53,18 @@ link:nodes[Nodes and Clouds]::
 Add, remove, control, and monitor the nodes used for the agents on which build jobs run.
 
 link:casc[Configuration as Code]::
-Configure your Jenkins instance using a human-readable YAML file rather than the UI.
+Configure your Jenkins controller using a human-readable YAML file rather than the UI.
 This is an optional feature that appears in this group
 only when the plugin is installed on your controller.
 
 == Security group
 
-Screens for configuring security features for your Jenkins instance.
+Screens for configuring security features for your Jenkins controller.
 See link:/doc/book/security/[Securing Jenkins] for general information
 about managing Jenkins security.
 
 link:system-configuration[Security]::
-Set configuration parameters that secure your Jenkins instance.
+Set configuration parameters that secure your Jenkins controller.
 
 link:/doc/book/using/using-credentials/#adding-new-global-credentials[Manage Credentials]::
 Configure the credentials that provide secure access
@@ -86,15 +86,15 @@ link:/doc/book/system-administration/viewing-logs/[System Log]::
 Jenkins log that contains all `java.util.logging` output related to Jenkins.
 
 *Load Statistics*::
-Displays information about resource utilization on you Jenkins instance.
+Displays information about resource utilization on you Jenkins controller.
 
 link:about-jenkins[About Jenkins]::
-Provides version and license information for your Jenkins instance.
+Provides version and license information for your Jenkins controller.
 
 == Troubleshooting group
 
 *Manage Old Data*::
-Remove configuration information related to plugins that have been removed from the instance.
+Remove configuration information related to plugins that have been removed from the controller.
 
 == Tools and Actions group
 

--- a/content/doc/book/managing/script-console.adoc
+++ b/content/doc/book/managing/script-console.adoc
@@ -54,7 +54,7 @@ agents should never be run as the `root` user (on Linux) or system
 administrator on any other flavor of OS. Videos linked in this page demonstrate
 and discuss security warnings.
 
-*Be sure to secure your Jenkins instance*
+*Be sure to secure your Jenkins controller*
 ====
 
 toc::[]
@@ -67,7 +67,7 @@ agents.
 === Running Script Console on the controller
 
 This feature can be accessed from _"Manage Jenkins" > "Script Console"_. 
-Or by visiting the sub-URL `/script` on your Jenkins instance.
+Or by visiting the sub-URL `/script` on your Jenkins controller.
 
 === Running Script Console on agents
 
@@ -298,7 +298,7 @@ java -jar jenkins.war
 ----
 
 Use CTRL+C to stop Jenkins. It is not recommended to try Script Console
-examples in a production Jenkins instance.
+examples in a production Jenkins controller.
 
 The following repositories offer solid examples of Groovy scripts for Jenkins.
 

--- a/content/doc/book/managing/system-info.adoc
+++ b/content/doc/book/managing/system-info.adoc
@@ -13,15 +13,15 @@ endif::[]
 = System Information
 
 The *Manage Jenkins >> System Information* page provides detailed information
-about what is available on this Jenkins instance:
+about what is available on this Jenkins controller:
 
 * *System Properties* that can be used as arguments
 to the command line used to start Jenkins.
 * *Environment Variables* recognized on this system,  with current values.
 This includes the environment variables defined by Jenkins
 and available on all systems
-as well as environment variables associated with plugins installed on this instance.
+as well as environment variables associated with plugins installed on this controller.
 * List of Plugins installed on the system.
-* *Memory Usage* gives a graph that shows the current memory usage for this instance.
+* *Memory Usage* gives a graph that shows the current memory usage for this controller.
 
 


### PR DESCRIPTION
As part of the work to resolve https://github.com/jenkins-infra/jenkins.io/issues/7291, the areas where "Jenkins instance" was used has been updated to use a more accurate terminology (controller).

These are mostly small updates as the content/context does not change when updating from "instance" to "controller".