### PR TITLE
feat(blog) add post for the two 1-hour update center brownouts

### DIFF
--- a/content/blog/2024/09/04/2024-09-04-update-center-brownouts.adoc
+++ b/content/blog/2024/09/04/2024-09-04-update-center-brownouts.adoc
@@ -1,0 +1,71 @@
+---
+layout: post
+title: "Brownout on Update Center (updates.jenkins.io):\n 6 and 9 September 2024"
+tags:
+- jenkins
+- jenkins-infra
+- update-center
+authors:
+- dduportal
+opengraph:
+  image: /images/post-images/2023/01/12/jenkins-newsletter/infrastructure.png
+overview: "We'll be using the new Update Center implementation in production for 1 hour, twice!"
+discourse: true
+---
+
+== Summary (link:https://en.wikipedia.org/wiki/Wikipedia:Too_long;_didn%27t_read[TL;DR])
+
+The service https://updates.jenkins.io will switch its implementation to a new system during 1 hour twice:
+
+- Friday 6 September 2024 from 07:00am UTC until 09:00am UTC
+- Monday 9 September 2024 from 02:00pm UTC until 03:00pm UTC
+
+
+All Jenkins users are impacted but should not see any functional change.
+
+⚠️ Please, check that your organization respects the advertised DNS TTL or you might be stuck in the brownout longer that expected.
+
+Under the hood, any HTTP request made to this service will be redirected to a mirror close to user locations during these brownouts.
+
+== What is the "Update Center"?
+
+Jenkins https://updates.jenkins.io[Update Center] is a web server at the core of the Jenkins public infrastructure which distributes the plugins, tool installers and versions index to all Jenkins servers all across the world.
+
+From the Wizard installation to regular plugin updates, if you run Jenkins then you use this service under the hood.
+
+Today, it serves around 50 Tb of data (outbound bandwidth) each month from a single Virtual Machine on AWS which costs around $6,000 per month.
+
+In order to sustain this service and improve it, the Jenkins infrastructure has relentlessly worked during the past years to have a new sustainable implementation for this service.
+
+The new Update Center implementation features an highly available system which redirects user requests to a download mirror close to their location.
+You can read the details on the (long) following issue GitHub: https://github.com/jenkins-infra/helpdesk/issues/2649.
+
+== Why this "link:https://en.wikipedia.org/wiki/Brownout_(electricity)[Brownout]"?
+
+We have reached the point where our functional/performance tests are meeting our expectation:
+
+- All of our Jenkins controllers are using the new Update Center implementation
+- We are using the new updates center (with DNS override) in our own networks in different geo-locations
+- All of our Jenkins Docker image are using the new system
+- Our initial performance tests
+
+But as the adage says: "No plan survives first contact".
+
+That's why we are planning these brownouts of one hour each to:
+
+- Validate our system above the tests we already ran to increase trust
+- Run a real life (production!) workload against the new system while limiting any unforeseen impact due to the short time window
+
+== How
+
+Both current and new Update Center are updated at the same time and serves the same index.
+
+Since 4 weeks, the Jenkins infra uses the new Update Center (https://azure.updates.jenkins.io ) with a client-side DNS override (`updates.jenkins.io` hostname points to this new service).
+
+During the brownouts, we'll simply switch the DNS entry `updates.jenkins.io` to this new service and watch for the logs and error rate.
+At the end of each brownout, we'll switch DNS back to the normal service and then analyse metrics and logs to see how the system behaved.
+
+- If no major problem is detected then we'll plan a 24 hours brownout soon.
+- Otherwise we'll analyse the discovered problem and plan solutions.
+
+More details in https://github.com/jenkins-infra/helpdesk/issues/2649.

--- a/content/blog/2024/09/04/2024-09-04-update-center-brownouts.adoc
+++ b/content/blog/2024/09/04/2024-09-04-update-center-brownouts.adoc
@@ -17,7 +17,7 @@ discourse: true
 
 The service https://updates.jenkins.io will switch its implementation to a new system during 1 hour twice:
 
-- Friday 6 September 2024 from 07:00am UTC until 09:00am UTC
+- Friday 6 September 2024 from 07:00am UTC until 08:00am UTC
 - Monday 9 September 2024 from 02:00pm UTC until 03:00pm UTC
 
 


### PR DESCRIPTION
First post to announce two 1-hour Update Center brownouts (see https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2330934069).

Note: I hope to have this published as soon as possible.