### PR TITLE
Fix typos in pipeline-as-code.adoc

### DIFF
--- a/content/doc/book/pipeline/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline/pipeline-as-code.adoc
@@ -250,7 +250,7 @@ Jenkins experience increases, organizations inevitably want to move beyond
 simple pipelines and create complex flows specific to their delivery process.
 
 These Jenkins users require a feature that treats complex pipelines as a
-first-class object, and so the plugin:workflow-aggregator[Pipeline plugin] 
+first-class object, and so the plugin:workflow-aggregator[Pipeline plugin]
 was developed.
 
 === Pre-requisites

--- a/content/doc/book/pipeline/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline/pipeline-as-code.adoc
@@ -249,9 +249,7 @@ plugins for several years. As their automation sophistication and their own
 Jenkins experience increases, organizations inevitably want to move beyond
 simple pipelines and create complex flows specific to their delivery process.
 
-These Jenkins users require a feature that treats complex pipelines as a
-first-class object, and so the plugin:workflow-aggregator[Pipeline plugin]
-was developed.
+These Jenkins users require a feature that treats complex pipelines as a first-class object, and so the plugin:workflow-aggregator[Pipeline plugin] was developed.
 
 === Pre-requisites
 

--- a/content/doc/book/pipeline/pipeline-as-code.adoc
+++ b/content/doc/book/pipeline/pipeline-as-code.adoc
@@ -220,7 +220,7 @@ Refresh the page after the job runs to ensure the view of repositories has been 
 [role="image-border"]
 image::organization-folder-repositories.png[alt = "Jenkins dashboard view for the 'CloudBeersInc' organization. The status section shows the repository count as 'Repositories (3)' with a table listing three repositories: 'community-docs', 'multibranch-demo', and 'PR-demo'. Each repository entry includes columns labeled 'S' for status of last build, 'W' for weather status of recent aggregated builds, 'Name', and 'Description'. The 'multibranch-demo' repository contains a description stating, 'Simple demonstration of how to use multibranch pipelines'. Icon size options (S, M, L) are available below the table.", scaledwidth="75%"]
 
-A this point, you're finished with basic project configuration and can now explore your imported repositories.
+At this point, you're finished with basic project configuration and can now explore your imported repositories.
 You can also investigate the results of the jobs run as part of the initial _Folder Computation_.
 
 [role="image-border"]
@@ -250,8 +250,8 @@ Jenkins experience increases, organizations inevitably want to move beyond
 simple pipelines and create complex flows specific to their delivery process.
 
 These Jenkins users require a feature that treats complex pipelines as a
-first-class object, and so the plugin:workflow-aggregator[Pipeline plugin]
-was developed .
+first-class object, and so the plugin:workflow-aggregator[Pipeline plugin] 
+was developed.
 
 === Pre-requisites
 


### PR DESCRIPTION
Fix minor typos in the "Pipeline as Code" documentation.
- `was developed .` to `was developed.` 
- `A this point,` to `At this point,` 