### PR TITLE
Add shivaylamba as a potential mentor for GSoC 2025

### DIFF
--- a/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
+++ b/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
@@ -20,6 +20,7 @@ skills:
 mentors:
 - "krisstern"
 - "harsh-ps-2003"
+- "shivaylamba"
 links:
   meetings: /projects/gsoc/#office-hours
 ---


### PR DESCRIPTION
Hey,

 I would like to mentor for GSoC 2025 for the potential project [Domain-specific LLM based on actual Jenkins usage using ci.jenkins.io data](https://www.jenkins.io/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data/)
 
I believe that my past mentoring experience in GSoC 2024 in the LLM project and Jenkins ML Plugin GSoC 2020 project, along with extensive experience with LLMs for log analysis and OpenLLMetry, can be a valuable addition to the project!

With regards
Shivay