### PR TITLE
Update to remove usage of "jenkins instance" in Using Jenkins documentation

### DIFF
--- a/content/doc/book/using/best-practices.adoc
+++ b/content/doc/book/using/best-practices.adoc
@@ -151,7 +151,7 @@ By following these practices, you can ensure that your controller provides the b
 
 Jenkins installations come with security enabled by default, which is a crucial aspect of protecting your system.
 While it is technically possible to disable security, it is strongly advised **not** to do so.
-Disabling security can leave your Jenkins instance vulnerable to unauthorized access and potential security breaches.
+Disabling security can leave your Jenkins controller vulnerable to unauthorized access and potential security breaches.
 It is important to maintain a secure environment by keeping security enabled at all times.
 
 Refer to the link:/doc/book/security/securing-jenkins/[securing Jenkins] chapter of the User Handbook for more details.

--- a/content/doc/book/using/change-time-zone.adoc
+++ b/content/doc/book/using/change-time-zone.adoc
@@ -15,7 +15,7 @@ endif::[]
 
 = Change time zone
 
-If your Jenkins instance is running in a different location than your own (for example: the server is in NY but you are in LA), then the NY time zone will most probably be used.
+If your Jenkins controller is running in a different location than your own (for example: the server is in NY but you are in LA), then the NY time zone will most probably be used.
 This may be quite annoying if you need to compare build dates.
 
 To see the time zone currently set, go to `jenkins_server/systemInfo` and see the `+user.timezone+` system property.

--- a/content/doc/book/using/pluggable-storage.adoc
+++ b/content/doc/book/using/pluggable-storage.adoc
@@ -229,7 +229,7 @@ Please try it out, report issues to link:https://github.com/jenkinsci/junit-plug
 
 The fingerprints are stored within `JENKINS_HOME` inside a local XML-based database.
 Externalizing fingerprints decreases the dependence of Jenkins on the physical disk storage of the controller, and allows configuring of cloud storages which can be cheaper, and more reliable.
-Another advantage is that it would allow tracing fingerprints across Jenkins instances and the entire CI/CD flow.
+Another advantage is that it would allow tracing fingerprints across Jenkins controllers and the entire CI/CD flow.
 
 Status:
 

--- a/content/doc/book/using/referencing-another-project-by-name.adoc
+++ b/content/doc/book/using/referencing-another-project-by-name.adoc
@@ -11,7 +11,7 @@ In many places throughout Jenkins, you can refer to another project/job by name.
 copyArtifacts projectName: 'myproject'
 ....
 
-That's all you need to do if your target project's name is simply alphanumeric, and is a simple project without subprojects, and has a unique name throughout your entire Jenkins instance. Read on for more complex scenarios…
+That's all you need to do if your target project's name is simply alphanumeric, and is a simple project without subprojects, and has a unique name throughout your entire Jenkins controller. Read on for more complex scenarios…
 
 == Differentiating between multiple projects with the same name
 
@@ -19,7 +19,7 @@ If you're using the plugin:cloudbees-folder[Folders Plugin] and you have multipl
 
 === Absolute paths
 
-Absolute paths begin with a forward slash, and refer to a project by describing the complete path to navigate to the project from the home page of your Jenkins instance. For example, to reference a project in the root of your Jenkins instance:
+Absolute paths begin with a forward slash, and refer to a project by describing the complete path to navigate to the project from the home page of your Jenkins controller. For example, to reference a project in the root of your Jenkins controller:
 
 ....
 /myproject

--- a/content/doc/book/using/remote-access-api.adoc
+++ b/content/doc/book/using/remote-access-api.adoc
@@ -20,7 +20,7 @@ URL where `+"..."+` portion is the data that it acts on.
 For example, if your Jenkins installation sits at https://ci.jenkins.io,
 visiting https://ci.jenkins.io/api/ will show just the top-level API
 features available – primarily a listing of the configured jobs for this
-Jenkins instance. +
+Jenkins controller. +
 Or if you want to access information about a particular build, e.g.
 https://ci.jenkins.io/job/Websites/job/jenkins.io/job/master/lastSuccessfulBuild/ , then go to
 https://ci.jenkins.io/job/Websites/job/jenkins.io/job/master/lastSuccessfulBuild/api/ and you'll
@@ -144,7 +144,7 @@ Services offered currently include:
 * Search for artifacts by simple criteria
 * Block until jobs are complete
 * Install artifacts to custom-specified directory structures
-* Authentication support for Jenkins instances
+* Authentication support for Jenkins controllers
 * Ability to search for builds by subversion revision
 * Ability to add/remove/query Jenkins agents
 

--- a/content/doc/book/using/using-credentials.adoc
+++ b/content/doc/book/using/using-credentials.adoc
@@ -61,12 +61,12 @@ Jenkins can store the following types of credentials:
 == Credential security
 
 To maximize security, credentials configured in Jenkins are stored in an
-encrypted form on the controller Jenkins instance (encrypted by the Jenkins
-instance ID) and are only handled in Pipeline projects via their credential IDs.
+encrypted form on the controller Jenkins controller (encrypted by the Jenkins
+controller ID) and are only handled in Pipeline projects via their credential IDs.
 
 This minimizes the chances of exposing the actual credentials themselves to
 Jenkins users and hinders the ability to copy functional credentials from one
-Jenkins instance to another.
+Jenkins controller to another.
 
 
 == Configuring credentials
@@ -81,14 +81,14 @@ link:../../managing/security/#authorization[Authorization] section of
 link:../../managing/security[Managing Security].
 
 Otherwise, any Jenkins user can add and configure credentials if the
-*Authorization* settings of your Jenkins instance's *Security*
+*Authorization* settings of your Jenkins controller's *Security*
 settings page is set to the default *Logged-in users can do anything* setting or
 *Anyone can do anything* setting.
 
 
 === Adding new global credentials
 
-To add new global credentials to your Jenkins instance:
+To add new global credentials to your Jenkins controller:
 
 . If required, ensure you are logged in to Jenkins (as a user with the
   *Credentials > Create* permission).
@@ -116,7 +116,7 @@ image:../../../images/using/system_global_credentials.png[image,title="System_gl
   * *Global* - if the credential/s to be added is/are for a Pipeline
     project/item. Choosing this option applies the scope of the credential/s to
     the Pipeline project/item "object" and all its descendant objects.
-  * *System* - if the credential/s to be added is/are for the Jenkins instance
+  * *System* - if the credential/s to be added is/are for the Jenkins controller
     itself to interact with system administration functions, such as email
     authentication, agent connection, etc. Choosing this option applies the
     scope of the credential/s to a single object only.
@@ -141,7 +141,7 @@ image:../../../images/using/system_global_credentials.png[image,title="System_gl
   `jenkins-user-for-xyz-artifact-repository`. The inbuilt (default) credentials provider
   can use uppercase or lowercase letters for the credential ID, as well as any valid separator character,
   other credential providers may apply further restrictions on allowed characters or lengths.
-  However, for the benefit of all users on your Jenkins instance, it is best to
+  However, for the benefit of all users on your Jenkins controller, it is best to
   use a single and consistent convention for specifying credential IDs. +
   *Note:* This field is optional. If you do not specify its value, Jenkins
   assigns a globally unique ID (GUID) value for the credential ID. Bear in mind


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291