### PR TITLE
fix(ui): patch bug(s) in current thank-you note implementation

### DIFF
--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -348,7 +348,11 @@ title: Download and deploy
           %p
             to the 
             - contributor['REPOSITORIES'].split.each_with_index do |repo, index|
-              %a{ href: "https://github.com/#{repo}", target: "_blank" }= repo
+              - repo_name = repo.split('/').last
+              - if index == contributor['REPOSITORIES'].split.size - 1
+                %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
               - unless index == contributor['REPOSITORIES'].split.size - 1
-                , 
-            repo in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!
+                = succeed ',' do
+                  %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
+          %p
+            repo#{'s' if contributor['REPOSITORIES'].split.size > 1} in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -122,7 +122,7 @@ homepage: true
         .desc-div
           %p
             Thank you 
-            %a{ href: contributor['GH_HANDLE_URL'], target: "_blank" }= contributor['GH_HANDLE']
+            %a{ href: contributor['GH_HANDLE_URL'], target: "_blank" }=contributor['GH_HANDLE']
           %p
             for making 
             = contributor['NBR_PR']
@@ -130,8 +130,11 @@ homepage: true
           %p
             to the 
             - contributor['REPOSITORIES'].split.each_with_index do |repo, index|
-              - repo_name = repo.split('/').last  
-              %a{ href: "https://github.com/#{repo}", target: "_blank" }= repo_name
+              - repo_name = repo.split('/').last
+              - if index == contributor['REPOSITORIES'].split.size - 1
+                %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
               - unless index == contributor['REPOSITORIES'].split.size - 1
-                , 
-              repo in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!
+                = succeed ',' do
+                  %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
+          %p
+            repo#{'s' if contributor['REPOSITORIES'].split.size > 1} in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!


### PR DESCRIPTION
Fixes #7965. 

### Description
1. Remove extra words that was repeated unnecessarily. 
2. Remove extra space before each comma in the repos list of each contributor to be thanked. 
3. When multiple repositories are listed, use the plural form "repos" instead of the singular form "repo"

### Before

![before-Screenshot 2025-03-08 081609](https://github.com/user-attachments/assets/33307b2b-377a-4a49-b652-a83a42b0207b)

### After

![after-Screenshot 2025-03-08 081632](https://github.com/user-attachments/assets/68a40891-5449-4b6e-b7bf-292669f611b2)
