### PR TITLE
Provide CVE for SECURITY-3292-2

### DIFF
--- a/content/security/advisory/2025-01-22.adoc
+++ b/content/security/advisory/2025-01-22.adoc
@@ -77,7 +77,7 @@ issues:
     fixed: '1.4'
 - id: SECURITY-3292 (2)
   title: Tokens displayed without masking by PLUGIN_NAME
-  cve: CVE pending
+  cve: CVE-2025-0148
   cvss:
     severity: Low
     vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N


### PR DESCRIPTION
We were waiting for the Zoom CNA to provide us with the missing CVE for the vulnerability, which was published this morning in their [security bulletin](https://www.zoom.com/en/trust/security-bulletin/zsb-25007/).