### PR TITLE
feat(docs): update Jenkins LTS version references in Docker documentation

### DIFF
--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -89,7 +89,23 @@ conditions:
   jenkinsThirdToLastVersion:
     kind: jenkins
     sourceid: JenkinsThirdToLastLTS
+  jenkinsLatestLTSJdk17Image:
+    kind: dockerimage
+    sourceid: JenkinsLatestLTS
+    spec:
+      image: "jenkins/jenkins"
+      tag: '{{ source "JenkinsLatestLTS" }}-jdk17'
 targets:
+  setJenkinsLatestLTSVersionInDockerTutorial:
+    kind: file
+    name: "Bump Jenkins latest LTS version in the Docker Tutorial"
+    sourceid: JenkinsLatestLTS
+    spec:
+      file: content/doc/book/installing/_docker-for-tutorials.adoc
+      matchpattern: >-
+        (.*FROM jenkins/jenkins:)(.*)(-jdk17.*)
+      replacepattern: >-
+        ${1}{{ source "JenkinsLatestLTSBaseline" }}${3}
   setJenkinsLatestLTSVersionInRecommendedVersions:
     kind: file
     name: "Bump Jenkins latest LTS version in the recommended versions section"
@@ -194,7 +210,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Update Jenkins LTS versions to {{ source "JenkinsLatestLTS" }} in various parts of the documentation
+    title: Update Jenkins LTS versions in various parts of the documentation
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
- **Documentation**
  - Updated the Docker tutorial to reflect the current Jenkins LTS version, ensuring clearer update instructions.