### PR TITLE
Update dead openbsd on dl page

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -121,7 +121,7 @@ title: Download and deploy
     },
     {
         "image": "openbsd",
-        "href": "https://openports.pl/path/devel/jenkins/stable",
+        "href": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/stable/",
         "title": "OpenBSD",
         "third_party": true
     },
@@ -189,7 +189,7 @@ title: Download and deploy
     },
     {
         "image": "openbsd",
-        "href": "https://openports.pl/path/devel/jenkins/devel",
+        "href": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/devel/",
         "title": "OpenBSD",
         "third_party": true
     },


### PR DESCRIPTION
As the title says, the URL provided is dead.