### PR TITLE
Update to remove usage of "jenkins instance" in Developer documentation

### DIFF
--- a/content/doc/developer/plugin-development/build-process.adoc
+++ b/content/doc/developer/plugin-development/build-process.adoc
@@ -13,7 +13,7 @@ references:
 Most Jenkins plugins are built with link:https://maven.apache.org[Maven].
 They typically use the link:https://github.com/jenkinsci/plugin-pom/[Jenkins plugin POM] as their parent link:https://maven.apache.org/pom.html[POM], which provides a sensible default configuration for the plugin build.
 The link:https://github.com/jenkinsci/maven-hpi-plugin/[Maven HPI plugin] is one of the plugins configured there.
-It does the heavy lifting, such as bundling plugins in the HPI/JPI archive format used for Jenkins plugins, or allowing developers to run a debug Jenkins instance with the plugin.
+It does the heavy lifting, such as bundling plugins in the HPI/JPI archive format used for Jenkins plugins, or allowing developers to run a debug Jenkins controller with the plugin.
 
 Since version 2.0 of the plugin POM, it's possible to specify the core version dependency of the parent POM independent of its version.footnote:[Up to Jenkins 1.645, the plugin POM was kept in sync with Jenkins releases, so that the minimum required Jenkins version for a plugin determined the versions of the tools used to build the plugin. These versions should no longer be used.]
 This allows plugins compatible with older Jenkins releases to benefit from fixes and improvements in the parent POM.

--- a/content/doc/developer/publishing/continuous-integration.adoc
+++ b/content/doc/developer/publishing/continuous-integration.adoc
@@ -3,7 +3,7 @@ title: Continuous Integration - buildPlugin
 layout: developersection
 ---
 
-The Jenkins project runs its own Jenkins instance for CI builds on link:https://ci.jenkins.io/[ci.jenkins.io].
+The Jenkins project runs its own Jenkins controller for CI builds on link:https://ci.jenkins.io/[ci.jenkins.io].
 It will build all plugin repositories in the `jenkinsci` organization that have a `Jenkinsfile` in the root of the repository.
 
 The typical plugin build (Maven or Gradle) can be run by just having the following statement in the `Jenkinsfile`:

--- a/content/doc/developer/publishing/plugin-site.adoc
+++ b/content/doc/developer/publishing/plugin-site.adoc
@@ -24,13 +24,13 @@ All plugins published to the current (weekly) update center are listed.
 === What is the plugin installation trend based on?
 
 This uses the monthly data from https://stats.jenkins.io as gathered
-from Jenkins instances that have not opted out of reporting data.
+from Jenkins controllers that have not opted out of reporting data.
 
 Learn more on the link:../usage-statistics[usage statistics page].
 
 === What does "most installed" mean?
 
-This ranks plugins by the number of different Jenkins instances that
+This ranks plugins by the number of different Jenkins controllers that
 reported the plugin installed during the previous month.
 
 === What does 'Recently updated' mean?

--- a/content/doc/developer/publishing/requesting-hosting.adoc
+++ b/content/doc/developer/publishing/requesting-hosting.adoc
@@ -45,7 +45,7 @@ This means:
 
 == Enable CI Builds
 
-The Jenkins project hosts a Jenkins instance to perform continuous integration builds for plugins.
+The Jenkins project hosts a Jenkins controller to perform continuous integration builds for plugins.
 We recommend you set up CI builds for your plugin in the `jenkinsci` GitHub organization by creating a `Jenkinsfile` in your plugin's GitHub repository.
 See link:../continuous-integration[the documentation for CI builds] for details how to do this.
 

--- a/content/doc/developer/publishing/usage-statistics.adoc
+++ b/content/doc/developer/publishing/usage-statistics.adoc
@@ -5,10 +5,10 @@ layout: developersection
 
 == Overview
 
-Anonymous usage statistics are collected from Jenkins instance that have not opted out from this.
+Anonymous usage statistics are collected from Jenkins controllers that have not opted out from this.
 They help us identify trends in Jenkins use and configuration, like the popularity of plugins and average number of plugins installed on instances.
 
-Those usage statistics are encrypted on individual Jenkins instances and sent to the Jenkins project infrastructure, where they are stored.
+Those usage statistics are encrypted on individual Jenkins controllers and sent to the Jenkins project infrastructure, where they are stored.
 Decryption and anonymization is done in one step using the https://github.com/jenkins-infra/usage-log-decrypter[Usage Log Decrypter] to ensure no private data, like private-source plugin usage information, is published.
 Only members of the link:/project/governance/#governance-board[Jenkins governance board] have the decryption key.
 

