### PR TITLE
fix(gsoc): change Jenkins GSoC 2025 mentoring org URL on GSoC project page

### DIFF
--- a/content/projects/gsoc/index.adoc
+++ b/content/projects/gsoc/index.adoc
@@ -29,7 +29,7 @@ image:/images/gsoc/opengraph.png[Jenkins GSoC, role=center, float=center]
 We are participating in Google Summer of Code in 2025. +
 // See our link:https://docs.google.com/document/d/1FYOBo12qz24Vxq0TxWuv9ElHH_rHP51ouMsPms4tTmw/edit?usp=sharing[Jenkins GSoC Mentoring Org Application Form].
 Google has accepted us as a mentoring organization in Google Summer of Code 2025.
-See our link:https://summerofcode.withgoogle.com/programs/2025-ao/organizations/jenkins-wp[Jenkins organization page on the GSoC website].
+See our link:https://summerofcode.withgoogle.com/programs/2025/organizations/jenkins-wp[Jenkins organization page on the GSoC website].
 
 // Uncomment when application is worked on and submitted (Feb 2025)
 //(link:./2025/application[Jenkins GSoC Organisation Application Form])


### PR DESCRIPTION
Google has changed our URL on their Google Summer of Code site, so am updating our URL on our GSoC project homepage to reflect this change. 