### PR TITLE
Restore LTS changelogs before 2.32.1

### DIFF
--- a/content/changelog-stable-old/index.html.haml
+++ b/content/changelog-stable-old/index.html.haml
@@ -31,6 +31,8 @@ actions:
       - unless release.changes || release.lts_changes
         %p No notable changes for this release.
 
+  = partial('changelog-stable.html')
+
 .app-banner
   This is the changelog archive. The changelog for recent releases can be found
   %a{:href => '/changelog-stable/'}


### PR DESCRIPTION
Fixes #8040. Amends #7746.

It's not pretty, but functional.