### PR TITLE
Fix broken internal link to Oleg statement

### DIFF
--- a/content/blog/2024/10/03/2024-10-03-jenkins-election-candidates.adoc
+++ b/content/blog/2024/10/03/2024-10-03-jenkins-election-candidates.adoc
@@ -33,7 +33,7 @@ Nominees for the Jenkins governance board include:
 * link:#slide_o_mix-board[Alex Earl]
 * link:#NotMyFault[Alexander Brandes]
 * link:#krisstern[Kris Stern]
-* link:#oleg-nenashev[Oleg Nenashev]
+* link:#oleg_nenashev[Oleg Nenashev]
 * link:#stefan_spieker[Stefan Spieker]
 * link:#jonesbusy[Valentin Delaye]
 


### PR DESCRIPTION
## Fix broken internal link to Oleg statement

Broken because I didn't update it to use the author link.

Confirmed with local site build that the broken link is fixed by this change.

