### PR TITLE
Only one macOS package installer, simplify the macOS pages

### DIFF
--- a/content/_partials/osx-brew-installer.html.haml
+++ b/content/_partials/osx-brew-installer.html.haml
@@ -1,7 +1,3 @@
-
-%h2
-  Homebrew Installer
-
 %p
   %a{:href => "https://formulae.brew.sh/formula/#{page.tag}"}
     %img{:alt=>"homebrew", :src=>"https://img.shields.io/homebrew/v/#{page.tag}"}
@@ -14,7 +10,10 @@
   Homebrew formula:
   %a{:href => "https://formulae.brew.sh/formula/#{page.tag}"}
     = "#{page.tag}"
-  This is a package supported by a third party which may be not as frequently updated as packages supported by the Jenkins project directly.
+
+%p
+  This package is supported by a third party.
+  It may not be as frequently updated as packages directly supported by the Jenkins project.
 
 Sample commands:
 %ul

--- a/content/download/lts/macos.html.haml
+++ b/content/download/lts/macos.html.haml
@@ -1,6 +1,6 @@
 ---
 :layout: simplepage
-:title: macOS Installers for Jenkins LTS
+:title: macOS Installer for Jenkins LTS
 ---
 
 = partial('osx-brew-installer.html.haml', :tag => 'jenkins-lts', :type => 'LTS')

--- a/content/download/weekly/macos.html.haml
+++ b/content/download/weekly/macos.html.haml
@@ -1,6 +1,6 @@
 ---
 :layout: simplepage
-:title: macOS Installers for Jenkins Weekly
+:title: macOS Installer for Jenkins Weekly
 ---
 
 = partial('osx-brew-installer.html.haml', :tag => 'jenkins', :type => 'Weekly')


### PR DESCRIPTION
## Only one macOS package installer, simplify the macOS pages

Homebrew is the only installer described on the page.  The page is describing the macOS Installer for Jenkins, not multiple macOS Installers for Jenkins.

Simplify the phrasing of the disclaimer.
