### PR TITLE
Update _docker-for-tutorials.adoc

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -94,13 +94,15 @@ docker run --name jenkins-docker --rm --detach \
 ----
 FROM jenkins/jenkins:{jenkins-stable}-jdk17
 USER root
-RUN apt-get update && apt-get install -y lsb-release
-RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \
-  https://download.docker.com/linux/debian/gpg
+RUN apt-get update && apt-get install -y lsb-release ca-certificates
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+RUN chmod a+r /etc/apt/keyrings/docker.asc
 RUN echo "deb [arch=$(dpkg --print-architecture) \
-  signed-by=/usr/share/keyrings/docker-archive-keyring.asc] \
+  signed-by=/etc/apt/keyrings/docker.asc] \
   https://download.docker.com/linux/debian \
-  $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+  $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
+  | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean:1.27.17 docker-workflow:611.v16e84da_6d3ff json-path-api"

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -94,16 +94,15 @@ docker run --name jenkins-docker --rm --detach \
 ----
 FROM jenkins/jenkins:{jenkins-stable}-jdk17
 USER root
-RUN apt-get update && apt-get install -y lsb-release ca-certificates
-RUN install -m 0755 -d /etc/apt/keyrings
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-RUN chmod a+r /etc/apt/keyrings/docker.asc
-RUN echo "deb [arch=$(dpkg --print-architecture) \
-  signed-by=/etc/apt/keyrings/docker.asc] \
-  https://download.docker.com/linux/debian \
-  $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
-  | tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN apt-get update && apt-get install -y docker-ce-cli
+RUN apt-get update && apt-get install -y lsb-release ca-certificates && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+    https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && apt-get install -y docker-ce-cli && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 USER jenkins
 RUN jenkins-plugin-cli --plugins "blueocean:1.27.17 docker-workflow:611.v16e84da_6d3ff json-path-api"
 ----

--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -94,7 +94,7 @@ docker run --name jenkins-docker --rm --detach \
 ----
 FROM jenkins/jenkins:{jenkins-stable}-jdk17
 USER root
-RUN apt-get update && apt-get install -y lsb-release ca-certificates && \
+RUN apt-get update && apt-get install -y lsb-release ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \


### PR DESCRIPTION
This commit updates the Jenkins Dockerfile example to align with the latest Docker official recommendations for installing the Docker CLI. The changes aim to enhance security and maintain consistency with modern best practices.

Changes include:

1. Expanded Package Installation:
- Added ca-certificates and curl to the list of required packages, improving HTTPS communication and certificate handling.

2. GPG Key Storage Update:
- Modified the key storage location from /usr/share/keyrings/docker-archive-keyring.asc to /etc/apt/keyrings/docker.asc per the latest Docker guidelines.
- Created the /etc/apt/keyrings directory (if not present) and set appropriate read permissions on the key.

3. Improved APT Repository Configuration:
- Replaced `$(lsb_release -cs)` with `$(. /etc/os-release && echo "$VERSION_CODENAME")` to dynamically and reliably retrieve the current Debian codename.
- Used the tee command to output the repository configuration to /etc/apt/sources.list.d/docker.list.