### PR TITLE
Add link to pipeline syntax parameters

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -68,6 +68,10 @@ linux true
 [Pipeline] }
 ----
 
+=== Additional arguments
+
+Additional arguments, such as the `registryUrl`, are described in the link:../syntax/#agent-parameters[agent parameters] syntax documentation.
+
 === Workspace synchronization
 
 If it is important to keep the workspace synchronized with other stages, use `reuseNode true`.
@@ -248,11 +252,6 @@ For Jenkins environments that have macOS, Windows, or other agents that are unab
 Pipeline provides a global option on the *Manage Jenkins* page and on the link:../../glossary/#folder[Folder] level, for specifying which agents (by link:../../glossary/#label[Label]) to use for running Docker-based Pipelines. To enable this option for Docker labels, the plugin:docker-workflow[*Docker Pipeline*] plugin must be installed.
 
 image::pipeline/configure-docker-label.png[alt = "Navigate from Dashboard to Manage Jenkins then to System. In the 'Declarative Pipeline (Docker)' section set the Docker label, Docker Registry URL and Registry Credentials."]
-
-
-=== Additional Arguments
-
-Some additional arguments, such as the `registryUrl`, are described here: link:../syntax/#agent-parameters[Agent Parameters].
 
 === Path setup for mac OS users
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -249,6 +249,11 @@ Pipeline provides a global option on the *Manage Jenkins* page and on the link:.
 
 image::pipeline/configure-docker-label.png[alt = "Navigate from Dashboard to Manage Jenkins then to System. In the 'Declarative Pipeline (Docker)' section set the Docker label, Docker Registry URL and Registry Credentials."]
 
+
+=== Additional Arguments
+
+Some additional arguments, such as the `registryUrl`, are described here: link:../syntax/#agent-parameters[Agent Parameters].
+
 === Path setup for mac OS users
 
 The `/usr/local/bin` directory is not included in the macOS `PATH` for Docker images by default.


### PR DESCRIPTION
Some docker step options are described on this page, others are defined here: https://www.jenkins.io/doc/book/pipeline/syntax/#agent-parameters. So it makes sense to link them, to help users find what they're looking for.

Edit: preview link: https://deploy-preview-7725--jenkins-io-site-pr.netlify.app/doc/book/pipeline/docker/