### PR TITLE
Update Java version to 21 in jenkins-lts updatecli file

### DIFF
--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -89,12 +89,12 @@ conditions:
   jenkinsThirdToLastVersion:
     kind: jenkins
     sourceid: JenkinsThirdToLastLTS
-  jenkinsLatestLTSJdk17Image:
+  jenkinsLatestLTSJdk21Image:
     kind: dockerimage
     sourceid: JenkinsLatestLTS
     spec:
       image: "jenkins/jenkins"
-      tag: '{{ source "JenkinsLatestLTS" }}-jdk17'
+      tag: '{{ source "JenkinsLatestLTS" }}-jdk21'
 targets:
   setJenkinsLatestLTSVersionInRecommendedVersions:
     kind: file


### PR DESCRIPTION
This PR is to update the java version in the jenkins-lts updatecli file so that it is pointing to Java 21 instead of Java 17. Thanks to @gounthar for confirming this update is correct.