### PR TITLE
feat(gsoc): update jenkins status post gsoc 2025 mentoring orgs selection

### DIFF
--- a/content/projects/gsoc/2025/project-ideas/backend-code-refactoring-for-infra-stats.adoc
+++ b/content/projects/gsoc/2025/project-ideas/backend-code-refactoring-for-infra-stats.adoc
@@ -14,6 +14,7 @@ skills:
 mentors:
 - "krisstern"
 - "berviantoleo"
+- "TheMeinerLP"
 links:
   meetings: /projects/gsoc/#office-hours
 ---

--- a/content/projects/gsoc/2025/project-ideas/plugin-modernizer-improvements.adoc
+++ b/content/projects/gsoc/2025/project-ideas/plugin-modernizer-improvements.adoc
@@ -15,6 +15,7 @@ mentors:
 - "gounthar"
 - "jonesbusy"
 - "sridamul"
+- "TheMeinerLP"
 links:
   meetings: /projects/gsoc/#office-hours
 ---

--- a/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
+++ b/content/projects/gsoc/2025/project-ideas/swagger-openapi-for-jenkins-rest-api.adoc
@@ -17,6 +17,7 @@ mentors:
 - "gounthar"
 - "iamrajiv"
 - "berviantoleo"
+- "TheMeinerLP"
 links:
   draft: /projects/gsoc/2019/project-ideas/automatic-spec-generator-for-jenkins-rest-api-draft.pdf
   meetings: /projects/gsoc/#office-hours

--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -24,11 +24,12 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 
 == GSoC 2025
 
-We are planning to participate in Google Summer of Code in 2025. +
+// We are planning to participate in Google Summer of Code in 2025. +
 
-// We are participating in Google Summer of Code in 2025. +
+We are participating in Google Summer of Code in 2025. +
 // See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
-// Google has accepted us as a mentoring organization in Google Summer of Code 2025.
+Google has accepted us as a mentoring organization in Google Summer of Code 2025.
+See our link:https://summerofcode.withgoogle.com/programs/2025-ao/organizations/jenkins-wp[Jenkins organization page on the GSoC website].
 
 // Uncomment when application is worked on and submitted (Feb 2025)
 //(link:./2025/application[Jenkins GSoC Organisation Application Form])
@@ -45,12 +46,12 @@ We are planning to participate in Google Summer of Code in 2025. +
 //
 // * link:/projects/gsoc/2025/projects/improving-maintainability-of-rpu[Improve Maintainability for the Repository Permission Updater] with link:https://github.com/TheMeinerLP[Phillipp Glanz] as the GSoC contributor.
 
-They were proposed and selected from these link:./2025/project-ideas[project ideas].
+// They were proposed and selected from these link:./2025/project-ideas[project ideas].
 
-// We have finalised a list of 9 project ideas.
+We have finalised a list of 11 project ideas, 8 of which are accepted ones.
 // Add your ideas by submitting an ad-hoc pull request as explained in our previous link:/blog/2022/11/16/gsoc-2023/[GSoC blog post].
 
-// The 2025 GSoC project ideas link:./2025/project-ideas[can be found here].
+The 2025 GSoC project ideas link:./2025/project-ideas[can be found here].
 
 NOTE: Every year, there are changes in how GSoC is organized.
 Jenkins GSoC documentation may be outdated in some places, please refer to the https://summerofcode.withgoogle.com/[official GSoC website] as a source of truth.


### PR DESCRIPTION
* Added Phillipp Glanz as potential gsoc 2025 project mentor.
* Updated gsoc landing page after Jenkins has been confirmed to be a gsoc 2025 mentoring org. 