### PR TITLE
Add Java 21 upgrade instructions

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -104,15 +104,15 @@ Additionally, link:/doc/book/platform-information/support-policy-java/[not all J
 There are multiple Java implementations which you can use.
 link:https://openjdk.java.net/[OpenJDK] is the most popular one at the moment, we will use it in this guide.
 
-Update the Debian apt repositories, install OpenJDK 17, and check the installation with the commands:
+Update the Debian apt repositories, install OpenJDK 21, and check the installation with the commands:
 [source,bash]
 ----
 sudo apt update
-sudo apt install fontconfig openjdk-17-jre
+sudo apt install fontconfig openjdk-21-jre
 java -version
-openjdk version "17.0.13" 2024-10-15
-OpenJDK Runtime Environment (build 17.0.13+11-Debian-2)
-OpenJDK 64-Bit Server VM (build 17.0.13+11-Debian-2, mixed mode, sharing)
+openjdk version "21.0.3" 2024-04-16
+OpenJDK Runtime Environment (build 21.0.3+11-Debian-2)
+OpenJDK 64-Bit Server VM (build 21.0.3+11-Debian-2, mixed mode, sharing)
 ----
 
 [NOTE]
@@ -141,7 +141,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install fontconfig java-17-openjdk
+sudo dnf install fontconfig java-21-openjdk
 sudo dnf install jenkins
 sudo systemctl daemon-reload
 ----
@@ -160,7 +160,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
-sudo dnf install fontconfig java-17-openjdk
+sudo dnf install fontconfig java-21-openjdk
 sudo dnf install jenkins
 ----
 
@@ -242,7 +242,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install fontconfig java-17-openjdk
+sudo yum install fontconfig java-21-openjdk
 sudo yum install jenkins
 sudo systemctl daemon-reload
 ----
@@ -261,7 +261,7 @@ sudo wget -O /etc/yum.repos.d/jenkins.repo \
 sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
-sudo yum install fontconfig java-17-openjdk
+sudo yum install fontconfig java-21-openjdk
 sudo yum install jenkins
 ----
 

--- a/content/doc/book/platform-information/_chapter.yml
+++ b/content/doc/book/platform-information/_chapter.yml
@@ -7,3 +7,4 @@ sections:
   - support-policy-servlet-containers
   - upgrade-java-to-11
   - upgrade-java-to-17
+  - upgrade-java-to-21

--- a/content/doc/book/platform-information/index.adoc
+++ b/content/doc/book/platform-information/index.adoc
@@ -32,4 +32,4 @@ Details of the support policies are available in the specific support policy pag
 == Java support and upgrade information
 
 In addition to support policies, this chapter provides information on upgrading your Java version in Jenkins.
-Depending on your current Java version, there are instructions for link:/doc/book/platform-information/upgrade-java-to-11/[upgrading to Java 11] and link:/doc/book/platform-information/upgrade-java-to-17/[upgrading to Java 17].
+Depending on your current Java version, there are instructions for link:/doc/book/platform-information/upgrade-java-to-11/[upgrading to Java 11], link:/doc/book/platform-information/upgrade-java-to-17/[upgrading to Java 17], and link:/doc/book/platform-information/upgrade-java-to-21/[upgrading to Java 21].

--- a/content/doc/book/platform-information/upgrade-java-to-11.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-11.adoc
@@ -1,13 +1,13 @@
 ---
 layout: subsection
-title: Upgrading to Java 11
+title: Upgrade to Java 11
 ---
 
 When upgrading the JVM used to run Jenkins from Java 8 to Java 11, there are some details you should know and precautions you should take.
 
 video::L2Uomz8RWUM[youtube,width=800,height=420]
 
-== Backing up Jenkins
+== Back up Jenkins
 
 As with any upgrade, we recommend:
  
@@ -33,7 +33,7 @@ Refer to <<Upgrading Plugins>> for further information.
 
 Starting with Jenkins releases 2.357 and LTS 2.361.1, Java 11 or Java 17 is required.
 
-== Upgrading Plugins
+== Upgrade Plugins
 
 When upgrading the Java version for Jenkins and the JVM, it is important to upgrade all plugins that support Java 11.
 Plugin upgrades assure compatibility with the most recent Jenkins releases.

--- a/content/doc/book/platform-information/upgrade-java-to-17.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-17.adoc
@@ -1,14 +1,14 @@
 ---
 layout: subsection
-title: Upgrading to Java 17
+title: Upgrade to Java 17
 ---
 
-When upgrading from JVM used to run Jenkins Java 11 to Java 17, there are some details you should know and precautions you should take.
+When upgrading the JVM used to run Jenkins from Java 11 to Java 17, there are some details you should know and precautions you should take.
 
 .Upgrading Jenkins Java Version From 11 to 17
 video::ZabUz6sl-8I[youtube,width=800,height=420]
 
-== Backing up Jenkins
+== Back up Jenkins
 
 As with any upgrade, we recommend:
 
@@ -16,7 +16,7 @@ As with any upgrade, we recommend:
 . Testing the upgrade with your backup.
 . Only after all required tests pass, performing the upgrade on your production controller.
 
-== Upgrading Jenkins
+== Upgrade Jenkins
 
 If you need to upgrade Jenkins, as well as the JVM, we recommend you:
 

--- a/content/doc/book/platform-information/upgrade-java-to-21.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-21.adoc
@@ -4,7 +4,7 @@ title: Upgrade to Java 21
 ---
 
 When upgrading the JVM used to run Jenkins from Java 17 to Java 21, there are some details you should know and precautions you should take.
-Java 21 is supported as of LTS 2.426.1 and Jenkins Weekly 2.419.
+NOTE: Java 21 is supported as of LTS 2.426.1 and Jenkins Weekly 2.419.
 
 == Back up Jenkins
 
@@ -12,7 +12,7 @@ As with any upgrade, we recommend:
 
 . link:https:/doc/book/system-administration/backing-up/#jenkins_home[Backing up `JENKINS_HOME`].
 . Testing the upgrade with your backup.
-. Only after all required tests pass, performing the upgrade on your production controller.
+. After all required tests pass, execute the upgrade on your production controller.
 
 === Upgrade the Jenkins Java version to Java 21
 
@@ -22,18 +22,19 @@ video::8xQVGpWeIe0[youtube,width=800,height=420]
 To verify the Java version currently used in your controller:
 
 . Navigate to *Manage Jenkins* and then select *System Information* in the *Status Information* section.
-. While on the *System Properties* tab, locate the `java.runtime.version` and reveal the hidden value to display your current Java version.
+. On the *System Properties* tab, locate the `java.runtime.version` and reveal the hidden value to display your current Java version.
 
 To verify the Java version currently used in your agent:
 
-. Select an agent name from the *Build Executor Status* widget and then select *System Information*
+. Select an agent name from the *Build Executor Status* widget and then select *System Information*.
 . Locate the `java.runtime.version` and reveal the hidden value to display the current Java version.
 
 The `checkNodes` script determines what version of Java is running the controller process, along with the version of the agent that's associated with that controller.
 The script then checks the version of Java that is on the agent.
 When these values are returned, `OK` means that the agent Java version matches the controller Java version.
 Otherwise, the result displays the expected Java version and the version found instead.
-To run the `checkNodes` script:
+
+7To run the `checkNodes` script:
 
 . Navigate to *Manage Jenkins* and select *Script Console* from the *Tools and Actions* section.
 . Copy the following script into the empty text box and select *Run*:
@@ -90,15 +91,15 @@ return;
 
 The following steps are taken from the video linked at the top of this page.
 
-. Stop the Jenkins controller using `systemctl stop jenkins`.
+. Stop the Jenkins controller with `systemctl stop jenkins`.
 . Install the corresponding Java version with `dnf -y install temurin-21-jdk`.
 . Check the Java version with `java -version`.
-. Change the default Java for the system using `update-alternatives --config java` and then enter `2` to select Java 21.
-. Restart Jenkins using `systemctl restart jenkins`.
+. Change the default Java for the system with `update-alternatives --config java` and then enter `2` to select Java 21.
+. Restart Jenkins with `systemctl restart jenkins`.
 
 === Upgrade Jenkins
 
-If you need to upgrade Jenkins, as well as the JVM, we recommend you:
+To upgrade Jenkins, as well as the JVM, we recommend you:
 
 . link:/doc/book/system-administration/backing-up/#jenkins_home[Back up `JENKINS_HOME`].
 . Stop the Jenkins controller.
@@ -121,12 +122,12 @@ Refer to link:/participate/report-issue/#issue-reporting[our issue reporting doc
 
 === JVM version on agents
 
-All agents must be running on the same JVM version as the controller, due to how controllers and agents communicate.
+Due to how controllers and agents communicate, all agents must run on the same JVM version as the controller.
 If you're upgrading your Jenkins controller to run on Java 21, you must upgrade the JVM on your agents.
 
 Validating the version of each agent can be done with the plugin:versioncolumn[Versions Node Monitors] plugin.
 This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins controller.
-This plugin can also be configured to automatically disconnect any agent with an incorrect JVM version.
+You can configure this plugin to automatically disconnect any agent with an incorrect JVM version.
 
 === Upgrade to Java 21 on agents
 

--- a/content/doc/book/platform-information/upgrade-java-to-21.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-21.adoc
@@ -34,7 +34,7 @@ The script then checks the version of Java that is on the agent.
 When these values are returned, `OK` means that the agent Java version matches the controller Java version.
 Otherwise, the result displays the expected Java version and the version found instead.
 
-7To run the `checkNodes` script:
+To run the `checkNodes` script:
 
 . Navigate to *Manage Jenkins* and select *Script Console* from the *Tools and Actions* section.
 . Copy the following script into the empty text box and select *Run*:
@@ -92,9 +92,9 @@ return;
 The following steps are taken from the video linked at the top of this page.
 
 . Stop the Jenkins controller with `systemctl stop jenkins`.
-. Install the corresponding Java version with `dnf -y install temurin-21-jdk`.
+. Install the corresponding Java version with `dnf -y install temurin-21-jdk` or with the package manager your system uses.
 . Check the Java version with `java -version`.
-. Change the default Java for the system with `update-alternatives --config java` and then enter `2` to select Java 21.
+. Change the default Java for the system by running `update-alternatives --config java` and then enter the number that corresponds to Java 21, for example `2` if that is the correct option.
 . Restart Jenkins with `systemctl restart jenkins`.
 
 === Upgrade Jenkins
@@ -134,7 +134,7 @@ You can configure this plugin to automatically disconnect any agent with an inco
 The following steps are taken from the video linked at the top of this page.
 
 . In the command line, log into the agent.
-. Enter `dnf -y install temurin-21-jdk`.
+. Enter `dnf -y install temurin-21-jdk`, or use the appropriate command for your package manager.
 . Check your java version using `java -version`.
 . Change the default Java version using `update-alternatives --config java` and then enter the selection corresponding to Java 21.
 . Verify the Java version has been updated with `java -version`.

--- a/content/doc/book/platform-information/upgrade-java-to-21.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-21.adoc
@@ -1,0 +1,141 @@
+---
+layout: subsection
+title: Upgrade to Java 21
+---
+
+When upgrading the JVM used to run Jenkins from Java 17 to Java 21, there are some details you should know and precautions you should take.
+Java 21 is supported as of LTS 2.426.1 and Jenkins Weekly 2.419.
+
+== Back up Jenkins
+
+As with any upgrade, we recommend:
+
+. link:https:/doc/book/system-administration/backing-up/#jenkins_home[Backing up `JENKINS_HOME`].
+. Testing the upgrade with your backup.
+. Only after all required tests pass, performing the upgrade on your production controller.
+
+=== Upgrade the Jenkins Java version to Java 21
+
+.Upgrading Jenkins Java Version From 17 to 21
+video::8xQVGpWeIe0[youtube,width=800,height=420]
+
+To verify the Java version currently used in your controller:
+
+. Navigate to *Manage Jenkins* and then select *System Information* in the *Status Information* section.
+. While on the *System Properties* tab, locate the `java.runtime.version` and reveal the hidden value to display your current Java version.
+
+To verify the Java version currently used in your agent:
+
+. Select an agent name from the *Build Executor Status* widget and then select *System Information*
+. Locate the `java.runtime.version` and reveal the hidden value to display the current Java version.
+
+The `checkNodes` script determines what version of Java is running the controller process, along with the version of the agent that's associated with that controller.
+The script then checks the version of Java that is on the agent.
+When these values are returned, `OK` means that the agent Java version matches the controller Java version.
+Otherwise, the result displays the expected Java version and the version found instead.
+To run the `checkNodes` script:
+
+. Navigate to *Manage Jenkins* and select *Script Console* from the *Tools and Actions* section.
+. Copy the following script into the empty text box and select *Run*:
+
+[source]
+----
+/*** BEGIN META {
+ "name" : "Check Nodes Version",
+ "comment" : "Check the .jar version and the java version of the Nodes against the Master versions",
+ "parameters" : [ ],
+ "core": "1.609",
+ "authors" : [
+ { name : "Allan Burdajewicz" }
+ ]
+ } END META**/
+
+import hudson.remoting.Launcher
+import hudson.slaves.SlaveComputer
+import jenkins.model.Jenkins
+
+def expectedAgentVersion = Launcher.VERSION
+def expectedJavaVersion = System.getProperty("java.version")
+println "Master"
+println " Expected Agent Version = '${expectedAgentVersion}'"
+println " Expected Java Version = '${expectedJavaVersion}'"
+Jenkins.instance.getComputers()
+        .findAll { it instanceof SlaveComputer }
+        .each { computer ->
+    println "Node '${computer.name}'"
+    if (!computer.getChannel()) {
+        println " is disconnected."
+    } else {
+        def isOk = true
+        def agentVersion = computer.getSlaveVersion()
+        if (!expectedAgentVersion.equals(agentVersion)) {
+            println " expected agent version '${expectedAgentVersion}' but got '${agentVersion}'"
+            isOk = false
+        }
+        def javaVersion = computer.getSystemProperties().get("java.version")
+        if (!expectedJavaVersion.equals(javaVersion)) {
+            println " expected java version '${expectedJavaVersion}' but got '${javaVersion}'"
+            isOk = false
+        }
+
+        if(isOk) {
+            println " OK"
+        }
+    }
+}
+return;
+----
+
+=== Upgrade to Java 21 on your Jenkins controller
+
+The following steps are taken from the video linked at the top of this page.
+
+. Stop the Jenkins controller using `systemctl stop jenkins`.
+. Install the corresponding Java version with `dnf -y install temurin-21-jdk`.
+. Check the Java version with `java -version`.
+. Change the default Java for the system using `update-alternatives --config java` and then enter `2` to select Java 21.
+. Restart Jenkins using `systemctl restart jenkins`.
+
+=== Upgrade Jenkins
+
+If you need to upgrade Jenkins, as well as the JVM, we recommend you:
+
+. link:/doc/book/system-administration/backing-up/#jenkins_home[Back up `JENKINS_HOME`].
+. Stop the Jenkins controller.
+. Upgrade the JVM on which Jenkins is running.
+** Use a package manager to install the new JVM.
+** Ensure the default JVM is the newly installed version.
+*** If it is not, run `systemctl edit jenkins`, and set either the `JAVA_HOME` environment variable or the `JENKINS_JAVA_CMD` environment variable.
+. Upgrade Jenkins to the most recent version.
+** How you upgrade Jenkins is dependent upon your original Jenkins installation method.
++
+TIP: We recommend that you use the package manager of your system (such as `apt` or `yum`).
+. Validate the upgrade to confirm that all plugins and jobs are loaded.
+. Upgrade the required plugins.
+
+When upgrading the Java version for Jenkins and the JVM, it is important to upgrade all plugins that support Java 21.
+Plugin upgrades assure compatibility with the most recent Jenkins releases.
+
+NOTE: If you discover a previously unreported issue, please let us know.
+Refer to link:/participate/report-issue/#issue-reporting[our issue reporting documentation] for guidance.
+
+=== JVM version on agents
+
+All agents must be running on the same JVM version as the controller, due to how controllers and agents communicate.
+If you're upgrading your Jenkins controller to run on Java 21, you must upgrade the JVM on your agents.
+
+Validating the version of each agent can be done with the plugin:versioncolumn[Versions Node Monitors] plugin.
+This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins controller.
+This plugin can also be configured to automatically disconnect any agent with an incorrect JVM version.
+
+=== Upgrade to Java 21 on agents
+
+The following steps are taken from the video linked at the top of this page.
+
+. In the command line, log into the agent.
+. Enter `dnf -y install temurin-21-jdk`.
+. Check your java version using `java -version`.
+. Change the default Java version using `update-alternatives --config java` and then enter the selection corresponding to Java 21.
+. Verify the Java version has been updated with `java -version`.
+. From the agent page in your Jenkins controller, select *Disconnect*.
+. After disconnecting the agent, reconnect it by selecting *Bring this node back online* and then selecting *Launch agent*.


### PR DESCRIPTION
This PR is to add instructions on upgrading to Java 21. It includes the video that Darin Pope has recorded, and step by step instructions on how to perform the upgrade for both the controller and agents. It also adjusts some of the section headings to adjust -ing verbs and phrases.