### PR TITLE
Update prepare.adoc

### DIFF
--- a/content/doc/developer/tutorial/prepare.adoc
+++ b/content/doc/developer/tutorial/prepare.adoc
@@ -37,7 +37,7 @@ To check if you have Java already installed, run `java -version` on a command pr
 // Install and configure Apache Maven
 include::doc/developer/tutorial-improve/_install-apache-maven.adoc[]
 
-Validate the versions you install are compatible with the link:https://jenkinsci.github.io/maven-hpi-plugin/plugin-info.html[minimum requirements] of the hpi plugin.
+Please ensure that the versions you install are compatible with the link:https://jenkinsci.github.io/maven-hpi-plugin/plugin-info.html[minimum requirements] of the HPI plugin.
 
 To verify that Maven is installed, run the following command:
 


### PR DESCRIPTION
There's a non obvious situation in which if you don't have the appropriate versions of JDK and Maven then you will get an issue saying `hpi` packaging is not available.