### PR TITLE
fix(election-walkthrough) account activation is now (2024) mandatory

### DIFF
--- a/content/project/election-walkthrough.adoc
+++ b/content/project/election-walkthrough.adoc
@@ -70,7 +70,7 @@ Joining the group is required to receive the invitation to cast your vote.
 
 To manage elections, the Jenkins project uses the link:https://civs1.civs.us/[Condorcet Internet Voting Service (CIVS)].
 
-If you haven't participated in Jenkins elections before, you need to link:https://civs1.civs.us/cgi-bin/opt_in.pl[activate your account] on the CIVS service manually.
+You need to link:https://civs1.civs.us/cgi-bin/opt_in.pl[activate your account] on the CIVS service manually.
 The following example shows the activation process:
 
 image::../project/election-walkthrough-screenshots/activate-civs-account.png[Activate your CIVS account]


### PR DESCRIPTION
The behavior of the CIVS platform changed in the past years; we must enable our account, it is not automatic anymore.

This PR adapt the wording to avoid confusion.