### PR TITLE
Update to remove usage of "jenkins instance" on LTS download page 

### DIFF
--- a/content/download/lts/index.adoc
+++ b/content/download/lts/index.adoc
@@ -106,7 +106,7 @@ If the backport is rejected, a label like `2.46.2-rejected` is used to indicate 
 ## Switching Between Release Lines
 
 Due to how Jenkins stores data internally, users are generally able to upgrade to newer releases, but not downgrade to older releases.
-In the context of LTS, the _baseline_ is almost always the deciding factor that determines to which releases of the other line a Jenkins instance can be migrated.
+In the context of LTS, the _baseline_ is almost always the deciding factor that determines to which releases of the other line a Jenkins controller can be migrated.
 
 ### Switching From LTS to Weekly
 


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291