### PR TITLE
Add contributor as a potential mentor for GSoC 2025

### DIFF
--- a/content/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling.adoc
+++ b/content/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling.adoc
@@ -16,6 +16,7 @@ mentors:
 - "krisstern"
 - "gounthar"
 - "kmartens27"
+- "iamrajiv"
 links:
   meetings: /projects/gsoc/#office-hours
 ---

--- a/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
@@ -15,6 +15,7 @@ skills:
 mentors:
 - "krisstern"
 - "gounthar"
+- "iamrajiv"
 links:
   draft: /projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api-draft.pdf
   meetings: /projects/gsoc/#office-hours


### PR DESCRIPTION
Hi, I am interested in mentoring the project [Swagger / OpenAPI standardization for Jenkins REST API](https://www.jenkins.io/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api/), and [Complete build retooling of jenkins.io ](https://www.jenkins.io/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling/). As an open-source enthusiast, I have completed the following programs: [GSoC 2022](https://github.com/iamrajiv/GSoC-2022) with Keptn, [LFX Mentorship Fall 2021](https://github.com/iamrajiv/LFX-2021) with moja global, [GSoD 2021](https://github.com/iamrajiv/GSoD-2021) with Wechaty, and [GSoD 2020](https://github.com/iamrajiv/GSoD-2020) with gRPC-Gateway. I have also mentored in the past with Jenkins during GSoC 2023 and GSoC 2024.

Regarding the tech stack in my programs with GSoD 2020 and GSoC 2022, I have worked on API documentation, Swagger, and creating version-based documentation engines. This has given me experience working with these technologies.