### PR TITLE
fix(ui): remove extra comma in thank-you note in single repo case

### DIFF
--- a/content/_partials/thank-you-note.html.haml
+++ b/content/_partials/thank-you-note.html.haml
@@ -22,7 +22,7 @@
               - repo_name = repo.split('/').last
               - if index == contributor['REPOSITORIES'].split.size - 1
                 %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
-              - unless index == contributor['REPOSITORIES'].split.size - 1 && index > 0
+              - unless index == contributor['REPOSITORIES'].split.size - 1
                 = succeed ',' do
                   %a{ href: "https://github.com/#{repo}", target: "_blank" }=repo_name
           %p


### PR DESCRIPTION
Remove redundant logic after trying out on actual single repo case in thank-you note. 