### PR TITLE
Update servlet container support policy for LTS and Weekly

### DIFF
--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -37,22 +37,22 @@ a|The versions of Winstone and Jetty bundled in the Jenkins link:/doc/book/insta
   We do not regularly test compatibility, and we may drop support at any time.
   We consider patches that do not put Level 1 support at risk and do not create maintenance overhead.
 a|
-  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
-  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
-  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
-  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
-  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
-  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
-  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
+  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
+  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
+  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
 
 | **Level 3:** Unsupported
 | These versions are known to be incompatible or to have severe limitations.
   We do not support the listed servlet containers.
 a|
-  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
-  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2 and older)
-  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2 and older)
-  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2 and older)
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2 and older*)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2 and older*)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2 and older*)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2 and older*)
 
 |===
 

--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -37,9 +37,9 @@ a|The versions of Winstone and Jetty bundled in the Jenkins link:/doc/book/insta
   We do not regularly test compatibility, and we may drop support at any time.
   We consider patches that do not put Level 1 support at risk and do not create maintenance overhead.
 a|
-  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474 and older)
-  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474 and older)
-  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474 and older)
+  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
+  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
+  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
   * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
   * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
   * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.475 and newer)
@@ -49,9 +49,14 @@ a|
 | These versions are known to be incompatible or to have severe limitations.
   We do not support the listed servlet containers.
 a|
-  * Support for Jakarta EE 8 is planned to end with the October LTS release.
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2, and older)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2 and older)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2 and older)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (Weekly 2.474, LTS 2.462.2 and older)
 
 |===
+
+WARNING: Support for Jakarta EE 8 is planned to end with the October LTS release.
 
 == References
 


### PR DESCRIPTION
The Support Policy page for servlet containers was updated to reflect the changes in weekly release 2.475, which now supports Jakarta EE 9. I had previously updated the page to ensure this was included, but in doing so removed the content from the unsupported section. Since the LTS release would still not support these changes until October, I have returned that content and tried to clarify/specify as best I can to ensure that it is understood (adding parentheses and bold).