### PR TITLE
Mention `st:bind` in inline JS guidelines

### DIFF
--- a/content/doc/developer/security/csp.adoc
+++ b/content/doc/developer/security/csp.adoc
@@ -82,6 +82,8 @@ This property is documented on link:/doc/developer/views/[Views] and emits comme
 
 === Inline JavaScript blocks
 
+==== General advice
+
 Do not use inline JavaScript (JS) in the Jenkins GUI, i.e., JS embedded in HTML output.
 
 This is typically done with `<script>` tags, like so:
@@ -93,12 +95,19 @@ alert("Hello, world!");
 
 The guidelines in link:/doc/developer/security/xss-prevention/#passing-values-to-javascript[the documentation on XSS prevention] can be useful to pass arguments to JavaScript, or otherwise control its behavior dynamically.
 
-If you're using `<st:bind>` tags inside inline JavaScript, add the `var` attribute to set the variable with the specified name, and reference that variable in your own scripts.
-Use a simple JavaScript identifier (complying with https://github.com/jenkinsci/stapler/blob/92458dd7afca3061956ccf92fedf1782a6e76e39/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java#L59-L63[this regular expression]) as `var` value, rather than a more complex expression.
-
 You can generally use https://github.com/jenkinsci/stapler/blob/master/docs/jelly-taglib-ref.adoc#adjunct[Stapler adjuncts] to load files related to UI views and ensure they are loaded only once.
 
 An example of this is https://github.com/jenkinsci/jenkins/pull/6849[jenkinsci/jenkins#6849].
+
+==== Inline `st:bind` tags
+
+If you're using `<st:bind>` tags inside inline JavaScript, add the `var` attribute to set the variable with the specified name, and reference that variable in your own scripts.
+Use a simple JavaScript identifier (complying with https://github.com/jenkinsci/stapler/blob/92458dd7afca3061956ccf92fedf1782a6e76e39/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java#L59-L63[this regular expression]) as `var` value, rather than a more complex expression.
+
+Make sure to not reuse the same `var` value when extracting multiple or repeatedly executed `<st:bind/>` tags from inline JS.
+You can use `${h.generateId()}` to generate a unique value.
+
+An example of this is https://github.com/jenkinsci/warnings-ng-plugin/pull/1862[warnings-ng-plugin#1862].
 
 === Standalone `st:bind` tags with disallowed `var` attribute
 

--- a/content/doc/developer/security/csp.adoc
+++ b/content/doc/developer/security/csp.adoc
@@ -91,6 +91,9 @@ alert("Hello, world!");
 
 The guidelines in link:/doc/developer/security/xss-prevention/#passing-values-to-javascript[the documentation on XSS prevention] can be useful to pass arguments to JavaScript, or otherwise control its behavior dynamically.
 
+If you're using `<st:bind>` tags inside inline JavaScript, add the `var` attribute to set the variable with the specified name, and reference that variable in your own scripts.
+Use a simple JavaScript identifier (complying with https://github.com/jenkinsci/stapler/blob/92458dd7afca3061956ccf92fedf1782a6e76e39/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java#L59-L63[this regular expression]) as `var` value, rather than a more complex expression.
+
 You can generally use https://github.com/jenkinsci/stapler/blob/master/docs/jelly-taglib-ref.adoc#adjunct[Stapler adjuncts] to load files related to UI views and ensure they are loaded only once.
 
 An example of this is https://github.com/jenkinsci/jenkins/pull/6849[jenkinsci/jenkins#6849].

--- a/content/doc/developer/security/csp.adoc
+++ b/content/doc/developer/security/csp.adoc
@@ -27,6 +27,8 @@ Inline `<script>` blocks::
 Referencing a file to load JavaScript from is fine, but inline block contents are not.
 All `<script>` tags without `src` are a problem.
 They will break without `'unsafe-inline'` in the `script-src` CSP directive.
+Standalone `st:bind` tags with disallowed `var` attribute::
+Only simple JavaScript identifiers are allowed for CSP-compliant `<st:bind>` tags.
 Inline event handler definitions::
 Any occurrence of `onclick`, `onload`, etc. in HTML files (e.g. Jelly and Groovy views) is a problem.
 Legacy `checkUrl` definitions::
@@ -98,6 +100,14 @@ You can generally use https://github.com/jenkinsci/stapler/blob/master/docs/jell
 
 An example of this is https://github.com/jenkinsci/jenkins/pull/6849[jenkinsci/jenkins#6849].
 
+=== Standalone `st:bind` tags with disallowed `var` attribute
+
+`<st:bind>` generates different output depending on how it is invoked.
+See the previous section for advice on adding the `var` attribute for standalone use, rather than inside inline JS.
+
+In addition to adding the `var` attribute, its value must comply with https://github.com/jenkinsci/stapler/blob/92458dd7afca3061956ccf92fedf1782a6e76e39/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java#L59-L63[this regular expression] to generate a CSP-compatible `<script>` tag.
+
+See https://github.com/jenkinsci/build-monitor-plugin/pull/830[build-monitor-plugin#830] for an example.
 
 === Inline event handlers
 


### PR DESCRIPTION
@yaroslavafenkin mentioned that this was not specifically documented.

As a common case of code people may not be very familiar with, IMO it makes sense to have this here. 