### PR TITLE
Put Google Summer of Code at top of projects list

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -391,7 +391,7 @@ categories:
       - feature
     - name: Document Jenkins on Kubernetes
       description: Describe the concepts, techniques, and choices available for Jenkins on Kubernetes
-      status: near-term
+      status: released
       link: /sigs/docs/#jenkins-on-kubernetes
       labels:
       - outreach-program

--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -105,7 +105,7 @@ link:jenkins-operator[*Learn more*]
 
 ---
 
-== Jenkins on Kubernetes (done)
+== Kubernetes Documentation (done)
 
 image:/images/gsod/gsod.png["Google Season of Docs", role=left]
 

--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -105,6 +105,20 @@ link:jenkins-operator[*Learn more*]
 
 ---
 
+== Jenkins on Kubernetes (done)
+
+image:/images/gsod/gsod.png["Google Season of Docs", role=left]
+
+Kubernetes is a popular platform for Jenkins.
+The Jenkins project uses Kubernetes to provide agents for ci.jenkins.io.
+Many Jenkins users install their controllers on Kubernetes.
+
+The link:/doc/book/installing/kubernetes/[Kubernetes installation guide] provides detailed instructions for Jenkins on Kubernetes.
+A link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/[Google Season of Docs project] created the Kubernetes installation guide.
+Maintenance of the Kubernetes installation guide is now provided by the link:/sigs/docs/[documentation special interest group].
+
+---
+
 == Blue Ocean (archived)
 
 image:/images/sunnyblueocean.png["Blue Ocean", role=right]
@@ -117,19 +131,5 @@ staying true to the extensibility that Jenkins always has had as a core value.
 include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
 link:blueocean[*Learn more*]
-
----
-
-== Jenkins on Kubernetes (done)
-
-image:/images/gsod/gsod.png["Google Season of Docs", role=left]
-
-Kubernetes is a popular platform for Jenkins.
-The Jenkins project uses Kubernetes to provide agents for ci.jenkins.io.
-Many Jenkins users install their controllers on Kubernetes.
-
-The link:/doc/book/installing/kubernetes/[Kubernetes installation guide] provides detailed instructions for Jenkins on Kubernetes.
-A link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/[Google Season of Docs project] created the Kubernetes installation guide.
-Maintenance of the Kubernetes installation guide is now provided by the link:/sigs/docs/[documentation special interest group].
 
 ---

--- a/content/projects/index.adoc
+++ b/content/projects/index.adoc
@@ -5,59 +5,9 @@ section: projects
 noblogs: true
 ---
 
-At the heart of the Jenkins project exists the automation engine's
-link:https://github.com/jenkinsci/jenkins[core] and hundreds of
-link:https://plugins.jenkins.io[plugins]. There are
-however other collaborative initiatives going on under the umbrella of the
+The Jenkins project includes Jenkins link:https://github.com/jenkinsci/jenkins[core] and over two thousand link:https://plugins.jenkins.io[plugins].
+There are other collaborative initiatives going on under the umbrella of the
 Jenkins project which grow or expand the project in new ways.
-
-== Blue Ocean
-
-image:/images/sunnyblueocean.png["Blue Ocean", role=right]
-
-Blue Ocean is a project that rethinks the user experience of Jenkins, modelling
-and presenting the process of software delivery by surfacing information that's
-important to development teams with as few clicks as possible, while still
-staying true to the extensibility that Jenkins always has had as a core value.
-
-
-Blue Ocean also incorporates "The Jenkins Design Language (JDL)" which is a
-standardized set of components and a style guide that help developers create
-plugins which effortlessly retain the look and feel of the Blue Ocean user
-experience.
-
-
-include::doc/book/blueocean/_blue-ocean-status.adoc[]
-
-
-link:blueocean[*Learn more*]
-
----
-
-
-== Document Jenkins on Kubernetes
-
-image:/images/gsod/gsod.png["Google Season of Docs", role=left]
-
-Kubernetes is a platform-agnostic container orchestration tool created 
-by Google and heavily supported by the open-source community as a project 
-of the Cloud Native Computing Foundation. Kubernetes is compatible with the 
-majority of CI/CD tools which allow developers to run tests, deploy builds 
-in Kubernetes and update applications with no downtime.
-
-
-Jenkins on Kubernetes is a popular theme for Jenkins users. There are a lot 
-of presentations and articles about running Jenkins on Kubernetes, however, 
-there’s currently no central location for documentation describing Jenkins 
-on Kubernetes. This project would create a new Kubernetes Volume which would 
-describe the concepts, techniques, and choices for Kubernetes users running Jenkins.
-
-
-
-link:document-jenkins-on-kubernetes[*Learn more*]
-
----
-
 
 == Google Summer of Code
 
@@ -77,7 +27,6 @@ link:gsoc[*Learn more*]
 
 ---
 
