### PR TITLE
Adjust content in GSoC GitHub permissions blog

### DIFF
--- a/content/blog/2024/08/26/2024-08-26-gsoc-manage-github-permissions.adoc
+++ b/content/blog/2024/08/26/2024-08-26-gsoc-manage-github-permissions.adoc
@@ -12,15 +12,15 @@ sig:
 ---
 = GSOC Manage jenkinsci GitHub permissions as code
 
-This blog showcases all the work done in the project link:/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization/[Manage jenkinsci GitHub permissions as code] during Google Summer of Code 2024.
+This blog showcases all the work done in the link:/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization/[Manage jenkinsci GitHub permissions as code] project during Google Summer of Code 2024.
 
 == About the Project
 
-This project aims to create a solution that allows the Repository Permission Updater (RPU) to manage jenkinsci GitHub permissions as code. RPU is a vital tool used by Jenkins to manage artifactory permissions, bridge discrepancies between Jira and GitHub issues, and enable automatic releases. Currently, RPU oversees over 2600 GitHub teams, with all team modifications handled manually by the hosting team. Automating these processes aims to significantly enhance productivity by reducing the manual workload.
+This project aims to create a solution that allows the Repository Permission Updater (RPU) to manage `jenkinsci` GitHub permissions as code. RPU is a vital tool used by Jenkins to manage artifactory permissions, bridge discrepancies between Jira and GitHub issues, and enable automatic releases. Currently, RPU oversees over 2600 GitHub teams, with all team modifications handled manually by the hosting team. Automating these processes aims to significantly enhance productivity by reducing the manual workload.
 
 In Jenkins, there is a strategy of using teams to manage permissions effectively. Teams are categorized into two types:
 
-*Repository Teams* are directly linked to specific repositories. The names of these teams typically follow the format $repo_name + Developers and they automatically assume the admin role. The developers in these teams are managed within the "permissions" section.
+*Repository Teams* are directly linked to specific repositories. The names of these teams typically follow the format `$repo_name + Developers` and they automatically assume the admin role. The developers in these teams are managed within the "permissions" section.
 
 *Additional GitHub Teams*, in contrast to repository teams, oversee multiple repositories without being attached to any particular one. The roles of these teams can vary, depending on the needs of the repositories they manage. The developers in these teams are organized within the "teams" section.
 
@@ -155,4 +155,4 @@ The development of this project has followed a complex path, shaped by real-worl
 * link:https://github.com/jenkins-infra/repository-permissions-updater/pull/3998[PR Review]
 
 == Summary
-I am grateful for the opportunity to be a part of this project; without it, my amazing journey at Jenkins would not have been possible. Special thanks to my mentor author:notmyfault[Alexander Brandes] for his support throughout the process. I also owe a lot to the org admins, particularly author:alyssat[Alyssa Tong], who not only adjusted her schedule to overcome time zone differences but also provided invaluable guidance in project management, author:krisstern[Kris Stern] was always there to assist with development challenges, offering as much help as he could. Lastly, thanks to author:gounthar[Bruno Verachten] for his support.
+I am grateful for the opportunity to be a part of this project; without it, my amazing journey at Jenkins would not have been possible. Special thanks to my mentor author:notmyfault[Alexander Brandes] for his support throughout the process. I also owe a lot to the org admins, particularly author:alyssat[Alyssa Tong], who not only adjusted her schedule to overcome time zone differences but also provided invaluable guidance in project management, author:krisstern[Kris Stern] was always there to assist with development challenges, offering as much help as she could, and lastly, thanks to author:gounthar[Bruno Verachten] for his support.


### PR DESCRIPTION
This PR is to adjust a handful of items in the GSoC Manage Jenkinsci Github Permissions as code blog. There were a couple of things that needed formatting, and pronoun correction for Kris Stern.