### PR TITLE
Update windows.adoc

### DIFF
--- a/content/doc/upgrade-guide/2.60/windows.adoc
+++ b/content/doc/upgrade-guide/2.60/windows.adoc
@@ -51,8 +51,7 @@ It should contain log entries related Runaway Process Killer after the successfu
 
 === Enabling extra Windows service features
 
-WinSW and Agent installer offer many advanced features you may want to enable.
+WinSW offers many advanced features you may want to enable.
 For more details see these documents:
 
-* link:https://github.com/kohsuke/winsw/blob/master/README.md[WinSW Documentation]
-* link:https://github.com/jenkinsci/windows-slave-installer-module/blob/master/README.md[Windows Agent Installer Documentation]
+* link:https://github.com/winsw/winsw/blob/master/README.md[WinSW Documentation]


### PR DESCRIPTION
* Updating a link to the current org name.
* Removing a link to an archived repo, dead since https://github.com/jenkinsci/jenkins/pull/6543. (It would be nice if someone resurrected https://github.com/jenkinsci/windows-slave-installer-module/blob/master/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java + https://github.com/jenkinsci/windows-slave-installer-module/pull/41 + https://github.com/jenkinsci/windows-slave-installer-module/blob/master/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml as a plugin offering a sidebar link in a Windows inbound agent.)

I note that https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-controllers/how-to-install-windows-agents-as-a-service#_resolution links to https://github.com/winsw/winsw/blob/v3/samples/jenkins.xml but this is for the controller, not an agent, so that is not helpful at all. This seems to have been true since https://github.com/winsw/winsw/pull/731. https://youtu.be/N8AQTlHoBKc by @darinpope also appears to show this file tree but then goes on to use a different content, not what is in `jenkins.xml`.