### PR TITLE
Update to remove usage of "jenkins instance" in Blue Ocean documentation

### DIFF
--- a/content/doc/book/blueocean/dashboard.adoc
+++ b/content/doc/book/blueocean/dashboard.adoc
@@ -19,7 +19,7 @@ endif::[]
 = Dashboard
 
 Blue Ocean's "Dashboard" is the default view when opening Blue Ocean.
-It displays an overview of all Pipeline projects configured on a Jenkins instance.
+It displays an overview of all Pipeline projects configured on a Jenkins controller.
 
 include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
@@ -48,8 +48,8 @@ When viewing the Dashboard, the navigation bar's contextual section includes:
 The *Pipelines* list is the Dashboard's default list. 
 It is the only list displayed the first time Blue Ocean is accessed.
 
-The list shows the overall state of each Pipeline configured in the Jenkins instance.
-The list can include other items configured in the Jenkins instance.
+The list shows the overall state of each Pipeline configured in the Jenkins controller.
+The list can include other items configured in the Jenkins controller.
 The following information is displayed for each Pipeline listed:
 
 * The item's *NAME*

--- a/content/doc/book/blueocean/getting-started.adoc
+++ b/content/doc/book/blueocean/getting-started.adoc
@@ -21,7 +21,7 @@ endif::[]
 
 This section describes how to get started with Blue Ocean in Jenkins.
 It includes instructions for link:#installing-blue-ocean[setting up Blue Ocean] on
-your Jenkins instance, how to link:#accessing-blue-ocean[access the Blue Ocean UI], and link:#switching-to-the-classic-ui[returning to the Jenkins classic UI].
+your Jenkins controller, how to link:#accessing-blue-ocean[access the Blue Ocean UI], and link:#switching-to-the-classic-ui[returning to the Jenkins classic UI].
 
 include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
@@ -29,20 +29,20 @@ include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 You can install Blue Ocean using the following methods:
 
-* As a suite of plugins on an link:#on-an-existing-jenkins-instance[existing Jenkins instance]. 
+* As a suite of plugins on an link:#on-an-existing-jenkins-instance[existing Jenkins controller]. 
 * As a part of link:#as-part-of-jenkins-in-docker[Jenkins in Docker].
 
-=== On an existing Jenkins instance
+=== On an existing Jenkins controller
 
 When Jenkins is installed on most platforms, the plugin:blueocean[Blue Ocean] plugin and all necessary dependent plugins, which compile the Blue Ocean suite of plugins, are not installed by default.
 
 
-Plugins can be installed on a Jenkins instance by any Jenkins user who has the
+Plugins can be installed on a Jenkins controller by any Jenkins user who has the
 *Administer* permission. This is set through *Matrix-based security*.
 Jenkins users with this permission can also configure the permissions of other users on their system.
 Refer to the link:../../security/managing-security/#authorization[Authorization] section of link:../../security/managing-security/[Managing Security] for more information.
 
-To install the Blue Ocean suite of plugins to your Jenkins instance:
+To install the Blue Ocean suite of plugins to your Jenkins controller:
 
 . Ensure you are logged in to Jenkins as a user with the *Administer* permission.
 . From the Jenkins home page, select *Manage Jenkins* on the left and then *Plugins*.
@@ -85,7 +85,7 @@ image:blueocean/intro/open-blue-ocean-link.png[alt="Open Blue Ocean link",width=
 Alternatively, you can access Blue Ocean directly by appending `/blue` to the end of your Jenkins server's URL.
 For example `\https://jenkins-server-url/blue`.
 
-If your Jenkins instance:
+If your Jenkins controller:
 
 * Already has existing Pipeline projects or other items present, the link:../dashboard[Blue Ocean Dashboard] displays.
 * Is new or does not have projects or other items configured, Blue Ocean displays a *Welcome to Jenkins* pane with a *Create a new Pipeline* button.

--- a/content/doc/book/blueocean/index.adoc
+++ b/content/doc/book/blueocean/index.adoc
@@ -126,7 +126,7 @@ To put this more simply, consider this quote from ice hockey legend Wayne Gretzk
 
 ==== Does Blue Ocean support freestyle jobs?
 
-Blue Ocean aims to deliver a great experience around Pipeline and compatibility with any freestyle jobs you already have configured in your Jenkins instance.
+Blue Ocean aims to deliver a great experience around Pipeline and compatibility with any freestyle jobs you already have configured in your Jenkins controller.
 However, you will not benefit from the features built for Pipelines, for example Pipeline visualization.
 
 Blue Ocean was designed to be extensible, so that the Jenkins community could extend Blue Ocean functionality.


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291