### PR TITLE
Link to `commons-compress-api` API plugin is incorrect

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25470,7 +25470,7 @@
           - jonesbusy
         pr_title: JENKINS-73355 Removal of commons-compress from core
         message: |-
-          Developer: The <code>commons-compress</code> library is no longer provided by Jenkins core, use the <a href="https://plugins.jenkins.io/commonscompressapi/">Commons Compress API plugin</a> instead.
+          Developer: The <code>commons-compress</code> library is no longer provided by Jenkins core, use the <a href="https://plugins.jenkins.io/commons-compress-api/">Commons Compress API plugin</a> instead.
       - type: rfe
         category: developer
         pull: 10019


### PR DESCRIPTION
Link is https://plugins.jenkins.io/commons-compress-api/