-
 == Infrastructure
 
 image:/images/network-workgroup.png["Infrastructure', role=left]
@@ -94,7 +43,6 @@ link:https://github.com/jenkins-infra[Jenkins project's infrastructure].
 link:infrastructure[*Learn more*]
 
 ---
-
 
 == Jenkins Area Meetups
 
@@ -126,7 +74,6 @@ It is also used for the Remoting-based CLI and the plugin:maven-plugin[Maven Int
 
 The Remoting sub-project includes the Remoting library itself, package for agents, and a number of Remoting-specific plugins and core modules.
 
-
 link:remoting[*Learn more*]
 
 ---
@@ -155,5 +102,34 @@ This project enables community to run Jenkins in a cloud-native environments lik
 Also, supports most of the public cloud providers (AWS, Azure, GCP) in terms of additional capabilities like backups, observability and cloud security.
 
 link:jenkins-operator[*Learn more*]
+
+---
+
+== Blue Ocean (archived)
+
+image:/images/sunnyblueocean.png["Blue Ocean", role=right]
+
+Blue Ocean was a project to improve the user experience of Jenkins, modelling
+and presenting the process of software delivery by surfacing information that's
+important to development teams with as few clicks as possible, while still
+staying true to the extensibility that Jenkins always has had as a core value.
+
+include::doc/book/blueocean/_blue-ocean-status.adoc[]
+
+link:blueocean[*Learn more*]
+
+---
+
+== Jenkins on Kubernetes (done)
+
+image:/images/gsod/gsod.png["Google Season of Docs", role=left]
+
+Kubernetes is a popular platform for Jenkins.
+The Jenkins project uses Kubernetes to provide agents for ci.jenkins.io.
+Many Jenkins users install their controllers on Kubernetes.
+
+The link:/doc/book/installing/kubernetes/[Kubernetes installation guide] provides detailed instructions for Jenkins on Kubernetes.
+A link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes/[Google Season of Docs project] created the Kubernetes installation guide.
+Maintenance of the Kubernetes installation guide is now provided by the link:/sigs/docs/[documentation special interest group].
 
 ---

--- a/content/sigs/docs/gsod/ideas.adoc
+++ b/content/sigs/docs/gsod/ideas.adoc
@@ -22,14 +22,6 @@ We encourage proposals based on a technical writer's expertise and interests.
 |=========================================================
 |Project idea | Keywords | Description and links
 
-| Document Jenkins on Kubernetes
-| AsciiDoc, Guide, Compilation, Kubernetes
-| Jenkins on Kubernetes is a popular theme for Jenkins users.
-  There were a lot of presentations and articles about running Jenkins on Kubernetes, but we need to expand the documentation describing Jenkins on Kubernetes.
-  We would like to create documentation that describes the concepts, techniques, and choices for Kubernetes users running Jenkins.
-  See the 2020 project link:/sigs/docs/gsod/2020/projects/document-jenkins-on-kubernetes[Document Jenkins on Kubernetes] for work areas and topics.
-  link:/sigs/docs/#jenkins-on-kubernetes[More Info]
-
 | Create new solution pages for Jenkins use-cases
 | AsciiDoc, Guide
 | Jenkins project has several link:/solutions/[solution pages] for various use-cases.

--- a/content/sigs/docs/gsod/index.adoc
+++ b/content/sigs/docs/gsod/index.adoc
@@ -88,13 +88,6 @@ Once the projects are announced, other project-specific channels may be created 
 * link:https://developers.google.com/season-of-docs/docs/project-selection[Selecting projects]
 * link:https://developers.google.com/season-of-docs/docs/tech-writer-collaboration[Working with a technical writer]
 
-=== Office Hours
-
-Documentation office hours are held each Tuesday at *01:30 UTC* (Asia and US West) and each Thursday at *15:00 UTC* (Europe and US East).
-Meetings are conducted and recorded using Zoom and archived to the link:https://www.youtube.com/user/jenkinsci[Jenkins YouTube channel] in the link:https://www.youtube.com/playlist?list=PLN7ajX_VdyaNp0lk5BmyAgqPS52u_4tC8[Jenkins Docs SIG YouTube playlist].
-Participant links are posted in the link:https://app.gitter.im/#/room/#jenkins/docs:matrix.org[SIG Gitter Chat] 10 minutes before the meeting starts.
-Participant links are also available in the link:/events[Jenkins event calendar].
-
 [#archive]
 == Previous years
 


### PR DESCRIPTION
## Put Google Summer of Code at top of projects page

While preparing to create a prototype of the [plugin maintainers project](https://docs.google.com/document/d/1GEI7tQp3UxGCbQQyF1JdujgwkoWcMluvUMFanV2nDGo/edit?usp=sharing) page, I saw that Blue Ocean and Kubernetes documentation were both above Google Summer of Code on the [Jenkins Subprojects overview](https://www.jenkins.io/projects/).  That will mislead readers, since those two projects are no longer active and Google Summer of Code is very active.  Let's highlight the most active projects at the top of the page.

While exploring, I found related areas for minor improvements, including:

- Remove Kubernetes docs from Season of Docs ideas
- Note in roadmap that Kubernetes docs Season of Docs project is complete
- Remove Google Season of Docs office hours, they no longer exist

If this is too much change in a single pull request, I am happy to split it into multiple pull requests.

I'd appreciate an optional review from @krisstern, @gounthar, or @alyssat if they are available.

