### PR TITLE
[chore] Remove note about a closed epic

### DIFF
--- a/content/participate/track-issue.adoc
+++ b/content/participate/track-issue.adoc
@@ -8,9 +8,6 @@ tags:
   - contributing
 ---
 
-NOTE: This page is under development, there will be more content added soon.
-See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
-
 == How-To Track an Issue
 
 The Jenkins JIRA is not a support site. If you need assistance or have


### PR DESCRIPTION
The note mentions an ongoing epic that has been closed for some time.