### PR TITLE
Update to remove usage of "jenkins instance" in System Adminstration documentation

### DIFF
--- a/content/doc/book/system-administration/admin-password-reset-instructions.adoc
+++ b/content/doc/book/system-administration/admin-password-reset-instructions.adoc
@@ -39,7 +39,7 @@ Select the User ID that you want to change the password for.
 12. Select Configure using the gear icon or the dropdown menu from the User ID.
 Locate the *Password* section to change your password.
 
-After changing the password, you will be able to log into your Jenkins instance again using the same username and the new password that you have just set.
+After changing the password, you will be able to log into your Jenkins controller again using the same username and the new password that you have just set.
 
 NOTE: Please ensure not to leave the Jenkins controller insecure.
 So, please re-enable the security by following these steps.

--- a/content/doc/book/system-administration/backing-up.adoc
+++ b/content/doc/book/system-administration/backing-up.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 = Backing-up/Restoring Jenkins
 
-Having good backups of your Jenkins instance is critically important.
+Having good backups of your Jenkins controller is critically important.
 Backups are used for:
 
 * Disaster recovery.
@@ -32,7 +32,7 @@ These are discussed in this section:
 
 * Filesystem snapshots
 * Plugins for backup
-* Write a shell script that backs up the Jenkins instance
+* Write a shell script that backs up the Jenkins controller
 
 === Filesystem snapshots
 
@@ -103,7 +103,7 @@ and list some files that could safely be excluded from at least some backups.
 === $JENKINS_HOME
 
 Backing up the entire `$JENKINS_HOME` directory
-preserves the entire Jenkins instance.
+preserves the entire Jenkins controller.
 To restore the system, just copy the entire backup to the new system.
 
 Note, however, that `JENKINS_HOME` includes a number of files that do not really need to be backed up.
@@ -175,14 +175,14 @@ Create a directory for the test validation (such as **/mnt/backup-test**)
 and restore the backup to that directory.
 
 Set $JENKINS_HOME to point to this directory,
-specifying a random HTTP port so you do not collide with the real Jenkins instance:
+specifying a random HTTP port so you do not collide with the real Jenkins controller:
 
 [source,bash]
 ----
 export JENKINS_HOME=/mnt/backup-test
 ----
 
-Now execute the restored Jenkins instance:
+Now execute the restored Jenkins controller:
 
 [source,bash]
 ----

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-iptables.adoc
@@ -123,8 +123,8 @@ target     prot opt source               destination
  +
 
 Once these rules are set and confirmed with iptables -L -n, and once
-your Jenkins instance is up and running on port 8080, attempt to access
-your Jenkins instance on port 80 instead of 8080.
+your Jenkins controller is up and running on port 8080, attempt to access
+your Jenkins controller on port 80 instead of 8080.
 It should work and your URL should stay on port 80 - in other words,
 it should not get redirected to 8080.
 The fact that forwarding from 80 to 8080 (or 443 to 8443) should remain

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
@@ -67,11 +67,11 @@ jenkins:
 
 Now, run `docker compose up`.
 
-== Set up your Jenkins instance
+== Set up your Jenkins controller
 
 If your Jenkins container is set up correctly, the Setup Wizard guides you through several prompts before you can access your dashboard.
 
-To set up your Jenkins instance:
+To set up your Jenkins controller:
 
 1. Go to `localhost:8080` and enter the admin user password to continue. You can find the admin user password in your Docker logs or in `/var/jenkins_home/secrets/initialAdminPassword`.
 


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291