### PR TITLE
Update keyring location

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -44,9 +44,9 @@ It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-
 
 [source,bash]
 ----
-sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
+sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
   https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
-echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc]" \
+echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc]" \
   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update
@@ -62,9 +62,9 @@ It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt re
 
 [source,bash]
 ----
-sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
+sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
   https://pkg.jenkins.io/debian/jenkins.io-2023.key
-echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc]" \
+echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc]" \
   https://pkg.jenkins.io/debian binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update


### PR DESCRIPTION
As in https://github.com/jenkinsci/packaging/pull/521, update the keyring location. Per [`sources.list(5)`](https://manpages.ubuntu.com/manpages/plucky/en/man5/sources.list.5.html):

> The recommended locations for keyrings are `/usr/share/keyrings` for keyrings managed by packages, and `/etc/apt/keyrings` for keyrings managed by the system operator.

The package does not manage any keyrings, so `/etc/apt/keyrings` is the more appropriate choice here.

### Testing done

Tested this location on my Ubuntu system; it works the same as before.