### PR TITLE
LTS 2.479.1 - Additional backports and Spring versions

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -11732,6 +11732,25 @@
     pr_title: "Update dependency io.jenkins.plugins:asm-api to v9.7.1-95.v9f552033802a_"
     message: |-
       Update ASM to 9.7.1 to match the most recent release of the ASM API and Jenkins ASM API plugin.
+  - type: bug
+    category: bug
+    pull: 9810
+    issue: 73835
+    authors:
+      - dwnusbaum
+    pr_title: "[JENKINS-73835] Do not allow builds to be deleted while they are
+      still running and ensure build discarders run after builds are fully complete"
+    message: |-
+      Do not allow builds to be deleted while they are still building.
+      Ensure build discarders only process builds which have fully completed.
+  - type: bug
+    category: bug
+    pull: 9882
+    authors:
+      - basil
+    pr_title: "Allow for null to be passed to doSafeRestart"
+    message: |-
+      Allow null to be passed as the first argument to <code>doSafeRestart</code>.
 
   lts_changes: # compared to lts_predecessor 2.462.3 (selected by personal review)
 
@@ -11757,12 +11776,18 @@
         title: Spring Framework 6.0.23 release notes
       - url: https://github.com/spring-projects/spring-framework/releases/tag/v6.1.12
         title: Spring Framework 6.1.12 release notes
+      - url: https://github.com/spring-projects/spring-framework/releases/tag/v6.1.13
+        title: Spring Framework 6.1.13 release notes
+      - url: https://github.com/spring-projects/spring-framework/releases/tag/v6.1.14
+        title: Spring Framework 6.1.14 release notes
       - url: https://github.com/spring-projects/spring-security/releases/tag/6.2.6
         title: Spring Security 6.2.6 release notes
       - url: https://github.com/spring-projects/spring-security/releases/tag/6.3.2
         title: Spring Security 6.3.2 release notes
       - url: https://github.com/spring-projects/spring-security/releases/tag/6.3.3
         title: Spring Security 6.3.3 release notes
+      - url: https://github.com/spring-projects/spring-security/releases/tag/6.3.4
+        title: Spring Security 6.3.4 release notes
       - url: https://projects.eclipse.org/releases/jakarta-ee-9
         title: Jarkata EE 9 release page
       - url: https://github.com/jenkinsci/ldap-plugin/releases/tag/733.vd3700c27b_043
@@ -11774,7 +11799,7 @@
       - pull: 9672
       - issue: 73278
     message: |-
-      Upgrade Spring Framework from 5.3.39 to 6.1.12, upgrade Spring Security from 5.8.14 to 6.3.3, and upgrade Java EE from 8 to 9.
+      Upgrade Spring Framework from 5.3.39 to 6.1.14, upgrade Spring Security from 5.8.14 to 6.3.4, and upgrade Java EE from 8 to 9.
       Users of the LDAP plugin must upgrade to version 733.vd3700c27b_043 in combination with upgrading Jenkins core.
       Users of the CAS plugin must upgrade to version 1.7.0 in combination with upgrading Jenkins core.
       Users of third-party servlet containers must upgrade their servlet container to an EE 9 version in accordance with the Jenkins Servlet Container Support Policy.


### PR DESCRIPTION
This PR is to add the additional backports to the changelog in the "changes since 2.479" section and update the Spring Security & Framework versions to the latest versions.