### PR TITLE
Added short section about jcasc in the testing dev docu

### DIFF
--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -570,9 +570,9 @@ public class MyTest {
 === Verifying compatibility with Configuration as Code (JCasC)
 
 The link:https://plugins.jenkins.io/configuration-as-code/[Configuration as Code plugin] is an opinionated way to configure Jenkins based on human-readable declarative configuration files.
-Writing such a file should be feasible without being a Jenkins expert, just translating into code a configuration process one is used to executing in the web UI.
-If the plugin should support JCasC, it should also test the compatability.
-More details can be found at the link:https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/PLUGINS.md[configuration-as-code-plugin documentation].
+Writing such a file can be done without being a Jenkins expert by translating a configuration process one is familiar with executing in the web UI into code.
+If the plugin supports JCasC, it also tests compatibility.
+More details can be found in the link:https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/PLUGINS.md[configuration-as-code-plugin documentation].
 
 == Increasing Tests Timeout
 

--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -567,6 +567,13 @@ public class MyTest {
 }
 ----
 
+=== Verifying compatibility with Configuration as Code (JCasC)
+
+The link:https://plugins.jenkins.io/configuration-as-code/[Configuration as Code plugin] is an opinionated way to configure Jenkins based on human-readable declarative configuration files.
+Writing such a file should be feasible without being a Jenkins expert, just translating into code a configuration process one is used to executing in the web UI.
+If the plugin should support JCasC, it should also test the compatability.
+More details can be found at the link:https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/PLUGINS.md[configuration-as-code-plugin documentation].
+
 == Increasing Tests Timeout
 
 The default timeout for Jenkins integration tests is 180 seconds.


### PR DESCRIPTION
Added short section about jcasc which was missing completely. Mainly sending the users to the plugin documentation.