### PR TITLE
Update to remove usage of "jenkins instance" in Security documentation 

### DIFF
--- a/content/doc/book/security/access-control.adoc
+++ b/content/doc/book/security/access-control.adoc
@@ -52,7 +52,7 @@ Granting Overall/Administer permission to _anonymous_ is similar to _Anyone can 
 
 Built-in node::
 Users with limited permissions link:/doc/book/security/controller-isolation/[must not be able to configure jobs that run on the built-in node].
-When setting up a new Jenkins instance, adding users and switching authorization strategies, it is important to also set up distributed builds and limit what jobs are able to run on the built-in node.
+When setting up a new Jenkins controller, adding users and switching authorization strategies, it is important to also set up distributed builds and limit what jobs are able to run on the built-in node.
 
 //In addition to the above items that discuss who may (effectively) be granted administrative access to Jenkins, you should be careful who you give any read access to Jenkins.
 //See link:/doc/book/security/access-control/permissions/#overall-read[the documentation of the level of access that granting basic read access gives].

--- a/content/doc/book/security/access-control/disable.adoc
+++ b/content/doc/book/security/access-control/disable.adoc
@@ -59,7 +59,7 @@ jenkins:
   authorizationStrategy: unsecured
 ----
 +
-2. Restart your Jenkins instance to re-apply the modified configuration.
+2. Restart your Jenkins controller to re-apply the modified configuration.
 
 ////
 TODO Review this advice -- it doesn't seem to make sense unless something deletes all previously applied documentation?

--- a/content/doc/book/security/access-control/permissions.adoc
+++ b/content/doc/book/security/access-control/permissions.adoc
@@ -41,7 +41,7 @@ As of Jenkins 2.290, the following extensions are provided as part of Jenkins (c
 * The `/whoAmI/` URL allows determining who the current user is.
   It is available to users without permissions to troubleshoot permissions issues.
 * `/wsagents/` handles agent connections using web sockets.
-* `/instance-identity/` provides a public key that allows identifying the Jenkins instance and setting up secure communication with it.
+* `/instance-identity/` provides a public key that allows identifying the Jenkins controller and setting up secure communication with it.
   See https://github.com/jenkinsci/instance-identity-plugin[the component documentation] for details.
 * `/static-files/` is used to implement the Resource Root URL feature serving user-provided contents from another domain.
   See link:/doc/book/security/configuring-content-security-policy[its documentation].

--- a/content/doc/book/security/credentials.adoc
+++ b/content/doc/book/security/credentials.adoc
@@ -63,7 +63,7 @@ and should be carefully protected:
 
 * You must be able to retrieve your secrets if you need to restore your instance.
 * If someone were to get access to your backups as well as the secret,
-they would have full access to your entire Jenkins instance and everything it accesses.
+they would have full access to your entire Jenkins controller and everything it accesses.
 
 The following practices are recommended to ensure that your secrets are kept secret:
 
@@ -73,7 +73,7 @@ The following practices are recommended to ensure that your secrets are kept sec
 ** A disk crash or data corruption for your application
 could cause the loss of all the encrypted information for your instance.
 ** If someone breaches your SCM and your _secrets_ are there,
-they have full access to your Jenkins instance.
+they have full access to your Jenkins controller.
 
 * Instead, keep a copy of the secrets in a location apart from other backups and copies of your application.
 The secret is small and never changes after it is created.

--- a/content/doc/book/security/csrf-protection.adoc
+++ b/content/doc/book/security/csrf-protection.adoc
@@ -33,7 +33,7 @@ The _Default Crumb Issuer_ encodes the following information in the https://en.w
 * The user name that the crumb was generated for
 * The web session ID that the crumb was generated in
 * The IP address of the user that the crumb was generated for
-* A https://en.wikipedia.org/wiki/Salt_(cryptography)[salt] unique to this Jenkins instance
+* A https://en.wikipedia.org/wiki/Salt_(cryptography)[salt] unique to this Jenkins controller
 
 All of this information needs to match when a crumb is sent back to Jenkins for that submission to be considered valid.
 

--- a/content/doc/book/security/index.adoc
+++ b/content/doc/book/security/index.adoc
@@ -13,7 +13,7 @@ Jenkins is used everywhere from workstations on corporate intranets, to high-pow
 To safely support this wide spread of security and threat profiles, Jenkins offers many configuration options for enabling, customizing, or disabling various security features.
 
 Many of the security options are enabled by default when passing the interactive setup wizard to ensure that Jenkins is secure.
-Others involve environment-specific setup and trade-offs and depend on specific use cases supported in individual Jenkins instances.
+Others involve environment-specific setup and trade-offs and depend on specific use cases supported in individual Jenkins controllers.
 
 This chapter will introduce the various security options available to Jenkins administrators and users, explaining the protections offered, and trade-offs to disabling some of them.
 

--- a/content/doc/book/security/markup-formatter.adoc
+++ b/content/doc/book/security/markup-formatter.adoc
@@ -30,6 +30,6 @@ This includes a description that is rendered using the configured markup formatt
 Therefore it can be unsafe to configure a markup formatter allowing arbitrary HTML even when restricting permissions like _Job/Configure_ and _Build/Update_ to fully trusted users:
 Anyone with an account will be able to edit their own description and any other user accessing their profile may become victim of an XSS attack.
 
-This is particularly risky on publicly accessible Jenkins instances when the security realm is implemented using a service like GitHub, GitLab, or Google accounts, resulting in potentially anyone being able to log in to Jenkins and edit their own profile.
+This is particularly risky on publicly accessible Jenkins controller when the security realm is implemented using a service like GitHub, GitLab, or Google accounts, resulting in potentially anyone being able to log in to Jenkins and edit their own profile.
 
 // TODO: Discuss HTML fallback features in formatters with other markup languages

--- a/content/doc/book/security/securing-builds.adoc
+++ b/content/doc/book/security/securing-builds.adoc
@@ -19,7 +19,7 @@ The following sections discuss potential issues and strategies to deal with them
 As discussed in link:../controller-isolation[Controller Isolation], Jenkins should be set up for _distributed builds_ to ensure build scripts are not executing on the controller, where they could access the Jenkins home directory or otherwise interfere with the operation of Jenkins.
 
 An additional concern is that builds need to be isolated from each other:
-While simple Jenkins instances building a single project may be able to operate securely with a single static agent, administrators of more complex instances need to consider whether builds need to be isolated from each other.
+While simple Jenkins controllers building a single project may be able to operate securely with a single static agent, administrators of more complex instances need to consider whether builds need to be isolated from each other.
 Some examples:
 
 - Jenkins hosts multiple teams, which are not allowed to access each others' projects or source code.
@@ -37,7 +37,7 @@ Solutions to this issue include the following:
 == Pull Request Abuse
 
 When using organization folders or https://plugins.jenkins.io/workflow-multibranch/[multibranch Pipelines], Jenkins automatically builds new pull requests by default.
-Especially when a Jenkins instance builds projects from public repositories, this can open the door for abuse, such as:
+Especially when a Jenkins controller builds projects from public repositories, this can open the door for abuse, such as:
 // General issue is tracked in https://issues.jenkins.io/browse/JENKINS-53752
 
 - Spam pull requests that trigger many new builds.


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291