### PR TITLE
Update servlet container policy

### DIFF
--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -37,13 +37,13 @@ a|The versions of Winstone and Jetty bundled in the Jenkins link:/doc/book/insta
   We do not regularly test compatibility, and we may drop support at any time.
   We consider patches that do not put Level 1 support at risk and do not create maintenance overhead.
 a|
-  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (2.474 and older)
-  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (2.474 and older)
-  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (2.474 and older)
-  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
-  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
-  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
-  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
+  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474 and older)
+  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474 and older)
+  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474 and older)
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
 
 | **Level 3:** Unsupported
 | These versions are known to be incompatible or to have severe limitations.

--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -49,6 +49,7 @@ a|
 | These versions are known to be incompatible or to have severe limitations.
   We do not support the listed servlet containers.
 a|
+  * Support for Jakarta EE 8 is planned to end with the October LTS release.
 
 |===
 

--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -37,17 +37,17 @@ a|The versions of Winstone and Jetty bundled in the Jenkins link:/doc/book/insta
   We do not regularly test compatibility, and we may drop support at any time.
   We consider patches that do not put Level 1 support at risk and do not create maintenance overhead.
 a|
-  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports.
-  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports.
-  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports.
+  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (2.474 and older)
+  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (2.474 and older)
+  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (2.474 and older)
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
 
 | **Level 3:** Unsupported
 | These versions are known to be incompatible or to have severe limitations.
   We do not support the listed servlet containers.
 a|
-  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports.
-  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports.
-  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports.
   * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports.
 |===
 

--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -43,12 +43,13 @@ a|
   * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
   * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
   * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (2.475 and newer)
 
 | **Level 3:** Unsupported
 | These versions are known to be incompatible or to have severe limitations.
   We do not support the listed servlet containers.
 a|
-  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports.
+
 |===
 
 == References


### PR DESCRIPTION
This PR is to update the servlet container policy page in the Platform Information section of documentation.

With the weekly release of 2.475, the Jakarta EE 9 support is now available, so this information needs to be provided accurately. However, this would also remove the "unsupported" versions from the chart, so that would still need to be filled in with what would not be supported.

Fixes #7501