### PR TITLE
feat(gsoc): add 2025 proposed project ideas

### DIFF
--- a/content/projects/gsoc/2024/index.adoc
+++ b/content/projects/gsoc/2024/index.adoc
@@ -1,4 +1,158 @@
 ---
-layout: redirect
-redirect_url: /projects/gsoc
+layout: project
+title: "Jenkins in Google Summer of Code 2024"
+description: "Landing page for the Google Summer of Code program in the Jenkins project"
+section: projects
+tags:
+- gsoc
+sig: gsoc
+opengraph:
+  image: /images/gsoc/opengraph.png
+links:
+  gitter: "jenkinsci_gsoc-sig:gitter.im"
+  meetings: "/projects/gsoc/#office-hours"
 ---
+
+// image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=left]
+link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
+(GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ weeks-long programming project under the guidance of dedicated mentors.
+
+GSoC contributors accepted into the program receive a stipend and are sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
+In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
+
+image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
+
+== GSoC 2024
+
+We are participating in Google Summer of Code in 2024. +
+// See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
+Google has accepted us as a mentoring organization in Google Summer of Code 2024.
+
+// Uncomment when application is worked on and submitted (Feb 2024)
+//(link:./2024/application[Jenkins GSoC Organisation Application Form])
+
+The selected projects are:
+
+* link:/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization[Manage Jenkinsci GitHub Permissions as Code] with link:https://github.com/Alaurant[Danyang Zhao] as the GSoC contributor.
+
+* link:/projects/gsoc/2024/projects/using-openrewrite-recipes-for-plugin-modernization-or-automation-plugin-build-metadata-updates[Using OpenRewrite Recipes for Plugin Modernization] with link:https://github.com/sridamul[Sridhar Sivakumar] as the GSoC contributor.
+
+* link:/projects/gsoc/2024/projects/implementing-ui-for-jenkins-infra-statistics[Implementing UI for Jenkins Infra Statistics] with link:https://github.com/shlomomdahan[Shlomo Dahan] as the GSoC contributor.
+
+* link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge[Enhancing an Existing LLM Model with Domain-specific Jenkins Knowledge] with link:https://github.com/nouralmulhem[Nour Almulhem] as the GSoC contributor.
+
+* link:/projects/gsoc/2024/projects/improving-maintainability-of-rpu[Improve Maintainability for the Repository Permission Updater] with link:https://github.com/TheMeinerLP[Phillipp Glanz] as the GSoC contributor.
+
+They were proposed and selected from these link:./project-ideas[project ideas].
+
+// We have finalised a list of 9 project ideas.
+// Add your ideas by submitting an ad-hoc pull request as explained in our previous link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
+
+// The 2024 GSoC project ideas link:./2024/project-ideas[can be found here].
+
+NOTE: Every year, there are changes in how GSoC is organized.
+Jenkins GSoC documentation may be outdated in some places, please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.
+Our documentation will be updated over time to reflect the changes in the GSoC program, please report any issues you encounter via our GitHub issue tracker.
+
+== GSoC Contributors
+
+* link:/projects/gsoc/contributors[Information and application guidelines for GSoC contributors]
+// * Online Meetup: Introduction to Jenkins in GSoC
+// (link:https://bit.ly/3pbJFuC[slides],
+// link:https://youtu.be/GDRTgEvIVBc[video])
+* link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
+* link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
+
+== Mentors
+
+Mentors are volunteers who help GSoC contributors to succeed in their projects.
+If you are interested in contributing to GSoC as a mentor, and have had either some GSoC contributor experience or have done mentoring before, please do not hesitate to reach out to us.
+We are always looking for new mentors to help us with the program.
+
+* link:/projects/gsoc/mentors[Information for mentors]
+* link:/projects/gsoc/proposing-project-ideas[HOWTO: Propose a project idea]
+* link:/projects/gsoc/roles-and-responsibilities[Roles and Responsibilities]
+* link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
+* link:https://community.jenkins.io/c/contributing/gsoc-mentors/25[Mentor's Dedicated Discourse group]
+
+== Org Admins
+
+Org Admins are the people managing the GSoC program for the Jenkins Organization.
+For 2024, our Org Admins are:
+
+* Alyssa Tong
+* Kris Stern
+* Bruno Verachten
+* Jean-Marc Meessen
+
+The following checklists and documents describe the role:
+
+* link:https://docs.google.com/document/d/1tShnTyka5fdBxaE0c93ptu-J_XTlSf3tKwJemhx5_nA/edit?usp=sharing[Org Admin runbook for the Jenkins project]
+* link:https://developers.google.com/open-source/gsoc/help/oa-tips[Org Admin tips by Google]
+
+== Contacts
+
+* We use the link:/sigs/gsoc[GSoC SIG] for communications about GSoC.
+Projects may also have their own mailing lists, chats, and meetings.
+Please take a look at the details on each of the project pages.
+* We use link:https://community.jenkins.io/c/contributing/gsoc/6[Discourse] for discussions.
+This is the **recommended** channel for communications.
+* There is also a link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for real-time communications, but it is better to use Discourse to request technical feedback or to have long-form discussions.
+* For private matters such as communication difficulties with mentors, GSoC contributors, or Org Admins,
+please use this mailto:gsoc-jenkins-org-admin@googlegroups.com[group email].
+
+=== GSoC Discourse
+
+Public communication channel: link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse].
+
+The purpose of GSoC Discourse is for all public communications on GSoC such as new mentor and new GSoC contributor introductions, project proposal questions and discussions, process and timeline related questions.
+
+=== Chats
+
+* link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[GSoC Gitter channel] for organizational topics related to Jenkins in GSoC
+* Project-specific chats, see project and project idea pages
+* link:/chat/[Common developer chats] for technical topics
+
+=== Office hours
+
+Although we use Discourse as the main communication channel, we also have regular "office hours" video calls.
+During these time slots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
+
+* Schedule: Weekly 30 minutes meetings. Office hours will be held on Thursdays at 13:00 UTC.
+Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
+// * link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
+* Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaODwGnSZzxjV6-6mqRfcoBe[here].
+
+// This meeting will be used for Q&A with GSoC applicants/contributors and mentors before the announcement of accepted projects as well as during the GSoC program.
+You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
+// More slots may be added on-demand, e.g. for project-specific discussions.
+
+In addition to these organization-wide meetings, each GSoC project has regular meetings during community bonding and coding phases.
+Please take a look at the project pages for the schedule.
+
+== Previous years
+
+* link:/projects/gsoc/2023[GSoC 2023] - 4 student projects
+* link:/projects/gsoc/2022[GSoC 2022] - 4 student projects
+* link:/projects/gsoc/2021[GSoC 2021] - 5 student projects
+* link:/projects/gsoc/2020[GSoC 2020] - 7 student projects
+* link:/projects/gsoc/2019[GSoC 2019] - 7 student projects
+* link:/projects/gsoc/2018[GSoC 2018] - 3 student projects
+* link:/projects/gsoc/gsoc2017[GSoC 2017] - not accepted
+* link:/projects/gsoc/gsoc2016[GSoC 2016] - 5 student projects
+* link:https://wiki.jenkins.io/display/JENKINS/Google+Summer+of+Code+2009[GSoC 2009] - as Hudson, not accepted
+
+== References, 2024
+
+* link:./project-ideas[GSoC 2024 project ideas]
+* link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp/[Jenkins page on the GSoC website]
+* link:/blog/2024/02/23/gsoc2024-announcement/[Jenkins GSoC 2024 announcement]
+* link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2024 announcement blog]
+
+== References
+
+You can find more information about GSoC in Jenkins below.
+
+* link:/sigs/gsoc[Jenkins GSoC Special Interest Group]
+* link:/sigs/advocacy-and-outreach/outreach-programs/[Other outreach programs in Jenkins]
+* link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]

