### PR TITLE
Fix doc for Jenkins on Kubernetes

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -43,12 +43,12 @@ We choose to use the `/data` directory. This directory will contain our Jenkins 
 
 *We will create a volume which is called jenkins-pv:*
 
-. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-volume.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkins-volume.yaml] into a YAML formatted file called `jenkins-volume.yaml`.
+. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-01-volume.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkinsHelm-01-volume.yaml] into a YAML formatted file called `jenkinsHelm-01-volume.yaml`.
 . Run the following command to apply the spec:
 +
 [source,bash]
 ----
-kubectl apply -f jenkins-volume.yaml
+kubectl apply -f jenkinsHelm-01-volume.yaml
 ----
 
 NOTE: It’s worth noting that, in the above spec, hostPath uses the /data/jenkins-volume/ of your node to emulate network-attached storage.
@@ -96,14 +96,14 @@ A RoleBinding may reference any Role in the same namespace.
 Alternatively, a RoleBinding can reference a ClusterRole and bind that ClusterRole to the namespace of the RoleBinding.
 To bind a ClusterRole to all the namespaces in our cluster, we use a ClusterRoleBinding.
 
-. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-sa.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkins-sa.yaml] into a YAML formatted file called
-`jenkins-sa.yaml`.
+. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-02-sa.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkinsHelm-02-sa.yaml] into a YAML formatted file called
+`jenkinsHelm-02-sa.yaml`.
 +
 . Run the following command to apply the spec:
 +
 [source,bash]
 ----
-kubectl apply -f jenkins-sa.yaml
+kubectl apply -f jenkinsHelm-02-sa.yaml
 ----
 
 === Install Jenkins
@@ -128,7 +128,7 @@ The `jenkins-values.yaml` is used as a template to provide values that are neces
 storageClass: jenkins-pv
 ----
 
-    * serviceAccount: the serviceAccount section of the jenkins-values.yaml file should look like this:
+    * serviceAccount: the serviceAccount section of the `jenkins-values.yaml` file should look like this:
 +
 [source,yaml]
 ----
@@ -190,7 +190,7 @@ NODE_IP=$(kubectl get nodes -n jenkins -o jsonpath=$jsonpath)
 echo http://$NODE_IP:$NODE_PORT/login
 ----
 3. Login with the password from step 1 and the username: admin
-4. Use Jenkins Configuration as Code by specifying configScripts in your values.yaml file.
+4. Use Jenkins Configuration as Code by specifying configScripts in your adaptation of the values.yaml file.
    See the plugin:configuration-as-code[configuration as code documentation] and  https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples].
 
 Visit the link:https://cloud.google.com/solutions/jenkins-on-container-engine[Jenkins on Kubernetes solutions page] for more information on running Jenkins on Kubernetes.
@@ -282,9 +282,9 @@ The YAML files are easily tracked, edited, and can be reused indefinitely.
 
 === Create Jenkins deployment file
 
-Copy the contents link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml[here] into your preferred text editor and create a jenkins-deployment.yaml file in the “jenkins” namespace we created in this link:/doc/book/installing/kubernetes/#create-a-namespace[section] above.
+Copy the contents link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-03-deployment.yaml[here] into your preferred text editor and create a jenkinsHelm-03-deployment.yaml file in the “jenkins” namespace we created in this link:/doc/book/installing/kubernetes/#create-a-namespace[section] above.
 
-* This link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml[deployment file] is defining a Deployment as indicated by the `kind` field.
+* This link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-03-deployment.yaml[deployment file] is defining a Deployment as indicated by the `kind` field.
 * The Deployment specifies a single replica. This ensures one and only one instance
 will be maintained by the Replication Controller in the event of failure.
 * The container image name is `jenkins` and version is a floating tag `lts-jdk21`
@@ -310,7 +310,7 @@ To create the deployment execute:
 
 [source,bash]
 ----
-kubectl create -f jenkins-deployment.yaml -n jenkins
+kubectl create -f jenkinsHelm-03-deployment.yaml -n jenkins
 ----
 
 The command also instructs the system to install Jenkins within the jenkins namespace.
