### PR TITLE
Update to remove usage of "jenkins instance" in Pipeline documentation 

### DIFF
--- a/content/doc/book/pipeline/development.adoc
+++ b/content/doc/book/pipeline/development.adoc
@@ -222,7 +222,7 @@ The extension adds four settings entries to VS Code which select the Jenkins ser
 
 The link:https://github.com/ckipp01/nvim-jenkinsfile-linter[nvim-jenkinsfile-linter]
 Neovim plugin allows you to validate a Jenkinsfile by using the Pipeline Linter API
-of your Jenkins instance and report any existing diagnostics in your editor.
+of your Jenkins controller and report any existing diagnostics in your editor.
 
 === Atom linter-jenkins package
 
@@ -234,7 +234,7 @@ link:https://atom.io/packages/language-jenkinsfile[Jenkinsfile language support 
 === Sublime Text Jenkinsfile package
 
 The link:https://github.com/june07/sublime-Jenkinsfile[Jenkinsfile] Sublime Text package allows 
-you to validate a Jenkinsfile by using the Pipeline Linter API of a running Jenkins instance over
+you to validate a Jenkinsfile by using the Pipeline Linter API of a running Jenkins controller over
 a secure channel (SSH).  You can install it directly from the Sublime Text package manager.
 
 ​You can find the package from within the Sublime Text interface via the Package Control package, at GitHub, or packagecontrol.io:

--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -253,7 +253,7 @@ which may rectify the issue.
 Pipeline ships with built-in documentation features to make it
 easier to create Pipelines of varying complexities. This built-in documentation
 is automatically generated and updated based on the plugins installed in the
-Jenkins instance.
+Jenkins controller.
 
 The built-in documentation can be found globally at `$\{YOUR_JENKINS_URL}/pipeline-syntax`.
 The same documentation is also linked as *Pipeline Syntax* in the side-bar for any
@@ -271,7 +271,7 @@ code for individual steps, discovering new steps provided by plugins, or
 experimenting with different parameters for a particular step.
 
 The Snippet Generator is dynamically populated with a list of the steps
-available to the Jenkins instance. The number of steps available is dependent
+available to the Jenkins controller. The number of steps available is dependent
 on the plugins installed which explicitly expose steps for use in Pipeline.
 
 To generate a step snippet with the Snippet Generator:
@@ -377,7 +377,7 @@ stage('Stage 1') {
 
 This section merely scratches the surface of what can be done with Jenkins
 Pipeline, but should provide enough of a foundation for you to start
-experimenting with a test Jenkins instance.
+experimenting with a test Jenkins controller.
 
 In the next section, <<jenkinsfile#, The Jenkinsfile>>, more Pipeline steps
 will be discussed along with patterns for implementing successful, real-world,

--- a/content/doc/book/pipeline/scaling-pipeline.adoc
+++ b/content/doc/book/pipeline/scaling-pipeline.adoc
@@ -33,7 +33,7 @@ There are 3 ways to configure the durability setting:
 Durability settings will take effect with the next applicable Pipeline run, not immediately.  The setting will be displayed in the log.
 
 == Will Higher-Performance Durability Settings Help Me?
-* Yes, if your Jenkins instance uses NFS, magnetic storage, runs many Pipelines at once, or shows high iowait.
+* Yes, if your Jenkins controller uses NFS, magnetic storage, runs many Pipelines at once, or shows high iowait.
 * Yes, if you are running Pipelines with many steps (more than several hundred).
 * Yes, if your Pipeline stores large files or complex data to variables in the script, keeps that variable in scope for future use, and then runs steps.  This sounds oddly specific but happens more than you'd expect.
 ** For example: `readFile` step with a large XML/JSON file, or using configuration information from parsing such a file with link:/doc/pipeline/steps/pipeline-utility-steps/#code-readjson-code-read-json-from-files-in-the-workspace[One of the Utility Steps].


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291