### PR TITLE
Add banner to 2.462.3 LTS changelog for end of Java 11 support

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -9644,9 +9644,9 @@
 - version: "2.414.3"
   date: 2023-10-18
   banner: >
-      Short tags (without "jdk" in them) such as <code>jenkins/jenkins:2.414.3-alpine</code> are using Java 17 and not Java 11 like previously.
-      If you need to keep using Java 11, use tags like <code>jenkins/jenkins:2.414.3-jdk11</code>.
-      Also note that two new tags (2.414.3-alpine-jdk17 & 2.414.3-slim-jdk17) have been published without any content change a week later than the original ones.
+    Short tags (without "jdk" in them) such as <code>jenkins/jenkins:2.414.3-alpine</code> are using Java 17 and not Java 11 like previously.
+    If you need to keep using Java 11, use tags like <code>jenkins/jenkins:2.414.3-jdk11</code>.
+    Also note that two new tags (2.414.3-alpine-jdk17 & 2.414.3-slim-jdk17) have been published without any content change a week later than the original ones.
   changes:
   - type: security
     message: Important security fix.
@@ -9737,10 +9737,10 @@
 - version: "2.426.1"
   date: 2023-11-15
   banner: >
-      Short container image tags (without "jdk" in them) such as <code>jenkins/jenkins:2.426.1</code> are now using Java 17.
-      If you need to continue using Java 11, use tags like <code>jenkins/jenkins:2.426.1-jdk11</code>.
-      The Windows container images of this release switch from a windowsservercore-1809 Temurin base image to a windowsservercore-ltsc2019 Microsoft base image.
-      Note also that a proper set of tags is now published for these Windows images and they include "ltsc2019" instead of only "2019".
+    Short container image tags (without "jdk" in them) such as <code>jenkins/jenkins:2.426.1</code> are now using Java 17.
+    If you need to continue using Java 11, use tags like <code>jenkins/jenkins:2.426.1-jdk11</code>.
+    The Windows container images of this release switch from a windowsservercore-1809 Temurin base image to a windowsservercore-ltsc2019 Microsoft base image.
+    Note also that a proper set of tags is now published for these Windows images and they include "ltsc2019" instead of only "2019".
   lts_predecessor: "2.414.3"
   lts_baseline: "2.426"
   changes: # compared to lts_baseline 2.426 - extracted from the RC commit(s)
@@ -11601,6 +11601,10 @@
 
 - version: "2.462.3"
   date: 2024-10-02
+  banner: >
+    This is the last Jenkins LTS release to support Java 11.
+    Future Jenkins LTS releases will require Java 17 or Java 21.
+    More information is available in the <a href="/doc/book/platform-information/support-policy-java/">Java support policy</a> and the <a href="/blog/2023/11/06/introducing-2-2-2-java-support-plan/">2 + 2 + 2 Java support plan</a> blog post
   changes:
   - type: security
     message: Security fixes.

--- a/content/doc/book/platform-information/support-policy-java.adoc
+++ b/content/doc/book/platform-information/support-policy-java.adoc
@@ -12,7 +12,7 @@ The following Java versions are required to run Jenkins:
 |===
 |Supported Java versions|Long term support (LTS) release|Weekly release
 
-|Java 17 or Java 21|N/A |2.463 (June 2024)
+|Java 17 or Java 21|2.479.1 (October 2024) |2.463 (June 2024)
 |Java 11, Java 17, or Java 21|2.426.1 (November 2023) |2.419 (August 2023)
 |Java 11 or Java 17|2.361.1 (September 2022)|2.357 (June 2022)
 |Java 8, Java 11, or Java 17|2.346.1 (June 2022)|2.340 (March 2022)


### PR DESCRIPTION
## Add banner to 2.462.3 LTS changelog for end of Java 11 support

One more place to alert users that Java 11 support is ending.

Also updates the Java support policy page to list 2.479.1 as the first LTS release to require Java 17 or newer.
