### PR TITLE
Harmonize since syntax (LTS / weekly)

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -91,7 +91,7 @@ properties:
   - escape hatch
   - security
   def: undefined
-  since: 2.442 and LTS 2.426.3
+  since: 2.426.3 / 2.442
   description: |
     Escape hatch for link:/security/advisory/2024-01-24/#SECURITY-3315[SECURITY-3315].
     The default behavior (when undefined) is to apply an `Origin` header check when an attempt is made to access the CLI via WebSocket.
@@ -104,7 +104,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.442 and LTS 2.426.3
+  since: 2.426.3 / 2.442
   description: |
     Escape hatch for link:/security/advisory/2024-01-24/#SECURITY-3314[SECURITY-3314].
 
@@ -114,7 +114,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.44 / 2.32.2
+  since: 2.32.2 / 2.44
   description: |
     Whether to load unsigned console notes.
     See SECURITY-382 on link:/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-console-notes[Jenkins Security Advisory 2017-02-01].
@@ -214,7 +214,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.121.3 and 2.138
+  since: 2.121.3 / 2.138
   description: |
     Disable security hardening for LogRecorderManager Stapler access.
     Possibly unsafe, link:/security/advisory/2018-12-05/#SECURITY-595[see 2018-12-05 security advisory].
@@ -362,7 +362,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.315 and 2.303.2
+  since: 2.303.2 / 2.315
   description: |
     Deprecated: Escape hatch for link:/security/advisory/2021-10-06/#SECURITY-2481[SECURITY-2481].
     Has no effect since 2.463.
@@ -373,7 +373,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.154 and 2.138.4
+  since: 2.138.4 / 2.154
   description: |
     Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-904[SECURITY-904] and link:/security/advisory/2021-01-13/#SECURITY-1452[SECURITY-1452].
 
@@ -383,7 +383,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.394 and 2.375.4
+  since: 2.375.4 / 2.394
   description: |
     Escape hatch for link:/security/advisory/2023-03-08/#SECURITY-1807[SECURITY-1807].
 
@@ -393,7 +393,7 @@ properties:
   - escape hatch
   def: |
     `sandbox; default-src 'none'; image-src 'self'; style-src 'self';`
-  since: 1.625.3, 1.641
+  since: 1.625.3 / 1.641
   description: |
     Determines the Content Security Policy header sent for static files served by Jenkins.
     Only affects controllers that don't have a resource root URL set up.
@@ -404,7 +404,7 @@ properties:
   - tuning
   def: |
     `86400000` (1 day)
-  since: '1.500'
+  since: 1.500
   description: |
     Interval between periodic downloads of _Downloadables_, typically tool installer metadata.
 
@@ -523,7 +523,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.471 and 2.452.4
+  since: 2.452.4 / 2.471
   description: |
     Allow non-admin users to access (and potentially change) other users' "My Views".
     Escape hatch for link:/security/advisory/2024-08-07/#SECURITY-3349[SECURITY-3349].
