### PR TITLE
Add LTS 2.479.1 to servlet container support policy

### DIFF
--- a/content/doc/book/platform-information/support-policy-servlet-containers.adoc
+++ b/content/doc/book/platform-information/support-policy-servlet-containers.adoc
@@ -37,22 +37,22 @@ a|The versions of Winstone and Jetty bundled in the Jenkins link:/doc/book/insta
   We do not regularly test compatibility, and we may drop support at any time.
   We consider patches that do not put Level 1 support at risk and do not create maintenance overhead.
 a|
-  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
-  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
-  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
-  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
-  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
-  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
-  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475 and newer*)
+  * Tomcat 9, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
+  * WildFly 26, based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
+  * Other servlet containers that are based on Servlet API 4.0 (Jakarta EE 8) with `javax.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475, LTS 2.479.1, and newer*)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475, LTS 2.479.1, and newer*)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475, LTS 2.479.1, and newer*)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.475, LTS 2.479.1, and newer*)
 
 | **Level 3:** Unsupported
 | These versions are known to be incompatible or to have severe limitations.
   We do not support the listed servlet containers.
 a|
-  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
-  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
-  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
-  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.2, and older*)
+  * Jetty 11 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
+  * Tomcat 10 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
+  * WildFly 27 or later, based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
+  * Other servlet containers that are based on Servlet API 5.0 (Jakarta EE 9) or later with `jakarta.servlet` imports. (*Weekly 2.474, LTS 2.462.3, and older*)
 
 |===
 


### PR DESCRIPTION
This PR is to add the latest LTS release to the servlet container policy page.