### PR TITLE
Fix GSoC 2025 project idea year

### DIFF
--- a/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
+++ b/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
@@ -3,7 +3,7 @@ layout: gsocprojectidea
 title: "Domain-specific LLM based on actual Jenkins usage using ci.jenkins.io data"
 goal: "To develop a web app using an existing open-source LLM model with Jenkins usage data collected for domain-specific Jenkins knowledge to be fine-tuned"
 category: Infra
-year: 2024
+year: 2025
 status: published
 sig: infra
 skills:


### PR DESCRIPTION
This PR updates the year for the 'Domain-specific LLM based on actual Jenkins usage using ci.jenkins.io data' project idea from 2024 to 2025.