### PR TITLE
Add atomicfilewriter entry to 2.491 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25582,8 +25582,8 @@
           - Vlatombe
         pr_title: "Simplify AtomicFileWriter and use clearer temporary file names"
         message: |-
-          Avoid printing the same stacktrace multiple times when file persistence fails.
-          Temporary file names used by the atomic file writer are now derived from the target file name.
+          Avoid printing the same stack trace multiple times when file persistence fails.
+          Temporary file names used by the <code>AtomicFileWriter</code> are now derived from the target file name.
       - type: bug
         category: bug
         pull: 10070

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -25575,6 +25575,15 @@
   - version: '2.491'
     date: 2024-12-19
     changes:
+      - type: rfe
+        category: rfe
+        pull: 10058
+        authors:
+          - Vlatombe
+        pr_title: "Simplify AtomicFileWriter and use clearer temporary file names"
+        message: |-
+          Avoid printing the same stacktrace multiple times when file persistence fails.
+          Temporary file names used by the atomic file writer are now derived from the target file name.
       - type: bug
         category: bug
         pull: 10070


### PR DESCRIPTION
This PR is to add an entry to the 2.491 changelog for https://github.com/jenkinsci/jenkins/pull/10058

The pr originally had the `skip-changelog` label assigned and no changelog entry suggested so it was not included by the automated changelog generator. 