### PR TITLE
Format 2.481 changelog to match automated formatting

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25037,7 +25037,8 @@
         category: rfe
         authors:
           - Vlatombe
-        pr_title: "[JENKINS-30101][JENKINS-30175] Simplify persistence design for temporarily offline status"
+        pr_title: "[JENKINS-30101][JENKINS-30175] Simplify persistence design for
+          temporarily offline status"
         references:
           - pull: 9855
           - issue: 30101
@@ -25060,7 +25061,8 @@
         issue: 72979
         authors:
           - debayangg
-        pr_title: "[JENKINS-72979] Remove trailing space from Windows agent secret file instructions"
+        pr_title: "[JENKINS-72979] Remove trailing space from Windows agent secret
+          file instructions"
         message: |-
           Remove trailing space from Windows agent secret file instructions.
       - type: bug
@@ -25069,7 +25071,8 @@
         issue: 73835
         authors:
           - dwnusbaum
-        pr_title: "[JENKINS-73835] Do not allow builds to be deleted while they are still running and ensure build discarders run after builds are fully complete"
+        pr_title: "[JENKINS-73835] Do not allow builds to be deleted while they are
+          still running and ensure build discarders run after builds are fully complete"
         message: |-
           Do not allow builds to be deleted while they are still building.
           Ensure build discarders only process builds which have fully completed.


### PR DESCRIPTION
Manually generated 2.481 changelog did not use same exact formatting as the automated formatter.  Match the automated formatter.