### PR TITLE
Add mailer plugin to reverse proxy auth upgrade instructions

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -11794,6 +11794,8 @@
         title: LDAP plugin 733.vd3700c27b_043
       - url: https://github.com/jenkinsci/reverse-proxy-auth-plugin/releases/tag/reverse-proxy-auth-plugin-1.8.0
         title: Reverse Proxy Auth plugin 1.8.0
+      - url: https://github.com/jenkinsci/mailer-plugin/releases/tag/489.vd4b_25144138f
+        title: Mailer plugin 489.vd4b_25144138f
       - url: https://github.com/jenkinsci/cas-plugin/releases/tag/cas-plugin-1.7.0
         title: CAS plugin 1.7.0
       - url: https://github.com/jenkinsci/negotiatesso-plugin/releases/tag/136.vda_2b_6a_744b_d8
@@ -11805,7 +11807,7 @@
     message: |-
       Upgrade Spring Framework from 5.3.39 to 6.1.14, upgrade Spring Security from 5.8.14 to 6.3.4, and upgrade Java EE from 8 to 9.
       Users of the LDAP plugin must upgrade to version 733.vd3700c27b_043 in combination with upgrading Jenkins core.
-      Users of the Reverse Proxy Auth plugin must upgrade to version 1.8.0 in combination with upgrading Jenkins core.
+      Users of the Reverse Proxy Auth plugin must upgrade to version 1.8.0 in combination with upgrading Jenkins core and must also upgrade the Mailer plugin to version 489.vd4b_25144138f.
       Users of the CAS plugin must upgrade to version 1.7.0 in combination with upgrading Jenkins core.
       Users of the Windows Negotiate SSO plugin must upgrade to version 136.vda_2b_6a_744b_d8 in combination with upgrading Jenkins core.
       Users of third-party servlet containers must upgrade their servlet container to an EE 9 version in accordance with the Jenkins Servlet Container Support Policy.

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -24627,6 +24627,8 @@
           - url: 
               https://github.com/jenkinsci/reverse-proxy-auth-plugin/releases/tag/reverse-proxy-auth-plugin-1.8.0
             title: Reverse Proxy Auth plugin 1.8.0
+          - url: https://github.com/jenkinsci/mailer-plugin/releases/tag/489.vd4b_25144138f
+            title: Mailer plugin 489.vd4b_25144138f
           - url: https://github.com/jenkinsci/cas-plugin/releases/tag/cas-plugin-1.7.0
             title: CAS plugin 1.7.0
           - url: 
@@ -24640,7 +24642,7 @@
         message: |-
           Upgrade Spring Framework from 5.3.39 to 6.1.12, upgrade Spring Security from 5.8.14 to 6.3.3, and upgrade Java EE from 8 to 9.
           Users of the LDAP plugin must upgrade it to version 733.vd3700c27b_043 in lockstep with upgrading Jenkins core.
-          Users of the Reverse Proxy Auth plugin must upgrade to version 1.8.0 in lockstep with upgrading Jenkins core.
+          Users of the Reverse Proxy Auth plugin must upgrade to version 1.8.0 in lockstep with upgrading Jenkins core and must also upgrade the Mailer plugin to version 489.vd4b_25144138f.
           Users of the CAS plugin must upgrade it to version 1.7.0 in lockstep with upgrading Jenkins core.
           Users of the Windows Negotiate SSO plugin must upgrade to version 136.vda_2b_6a_744b_d8 in lockstep with upgrading Jenkins core.
           Users of third-party servlet containers must upgrade the servlet container to an EE 9 version in accordance with the Jenkins Servlet Container Support Policy.

--- a/content/_data/upgrades/2-479-1.adoc
+++ b/content/_data/upgrades/2-479-1.adoc
@@ -71,7 +71,7 @@ Prior to upgrading Jenkins, make sure that all plugins have been brought up to d
 After completing the Jenkins upgrade, update your plugins once more to ensure that they are in line with the latest LTS build.
 
 Users of the LDAP plugin **must** upgrade it to link:https://plugins.jenkins.io/ldap/releases/#version_733.vd3700c27b_043[version 733.vd3700c27b_043] in tandem with upgrading Jenkins core.
-Users of the Reverse Proxy Auth plugin **must** upgrade it to link:https://plugins.jenkins.io/reverse-proxy-auth-plugin/releases/#version_1.8.0[version 1.8.0] in tandem with upgrading Jenkins core.
+Users of the Reverse Proxy Auth plugin **must** upgrade it to link:https://plugins.jenkins.io/reverse-proxy-auth-plugin/releases/#version_1.8.0[version 1.8.0] in tandem with upgrading Jenkins core and must also upgrade the Mailer plugin to link:https://updates.jenkins.io/download/plugins/mailer/489.vd4b_25144138f/mailer.hpi[version 489.vd4b_25144138f].
 Users of the CAS plugin **must** upgrade it to link:https://plugins.jenkins.io/cas-plugin/releases/#version_1.7.0[version 1.7.0] in tandem with upgrading Jenkins core.
 Users of the Windows Negotiate SSO plugin **must** upgrade it to link:https://plugins.jenkins.io/NegotiateSSO/releases/#version_136.vda_2b_6a_744b_d8[version 136.vda_2b_6a_744b_d8] in tandem with upgrading Jenkins core.
 Users of third-party servlet containers **must** upgrade the servlet container to an EE 9 version in accordance with the link:https://www.jenkins.io/doc/book/platform-information/support-policy-servlet-containers/[Jenkins Servlet Container Support Policy].
@@ -88,6 +88,8 @@ To upgrade the Reverse Proxy Auth plugin, follow these steps:
 . Stop the Jenkins service with `systemctl stop jenkins` on Linux or similar commands on other operating systems.
 . Download the Reverse Proxy Auth plugin from the link:https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/1.8.0/reverse-proxy-auth-plugin.hpi[Jenkins update center].
 . Move reverse-proxy-auth-plugin.hpi into $JENKINS_HOME/plugins/reverse-proxy-auth-plugin.jpi and set the correct ownership and permissions.
+. Download the Mailer plugin from the link:https://updates.jenkins.io/download/plugins/mailer/489.vd4b_25144138f/mailer.hpi[Jenkins update center].
+. Move mailer.hpi into $JENKINS_HOME/plugins/mailer.jpi and set the correct ownership and permissions.
 . Start the Jenkins service with `systemctl start jenkins` or similar commands on other operating systems.
 
 To upgrade the CAS plugin, follow these steps:


### PR DESCRIPTION
## Add mailer plugin to reverse proxy auth upgrade instructions

[JENKINS-74841](https://issues.jenkins.io/browse/JENKINS-74841) includes a comment that notes the mailer plugin is also required when upgrading to 2.479.1.
