### PR TITLE
Update Pipeline Syntax docs to remove role from text

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -24,7 +24,7 @@ As discussed at the link:../[start of this chapter], the most fundamental part o
 
 For an overview of available steps, please refer to the link:/doc/pipeline/steps[Pipeline Steps reference] which contains a comprehensive list of steps built into Pipeline as well as steps provided by plugins.
 
-[role=syntax]
+[[declaritive-pipeline]]
 == Declarative Pipeline
 
 Declarative Pipeline presents a more simplified and opinionated syntax on top of the Pipeline sub-systems.
@@ -32,7 +32,7 @@ In order to use them, install the plugin:pipeline-model-definition[Pipeline: Dec
 
 All valid Declarative Pipelines must be enclosed within a `pipeline` block, for example:
 
-[.width-min ]
+[.width-min]
 [source,groovy]
 ----
 pipeline {

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -24,7 +24,7 @@ As discussed at the link:../[start of this chapter], the most fundamental part o
 
 For an overview of available steps, please refer to the link:/doc/pipeline/steps[Pipeline Steps reference] which contains a comprehensive list of steps built into Pipeline as well as steps provided by plugins.
 
-[[declaritive-pipeline]]
+[[declarative-pipeline]]
 == Declarative Pipeline
 
 Declarative Pipeline presents a more simplified and opinionated syntax on top of the Pipeline sub-systems.

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -2019,7 +2019,7 @@ pipeline {
 ----
 =====
 
-[role=syntax]
+[[scripted-pipeline]]
 == Scripted Pipeline
 
 Scripted Pipeline, like <<declarative-pipeline>>, is built on top of the underlying Pipeline sub-system.


### PR DESCRIPTION
The current Pipeline Syntax page has bars spanning the page under section headers. These bars appear in both dark & light mode:

Dark mode:
<img width="1005" alt="Screenshot 2025-04-25 at 10 47 29 AM" src="https://github.com/user-attachments/assets/a8714ac4-69db-421c-b4cd-6db4f660a6b7" />

Light mode:
<img width="957" alt="Screenshot 2025-04-25 at 10 51 59 AM" src="https://github.com/user-attachments/assets/21f773e7-d563-4187-9155-fd7b1913b603" />


This PR removes the unnecessary `[role=sytax]` above the Declarative Pipeline header, thus removing the bars from the page:

Dark mode:
![Screenshot 2025-04-25 at 10 47 35 AM](https://github.com/user-attachments/assets/c8e67401-d458-42ed-a7d1-0d5b63d1ca6d)

Light mode:
![Screenshot 2025-04-25 at 10 54 58 AM](https://github.com/user-attachments/assets/7f2995a3-69ea-4570-8084-10ce830a89d3)
