### PR TITLE
fix: ensure "No results for..." text is visible in Algolia search box

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1546,6 +1546,7 @@ ion-icon.report {
   max-height: 128px;
 }
 
+/* Algolia searchbox "No results" text */
 .DocSearch-NoResults p.DocSearch-Title {
   color: rgba(0, 0, 0, 0.528);
   font-weight: bold;

--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1545,3 +1545,8 @@ ion-icon.report {
   height: 25vw;
   max-height: 128px;
 }
+
+.DocSearch-NoResults p.DocSearch-Title {
+  color: rgba(0, 0, 0, 0.528);
+  font-weight: bold;
+}


### PR DESCRIPTION
#### Fixes #7856 

### Description : 

This PR resolves the issue where the "No results for..." text in the Algolia search box was not visible due to the white text color blending into the white background.

### Changes made:

- Updated the CSS for `p.DocSearch-Title` within the `DocSearch-NoResults` container to set the text color to more visible color type. 
- Ensured the fix aligns with the overall design consistency and improves user accessibility.


### Testing:

- Tested the website using `make` and `make run` .

### Before : 

<img width="712" alt="Screenshot 2025-02-12 at 5 08 39 PM" src="https://github.com/user-attachments/assets/08b144fb-d5c7-4682-86f2-3c3e60295386" />

### After : 

<img width="661" alt="Screenshot 2025-02-12 at 5 14 01 PM" src="https://github.com/user-attachments/assets/0293871d-cbe0-407c-8b1b-174aeec2248d" />


Please review and let me know for improvements. 
