### PR TITLE
Add a register now button to candidate statements

### DIFF
--- a/content/blog/2024/10/03/2024-10-03-jenkins-election-candidates.adoc
+++ b/content/blog/2024/10/03/2024-10-03-jenkins-election-candidates.adoc
@@ -27,6 +27,15 @@ opengraph:
 Candidate nominations for the 2024 Jenkins elections are now complete.
 Thanks to everyone who submitted nominations and to the candidates that have accepted the nominations.
 
+== Register to vote
+
+Voters must register an account on the link:https://community.jenkins.io[Jenkins community forums] and must have made at least one contribution to Jenkins before September 1, 2024.
+You can use an existing GitHub account or create a new account specifically for link:https://community.jenkins.io[Jenkins community forums].
+
+image:/images/post-images/jenkins-is-the-way/register-button.png[link="https://community.jenkins.io/g/election-voter-2024", role=center, height=48]
+
+== Candidate statements
+
 This announcement shares the election candidates and their statements.
 Nominees for the Jenkins governance board include:
 


### PR DESCRIPTION
## Add a register now button to candidate statements

Need to continue encouraging readers to register to vote.  A single big button is an easy way to do that.
