### PR TITLE
Remove hardlinks to jenkins.io in blog post

### DIFF
--- a/content/blog/2024/08/25/2024-08-25-gsoc-enhancing-llm.adoc
+++ b/content/blog/2024/08/25/2024-08-25-gsoc-enhancing-llm.adoc
@@ -51,7 +51,7 @@ This project included several stages that we have gone through:
 
 === Stage #1: data collection
 
-Different sources were used to collect Jenkins knowledge, including link:/doc/book/[Jenkins documentation] and link:/blog/[blog posts], link:https://community.jenkins.io/c/using-jenkins/7[discourse community questions], and many external sources like link:https://stackoverflow.com/[Stack Overflow], link:https://askubuntu.com/[ask Ubuntu], and link:https://stackexchange.com/[Stack Exchange].
+Different sources were used to collect Jenkins knowledge, including link:/doc/book/getting-started/[Jenkins documentation] and link:/blog/[blog posts], link:https://community.jenkins.io/c/using-jenkins/7[discourse community questions], and many external sources like link:https://stackoverflow.com/[Stack Overflow], link:https://askubuntu.com/[ask Ubuntu], and link:https://stackexchange.com/[Stack Exchange].
 
 === Stage #2: data preprocessing and refinement
 

--- a/content/blog/2024/08/25/2024-08-25-gsoc-enhancing-llm.adoc
+++ b/content/blog/2024/08/25/2024-08-25-gsoc-enhancing-llm.adoc
@@ -33,7 +33,7 @@ We aim to provide faster and more reliable assistance to our users. The model is
 
 The project outcomes are:
 
-. Collected datasets from different sources, like link:https://www.jenkins.io/blog/[Jenkins blogs], link:https://community.jenkins.io/c/using-jenkins/7[community questions], and other external sources.
+. Collected datasets from different sources, like link:/blog/[Jenkins blogs], link:https://community.jenkins.io/c/using-jenkins/7[community questions], and other external sources.
 . Preprocessing this dataset to make sure it is clean and not confusing the model.
 . Fine-tuning llama2 on this data and providing a new open-source fine-tuned model.
 . Creating a user interface with a small server to interact with the model.
@@ -45,13 +45,13 @@ The project outcomes are:
 * This project combines Jenkins knowledge with AI to assist all users with the knowledge that a Jenkins expert usually has, providing a complete solution.
 * We empower users to interact with this knowledge through a smooth UI instead of looking for your answer here and there.
 
-== Milestones 
+== Milestones
 
 This project included several stages that we have gone through:
 
 === Stage #1: data collection
 
-Different sources were used to collect Jenkins knowledge, like link:https://www.jenkins.io/blog/[Jenkinsn documents and blogs], link:https://community.jenkins.io/c/using-jenkins/7[discourse community questions], and many external sources like link:https://stackoverflow.com/[Stack Overflow], link:https://askubuntu.com/[ask Ubuntu], and link:https://stackexchange.com/[Stack Exchange].
+Different sources were used to collect Jenkins knowledge, including link:/doc/book/[Jenkins documentation] and link:/blog/[blog posts], link:https://community.jenkins.io/c/using-jenkins/7[discourse community questions], and many external sources like link:https://stackoverflow.com/[Stack Overflow], link:https://askubuntu.com/[ask Ubuntu], and link:https://stackexchange.com/[Stack Exchange].
 
 === Stage #2: data preprocessing and refinement
 
@@ -111,15 +111,15 @@ I want to take this chance and extend my gratitude to:
 
 * Google Summer of Code for organizing this and their mentors who provided help throughout the program.
 * Jenkins and GSoC org admins for having me contribute to this challenging problem and thank you for your flexibility along the way.
-* My team mentors link:https://www.jenkins.io/blog/authors/krisstern/[Kris Stern](as a lead mentor), link:https://www.jenkins.io/blog/authors/gounthar/[Bruno Verachten], link:https://www.jenkins.io/blog/authors/harsh-ps-2003/[Harsh Pratap Singh], and link:https://www.jenkins.io/blog/authors/shivaylamba/[Shivay Lamba] for their continuous support and guidance throughout the project, answering my questions, and pointing out some great ideas so we are not left with something incomplete. They were a great reason for making this a success.
+* My team mentors author:krisstern/[Kris Stern](as a lead mentor), author:gounthar/[Bruno Verachten], author:harsh-ps-2003/[Harsh Pratap Singh], and author:shivaylamba/[Shivay Lamba] for their continuous support and guidance throughout the project, answering my questions, and pointing out some great ideas so we are not left with something incomplete. They were a great reason for making this a success.
 
 == Useful Links
 
 - link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
-- link:https://www.jenkins.io/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge/[LLM Project Selection Post]
+- link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge/[LLM Project Selection Post]
 - link:https://github.com/nouralmulhem/Enhancing-LLM-with-Jenkins-Knowledge[Our Github Repository]
 - link:https://github.com/users/nouralmulhem/projects/1[Our Github Kanban]
-- link:https://www.jenkins.io/blog/authors/nouralmulhem/[Personal Information]
+- author:nouralmulhem/[Personal Information]
 - link:https://docs.google.com/document/d/1Ri24koZto5iSj5HIQF-8VK66PX-2cZRxzZEJNvg_GXY/edit?usp=sharing[Out weekly instance meeting notes]
 - link:https://huggingface.co/nouralmulhem/Llama-2-7b-chat-finetune[Fine-tuned model on Hugging Face]
 - link:https://huggingface.co/nouralmulhem/Llama-2-7b-finetune-q8[Our GGML version of the model]


### PR DESCRIPTION
This PR is to adjust some of the links in one of the 2024 GSoC recap blog posts. There were a few hardlinks to jenkins.io, so they have been updated to use the `link:/doc/book` formatting. There were also links to the author pages of mentors/org-admins, so these have been updated to use the `author:[]` macro.