### PR TITLE
Use standard 'JENKINS-' key for issues

### DIFF
--- a/content/_partials/changelog-changes.html.haml
+++ b/content/_partials/changelog-changes.html.haml
@@ -24,7 +24,7 @@
                 ,&nbsp;
               - if reference.issue
                 %a{:href => "https://issues.jenkins.io/browse/JENKINS-#{reference.issue}" }<>
-                  = "issue #{reference.issue}"
+                  = "JENKINS-#{reference.issue}"
               - if reference.pull
                 %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{reference.pull}" }<>
                   = "pull #{reference.pull}"
@@ -36,7 +36,7 @@
                     = reference.url
           - elsif change.issue
             %a{:href => "https://issues.jenkins.io/browse/JENKINS-#{change.issue}" }<>
-              = "issue #{change.issue}"
+              = "JENKINS-#{change.issue}"
           - elsif change.pull
             %a{:href => "https://github.com/jenkinsci/jenkins/pull/#{change.pull}" }<>
               = "pull #{change.pull}"


### PR DESCRIPTION
The change proposed applies the default pattern for community reported issues:
![Screenshot 2024-09-01 at 22 37 10](https://github.com/user-attachments/assets/eb90d4f9-2ab2-4f8a-b54a-635be0e8a6b0)
to the issue or feature description in the changelog:
![Screenshot 2024-09-01 at 22 38 36](https://github.com/user-attachments/assets/7cc85d61-25c6-488b-85f9-ae9b10eaa661)
applying the standard pattern we're using for JIRA issues.