### PR TITLE
Fix reuseNode sample Pipeline

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -106,7 +106,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'gradle --version'
+                sh 'gradle -g gradle-user-home --version'
             }
         }
     }


### PR DESCRIPTION
## Fix reuseNode sample Pipeline

The original gradle command fails with the message:

```
  + gradle --version

  FAILURE: Build failed with an exception.

  * What went wrong:
  Gradle could not start your build.
  > Could not initialize native services.
  > Failed to load native library 'libnative-platform.so' for Linux amd64.

  * Try:
  > Run with --stacktrace option to get the stack trace.
  > Run with --info or --debug option to get more log output.
  > Run with --scan to get full insights.
  > Get more help at https://help.gradle.org.
```

A workaround / solution is offered in a [stackoverflow article](https://stackoverflow.com/questions/38519643/failed-to-load-native-library-libnative-platform-so-for-linux-amd64).

Once that change is made, the Pipeline output is:

```
  + gradle -g gradle-user-home --version

  Welcome to Gradle 8.14!

  Here are the highlights of this release:
   - Java 24 support
   - GraalVM Native Image toolchain selection
   - Enhancements to test reporting
   - Build Authoring improvements

  For more details see https://docs.gradle.org/8.14/release-notes.html
```
