### PR TITLE
Update weekly 2.481 to include all entries

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25003,6 +25003,47 @@
   - version: '2.481'
     date: 2024-10-15
     changes:
+      - type: rfe
+        category: rfe
+        pull: 9787
+        issue: 73813
+        authors:
+          - mawinter69
+        pr_title: "[JENKINS-73813] Show a notification when scheduling a build fails"
+        message: |-
+          Show a notification when scheduling a build fails.
+      - type: rfe
+        category: rfe
+        pull: 9833
+        authors:
+          - janfaracik
+        pr_title: "Refine content and appearance of the 'Edit View' screen"
+        message: |-
+          Refine content and appearance of the <strong>Edit View</strong> screen.
+      - type: rfe
+        category: rfe
+        authors:
+          - basil
+        pr_title: "Winstone 8.2: Upgrade Jetty from 12.0.13 to Jetty 12.0.14"
+        references:
+          - pull: 9841
+          - url: https://github.com/jetty/jetty.project/releases/jetty-12.0.14
+            title: Jetty 12.0.14 changelog
+          - url:https://github.com/jenkinsci/winstone/releases/winstone-8.2
+            title: Winstone 8.2 changelog
+        message: |-
+          Winstone 8.2: Upgrade Jetty from 12.0.13 to 12.0.14.
+      - type: rfe
+        category: rfe
+        authors:
+          - Vlatombe
+        pr_title: "[JENKINS-30101][JENKINS-30175] Simplify persistence design for temporarily offline status"
+        references:
+          - pull: 9855
+          - issue: 30101
+          - issue: 30175
+        message: |-
+          Keep user offline when agent connects or disconnects for technical reasons.
       - type: bug
         category: bug
         pull: 9727
@@ -25013,7 +25054,33 @@
           when deserializing XML files"
         message: |-
           Ignore values with incorrect types when deserializing collections and maps in XML files.
-
+      - type: bug
+        category: bug
+        pull: 9739
+        issue: 72979
+        authors:
+          - debayangg
+        pr_title: "[JENKINS-72979] Remove trailing space from Windows agent secret file instructions"
+        message: |-
+          Remove trailing space from Windows agent secret file instructions.
+      - type: bug
+        category: bug
+        pull: 9810
+        issue: 73835
+        authors:
+          - dwnusbaum
+        pr_title: "[JENKINS-73835] Do not allow builds to be deleted while they are still running and ensure build discarders run after builds are fully complete"
+        message: |-
+          Do not allow builds to be deleted while they are still building.
+          Ensure build discarders only process builds which have fully completed.
+      - type: rfe
+        category: developer
+        pull: 9813
+        authors:
+          - Vlatombe
+        pr_title: "Create a new taglib to capture the save/apply bottom bar"
+        message: |-
+          Developer: a new taglib <code><f:saveApplyBar/></code> is now available for configuration forms.
   # pull: 9844 (PR title: Update dependency org.jenkins-ci.plugins:matrix-project to v839)
   # pull: 9845 (PR title: Update jenkins/ath Docker tag to v6032)
   # pull: 9847 (PR title: Update jenkins/ath Docker tag to v6034)


### PR DESCRIPTION
This PR is to update the 2.481 changelog so that it includes all intended entries that were missed as a result of the changelog generator not picking them up.