### PR TITLE
fix(authors) remove dduportal's Twitter

### DIFF
--- a/content/_data/authors/dduportal.adoc
+++ b/content/_data/authors/dduportal.adoc
@@ -1,6 +1,5 @@
 ---
 name: "Damien DUPORTAL"
-twitter: DamienDuportal
 github: dduportal
 irc: dduportal
 ---


### PR DESCRIPTION
I left Twitter and we don't have Bluesky tracking, so let's remove the link in my bio

Same as https://github.com/jenkins-infra/jenkins.io/pull/7835 :)