### PR TITLE
Update GitHub solution page usage of "instance"

### DIFF
--- a/content/solutions/github.adoc
+++ b/content/solutions/github.adoc
@@ -5,10 +5,10 @@ title: "Jenkins with GitHub"
 
 Jenkins, itself link:https://github.com/jenkinsci[located on GitHub], has a
 number of plugins for integrating into link:https://github.com[GitHub]. 
-The primary avenues for integrating your Jenkins instance with GitHub are:
+The primary avenues for integrating your Jenkins deployment with GitHub are:
 
 * "build integration" - using GitHub to trigger builds
-* "authentication integration" - using GitHub as the source of authentication information to secure a Jenkins instance.
+* "authentication integration" - using GitHub as the source of authentication information to secure a Jenkins controller and its agents.
 
 == Build integration
 
@@ -20,7 +20,7 @@ The plugin:github[GitHub plugin] extends
 upon that integration further by providing improved bi-directional
 integration with GitHub. Allowing you to set up a link:https://developer.github.com/webhooks/#service-hooks[Service
 Hook] which will hit
-your Jenkins instance every time a change is pushed to GitHub.
+your Jenkins controller every time a change is pushed to GitHub.
 
 
 image::/images/solution-images/jenkins-github-services.png['Jenkins in the GitHub WebHooks/Services view', role=center]
@@ -34,10 +34,10 @@ link:https://stackoverflow.com/questions/14274293/show-current-state-of-jenkins-
 
 Using the plugin:github-oauth[GitHub Authentication plugin]
 it is possible to use GitHub's own authentication scheme
-for implementing authentication in your Jenkins instance.
+for implementing authentication in your Jenkins controller.
 
 The **plugin:github-oauth#GithubOAuthPlugin-Setup[setup guide]**
 will help walk you through configuring the GitHub OAuth side, and your
-Jenkins instance, to provide easy authentication/authorization for users.
+Jenkins controller, to provide easy authentication/authorization for users.
 
 image::/images/solution-images/jenkins-github-oauth-enable.png['Configuring "Global Security" to use GitHub', role=center]


### PR DESCRIPTION
This PR is to update the usage of the word "instance" as it is found in the page. The wording has been updated to use controller (primarily), controller and agents (where needed), and deployment (intro of page). This is part of the work being done to address https://github.com/jenkins-infra/jenkins.io/issues/7291