### PR TITLE
Weekly 2.475 - adding PR and Issue to references

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24606,8 +24606,6 @@
     changes:
       - type: rfe
         category: rfe
-        pull: 9672
-        issue: 73278
         authors:
           - basil
         pr_title: "[JENKINS-73278] Migrate core from EE 8 to EE 9"
@@ -24628,6 +24626,8 @@
             title: LDAP plugin 733.vd3700c27b_043
           - url: https://www.jenkins.io/doc/book/platform-information/support-policy-servlet-containers/
             title: Servlet Container Support Policy
+          - pull: 9672
+          - issue: 73278
         message: |-
           Upgrade Spring Framework from 5.3.39 to 6.1.12, upgrade Spring Security from 5.8.14 to 6.3.3, and upgrade Java EE from 8 to 9.
           Users of the LDAP plugin must upgrade it to version 733.vd3700c27b_043 in lockstep with upgrading Jenkins core.


### PR DESCRIPTION
Update to add the pull request & issue to the references section of the Jakarta EE 9/ Spring Security entry. As @daniel-beck pointed out, since there was a listed reference section for this entry, these two items are not rendering correctly since they are not part of the references section. Now that they have been added accordingly, they should be available from the changelog entry.