### PR TITLE
Make non issue for googlegroups configuration more generic

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -91,7 +91,7 @@ The following behaviors/issues are not vulnerabilities in Jenkins project infras
 * Public repositories in the https://github.com/jenkins-infra/[`jenkins-infra` GitHub organization] expose how many of our services are configured.
   This is intentional.
   Please only report leaked secrets, or similar information disclosure, that results in a direct, immediate risk.
-* DMARC/DKIM/SPF configuration of googlegroups.com, which we use for our link:/mailing-lists/[mailing lists].
+* Configuration of googlegroups.com, which we use for our link:/mailing-lists/[mailing lists] (e.g, DMARC/DKIM/SPF/TLS).
   We trust Google to choose the correct tradeoffs for their Google Groups service, and have no power to change anything anyway.
 * The public availability of the Algolia API key. It needs to be public.
 // TODO Possibly other keys as well?

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -91,7 +91,7 @@ The following behaviors/issues are not vulnerabilities in Jenkins project infras
 * Public repositories in the https://github.com/jenkins-infra/[`jenkins-infra` GitHub organization] expose how many of our services are configured.
   This is intentional.
   Please only report leaked secrets, or similar information disclosure, that results in a direct, immediate risk.
-* Configuration of googlegroups.com, which we use for our link:/mailing-lists/[mailing lists] (e.g, DMARC/DKIM/SPF/TLS).
+* Configuration of googlegroups.com, which we use for our link:/mailing-lists/[mailing lists] (e.g., DMARC/DKIM/SPF/TLS).
   We trust Google to choose the correct tradeoffs for their Google Groups service, and have no power to change anything anyway.
 * The public availability of the Algolia API key. It needs to be public.
 // TODO Possibly other keys as well?


### PR DESCRIPTION
We're receiving reports for googlegroups.com configuration that are not listed in our documentation.

Let's make this non issue more generic to cover them.