### PR TITLE
Fix the example Docker plugin installation definition

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -2,11 +2,9 @@
 This file is only meant to be included as a snippet in other documents.
 There is a version of this file for the general 'Installing Jenkins' page
 (index.adoc) and another for tutorials (_run-jenkins-in-docker.adoc).
-This file is for the index.adoc page used in the general 'Installing Jenkins'
-page.
+This file is for the index.adoc page used in the general 'Installing Jenkins' page.
 If you update content on this page, please ensure the changes are reflected in
-the sibling file _docker-for-tutorials.adoc (used in
-_run-jenkins-in-docker.adoc).
+the sibling file _docker-for-tutorials.adoc (used in _run-jenkins-in-docker.adoc).
 ////
 
 
@@ -90,7 +88,7 @@ RUN apt-get update && apt-get install -y lsb-release ca-certificates curl && \
     apt-get update && apt-get install -y docker-ce-cli && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
+RUN jenkins-plugin-cli --plugins "blueocean docker-workflow json-path-api"
 ----
 .. Build a new docker image from this Dockerfile, and assign the image a meaningful name, such as "myjenkins-blueocean:{jenkins-stable}-1":
 +
@@ -203,7 +201,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y docker-ce-cli
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean docker-workflow"
+RUN jenkins-plugin-cli --plugins "blueocean docker-workflow json-path-api"
 ----
 .. Build a new docker image from this Dockerfile and assign the image a meaningful name, e.g. "myjenkins-blueocean:{jenkins-stable}-1":
 +


### PR DESCRIPTION
## Fix the example Docker plugin installation definition

The [Docker install](https://www.jenkins.io/doc/book/installing/docker/) fails to load plugins.  The container starts but does not load many of the plugins because the token macro plugin fails to load.  The token macro plugin fails to load because the plugin installation manager tool does not download its dependency on the json path api plugin.

The issue is reported in the plugin installation manager tool:

* https://github.com/jenkinsci/plugin-installation-manager-tool/issues/628

The fix was already applied to the [Blue Ocean tutorial](https://www.jenkins.io/doc/tutorials/create-a-pipeline-in-blue-ocean/) in:

* https://github.com/jenkins-infra/jenkins.io/pull/7084

## Testing done

Checked that the instructions work as described and created a Jenkins job that ran docker commands from inside the controller.

Test Pipeline was:

```
pipeline {
    agent any
    stages {
        stage('Docker') {
            steps {
                sh 'echo FROM jenkins/jenkins:2.492.3 > Dockerfile && \
                    docker build -t my-jenkins:$BUILD_ID . && \
                    docker images && \
                    docker run --rm my-jenkins:$BUILD_ID --version'
            }
        }
    }
}
```
