### PR TITLE
fix(updatecli): Handle 307 HTTP redirect

### DIFF
--- a/updatecli/scripts/jenkins-oldest-supported-version.sh
+++ b/updatecli/scripts/jenkins-oldest-supported-version.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Fetch the JSON data from the Jenkins update site and store it in a variable.
-json_data=$(curl -s https://updates.jenkins.io/tiers.json)
+json_data=$(curl -sL https://updates.jenkins.io/tiers.json)
 
 # Extract the oldest LTS version from the JSON data.
 # The jq command is used to parse the JSON data and extract the oldest LTS version, which is stored in the oldest_lts variable.

--- a/updatecli/scripts/jenkins-oldest-supported-version.sh
+++ b/updatecli/scripts/jenkins-oldest-supported-version.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Fetch the JSON data from the Jenkins update site and store it in a variable.
-json_data=$(curl -sL https://updates.jenkins.io/tiers.json)
+json_data=$(curl --silent --location https://updates.jenkins.io/tiers.json)
 
 # Extract the oldest LTS version from the JSON data.
 # The jq command is used to parse the JSON data and extract the oldest LTS version, which is stored in the oldest_lts variable.

--- a/updatecli/scripts/jenkins-split.sh
+++ b/updatecli/scripts/jenkins-split.sh
@@ -21,4 +21,4 @@ url="https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/re
 # In other words, it operates on the last line of the input.
 # '{print $2}' tells awk to print the second field of the line. By default, awk splits the line into fields based on whitespace,
 # so this will print the part of the line between the first and second space.
-curl -sL $url | awk 'END{print $2}'
+curl --silent --location $url | awk 'END{print $2}'

--- a/updatecli/scripts/jenkins-split.sh
+++ b/updatecli/scripts/jenkins-split.sh
@@ -21,4 +21,4 @@ url="https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/re
 # In other words, it operates on the last line of the input.
 # '{print $2}' tells awk to print the second field of the line. By default, awk splits the line into fields based on whitespace,
 # so this will print the part of the line between the first and second space.
-curl -s $url | awk 'END{print $2}'
+curl -sL $url | awk 'END{print $2}'


### PR DESCRIPTION
The `updatecli` check in #7630 was failing because the `curl` command in the `bash` script wasn't properly following `307` HTTP redirects (which weren't occurring when the script was originally developed).

Question: Is this failure related to the current brownout?

## Testing
```
updatecli diff --debug --config ./updatecli/updatecli.d/ --values ./updatecli/values.github-action.yaml 2>&1
[...]
Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  11
  * Total:      11
```