### PR TITLE
Removing role attributes from Jenkinsfile documentation

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -98,7 +98,7 @@ link:http://groovy-lang.org[Groovy]
 syntax highlighting, create a new `Jenkinsfile` in the root directory of the
 project.
 
-[role=declarative-pipeline]
+
 The Declarative Pipeline example above contains the minimum necessary structure
 to implement a continuous delivery pipeline. The <<syntax#agent, agent
 directive>>, which is required, instructs Jenkins to allocate an executor and
@@ -111,8 +111,7 @@ The <<syntax#stages, stages directive>>, and <<syntax#steps, steps directives>>
 are also required for a valid Declarative Pipeline as they instruct Jenkins
 what to execute and in which stage it should be executed.
 
-[role=scripted-pipeline]
-====
+
 For more advanced usage with Scripted Pipeline, the example above `node` is
 a crucial first step as it allocates an executor and workspace for the Pipeline.
 In essence, without `node`, a Pipeline cannot do any work! From within `node`,
@@ -121,6 +120,7 @@ project.  Since the `Jenkinsfile` is being pulled directly from source control,
 Pipeline provides a quick and easy way to access the right revision of the
 source code
 
+[role=scripted-pipeline]
 [pipeline]
 ----
 // Script //
@@ -133,7 +133,7 @@ node {
 <1> The `checkout` step will checkout code from source control; `scm` is a
 special variable which instructs the `checkout` step to clone the specific
 revision which triggered this Pipeline run.
-====
+
 
 
 === Build
@@ -291,7 +291,7 @@ Assuming everything has executed successfully in the example Jenkins Pipeline,
 each successful Pipeline run will have associated build artifacts archived,
 test results reported upon and the full console output all in Jenkins.
 
-[role=scripted-pipeline]
+
 A Scripted Pipeline can include conditional tests (shown above), loops,
 try/catch/finally blocks and even functions. The next section will cover this
 advanced Scripted Pipeline syntax in more detail.
@@ -1137,8 +1137,7 @@ node {
 }
 ----
 
-[role=scripted-pipeline]
-====
+
 Scripted Pipeline however relies on Groovy's built-in `try`/`catch`/`finally` semantics
 for handling failures during execution of the Pipeline.
 
@@ -1150,7 +1149,6 @@ there has been a test failure or not.
 An alternative way of handling this, which preserves the early-exit behavior of
 failures in Pipeline, while still giving `junit` the chance to capture test
 reports, is to use a series of `try`/`finally` blocks:
-====
 
 
 === Using multiple agents


### PR DESCRIPTION
Addresses https://github.com/jenkins-infra/jenkins.io/issues/7652

Currently, the "Using a Jenkinsfile" documentation is rendering an odd styling for some parts of the page:

<img width="1105" alt="Screenshot 2024-11-25 at 2 51 05 PM" src="https://github.com/user-attachments/assets/c6c19aa8-95d3-4391-853e-cbf7d536ad7a">

It appears that there are some role attributes in the page causing this inline formatting to take place.

I have removed the role attributes from all but one place, where it was moved to directly affect the scripted pipeline code example (line 123).

After removing the attributes, the page now renders uniformly without the offset:

![Screenshot 2024-11-25 at 2 48 05 PM](https://github.com/user-attachments/assets/6bc746c1-9695-4065-ad56-57dbc13727d1)

![Screenshot 2024-11-25 at 2 48 34 PM](https://github.com/user-attachments/assets/3a67e4b7-3ba9-4a21-9b69-7ae820a7dc92)

![Screenshot 2024-11-25 at 2 50 22 PM](https://github.com/user-attachments/assets/ddab7b74-f0bc-46a2-9a33-7474875fd43f)

Role attributes are not used consistently throughout the documentation, so this may be a remnant of previous docsite builds or formatting. This formatting is especially visible when using dark mode:

<img width="1133" alt="Screenshot 2024-11-25 at 3 05 47 PM" src="https://github.com/user-attachments/assets/242f5fab-4119-4fa6-8ee2-d52e451a5a5e">

