### PR TITLE
fix(gsoc): patch broken link found in gsoc 2025 llm project idea

### DIFF
--- a/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
+++ b/content/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data.adoc
@@ -32,7 +32,7 @@ This full-stack project focuses on a proof-of-concept (PoC) idea to fine-tune an
 The main source of raw data will be the publicly available ci.jenkins.io datasets.
 It is expected that there will be two parts of the project: the first part which is to analyze the ci.jenkins.io data using machine learning techniques, and the second part which is to "ingest" the knowledge gained via part one to fine-tune an existing LLM model to help with any infra-related troubleshooting tasks.
 The contributor will get to be involved in every step of the application development process, from data collection, wrangling, and processing to fine-tuning the model and developing the UI.
-Unlike the very similar link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc[GSoC 2024 LLM counterpart], this project is very research-focused and data-driven, and will be a lot more difficult to achieve a successful outcome.
+Unlike the very similar link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge[GSoC 2024 LLM counterpart], this project is very research-focused and data-driven, and will be a lot more difficult to achieve a successful outcome.
 We will build on the completed work available via GitHub at link:https://github.com/jenkins-infra/Enhancing-LLM-with-Jenkins-Knowledge/[].
 It is expected that some benchmarking will be conducted by the GSoC contributor selected towards the end of the project to gauge the effectiveness of the work completed, which will also serve as a basis for future similar projects.
 
@@ -65,5 +65,5 @@ Intermediate to Advanced
 
 == Quick Start
 
-Become familiarized with the flow of the link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge.adoc[GSoC 2024 LLM project].
+Become familiarized with the flow of the link:/projects/gsoc/2024/projects/enhancing-an-existing-llm-model-with-domain-specific-jenkins-knowledge/[GSoC 2024 LLM project].
 We will reference the source code from the GSoC 2024 LLM project at link:https://github.com/jenkins-infra/Enhancing-LLM-with-Jenkins-Knowledge/[its official repo on GitHub].


### PR DESCRIPTION
Fixes #7780 

Removed the redundant file extensions `.adoc` from the broken links in the GSoC 2025 LLM project idea page at https://www.jenkins.io/projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci.jenkins.io-data/. 