### PR TITLE
Update docs office hours schedule

### DIFF
--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -174,7 +174,7 @@ This project was tracked in the jira:WEBSITE-742[] EPIC.
 
 == Office Hours
 
-Documentation office hours are held each Thursday at *17:00 UTC* (Europe and US East) and each Friday at *01:30 UTC* (Asia and US West).
+Documentation office hours are held once every two weeks on Thursday at *17:00 UTC*.
 Office hours are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
 Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] before the meeting starts.
 


### PR DESCRIPTION
This PR is to update the description of the docs office hours schedule to reflect the current times. Currently, docs office hours are once every two weeks, but the current documentation has the previous cadence of twice a week every week. The time will remain the same, unless there is consensus to move it earlier/later.