### PR TITLE
Update UX SIG page to include Design Library 3

### DIFF
--- a/content/blog/2024/08/29/2024-08-29-jenkins-design.adoc
+++ b/content/blog/2024/08/29/2024-08-29-jenkins-design.adoc
@@ -8,6 +8,7 @@ tags:
 - user-experience
 - devopsworld
 - devopsworld2024
+- ux
 authors:
 - janfaracik
 - timja

--- a/content/blog/2024/12/02/2024-12-02-pr-titles.adoc
+++ b/content/blog/2024/12/02/2024-12-02-pr-titles.adoc
@@ -7,6 +7,7 @@ tags:
 - gitlab
 - bitbucket
 - user-experience
+- ux
 authors:
 - janfaracik
 opengraph:

--- a/content/blog/2025/01/2025-01-10-design-library.adoc
+++ b/content/blog/2025/01/2025-01-10-design-library.adoc
@@ -4,6 +4,7 @@ title: "Introducing Jenkins Design Library 3"
 tags:
 - jenkins
 - user-experience
+- ux
 authors:
 - janfaracik
 opengraph:

--- a/content/blog/2025/02/2025-02-05-command-palette.adoc
+++ b/content/blog/2025/02/2025-02-05-command-palette.adoc
@@ -4,6 +4,7 @@ title: "A new way to search in Jenkins 2.492.1"
 tags:
 - jenkins
 - user-experience
+- ux
 authors:
 - janfaracik
 opengraph:

--- a/content/sigs/ux/index.adoc
+++ b/content/sigs/ux/index.adoc
@@ -63,6 +63,13 @@ In general, all Jenkins users would benefit from better navigation and layouts.
 
 See the jira:JENKINS-62268[] EPIC for more details about the scope.
 
+[[design-library]]
+=== UI/UX: Jenkins Design Library
+
+The UX SIG has released the updated link:https://weekly.ci.jenkins.io/design-library[Jenkins Design Library 3].
+This release provides an enhanced experience for developers looking to create and customize their Jenkins UI.
+Read more and explore the Jenkins Design Library 3 link:/blog/2025/01/10/design-library/[in our announcement blog post].
+
 == Meetings
 We have regular meetings on Wednesday every four weeks, at *4PM UTC*.
 See the link:/event-calendar[Jenkins Event Calendar] for the schedule.


### PR DESCRIPTION
This PR is to update some recent blog posts to include the `ux` tag so that they are displayed in the list of recent blog posts.

It also updates the UX SIG page to include the recently released Jenkins Design Library 3, along with a link to the blog post announcing it.

@janfaracik if there is anything else that should be added to the UX SIG page, just let me know!