### PR TITLE
Replace incorrect GCP link on downloads page, update GCP tutorial

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -60,6 +60,7 @@ check-filename = false
 "loLSNdCv6K4" = "loLSNdCv6K4"
 "ArachnePnR" = "ArachnePnR"
 "LIy90gGvmIU" = "LIy90gGvmIU"
+"71Nd_6OqdQk" = "71Nd_6OqdQk"
 "PNGs" = "PNGs"
 "Lso" = "Lso"
 "ND" = "ND"

--- a/content/doc/tutorials/tutorials-for-installing-jenkins-on-Google-Cloud.adoc
+++ b/content/doc/tutorials/tutorials-for-installing-jenkins-on-Google-Cloud.adoc
@@ -7,18 +7,31 @@ section: doc
 :imagesdir: ../../book/resources/
 
 You should have a Google Cloud account, otherwise you can https://cloud.google.com/gcp/getting-started[start here].
-At the end of the tutorial you will have a Jenkins up and running on the Google Cloud.
 
-## Jenkins on Google Compute Engine
+A link:https://medium.com/@beygumer/setting-up-jenkins-on-google-compute-engine-instance-and-deploying-to-gke-using-jenkins-agent-pod-74d83d9fc803[2023 blog post by Umer Beigh] provides detailed steps to configure Google Cloud and Google Kubernetes Engine with Jenkins.
 
-This tutorial assumes you are familiar with the following software:
+Additional guidance is available from https://cloud.google.com/blog/products/gcp/using-jenkins-on-google-compute-engine-for-distributed-builds[Vic Iglesias' blog post].
 
-* **Packer** tool for creating images.
+Darin Pope has created several video tutorials of various aspects of Google Cloud Platform.
 
-### Dive into the tutorial for installing jenkins on Google Cloud
+## Using the gcloud command line interface
 
-* Watch the video tutorial here:
+Google Cloud operations are often performed with the link:https://cloud.google.com/sdk/docs[`gcloud` command line interface].
+This tutorial illustrates the steps to configure and use the `gcloud` command line interface from a Jenkins Pipeline.
 
 video::Zy_FQEYkaRw[youtube, width=640, height=360,  align="center"]
 
-For a reference to the video, check out this https://cloud.google.com/blog/products/gcp/using-jenkins-on-google-compute-engine-for-distributed-builds[blog post], which provides more details on how.
+## Using Google Cloud Run
+
+link:https://cloud.google.com/run/docs[Google Cloud Run] is a managed compute platform that enables you to run containers that are invocable via requests or events.
+Cloud Run is serverless: it abstracts away all infrastructure management, so you can focus on what matters most - building great applications.
+This tutorial illustrates the steps to deploy a container image to Google Cloud Run.
+
+video::71Nd_6OqdQk[youtube, width=640, height=360,  align="center"]
+
+## Using Google Secret Manager
+
+link:https://cloud.google.com/secret-manager/docs[Google Secret Manager] as a centralized credential manager available with Google Cloud.
+This tutorial illustrates the steps to use Google Secret Manager for Jenkins credentials.
+
+video::eHtRGc6EMY4[youtube, width=640, height=360,  align="center"]

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -280,7 +280,7 @@ title: Download and deploy
     {
       "image": "google-cloud",
       "title": "Using Jenkins for distributed builds on Compute Engine",
-      "href": "https://cloud.google.com/architecture/using-jenkins-for-distributed-builds-on-compute-engine",
+      "href": "/doc/tutorials/tutorials-for-installing-jenkins-on-Google-Cloud/",
       "background": "#34a853",
       "color": "color-mix(in srgb, #34a853 75%, var(--color))"
     },


### PR DESCRIPTION
## Replace incorrect GCP link on downloads page, update GCP page

Preview page is available [here](https://deploy-preview-7610--jenkins-io-site-pr.netlify.app/doc/tutorials/tutorials-for-installing-jenkins-on-google-cloud/)

The current link to GCP from the downloads page is for an unrelated page.  The original page was a 2018 blog post.  Much newer information is available from other sources.  Rather than link to an unrelated page, let's link to a page that we maintain and that we can update with more content.

The linked blog post from medium.com that is now included in the Jenkins tutorial page is the most thorough Jenkins installation tutorial (that I could fine) for Google Cloud Platform.  It describes the Jenkins controller installation and the configuration of Kubernetes agents for that Jenkins controller using Google Kubernetes Engine.

The video "How to integrate Jenkins with GCP" provides detailed instructions to configure and use the `gcloud` command from inside a Jenkins job.  It does not require any knowledge of Packer or any use of Packer images.

The second video, "Using Google Cloud Run", builds on the material from the first video and shows how to use the serverless Google Cloud Run facility to deploy a container image to Google Cloud.

The third video describes how to use Google Secret Manager for Jenkins credentials.
