### PR TITLE
Directly link to Create Issue form instead of just SECURITY project

### DIFF
--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -39,7 +39,7 @@ Even if you run Jenkins on a private network and trust everyone in your team, se
 [[reporting-vulnerabilities]]
 == How to Report a Security Vulnerability
 
-If you find a vulnerability in Jenkins, please report it in the issue tracker under the link:https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103[SECURITY project].
+If you find a vulnerability in Jenkins, please link:https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103[report it in the issue tracker under the SECURITY project].
 This project is configured in such a way that only the reporter, the maintainers, and the Jenkins security team can see the details.
 Restricting access to this potentially sensitive information allows core and plugin maintainers to develop effective security fixes that are safe to apply.
 We provide issue reporting guidelines and an overview of our process on link:reporting[Reporting Security Vulnerabilities].

--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -39,7 +39,7 @@ Even if you run Jenkins on a private network and trust everyone in your team, se
 [[reporting-vulnerabilities]]
 == How to Report a Security Vulnerability
 
-If you find a vulnerability in Jenkins, please report it in the issue tracker under the link:https://issues.jenkins.io/browse/SECURITY[SECURITY project].
+If you find a vulnerability in Jenkins, please report it in the issue tracker under the link:https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103[SECURITY project].
 This project is configured in such a way that only the reporter, the maintainers, and the Jenkins security team can see the details.
 Restricting access to this potentially sensitive information allows core and plugin maintainers to develop effective security fixes that are safe to apply.
 We provide issue reporting guidelines and an overview of our process on link:reporting[Reporting Security Vulnerabilities].

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -9,7 +9,7 @@ section: security
 
 Thanks for your interest in reporting vulnerabilities to the Jenkins project!
 
-Please report them in the issue tracker under the link:https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103[SECURITY project]. 
+Please link:https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103[report them in the issue tracker under the SECURITY project].
 This project is configured in such a way that only the reporter and the security team can see the details.
 By restricting access to this potentially sensitive information, we can work on a fix and deliver it before the method of attack becomes well-known.
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -9,7 +9,7 @@ section: security
 
 Thanks for your interest in reporting vulnerabilities to the Jenkins project!
 
-Please report them in the issue tracker under the link:https://issues.jenkins.io/browse/SECURITY[SECURITY project]. 
+Please report them in the issue tracker under the link:https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10180&issuetype=10103[SECURITY project]. 
 This project is configured in such a way that only the reporter and the security team can see the details.
 By restricting access to this potentially sensitive information, we can work on a fix and deliver it before the method of attack becomes well-known.
 


### PR DESCRIPTION
Perhaps this makes it easier for reporters to find where to report issues in Jira if they are unfamiliar with it?

Unlike the link for plugins on e.g. https://www.jenkins.io/participate/report-issue/redirect/#18146 nothing is already filled out, since we don't know what the component will be.

We could also add some quick instructions to the description. Any suggestions?