@@ -692,7 +692,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.44 / 2.32.2
+  since: 2.32.2 / 2.44
   description: |
     Whether admins accessing `/user/example` creates a user record (see SECURITY-406 on https://wiki.jenkins.io/display/SECURITY/Jenkins+Security+Advisory+2017-02-01[Jenkins Security Advisory 2017-02-01])
 
@@ -840,7 +840,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.471 and 2.452.4
+  since: 2.452.4 / 2.471
   description: |
     Disable validation of URLs attempted to be read by agents.
     Escape hatch for link:/security/advisory/2024-08-07/#SECURITY-3430[SECURITY-3430].
@@ -851,7 +851,7 @@ properties:
   - scape hatch
   def: |
     `false`
-  since: 2.319 and 2.303.3
+  since: 2.303.3 / 2.319
   description: |
     Disable requirement for remoting callables to perform a role check.
     See link:/doc/upgrade-guide/2.303/#SECURITY-2458[the description in the upgrade guide].
@@ -861,7 +861,7 @@ properties:
   - security
   - scape hatch
   def: undefined
-  since: 2.319 and 2.303.3
+  since: 2.303.3 / 2.319
   description: |
     Comma-separated list of class names allowed to bypass role check requirement.
     See link:/doc/upgrade-guide/2.303/#SECURITY-2458[the description in the upgrade guide].
@@ -929,7 +929,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.46 / 2.32.3
+  since: 2.32.3 / 2.46
   description: |
     If set to true, restore pre-2.46 behavior of sending HTTP headers on "access denied" pages listing group memberships.
 
@@ -949,7 +949,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.228 and 2.204.6
+  since: 2.204.6 / 2.228
   description: |
     Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
 
@@ -959,7 +959,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.186 and 2.176.2
+  since: 2.176.2 / 2.186
   description: |
     Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-626[SECURITY-626].
 
@@ -999,7 +999,7 @@ properties:
   - escape hatch
   def: |
     `+[a-zA-Z0-9_-]++`
-  since: 2.121 and 2.107.3
+  since: 2.107.3 / 2.121
   description: |
     Regex for legal user names in Jenkins user database.
     See link:/security/advisory/2018-05-09/#SECURITY-786[SECURITY-786].
@@ -1026,7 +1026,7 @@ properties:
   - escape hatch
   def: |
     `1`
-  since: 2.300 and 2.289.2
+  since: 2.289.2 / 2.300
   description: |
     Escape hatch for link:/security/advisory/2021-06-30/#SECURITY-2371[SECURITY-2371].
     Set to `0` to disable the fix or to `2` to select an alternative implementation.
@@ -1037,7 +1037,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.160 and 2.150.2
+  since: 2.150.2 / 2.160
   description: |
     Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-868[SECURITY-868]
 
@@ -1354,7 +1354,7 @@ properties:
   - security
   def: |
     `1000`
-  since: 2.375.4, 2.394
+  since: 2.375.4 / 2.394
   description: |
     Limits the number of form fields that can be processed in one `multipart/form-data` request.
     Used to set `org.apache.commons.fileupload.servlet.ServletFileUpload#setFileCountMax(long)`.
@@ -1368,7 +1368,7 @@ properties:
   - security
   def: |
     `-1`
-  since: 2.375.4, 2.394
+  since: 2.375.4 / 2.394
   description: |
     Limits the size (in bytes) of individual fields that can be processed in one `multipart/form-data` request.
     Despite the name, this applies to all form fields, not just actual file attachments.
@@ -1381,7 +1381,7 @@ properties:
     - security
   def: |
     `-1`
-  since: 2.375.4, 2.394
+  since: 2.375.4 / 2.394
   description: |
     Limits the total request size (in bytes) that can be processed in one `multipart/form-data` request.
     Used to set `org.apache.commons.fileupload.servlet.ServletFileUpload#setSizeMax(long)`.
@@ -1515,7 +1515,7 @@ properties:
   - escape hatch
   def: |
     `5`
-  since: 2.334 and 2.319.3
+  since: 2.319.3 / 2.334
   description: |
     The maximum number of seconds that adding elements to collections may cumulatively take when loading an XML document using XStream, or `-1` to disable.
     See link:/security/advisory/2022-02-09/#SECURITY-2602[2022-02-09 security advisory] for context.
@@ -1568,7 +1568,7 @@ properties:
   - obsolete
   def: |
     `false`
-  since: 2.32 and 2.19.3
+  since: 2.19.3 / 2.32
   description: |
     `true` to disable Jenkins CLI via JNLP and HTTP (SSHD can still be enabled). This has no effect since 2.165.
 
@@ -1597,7 +1597,7 @@ properties:
   - security
   - packaging
   def: The default admin account will not have an API Token unless a value is provided for this system property
-  since: "2.260"
+  since: 2.260
   description: |
     This property determines the behavior during the SetupWizard install phase concerning the API Token creation for the initial admin account.
     The behavior depends on the provided value:
@@ -1737,7 +1737,7 @@ properties:
   - escape hatch
   def: |
     `true`
-  since: 2.315 and 2.303.2
+  since: 2.303.2 / 2.315
   description: |
     Set to `false` to allow names to end with a trailing `.` character, which can cause problems on Windows.
     Escape hatch for link:/security/advisory/2021-10-06/#SECURITY-2424[SECURITY-2424].
@@ -1765,7 +1765,7 @@ properties:
   - feature
   def: |
     `false`
-  since: 2.19.4 and 2.24
+  since: 2.19.4 / 2.24
   description: |
     If true, enforces the specified `jenkins.model.Jenkins.slaveAgentPort` on startup and will not allow changing it through the UI
 
@@ -1792,7 +1792,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 2.197 / LTS 2.176.4
+  since: 2.176.4 / 2.197
   description: |
     Disable URL validation intended to prevent an XSS vulnerability.
     See link:/security/advisory/2019-09-25/#SECURITY-1471[SECURITY-1471] for details.
@@ -1977,7 +1977,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: 1.587 and 1.580.1
+  since: 1.580.1 / 1.587
   description: |
     This flag can be set to `true` to disable the agent-to-controller security system entirely.
     Since Jenkins 2.326, this is the only way to do that, as the UI option has been removed.
@@ -1988,7 +1988,7 @@ properties:
   - obsolete
   def: |
     `true`
-  since: 2.319 and 2.303.3
+  since: 2.303.3 / 2.319
   description: |
     This flag can be set to `false` to explicitly reject `Callable` implementations that do not declare any required role.
     It is unclear whether this can safely be set to `false` in Jenkins before 2.335, or whether that would cause problems with some remoting built-in callables.
@@ -2000,7 +2000,7 @@ properties:
   - security
   def: |
     `false`
-  since: 1.587 and 1.580.1
+  since: 1.580.1 / 1.587
   description: |
     Allow all file paths on the Jenkins controller to be accessed from agents.
     This disables a big part of link:/security/advisory/2014-10-30/[SECURITY-144] protections.
@@ -2010,7 +2010,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.471 and 2.452.4
+  since: 2.452.4 / 2.471
   description: |
     Reject all attempts by agents to use `ClassLoaderProxy#fetchJar`.
     Drops backward compatibility with releases of remoting (`agent.jar`) before 2024-08.
@@ -2022,7 +2022,7 @@ properties:
   - security
   def: |
     `true`
-  since: 2.319 and 2.303.3
+  since: 2.303.3 / 2.319
   description: |
     Set to `false` to not reject attempts to access file paths in build directories of builds not currently being built on the accessing agent.
     Instead, only a warning is logged.
@@ -2035,7 +2035,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.319 and 2.303.3
+  since: 2.303.3 / 2.319
   description: |
     Set to `true` to disable the additional protection to not reject attempts to access file paths in build directories.
     This will restore access to any build directories both from agents and from other processes with a remoting channel, like Maven Integration Plugin.
@@ -2047,7 +2047,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.160 and 2.105.2
+  since: 2.105.2 / 2.160
   description: |
     Disables _user seed_.
     Escape hatch for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
@@ -2058,7 +2058,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.160 and 2.105.2
+  since: 2.105.2 / 2.160
   description: |
     Hide the UI for _user seed_ introduced for link:/security/advisory/2019-01-16/#SECURITY-901[SECURITY-901].
 
@@ -2068,7 +2068,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.186 and 2.176.2
+  since: 2.176.2 / 2.186
   description: |
     Escape hatch for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534].
 
