### PR TITLE
Add bug entry to 2.484 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25241,6 +25241,14 @@
         pr_title: Translate RSS links to Turkish
         message: |-
           Translate RSS links to Turkish.
+      - type: bug
+        category: bug
+        pull: 9925
+        authors:
+          - jglick
+        pr_title: "Race condition & memory leak in TypedFilter"
+        message: |-
+          Fix a rare race condition rendering pages soon after startup.
 
   # pull: 9778 (PR title: Avoid saving `nextBuildNumber` while loading `Job`)
   # pull: 9846 (PR title: `Job.BuildNumberAssigner`)


### PR DESCRIPTION
This bug was missed by the automated changelog generator, and when I went to go review it there was no indication that it was part of 2.484 (the merged commit did not have the 2.484 tag attached).

This PR is to add the entry to the changelog accordingly.