### PR TITLE
Additional updates for Java 21 in documentation

### DIFF
--- a/content/doc/book/installing/_docker-for-tutorials.adoc
+++ b/content/doc/book/installing/_docker-for-tutorials.adoc
@@ -92,7 +92,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk17
+FROM jenkins/jenkins:{jenkins-stable}-jdk21
 USER root
 RUN apt-get update && apt-get install -y lsb-release ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
@@ -242,7 +242,7 @@ docker run --name jenkins-docker --detach ^
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk17
+FROM jenkins/jenkins:{jenkins-stable}-jdk21
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \

--- a/content/doc/book/pipeline/shared-libraries.adoc
+++ b/content/doc/book/pipeline/shared-libraries.adoc
@@ -722,8 +722,8 @@ By opening a pull request on https://github.com/jenkinsci/jenkins-infra-test-plu
   buildPlugin(
     useContainerAgent: true,
     configurations: [
-      [platform: 'linux', jdk: 17],
-      [platform: 'windows', jdk: 11],
+      [platform: 'linux', jdk: 21],
+      [platform: 'windows', jdk: 17],
   ])
 ----
 

--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -344,14 +344,14 @@ pipeline {
     agent none // <1>
     stages {
         stage('Example Build') {
-            agent { docker 'maven:3.9.3-eclipse-temurin-17' } // <2>
+            agent { docker 'maven:3.9.9-eclipse-temurin-21' } // <2>
             steps {
                 echo 'Hello, Maven'
                 sh 'mvn --version'
             }
         }
         stage('Example Test') {
-            agent { docker 'openjdk:17-jre' } // <3>
+            agent { docker 'openjdk:21-jre' } // <3>
             steps {
                 echo 'Hello, JDK'
                 sh 'java -version'

--- a/content/doc/book/scaling/architecting-for-manageability.adoc
+++ b/content/doc/book/scaling/architecting-for-manageability.adoc
@@ -163,7 +163,7 @@ control our _$JENKINS_HOME_ in a Github repository known as "demo-joc". The
 
 [source,bash]
 ----
-FROM eclipse-temurin:17-jdk-jammy
+FROM eclipse-temurin:21-jdk-jammy
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/content/doc/book/scaling/scaling-jenkins-on-kubernetes.adoc
+++ b/content/doc/book/scaling/scaling-jenkins-on-kubernetes.adoc
@@ -57,7 +57,7 @@ So let’s create our first example Dockerfile for the Jenkins controller:
 .Dockerfile
 [source,Dockerfile]
 ----
-FROM jenkins/jenkins:lts-slim-jdk17 <1>
+FROM jenkins/jenkins:lts-slim-jdk21 <1>
 # Pipelines with Blue Ocean UI and Kubernetes
 RUN jenkins-plugin-cli --plugins blueocean kubernetes <2>
 ----

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-pomerium.adoc
@@ -51,7 +51,7 @@ In the `docker-compose.yaml` file, add the following code:
 jenkins:
   networks:
     main: {}
-  image: jenkins/jenkins:lts-jdk17
+  image: jenkins/jenkins:lts-jdk21
   privileged: true
   user: root
   ports:
@@ -172,7 +172,7 @@ services:
  jenkins:
    networks:
      main: {}
-   image: jenkins/jenkins:lts-jdk17
+   image: jenkins/jenkins:lts-jdk21
    privileged: true
    user: root
    ports:

--- a/content/doc/book/system-administration/systemd-services.adoc
+++ b/content/doc/book/system-administration/systemd-services.adoc
@@ -87,7 +87,7 @@ Environment="JAVA_OPTS=-Djava.awt.headless=true -XX:+UseStringDeduplication"
 
 # Arbitrary additional arguments to pass to Jenkins.
 # Full option list: java -jar jenkins.war --help
-Environment="JENKINS_OPTS=--prefix=/jenkins --javaHome=/opt/jdk-17"
+Environment="JENKINS_OPTS=--prefix=/jenkins --javaHome=/opt/jdk-21"
 
 # Configuration as code directory
 Environment="CASC_JENKINS_CONFIG=/var/lib/jenkins/configuration-as-code/"

--- a/content/doc/book/using/using-agents.adoc
+++ b/content/doc/book/using/using-agents.adoc
@@ -125,7 +125,7 @@ Here we will use the link:https://github.com/jenkinsci/docker-ssh-agent[docker-s
 ----
 docker run -d --rm --name=agent1 -p 22:22 \
 -e "JENKINS_AGENT_SSH_PUBKEY=[your-public-key]" \
-jenkins/ssh-agent:alpine-jdk17
+jenkins/ssh-agent:alpine-jdk21
 ----
 +
 [NOTE]
@@ -150,7 +150,7 @@ Here we will use the link:https://github.com/jenkinsci/docker-ssh-agent[docker-s
 ----
 docker run -d --rm --name=agent1 --network jenkins -p 22:22 `
   -e "JENKINS_AGENT_SSH_PUBKEY=[your-public-key]" `
-  jenkins/ssh-agent:jdk17
+  jenkins/ssh-agent:jdk21
 ----
 +
 [NOTE]

--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -26,9 +26,9 @@ endif::[]
 
 // TIMEBASED
 Jenkins is based on Java, so to build Jenkins plugins you need to install a Java Development Kit (JDK).
-Java 17 is the version we recommend to users, so that's what we're using in this tutorial.
+Java 21 is the version we recommend to users, so that's what we're using in this tutorial.
 
-You can download and install Java 17 from the link:https://adoptium.net/[Eclipse Temurin website].
+You can download and install Java 21 from the link:https://adoptium.net/[Eclipse Temurin website].
 
 NOTE: Many Linux distributions provide packages for Java for an easier install and upgrade experience.
 Consult your distribution's documentation for details.
@@ -44,7 +44,7 @@ To verify that Maven is installed, run the following command:
 mvn -version
 ----
 This command prints some diagnostic output, including the versions of Java and Maven, and which Java installation was found by Maven.
-It should indicate a _17_ version of Java, and list the path to where Java is located.
+It should indicate a _21_ version of Java, and list the path to where Java is located.
 If you don't see this information, see <<Troubleshooting>>.
 
 == Setting up a productive environment with your IDE

--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -96,16 +96,6 @@ conditions:
       image: "jenkins/jenkins"
       tag: '{{ source "JenkinsLatestLTS" }}-jdk17'
 targets:
-  setJenkinsLatestLTSVersionInDockerTutorial:
-    kind: file
-    name: "Bump Jenkins latest LTS version in the Docker Tutorial"
-    sourceid: JenkinsLatestLTS
-    spec:
-      file: content/doc/book/installing/_docker-for-tutorials.adoc
-      matchpattern: >-
-        (.*FROM jenkins/jenkins:)(.*)(-jdk17.*)
-      replacepattern: >-
-        ${1}{{ source "JenkinsLatestLTSBaseline" }}${3}
   setJenkinsLatestLTSVersionInRecommendedVersions:
     kind: file
     name: "Bump Jenkins latest LTS version in the recommended versions section"


### PR DESCRIPTION
These are additional updates for Java 21 throughout various parts of the documentation.

This also matches the shared libraries info with the [jenkins infra test plugin](https://github.com/jenkinsci/jenkins-infra-test-plugin) where linux uses 21, but windows is using 17.