### PR TITLE
Weekly 2.481 - adjust ofline agent entry message

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25043,7 +25043,7 @@
           - issue: 30101
           - issue: 30175
         message: |-
-          Keep user-generated offline reason when agent connects or disconnects for technical reasons.
+          Retain user-generated offline reason when agent connects or disconnects for technical reasons.
       - type: bug
         category: bug
         pull: 9727

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25043,7 +25043,7 @@
           - issue: 30101
           - issue: 30175
         message: |-
-          Keep user offline reason when agent connects or disconnects for technical reasons.
+          Keep user-generated offline reason when agent connects or disconnects for technical reasons.
       - type: bug
         category: bug
         pull: 9727


### PR DESCRIPTION
This PR is to clarify the message for user created offline reasoning when agents are either connected or disconnected. 