--- a/content/projects/gsoc/2024/index.adoc
+++ b/content/projects/gsoc/2024/index.adoc
@@ -18,7 +18,7 @@ link:https://developers.google.com/open-source/gsoc/[Google Summer of Code]
 (GSoC) is a global, online program focused on bringing students and new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ weeks-long programming project under the guidance of dedicated mentors.
 
 GSoC contributors accepted into the program receive a stipend and are sponsored by Google, to work on well-defined projects to improve or enhance the Jenkins project.
-In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and succeed in completing their projects.
+In exchange, numerous Jenkins community members volunteer as "mentors" for the selected GSoC contributors to help integrate them into the open source community and successfully complete their projects.
 
 image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 

--- a/content/projects/gsoc/2025/index.adoc
+++ b/content/projects/gsoc/2025/index.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: /projects/gsoc
+---

--- a/content/projects/gsoc/2025/project-ideas.html.haml
+++ b/content/projects/gsoc/2025/project-ideas.html.haml
@@ -38,7 +38,7 @@ opengraph:
     %a{:href => expand_link("/projects/gsoc/")}
     for more information about this project and applications.
 %p
-  Below you can find project ideas which have been proposed for this year.
+  Below you can find project ideas that have been proposed for this year.
   New ideas may be proposed by interested mentors or GSoC contributors, such as new features in the core or "write a plugin for MY_TOOL_OR_SERVICE".
   Project ideas without potential mentors will be considered, though applicants may need to work with the community and GSoC org admins to find mentors.
   To add a new project idea, see:
@@ -50,10 +50,10 @@ opengraph:
   Accepted ideas
 
 %p
-  In the following list, you will find the project ideas that fully match the Jenkins' project idea standard.
+  The following list contains the project ideas that fully match the Jenkins project idea standard.
   The scope of these ideas is understood and we don't normally expect deep changes.
-  All ideas have quick start guidelines and newbie-friendly issues referenced.
-  We welcome contributors to join the mentor teams, and we invite GSoC contributors to submit project proposal applications in relation to these ideas.
+  All ideas have quick-start guidelines and newbie-friendly issues referenced.
+  We welcome contributors to join the mentor teams and invite GSoC contributors to submit project proposal applications related to these ideas.
 
 %table.pi_table.grid-all
   %thead

--- a/content/projects/gsoc/2025/project-ideas.html.haml
+++ b/content/projects/gsoc/2025/project-ideas.html.haml
@@ -1,0 +1,161 @@
+---
+layout: simplepage
+title: "GSoC 2025 Project Ideas"
+year: 2025
+tags:
+- gsoc
+- gsoc2025
+project: gsoc
+opengraph:
+  image: /images/gsoc/opengraph.png
+---
+
+//The individual page's layout is located at /content/_layouts/gsocprojectidea.html.haml
+
+:css
+  .pi_table {
+    width: 100%;
+  }
+  .pi_table_header {
+    text-align: center;
+  }
+  .pi_table_category {
+    width: 100px;
+  }
+  .pi_table_skills {
+    width: 175px;
+  }
+
+%img{:title => "Jenkins GSoC", :src => expand_link("/images/gsoc/jenkins-gsoc-logo_small.png"), :style => "float:right", :width => "128"}
+
+
+%p
+  = succeed '.' do
+    This page aggregates project ideas for Google Summer of Code
+    = page.year
+  = succeed '.' do
+    Refer to the Jenkins Google Summer of Code page
+    %a{:href => expand_link("/projects/gsoc/")}
+    for more information about this project and applications.
+%p
+  Below you can find project ideas which have been proposed for this year.
+  New ideas may be proposed by interested mentors or GSoC contributors, such as new features in the core or "write a plugin for MY_TOOL_OR_SERVICE".
+  Project ideas without potential mentors will be considered, though applicants may need to work with the community and GSoC org admins to find mentors.
+  To add a new project idea, see:
+  = succeed '.' do
+    %a{:href => expand_link("/projects/gsoc/proposing-project-ideas/")}
+      proposing project ideas
+
+%h3
+  Accepted ideas
+
+%p
+  In the following list, you will find the project ideas that fully match the Jenkins' project idea standard.
+  The scope of these ideas is understood and we don't normally expect deep changes.
+  All ideas have quick start guidelines and newbie-friendly issues referenced.
+  We welcome contributors to join the mentor teams, and we invite GSoC contributors to submit project proposal applications in relation to these ideas.
+
+%table.pi_table.grid-all
+  %thead
+    %tr.pi_table_header
+      %th Project
+      %th Category
+      %th Skills to study/improve
+  %tbody
+    // TODO: parameterize year
+    - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2025\/project-ideas\/[^\/]+.adoc/ }
+    - ideas.each do |item|
+      - if item.status == "published"
+        %tr
+          %td
+            %a{:href => item.url}
+              %strong
+                = item.title
+            %br
+            = succeed '.' do
+              = item.goal
+            %br
+            %b
+              Potential Mentor(s):
+            - item.mentors.each do |mentor|
+              = display_user_optional(mentor)
+          %td.pi_table_category
+            - if item.category
+              = item.category
+            - else
+              Undefined
+          %td.pi_table_skills
+            = item.skills.join(", ")
+
+%h3
+  Draft project ideas
+
+%p
+  In the following list, you can refer to draft project ideas, which are currently under review.
+  The scope of such ideas may change during the discussions, but the idea is accepted in principle.
+  You are welcome to comment on the draft and join the project as a mentor.
+  If you are a GSoC contributor, it is also fine to explore and apply to the draft project ideas.
+
+%table.pi_table.grid-all
+  %thead
+    %tr.pi_table_header
+      %th Project
+      %th Category
+      %th Skills to study/improve
+  %tbody
+    // TODO: parameterize year
+    - ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2025\/project-ideas\/[^\/]+.adoc/ }
+    - ideas.each do |item|
+      - if item.status == "draft"
+        %tr
+          %td
+            %a{:href => item.url}
+              %strong
+                = item.title
+            %br
+              = succeed '.' do
+                = item.goal
+            %b
+              Potential Mentor(s):
+            - item.mentors.each do |mentor|
+              = display_user_optional(mentor)
+          %td.pi_table_category
+            - if item.category
+              = item.category
+            - else
+              Undefined
+          %td.pi_table_skills
+            = item.skills.join(", ")
+
+// TODO parameterize year
+- ideas = site.pages.select { |p| p.source_path =~ /\/content\/projects\/gsoc\/2025\/project-ideas\/[^\/]+.adoc/ }
+- if ideas.length > 1
+  %h3
+    Ongoing discussion
+
+  %p.markdown
+    These proposals are suggestions from the mailing list, which have not been published as project ideas yet.
+    The feasibility is yet to be defined, and the idea may be dismissed depending on the feedback.
+    Everyone is welcome to participate in the discussion and join as a potential mentor.
+
+  %table.pi_table.grid-all
+    %thead
+      %tr.pi_table_header
+        %th Project
+        %th Category
+    %tbody
+      - ideas.each do |item|
+        - if item.status == "discussion"
+          %tr
+            %td
+              %a{:href => item.links.emailThread}
+                %strong
+                  = item.title
+              %br
+                = succeed '.' do
+                  = item.goal
+            %td.pi_table_category
+              - if item.category
+                = item.category
+              - else
+                Undefined

