### PR TITLE
Explain the JCasC behavior on deprecated configuration elements

### DIFF
--- a/content/_data/upgrades/2-492-1.adoc
+++ b/content/_data/upgrades/2-492-1.adoc
@@ -14,5 +14,18 @@ Full removal of YUI will occur in a later LTS release, providing time for users 
 
 The list of agent protocols is no longer configurable through the GUI or the Configuration as Code (JCasC) plugin.
 Going forward, there are two protocols: one for inbound TCP agents and a ping protocol used to test connectivity.
-The `agentProtocols` section of a JCasC bundle should be deleted because it will now be ignored.
+The `agentProtocols` section of a configuration as code global configuration should be deleted because it will now be ignored.
 If you do not wish to allow inbound TCP agents, disable the port instead of the protocol.
+
+By default, the plugin:configuration-as-code[Configuration as Code Plugin] cancels Jenkins startup when a deprecated section is detected.
+If the `agentProtocols` section is in a Jenkins 2.492.1 global configuration, Jenkins 2.492.1 will cancel startup and process no jobs.
+That is the intentional behavior of the plugin so that administrators detect and apply configuration changes immediately.
+
+The Configuration as Code Plugin can warn when deprecated configuration elements are found instead of canceling startup.
+Warning on deprecated configuration elements may not handle all configuration changes.
+If an administrator wants a warning for configuration as code deprecations instead of canceling startup, they can add the following to their configuration as code global configuration:
+
+```yaml
+configuration-as-code:
+  deprecated: warn
+```


### PR DESCRIPTION
## Explain the JCasC behavior on deprecated configuration elements

Configuration as code intentionally cancels Jenkins startup when a deprecated configuration element is detected.  This forces administrators to resolve the deprecations immediateely rather than delyaing the resolution of the deprecation.

Describe the configuration as code setting that will change the default behavior to warn on deprecation rather than canceling startup.  Explain the risks of that choice.

The [pull request comment](https://github.com/jenkinsci/jenkins/pull/9903#issuecomment-2640241966) requests a more detailed description of the behavior.  This is that more detailed comment.