@@ -2078,7 +2078,7 @@ properties:
   - security
   def: |
     `stapler-views-whitelist.txt` in `JENKINS_HOME`
-  since: 2.186 and 2.176.2
+  since: 2.176.2 / 2.186
   description: |
     Override the location of the user configurable whitelist for stapler view dispatches.
     This augments the built-in whitelist for link:/security/advisory/2019-07-17/#SECURITY-534[SECURITY-534] that allows dispatches to views that would otherwise be prohibited.
@@ -2089,7 +2089,7 @@ properties:
   - security
   def: |
     `stapler-whitelist.txt` in `JENKINS_HOME`
-  since: 2.154 and 2.138.4
+  since: 2.138.4 / 2.154
   description: |
     Override the location of the user configurable whitelist for stapler request routing.
     This augments the built-in whitelist for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595] that allows routing requests through methods that would otherwise be prohibited.
@@ -2100,7 +2100,7 @@ properties:
   - security
   def: |
     `true`
-  since: 2.154 and 2.138.4
+  since: 2.138.4 / 2.154
   description: |
     Prohibits access to `public static` fields when routing requests in Stapler.
     Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
@@ -2111,7 +2111,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.154 and 2.138.4
+  since: 2.138.4 / 2.154
   description: |
     Skip (return) type check when determining whether a method or field should be routable with Stapler (i.e. allow any return type).
     Escape hatch for link:/security/advisory/2018-12-05/#SECURITY-595[SECURITY-595].
