### PR TITLE
Make it clear that relativePath must be present on the parent pom

### DIFF
--- a/content/doc/developer/tutorial-improve/update-parent-pom.adoc
+++ b/content/doc/developer/tutorial-improve/update-parent-pom.adoc
@@ -70,6 +70,7 @@ index e6a8356..3a42d47 100644
      <artifactId>plugin</artifactId>
 -    <version>3.50</version>
 +    <version>4.80</version>
+     <relativePath />
    </parent>
 
    <artifactId>your-plugin</artifactId>


### PR DESCRIPTION
Small change but was missing on the improve a plugin tutorial

This is even recommended since parent 2.x : https://www.jenkins.io/doc/developer/plugin-development/updating-parent/

SInce I'm starting to run https://github.com/jenkins-infra/plugin-modernizer-tool to fix this on most plugin I would like to link to this page