### PR TITLE
Fix 2 weekly.ci.jenkins.io hyperlinks

### DIFF
--- a/content/doc/developer/forms/adding-tool-tips.adoc
+++ b/content/doc/developer/forms/adding-tool-tips.adoc
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_url: "https://weekly.ci.jenkins.io/design-library/Tooltips/"
+redirect_url: "https://weekly.ci.jenkins.io/design-library/tooltips/"
 ---

--- a/content/doc/developer/views/symbols.adoc
+++ b/content/doc/developer/views/symbols.adoc
@@ -24,4 +24,4 @@ in buttons and in tables. Symbols are scalable, support different weights and ad
 
 === Using Symbols
 
-Read more about symbols and how to use them in your plugin on the link:https://weekly.ci.jenkins.io/design-library/Symbols/[design library documentation] page.
+Read more about symbols and how to use them in your plugin on the link:https://weekly.ci.jenkins.io/design-library/symbols/[design library documentation] page.


### PR DESCRIPTION
## Fix 2 hyperlinks to weekly.ci.jenkins.io

The URL to each of the pages has changed.  Update it in the documentation so that the link works.

- **Fix link to design library symbols page**
- **Fix tooltip hyperlink**
