### PR TITLE
Use dependabot syntax from archetype in "Improve a plugin"

### DIFF
--- a/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
+++ b/content/doc/developer/tutorial-improve/automate-dependency-update-checks.adoc
@@ -29,16 +29,14 @@ Automated dependency checks by dependabot are defined in a .github/dependabot.ym
 ----
 mkdir .github
 cat > .github/dependabot.yml <<END-OF-HERE-DOC
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
 version: 2
 updates:
-# Maintain dependencies for your plugin
 - package-ecosystem: maven
   directory: /
   schedule:
     interval: monthly
-  open-pull-requests-limit: 10
-  target-branch: master
-# Maintain dependencies for GitHub Actions
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
## Use dependabot syntax from archetype in "Improve a plugin"

The Jenkins plugin archetype is a good example of the preferred configuration of Jenkins plugins.  Let's use its syntax when we have a choice.  If we need additional explanatory comments, let's place them outside the code block rather than embedding them in the code block.
