### PR TITLE
Create OpenBSD install instructions like macOS

### DIFF
--- a/content/_partials/openbsd-pkg_add-installer.html.haml
+++ b/content/_partials/openbsd-pkg_add-installer.html.haml
@@ -1,0 +1,46 @@
+-# Intentionally does not include a version in the pkg_add command.
+-# User will be prompted with the list of available package versions.
+-# We do not track the OpenBSD package version numbers.
+
+-# Intentionally does not include upgrade instructions.
+
+-# Stuart Henderson noted that if the user is running a development
+-# snapshot then they'll need to be running packages in sync with the
+-# base OS version that they're running, otherwise typically the jenkins
+-# packages don't get updated between OS releases, and users would
+-# generally know how to update for those anyway.
+
+-# https://marc.info/?l=openbsd-ports&m=173979027021545&w=2
+
+%p
+  Jenkins can be installed using
+  %a{:href => 'https://man.openbsd.org/pkg_add'}
+    pkg_add
+  , the
+  %a{:href => 'https://www.openbsd.org/faq/faq15.html#PkgInstall'}
+    OpenBSD package manager
+  \.
+  Package definition:
+  %a{:href => "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/#{page.tag}"}
+    = "jenkins/#{page.tag}"
+
+%p
+  This package is supported by a third party.
+  It may not be as frequently updated as packages directly supported by the Jenkins project.
+
+Sample commands:
+%ul
+  %li
+    = "Install the latest #{page.type} version:"
+    %code
+      = "pkg_add jenkins"
+  %li
+    = "Start the Jenkins service:"
+    %code
+      = "rcctl start jenkins"
+  %li
+    = "Restart the Jenkins service:"
+    %code
+      = "rcctl restart jenkins"
+
+After starting the Jenkins service, browse to http://localhost:8080 and follow the instructions to complete the installation.

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -121,7 +121,7 @@ title: Download and deploy
     },
     {
         "image": "openbsd",
-        "href": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/stable/",
+        "href": "/download/lts/openbsd",
         "title": "OpenBSD",
         "third_party": true
     },
@@ -189,7 +189,7 @@ title: Download and deploy
     },
     {
         "image": "openbsd",
-        "href": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/devel/",
+        "href": "/download/weekly/openbsd",
         "title": "OpenBSD",
         "third_party": true
     },

--- a/content/download/lts/openbsd.html.haml
+++ b/content/download/lts/openbsd.html.haml
@@ -1,0 +1,6 @@
+---
+:layout: simplepage
+:title: OpenBSD Installer for Jenkins LTS
+---
+
+= partial('openbsd-pkg_add-installer.html.haml', :tag => 'stable', :type => 'LTS')

--- a/content/download/weekly/openbsd.html.haml
+++ b/content/download/weekly/openbsd.html.haml
@@ -1,0 +1,6 @@
+---
+:layout: simplepage
+:title: OpenBSD Installer for Jenkins Weekly
+---
+
+= partial('openbsd-pkg_add-installer.html.haml', :tag => 'devel', :type => 'weekly')


### PR DESCRIPTION
## Create OpenBSD install instructions like macOS

[PR-7885](https://github.com/jenkins-infra/jenkins.io/pull/7885) detected that the OpenBSD download links for weekly and LTS were pointing to a site that is offline.  It corrected that by pointing to the package definitions in the OpenBSD ports.

The package definitions in OpenBSD ports are not helpful for a user that wants to install on OpenBSD.  They need more instructions.

Stuart Henderson recommended that the macOS install pages are a good model to also explain OpenBSD installation.  Refer to the OpenBSD ports [mailing list thread](https://marc.info/?l=openbsd-ports&m=173979027021545&w=2) for more details.

These instructions intentionally do not include a package version number in the pkg_add command line.  The Jenkins install page should not track OpenBSD package versions.

The [OpenBSD package installation FAQ](https://www.openbsd.org/faq/faq15.html#PkgInstall) shows that the user will be prompted to choose one of the available versions when they use 'jenkins' without a package version number.

No upgrade instructions are included because Stuart Henderson suggests that OpenBSD users of Jenkins will tend to install the current Jenkins at the time they install the operating system and will perform updates themselves based on their configuration of OpenBSD.

### Previews

* [LTS preview page](https://deploy-preview-7889--jenkins-io-site-pr.netlify.app/download/lts/openbsd/)
* [Weekly preview page](https://deploy-preview-7889--jenkins-io-site-pr.netlify.app/download/weekly/openbsd/)