### PR TITLE
feat(gsoc): update rest of gsoc pages in preparation of gsoc 2025

### DIFF
--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -23,6 +23,7 @@ Print it and hang it where you can see it every day!
 
 The aforementioned documents are the reference and the inspiration for this document.
 
+[#eligibility-steps]
 === Eligibility steps
 
 You must verify that you are eligible to participate in the program.
@@ -33,7 +34,7 @@ We cannot make any exception. Please:
 
 === Application steps
 
-. Check out the link:/projects/gsoc/2024/project-ideas[GSoC 2024 Project ideas]
+. Check out the link:/projects/gsoc/2025/project-ideas[GSoC 2025 Project ideas]
 . Select an interesting project idea or draft your own proposal.
 . Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
@@ -52,7 +53,7 @@ You can find more details about application steps below.
 [#expectations]
 === Expectations
 
-When you apply to the GSoC program, you are committing to 30..40 hours of coding per week for the duration of the program.
+When you apply to the GSoC program, you are committing to between 15 and 40 hours (depending on the size and duration of the project) of coding per week for the duration of the program.
 
 . We expect contributors to get involved into project discussions at the beginning of the GSoC contributor application period in order to have the opportunity to discuss the project with potential mentors and to jointly review the proposal drafts.
 . We expect contributors to attend at least one office hours during the application period.
@@ -67,7 +68,7 @@ good communications. This is a challenge for mentors and contributors alike.
 
 We encourage all contributors to spend some time improving their knowledge of
 the English language to increase their chances of success in open source.
-There are many good videos on youtube that can help you improve written and spoken
+There are many good videos on YouTube that can help you improve written and spoken
 English.
 
 Remember that the goal when communicating is to be understood.
@@ -116,7 +117,7 @@ development organization, where all proposals and ideas are debated
 in public and are visible to the entire community. There is always a
 public debate on ideas and proposals.
 
-[#student-proposals]
+[#contributor-proposals]
 === GSoC Contributor Proposals
 
 We expect proposals from contributors to contain all the sections discussed in the
@@ -155,7 +156,7 @@ It is required to use this channel for the initial review and feedback collectio
 
 === First begin a communication in link:https://community.jenkins.io/c/contributing/gsoc/[Discourse]
 
-* Please use the _[GSOC 2024 PROPOSAL] Your Name and Project Title_ subject in discussion.
+* Please use the _[GSoC 2025 PROPOSAL] Your Name and Project Title_ subject in discussion.
 ** If another contributor is interested in the same project idea, you can contribute to their thread, or start your own thread.
 * Contents. In the first communication we would be interested to see the following information:
 ** A short self-introduction: your area of study, interests, background
@@ -240,15 +241,16 @@ Use the community bonding to:
   *** Some people find it useful to write a mini user guide or how-to guide, as if the project was already done. This usually helps define the project.,
   * Create an implementation plan with milestones per coding period.
   * At this point it may be appropriate to discuss the project on the _jenkinsci-dev@googlegroups.com_ mailing list or on the relevant SIG mailing list. Talk to the mentor about it.
-. Setup your computer and your development environment to work on the project (see <<UsefulLinks>>).
+. Set up your computer and your development environment to work on the project (see <<UsefulLinks>>).
 . Learn and discuss the process with the mentors:
-  * Setup the github project,
-  * Pull-requests,
-  * Code reviews.
-. We use link:https://issues.jenkins.io/secure/Dashboard.jspa[Jira] to track GSoC tasks:
+  * Set up the GitHub project
+  * Pull-requests
+  * Code reviews
+. We may use link:https://issues.jenkins.io/secure/Dashboard.jspa[Jira] to track GSoC tasks:
   * Create an account using link:https://accounts.jenkins.io/login[this link].
   * Become familiar with navigating Jira.
 
+[#coding-periods]
 == Coding periods
 
 GSoC contributors are expected to...
@@ -271,7 +273,7 @@ GSoC contributors are expected to...
  * Have a finalized deliverable at the end of the project.
  ** For plugin development projects, this means releasing a plugin to the alpha or to the official update center.
  ** Have documentation on how to use the plugin of the features developed during the project.
- *** Documentation usually starts at the README file of the github repository
+ *** Documentation usually starts at the README file of the GitHub repository
  *** The format is either link:https://guides.github.com/features/mastering-markdown/[Github Markdown] or link:https://asciidoctor.org/docs/[Asciidoctor].
 . Take Time off
  * You have approximately 5 "vacation days" during the project, do not hesitate to use them if required.
@@ -293,6 +295,7 @@ GSoC contributors are **not** expected to...
 . Investigate and solve *every* issue on your own
  * We have mentors and experts, who can help you by answering questions and doing joint investigation if required
 
+[[evaluations]]
 === Evaluations
 
 At the end of each coding period, GSoC contributors are expected to:
@@ -316,11 +319,20 @@ Repeating a presentation numerous times will help you breeze through it with flu
 
 Past years presentations and blog posts may inspire you. Here are some links:
 
-* GSoC 2018 blog posts:
-** link:/blog/2018/07/23/remoting-kafka-plugin-1/[Remoting over Kafka]
-** link:/blog/2018/08/17/code-coverage-api-plugin-1/[Code Coverage API]
-* GSoC 2016 blog post:
-** link:/blog/tags/external-workspace-manager/[External Workspace Manager]
+* GSoC 2024 blog posts:
+** link:/blog/2024/06/04/jenkins-in-google-summer-of-code-community-bonding-contributors-takeaways/[Jenkins in Google Summer of Code Community Bonding, Contributors' Takeaways]
+** link:/blog/2024/08/26/gsoc-using-openrewrite-for-plugin-modernization/[Using OpenRewrite Recipes for Plugin Modernization]
+** link:/blog/2024/08/26/gsoc-manage-github-permissions/[GSoC Manage jenkinsci GitHub permissions as code]
+** link:/blog/2024/08/25/gsoc-enhancing-llm/[Enhancing an Existing LLM Model with Domain-specific Jenkins Knowledge]
+* GSoC 2023 blog posts:
+** link:/blog/2023/09/24/building-jenkinsio-with-alternative-tools/[GSoC Building Jenkins.io with alternative tools]
+** link:/blog/2023/09/22/incremental-build-detection-probe/[Incremental Build Detection Probe]
+** link:/blog/2023/08/24/gsoc-docker-based-quickstart/[Docker-based Jenkins quick start examples]
+** link:/blog/2023/08/24/gitlab-plugin-modernization-report/[GSoC GitLab Plugin Modernization Project]
+* GSoC 2022 blog posts:
+** link:/blog/2022/10/10/plugin-health-scoring-system-report/[Plugin Health Scoring System]
+** link:/blog/2022/10/10/pipeline-steps-improvement-gsoc-report/[Pipeline Steps Documentation Generator Improvements]
+** link:/blog/2022/09/07/jenkinsfile-runner-as-github-actions/[A near Feature-complete version of Jenkinsfile Runner Actions as GitHub Actions]
 
 [[codestyle]]
 == Code Style Best Practices
@@ -350,7 +362,7 @@ When it comes to testing, Jenkins projects must come with:
 * link:https://wiki.jenkins.io/display/JENKINS/Unit+Test[Unit] tests,
 * and for plugins, link:https://github.com/jenkinsci/acceptance-test-harness[Acceptance Test Harness] tests.
 
-If your project is a plugin and you are ready to release it,
+If your project is a plugin, and you are ready to release it,
 you also need to learn the link:https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins[plugin release process].
 
 == Getting in touch
@@ -369,7 +381,7 @@ Contributors should join the following Jenkins mailing lists:
 
 Other mailing lists:
 
-* link:/projects/gsoc/#orgadmin[Org admins mailing list]- for **private** communications with org admins (escalations, issues with mentors)
+* link:/projects/gsoc/#orgadmin[Org admins mailing list] - for **private** communications with org admins (escalations, issues with mentors)
 ** Please *DO NOT* use this mailing list for applications and intro emails
 
 === Chat
@@ -399,15 +411,15 @@ You can:
 . Continue to develop your project within the Jenkins community
 . Present your work at a local link:/projects/jam[Jenkins Area Meetup]
 . Participate in other Jenkins projects
-. Participate again next year
+. Participate again next year (as every contributor is welcome to participate in GSoC for up to 2 years)
 . Become a mentor in link:https://summerofcode.withgoogle.com[Google Summer of Code] for next year
 . Become a mentor in link:https://codein.withgoogle.com/[Google Code In]
 
-Depending on the project results, and available budget, we may offer a sponsored trip
-to link:https://www.cloudbees.com/devops-world/[DevOps World] or another Jenkins-related event to contributors
-who successfully finish their projects.
-This sponsorship is not guaranteed though.
+// Depending on the project results, and available budget, we may offer a sponsored trip
+// to link:https://www.cloudbees.com/devops-world/[DevOps World] or another Jenkins-related event to contributors
+// who successfully finish their projects.
+// This sponsorship is not guaranteed though.
 
-If contributors agree to go to such event, we expect contributors to present their project and to write a blog-post about the trip.
-In 2018, one of our students, Pham Vu Tuan, attended DevOps World - Jenkins World,
-and wrote link:https://pvtuan10.github.io/essays/20181019-DWJW18.html[this blog post] about it.
+// If contributors agree to go to such event, we expect contributors to present their project and to write a blog-post about the trip.
+// In 2018, one of our students, Pham Vu Tuan, attended DevOps World - Jenkins World,
+// and wrote link:https://pvtuan10.github.io/essays/20181019-DWJW18.html[this blog post] about it.

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -43,8 +43,8 @@ Additional links:
 
 == How to become a mentor?
 
-During GSoC you can join an existing project at any time, including community bonding and coding periods.
-Just send an email to our GSoC mailing list.
+Prior to the start of GSoC you can join a project at any time.
+If you are interested, feel free to email us via our GSoC mailing list.
 You can also link:/projects/gsoc/proposing-project-ideas[propose your own project] for GSoC, see below.
 
 == Expectations from mentors
@@ -175,7 +175,7 @@ This means that you need to:
 ** of course we appreciate if you help us find more mentors if you can
 * participate in the weekly public meeting
 * make sure the GSoC Contributors follow the process and that their application meets the requirements in the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/edit[template]
-** make sure the GSoC Contributors determine whether they are link:../students/#eligibility-steps[eligible]
+** make sure the GSoC Contributors determine whether they are link:../contributors/#eligibility-steps[eligible]
 * if the GSoC Contributor proposes a genuine project idea in your area of interest or expertise, make sure it is presented and discussed in the community
 
 You can still submit new project ideas during this phase.
@@ -250,7 +250,7 @@ Then we send our slot request min and max numbers to Google.
 This phase is very short and starts immediately when Google sends us our final number of slots.
 
 We may get only the minimum of slots.
-Sometimes heart wrenching decisions need to be made.
+Sometimes heart-wrenching decisions need to be made.
 
 Org Admins and Mentors need to make an extra effort to devote time to this phase because it is very short and this does not leave us much time to make critical decisions, and it just as important as the other phases.
 
@@ -285,7 +285,7 @@ Mentors are expected to:
 * Make sure the GSoC Contributor has a detailed plan and a design document for the first coding phase before it starts
 * Get the GSoC Contributor to create issues in Jira for the work items of the coming coding phase
 
-We have written a guide for this phase, link:../students/#community-bonding[read it] and follow it.
+We have written a guide for this phase, link:../contributors/#community-bonding[read it] and follow it.
 
 In rare cases, it is acceptable to re-work the project idea, even change it completely, as long as the GSoC Contributor and the mentors all agree.
 Written documentation about this is essential, if it happens, let the Org Admins know.
@@ -299,7 +299,7 @@ GSoC Contributors and mentors alike benefit from attending.
 
 *Expectation:* about 5 to 8 hours per week until the end of the program.
 
-See also: link:../students/#coding-periods[student coding periods].
+See also: link:../contributors/#coding-periods[contributor coding periods].
 
 You are mentoring now. Guide, coach, review pull-requests, unblock the GSoC Contributor,
 ensure GSoC Contributors use Jira for task, bug and feature tracking,
@@ -313,7 +313,7 @@ What if the GSoC Contributor is done early? GSoC Contributor and mentor must det
 
 *Expectation:* same as during the coding periods.
 
-See also: link:../students/#evaluations[student evaluations].
+See also: link:../contributors/#evaluations[contributor evaluations].
 
 Mentors are expected to evaluate their GSoC Contributor, while they continue to mentor them.
 Coding seldom completely stops during this period.
@@ -332,7 +332,7 @@ This period is a good time to review the Jira tickets and prepare the tickets fo
 If too little code is produced for reasons that cannot be understood,
 inform your GSoC Contributor of your concerns, and ask the GSoC Contributor why this is happening.
 Often GSoC Contributors are blocked on a technical problem and do not communicate with their mentors.
-As a rule of thumb, there should be code pushed to Github almost every day.
+As a rule of thumb, there should be code pushed to GitHub almost every day.
 If not, let the Org Admins know as soon as possible.
 
 [[after_the_program]]
@@ -340,7 +340,7 @@ If not, let the Org Admins know as soon as possible.
 
 Many GSoC Contributors ask their mentors how they can continue to contribute after the program.
 
-You could setup one-on-one on-line meeting with the GSoC Contributor on a monthly basis.
+You could set up one-on-one on-line meeting with the GSoC Contributor on a monthly basis.
 You can invite the GSoC Contributor to SIG or other community meetings.
 Jenkins also has on-line meetups with various people presenting that the GSoC Contributor might be interested in joining.
 

--- a/content/projects/gsoc/proposing-project-ideas.adoc
+++ b/content/projects/gsoc/proposing-project-ideas.adoc
@@ -12,7 +12,7 @@ opengraph:
 New project ideas for GSoC can be proposed by mentors, GSoC applicants, or anyone in the Jenkins
 community with an idea they'd like to see implemented.
 
-Note: Project ideas should not be confused with link:../students#student-proposals[GSoC applicant proposals].
+Note: Project ideas should not be confused with link:../contributors#contributor-proposals[GSoC applicant proposals].
 
 GSoC applicants: to browse the existing project ideas offered by the Jenkins Organisation,
 please read the instructions on the link:../students/[GSoC contributor page].
@@ -24,7 +24,7 @@ then you are a Jenkins GSoC Idea champion. You should follow the following steps
 
 . Share your idea on the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC gitter channel] or on the
 link:https://community.jenkins.io/c/contributing/gsoc/6[GSoC Discourse channel]
-. On Discourse, use `[GSOC 2023 PROJECT IDEA] Title of idea` as the subject
+. On Discourse, use `[GSoC 2025 PROJECT IDEA] Title of idea` as the subject
 . The GSoC idea must:
 .. be about coding
 .. be about Jenkins
@@ -48,13 +48,14 @@ For more on the `adoc` format see link:https://asciidoctor.org/[asciidoctor.org]
 
 The format for the `.adoc` file is as follows:
 
-```
+[source]
+----
 ---
 layout: gsocprojectidea
 title: "Specify the project idea title"
 goal: "One sentence summarizing the goal of your idea"
 category: Plugins
-year: 2023
+year: 2025
 status: discussion
 mentors:
 - "userid1"   # This userid must exist under /content/_data/authors/userid.adoc on jenkins.io
@@ -67,7 +68,7 @@ links:
 ---
 
 TODO: DRAFT (this is a placeholder, it will not be shown)
-```
+----
 
 The last step is to submit this new file as a pull-request.
 
@@ -95,14 +96,14 @@ or in a chat room or Discourse. Both are offered and simultaneously possible, us
 
 To use the `.adoc` file for the details, please modify your `.adoc` file according to this template:
 
-
-```
+[source]
+----
 ---
 layout: gsocprojectidea
 title: "Specify the project idea title"
 goal: "One sentence summarizing the goal of your idea"
 category: Plugins
-year: 2023
+year: 2025
 status: draft
 mentors:
 - "userid1"   # This userid must exist under /content/_data/authors/userid.adoc on jenkins.io
@@ -147,19 +148,20 @@ If you are a potential mentor, propose examples of tickets the applicants could
 study while preparing their project proposals.
 We do NOT require GSoC contributors to make contributions before applying,
 but such tasks may help to select GSoC contributors who are interested to work on the project.
-```
+----
 
 === Using a Google Doc for capturing the details of the idea
 
 To use a Google Doc for the details, please modify your `.adoc` file according to this template:
 
-```
+[source]
+----
 ---
 layout: gsocprojectidea
 title: "Specify the project idea title"
 goal: "One sentence summarizing the goal of your idea"
 category: Plugins
-year: 2023
+year: 2025
 status: draft
 showGoogleDoc: true  # This line causes the google doc to be embedded on jenkins.io
 mentors:
@@ -172,16 +174,18 @@ links:
   draft: <link to Google Doc>
 ---
 See Google doc.
-```
+----
 
 === Using both the `.adoc` and the Google Doc
 
 To use both, add a `draft` entry to the `links` like this:
-```
+
+[source]
+----
 links:
     draft: <link to google doc>
     ...
-```
+----
 
 And remove the line that says `showGoogleDoc: true`.
 
@@ -192,11 +196,12 @@ The `.adoc` will be displayed, and the Google Doc will be linked at the bottom.
 The `.adoc` can have links to chat rooms, Discourse channel, mailing lists etc. Simply name the links
 and they will be displayed:
 
-```
+[source]
+----
 links:
     mailing list: https://somelink to the mailing list
     chat: https://some link to a chat room on gitter or slask or other
-```
+----
 
 == Submitting the project details
 

--- a/content/projects/gsoc/roles-and-responsibilities.adoc
+++ b/content/projects/gsoc/roles-and-responsibilities.adoc
@@ -12,7 +12,7 @@ opengraph:
 We define several roles and responsibilities. They are not mutually exclusive.
 
 [[champion]]
-## Champion
+== Champion
 
 The champion is the person proposing and driving a project idea
 
@@ -21,9 +21,9 @@ The champion may not have all the Jenkins code expertise needed, but by working 
 the knowledge gap can be bridged.
 
 The champion works with the GSoC contributor to define the project and acts mostly as a "customer" of the project.
-The champion usually knows enough about coding to comment on pull-requests with regards to the overall quality, style and features of the code.
+The champion usually knows enough about coding to comment on pull-requests in regard to the overall quality, style and features of the code.
 
-## Mentor team
+== Mentor team
 
 A mentor team consists of mentors working together on the same with the same GSoC contributor on the contributor's GSoC project.
 A mentor team has a <<lead_mentor>> and one or more <<mentors>>. The <<champion>> should be one of the mentors.
@@ -34,14 +34,14 @@ The GSoC contributors would be quite confused otherwise.
 
 A mentor team needs:
 
-* enough Jenkins community knowledge to find subject matter experts and other resources when needed by the GSoC contributor
+* enough Jenkins community knowledge to find subject-matter experts and other resources when needed by the GSoC contributor
 * enough Jenkins development process knowledge to make the GSoC contributor work effectively
 * enough domain specific expertise in the project to guide the implementation performed by the GSoC contributor
 
 The mentor team can acquire some of that expertise from a <<subject_matter_expert>>.
 
 [[lead_mentor]]
-## Lead mentor
+== Lead mentor
 
 The lead mentor, on top of being a <<mentors>>, has administrative responsibilities commonly found in GSoC:
 
@@ -51,33 +51,32 @@ The lead mentor, on top of being a <<mentors>>, has administrative responsibilit
 * report issues to the Org Admin team.
 
 [[mentors]]
-## Mentor / co-mentor
+== Mentor / co-mentor
 
 This is the mentor who knows enough about the Jenkins code to guide the GSoC contributor on coding,
 and to provide Jenkins specific code reviews on pull-requests,
 but has limited involvement outside the coding activity of the GSoC contributor.
 
 [[subject_matter_expert]]
-## Subject Matter Expert
+== Subject-Matter Expert
 
-Subject matter experts, or SMEs, are individuals that mentors
+Subject-matter experts, or SMEs, are individuals that mentors
 reach out to 3-4 times during the project for advice and guidance,
 and sometimes complicated programming challenges.
 
-Subject matter experts may be technical or non-technical, depending on context.
+Subject-matter experts may be technical or non-technical, depending on context.
 
-A technical advisor is one type of subject matter expert.
+A technical advisor is one type of subject-matter expert.
 
-## GSoC contributor
+== GSoC contributor
 
 GSoC contributors are the active learners and coders.
 
 To learn more about their role, please see link:/projects/gsoc/contributors/[information for GSoC contributors]
 
-## Org Admin
+== Org Admin
 
 To learn more, please see link:https://developers.google.com/open-source/gsoc/help/responsibilities[Roles and Responsibilities].
 
 Responsible for providing initial feedback (structure, compliance with application rules, GSoC rules compliance),
 advising on how to reach out to the community, and final publishing once there is enough feedback.
-


### PR DESCRIPTION
Updated the rest of the GSoC pages in preparation of GSoC 2025, in advance of the official contributor application period taking place from late March to early April, 2025. 