### PR TITLE
Update documentation for Docker Groovy script path

### DIFF
--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -51,7 +51,7 @@ Jenkins.instance.doQuietDown();
 Output is logged to the Jenkins log file. For Debian based users, this
 is /var/log/jenkins/jenkins.log
 
-NOTE: If using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist.
+NOTE: If you are using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist.
 Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
 
 == Boot failure hook

--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -53,7 +53,7 @@ is /var/log/jenkins/jenkins.log
 
 NOTE: If you are using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist.
 Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
-For more details, see the official documentation : https://github.com/jenkinsci/docker?tab=readme-ov-file#installing-more-tools
+For more details, refer to the link:https://github.com/jenkinsci/docker?tab=readme-ov-file#installing-more-tools[installing more tools documentation].
 
 == Boot failure hook
 When Jenkins encounters a fatal problem during boot, it'll invoke

--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -51,6 +51,7 @@ Jenkins.instance.doQuietDown();
 Output is logged to the Jenkins log file. For Debian based users, this
 is /var/log/jenkins/jenkins.log
 
+NOTE: If using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist. Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
 
 == Boot failure hook
 When Jenkins encounters a fatal problem during boot, it'll invoke

--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -51,7 +51,8 @@ Jenkins.instance.doQuietDown();
 Output is logged to the Jenkins log file. For Debian based users, this
 is /var/log/jenkins/jenkins.log
 
-NOTE: If using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist. Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
+NOTE: If using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist.
+Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
 
 == Boot failure hook
 When Jenkins encounters a fatal problem during boot, it'll invoke

--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -53,6 +53,7 @@ is /var/log/jenkins/jenkins.log
 
 NOTE: If you are using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist.
 Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
+For more details, see the official documentation : https://github.com/jenkinsci/docker?tab=readme-ov-file#installing-more-tools
 
 == Boot failure hook
 When Jenkins encounters a fatal problem during boot, it'll invoke

--- a/content/doc/book/managing/groovy-hook-scripts.adoc
+++ b/content/doc/book/managing/groovy-hook-scripts.adoc
@@ -53,7 +53,7 @@ is /var/log/jenkins/jenkins.log
 
 NOTE: If you are using the Jenkins Docker image, `$JENKINS_HOME/init.groovy.d/` does not exist.
 Instead, you should place the Groovy script files in `/usr/share/jenkins/ref/init.groovy.d/`, as this directory is copied when the Docker container starts.
-For more details, refer to the link:https://github.com/jenkinsci/docker?tab=readme-ov-file#installing-more-tools[installing more tools documentation].
+For more details, refer to the link:https://github.com/jenkinsci/docker?tab=readme-ov-file#installing-more-tools[Installing more tools documentation].
 
 == Boot failure hook
 When Jenkins encounters a fatal problem during boot, it'll invoke


### PR DESCRIPTION
Fixes #7051

Issue description:Mention that if using docker the user should use /usr/share/jenkins/ref/init.groovy.d and not $JENKINS_HOME/init.groovy.d/

Changes made:

1.Added a note in the "Post initialization script (init hook)" section.
2.The note clarifies that when using the Jenkins Docker image, the $JENKINS_HOME/init.groovy.d/ directory does not exist. Instead, users should place their Groovy script files in /usr/share/jenkins/ref/init.groovy.d/ since this directory is copied when the Docker container starts.

This change aims to improve the clarity of the documentation and help users running Jenkins in Docker environments correctly place their initialization scripts.

i hope this solves the issue  @tzachs @kmartens27