### PR TITLE
Update python.adoc due to nosetest and Cobertura EOL statuses

### DIFF
--- a/content/solutions/python.adoc
+++ b/content/solutions/python.adoc
@@ -10,9 +10,9 @@ integration and delivery.
 In the Python ecosystem there are tools which can be integrated into Jenkins
 for testing/reporting such as:
 
-* link:https://github.com/nose-devs/nose2[nose2] and link:https://docs.pytest.org/en/latest[pytest]
+* link:link:https://docs.pytest.org/en/latest[pytest]
   for executing unit tests and generating JUnit-compatible XML test reports _and_
-  plugin:cobertura[Cobertura]-compatible
+  plugin:coverage[Coverage]-compatible
   code coverage reports.
 
 


### PR DESCRIPTION
Cobertura is deprecated and no longer in support
Same with nosetests and its successor nose2

Instead - steer peoples towards using pytest