### PR TITLE
Add Ubuntu 24.04 install video to Debian/Ubuntu instructions

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -25,6 +25,16 @@ include::doc/book/installing/_installation_requirements.adoc[]
 
 On Debian and Debian-based distributions like Ubuntu you can install Jenkins through `apt`.
 
+// Using Ubuntu 24.04 because the Jenkins project infrastructure uses Ubuntu
+.How To Install Jenkins on Ubuntu 24.04
+video::8fVOdFdzlKc[youtube, width=640, height=360]
+
+// Debian 12 and Ubuntu 24.04 installation processes are similar
+// .How To Install Jenkins on Debian 12
+// video::0EevQXwBV2A[youtube, width=640, height=360]
+
+You need to choose either the Jenkins Long Term Support release or the Jenkins weekly release.
+
 [#debian-stable]
 === Long Term Support release
 


### PR DESCRIPTION
## Add Ubuntu 24.04 install video to Debian/Ubuntu instructions

The Red Hat instructions include a similar video.  That video has over 18000 views.

Intentionally uses Ubuntu 24.04 instead of Debian 12 because the Jenkins infrastructure uses Ubuntu.

The video includes installation instructions for Eclipse Temurin Java 21.  Eclipse Temurin Java is the distribution included in the Jenkins container images for the controller and for the agents.

See the [preview site](https://deploy-preview-7912--jenkins-io-site-pr.netlify.app/doc/book/installing/linux/#debianubuntu) to review it.