### PR TITLE
Add links to Docker installation instructions

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -76,6 +76,7 @@ When they are ready, you will push your changes to your fork and submit a PR fro
 == Building
 
 This project uses GNU/Make and Docker to generate the fully statically link:https://jenkins.io[jenkins.io] web site.
+If you need to install Docker, utilize the instructions for link:https://docs.docker.com/engine/install/[Docker Engine] or link:https://docs.docker.com/desktop/[Docker Desktop] depending on your environment.
 The key tool to convert source code into the site is the link:https://github.com/awestruct/awestruct[Awestruct] static site generator, which is downloaded automatically as part of the build process.
 
 Ensure you have GNU/Make and Curl and Docker available on your machine:


### PR DESCRIPTION
This PR is to help address one of the suggestions in https://github.com/jenkins-infra/jenkins.io/issues/7844 by adding links to both the Docker Engine and Docker Desktop installation guides.