### PR TITLE
Update to remove usage of "jenkins instance" in Tutorials

### DIFF
--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -54,9 +54,9 @@ To begin this process, do either of the following, where `<your-username>` is th
 git clone https://github.com/YOUR-GITHUB-ACCOUNT-NAME/simple-java-maven-app
 ----
 
-=== Start your Jenkins instance
+=== Start your Jenkins controller
 
-1. Obtain the latest Jenkins instance, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
+1. Obtain the latest Jenkins deployment, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
 2. After cloning, navigate to the `quickstart-tutorials` directory, and execute the command
 +
 ----
@@ -67,7 +67,7 @@ to run the example.
 
 If you are unable to install `docker compose` on your machine for any reason, you can still run the example in the cloud for free thanks to link:https://www.gitpod.io/[GitPod]. GitPod link:https://www.gitpod.io/pricing[is free] for 50 hours per month.
 You need to link it to your GitHub account so you can run the example in the cloud.
-Click on link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[that link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins instance, and run the rest of the tutorial.
+Click on link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[that link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins controller, and run the rest of the tutorial.
 
 Now, log in using the `admin` username and `admin` password.
 

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -125,9 +125,9 @@ git checkout master
   production
 ----
 
-=== Start your Jenkins instance
+=== Start your Jenkins controller
 
-1. Obtain the latest Jenkins instance, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
+1. Obtain the latest Jenkins deployment, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
 2. After cloning, navigate to the `quickstart-tutorials` directory, and execute the command
 +
 ----
@@ -138,7 +138,7 @@ to run the example.
 
 If you are unable to install `docker compose` on your machine for any reason, you can still run the example in the cloud for free thanks to link:https://www.gitpod.io/[GitPod]. GitPod link:https://www.gitpod.io/pricing[is free] for 50 hours per month.
 You need to link it to your GitHub account so you can run the example in the cloud.
-Click on link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[that link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins instance, and run the rest of the tutorial.
+Click on link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[that link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins controller, and run the rest of the tutorial.
 
 Now, log in using the `admin` username and `admin` password.
 

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -71,9 +71,9 @@ If you need help with this process, refer to the https://help.github.com/article
    `git clone \https://github.com/YOUR-GITHUB-ACCOUNT-NAME/simple-node-js-react-npm-app` +
    where `YOUR-GITHUB-ACCOUNT-NAME` is the name of your GitHub account.
 
-=== Start your Jenkins instance
+=== Start your Jenkins controller
 
-1. Obtain the latest Jenkins instance, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
+1. Obtain the latest Jenkins deployment, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
 2. After cloning, navigate to the `quickstart-tutorials` directory and execute the command
 +
 ----
@@ -85,7 +85,7 @@ to run the example.
 If you are unable to install `docker compose` on your machine for any reason, you can still run the example in the cloud for free thanks to link:https://www.gitpod.io/[GitPod].
 GitPod link:https://www.gitpod.io/pricing[is free] for 50 hours per month.
 You need to link it to your GitHub account so you can run the example in the cloud.
-Utilize link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[this link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins instance and run the rest of the tutorial.
+Utilize link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[this link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins controller and run the rest of the tutorial.
 
 Now, log in using the `admin` username and `admin` password.
 

--- a/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
+++ b/content/doc/tutorials/build-a-python-app-with-pyinstaller.adoc
@@ -77,9 +77,9 @@ To begin this process, do either of the following (where `<your-username>` is th
    `git clone \https://github.com/YOUR-GITHUB-ACCOUNT-NAME/simple-python-pyinstaller-app` +
    where `YOUR-GITHUB-ACCOUNT-NAME` is the name of your GitHub account.
 
-=== Start your Jenkins instance
+=== Start your Jenkins controller
 
-1. Obtain the latest Jenkins LTS instance, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
+1. Obtain the latest Jenkins LTS deployment, customized for this tutorial, by cloning the link:https://github.com/jenkins-docs/quickstart-tutorials.git[quickstart-tutorials repository].
 2. After cloning, navigate to the `quickstart-tutorials` directory, and execute the command
 +
 ----
@@ -91,7 +91,7 @@ to run the example.
 If you are unable to install `docker compose` on your machine for any reason, you can still run the example in the cloud for free thanks to link:https://www.gitpod.io/[GitPod].
 GitPod link:https://www.gitpod.io/pricing[is free] for 50 hours per month.
 You need to link it to your GitHub account so you can run the example in the cloud.
-Click on link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[that link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins instance, and run the rest of the tutorial.
+Click on link:https://gitpod.io/?autostart=true#https://github.com/jenkins-docs/quickstart-tutorials[that link] to open a new browser tab with a GitPod workspace where you'll be able to start the Jenkins controller, and run the rest of the tutorial.
 
 Now, log in using the `admin` username and `admin` password.
 

--- a/content/doc/tutorials/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
+++ b/content/doc/tutorials/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
@@ -12,7 +12,7 @@ This tutorial shows you how to use link:https://jenkinsci.github.io/jfr-action-d
 
 === The concept
 
-Classical Jenkins instances bind physically with the permanently running servers. 
+Classical Jenkins controllers bind physically with the permanently running servers. 
 link:https://github.com/jenkinsci/jenkinsfile-runner[Jenkinsfile Runner] packages the Jenkins core and other necessary items, and serves as an entry point to your pipeline job.
 At a high level, Jenkinsfile Runner GitHub Actions wrap around the Jenkinsfile Runner and other necessary modules for the user. 
 Once the user commits the changes to the remote GitHub repository, the GitHub Actions will run the pipeline as defined by the Jenkinsfile. 
@@ -68,7 +68,7 @@ pipeline {
 
 === Create a plugin list file
 
-In this section, you will create a plugin list file, which specifies the plugins you will need to install in the ephemeral Jenkins instance. 
+In this section, you will create a plugin list file, which specifies the plugins you will need to install in the ephemeral Jenkins controller. 
 Please refer to link:https://github.com/jenkinsci/plugin-installation-manager-tool#plugin-input-format[the valid plugin input format]. 
 
 The following example plugin list file will install all the specified latest plugins.
@@ -205,8 +205,8 @@ image:tutorials/jenkinsfile-runner-github-actions-01-access-workflow-logs.jpeg[a
 === Add JCasC (optional)
 
 Typically, we need to access the web UI to set up Jenkins. 
-However, we’re unable to access the web UI under the circumstances of running Jenkins pipeline in the GitHub Actions, since the Jenkins instance is ephemeral. 
-The JCasC (link:https://github.com/jenkinsci/configuration-as-code-plugin[Jenkins Configuration as Code]) plugin can configure this ephemeral Jenkins instance, by providing the human-readable declarative configuration files. 
+However, we’re unable to access the web UI under the circumstances of running Jenkins pipeline in the GitHub Actions, since the Jenkins controller is ephemeral. 
+The JCasC (link:https://github.com/jenkinsci/configuration-as-code-plugin[Jenkins Configuration as Code]) plugin can configure this ephemeral Jenkins controller, by providing the human-readable declarative configuration files. 
 
 In this example, we review how to set up the environment variables by JCasC and access them in the Jenkinsfile.
 
@@ -249,17 +249,17 @@ with:
   jcasc: jcasc.yml
 ----
 
-For additional information, refer to the link:https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples] provided by the plugin:configuration-as-code[Configuration as Code] plugin, and learn how to configure the Jenkins instance without using the UI page. 
+For additional information, refer to the link:https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples] provided by the plugin:configuration-as-code[Configuration as Code] plugin, and learn how to configure the Jenkins controller without using the UI page. 
 Some plugins do not have concrete examples, but you can debug and find their JCasC in the UI page. 
 You can check the configuration in *Manage Jenkins* -> *Configuration as Code* -> *View Configuration*. 
 Then, you can copy the parts you need to the JCasC file.
 
 === Add and configure plugins (optional)
 
-There are many powerful plugins that can be part of your Jenkins instance. 
+There are many powerful plugins that can be part of your Jenkins controller. 
 You can add the plugins in the plugin list file, and configure the plugins in the JCasC YAML file as needed.
 
-In this example, we review how to install JDK11 in the ephemeral Jenkins instance.
+In this example, we review how to install JDK11 in the ephemeral Jenkins controller.
 
 . Specify `adoptopenjdk` plugin in the plugins.txt file. 
 As the version is not specified, the latest version will be installed.
@@ -320,16 +320,16 @@ with:
   jcasc: jcasc.yml
 ----
 
-=== Configure ephemeral Jenkins instance (optional)
+=== Configure ephemeral Jenkins controller (optional)
 
 Sometimes, JCasC might not be able to provide the configurations you need. 
-In this case, refer to link:/doc/book/managing/groovy-hook-scripts/[Groovy Hook Scripts] to set up the ephemeral Jenkins instance.
+In this case, refer to link:/doc/book/managing/groovy-hook-scripts/[Groovy Hook Scripts] to set up the ephemeral Jenkins controller.
 These Groovy scripts will have full access to the ephemeral Jenkins server and will be executed right after Jenkins starts up.
 
 NOTE: This option and its core are still in progress, so it’s not mentioned in the Jenkinsfile Runner GitHub Actions official guide.
 However, it does work and can be used at this time.
 
-In this example, we review how to use Groovy scripts to set up the Jenkins instance:
+In this example, we review how to use Groovy scripts to set up the Jenkins controller:
 
 . Create a directory, for example `groovy.init.d`, to store all your Groovy setup scripts.
 . Create a Groovy file called `test.groovy`.
@@ -418,7 +418,7 @@ Refer to the link:https://github.com/jenkinsci/jfr-action-demo/tree/master/demo/
 Well done!
 You have now built your project by using Jenkinsfile Runner GitHub Actions!
 
-When you want to make your ephemeral Jenkins instances in the GitHub Actions more extensible, you can refer to the link:https://jenkinsci.github.io/jfr-action-doc/[official guide] for more details.
+When you want to make your ephemeral Jenkins controllers in the GitHub Actions more extensible, you can refer to the link:https://jenkinsci.github.io/jfr-action-doc/[official guide] for more details.
 The official guide shows the parameters of these GitHub Actions, their comparisons, and other advanced functionality.
 You can also find additional examples in the link:https://github.com/jenkinsci/jfr-action-demo[official demo repository].
 


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291