### PR TITLE
Update gsoc contributor docs

### DIFF
--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -99,9 +99,7 @@ respond to such contributors inquiries when made in private. Contributors will
 get much better answers when they ask in public rather than in private,
 as mentors will collectively complement each other.
 
-Contributors, please note that mentors do not have "special information",
-or "privileged information" that they would reveal only to you
-privately. Contributors should not ask mentors to hide information from
+Contributors, please note that mentors do not have "special information" or "privileged information" that they would reveal only to you privately. Contributors should not ask mentors to hide information from
 other contributors, this is simply not how open-source development works. In
 open-source development, all ideas are presented and debated publicly.
 All the information we have is in the project ideas, or is shared on

--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -12,7 +12,7 @@ opengraph:
 image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=right]
 
 This page provides information for contributors about participating in Jenkins GSoC program.
-See link:/projects/gsoc[the main GSoC project] page for other information and links.
+Refer to link:/projects/gsoc[the main GSoC project] page for other information and links.
 
 == GSoC Contributor Application Process
 
@@ -21,7 +21,7 @@ First of all, take the time to read the link:https://google.github.io/gsocguides
 Also bookmark the link:https://developers.google.com/open-source/gsoc/timeline[timeline].
 Print it and hang it where you can see it every day!
 
-The aforementioned documents are the reference and the inspiration for this document.
+The aforementioned documents are the reference and inspiration for this document.
 
 [#eligibility-steps]
 === Eligibility steps
@@ -38,15 +38,15 @@ We cannot make any exception. Please:
 . Select an interesting project idea or draft your own proposal.
 . Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
-. Join the link:https://community.jenkins.io/c/contributing/gsoc/[Discourse communication channel]
-. Join the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC Gitter Chat]
+. Join the link:https://community.jenkins.io/c/contributing/gsoc/[Discourse communication channel].
+. Join the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC Gitter Chat].
 . Using the Discourse channel or the Gitter chat:
-  .. Introduce yourself to the Jenkins GSoC community,
+  .. Introduce yourself to the Jenkins GSoC community.
   .. Start a discussion about a Jenkins GSoC project.
   .. Be patient, there are time zones, and mentors have full time jobs outside of the Jenkins community.
-. Eventually, you may have to join both the Gitter chat and the Discourse channel, but initially you can reach us either way.
+. Eventually, you may have to join both the Gitter chat and the Discourse channel, but initially you can reach us through either channel.
 . Add GSoC office hours to your calendar (to be announced on link:/projects/gsoc[the main GSoC project] page).
-. Recommended: Do some contributions in the area of your project idea
+. Recommended: Submit some contributions in the area of your project idea.
 
 You can find more details about application steps below.
 
@@ -55,7 +55,7 @@ You can find more details about application steps below.
 
 When you apply to the GSoC program, you are committing to between 15 and 40 hours (depending on the size and duration of the project) of coding per week for the duration of the program.
 
-. We expect contributors to get involved into project discussions at the beginning of the GSoC contributor application period in order to have the opportunity to discuss the project with potential mentors and to jointly review the proposal drafts.
+. We expect contributors to get involved in project discussions at the beginning of the GSoC contributor application period, in order to have the opportunity to discuss the project with potential mentors and to jointly review the proposal drafts.
 . We expect contributors to attend at least one office hours during the application period.
 
 === Rules of Engagement
@@ -64,7 +64,7 @@ When you apply to the GSoC program, you are committing to between 15 and 40 hour
 
 The official communication language is English, and English is a second
 language to most of us. Learning proper English grammar is key to
-good communications. This is a challenge for mentors and contributors alike.
+good communication. This is a challenge for mentors and contributors alike.
 
 We encourage all contributors to spend some time improving their knowledge of
 the English language to increase their chances of success in open source.
@@ -78,8 +78,8 @@ link:http://guidetogrammar.org/grammar/fragments.htm[sentence fragments] (they a
 or miss constructing link:http://guidetogrammar.org/grammar/clauses.htm[clauses]
 and link:http://guidetogrammar.org/grammar/phrases.htm[phrases] (confusing).
 
-It is always good to start at the basics,
-that is how to write a sentence, and how to write a paragraph.
+It is always good to start with the basics,
+such as how to write a sentence, and how to write a paragraph.
 
 The following links are suggestions to help you improve your communication skills:
 
@@ -95,11 +95,11 @@ We expect almost all communications to be done in public.
 
 Contributors and mentors do not communicate privately regarding the technical
 aspects of the project or the GSoC program. Mentors are not expected to
-respond to such contributors inquiries when made in private.  Contributors will
+respond to such contributors inquiries when made in private. Contributors will
 get much better answers when they ask in public rather than in private,
 as mentors will collectively complement each other.
 
-Contributors please note that mentors do not have "special information",
+Contributors, please note that mentors do not have "special information",
 or "privileged information" that they would reveal only to you
 privately. Contributors should not ask mentors to hide information from
 other contributors, this is simply not how open-source development works. In
@@ -204,7 +204,7 @@ We will not discuss the selection with students until Google makes the announcem
 
 == Congratulations, you have been selected... or not
 
-We thank all GSoc contributors who reach out to us during the application period.
+We thank all GSoC contributors who reach out to us during the application period.
 If you have not been selected link:https://google.github.io/gsocguides/student/being-turned-down[read this],
 there could be many reasons, and some are even outside of our control.
 Do not feel bad, we encourage you to stay with the community, and apply again next year.
@@ -213,7 +213,7 @@ If you have been selected, the community bonding period starts within two days a
 
 == Community Bonding
 
-As soon as the GSoC contributors are accepted, the community bounding period starts.
+As soon as the GSoC contributors are accepted, the community bonding period starts.
 During this period, contributors are not expected to be coding immediately.
 Instead they are expected to prepare to code.
 


### PR DESCRIPTION
This PR is to adjust some of the text and punctuation on the GSoC contributors page to make sure that things are formatted correctly and grammatically accurate.