### PR TITLE
Do not show "Notable changes" section for unreleased LTS versions

### DIFF
--- a/content/changelog-stable/index.html.haml
+++ b/content/changelog-stable/index.html.haml
@@ -23,10 +23,10 @@ actions:
         %div.app-releases__list__items
           = partial('changelog-changes.html.haml', :changes => release.changes)
 
-    - if release.changes and release.lts_changes
-      .app-releases__notable-changes
-        = "Notable changes since #{release.lts_predecessor}"
-      %div.app-releases__list__items
-        = partial('changelog-changes.html.haml', :changes => release.lts_changes)
+      - if release.changes and release.lts_changes
+        .app-releases__notable-changes
+          = "Notable changes since #{release.lts_predecessor}"
+        %div.app-releases__list__items
+          = partial('changelog-changes.html.haml', :changes => release.lts_changes)
 
   = partial('changelog-stable.html')


### PR DESCRIPTION
Amends #7479.

Too little indentation here means the LTS changelog starts with the "Notable changes" for an unreleased version at the moment.

> <img width="1557" alt="Screenshot 2024-10-29 at 16 02 06" src="https://github.com/user-attachments/assets/b4b2817c-9179-469a-bd47-ef86204d979c">
