### PR TITLE
fix(gsoc): replace goal for revamping jenkins.io website success stories feature

### DIFF
--- a/content/projects/gsoc/2025/project-ideas/revamping-jenkins-io-website-success-stories-feature.adoc
+++ b/content/projects/gsoc/2025/project-ideas/revamping-jenkins-io-website-success-stories-feature.adoc
@@ -1,7 +1,7 @@
 ---
 layout: gsocprojectidea
 title: "Revamping jenkins.io website Success Stories feature"
-goal: "To revamp jenkins.io website's Success Stories feature to update both tooling and UI/UX experince with new design"
+goal: "To revamp jenkins.io website's Success Stories feature to update both tooling and UI/UX experience with new design"
 category: UI/UX
 year: 2025
 status: published

--- a/content/projects/gsoc/2025/project-ideas/revamping-jenkins-io-website-success-stories-feature.adoc
+++ b/content/projects/gsoc/2025/project-ideas/revamping-jenkins-io-website-success-stories-feature.adoc
@@ -1,7 +1,7 @@
 ---
 layout: gsocprojectidea
 title: "Revamping jenkins.io website Success Stories feature"
-goal: "To investigate the current state of the Jenkinsfile Runner project and to improve its abilities as well as those of GitHub Actions when used in conjunction"
+goal: "To revamp jenkins.io website's Success Stories feature to update both tooling and UI/UX experince with new design"
 category: UI/UX
 year: 2025
 status: published


### PR DESCRIPTION
Previously we have omitted to update the goal for the revamping jenkins.io website success stories project idea. This PR is to correct that. 