### PR TITLE
chore(gemfile): add base64 dependency and bump ruby docker image to 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'colorize'
+gem 'base64' # needed since ruby 3.4 https://github.com/igrigorik/em-websocket/pull/161
 gem 'awestruct', '~> 0.6.7'
 gem 'naturally', '~> 2.2.1'
 gem 'asciidoctor', '~> 2.0.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
       rack (~> 2.0)
       rest-client (~> 2.0)
       tilt (~> 2.0, >= 2.0.1)
+    base64 (0.2.0)
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.3.4)
@@ -140,6 +141,7 @@ DEPENDENCIES
   asciidoctor (~> 2.0.18)
   asciidoctor-jenkins-extensions (~> 0.9.0)
   awestruct (~> 0.6.7)
+  base64
   colorize
   concurrent-ruby (~> 1.1)
   faraday (~> 2.12.0)

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -10,6 +10,8 @@ if [ -n "${USE_LOCAL_RUBY}" ]; then
     exit
 fi
 
+# TODO: track with 'updatecli' from https://github.com/jenkins-infra/packer-images/blob/2.20.0/provisioning/tools-versions.yml#L42
+# with the same technique as https://github.com/jenkins-infra/jenkins-infra/blob/8cd6e81d4f2f6a2df46809917298ff676f4dbefa/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml#L16-L32
 CONTAINER_NAME=ruby:3.4.1
 source ./scripts/docker-env
 

--- a/scripts/ruby
+++ b/scripts/ruby
@@ -10,7 +10,7 @@ if [ -n "${USE_LOCAL_RUBY}" ]; then
     exit
 fi
 
-CONTAINER_NAME=ruby:3.3.6
+CONTAINER_NAME=ruby:3.4.1
 source ./scripts/docker-env
 
 if [ ! -z ${LISTEN+x} ]; then


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4476

`base64` is now required as a dependency in the Gemfile

and I bumped the ruby version to match the infra packer-image version https://github.com/jenkins-infra/packer-images/blob/53dfc01e68aa3c9f9e566131dd4b85a17d638c62/provisioning/tools-versions.yml#L42