### PR TITLE
Remove old blog container style

### DIFF
--- a/content/blog/index.html.haml
+++ b/content/blog/index.html.haml
@@ -21,7 +21,7 @@ section: blog
   end
   tags = tags.sort_by {|obj| obj.to_s.downcase}
 
-%div.app-blog-page
+%div.app-container.app-blog-page
   - if page.author
     = partial("author.html.haml", :author => page.author, :blogroll => true)
   - else

--- a/content/stylesheets/pages/_blog.scss
+++ b/content/stylesheets/pages/_blog.scss
@@ -1,14 +1,4 @@
 .app-blog-page {
-  position: relative;
-  max-width: Max(Min(85vw, 1600px), $app-tablet-breakpoint);
-  margin: auto;
-  padding: 5rem 1rem;
-
-  @media screen and (max-width: $app-tablet-breakpoint) {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
-  }
-
   .blog-date {
     font-size: 0.8rem;
     font-weight: 800;


### PR DESCRIPTION
The `.app-blog-page` class predates the introduction of `.app-container`, it largely does the same thing (albeit with more vertical padding). This PR adds `.app-container` to the blog page and removes the duplicated styling.