### PR TITLE
Slight wording adjustments for Security pages

### DIFF
--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -149,8 +149,8 @@ The most recent LTS releases are Jenkins 2.361.4 and Jenkins 2.375.1, and the cu
 The plugin's latest release, version 2.2, has a Jenkins dependency of 2.380 because it makes use of a new feature in that release.
 The most recent lower Jenkins dependency of the plugin was Jenkins 2.361.3 in plugin version 2.0.
 
-In this case, instances on both 2.361.4 and 2.375.1 will be able to install a security fix provided on top of version 2.0 of the plugin.
-Instances on the weekly release line will be able to install a security fix provided on top of version 2.2.
+In this case, controllers on both 2.361.4 and 2.375.1 will be able to install a security fix provided on top of version 2.0 of the plugin.
+Controllers and agents on the weekly release line will be able to install a security fix provided on top of version 2.2.
 So the plugin should get updates with the security fix based on top of version 2.2 (e.g., 2.2.1 or 2.3) _and_ 2.0 (e.g., 2.0.1 or 2.0.0.1, whichever version would be between 2.0 and the next release that already exists).
 
 Now consider the case of the plugin version 2.1 previously raising the core dependency from 2.361.2 to Jenkins 2.370 (before 2.2 raised it to 2.380).

--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -150,7 +150,7 @@ The plugin's latest release, version 2.2, has a Jenkins dependency of 2.380 beca
 The most recent lower Jenkins dependency of the plugin was Jenkins 2.361.3 in plugin version 2.0.
 
 In this case, controllers on both 2.361.4 and 2.375.1 will be able to install a security fix provided on top of version 2.0 of the plugin.
-Controllers and agents on the weekly release line will be able to install a security fix provided on top of version 2.2.
+Controllers on the weekly release line will be able to install a security fix provided on top of version 2.2.
 So the plugin should get updates with the security fix based on top of version 2.2 (e.g., 2.2.1 or 2.3) _and_ 2.0 (e.g., 2.0.1 or 2.0.0.1, whichever version would be between 2.0 and the next release that already exists).
 
 Now consider the case of the plugin version 2.1 previously raising the core dependency from 2.361.2 to Jenkins 2.370 (before 2.2 raised it to 2.380).

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -95,7 +95,7 @@ The following behaviors/issues are not vulnerabilities in Jenkins project infras
   We trust Google to choose the correct tradeoffs for their Google Groups service, and have no power to change anything anyway.
 * The public availability of the Algolia API key. It needs to be public.
 // TODO Possibly other keys as well?
-* Publicly accessible Jenkins instances other than ci.jenkins.io and weekly.ci.jenkins.io are not operated by the Jenkins project.
+* Publicly accessible Jenkins controllers other than ci.jenkins.io and weekly.ci.jenkins.io are not operated by the Jenkins project.
   Please do not contact us with any concerns regarding them.
 
 == Issue Handling Process

--- a/content/security/team.adoc
+++ b/content/security/team.adoc
@@ -5,7 +5,7 @@ section: security
 ---
 
 The Jenkins Security Team is a group of volunteers led by the link:/project/board/#security[Jenkins Security Officer].
-Our goal is to improve the security of Jenkins and to give administrators the tools and information they need to secure their Jenkins instances.
+Our goal is to improve the security of Jenkins and to give administrators the tools and information they need to secure their Jenkins controllers and agents.
 
 
 ## What We Do
@@ -61,7 +61,7 @@ You can contribute to the security of Jenkins and its plugin ecosystem even with
 * Inform us about plugin security updates without a corresponding security advisory.
   Plugin maintainers may be unaware of our process, so this helps ensure all security updates are properly announced.
 * Document security best practices for Jenkins administrators and Jenkins developers.
-* As a Jenkins developer, develop features and improvements that help admins secure their instance.
+* As a Jenkins developer, develop features and improvements that help admins secure their controller and agents.
   link:/security/improvements/[Check out these improvements delivered by security team members over the years.]
 * As a plugin maintainer:
 ** Be responsive when contacted by the security team.

--- a/content/security/team.adoc
+++ b/content/security/team.adoc
@@ -61,7 +61,7 @@ You can contribute to the security of Jenkins and its plugin ecosystem even with
 * Inform us about plugin security updates without a corresponding security advisory.
   Plugin maintainers may be unaware of our process, so this helps ensure all security updates are properly announced.
 * Document security best practices for Jenkins administrators and Jenkins developers.
-* As a Jenkins developer, develop features and improvements that help admins secure their controller and agents.
+* As a Jenkins developer, develop features and improvements that help admins secure their controllers and agents.
   link:/security/improvements/[Check out these improvements delivered by security team members over the years.]
 * As a plugin maintainer:
 ** Be responsive when contacted by the security team.


### PR DESCRIPTION
This PR is to adjust some uses of the word "instance" to be more clear and utilize "controller" or "controller and agents" where necessary. This is part of the work inspired by https://github.com/jenkins-infra/jenkins.io/issues/7291 to provide more clear and descriptive documentation.