### PR TITLE
Fix openjdk package name such that it can actually be found

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -242,7 +242,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install fontconfig java-17-openjdk
+sudo yum install fontconfig java-1.7.0-openjdk
 sudo yum install jenkins
 ----
 


### PR DESCRIPTION
Hi all! 

The package name for the openjdk version 17 that was used in the guide (java-17-openjdk) could not be found (when I tried it). The package name that did work (that I found after some googling) was java-1.7.0-openjdk. An even better fix would be to use the 'java' package name as that automatically resolves to the latest available version of openjdk, but I guess you want to keep it version-locked as you are also using the 2023 key instead of the latest key.

I would kindly suggest to also use the latest key instead of year-locking it to 2023 as using 2023 causes people to use an outdated version of jenkins when installing it via this guide. But that's up to you.

Have a nice day!