### PR TITLE
Remove HipChat from Pipeline examples

### DIFF
--- a/content/doc/pipeline/tour/post.adoc
+++ b/content/doc/pipeline/tour/post.adoc
@@ -62,8 +62,7 @@ node {
 ----
 
 There are plenty of ways to send notifications, below are a few snippets
-demonstrating how to send notifications about a Pipeline to an email, a Hipchat
-room, or a Slack channel.
+demonstrating how to send notifications about a Pipeline to an email or a Slack channel.
 
 === Email
 
@@ -74,19 +73,6 @@ post {
         mail to: 'team@example.com',
              subject: "Failed Pipeline: ${currentBuild.fullDisplayName}",
              body: "Something is wrong with ${env.BUILD_URL}"
-    }
-}
-----
-
-
-=== Hipchat
-
-[source,groovy]
-----
-post {
-    failure {
-        hipchatSend message: "Attention @here ${env.JOB_NAME} #${env.BUILD_NUMBER} has failed.",
-                    color: 'RED'
     }
 }
 ----

--- a/content/pipeline/getting-started-pipelines.adoc
+++ b/content/pipeline/getting-started-pipelines.adoc
@@ -168,8 +168,6 @@ Pipeline-related plugins other than those listed above are regularly “whitelis
 |
 |HtmlPublisher (htmlpublisher)
 |
-|HipChatNotifier (hipchat)
-|
 |LogParserPublisher (log-parser)
 |
 |SeleniumHtmlReportPublisher (seleniumhtmlreport)


### PR DESCRIPTION
## Remove HipChat from Pipeline examples

https://en.wikipedia.org/wiki/HipChat notes that HipChat is no longer available.  No reason to leave it in our documentation.
