### PR TITLE
fix(ui): patch potential logical bug when thank-you note contributor only has one repo

### DIFF
--- a/content/_partials/thank-you-note.html.haml
+++ b/content/_partials/thank-you-note.html.haml
@@ -1,0 +1,29 @@
+:ruby
+  contributors = site.indexpage[:thank_you]
+
+.thank-you-block
+  .thank-you-box
+    .contributor-data
+      - contributors.each do |contributor|
+        .image-div
+          %img{ src: contributor['GH_HANDLE_AVATAR'], alt: "Avatar", width: "50", height: "50" }
+
+        .desc-div
+          %p
+            Thank you
+            %a{ href: contributor['GH_HANDLE_URL'], target: "_blank" }=contributor['GH_HANDLE']
+          %p
+            for making
+            = contributor['NBR_PR']
+            pull request#{'s' if contributor['NBR_PR'].to_i > 1}
+          %p
+            to the
+            - contributor['REPOSITORIES'].split.each_with_index do |repo, index|
+              - repo_name = repo.split('/').last
+              - if index == contributor['REPOSITORIES'].split.size - 1
+                %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
+              - unless index == contributor['REPOSITORIES'].split.size - 1 && index > 0
+                = succeed ',' do
+                  %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
+          %p
+            repo#{'s' if contributor['REPOSITORIES'].split.size > 1} in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -351,7 +351,7 @@ title: Download and deploy
               - repo_name = repo.split('/').last
               - if index == contributor['REPOSITORIES'].split.size - 1
                 %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-              - unless index == contributor['REPOSITORIES'].split.size - 1
+              - unless index == contributor['REPOSITORIES'].split.size - 1 && index > 0
                 = succeed ',' do
                   %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
           %p

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -2,8 +2,6 @@
 layout: simplepage
 title: Download and deploy
 ---
-:ruby
-  contributors = site.indexpage[:thank_you]
 
 %p.app-description
   The Jenkins project produces two release lines: Stable (LTS) and weekly.
@@ -330,29 +328,4 @@ title: Download and deploy
         Learn more
         %ion-icon{:name => "arrow-forward-outline"}
 
-.thank-you-block
-  .thank-you-box
-    .contributor-data
-      - contributors.each do |contributor|
-        .image-div
-          %img{ src: contributor['GH_HANDLE_AVATAR'], alt: "Avatar", width: "50", height: "50" }
-
-        .desc-div
-          %p
-            Thank you 
-            %a{ href: contributor['GH_HANDLE_URL'], target: "_blank" }= contributor['GH_HANDLE']
-          %p
-            for making 
-            = contributor['NBR_PR']
-            pull request#{'s' if contributor['NBR_PR'].to_i > 1}
-          %p
-            to the 
-            - contributor['REPOSITORIES'].split.each_with_index do |repo, index|
-              - repo_name = repo.split('/').last
-              - if index == contributor['REPOSITORIES'].split.size - 1
-                %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-              - unless index == contributor['REPOSITORIES'].split.size - 1 && index > 0
-                = succeed ',' do
-                  %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-          %p
-            repo#{'s' if contributor['REPOSITORIES'].split.size > 1} in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!
+= partial('thank-you-note.html.haml')

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -133,7 +133,7 @@ homepage: true
               - repo_name = repo.split('/').last
               - if index == contributor['REPOSITORIES'].split.size - 1
                 %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-              - unless index == contributor['REPOSITORIES'].split.size - 1
+              - unless index == contributor['REPOSITORIES'].split.size - 1 && index > 0
                 = succeed ',' do
                   %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
           %p

--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -10,7 +10,6 @@ homepage: true
 
   supporters = site.indexpage[:supporters]
   slides = site.indexpage[:carousel]
-  contributors = site.indexpage[:thank_you]
 
 = partial('downloadbanner.html.haml')
 
@@ -112,29 +111,4 @@ homepage: true
             %li
               %a{:href => supporter['url'], :target => '_blank', :rel => 'noreferrer noopener'}= supporter['name']
 
-.thank-you-block
-  .thank-you-box
-    .contributor-data
-      - contributors.each do |contributor|
-        .image-div
-          %img{ src: contributor['GH_HANDLE_AVATAR'], alt: "Avatar", width: "50", height: "50" }
-
-        .desc-div
-          %p
-            Thank you 
-            %a{ href: contributor['GH_HANDLE_URL'], target: "_blank" }=contributor['GH_HANDLE']
-          %p
-            for making 
-            = contributor['NBR_PR']
-            pull request#{'s' if contributor['NBR_PR'].to_i > 1}
-          %p
-            to the 
-            - contributor['REPOSITORIES'].split.each_with_index do |repo, index|
-              - repo_name = repo.split('/').last
-              - if index == contributor['REPOSITORIES'].split.size - 1
-                %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-              - unless index == contributor['REPOSITORIES'].split.size - 1 && index > 0
-                = succeed ',' do
-                  %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-          %p
-            repo#{'s' if contributor['REPOSITORIES'].split.size > 1} in #{Date.parse(contributor['MONTH'] + "-01").strftime("%B %Y")}!
+= partial('thank-you-note.html.haml')


### PR DESCRIPTION
## Tasks completed
1. Added logic to make sure when the thank-you note contributor has only one repo there would be no duplicate repo names shown. 
2. Moved the thank-you note code to its own partial. 