### PR TITLE
Fix changelog formatting (add trailing space)

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24624,7 +24624,7 @@
             title: Jarkata EE 9 release page
           - url: https://github.com/jenkinsci/ldap-plugin/releases/tag/733.vd3700c27b_043
             title: LDAP plugin 733.vd3700c27b_043
-          - url:
+          - url: 
               https://www.jenkins.io/doc/book/platform-information/support-policy-servlet-containers/
             title: Servlet Container Support Policy
           - pull: 9672


### PR DESCRIPTION
## Fix changelog formatting (add trailing space)

Earlier attempt did not include all the needed changes.  Mistake was in:

* https://github.com/jenkins-infra/jenkins.io/pull/7519
