### PR TITLE
Do not depend on nodeJS version in example output

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -37,7 +37,7 @@ pipeline {
     stages {
         stage('Test') {
             steps {
-                sh 'node --version'
+                sh 'node --eval "console.log(process.platform,process.env.CI)"'
             }
         }
     }
@@ -47,7 +47,7 @@ node {
     /* Requires the Docker Pipeline plugin to be installed */
     docker.image('node:22.11.0-alpine3.20').inside {
         stage('Test') {
-            sh 'node --version'
+            sh 'node --eval "console.log(process.platform,process.env.CI)"'
         }
     }
 }
@@ -61,8 +61,8 @@ When the Pipeline executes, Jenkins will automatically start the specified conta
 [Pipeline] { (Test)
 [Pipeline] sh
 [guided-tour] Running shell script
-+ node --version
-v16.13.1
++ node --eval 'console.log(process.platform,process.env.CI)'
+linux true
 [Pipeline] }
 [Pipeline] // stage
 [Pipeline] }

--- a/content/doc/pipeline/tour/agents.adoc
+++ b/content/doc/pipeline/tour/agents.adoc
@@ -53,7 +53,7 @@ pipeline {
     stages {
         stage('Test') {
             steps {
-                sh 'node --version'
+                sh 'node --eval "console.log(process.arch,process.platform)"'
             }
         }
     }
@@ -63,7 +63,7 @@ node {
     /* Requires the Docker Pipeline plugin to be installed */
     docker.image('node:22.11.0-alpine3.20').inside {
         stage('Test') {
-            sh 'node --version'
+            sh 'node --eval "console.log(process.arch,process.platform)"'
         }
     }
 }
@@ -78,8 +78,8 @@ container and execute the defined steps within it:
 [Pipeline] { (Test)
 [Pipeline] sh
 [guided-tour] Running shell script
-+ node --version
-v14.15.0
++ node --eval 'console.log(process.platform,process.env.CI)'
+linux true
 [Pipeline] }
 [Pipeline] // stage
 [Pipeline] }


### PR DESCRIPTION
## Do not depend on nodeJS version in example output

A recent documentation feedback noted that the incorrect version number string is included in the sample output.  Rather than adjust the example output, let's use example output that is unlikely to change between NodeJS releases.  This example uses `process.platform` and `process.env.CI`.  Those are not likely to change from one version of nodeJS to the next.

The [feedback sheet](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit?usp=sharing) includes the note that the NodeJS version number is incorrect in the example output.
