### PR TITLE
Update usage of "instance" in Managing documentation

### DIFF
--- a/content/doc/book/managing/_built-in-node-migration.adoc
+++ b/content/doc/book/managing/_built-in-node-migration.adoc
@@ -20,12 +20,12 @@ These features include:
 
 == Migration
 
-Due to the potential impact to build behavior, instances upgrading Jenkins to version 2.307 or newer do not automatically get these behavior changes applied.
+Due to the potential impact to build behavior, deployments upgrading Jenkins to version 2.307 or newer do not automatically get these behavior changes applied.
 Instead, an administrative monitor informs administrators about this change and allows them to apply it.
 
 // Screenshot here? Is this useful?
 
-Before applying the built-in node name and label migration, administrators are advised to review their configuration and build scripts to assess the impact to their instance and jobs.
+Before applying the built-in node name and label migration, administrators are advised to review their configuration and build scripts to assess the impact to their controller and jobs.
 
 Most problems with label assignments can likely be worked around by manually assigning the label `master` to the built-in node and then migrating affected configuration incrementally to not need this workaround.
 

--- a/content/doc/book/managing/plugins.adoc
+++ b/content/doc/book/managing/plugins.adoc
@@ -320,7 +320,7 @@ to avoid extra info in the console.
 In the same way than enabling and disabling plugins from the UI requires a restart
 to complete the process, the changes made with the CLI commands will take effect
 once Jenkins is restarted. The `-restart` option forces a safe restart of the
-instance once the command has successfully finished, so the changes will be
+controller once the command has successfully finished, so the changes will be
 immediately applied.
 ====
 

--- a/content/doc/book/managing/script-approval.adoc
+++ b/content/doc/book/managing/script-approval.adoc
@@ -58,7 +58,7 @@ Administrator intervention. The second, Script
 Approval, allows Administrators to approve or deny unsandboxed scripts, or
 allow sandboxed scripts to execute additional methods.
 
-For most instances, the combination of the Groovy Sandbox and the
+For most systems, the combination of the Groovy Sandbox and the
 link:https://github.com/jenkinsci/script-security-plugin/tree/master/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists[Script Security's built-in list]
 of approved method signatures, will be sufficient. It is strongly recommended
 that Administrators only deviate from these defaults if absolutely necessary.
@@ -107,7 +107,7 @@ check the Administrator-managed list of approved scripts and methods.
 ====
 When a script is approved, it is approved for use in any Jenkins feature or plugin that integrates with script approval.
 Script approval is not tied to a specific job or to any other specific use of the script.
-Due to this, care must be taken when approving a script to ensure that any user supplied parameters can not be used to exploit the instance.
+Due to this, care must be taken when approving a script to ensure that any user supplied parameters can not be used to exploit the controller.
 ====
 
 For scripts which wish to execute outside of the <<groovy-sandbox>>, the

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -396,7 +396,7 @@ properties:
   since: 1.625.3, 1.641
   description: |
     Determines the Content Security Policy header sent for static files served by Jenkins.
-    Only affects instances that don't have a resource root URL set up.
+    Only affects controllers that don't have a resource root URL set up.
     See link:../../system-administration/security/configuring-content-security-policy/[Configuring Content Security Policy] for more details.
 
 - name: hudson.model.DownloadService$Downloadable.defaultInterval
@@ -684,7 +684,7 @@ properties:
   since: 1.602
   description: |
     When `true`, does not check auth realm for existence of user if there's a record in Jenkins.
-    Unsafe, but may be used on some instances for service accounts
+    Unsafe, but may be used on some controllers for service accounts
 
 - name: hudson.model.User.allowUserCreationViaUrl
   tags:
@@ -1217,7 +1217,7 @@ properties:
   since: 2.114
   description: |
     Allows to move the logs usually found under `$JENKINS_HOME/logs` to another location.
-    Beware that no migration is handled if you change it on an existing instance.
+    Beware that no migration is handled if you change it on an existing deployment.
 
 - name: hudson.triggers.SCMTrigger.starvationThreshold
   tags:
@@ -2451,7 +2451,7 @@ properties:
 = Jenkins Features Controlled with System Properties
 
 Jenkins has several "hidden" features that can be enabled with system properties.
-This page documents many of them and explain how to configure them on your instance.
+This page documents many of them and explains how to configure them on your controller.
 
 Some system properties related to the Remoting library used for communication between controller and agents are documented in https://github.com/jenkinsci/remoting/blob/master/docs/configuration.md[that component's repository].
 


### PR DESCRIPTION
This PR is to update some uses of the word "instance" to be more clear and better defined within the context of Jenkins usage. Other grammatical adjustments are being made as needed as well.