@@ -334,9 +334,9 @@ It allows us to maintain a persistent connection to the pod regardless of the ch
 With a local deployment, this means creating a NodePort service type.
 A NodePort service type exposes a service on a port on each node in the cluster.
 The service is accessed through the Node IP address and the service nodePort.
-A simple service is defined link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-service.yaml[here]:
+A simple service is defined link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-04-service.yaml[here]:
 
-* This link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-service.yaml[service file] is defining a Service as
+* This link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-04-service.yaml[service file] is defining a Service as
 indicated by the `kind` field.
 * The Service is of type NodePort. Other options are ClusterIP (only accessible within the cluster) and LoadBalancer (IP address assigned by a cloud provider e.g. AWS Elastic IP).
 * The list of ports specified within the spec is a list of ports exposed by this service.
@@ -348,7 +348,7 @@ To create the service execute:
 
 [source,bash]
 ----
-kubectl create -f jenkins-service.yaml -n jenkins
+kubectl create -f jenkinsHelm-04-service.yaml -n jenkins
 ----
 
 To validate that creating the service was successful you can run:

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -287,7 +287,11 @@ Copy the contents link:https://raw.githubusercontent.com/jenkins-infra/jenkins.i
 * This link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml[deployment file] is defining a Deployment as indicated by the `kind` field.
 * The Deployment specifies a single replica. This ensures one and only one instance
 will be maintained by the Replication Controller in the event of failure.
-* The container image name is jenkins and version is 2.32.2
+* The container image name is `jenkins` and version is a floating tag `lts-jdk21`
+(for determinism, you may want a specific version tag like `2.32.2` instead -- but
+then you would have to update and re-apply it with iterations of this file).
+Note you may have to set up an `imagePullPolicy: Always` to pull new images according
+to changes of the floating tag (e.g. when new LTS is released).
 * The list of ports specified within the spec are a list of ports to expose from
 the container on the Pods IP address.
 ** Jenkins running on (http) port 8080.

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -22,7 +22,21 @@ and underlying infrastructure are not overloaded.
 Kubernetes' ability to orchestrate container deployment ensures that Jenkins always
 has the right amount of resources available.
 
-Hosting Jenkins on a Kubernetes Cluster is beneficial for Kubernetes-based deployments and dynamic container-based scalable Jenkins agents.
+Hosting Jenkins on a Kubernetes Cluster is beneficial for Kubernetes-based
+deployments and dynamic container-based scalable Jenkins agents.
+
+Several strategies for such setup and maintenance are explored below, including:
+
+* direct use of `kubectl` and YAML files to configure certain aspects of
+  the deployment,
+* or use of `helm` tool and Helm Chart files to manage a whole ecosystem
+  (e.g. both the controller AND a population of agents where actual work
+  happens),
+* or further use of the Jenkins Operator to manage operations for Jenkins
+  on Kubernetes in the cluster.
+
+'''
+
 Here, we see a step-by-step process for setting up Jenkins on a Kubernetes Cluster.
 
 == Setup Jenkins On Kubernetes
@@ -394,8 +408,12 @@ kubectl exec -it "deployment.apps/jenkins" cat /var/jenkins_home/secrets/initial
 kubectl exec -it jenkins-559d8cd85c-cfcgk cat /var/jenkins_home/secrets/initialAdminPassword -n devops-tools
 ----
 
-Once you enter the password, proceed to install the suggested plugin and create an admin user. 
+Once you enter the password, proceed to install the suggested plugin and create an admin user.
 All of these steps are self-explanatory from the Jenkins dashboard.
+
+'''
+
+Below we will explore further deployment strategies.
 
 include::doc/book/installing/_kubernetes.adoc[]
 

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -271,7 +271,7 @@ spec:
 In this Jenkins Kubernetes deployment we have used the following:
 
 [arabic]
