### PR TITLE
Add CAS plugin release to documentation

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24624,6 +24624,8 @@
             title: Jarkata EE 9 release page
           - url: https://github.com/jenkinsci/ldap-plugin/releases/tag/733.vd3700c27b_043
             title: LDAP plugin 733.vd3700c27b_043
+          - url: https://github.com/jenkinsci/cas-plugin/releases/tag/cas-plugin-1.7.0
+            title: CAS plugin 1.7.0
           - url: 
               https://www.jenkins.io/doc/book/platform-information/support-policy-servlet-containers/
             title: Servlet Container Support Policy
@@ -24632,6 +24634,7 @@
         message: |-
           Upgrade Spring Framework from 5.3.39 to 6.1.12, upgrade Spring Security from 5.8.14 to 6.3.3, and upgrade Java EE from 8 to 9.
           Users of the LDAP plugin must upgrade it to version 733.vd3700c27b_043 in lockstep with upgrading Jenkins core.
+          Users of the CAS plugin must upgrade it to version 1.7.0 in lockstep with upgrading Jenkins core.
           Users of third-party servlet containers must upgrade the servlet container to an EE 9 version in accordance with the Jenkins Servlet Container Support Policy.
       - type: rfe
         category: rfe


### PR DESCRIPTION
CAS plugin was recently released with Spring Security 6.x support, so mention this in the changelog.