### PR TITLE
Clarify that one of two ways mark a plugin for adoption

### DIFF
--- a/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
+++ b/content/doc/developer/plugin-governance/adopt-a-plugin.adoc
@@ -124,10 +124,13 @@ Before marking a plugin for adoption,
 we recommend to announce the incoming change in the link:https://groups.google.com/g/jenkinsci-dev[Jenkins Developer Mailing list] or in other appropriate channels.
 It may help you find new maintainers and, ideally, to establish a transition and knowledge transfer process.
 
-. Add the `+adopt-this-plugin+` label to the plugin. It can be done in 2 ways:
+. Add the `+adopt-this-plugin+` label to the plugin. A plugin is marked for adoption in one of two ways:
 ** Put an `+adopt-this-plugin+` topic in the plugin's GitHub repository.
-   If you have multiple plugins inside a single repository, it will apply to all of them
+   If multiple plugins are maintained inside a single repository, the repository topic marks all of them for adoption.
+   This is the preferred method because the maintainer directly controls the topics assigned to the plugin repository
 ** Add an `+adopt-this-plugin+` label to the plugin entry in the Update Center's link:https://github.com/jenkins-infra/update-center2/blob/master/resources/label-definitions.properties[label-definitions.properties] file
+   If multiple plugins are maintained inside a single repository, an update center entry can mark a subset of the plugins for adoption.
+   This is not the preferred method because the maintainer does not directly control the Update Center file
 . Optional: If you want to explain why you're marking that plugin as up for adoption,
   add a section to the plugin's documentation.
   You can also document your vision for the plugin there so that new maintainers can take it into account.


### PR DESCRIPTION
## Clarify that one of two ways mark a plugin for adoption

https://github.com/jenkins-infra/update-center2/pull/804#issuecomment-2380582157 notes that two ways are offered but only one of the two ways is needed.  Since one of the two ways is preferred due to its scalability, let's state that in the documentation.