@@ -2122,7 +2122,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.228 and 2.204.6
+  since: 2.204.6 / 2.228
   description: |
     Escape hatch for link:/security/advisory/2020-03-25/#SECURITY-1774[SECURITY-1774].
     Allows requests to URLs with semicolon characters (`;`) in the request path.
@@ -2198,7 +2198,7 @@ properties:
   - security
   def: |
     `true`
-  since: 2.319 and 2.303.3
+  since: 2.303.3 / 2.319
   description: |
     Set to `false` to not redact error messages when the agent-to-controller file path filters reject a file access.
     This can give attackers information about files and directories on the Jenkins controller file system.
@@ -2315,7 +2315,7 @@ properties:
   - security
   def: |
     `false`
-  since: 2.138.2, 2.146
+  since: 2.138.2 / 2.146
   description: |
     Allows specifying non-simple names for views, including ones resulting in path traversal.
     This is an escape hatch for the link:/security/advisory/2018-10-10/#SECURITY-867[SECURITY-867] fix.
@@ -2325,7 +2325,7 @@ properties:
   - escape hatch
   def: |
     `false`
-  since: '2.288'
+  since: 2.288
   description: |
     Do not log attempts to set the `class` property of `st:include` tags directly.
     No log messages should be emitted in regular use, but they can be disabled if they cause unnecessary noise in the system log.
@@ -2336,7 +2336,7 @@ properties:
   - security
   def: |
     `POST`
-  since: 2.277.2, 2.287
+  since: 2.277.2 / 2.287
   description: |
     HTTP verbs of requests that are allowed to provide `StaplerRequest#getSubmittedForm` or `@SubmittedForm`.
     Escape hatch for a security hardening, see link:/doc/upgrade-guide/2.277/#submittedform[2.277.2 upgrade guide].
@@ -2348,7 +2348,7 @@ properties:
   - security
   def: |
     `1000`
-  since: 2.375.4, 2.394
+  since: 2.375.4 / 2.394
   description: |
     Limits the number of form fields that can be processed in one `multipart/form-data` request.
     Used to set `org.apache.commons.fileupload.servlet.ServletFileUpload#setFileCountMax(long)`.
@@ -2362,7 +2362,7 @@ properties:
   - security
   def: |
     `-1`
-  since: 2.375.4, 2.394
+  since: 2.375.4 / 2.394
   description: |
     Limits the size (in bytes) of individual fields that can be processed in one `multipart/form-data` request.
     Despite the name, this applies to all form fields, not just actual file attachments.
@@ -2375,7 +2375,7 @@ properties:
   - security
   def: |
     `-1`
-  since: 2.375.4, 2.394
+  since: 2.375.4 / 2.394
   description: |
     Limits the total request size (in bytes) that can be processed in one `multipart/form-data` request.
     Used to set `org.apache.commons.fileupload.servlet.ServletFileUpload#setSizeMax(long)`.


### PR DESCRIPTION
Harmonize since syntax (LTS / weekly) because we used several formats in this document. I had the impression that LTS / weekly was the most used syntax, so I chose that. With that, it is also ordered.