### PR TITLE
Update release date for last 2 weekly releases

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26563,7 +26563,7 @@
   # pull: 10552 (PR title: Update Yarn to v4.9.1)
 
   - version: '2.507'
-    date: 2025-04-21
+    date: 2025-04-22
     changes:
       - type: major rfe
         category: major rfe
@@ -26612,7 +26612,7 @@
   # pull: 10575 (PR title: Update bridge-method-injector.version to v1.31)
 
   - version: '2.508'
-    date: 2025-04-28
+    date: 2025-04-29
     changes:
       - type: bug
         category: bug


### PR DESCRIPTION
This PR is to update the last two weekly releases' (2.508 & 2.507) release dates. They are currently showing as though they were released on the day prior to the actual release.