### PR TITLE
fix: put the unwanted file inside .gitignore to avoid noise in PR's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ build/
 # external - see scripts/fetch-external-resources
 /content/_tmp/
 /content/_data/_generated/
-
+/content/_data/indexpage/thank_you.yml
 
 # external - files unzipped from /content/_tmp/
 # generated pipeline step documentation


### PR DESCRIPTION
### Description :

-  small fix of the unwanted file that was coming in PR after pushing changes automatically.
-  root cause might be in this file  : https://github.com/lakshmishreea122003/jenkins.io/blob/dc20fc726348fd416ac51257df253e6e3632349d/scripts/fetch-external-resources
-  put the file inside .gitignore to handle that issue.