### PR TITLE
Update Pipeline Guided Tour prerequisites

### DIFF
--- a/content/doc/pipeline/tour/getting-started.adoc
+++ b/content/doc/pipeline/tour/getting-started.adoc
@@ -16,7 +16,7 @@ For this tour, you will require:
 ** 256 MB of RAM, although more than 2 GB is recommended
 ** 10 GB of drive space (for Jenkins and your Docker image)
 * The following software installed:
-** Java 11, 17, or 21
+** Java 17 or 21
 ** https://docs.docker.com/[Docker] (navigate to https://docs.docker.com/get-docker/[*Get Docker*] site to access the Docker download that's suitable for your platform)
 
 === Download and run Jenkins


### PR DESCRIPTION
This PR is to update the Pipeline Guided Tour tutorial as it currently states that Prerequisites includes "Java 11, 17, or 21" and this will actually cause issues for anyone that decides to follow the guided tour with the weekly release line. Since the existing LTS line also supports Java 17, there is no reason to recommend Java 11 to users following this tutorial.