-. The Jenkins container version is referenced in the example YAML above by a floating tag `lts`, so the optional `imagePullPolicy: Always` line is added to pull and deploy a new LTS image release (if exists) *whenever* the pod is restarted. Otherwise, the currently deployed version is used after restart (and there's no other way to tell Kubernetes to pull a newer image, short of locating and deleting the old one from the node's cache).
+. The Jenkins container version is referenced in the example YAML above by a floating tag `lts`, so the optional `imagePullPolicy: Always` line is added to pull and deploy a new LTS image release (if it exists) *whenever* the pod is restarted. Otherwise, the currently deployed version is used after restart (and there's no other way to tell Kubernetes to pull a newer image, short of locating and deleting the old one from the node's cache).
   * Note that "whenever the pod is restarted" includes e.g. server reboot or the restart requested in Web-UI to apply downloaded plugin updates.
   * Kubernetes automatically uses this policy by default if the `:latest` image tag is specified, or none is specified at all (then the `:latest` image tag is automatically defaulted).
   * For predictable and deterministic updates, use the version-based image tags instead. Search https://hub.docker.com/r/jenkins/jenkins/tags for the ones currently served.

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -257,7 +257,11 @@ spec:
 In this Jenkins Kubernetes deployment we have used the following:
 
 [arabic]
-. Jenkins container version is referenced by a floating tag `lts`, so the optional `imagePullPolicy: Always` is added to pull and deploy a new release (if exists) whenever the pod is restarted.
+. The Jenkins container version is referenced in the example YAML above by a floating tag `lts`, so the optional `imagePullPolicy: Always` line is added to pull and deploy a new LTS image release (if exists) *whenever* the pod is restarted. Otherwise, the currently deployed version is used after restart (and there's no other way to tell Kubernetes to pull a newer image, short of locating and deleting the old one from the node's cache).
+  * Note that "whenever the pod is restarted" includes e.g. server reboot or the restart requested in Web-UI to apply downloaded plugin updates.
+  * Kubernetes automatically uses this policy by default if the `:latest` image tag is specified, or none is specified at all (then the `:latest` image tag is automatically defaulted).
+  * For predictable and deterministic updates, use the version-based image tags instead. Search https://hub.docker.com/r/jenkins/jenkins/tags for the ones currently served.
+  * Consider an image tag like `lts-jdk21` to avoid surprises when the Jenkins core switches to using a newer JDK (usually they are backwards compatible, but...) or stay with `lts` for indefinite hands-off maintenance approach.
 . 'securityContext' for Jenkins pod to be able to write to the local persistent volume.
 . Liveness and readiness probe to monitor the health of the Jenkins pod.
 . Local persistent volume based on local storage class that holds the Jenkins data path '/var/jenkins_home'.

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -27,12 +27,12 @@ deployments and dynamic container-based scalable Jenkins agents.
 
 Several strategies for such setup and maintenance are explored below, including:
 