--- a/content/projects/gsoc/2025/project-ideas/android-or-ios-tutorial-pages.adoc
+++ b/content/projects/gsoc/2025/project-ideas/android-or-ios-tutorial-pages.adoc
@@ -1,0 +1,67 @@
+---
+layout: gsocprojectidea
+title: "Android and/or iOS tutorials in official documentation"
+goal: "Adding Android and/or iOS tutorials for Jenkins in the official documentation"
+category: Documentation
+year: 2025
+status: draft
+sig: documentation
+skills:
+- Documentation
+- Java
+- YAML
+- Android / iOS development
+- Command line tools
+mentors:
+- "gounthar"
+- "krisstern"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+Topics such as _how to proceed_, _what are the successful patterns_, and _what are the pitfalls_ are poorly documented.
+It very often requires potential users and Jenkins Administrators to "reinvent the wheel".
+
+==== iOS
+The project idea is to have a clear status of what can be done with Jenkins for iOS app builds now.
+There are only a few articles here and there about iOS.
+
+==== Android
+For Android development, some experiments are link:https://github.com/gounthar/MyFirstAndroidAppBuiltByJenkins[available] and were link:https://www.youtube.com/watch?v=fmTdT4Y-uCw&ab_channel=JeanQuinze[presented publicly].
+
+The proof of concept could be docker-compose based.
+It would work under Windows, Linux, Vagrant, macOS (x86 and ARM), and _mostly_ on Gitpod.
+It should be easily transposable to a production environment.
+The demo/proof-of-concept would be composed of a Jenkins controller (configured with JCasc), an Android agent, a generic Docker agent, an Android emulator, and an Android device farm (link:https://github.com/DeviceFarmer[STF]).
+
+The idea is to have a more precise status of what can be done now with Jenkins.
+We could then amend the existing link:/solutions/android/[Android documentation] and describe architectures for:
+
+* Standalone Android projects
+* Android apps building farms
+* Android distro building (customized AOSP)
+
+
+=== Skills to Study and Improve
+
+- Jenkins technical architecture
+- iOS application development
+- CI principle and practice
+- Android application development
+- Docker
+
+
+=== Project Size
+175 - 350 hours
+
+
+=== Project Difficulty Level
+
+Intermediate
+
+
+=== Expected outcomes
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase.

--- a/content/projects/gsoc/2025/project-ideas/backend-code-refactoring-for-infra-stats.adoc
+++ b/content/projects/gsoc/2025/project-ideas/backend-code-refactoring-for-infra-stats.adoc
@@ -1,0 +1,35 @@
+---
+layout: gsocprojectidea
+title: "Backend code refactoring for Infra Statistics"
+goal: "To significantly refactor backend code for the Infra Statistics"
+category: Infra
+year: 2025
+status: draft
+sig: infra
+skills:
+- Groovy
+- Backend-frontend Integration
+- Code Refactoring
+- Infra / DevOps Processes
+mentors:
+- "krisstern"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+The project aims to refactor the code at link:https://github.com/jenkins-infra/infra-statistics[] as well as to audit and improve the infra processes used for collecting the infra statistics data.
+
+
+=== Project Size
+175 - 350 hours
+
+
+=== Project Difficulty
+Intermediate
+
+
+=== Expected outcomes
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase.

--- a/content/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling.adoc
+++ b/content/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling.adoc
@@ -26,7 +26,7 @@ The link:/[jenkins.io] website is generated as a static website using Awestruct 
 One of the drawbacks of the current build method is that the technical documentation is not product version bound.
 It is thus not possible to view the documentation for a given Jenkins version.
 Only the latest can be viewed.
-This can lead to unnecessary confusion and is a worse experience than many other documentation sites like the git site, FreeBSD, and others..
+This can lead to unnecessary confusion and is a worse experience than many other documentation sites like the git site, FreeBSD, and others...
 
 The preferred tool to replace Awestruct is link:https://antora.org/[Antora].
 
@@ -35,11 +35,11 @@ Once the existing site is generated with Antora, the site should be extended to 
 
 The project has been discussed extensively at link:https://github.com/jenkins-infra/jenkins.io/issues/5474[GitHub issue #5474], where some existing proof-of-concept code can be found referenced there.
 
-There are multiple ways to approach the implementation, but from experimentation it has been found that the backend replacement requires minimal effort for the documentation, with the frontend implementation expected to require much effort to reproduce the look and feel of the current link:/[jenkins.io] website. However, the blog can be split from the documentation using something like link:https://www.gatsbyjs.com/[Gatsby], which is expected to make it easier for users to submit posts in the future.
+There are multiple ways to approach the implementation, but from experimentation, it has been found that the backend replacement requires minimal effort for the documentation, with the frontend implementation expected to require much effort to reproduce the look and feel of the current link:/[jenkins.io] website. However, the blog can be split from the documentation using something like link:https://www.gatsbyjs.com/[Gatsby], which is expected to make it easier for users to submit posts in the future.
 
-While the tasks of the project are very clearly defined, the scope may vary depending on the plans of the contributor. If we split the project into milestones, we see three important ones that can be tackled in sequence: The most urgent milestone is (1) to set up the user documentation using Antora with versioning, while next would be (2) to set up the developer documentation with Antora without versioning, and finally (3) to set up the blog using Gatsby. The contributor can choose either 1, or a combination of 1 + 2, or a combination of 1 + 2 + 3, but not in any other way. The expected project outcome is at least a drop-in replacement website that is building locally.
+While the tasks of the project are very clearly defined, the scope may vary depending on the plans of the contributor. If we split the project into milestones, we see three important ones that can be tackled in sequence: The most urgent milestone is (1) to set up the user documentation using Antora with versioning, while the next would be (2) to set up the developer documentation with Antora without versioning, and finally (3) to set up the blog using Gatsby. The contributor can choose either 1, a combination of 1 + 2, or a combination of 1 + 2 + 3, but not in any other way. The expected project outcome is at least a drop-in replacement website that is building locally.
 
-The outcome of this project is expected to produce visible impact they can showcase in their portfolio of the link:/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
+The outcome of this project is expected to produce a visible impact they can showcase in their portfolio of the link:/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
 
 Please note that for the UI/UX improvement portion we may need to deal with the link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo], where the code for components shared by various Jenkins websites (link:/[jenkins.io], link:https://plugins.jenkins.io/[plugins.jenkins.io], etc.) is currently hosted.
 

--- a/content/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling.adoc
+++ b/content/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling.adoc
@@ -1,0 +1,123 @@
+---
+layout: gsocprojectidea
+title: "Complete build retooling of jenkins.io"
+goal: "Using alternative tooling with Gatsby and Antora to build the Jenkins static site and provide versioned Jenkins documentation"
+category: Tools
+year: 2025
+status: published
+sig: documentation
+skills:
+- Web development
+- AsciiDoc
+- Static website tooling
+- Documentation
+- Website retooling
+mentors:
+- "krisstern"
+- "gounthar"
+- "vandit1604"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+The link:/[jenkins.io] website is generated as a static website using Awestruct from AsciiDoc sources, YAML data files, and HAML templates stored in GitHub.
+One of the drawbacks of the current build method is that the technical documentation is not product version bound.
+It is thus not possible to view the documentation for a given Jenkins version.
+Only the latest can be viewed.
+This can lead to unnecessary confusion and is a worse experience than many other documentation sites like the git site, FreeBSD, and others..
+
+The preferred tool to replace Awestruct is link:https://antora.org/[Antora].
+
+The potential GSoC project would be to build a working site generator to demonstrate the existing site.
+Once the existing site is generated with Antora, the site should be extended to add version specific documentation.
+
+The project has been discussed extensively at link:https://github.com/jenkins-infra/jenkins.io/issues/5474[GitHub issue #5474], where some existing proof-of-concept code can be found referenced there.
+
+There are multiple ways to approach the implementation, but from experimentation it has been found that the backend replacement requires minimal effort for the documentation, with the frontend implementation expected to require much effort to reproduce the look and feel of the current link:/[jenkins.io] website. However, the blog can be split from the documentation using something like link:https://www.gatsbyjs.com/[Gatsby], which is expected to make it easier for users to submit posts in the future.
+
+While the tasks of the project are very clearly defined, the scope may vary depending on the plans of the contributor. If we split the project into milestones, we see three important ones that can be tackled in sequence: The most urgent milestone is (1) to set up the user documentation using Antora with versioning, while next would be (2) to set up the developer documentation with Antora without versioning, and finally (3) to set up the blog using Gatsby. The contributor can choose either 1, or a combination of 1 + 2, or a combination of 1 + 2 + 3, but not in any other way. The expected project outcome is at least a drop-in replacement website that is building locally.
+
+The outcome of this project is expected to produce visible impact they can showcase in their portfolio of the link:/[jenkins.io] website, as the GSoC contributor is also expected to contribute via UI/UX improvements beyond the basic tooling required.
+
+Please note that for the UI/UX improvement portion we may need to deal with the link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo], where the code for components shared by various Jenkins websites (link:/[jenkins.io], link:https://plugins.jenkins.io/[plugins.jenkins.io], etc.) is currently hosted.
+
+
+=== Quick Start
+
+Documentation quick start steps include:
+
+* Build the current documentation site locally
+* Become familiar with the current site, including:
+** Page types and how they are generated
+*** Changelogs
+*** Roadmap
+*** User handbook
+*** Developer handbook
+*** Artwork
+*** Security advisories
+*** Version specific content in tutorials (like "Improve a plugin")
+** Page content sources
+*** Asciidoc
+*** HAML / Ruby
+*** Web components
+** Build process
+*** Makefile
+*** Docker containers
+*** Syntax and spelling checks
+* Fix several link:https://github.com/jenkins-infra/jenkins.io/labels/good%20first%20issue/["good first issues"]
+* Explore link:https://github.com/jenkins-infra/jenkins-io-components[jenkins-io-components repo]
+* Explore link:https://antora.org/[Antora]
+* Review version specific documentation techniques (some of them are Antora sites)
+** link:https://docs.cloudbees.com/docs/cloudbees-ci/latest/cloud-secure-guide/folders-plus[CloudBees documentation site]
+** link:https://git-scm.com/docs/git-config[Git reference pages]
+** link:https://docs.python.org/3/[Python] (sphinx is the generator)
+** link:https://pytorch.org/docs/stable/index.html[PyTorch]
+** link:https://www.tensorflow.org/api_docs[TensorFlow]
+
+
+=== Skills to Study and Improve
+
+* Web development
+* AsciiDoc
+* Static website tooling
+** HAML templates
+** YAML data files
+* Documentation
+
+
+=== Project Difficulty Level
+
+Intermediate
+
+
+=== Project Size
+
+175 to 350 hours
+
+
+=== Expected outcomes
+
+The deliverables of the project would be:
+
+1. Iterative and incremental improvements to the site throughout the project
+2. A fully automated (CI ready) build procedure, equivalent to the existing one, but using Antora
+3. Demonstration that all the existing pages are rendered in an equivalent way
+    - Suggestions of improved page design(s)
+    - A list of all automation that are difficult/impossible to port to the new tool
+    - Suggestions and demos of alternative ways to solve this
+4. Demonstration of the versioned documentation automated tooling
+    - Description of the publication process (how does one contribute to document a new or modified feature)
+5. Successful migration of revamped link:/[jenkins.io] website to replace website using old tooling
+
+
+=== New features
+
+Improved layout of the existing site and its pages.
+New link:/[jenkins.io] website.
+
+
+=== Newbie Friendly Issues
+
+Basically any good-first-issue listed in the jenkins.io GitHub repo would do. These can be accessed at the link:https://github.com/jenkins-infra/jenkins.io/labels/good%20first%20issue/[GitHub repo issues tracker with the "good first issue" label].

--- a/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
+++ b/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
@@ -1,0 +1,56 @@
+---
+layout: gsocprojectidea
+title: "Domain-specific LLM based on actual Jenkins usage using ci.jenkins.io data"
+goal: "To develop a web app using an existing open-source LLM model with Jenkins usage data collected for domain-specific Jenkins knowledge to be fine-tuned"
+category: Infra
+year: 2024
+status: published
+sig: infra
+skills:
+- Python
+- React.js
+- LLM
+- AI/ML
+- Jenkins
+- Ollama
+- LangChain
+- UI
+- Infra statistics
+- Data Analytics
+mentors:
+- "krisstern"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+This full-stack project focuses on a proof-of-concept (PoC) idea to fine-tune an existing open-source LLM model (such as Llama 2) with domain-specific Jenkins data to be compiled, wrangled, and processed by the contributor as a part of an AI-driven application, to develop a minimalistic UI for the user to interact with the LLM as a complete end-to-end product.
+The main source of raw data will be the publicly available ci.jenkins.io datasets.
+The contributor will get to be involved in every step of the application development process, from data collection, wrangling, and processing to fine-tuning the model and developing the UI.
+Unlike the very similar link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc[GSoC 2024 LLM counterpart], this project is very research-focused and data-driven, and will be a lot more difficult to achieve a successful outcome.
+
+==== Summary
+
+* Strategy: Test failure analysis based on the test data from ci.jenkins.io
+** Help the user with failure diagnosis
+*** Is the failure due to infra?
+*** Is the failure due to a code change?
+*** Is the failure due to an unreliable test (“flaky test”)?
+** Sample repositories and use cases
+*** Jenkins core
+*** Jenkins acceptance test harness
+*** Jenkins plugin BOM
+
+
+=== Project Size
+175 - 350 hours
+
+
+=== Project Difficulty
+Intermediate to Advanced
+
+
+== Quick Start
+
+Become familiarized with the flow of the link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc[GSoC 2024 LLM project].

--- a/content/projects/gsoc/2025/project-ideas/further-pipeline-documentation-improvements.adoc
+++ b/content/projects/gsoc/2025/project-ideas/further-pipeline-documentation-improvements.adoc
@@ -1,0 +1,47 @@
+---
+layout: gsocprojectidea
+title: "Pipeline documentation improvements - Phase 2 and Phase 3"
+goal: "Improving the navigation and implementation of the Pipeline Steps Reference"
+category: Documentation
+year: 2025
+status: draft
+sig: documentation
+skills:
+- Documentation
+- Web development
+- Jenkins plugins
+mentors:
+- "krisstern"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+Continuing from link:https://www.jenkins.io/projects/gsoc/2022/projects/pipeline-step-documentation-generator/[the GSoC 2022 Pipeline Step Documentation Generator project] as Phase 2 of that project.
+More to do during this Phase 2 and the next Phase 3, as we will need to include both the refinement of the detailing and the navigation design.
+The project will involve the adopting of multiple plugins and improving their Pipeline Steps documentation.
+The selected contributor is expected to do lots of writing, exploring, testing, but not lots of coding.
+
+
+=== Quick Start
+
+Studying all materials relevant to link:https://www.jenkins.io/projects/gsoc/2022/projects/pipeline-step-documentation-generator/[the GSoC 2022 Pipeline Step Documentation Generator project] and become familiar with them.
+
+
+=== Skills to Study and Improve
+
+* Jenkins plugin development life cycle
+* Documentation
+* Web UI/UX design for documentation
+* Testing Jenkins plugins
+
+
+=== Project Difficulty Level
+
+Beginner to Intermediate
+
+
+=== Project Size
+
+175 to 350 hours (depending on the scope)

--- a/content/projects/gsoc/2025/project-ideas/improving-jenkinsfile-runner-abilities-and-github-actions.adoc
+++ b/content/projects/gsoc/2025/project-ideas/improving-jenkinsfile-runner-abilities-and-github-actions.adoc
@@ -1,0 +1,50 @@
+---
+layout: gsocprojectidea
+title: "Improving Jenkinsfile Runner abilities and GitHub Actions"
+goal: "To investigate the current state of the Jenkinsfile Runner project and to improve its abilities as well as those of GitHub Actions when used in conjunction"
+category: Tools
+year: 2025
+status: draft
+sig: platform
+skills:
+- Java
+- Jenkinsfile Runner
+- Docker
+- GitHub Actions
+mentors:
+- "jonesbusy"
+- "krisstern"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+This project idea is a continuation of the link:/projects/gsoc/2022/projects/jenkinsfile-runner-action-for-github-actions.adoc/[GSoC 2022 Jenkinsfile Runner Action for GitHub Actions project].
+The current link:https://github.com/jenkinsci/jenkinsfile-runner[Jenkninsfile Runner project] will need to switch to Spring Security 6, Jetty 12, as well as Jakarta EE 9 as part of its modernization.
+We would like to encourage more adoption and compatibility with the latest Jenkins version.
+There are many open issues within this project.
+We will also need to work on reporting on GitHub checks.
+
+
+=== Skills to Study and Improve
+
+* Java
+* To run Jenkinsfile Runner (an incubating project) to create an action inside Docker
+* Docker configuration
+* GitHub Actions configuration
+* Jenkins modernization
+
+
+=== Project Size
+175 - 350 hours
+
+
+=== Project Difficulty Level
+
+Intermediate to Advanced
+
+
+=== Expected outcomes
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase.

--- a/content/projects/gsoc/2025/project-ideas/revamping-jenkins-io-website-success-stories-feature.adoc
+++ b/content/projects/gsoc/2025/project-ideas/revamping-jenkins-io-website-success-stories-feature.adoc
@@ -1,0 +1,44 @@
+---
+layout: gsocprojectidea
+title: "Revamping jenkins.io website Success Stories feature"
+goal: "To investigate the current state of the Jenkinsfile Runner project and to improve its abilities as well as those of GitHub Actions when used in conjunction"
+category: UI/UX
+year: 2025
+status: accepted
+sig: infra
+skills:
+- Website development
+- UI/UX design
+- Geospatial data visualization
+- Gatsby.js and React.js
+mentors:
+- "krisstern"
+links:
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+
+The current jenkins.io "Success Stories" feature at link:https://stories.jenkins.io/[] is in need of a revamp to keep it looking sharp and relevant. The project at link:https://github.com/jenkins-infra/stories/[] is in need of modernization tech-stack wise, kas we ill need to upgrade the React version used as well as upgrade the versions of most of the dependencies used. Besides, we will need to redesign the layout of its UI/UX including but not limited to the landing page, the story page, the map, etc.
+
+
+=== Skills to Study and Improve
+
+* Website development
+* UI/UX design
+* Geospatial data visualization
+* Gatsby.js and React.js
+
+
+=== Project Size
+175 hours
+
+
+=== Project Difficulty Level
+
+Beginner
+
+
+=== Expected outcomes
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase.

--- a/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
@@ -30,7 +30,7 @@ Users of the REST API most often want:
 
 Jenkins does not have automated REST API documentation at all at this time.
 A lot of APIs are contributed from extensions, so there are multiple REST APIs (core and plugins) of varying versions.
-The goal of this project is to find and implement the extraction of the REST APIs from the sources and generate and publish the REST APIs respective documentation.
+The goal of this project is to find and implement the extraction of the REST APIs from the sources and generate and publish the REST APIs' respective documentation.
 
 
 ==== Project Details
@@ -41,7 +41,7 @@ For example, they could be extracted from Javadocs and annotations.
 
 As part of the community bonding and student project proposal phase, the student is expected to make a few proposals on how to specify and generate the REST API for the Jenkins core and for the plugins.
 In the case the student finds that it is not possible to generate the REST API from a specification, the student should identify why this is not possible.
-We also ask the student to explore and propose a way to have REST API of plugins be generated from a REST API specification.
+We also ask the student to explore and propose a way to have REST API of plugins generated from a REST API specification.
 For example, some auto-code could populate what the javadoc would look like in an empty-plugin used by the maven plugin generator.
 
 The student is also expected to study and propose how the REST API documentation generation could be part of the REST API generator.

--- a/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
@@ -1,0 +1,118 @@
+---
+layout: gsocprojectidea
+title: "Swagger / OpenAPI standardization for Jenkins REST API"
+goal: "Standardizing Jenkins REST API documentation using Swagger or the OpenAPI specifications"
+category: Tools
+year: 2025
+status: published
+sig: documentation
+skills:
+- Swagger / OpenAPI standardization
+- REST API
+- Documentation
+- Automation
+- Java
+mentors:
+- "krisstern"
+- "gounthar"
+links:
+  draft: /projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api-draft.pdf
+  meetings: /projects/gsoc/#office-hours
+---
+
+=== Background
+Developers need to know what to expect in terms of responses for each REST API endpoint, so external tools like jenkins-rest can be developed with confidence, and possibly with the help of some REST specification automation.
+For example, this could be done using the link:https://www.openapis.org/[OpenAPI Specification] (formerly known as Swagger Specification).
+Users of the REST API most often want:
+
+* HTTP responses and codes
+* Body of message and its format (e.g. JSON, html, etc.)
+
+Jenkins does not have automated REST API documentation at all at this time.
+A lot of APIs are contributed from extensions, so there are multiple REST APIs (core and plugins) of varying versions.
+The goal of this project is to find and implement the extraction of the REST APIs from the sources and generate and publish the REST APIs respective documentation.
+
+
+==== Project Details
+
+Generating the expected HTTP responses is a difficult task.
+The student is expected to study Jenkins core to identify ways to extract them.
+For example, they could be extracted from Javadocs and annotations.
+
+As part of the community bonding and student project proposal phase, the student is expected to make a few proposals on how to specify and generate the REST API for the Jenkins core and for the plugins.
+In the case the student finds that it is not possible to generate the REST API from a specification, the student should identify why this is not possible.
+We also ask the student to explore and propose a way to have REST API of plugins be generated from a REST API specification.
+For example, some auto-code could populate what the javadoc would look like in an empty-plugin used by the maven plugin generator.
+
+The student is also expected to study and propose how the REST API documentation generation could be part of the REST API generator.
+
+It might be helpful to automatically generate some code for the REST API when the plugin developer creates a plugin for the first time using the plugin skeleton generator.
+Any methodology created to handle the REST API should be built into the skeleton generator.
+
+The jenkins core REST API and the plugins own REST API need to be versioned separately.
+It is suggested to focus first on generating the specification, then later look at the versioning of the REST API.
+Nested objects make versioning challenging.
+
+Jenkins users should be easily able to see the REST APIs available for their installed Jenkins.
+For Jenkins core, this could be done with a URL like:  `http://localhost/rest/api/1.0`.
+The plugins would have their own REST API path with a version number like: `http://localhost/plugin/rest/api/1.0`.
+Plugins and the core would thus have their own version number, and an additional REST API version number.  Automated API documentation using the OpenAPI 3.0 specification is part of identifying the API specs.
+
+More details are in the link:/projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api-draft.pdf[draft project idea].
+
+
+=== Links
+
+There are many examples of such documentation on the web:
+
+* link:https://docs.atlassian.com/bitbucket-server/rest/5.15.0/bitbucket-rest.html?utm_source=%2Fstatic%2Frest%2Fbitbucket-server%2Flatest%2Fbitbucket-rest.html&utm_medium=301[Bitbucket REST API] (link to Bitbucket documentation)
+* link:https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API[Artifactory REST API ](link to Artifactory documentation)
+* OpenAPI3 description of the Jenkins REST API: link:https://github.com/cliffano/swaggy-jenkins[swaggy jenkins] (note: the swaggy-jenkins author now recommends OpenAPI (explanation).
+* This link:https://stackoverflow.com/questions/12405911/how-can-i-generate-wadl-for-rest-services[stackoverflow] question talks briefly about generating a REST API spec in WADL format
+* A link:https://swagger.io/blog/api-development/getting-started-with-swagger-i-what-is-swagger/[blog post] that talks about swagger and WADL
+* Making Stapler more declarative link:https://groups.google.com/d/msg/jenkinsci-dev/UrVVT8wbHIE/_1O35oU4AgAJ[discussion] leading to a comment on swagger.
+* A link:https://groups.google.com/forum/#!topic/jenkinsci-dev/mYeM5qA6tGM[google group discussion] on seeking help on clarifying this proposal
+* link:https://github.com/jenkinsci/maven-hpi-plugin[Plugin skeleton generator]
+* link:https://issues.jenkins.io/browse/JENKINS-35808[Jira ticket JENKINS-35808] on generating spec for Jenkins REST API from 2016
+
+
+=== Quick-start
+
+1. Watch the link:https://www.youtube.com/watch?v=06E1usE6j1Q[project discussion meeting recording].
+It summarizes the project and the first possible steps
+2. Study the link:https://swagger.io/docs/specification/about/[Open API specification],
+go through examples for other services
+3. Explore ways to index the REST API endpoints in Jenkins and Stapler.
+It includes `@Exported` and `@ExportedBean` annotations, and other methods from the Stapler framework.
+See the video for the links.
+
+
+=== Newbie-friendly issues
+
+* link:https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20labels%20%3D%20newbie-friendly%20and%20labels%20%3D%20REST[Jira Query]
+* Create an Open API specification for a Jenkins plugin with REST API,
+add it to the respective plugin repository
+* Contribute to documentation of Jenkins REST API, e.g. see the `_api.jelly` files in the Jenkins Core and plugins
+* Javadoc Landing Page — While Javadoc isn’t Rest API, user experience concerns described in jira:INFRA-1717[] for Javadoc Landing Page could be re-considered when determining where to publish Rest API accordingly
+
+
+=== Skills to improve/study
+* Java
+* REST API
+* OpenAPI specification details and automatic generators
+* link:http://github.com/stapler/[Stapler] (more info:https://github.com/jenkins-infra/jenkins.io/pull/2157#issuecomment-471230609)
+
+
+=== Project Difficulty Level
+
+Intermediate
+
+
+=== Project Size
+
+175 to 350 hours
+
+
+=== Expected outcomes
+
+Details to be clarified interactively, together with the mentors, during the Contributor Application drafting phase.

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -1,6 +1,6 @@
 ---
 layout: project
-title: "Google Summer of Code in Jenkins"
+title: "Jenkins in Google Summer of Code 2025"
 description: "Landing page for the Google Summer of Code program in the Jenkins project"
 section: projects
 tags:
@@ -22,33 +22,35 @@ In exchange, numerous Jenkins community members volunteer as "mentors" for the s
 
 image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
-== GSoC 2024
+== GSoC 2025
 
-We are participating in Google Summer of Code in 2024. +
+We are planning to participate in Google Summer of Code in 2025. +
+
+// We are participating in Google Summer of Code in 2025. +
 // See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
-Google has accepted us as a mentoring organization in Google Summer of Code 2024.
+// Google has accepted us as a mentoring organization in Google Summer of Code 2025.
 
-// Uncomment when application is worked on and submitted (Feb 2024)
-//(link:./2024/application[Jenkins GSoC Organisation Application Form])
+// Uncomment when application is worked on and submitted (Feb 2025)
+//(link:./2025/application[Jenkins GSoC Organisation Application Form])
 
-The selected projects are:
+// The selected projects are:
+//
+// * link:/projects/gsoc/2025/projects/automating-rpu-for-jenkinsci-organization[Manage Jenkinsci GitHub Permissions as Code] with link:https://github.com/Alaurant[Danyang Zhao] as the GSoC contributor.
+//
+// * link:/projects/gsoc/2025/projects/using-openrewrite-recipes-for-plugin-modernization-or-automation-plugin-build-metadata-updates[Using OpenRewrite Recipes for Plugin Modernization] with link:https://github.com/sridamul[Sridhar Sivakumar] as the GSoC contributor.
+//
+// * link:/projects/gsoc/2025/projects/implementing-ui-for-jenkins-infra-statistics[Implementing UI for Jenkins Infra Statistics] with link:https://github.com/shlomomdahan[Shlomo Dahan] as the GSoC contributor.
+//
+// * link:/projects/gsoc/2025/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge[Enhancing an Existing LLM Model with Domain-specific Jenkins Knowledge] with link:https://github.com/nouralmulhem[Nour Almulhem] as the GSoC contributor.
+//
+// * link:/projects/gsoc/2025/projects/improving-maintainability-of-rpu[Improve Maintainability for the Repository Permission Updater] with link:https://github.com/TheMeinerLP[Phillipp Glanz] as the GSoC contributor.
 
-* link:/projects/gsoc/2024/projects/automating-rpu-for-jenkinsci-organization[Manage Jenkinsci GitHub Permissions as Code] with link:https://github.com/Alaurant[Danyang Zhao] as the GSoC contributor.
-
-* link:/projects/gsoc/2024/projects/using-openrewrite-recipes-for-plugin-modernization-or-automation-plugin-build-metadata-updates[Using OpenRewrite Recipes for Plugin Modernization] with link:https://github.com/sridamul[Sridhar Sivakumar] as the GSoC contributor.
-
-* link:/projects/gsoc/2024/projects/implementing-ui-for-jenkins-infra-statistics[Implementing UI for Jenkins Infra Statistics] with link:https://github.com/shlomomdahan[Shlomo Dahan] as the GSoC contributor.
-
-* link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge[Enhancing an Existing LLM Model with Domain-specific Jenkins Knowledge] with link:https://github.com/nouralmulhem[Nour Almulhem] as the GSoC contributor.
-
-* link:/projects/gsoc/2024/projects/improving-maintainability-of-rpu[Improve Maintainability for the Repository Permission Updater] with link:https://github.com/TheMeinerLP[Phillipp Glanz] as the GSoC contributor.
-
-They were proposed and selected from these link:./2024/project-ideas[project ideas].
+They were proposed and selected from these link:./2025/project-ideas[project ideas].
 
 // We have finalised a list of 9 project ideas.
 // Add your ideas by submitting an ad-hoc pull request as explained in our previous link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
 
-// The 2024 GSoC project ideas link:./2024/project-ideas[can be found here].
+// The 2025 GSoC project ideas link:./2025/project-ideas[can be found here].
 
 NOTE: Every year, there are changes in how GSoC is organized.
 Jenkins GSoC documentation may be outdated in some places, please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.
@@ -60,7 +62,7 @@ Our documentation will be updated over time to reflect the changes in the GSoC p
 // * Online Meetup: Introduction to Jenkins in GSoC
 // (link:https://bit.ly/3pbJFuC[slides],
 // link:https://youtu.be/GDRTgEvIVBc[video])
-* link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
+* link:https://summerofcode.withgoogle.com/programs/2025/organizations/jenkins-wp[Jenkins organization page on the GSoC website]
 * link:https://summerofcode.withgoogle.com/[Google Summer of Code portal]
 
 == Mentors
@@ -78,12 +80,11 @@ We are always looking for new mentors to help us with the program.
 == Org Admins
 
 Org Admins are the people managing the GSoC program for the Jenkins Organization.
-For 2024, our Org Admins are:
+For 2025, our Org Admins are:
 
 * Alyssa Tong
 * Kris Stern
 * Bruno Verachten
-* Jean-Marc Meessen
 
 The following checklists and documents describe the role:
 
@@ -115,39 +116,40 @@ The purpose of GSoC Discourse is for all public communications on GSoC such as n
 
 === Office hours
 
-Although we use Discourse as the main communication channel, we also have regular "office hours" video calls.
+Although we use Discourse as the main communication channel, we will have regular "office hours" video calls.
 During these time slots Jenkins GSoC org admins and mentors are available for any GSoC-related questions.
 
-* Schedule: Weekly 30 minutes meetings. Office hours will be held on Thursdays at 13:00 UTC.
-  Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
+// * Schedule: Weekly 30 minutes meetings. Office hours will be held on Thursdays at 13:00 UTC.
+//   Use the link:/event-calendar[Jenkins event calendar] to view the meeting time in your own time zone.
 // * link:https://docs.google.com/document/d/1UykfAHpPYtSx-r_PQIRikz2QUrX1SG-ySriz20rVmE0/edit?usp=sharing[Agenda]
-* Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaODwGnSZzxjV6-6mqRfcoBe[here].
+// * Meetings are commonly recorded on-demand and posted link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaODwGnSZzxjV6-6mqRfcoBe[here].
 
 // This meeting will be used for Q&A with GSoC applicants/contributors and mentors before the announcement of accepted projects as well as during the GSoC program.
-You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
+// You can add the office hours to your calendar when you visit the link:/event-calendar[Jenkins event calendar].
 // More slots may be added on-demand, e.g. for project-specific discussions.
 
-In addition to these organization-wide meetings, each GSoC project has regular meetings during community bonding and coding phases.
-Please take a look at the project pages for the schedule.
+In addition to these organization-wide meetings, each GSoC project will hold regular meetings during community bonding and coding phases.
+// Please take a look at the project pages for the schedule.
 
 == Previous years
 
-* link:/projects/gsoc/2023[GSoC 2023] - 4 student projects
-* link:/projects/gsoc/2022[GSoC 2022] - 4 student projects
-* link:/projects/gsoc/2021[GSoC 2021] - 5 student projects
-* link:/projects/gsoc/2020[GSoC 2020] - 7 student projects
-* link:/projects/gsoc/2019[GSoC 2019] - 7 student projects
-* link:/projects/gsoc/2018[GSoC 2018] - 3 student projects
+* link:/projects/gsoc/2024[GSoC 2024] - 5 contributor projects
+* link:/projects/gsoc/2023[GSoC 2023] - 4 contributor projects
+* link:/projects/gsoc/2022[GSoC 2022] - 4 contributor projects
+* link:/projects/gsoc/2021[GSoC 2021] - 5 contributor projects
+* link:/projects/gsoc/2020[GSoC 2020] - 7 contributor projects
+* link:/projects/gsoc/2019[GSoC 2019] - 7 contributor projects
+* link:/projects/gsoc/2018[GSoC 2018] - 3 contributor projects
 * link:/projects/gsoc/gsoc2017[GSoC 2017] - not accepted
-* link:/projects/gsoc/gsoc2016[GSoC 2016] - 5 student projects
+* link:/projects/gsoc/gsoc2016[GSoC 2016] - 5 contributor projects
 * link:https://wiki.jenkins.io/display/JENKINS/Google+Summer+of+Code+2009[GSoC 2009] - as Hudson, not accepted
 
-== References, 2024
+== References, 2025
 
-* link:./2024/project-ideas[GSoC 2024 project ideas]
-* link:https://summerofcode.withgoogle.com/programs/2024/organizations/jenkins-wp/[Jenkins page on the GSoC website]
-* link:/blog/2024/02/23/gsoc2024-announcement/[Jenkins GSoC 2024 announcement]
-* link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2024 announcement blog]
+* link:./2025/project-ideas[GSoC 2025 project ideas]
+// * link:https://summerofcode.withgoogle.com/programs/2025/organizations/jenkins-wp/[Jenkins page on the GSoC website]
+// * link:/blog/2025/02/23/gsoc2025-announcement/[Jenkins GSoC 2025 announcement]
+// * link:https://opensource.googleblog.com/2022/11/get-ready-for-google-summer-of-code-2023.html[Google GSoC 2025 announcement blog]
 
 == References
 


### PR DESCRIPTION
### Description

Added a total of 8 new GSoC project ideas for 2025:

1. Android and/or iOS tutorials in official documentation
2. Backend code refactoring for Infra Statistics
3. Complete build retooling of jenkins.io
4. Domain-specific LLM based on actual Jenkins usage using ci.jenkins.io data
5. Pipeline documentation improvements - Phase 2 and Phase 3
6. Improving Jenkinsfile Runner abilities and GitHub Actions
7. Revamping jenkins.io website Success Stories feature
8. Swagger / OpenAPI standardization for Jenkins REST API

These are as discussed internally among @MarkEWaite the org admins @alyssat @gounthar and @krisstern as well as potential lead mentor @jonesbusy. 