### PR TITLE
Update governance board page

### DIFF
--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -14,17 +14,17 @@ links:
 :ruby
   board_members = [
     ["jonesbusy", "2024/12/03", "2026/12/02" ],
-    ["notmyfault", "2024/12/03", "2026/12/02"],
+    ["notmyfault", "2022/12/03", "2026/12/02"],
     ["basil", "2023/12/11", "2025/12/15"],
     ["slide_o_mix", "2024/12/03", "2026/12/02"],
     ["markewaite", "2021/12/03", "2025/12/15"],
   ]
   officers = [
-    ["Security", "wadeck", "2024/12/03", "2025/12/02"],
-    ["Release", "timja", "2024/12/03", "2025/12/02"],
-    ["Infrastructure", "dduportal", "2024/12/03", "2025/12/02"],
-    ["Events", "alyssat", "2024/12/03", "2025/12/02"],
-    ["Documentation", "kmartens27", "2024/12/03", "2025/12/02"]
+    ["Security", "wadeck", "2021/12/03", "2025/12/02"],
+    ["Release", "timja", "2020/12/03", "2025/12/02"],
+    ["Infrastructure", "dduportal", "2021/12/03", "2025/12/02"],
+    ["Events", "alyssat", "2021/12/03", "2025/12/02"],
+    ["Documentation", "kmartens27", "2022/12/03", "2025/12/02"]
   ]
 
 As per the Jenkins project

--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -13,18 +13,18 @@ links:
 
 :ruby
   board_members = [
-    ["kohsuke"],
-    ["notmyfault", "2022/12/03", "2024/12/02"],
+    ["jonesbusy", "2024/12/03", "2026/12/02" ],
+    ["notmyfault", "2024/12/03", "2026/12/02"],
     ["basil", "2023/12/11", "2025/12/15"],
-    ["uhafner", "2022/12/03", "2024/12/02"],
+    ["slide_o_mix", "2024/12/03", "2026/12/02"],
     ["markewaite", "2021/12/03", "2025/12/15"],
   ]
   officers = [
-    ["Security", "wadeck", "2021/12/03", "2024/12/16"],
-    ["Release", "timja", "2020/12/03", "2024/12/16"],
-    ["Infrastructure", "dduportal", "2021/12/03", "2024/12/16"],
-    ["Events", "alyssat", "2021/12/03", "2024/12/16"],
-    ["Documentation", "kmartens27", "2022/12/03", "2024/12/16"]
+    ["Security", "wadeck", "2024/12/03", "2025/12/02"],
+    ["Release", "timja", "2024/12/03", "2025/12/02"],
+    ["Infrastructure", "dduportal", "2024/12/03", "2025/12/02"],
+    ["Events", "alyssat", "2024/12/03", "2025/12/02"],
+    ["Documentation", "kmartens27", "2024/12/03", "2025/12/02"]
   ]
 
 As per the Jenkins project


### PR DESCRIPTION
This PR is to update the governance board page to include the new governance board members and update the terms to reflect the correct time frame that everyone will be serving.