### PR TITLE
Added a description how to speed up testing with parallel execution

### DIFF
--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -153,9 +153,10 @@ Most Java IDEs should be able to run JUnit tests and report on the results.
 The test runner (Surefire) supports running tests in parallel to speed them up.
 A possibility to configure this machine wide is to adjust the `forkCount` within maven.
 The default setting is `forkCount=1`, which means no parallel testing.
-An often used setting is `1C`, wich spawns as many testing processes in parallel as cpu cores are present.
+An often used setting is `1C`, which spawns as many testing processes in parallel as cpu cores are present.
 If you have a machine with many cores it might be faster to set it to a smaller number, like `0.45C`.
 For example with 16 cores the runner will be spawning up to 7 processes.
+More details can be found at https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html[maven surefire documentation].
 
 You can also adjust this globally within a maven profile setting, independently of the Plugin configuration.
 The maven profile can be typically found at: `~/.m2/settings.xml` (Linux) or `%userprofile%/.m2` (Windows).
@@ -174,7 +175,7 @@ A profile setting with the name "faster", which is enabled by default can look l
 </profile>
 ----
 
-In the IDE this setting wil be able to enable or disable depending on the test suite you are working on.
+In the IDE this setting will be able to enable or disable depending on the test suite you are working on.
 In case of problems it can also be deactivated on the command-line with `-P=-faster`.
 
 == What to Test

--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -148,6 +148,35 @@ Most Java IDEs should be able to run JUnit tests and report on the results.
 //==== From the Command Line
 //==== From an IDE
 
+=== Performance considerations
+
+The test runner (Surefire) supports running tests in parallel to speed them up.
+A possibility to configure this machine wide is to adjust the `forkCount` within maven.
+The default setting is `forkCount=1`, which means no parallel testing.
+An often used setting is `1C`, wich spawns as many testing processes in parallel as cpu cores are present.
+If you have a machine with many cores it might be faster to set it to a smaller number, like `0.45C`.
+For example with 16 cores the runner will be spawning up to 7 processes.
+
+You can also adjust this globally within a maven profile setting, independently of the Plugin configuration.
+The maven profile can be typically found at: `~/.m2/settings.xml` (Linux) or `%userprofile%/.m2` (Windows).
+A profile setting with the name "faster", which is enabled by default can look like this:
+
+[source,xml]
+----
+<profile>
+  <id>faster</id>
+  <activation>
+    <activeByDefault>true</activeByDefault>
+  </activation>
+  <properties>
+    <forkCount>0.45C</forkCount>
+  </properties>
+</profile>
+----
+
+In the IDE this setting wil be able to enable or disable depending on the test suite you are working on.
+In case of problems it can also be deactivated on the command-line with `-P=-faster`.
+
 == What to Test
 Now that we can write a basic test, we should discuss what you should be testing…
 

--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -151,15 +151,15 @@ Most Java IDEs should be able to run JUnit tests and report on the results.
 === Performance considerations
 
 The test runner (Surefire) supports running tests in parallel to speed them up.
-A possibility to configure this machine wide is to adjust the `forkCount` within maven.
+A possibility to configure this machine-wide is to adjust the `forkCount` within Maven.
 The default setting is `forkCount=1`, which means no parallel testing.
-An often used setting is `1C`, which spawns as many testing processes in parallel as cpu cores are present.
+An often-used setting is `1C`, which spawns as many testing processes in parallel as CPU cores are present.
 If you have a machine with many cores it might be faster to set it to a smaller number, like `0.45C`.
 For example with 16 cores the runner will be spawning up to 7 processes.
-More details can be found at https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html[maven surefire documentation].
+More details can be found at link:https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html[maven surefire documentation].
 
-You can also adjust this globally within a maven profile setting, independently of the Plugin configuration.
-The maven profile can be typically found at: `~/.m2/settings.xml` (Linux) or `%userprofile%/.m2` (Windows).
+You can also adjust this globally within a Maven profile setting, independently of the Plugin configuration.
+The Maven profile can be typically found at: `~/.m2/settings.xml` (Linux) or `%userprofile%/.m2` (Windows).
 A profile setting with the name "faster", which is enabled by default can look like this:
 
 [source,xml]

--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -154,9 +154,9 @@ The test runner (Surefire) supports running tests in parallel to speed them up.
 A possibility to configure this machine-wide is to adjust the `forkCount` within Maven.
 The default setting is `forkCount=1`, which means no parallel testing.
 An often-used setting is `1C`, which spawns as many testing processes in parallel as CPU cores are present.
-If you have a machine with many cores it might be faster to set it to a smaller number, like `0.45C`.
-For example with 16 cores the runner will be spawning up to 7 processes.
-More details can be found at link:https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html[maven surefire documentation].
+If you have a machine with many cores, it might be faster to set it to a smaller number, like `0.45C`.
+For example, with 16 cores the runner will be spawning up to 7 processes.
+More details can be found in the link:https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html[Maven Surefire documentation].
 
 You can also adjust this globally within a Maven profile setting, independently of the Plugin configuration.
 The Maven profile can be typically found at: `~/.m2/settings.xml` (Linux) or `%userprofile%/.m2` (Windows).


### PR DESCRIPTION
Added a description how to speed up testing with parallel execution and setting this up globally within the maven profile.
Thanks to @MarkEWaite for inspiring me with his PR https://github.com/jenkinsci/job-config-history-plugin/pull/312