### PR TITLE
Update Docker installation for jdk21

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -78,7 +78,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk17
+FROM jenkins/jenkins:{jenkins-stable}-jdk21
 USER root
 RUN apt-get update && apt-get install -y lsb-release ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
@@ -192,7 +192,7 @@ docker run --name jenkins-docker --rm --detach ^
 +
 [source,dockerfile,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk17
+FROM jenkins/jenkins:{jenkins-stable}-jdk21
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \


### PR DESCRIPTION
This PR is to update the jdk used in the Docker installation instructions from 17 to 21.