### PR TITLE
Adjust 2.480 changelog entry for correct message & issue

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24944,8 +24944,8 @@
         pr_title: "[JENKINS-60866][JENKINS-71515] Use `JSON#parse` to process `codemirror-config`
           argument"
         message: |-
-          Improve Content Security Policy compatibility by removing an <code>eval</code> call from JS.
-          Developer: Require syntactically valid JSON snippet to be returned from <code>MarkupFormatter#getCodemirrorConfig</code> / provided to <code>codemirrorconfig</code> in <code>f:textarea</code>.
+          Developer: Improve Content Security Policy compatibility by removing an <code>eval</code> call from JS.
+          Require syntactically valid JSON snippet to be returned from <code>MarkupFormatter#getCodemirrorConfig</code> / provided to <code>codemirrorconfig</code> in <code>f:textarea</code>.
       - type: bug
         category: bug
         pull: 9827

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24937,13 +24937,14 @@
       - type: rfe
         category: developer
         pull: 6867
-        issue: 60866
+        issue: 71515
         authors:
           - daniel-beck
           - basil
         pr_title: "[JENKINS-60866][JENKINS-71515] Use `JSON#parse` to process `codemirror-config`
           argument"
         message: |-
+          Improve Content Security Policy compatibility by removing an <code>eval</code> call from JS.
           Developer: Require syntactically valid JSON snippet to be returned from <code>MarkupFormatter#getCodemirrorConfig</code> / provided to <code>codemirrorconfig</code> in <code>f:textarea</code>.
       - type: bug
         category: bug


### PR DESCRIPTION
This PR is to adjust the 2.480 changelog so that the entry regarding CSP improvements describes this idea. It also updates the issue that it should be connected to so that it is now correct.