### PR TITLE
Updating Platform Information documentation to remove use of "Jenkins instance"

### DIFF
--- a/content/doc/book/platform-information/upgrade-java-to-11.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-11.adoc
@@ -18,7 +18,7 @@ As with any upgrade, we recommend:
 If you need to upgrade Jenkins, as well as the JVM, we recommend you:
 
 . link:/doc/book/system-administration/backing-up/#jenkins_home[Back up `JENKINS_HOME`].
-. Stop the Jenkins instance.
+. Stop the Jenkins controller.
 . Upgrade the JVM on which Jenkins is running.
 ** Use a package manager to install the new JVM.
 ** Ensure the default JVM is the newly installed version.

--- a/content/doc/book/platform-information/upgrade-java-to-17.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-17.adoc
@@ -21,7 +21,7 @@ As with any upgrade, we recommend:
 If you need to upgrade Jenkins, as well as the JVM, we recommend you:
 
 . link:/doc/book/system-administration/backing-up/#jenkins_home[Back up `JENKINS_HOME`].
-. Stop the Jenkins instance.
+. Stop the Jenkins controller.
 . Upgrade the JVM on which Jenkins is running.
 ** Use a package manager to install the new JVM.
 ** Ensure the default JVM is the newly installed version.


### PR DESCRIPTION
As part of the work to resolve https://github.com/jenkins-infra/jenkins.io/issues/7291, the areas where "Jenkins instance" was used has been updated to use a more accurate terminology (controller).

These are mostly small updates as the content/context does not change when updating from "instance" to "controller".