### PR TITLE
fix: fully render `.1` release Changelog entries in LTS Changelog archive page

### DIFF
--- a/content/changelog-stable-old/index.html.haml
+++ b/content/changelog-stable-old/index.html.haml
@@ -11,7 +11,7 @@ actions:
 ---
 
 .ratings
-  - # Load older changelogs (all except the most recent 25, ordered correctly)
+  - # Load older changelogs (all except the most recent 25, ordered correctly with full entries list)
   - archived_changelogs = site.changelogs[:lts].reverse.drop(25)
   - archived_changelogs.each do |release|
     %div

--- a/content/changelog-stable-old/index.html.haml
+++ b/content/changelog-stable-old/index.html.haml
@@ -17,9 +17,17 @@ actions:
     %div
       = partial('../_partials/release-header.html.haml', :release => release, :url => 'changelog-stable-old')
       - if release.changes
+        .app-releases__notable-changes{:style => "margin-top: 15px"}
+          = "Changes since #{release.lts_baseline}"
         %div.app-releases__list__items
           = partial('../_partials/changelog-changes.html.haml', :changes => release.changes)
-      - else
+      - if release.lts_changes
+        .app-releases__notable-changes
+          - if release.lts_predecessor
+            = "Notable changes since #{release.lts_predecessor}"
+        %div.app-releases__list__items
+          = partial('../_partials/changelog-changes.html.haml', :changes => release.lts_changes)
+      - unless release.changes || release.lts_changes
         %p No notable changes for this release.
 
 .app-banner

--- a/content/changelog-stable-old/index.html.haml
+++ b/content/changelog-stable-old/index.html.haml
@@ -17,8 +17,9 @@ actions:
     %div
       = partial('../_partials/release-header.html.haml', :release => release, :url => 'changelog-stable-old')
       - if release.changes
-        .app-releases__notable-changes{:style => "margin-top: 15px"}
-          = "Changes since #{release.lts_baseline}"
+        - if release.version.end_with?('.1') && release.lts_baseline
+          .app-releases__notable-changes{:style => "margin-top: 15px"}
+            = "Changes since #{release.lts_baseline}"
         %div.app-releases__list__items
           = partial('../_partials/changelog-changes.html.haml', :changes => release.changes)
       - if release.lts_changes

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -121,7 +121,7 @@ title: Download and deploy
     },
     {
         "image": "openbsd",
-        "href": "https://openports.pl/path/devel/jenkins/stable",
+        "href": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/stable/",
         "title": "OpenBSD",
         "third_party": true
     },
@@ -189,7 +189,7 @@ title: Download and deploy
     },
     {
         "image": "openbsd",
-        "href": "https://openports.pl/path/devel/jenkins/devel",
+        "href": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/jenkins/devel/",
         "title": "OpenBSD",
         "third_party": true
     },


### PR DESCRIPTION
#### Fixes #7866 

### Description:

- This PR addresses the issue where the  [LTS changelog archive](https://www.jenkins.io/changelog-stable-old/)  does not fully render changelog entries for `.1` releases. Specifically, entries under `lts_changes` (changes compared to the LTS predecessor) were missing, while only entries under` lts_baseline` (changes compared to the baseline version) were displayed. This fix ensures that both changes and l`ts_changes` are properly rendered for all releases, including `.1` releases.

### Changes Made:

- Updated the content/changelog-stable-old/index.html.haml file to include logic for rendering lts_changes alongside changes.

- Ensured that the archive page now displays both changes and lts_changes for each release, similar to the main changelog page (changelog-stable).

- Verified the fix by testing the archive page with multiple .1 releases to confirm that all entries are now fully rendered.

### Testing:

- ran `make` and `make run` to view my changes

- Tested the changes locally by rendering the archive page and verifying that .1 releases (e.g., 2.375.1) now display all expected changelog entries.

## Example Screenshots - 

### Before : 

<img width="1512" alt="Screenshot 2025-02-17 at 8 58 01 PM" src="https://github.com/user-attachments/assets/0dd73680-5837-43a8-aa1d-9bf337919f89" />

### After : 

<img width="1512" alt="Screenshot 2025-02-17 at 8 58 29 PM" src="https://github.com/user-attachments/assets/08ef0727-f2c2-48fb-a4f7-85c2ed866a5a" />


CC: @kmartens27 



