### PR TITLE
Update jumbotron with 2025 Community awards

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -10,17 +10,18 @@
     :text: More info
     :href: /blog/2024/10/04/content-security-policy-grant/
 
-# Jenkins in GSoC 2025
-- :href: /blog/2025/03/05/Jenkins-in-Google-Summer-of-Code-2025/
-  :title: Jenkins accepted into Google Summer of Code 2025
-  :intro: We are excited to announce that Jenkins 
-    has been accepted into Google Summer of Code 2025 as a mentor organization!
+# Jenkins 2025 Community Awards Open
+- :href: /blog/2025/03/18/jenkins-contributor-awards-2025-nomination-is-open/
+  :title: Jenkins 2025 Community Awards
+  :intro: Nominations for the 2025 
+    Jenkins Community Awards are now open!
+    Nominations are open until April 14, 2025.
   :image:
-    :src: /images/post-images/2025/03/GSoC2025_opengraph.png
+    :src: /images/post-images/2025/03/community-awards-2025-jenkins.png
     :height: 285px
   :call_to_action:
-    :text: More info
-    :href: /blog/2025/03/05/Jenkins-in-Google-Summer-of-Code-2025/
+    :text: Additional information is available in our blog post 
+    :href: /blog/2025/03/18/jenkins-contributor-awards-2025-nomination-is-open/
 
 # Jenkins 2024 DevOps Dozen Award
 - :href: https://devopsdozen.com/devops-dozen-2024-community-award-winners/


### PR DESCRIPTION
This PR is to update the Jumbotron to remove the GSoC involvement item and add the 2025 community awards.