### PR TITLE
Fix missing background on pagination button

### DIFF
--- a/content/stylesheets/components/_pagination.scss
+++ b/content/stylesheets/components/_pagination.scss
@@ -56,11 +56,7 @@
     padding: 0 0.85rem;
 
     &__current {
-      color: var(--color);
-
-      &::before {
-        opacity: 0.1;
-      }
+      --button-background-opacity: 10%;
     }
 
     &:hover {


### PR DESCRIPTION
Small one to fix the current, active pagination button missing its background.

**Before**
<img width="372" alt="image" src="https://github.com/user-attachments/assets/52b8c058-f98c-4039-85c8-7c6c89fbac77">

**After**
<img width="381" alt="image" src="https://github.com/user-attachments/assets/92fa0103-6acd-468a-bb5f-0fcc4ec96850">
