### PR TITLE
Fix brownout link formatting

### DIFF
--- a/content/blog/2024/11/07/2024-11-07-update-center-brownouts-6.adoc
+++ b/content/blog/2024/11/07/2024-11-07-update-center-brownouts-6.adoc
@@ -17,7 +17,7 @@ discourse: true
 
 Note: this is a follow up of link:/blog/2024/10/24/update-center-brownouts-5/[the 24 and 25 October 2024 24 hours brownout].
 
-The service link:https://updates.jenkins.io will switch its implementation to a new system during 1 day:
+The service link:https://updates.jenkins.io[] will switch its implementation to a new system during 1 day:
 
 - From Thursday 7 November 2024 09:00 am UTC until Friday 8 November 2024 09:00 am UTC
 

--- a/content/blog/2024/11/07/2024-11-07-update-center-brownouts-6.adoc
+++ b/content/blog/2024/11/07/2024-11-07-update-center-brownouts-6.adoc
@@ -17,7 +17,7 @@ discourse: true
 
 Note: this is a follow up of link:/blog/2024/10/24/update-center-brownouts-5/[the 24 and 25 October 2024 24 hours brownout].
 
-The service link:https://updates.jenkins.io[] will switch its implementation to a new system during 1 day:
+The service link:https://updates.jenkins.io[updates.jenkins.io] will switch its implementation to a new system during 1 day:
 
 - From Thursday 7 November 2024 09:00 am UTC until Friday 8 November 2024 09:00 am UTC
 


### PR DESCRIPTION
The link was missing a set of brackets ([]) at the end so this adds them and fixes the link.