### PR TITLE
Move Blue Ocean tutorial section towards bottom of page

### DIFF
--- a/content/doc/tutorials/index.adoc
+++ b/content/doc/tutorials/index.adoc
@@ -64,7 +64,7 @@ You may find more tutorials in link:/blog/tags/tutorial[Tutorial blogposts].
 [[blueocean]]
 == Blue Ocean
 
-NOTE: Blue Ocean is no longer being actively maintained and has been removed from Jenkins controllers thanks to work from the Jenkins infra team.
+NOTE: Blue Ocean is no longer being actively maintained.
 These tutorials will continue to work until Blue Ocean is completely deprecated, at which point the tutorials will be removed from the documentation.
 
 * link:/blog/2017/04/05/welcome-to-blue-ocean/[Getting Started with Blue Ocean]

--- a/content/doc/tutorials/index.adoc
+++ b/content/doc/tutorials/index.adoc
@@ -33,14 +33,6 @@ processes to build your applications:
 * link:/blog/2017/01/19/converting-conditional-to-pipeline/[Converting Conditional Build Steps to Jenkins Pipeline]
 * link:/blog/2017/05/18/pipeline-dev-tools/[Pipeline Development Tools]
 
-[[blueocean]]
-== Blue Ocean
-
-* link:/blog/2017/04/05/welcome-to-blue-ocean/[Getting Started with Blue Ocean]
-* Getting Started with Blue Ocean's Visual Pipeline Editor (link:create-a-pipeline-in-blue-ocean[guide], link:/blog/2017/04/06/welcome-to-blue-ocean-editor/[video guide])
-* link:/blog/2017/04/11/welcome-to-blue-ocean-pipeline-activity/[Getting Started with Blue Ocean's Activity View ]
-* link:/blog/2017/04/12/welcome-to-blue-ocean-dashboard/[Getting Started with the Blue Ocean Dashboard]
-
 [[tools]]
 == Using build tools
 
@@ -69,6 +61,16 @@ You may find more tutorials in link:/blog/tags/tutorial[Tutorial blogposts].
 * link:/blog/2016/08/10/rails-cd-with-pipeline/[Continuous Security for Rails apps with Pipeline and Brakeman]
 * link:/blog/2016/08/29/sauce-pipeline/[Browser-testing with Sauce OnDemand and Pipeline]
 
+[[blueocean]]
+== Blue Ocean
+
+NOTE: Blue Ocean is no longer being actively maintained and has been removed from Jenkins controllers thanks to work from the Jenkins infra team.
+These tutorials will continue to work until Blue Ocean is completely deprecated, at which point the tutorials will be removed from the documentation.
+
+* link:/blog/2017/04/05/welcome-to-blue-ocean/[Getting Started with Blue Ocean]
+* Getting Started with Blue Ocean's Visual Pipeline Editor (link:create-a-pipeline-in-blue-ocean[guide], link:/blog/2017/04/06/welcome-to-blue-ocean-editor/[video guide])
+* link:/blog/2017/04/11/welcome-to-blue-ocean-pipeline-activity/[Getting Started with Blue Ocean's Activity View ]
+* link:/blog/2017/04/12/welcome-to-blue-ocean-dashboard/[Getting Started with the Blue Ocean Dashboard]
 
 '''
 ++++


### PR DESCRIPTION
This PR is to move the Blue Ocean tutorial section toward the bottom of the page and add a note indicating the status of Blue Ocean and its eventual deprecation