### PR TITLE
Fix size of user avatars

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1402,6 +1402,7 @@ ion-icon.report {
   min-width: 64px;
   width: 25vw; 
   max-width: 128px; 
-  min-height: 64px; 
+  min-height: 64px;
+  height: 25vw;
   max-height: 128px
 }

--- a/content/stylesheets/components/_chips.scss
+++ b/content/stylesheets/components/_chips.scss
@@ -6,9 +6,11 @@
 
   .app-avatar {
     width: 1.4rem;
+    height: 1.4rem;
 
     @media (max-width: $app-mobile-breakpoint) {
       width: 1.625rem;
+      height: 1.625rem;
     }
   }
 }


### PR DESCRIPTION
Small one to fix user avatar sizes. The icons are supposed to be 1x1, however for users with non square pictures they ended up being distorted.

**Before**
<img width="289" alt="image" src="https://github.com/user-attachments/assets/f1bbb6eb-9df2-4b79-b073-1661d753d5a7">

**After**
<img width="293" alt="image" src="https://github.com/user-attachments/assets/e3e451bb-519a-4bce-8139-0e129c933e1f">

**Before**
<img width="505" alt="image" src="https://github.com/user-attachments/assets/cdb05606-00fa-4a71-b561-be0031018567">

**After**
<img width="647" alt="image" src="https://github.com/user-attachments/assets/643bc58a-ffbf-4d98-9839-303229215f5a">


