### PR TITLE
Remove changes from 2.426.1 changelog that weren't new to LTS.

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9812,28 +9812,6 @@
     pr_title: "Add telemetry for Jenkins uptime"
     message: |-
       Add telemetry for Jenkins uptime.
-  - type: rfe
-    category: rfe
-    pull: 8587
-    issue: 72156
-    authors:
-    - olamy
-    pr_title: "[JENKINS-72156] Backport Upgrade to Winstone 6.14 which contains an upgrade to Jetty 10.0.17"
-    references:
-      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.13
-        title: Winstone 6.13 changelog
-      - url: https://github.com/jenkinsci/winstone/releases/tag/winstone-6.14
-        title: Winstone 6.14 changelog
-      - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.16
-        title: Jetty 10.0.16 changelog
-      - url: https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.17
-        title: Jetty 10.0.17 changelog
-      - url: https://nvd.nist.gov/vuln/detail/CVE-2023-44487
-        title: CVE-2023-44487
-    message: |-
-      Upgrade Winstone from 6.12 to 6.14.
-      This includes the upgrade of Jetty from 10.0.15 to 10.0.17.
-      The Jetty upgrade includes fixes for several CVEs.
   - type: bug
     category: regression
     pull: 8606
@@ -9865,17 +9843,6 @@
 
   lts_changes: # compared to lts_predecessor 2.414.3 (selected by personal review)
 
-  - type: security
-    authors:
-      - Kevin-CB
-      - dwnusbaum
-    message: |-
-      Important security fixes.
-    references:
-      - url: /security/advisory/2023-09-20/
-        title: 2023-09-20 security advisory
-      - url: /security/advisory/2023-07-26/
-        title: 2023-07-26 security advisory
   - type: major rfe
     category: major rfe
     authors:
@@ -10064,14 +10031,6 @@
       Allow requests to resources like stylesheets and images, even if a reverse proxy prohibits cross-site requests.
   - type: rfe
     category: rfe
-    pull: 8129
-    authors:
-      - janfaracik
-    pr_title: Add last build status to job page
-    message: |-
-      Add last build status to job page.
-  - type: rfe
-    category: rfe
     pull: 8446
     authors:
     - mustafau
@@ -10096,25 +10055,6 @@
     pr_title: "Remove KXML2 library"
     message: |-
       Stop shipping <code>net.sf.kxml:kxml2</code> because Jenkins no longer depends on it.
-  - type: bug
-    category: bug
-    pull: 8425
-    issue: 71479
-    authors:
-      - dwnusbaum
-    pr_title: "[JENKINS-71479] Do not use SCSS lighten function directly to avoid\
-      \ invalid CSS"
-    message: |-
-      Fix invalid CSS which caused some buttons to become invisible on hover.
-  - type: bug
-    category: bug
-    pull: 8529
-    issue: 72067
-    authors:
-      - basil
-    pr_title: "[JENKINS-72067] High memory usage from `XStream2.AssociatedConverterImpl`"
-    message: |-
-      Reduce high memory usage from <code>XStream2.AssociatedConverterImpl</code>.
   - type: bug
     category: bug
     pull: 8474
@@ -10142,16 +10082,6 @@
       \ CSS class are not hidden when they are alone"
     message: |-
       Hide the delete button from the only repeatable element in configuration forms when at least one element is expected.
-  - type: bug
-    category: bug
-    pull: 8490
-    issue: 72016
-    authors:
-      - jglick
-    pr_title: "[JENKINS-72016] Define a thread pool for `ProxyConfiguration`'s\
-      \ `HttpClient`"
-    message: |-
-      Do not create a large number of threads when making numerous HTTP requests.
   - type: bug
     category: bug
     pull: 8471
@@ -10207,16 +10137,6 @@
     message: |-
       Add the <code>X-Content-Type-Options</code> HTTP header to the response from the agent listener.
       Silence security scanners that incorrectly report an issue when the HTTP header is missing.
-  - type: bug
-    category: bug
-    pull: 8293
-    issue: 71698
-    authors:
-      - timja
-    pr_title: "[JENKINS-71698] Only disable plugin manager button if none are\
-      \ selected"
-    message: |-
-      Only disable the plugin manager "install" button if no plugins are selected.
   - type: bug
     category: bug
     pull: 8233


### PR DESCRIPTION
Amends #6802.

PTAL @kmartens27 since there seems to be a misunderstanding about the purpose of this section.

As a rule of thumb, if it's already listed on https://www.jenkins.io/changelog-stable/ , don't add it to `lts_changes` of a new `.1`.