### PR TITLE
Update Pipeline docs usage of "instance"

### DIFF
--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -164,7 +164,7 @@ the symbol `_` is annotated.
 
 It is not recommended to `import` a global variable/function,
 since this will force the compiler to interpret fields and methods as `static`
-even if they were intended to be instance.
+even if they were intended to be customized.
 The Groovy compiler in this case can produce confusing error messages.
 ====
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -627,7 +627,7 @@ disableResume:: Do not allow the pipeline to resume if the controller restarts.
 For example: `options { disableResume() }`
 
 newContainerPerStage:: Used with `docker` or `dockerfile` top-level agent.
-When specified, each stage will run in a new container instance on the same node, rather than all stages running in the same container instance.
+When specified, each stage will run in a new container deployed on the same node, rather than all stages running in the same container deployment.
 
 overrideIndexTriggers:: Allows overriding default treatment of branch indexing triggers.
 If branch indexing triggers are disabled at the multibranch or organization label, `options { overrideIndexTriggers(true) }` will enable them for this job only.


### PR DESCRIPTION
This PR is to update the usage of "instance" in the pipeline documentation. There are only a few places where the change was made, and one where I changed the wording to try and better fit the context of what was written.