### PR TITLE
Remove low impact bug fix from 2.508 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26613,16 +26613,7 @@
 
   - version: '2.508'
     date: 2025-04-29
-    changes:
-      - type: bug
-        category: bug
-        pull: 10601
-        issue: 75605
-        authors:
-          - mpohajac
-        pr_title: "[JENKINS-75605] sl message catalog typo fix"
-        message: |-
-          Correct the spelling of <code>Success</code> in the Slovenian translation.
+    changes: []
 
   # pull: 10564 (PR title: Tweak 'App bar' height)
   # pull: 10569 (PR title: Simplify `LoadStatistics`)
@@ -26642,6 +26633,7 @@
   # pull: 10598 (PR title: Update dependency io.jenkins.plugins:design-library to v380)
   # pull: 10599 (PR title: Update dependency org.jenkins-ci.main:jenkins-test-harness to v2439)
   # pull: 10600 (PR title: Update dependency stylelint to v16.19.0)
+  # pull: 10601 (PR title: [JENKINS-75605] sl message catalog typo fix)
   # pull: 10602 (PR title: Update dependency io.jenkins.plugins:echarts-api to v5.6.0-4)
   # pull: 10603 (PR title: Update dependency com.puppycrawl.tools:checkstyle to v10.23.1)
   # pull: 10605 (PR title: Update dependency webpack to v5.99.7)


### PR DESCRIPTION
## Remove low impact bug fix from 2.508 changelog

Address [concern](https://github.com/jenkins-infra/jenkins.io/pull/8053#issuecomment-2848761005) from Daniel Beck that the spelling fix in the message is not impactful enough to justify an entry in the weekly changelog.

The Jenkins 2.478 changelog has an empty entry that is displayed as "No notable changes in this release".  This will be displayed in the same way.

For comparison, see 2.478 on www.jenkins.io and on the GitHub repository:

* https://www.jenkins.io/changelog/2.478/
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.478

This changelog retains the comments for the skipped entries.  The 2.478 changelog data has not been adjusted to include the skipped entries.
