### PR TITLE
Update reverse proxy instructions for Java 17

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
@@ -51,7 +51,7 @@ In the `docker-compose.yaml` file, add the following code:
 jenkins:
   networks:
     main: {}
-  image: jenkins/jenkins:lts-jdk11
+  image: jenkins/jenkins:lts-jdk17
   privileged: true
   user: root
   ports:
@@ -172,7 +172,7 @@ services:
  jenkins:
    networks:
      main: {}
-   image: jenkins/jenkins:lts-jdk11
+   image: jenkins/jenkins:lts-jdk17
    privileged: true
    user: root
    ports:


### PR DESCRIPTION
This is just a small update to adjust the Jenkins images being used in this configuration to be the Java 17 supported image.