### PR TITLE
fix: patch incorrect hash link redirect

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -151,6 +151,9 @@ Useful links:
 * link:https://github.com/jenkins-infra/plugin-site/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Newbie-friendly issues for the plugin site]
 
 [[user-guide]]
+=== User Guide Rework
+
+Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
 link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve user documentation.
 Common improvement themes include adding migration of the documentation from Wiki, pipeline examples with each of the pipeline steps, additional tutorials for new users, better searching, and navigation.
 

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -37,22 +37,6 @@ overview: >
 (function () {
     var anchorMap = {
         "ji-toolbar": "/sigs/docs/", /* Algolia search redirect to stay on same page */
-        "members": "/sigs/docs/#members",
-        "topics": "/sigs/docs/#topics",
-        "description": "/sigs/docs/#description",
-        "overview": "/sigs/docs/#overview",
-        "contributing": "/sigs/docs/#contributing",
-        "past-projects": "/sigs/docs/#past-projects",
-        "google-season-of-docs": "/sigs/docs/#google-season-of-docs",
-        "plugin-documentation-on-github": "/sigs/docs/#plugin-documentation-on-github",
-        "plugin-site-integration-with-github": "/sigs/docs/#plugin-site-integration-with-github",
-        "user-guide": "/sigs/docs/#user-guide",
-        "administrator-guide": "/sigs/docs/#administrator-guide",
-        "solution-pages": "/sigs/docs/#solution-pages",
-        "documentation-reviews": "/sigs/docs/#documentation-reviews",
-        "office-hours": "/sigs/docs/#office-hours",
-        "meetings": "/sigs/docs/#meetings",
-        "meeting-agendas": "/sigs/docs/#meeting-agendas",
         "jenkins-on-kubernetes": "/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/",
     }
     /*

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -37,6 +37,22 @@ overview: >
 (function () {
     var anchorMap = {
         "ji-toolbar": "/sigs/docs/", /* Algolia search redirect to stay on same page */
+        "members": "/sigs/docs/#members",
+        "topics": "/sigs/docs/#topics",
+        "description": "/sigs/docs/#description",
+        "overview": "/sigs/docs/#overview",
+        "contributing": "/sigs/docs/#contributing",
+        "past-projects": "/sigs/docs/#past-projects",
+        "google-season-of-docs": "/sigs/docs/#google-season-of-docs",
+        "plugin-documentation-on-github": "/sigs/docs/#plugin-documentation-on-github",
+        "plugin-site-integration-with-github": "/sigs/docs/#plugin-site-integration-with-github",
+        "user-guide": "/sigs/docs/#user-guide",
+        "administrator-guide": "/sigs/docs/#administrator-guide",
+        "solution-pages": "/sigs/docs/#solution-pages",
+        "documentation-reviews": "/sigs/docs/#documentation-reviews",
+        "office-hours": "/sigs/docs/#office-hours",
+        "meetings": "/sigs/docs/#meetings",
+        "meeting-agendas": "/sigs/docs/#meeting-agendas",
         "jenkins-on-kubernetes": "/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/",
     }
     /*
@@ -44,7 +60,7 @@ overview: >
     * https://stackoverflow.com/a/10076097/151365
     */
     var hash = window.location.hash.substring(1);
-    if (hash) {
+    if (hash && anchorMap[hash] !== undefined) {
         /*
         * Best practice for javascript redirects:
         * https://stackoverflow.com/a/506004/151365
@@ -135,9 +151,6 @@ Useful links:
 * link:https://github.com/jenkins-infra/plugin-site/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[Newbie-friendly issues for the plugin site]
 
 [[user-guide]]
-=== User Guide Rework
-
-Jenkins user topics are included in the current link:/doc/book[Jenkins Handbook].
 link:https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709[Feedback requests] are frequently received to improve user documentation.
 Common improvement themes include adding migration of the documentation from Wiki, pipeline examples with each of the pipeline steps, additional tutorials for new users, better searching, and navigation.
 


### PR DESCRIPTION
#### Fixes #5961 

### Description:

- This PR addresses two key issues in the Jenkins documentation:

1.Fixing Incorrect Sublink Redirections

-Previously, sublinks under /sigs/docs/ were incorrectly redirected to undefined pages or non-existing sections.
-Updated the redirection mechanism to correctly resolve sublinks such as #members, #description, and #topics, ensuring they direct to the correct sections.

2.Improving Algolia Search Functionality

-When a search query had no direct matches, Algolia suggested links that did not exist or led to incorrect redirections.
-Adjusted the search index behavior to exclude invalid links and prevent misleading recommendations.
-Ensured that valid sublinks are properly indexed and accessible through the search results.

### Impact:

- Users can now navigate correctly to sub-sections within /sigs/docs/ without broken redirections.
- Search functionality is more reliable, reducing frustration from incorrect suggestions.
- Enhances the overall documentation experience by fixing link inconsistencies.

### Before:


https://github.com/user-attachments/assets/89b96db9-3e63-4a15-9956-51a2554e0f89

### After : 


https://github.com/user-attachments/assets/97ee9710-aac9-4381-926e-4f917a844836



### Testing:

- Verified sublink navigation correctness after changes by running `make` and `make run`.
- Ensured no unintended side effects on other documentation pages.



Looking forward to feedback and suggestions! 
