### PR TITLE
Fix typo

### DIFF
--- a/content/blog/2024/12/03/2024-12-03-election-results.adoc
+++ b/content/blog/2024/12/03/2024-12-03-election-results.adoc
@@ -50,7 +50,7 @@ The estimated end of the term for them is December 1, 2026.
 == Officer election details
 
 All 5 officer positions were up for election this year.
-These roles have a 1-year term, with the estimated end of term on December 1, 2026.
+These roles have a 1-year term, with the estimated end of term on December 1, 2025.
 After the initial review of nominations and confirmations with potential candidates, 4 officer positions were uncontested:
 
 * **Alyssa Tong** - link:/project/team-leads/#events[Events Officer]


### PR DESCRIPTION
1 year from now is 2025 not 2026.

This assume the the position is for 1 year not 2, the typo could be in the duration 

@MarkEWaite 