--- a/content/doc/developer/security/misc.adoc
+++ b/content/doc/developer/security/misc.adoc
@@ -66,7 +66,7 @@ Other programs should generally be invoked using a jenkinsdoc:hudson.Launcher[`L
 Directly using `Runtime#exec` and similar Java APIs is usually a bug and can in some cases constitute a security vulnerability:
 While users with the permissions to configure and run jobs may be able to invoke arbitrary tools on those agents, they should not be able to run programs on the Jenkins controller.
 
-NOTE: Most Jenkins instances archive artifacts on the Jenkins controller file system, so even possible constraints, such as for the command to exist on the controller's file system, or not taking any arguments, is trivially bypassed.
+NOTE: Most Jenkins controllers archive artifacts on the Jenkins controller file system, so even possible constraints, such as for the command to exist on the controller's file system, or not taking any arguments, is trivially bypassed.
 
 
 === Dealing with SSL/TLS Connection Issues
@@ -78,7 +78,7 @@ This is a very unsafe behavior and must never be the default in plugins distribu
 Ignoring SSL/TLS errors is only permitted if the following constraints are both followed:
 
 1. Ignoring SSL/TLS errors is limited to the specific connections opened by the plugin.
-   Plugins should never cause SSL/TLS errors to be ignored for the entire Jenkins instance.
+   Plugins should never cause SSL/TLS errors to be ignored for the entire Jenkins controller.
    As a consequence, APIs like `HttpsURLConnection#setDefaultHostnameVerifier` or `HttpsURLConnection#setDefaultSSLSocketFactory` must not be called by plugins.
    The only exceptions to this rule are dedicated plugins with only this purpose, like plugin:skip-certificate-check[skip-certificate-check].
 2. Ignoring SSL/TLS problems for specific connections (e.g. `HttpsURLConnection#setHostnameVerifier` or `HttpsURLConnection#setSSLSocketFactory`) is allowed, but users need to opt in to this behavior.

--- a/content/doc/developer/security/secrets.adoc
+++ b/content/doc/developer/security/secrets.adoc
@@ -94,4 +94,4 @@ Common key ids include:
 * `hudson.util.Secret`: used for generic secrets;
 * `com.cloudbees.plugins.credentials.SecretBytes.KEY`: used for some credentials types;
 * `jenkins.model.Jenkins.crumbSalt`: used by the link:/doc/book/managing/security/#cross-site-request-forgery[CSRF protection mechanism]; and
-* `org.jenkinsci.main.modules.instance_identity.InstanceIdentity.KEY`: used to identify the Jenkins instance.
+* `org.jenkinsci.main.modules.instance_identity.InstanceIdentity.KEY`: used to identify the Jenkins controller.

--- a/content/doc/developer/security/xss-prevention.adoc
+++ b/content/doc/developer/security/xss-prevention.adoc
@@ -71,7 +71,7 @@ blurb=<a href="https://jenkins.io/">{0}</a>
 === Rendering Pre-Escaped Content
 
 In rare cases, it might be necessary to render content that has previously been escaped or otherwise processed, without further escaping.
-A common reason to do this is to support formatting using the jenkinsdoc:MarkupFormatter[markup formatter configured for the current Jenkins instance], with might support a plugin:antisamy-markup-formatter[safe subset of HTML], or other markup languages, like plugin:pegdown-formatter[Markdown].
+A common reason to do this is to support formatting using the jenkinsdoc:MarkupFormatter[markup formatter configured for the current Jenkins controller], with might support a plugin:antisamy-markup-formatter[safe subset of HTML], or other markup languages, like plugin:pegdown-formatter[Markdown].
 In those cases, the security is controlled by the markup formatter.
 
 To do that, use the `<j:out>` Jelly tag:

--- a/content/doc/developer/telemetry/index.adoc
+++ b/content/doc/developer/telemetry/index.adoc
@@ -42,5 +42,5 @@ This should best be done before the telemetry change is released or even merged,
 
 === Backporting (Jenkins core)
 
-As telemetry is time-sensitive, and the majority of users use LTS releases, telemetry implementations in core should generally be backported freely into LTS releases to ensure data is collected from as many up-to-date Jenkins instances as possible.
+As telemetry is time-sensitive, and the majority of users use LTS releases, telemetry implementations in core should generally be backported freely into LTS releases to ensure data is collected from as many up-to-date Jenkins controllers as possible.
 The link:/download/lts/#backporting-process[general LTS backporting rules] are relaxed for telemetry-related changes.

--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -164,7 +164,7 @@ These are fewer in number compared to unit tests.
 Integration tests verify that different parts of the system work together as intended.
 For Jenkins, this makes use of the link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/JenkinsRule.html[`JenkinsRule`] to test the integration of the plugin into Jenkins.
 For Jenkins, integration tests including the UI make use of the link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/JenkinsRule.html[`JenkinsRule`], link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/JenkinsSessionRule.html[`JenkinsSessionRule`] or link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/RealJenkinsRule.html[`RealJenkinsRule`] in combination with the link:https://javadoc.jenkins.io/component/jenkins-test-harness/org/jvnet/hudson/test/JenkinsRule.html#createWebClient()[`createWebClient()`]-call, which is used to create a call to an HTML-Unit endpoint to then assert something on the result.
-The different Rule types get more and more realistic towards a real Jenkins instance, but are still for integration tests.
+The different Rule types get more and more realistic towards a real Jenkins controller, but are still for integration tests.
 This can be a test for a new build step and testing the results in the UI with a test pipeline.
 
 3. *End-to-End Tests (E2E) and UI Tests*: At the top of the pyramid, end-to-end tests are the fewest in number but typically the most complex.
@@ -460,7 +460,7 @@ computer.disconnect(new OfflineCause.IdleOfflineCause());
 ----
 
 === Enabling security
-If you need a security realm for testing you can use a `MockAuthorizationStrategy()` where you can grant rights as needed for your test. In the following example everyone gets `READ` on the Jenkins instance and users *alice* and *bob* get individual rights. Using `LocalData` presets can be used if you need to setup a lot for your test.
+If you need a security realm for testing you can use a `MockAuthorizationStrategy()` where you can grant rights as needed for your test. In the following example everyone gets `READ` on the Jenkins controller and users *alice* and *bob* get individual rights. Using `LocalData` presets can be used if you need to setup a lot for your test.
 
 [source,java]
 ----

--- a/content/doc/developer/tutorial/extend.adoc
+++ b/content/doc/developer/tutorial/extend.adoc
@@ -88,7 +88,7 @@ Now, we actually need to create an instance of this class when the build step is
 
 Save these changes, and run the plugin again using `mvn hpi:run`.
 
-NOTE: Whenever changing the Java source code or adding or removing resource files, you will need to restart the Jenkins instance for the changes to take effect. Only some resource files can be edited while Jenkins is running via `hpi:run`.
+NOTE: Whenever changing the Java source code or adding or removing resource files, you will need to restart the Jenkins controller for the changes to take effect. Only some resource files can be edited while Jenkins is running via `hpi:run`.
 
 Now, when running a build with this build step, the action will be added to the build data. We can confirm this by looking at the `build.xml` file corresponding to the build in the `work/jobs/_JOBNAME_/builds/_BUILDNUMBER_/` directory.
 

--- a/content/doc/developer/tutorial/run.adoc
+++ b/content/doc/developer/tutorial/run.adoc
@@ -19,7 +19,7 @@ endif::[]
 - link:../extend[Step 4: Extend the Plugin]
 
 The Maven HPI Plugin is used to build and package Jenkins plugins.
-It also provides a convenient way to run a Jenkins instance with your plugin:
+It also provides a convenient way to run a Jenkins controller with your plugin:
 
 [source,bash]
 ----
@@ -34,7 +34,7 @@ mvn hpi:run -Dport=5000
 
 NOTE: To learn more about Maven HPI Plugin and the goals it provides, see link:https://jenkinsci.github.io/maven-hpi-plugin/[its documentation].
 
-This will set up a Jenkins instance on `\http://localhost:8080/jenkins/`. Wait for the following console output, then open a web browser and look at what the plugin does.
+This will set up a Jenkins controller on `\http://localhost:8080/jenkins/`. Wait for the following console output, then open a web browser and look at what the plugin does.
 
 [listing]
 INFO: Jenkins is fully up and running

--- a/content/doc/developer/views/table-to-div-migration.adoc
+++ b/content/doc/developer/views/table-to-div-migration.adoc
@@ -73,7 +73,7 @@ it would be good to contribute fixes or enhancements to core rather than doing t
 Maintaining such support is preferred where it is easily possible, to allow plugins to be updated and used
 on Jenkins deployments with older core versions (including current LTS 2.263.x at the time of this writing).
 
-There is a jelly property set on Jenkins instances that use div's for form layout called `divBasedFormLayout`,
+There is a jelly property set on Jenkins controllers that use div's for form layout called `divBasedFormLayout`,
 so you can adapt your plugin UI based on the presence of this property.
 
 _Note: This property is only set if the form tag uses the `f:form` jelly tag, and not the HTML `form` tag,
@@ -107,7 +107,7 @@ Jelly example:
 </j:jelly>
 ----
 
-This will use a table on Jenkins instances that don't have `divBasedFormLayout` and will use a div when it is set.
+This will use a table on Jenkins controllers that don't have `divBasedFormLayout` and will use a div when it is set.
 
 _Note: You will likely need more tags to adapt the `tr` and `td` tags to divs see link:https://github.com/jenkinsci/multiple-scms-plugin/pull/25[multiple-scms-plugin#25] for a full example, or link:https://github.com/jenkinsci/notification-plugin/pull/40/files[notification-plugin#40] for an even more extensive example of different wrapper types (note they are shipped in separate files, included from the jelly files to edit with references like `xmlns:p="/lib/notification"` with a path part relative to `src/main/resources/` directory)._
 


### PR DESCRIPTION
This PR is part of the work to update the usage of "jenkins instance" in the documentation to something more correct/concrete with "controller" in most cases.

Original issue related to this task: https://github.com/jenkins-infra/jenkins.io/issues/7291