### PR TITLE
Recommend Maven 3.9.6 or newer

### DIFF
--- a/content/doc/developer/tutorial-improve/_install-apache-maven.adoc
+++ b/content/doc/developer/tutorial-improve/_install-apache-maven.adoc
@@ -14,7 +14,8 @@ Make sure to download one of the binary archives (with `bin` in their name).
 NOTE: Many Linux distributions provide packages for Maven for an easier install and upgrade experience.
 Consult your distribution's documentation for details.
 On macOS, the link:https://brew.sh/[Homebrew] package manager offers Maven packages.
-Make sure a recent version of Maven 3, ideally 3.8.6 or newer, is provided if you decide to go this route.
+Make sure a recent version of Maven 3, ideally 3.9.6 or newer, is provided if you decide to go this route.
+Older versions can cause an error "Unknown packaging: hpi".
 
 Next, you will need to extract Maven and take note of its location.
 When you extract the Maven files, make sure you extract them directly into the target directory.


### PR DESCRIPTION
Plugin POM 5.0 requires Maven 3.9.6 or later:
<https://github.com/jenkinsci/plugin-pom/pull/1018>