### PR TITLE
adding harsh-ps-2003 as a potential mentor for GSoC 2025

### DIFF
--- a/content/_data/authors/harsh-ps-2003.adoc
+++ b/content/_data/authors/harsh-ps-2003.adoc
@@ -8,5 +8,5 @@ Harsh is currently an undergrad at the Indian Institute of Technology, Kanpur, w
 Other than software development, his interest lies in economics, philosophy, and psychology.
 He was a Jenkins Google Summer of Code (GSoC) contributor in 2023, participating in the link:https://github.com/jenkinsci/gitlab-plugin[GitLab Plugin Modernization] project.
 He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin].
-Know more about him from his link:https://harsh-ps-2003.bearblog.dev/[personal website].
+Learn more about him from his link:https://harsh-ps-2003.bearblog.dev/[personal website].
 

--- a/content/_data/authors/harsh-ps-2003.adoc
+++ b/content/_data/authors/harsh-ps-2003.adoc
@@ -4,8 +4,9 @@ github: harsh-ps-2003
 twitter: harsh_ps2003
 linkedin: harsh-pratap-singh-787485255
 ---
-Harsh is currently an undergrad at the Indian Institute of Technology, Kanpur, whose interests lies in rapidly evolving Computer Science fields like Linux Performance, DevOps, GenAI and more. He is an avid open-source contributor and is inspired by the idea of developing useful open-source software for the masses to use. 
+Harsh is currently an undergrad at the Indian Institute of Technology, Kanpur, who is passionate about Distributed Systems, Applied Cryptography and Secure Machine Learning. He is an avid open-source contributor and is inspired by the idea of developing useful open-source software for the masses to use. 
 Other than software development, his interest lies in economics, philosophy, and psychology.
 He was a Jenkins Google Summer of Code (GSoC) contributor in 2023, participating in the link:https://github.com/jenkinsci/gitlab-plugin[GitLab Plugin Modernization] project.
 He started his journey of contributing to Jenkins in February 2023 and got hooked since. He is also a maintainer of link:https://plugins.jenkins.io/gitlab-plugin/[GitLab Plugin].
+Know more about him from his link:https://harsh-ps-2003.bearblog.dev/[personal website].
 

--- a/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
+++ b/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
@@ -19,6 +19,7 @@ skills:
 - Data Analytics
 mentors:
 - "krisstern"
+- "harsh-ps-2003"
 links:
   meetings: /projects/gsoc/#office-hours
 ---


### PR DESCRIPTION
Hey,
 I would also like to be the mentor for GSoC 2025 for the project [Domain-specific LLM based on actual Jenkins usage using ci.jenkins.io data](https://www.jenkins.io/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data/)
 
I believe that my past mentoring experience in GSoC 2024 and contributing experience in GSoC 2023, along with Jenkins plugin development and Infrastructure knowledge, can be a valuable addition to the project!

Thanking you in Anticipation 
Warm Regards