### PR TITLE
Rename Tweet button to "Post"

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -27,7 +27,7 @@ section: blog
       = page.date.strftime('%B %-d, %Y')
 
     %a.twitter-share-button{:href => "https://twitter.com/intent/tweet?text=#{CGI::escape(page.title)}&url=#{CGI::escape("https://www.jenkins.io" + expand_link(page.url))}", :'data-lang' => 'en', 'rel' => 'noreferrer nofollow', 'target' => '_blank'}
-      Tweet
+      Post
 
   %div.blog-content
     - if page.note


### PR DESCRIPTION
Noticed that the Tweet button has the X logo so changed the content to "Post" for consistency.

<img width="680" alt="image" src="https://github.com/user-attachments/assets/52235db6-9bef-4f4a-b747-07dc79f69a39" />
