### PR TITLE
Fix link in brownout blog post

### DIFF
--- a/content/blog/2024/10/24/2024-10-24-update-center-brownouts-5.adoc
+++ b/content/blog/2024/10/24/2024-10-24-update-center-brownouts-5.adoc
@@ -54,11 +54,11 @@ As such, a fifth brownout serves to verify the above (minor) problems are solved
 
 Both current and new Update Centers are updated at the same time and serve the same index.
 
-Starting 12 weeks ago, the Jenkins infrastructure has been using the new Update Center (link:https://azure.updates.jenkins.io) with a client-side DNS override (`updates.jenkins.io` hostname points to this new service).
+Starting 12 weeks ago, the Jenkins infrastructure has been using the new Update Center (link:https://azure.updates.jenkins.io[azure.updates.jenkins.io]) with a client-side DNS override (`updates.jenkins.io` hostname points to this new service).
 
 During this brownout, we'll simply switch the DNS entry `updates.jenkins.io` to this new service and watch for the logs and error rate.
 At the end, we'll switch DNS back to the normal service and then analyze metrics and logs to see how the system behaved.
 
-We are confident the new system will perform as expected
+We are confident the new system will perform as expected.
 
 Please refer to the link:https://github.com/jenkins-infra/helpdesk/issues/2649[helpdesk ticket] for more information.


### PR DESCRIPTION
## Fix link in brownout blog post

Text shown to user is:

> Starting 12 weeks ago, the Jenkins infrastructure has been using the new Update Center (link:https://azure.updates.jenkins.io)

Replace the link: with a hyperlink
