### PR TITLE
chore(Jenkinsfile) collect `azcopy` publication logs when failing deployment on trusted.ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,11 +105,6 @@ node('docker&&linux') {
                         --put-md5 \
                         --local-hash-storage-mode=HiddenFiles \
                         ./build/_site/ "${FILESHARE_SIGNED_URL}"
-    
-                    # Retrieve azcopy logs to archive them
-                    cat /home/jenkins/.azcopy/*.log > azcopy.log
-                    '''
-                    archiveArtifacts 'azcopy.log'
                 }
             } catch (err) {
                 currentBuild.result = 'FAILURE'
@@ -118,7 +113,7 @@ node('docker&&linux') {
                 # Retrieve azcopy logs to archive them
                 cat /home/jenkins/.azcopy/*.log > azcopy.log
                 '''
-                archiveArtifacts 'azcopy.log' 
+                archiveArtifacts 'azcopy.log'
             }
         }
         stage('Purge cached CSS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ node('docker&&linux') {
                         --put-md5 \
                         --local-hash-storage-mode=HiddenFiles \
                         ./build/_site/ "${FILESHARE_SIGNED_URL}"
-                      '''
+                    '''
                 }
             } catch (err) {
                 currentBuild.result = 'FAILURE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ node('docker&&linux') {
                         --put-md5 \
                         --local-hash-storage-mode=HiddenFiles \
                         ./build/_site/ "${FILESHARE_SIGNED_URL}"
-                  '''
+                      '''
                 }
             } catch (err) {
                 currentBuild.result = 'FAILURE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,7 @@ node('docker&&linux') {
                         --put-md5 \
                         --local-hash-storage-mode=HiddenFiles \
                         ./build/_site/ "${FILESHARE_SIGNED_URL}"
+                  '''
                 }
             } catch (err) {
                 currentBuild.result = 'FAILURE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,29 +86,39 @@ node('docker&&linux') {
     */
     if (infra.isTrusted() && env.BRANCH_NAME == null) {
         stage('Publish site') {
-            infra.withFileShareServicePrincipal([
-                servicePrincipalCredentialsId: 'trustedci_jenkinsio_fileshare_serviceprincipal_writer',
-                fileShare: 'jenkins-io',
-                fileShareStorageAccount: 'jenkinsio'
-            ]) {
+            try {
+                infra.withFileShareServicePrincipal([
+                    servicePrincipalCredentialsId: 'trustedci_jenkinsio_fileshare_serviceprincipal_writer',
+                    fileShare: 'jenkins-io',
+                    fileShareStorageAccount: 'jenkinsio'
+                ]) {
+                    sh '''
+                    # Don't output sensitive information
+                    set +x
+    
+                    # Synchronize the File Share content
+                    azcopy sync \
+                        --skip-version-check \
+                        --recursive=true\
+                        --delete-destination=true \
+                        --compare-hash=MD5 \
+                        --put-md5 \
+                        --local-hash-storage-mode=HiddenFiles \
+                        ./build/_site/ "${FILESHARE_SIGNED_URL}"
+    
+                    # Retrieve azcopy logs to archive them
+                    cat /home/jenkins/.azcopy/*.log > azcopy.log
+                    '''
+                    archiveArtifacts 'azcopy.log'
+                }
+            } catch (err) {
+                currentBuild.result = 'FAILURE'
+                // Only collect azcopy log when the deployment fails, because it is an heavy one
                 sh '''
-                # Don't output sensitive information
-                set +x
-
-                # Synchronize the File Share content
-                azcopy sync \
-                    --skip-version-check \
-                    --recursive=true\
-                    --delete-destination=true \
-                    --compare-hash=MD5 \
-                    --put-md5 \
-                    --local-hash-storage-mode=HiddenFiles \
-                    ./build/_site/ "${FILESHARE_SIGNED_URL}"
-
                 # Retrieve azcopy logs to archive them
                 cat /home/jenkins/.azcopy/*.log > azcopy.log
                 '''
-                archiveArtifacts 'azcopy.log'
+                archiveArtifacts 'azcopy.log' 
             }
         }
         stage('Purge cached CSS') {


### PR DESCRIPTION
Inspired by https://github.com/jenkins-infra/javadoc/blob/238c39e60a4e2adfb179539ad03f67d24eb39008/Jenkinsfile#L52-L87