### PR TITLE
Modified windows.adoc: Added brief LogonAsService Note

### DIFF
--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -58,7 +58,9 @@ click on *Test Credentials* to test your domain credentials and click on *Next*.
 
 image:tutorials/windows-jenkins-logon-credentials.png[alt="Jenkins Service Logon Credentials",width=80%]
 
-NOTE: If you get *Invalid Logon* Error pop-up while trying to test your credentials,
+NOTE: The user account running Jenkins requires the `LogonAsService` permission to run Jenkins 
+as a service.
+If you get *Invalid Logon* Error pop-up while trying to test your credentials,
 follow the steps explained <<invalid-service-logon-credentials,here>> to resolve it.
 
 Step 4: Port selection::
@@ -268,9 +270,9 @@ When installing a service to run under a domain user account, the account must h
 Perform the following steps below to edit the Local Security Policy of the computer you want to define the ‘logon as a service’ permission:
 
 . Logon to the computer with administrative privileges.
-. Open the *Administrative Tools* and open the *Local Security Policy*
+. Open the *Administrative Tools* and open the *Local Security Policy* or typing `secpol.msc` in the Run dialog (Win + R) and pressing Enter.
 . If the *Local Security Policy* is missing in your system, refer to the answer in the https://answers.microsoft.com/en-us/windows/forum/all/where-to-download-gpeditmsc-for-windows-10-home/c39bd656-8d4a-4374-be39-394c09deec4e[Where to download GPEdit.msc for Windows 10 Home?] question on Microsoft Community to troubleshoot
-. Expand *Local Policy* and click on *User Rights Assignment*
+. In the *Local Security Policy* window, Expand *Local Policy* and click on *User Rights Assignment*
 . In the right pane, right-click *Log on as a service* and select properties.
 . Click on the *Add User or Group…* button to add the new user.
 . In the *Select Users or Groups* dialogue, find the user you wish to enter and click *OK*


### PR DESCRIPTION
- Added a brief note in "Step 3: Service logon credentials::" to indicate that the Jenkins service account requires `LogonAsService` permission.
- Slightly adjusted wording in the troubleshooting section.

Reference: [JENKINS-63477](https://issues.jenkins.io/browse/JENKINS-63477).