### PR TITLE
Update Community Awards jumbotron with voting form

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -13,15 +13,14 @@
 # Jenkins 2025 Community Awards Open
 - :href: /blog/2025/03/18/jenkins-contributor-awards-2025-nomination-is-open/
   :title: Jenkins 2025 Community Awards
-  :intro: Nominations for the 2025 
-    Jenkins Community Awards are now open!
-    Nominations are open until April 14, 2025.
+  :intro: Voting is now open!
+    Voting begins on April 22 and closes on June 5, 2025.
   :image:
     :src: /images/post-images/2025/03/community-awards-2025-jenkins.png
     :height: 285px
   :call_to_action:
-    :text: Additional information is available in our blog post 
-    :href: /blog/2025/03/18/jenkins-contributor-awards-2025-nomination-is-open/
+    :text: Make your voice heard by voting through this Google form.
+    :href: https://forms.gle/TjFR6kgYoasrUrFF9
 
 # Jenkins 2024 DevOps Dozen Award
 - :href: https://devopsdozen.com/devops-dozen-2024-community-award-winners/

--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -13,8 +13,8 @@
 # Jenkins 2025 Community Awards Open
 - :href: /blog/2025/03/18/jenkins-contributor-awards-2025-nomination-is-open/
   :title: Jenkins 2025 Community Awards
-  :intro: Voting is now open!
-    Voting begins on April 22 and closes on June 5, 2025.
+  :intro: Vote for the Jenkins 2025 Community Awards!
+    Voting opened on April 22 and closes on June 5, 2025.
   :image:
     :src: /images/post-images/2025/03/community-awards-2025-jenkins.png
     :height: 285px


### PR DESCRIPTION
This PR is to update the 2025 Jenkins Community Awards slide on the jumbotron to include the link to the voting form and update the text a bit. The overall slide still links to the blog post, but the link button has been updated to go directly to the form.