### PR TITLE
Update to remove usage of "jenkins instance" in Scaling documentation 

### DIFF
--- a/content/doc/book/scaling/architecting-for-manageability.adoc
+++ b/content/doc/book/scaling/architecting-for-manageability.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 With over 1,800 plugins and countless versions of said plugins in the
 open-source community, testing for all possible conflicts before upgrading one
-or more production Jenkins instances is simply not feasible. While Jenkins
+or more production Jenkins controllers is simply not feasible. While Jenkins
 itself will warn of potential incompatibility if it detects that a plugin
 requires a newer version of the Jenkins core, there is no automatic way to
 detect conflicts between plugins or to automatically quantify the impact of
@@ -31,7 +31,7 @@ Effective upgrade testing can prevent production downtime.
 
 A test controller is a Jenkins controller used solely for testing configurations and
 plugins in a non-production environment.
-A test controller is highly recommended for organizations with a mission-critical Jenkins instance.
+A test controller is highly recommended for organizations with a mission-critical Jenkins controller.
 
 Upgrading or downgrading either the Jenkins core or any plugins can sometimes
 have the unintended side effect of crippling another plugin's functionality or

--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -31,7 +31,7 @@ to an existing controller.
 There are potential pitfalls associated with each approach to scaling Jenkins,
 but with careful planning, many of them can be avoided or managed. Here are
 some things to consider when choosing a strategy for scaling your
-organization's Jenkins instances:
+organization's Jenkins controllers:
 
 * **Do you have the resources to run a distributed build system?** If possible,
   it is recommended set up dedicated build nodes that run separately from the
@@ -51,7 +51,7 @@ organization's Jenkins instances:
   downed controller. Also consider converting any mission-critical project
   pipelines to Pipeline jobs, which continue executing even when the
   agent connection to the controller is lost.
-* **How important is a fast start-up time for your Jenkins instance?** The more
+* **How important is a fast start-up time for your Jenkins controller?** The more
   jobs a controller has configured, the longer it takes to load Jenkins after an
   upgrade or a crash. The use of folders and views to organize jobs can limit
   the number of that need to be rendered on start up.
@@ -403,7 +403,7 @@ This policy can be set on a job's configuration page.
 == Setting up a backup policy
 
 It is a best practice to take regular backups of your $JENKINS_HOME.
-A backup ensures that your Jenkins instance can be restored despite a misconfiguration,
+A backup ensures that your Jenkins controller can be restored despite a misconfiguration,
 accidental job deletion, or data corruption. 
 See the link:/doc/book/system-administration/backing-up/[Backup policies] for more details.
 
@@ -642,7 +642,7 @@ _secret.key.not-so-secret_ file.
 
 
 The _identity.key_ is an RSA key pair that identifies and authenticates the
-current Jenkins instance.
+current Jenkins controller.
 
 The _secret.key_ is used to encrypt plugin and other Jenkins data, and to
 establish a secure connection between a controller and agent.
@@ -658,7 +658,7 @@ some Jenkins data like the credentials.xml, while the _master.key_ is used for
 encrypting the hudson.util.Secret key. Finally, the _InstanceIdentity.KEY_ is
 used to identity this instance and for producing digital signatures.
 
-=== Define a Jenkins instance to rollback to
+=== Define a Jenkins controller to rollback to
 
 In the case of a total machine failure, it is important to ensure that there is
 a plan in place to get Jenkins both back online and in its last good state.
@@ -681,7 +681,7 @@ Administrators are constantly adding more and more teams to the software
 factory, making administrators in the business of making their instances
 resilient to failures and scaling them in order to onboard more teams.
 
-Adding build nodes to a Jenkins instance while beefing up the machine that runs
+Adding build nodes to a Jenkins controller while beefing up the machine that runs
 the Jenkins controller is the typical way to scale Jenkins. Said differently,
 administrators scale their Jenkins controller vertically. However, there is a limit
 to how much an instance can be scaled. These limitations are covered in the

--- a/content/doc/book/scaling/hardware-recommendations.adoc
+++ b/content/doc/book/scaling/hardware-recommendations.adoc
@@ -30,13 +30,13 @@ Jenkins Scalability Summit.
 [[choosing-the-right-hardware-for-masters]]
 == Choosing the Right Hardware for Controllers
 
-One of the greatest challenges of properly setting up a Jenkins instance is that
+One of the greatest challenges of properly setting up a Jenkins controller is that
 there is no _one size fits all_ answer - the exact specifications of the
 hardware that you will need will depend heavily on your organization's current
 and future needs.
 
 Your Jenkins controller will be serving HTTP requests and storing all of the
-important information for your Jenkins instance in its _$JENKINS_HOME_ folder
+important information for your Jenkins controller in its _$JENKINS_HOME_ folder
 (configurations, build histories and plugins).
 
 More information on sizing controllers based on organizational needs can be found in

--- a/content/doc/book/scaling/scaling-jenkins-on-kubernetes.adoc
+++ b/content/doc/book/scaling/scaling-jenkins-on-kubernetes.adoc
@@ -29,7 +29,7 @@ called Jenkins agents.
 Scalability is a measure that shows the ability of a system to expand its capabilities
 to handle additional load.
 One of the strongest sides of Jenkins is that it has a scaling feature out-of-the-box.
-Jenkins scaling is based on the controller/agents model, where you have a number of agent instances and one main Jenkins instance called the controller that is responsible mainly for distributing jobs across the agents.
+Jenkins scaling is based on the controller/agents model, where you have a number of agent instances and one main Jenkins controller that is responsible mainly for distributing jobs across the agents.
 Jenkins agents run a small program that communicates with the Jenkins controller to check if there’s any job it can run.
 When Jenkins finds a job scheduled, it transfers the build to the agent.
 


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291