### PR TITLE
Remove duplicate changelog entry from 2.492.1

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -12445,15 +12445,6 @@
         title: Winstone 8.2 changelog
     message: |-
       Upgrade Winstone to 8.2 in order to update Jetty from 12.0.13 to 12.0.14.
-  - type: rfe
-    category: rfe
-    pull: 9787
-    issue: 73813
-    authors:
-      - mawinter69
-    pr_title: "[JENKINS-73813] Show a notification when scheduling a build fails"
-    message: |-
-      Show a notification when scheduling a build fails.
   - type: bug
     category: bug
     pull: 10106


### PR DESCRIPTION
This PR is to remove a duplicate entry from the 2.492.1 changelog as noted by @darinpope.