### PR TITLE
Update Gradle image for docker in pipeline

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -130,7 +130,7 @@ The following example will cache `~/.m2` between Pipeline runs utilizing the lin
 pipeline {
     agent {
         docker {
-            image 'maven:3.9.3-eclipse-temurin-17'
+            image 'maven:3.9.9-eclipse-temurin-21'
             args '-v $HOME/.m2:/root/.m2'
         }
     }

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -98,7 +98,7 @@ pipeline {
         stage('Build') {
             agent {
                 docker {
-                    image 'gradle:8.2.0-jdk17-alpine'
+                    image 'gradle:8.14.0-jdk21-alpine'
                     // Run the container on the node specified at the
                     // top-level of the Pipeline, in the same workspace,
                     // rather than on a new node entirely:


### PR DESCRIPTION
This PR is to update the image used in the Using Docker with Pipeline documentation to use Java 21. Grabbing the latest image from the Gradle dockerhub shows that it is `8.14.0-jdk21-alpine` and adding the `maven:3.9.9-eclipse-temurin-21`