-* direct use of `kubectl` and YAML files to configure certain aspects of
-  the deployment,
-* or use of `helm` tool and Helm Chart files to manage a whole ecosystem
-  (e.g. both the controller AND a population of agents where actual work
-  happens),
-* or further use of the Jenkins Operator to manage operations for Jenkins
+* Direct use of `kubectl` and YAML files to configure certain aspects of
+  the deployment.
+* Use of the `helm` tool and Helm Chart files to manage a whole ecosystem.
+  For example, both the controller AND a population of agents where actual work
+  happens.
+* Further use of the Jenkins Operator to manage operations for Jenkins
   on Kubernetes in the cluster.
 
 '''

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -390,6 +390,8 @@ while sleep 0.1 ; do kubectl logs -f -l app=jenkins-server -n devops-tools ; don
 ----
 
 (The label `jenkins-server` is defined in `jenkins-03-deployment.yaml`)
+
+Alternatively, link:https://github.com/stern/stern[stern] tool can be used to watch multiple pods' logs.
 ======
 
 Alternatively, you can run the exec command to get the password directly from the location as shown below.

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -272,7 +272,7 @@ In this Jenkins Kubernetes deployment we have used the following:
 
 [arabic]
 . The Jenkins container version is referenced in the example YAML above by a floating tag `lts`, so the optional `imagePullPolicy: Always` line is added to pull and deploy a new LTS image release (if it exists) *whenever* the pod is restarted. Otherwise, the currently deployed version is used after restart (and there's no other way to tell Kubernetes to pull a newer image, short of locating and deleting the old one from the node's cache).
-  * Note that "whenever the pod is restarted" includes e.g. server reboot or the restart requested in Web-UI to apply downloaded plugin updates.
+  * Note that "whenever the pod is restarted" includes events such as a server reboot or the restart requested in Web-UI to apply downloaded plugin updates.
   * Kubernetes automatically uses this policy by default if the `:latest` image tag is specified, or none is specified at all (then the `:latest` image tag is automatically defaulted).
   * For predictable and deterministic updates, use the version-based image tags instead. Search https://hub.docker.com/r/jenkins/jenkins/tags for the ones currently served.
   * Consider an image tag like `lts-jdk21` to avoid surprises when the Jenkins core switches to using a newer JDK (usually they are backwards compatible, but...) or stay with `lts` for indefinite hands-off maintenance approach.

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -65,7 +65,7 @@ kubectl create namespace devops-tools
 ----
 
 [#create-a-service-account]
-*Step 2:* Create a 'serviceAccount.yaml' file and copy the following admin service account manifest.
+*Step 2:* Create a 'jenkins-01-serviceAccount.yaml' file and copy the following admin service account manifest.
 [source,yaml]
 ----
 ---
@@ -98,7 +98,7 @@ subjects:
   namespace: devops-tools
 ----
 
-The 'serviceAccount.yaml' creates a 'jenkins-admin' clusterRole, 'jenkins-admin' ServiceAccount and binds the 'clusterRole' to the service account.
+The 'jenkins-01-serviceAccount.yaml' creates a 'jenkins-admin' clusterRole, 'jenkins-admin' ServiceAccount and binds the 'clusterRole' to the service account.
 
 The 'jenkins-admin' cluster role has all the permissions to manage the cluster components.
 You can also restrict access by specifying individual resource actions.
@@ -107,11 +107,11 @@ Now create the service account using kubectl.
 
 [source,bash]
 ----
-kubectl apply -f serviceAccount.yaml
+kubectl apply -f jenkins-01-serviceAccount.yaml
 ----
 
 [#create-a-volume]
-**Step 3: **Create 'volume.yaml' and copy the following persistent volume manifest.
+**Step 3: **Create 'jenkins-02-volume.yaml' and copy the following persistent volume manifest.
 
 [source,yaml]
 ----
@@ -185,11 +185,11 @@ Let’s create the volume using kubectl
 
 [source,bash]
 ----
-kubectl create -f volume.yaml
+kubectl create -f jenkins-02-volume.yaml
 ----
 
 [#create-a-deployment]
-*Step 4:* Create a Deployment file named 'deployment.yaml' and copy the following deployment manifest.
+*Step 4:* Create a Deployment file named 'jenkins-03-deployment.yaml' and copy the following deployment manifest.
 
 [source,yaml]
 ----
@@ -275,7 +275,7 @@ Create the deployment using kubectl.
 
 [source,bash]
 ----
-kubectl apply -f deployment.yaml
+kubectl apply -f jenkins-03-deployment.yaml
 ----
 
 Check the deployment status.
@@ -299,7 +299,7 @@ We have now created a deployment.
 However, it is not accessible to the outside world.
 For accessing the Jenkins deployment from the outside world, we need to create a service and map it to the deployment.
 
-Create 'service.yaml' and copy the following service manifest:
+Create 'jenkins-04-service.yaml' and copy the following service manifest:
 
 [source,yaml]
 ----
@@ -330,7 +330,7 @@ Create the Jenkins service using kubectl.
 
 [source,bash]
 ----
-kubectl apply -f service.yaml
+kubectl apply -f jenkins-04-service.yaml
 ---- 
 
 Now, when browsing to any one of the Node IPs on port 32000, you will be able to access the Jenkins dashboard.

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -367,8 +367,28 @@ kubectl logs jenkins-deployment-2539456353-j00w5 --namespace=devops-tools
 
 The password can be found at the end of the log.
 
+[NOTE]
+======
+You can watch the Jenkins server logs (posted to `stdout` or `stderr` of the JVM and collected by Kubernetes) with the following loop to handle Jenkins restarts as well:
+
+----
+while sleep 0.1 ; do kubectl logs -f -l app=jenkins-server -n devops-tools ; done &
+----
+
+(The label `jenkins-server` is defined in `jenkins-03-deployment.yaml`)
+======
+
 Alternatively, you can run the exec command to get the password directly from the location as shown below.
 
+* Using the first (normally only) instance of the application pod:
++
+[source,bash]
+----
+kubectl exec -it "deployment.apps/jenkins" cat /var/jenkins_home/secrets/initialAdminPassword -n devops-tools
+----
+
+* ...or, using a specific container instance:
++
 [source,bash]
 ----
 kubectl exec -it jenkins-559d8cd85c-cfcgk cat /var/jenkins_home/secrets/initialAdminPassword -n devops-tools

--- a/content/doc/book/installing/kubernetes.adoc
+++ b/content/doc/book/installing/kubernetes.adoc
@@ -215,6 +215,8 @@ spec:
       containers:
         - name: jenkins
           image: jenkins/jenkins:lts
+          # OPTIONAL: check for new floating-tag LTS releases whenever the pod is restarted:
+          imagePullPolicy: Always
           resources:
             limits:
               memory: "2Gi"
@@ -255,6 +257,7 @@ spec:
 In this Jenkins Kubernetes deployment we have used the following:
 
 [arabic]
+. Jenkins container version is referenced by a floating tag `lts`, so the optional `imagePullPolicy: Always` is added to pull and deploy a new release (if exists) whenever the pod is restarted.
 . 'securityContext' for Jenkins pod to be able to write to the local persistent volume.
 . Liveness and readiness probe to monitor the health of the Jenkins pod.
 . Local persistent volume based on local storage class that holds the Jenkins data path '/var/jenkins_home'.

--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-01-volume.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-01-volume.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jenkins-pv
+  namespace: jenkins
+spec:
+  storageClassName: jenkins-pv
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 20Gi
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /data/jenkins-volume/
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jenkins-pv
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-02-sa.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-02-sa.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins
+  namespace: jenkins
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: jenkins
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - statefulsets
+  - services
+  - replicationcontrollers
+  - replicasets
+  - podtemplates
+  - podsecuritypolicies
+  - pods
+  - pods/log
+  - pods/exec
+  - podpreset
+  - poddisruptionbudget
+  - persistentvolumes
+  - persistentvolumeclaims
+  - jobs
+  - endpoints
+  - deployments
+  - deployments/scale
+  - daemonsets
+  - cronjobs
+  - configmaps
+  - namespaces
+  - events
+  - secrets
+  verbs:
+  - create
+  - get
+  - watch
+  - delete
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: jenkins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jenkins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:jenkins

--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-03-deployment.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-03-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      containers:
+      - name: jenkins
+        image: jenkins/jenkins:lts-jdk21
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: jenkins-home
+          mountPath: /var/jenkins_home
+      volumes:
+      - name: jenkins-home
+        emptyDir: { }

--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-04-service.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-04-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins
+spec:
+  type: NodePort
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    app: jenkins

--- a/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml
+++ b/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: jenkins
-        image: jenkins/jenkins:lts-jdk11
+        image: jenkins/jenkins:lts-jdk21
         ports:
         - containerPort: 8080
         volumeMounts:


### PR DESCRIPTION
Update the documentation for Jenkins on Kubernetes setup:
* Clarify that there are actually several different setup scenarios explored here;
* Discuss use of floating-tag (LTS) vs. specific version tagged images, including impact on image pulling (and whether the admin wants it automatic or deterministic)
* Bump image version reference in Helm doc example
* Some suggestions about log watching and access to containers without reliance on ever-randomized pod names

Cross-link to https://github.com/scriptcamp/kubernetes-jenkins/pull/6 : we refer to that repo in text (even if YAML file contents are presented and maintained in text directly), and perhaps this document started from the blog illustrated by that repo. So as we shift to numbered filenames here, that PR proposes to do similarly in "upstream".