### PR TITLE
feat(gsoc): update 2024 mentions to 2025

### DIFF
--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -33,7 +33,7 @@ We cannot make any exception. Please:
 
 === Application steps
 
-. Check out the link:/projects/gsoc/2024/project-ideas[GSoC 2024 Project ideas]
+. Check out the link:/projects/gsoc/2025/project-ideas[GSoC 2025 Project ideas]
 . Select an interesting project idea or draft your own proposal.
 . Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
@@ -155,7 +155,7 @@ It is required to use this channel for the initial review and feedback collectio
 
 === First begin a communication in link:https://community.jenkins.io/c/contributing/gsoc/[Discourse]
 
-* Please use the _[GSOC 2024 PROPOSAL] Your Name and Project Title_ subject in discussion.
+* Please use the _[GSOC 2025 PROPOSAL] Your Name and Project Title_ subject in discussion.
 ** If another contributor is interested in the same project idea, you can contribute to their thread, or start your own thread.
 * Contents. In the first communication we would be interested to see the following information:
 ** A short self-introduction: your area of study, interests, background


### PR DESCRIPTION
### Description : 

- Updated the mention of GSOC 2024 to GSOC 2025 in the contributor page to get align with the doc present in that page.
- Updated the link to GSOC 2025 Project ideas.