### PR TITLE
Add banner for docker image Java 21 change

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26617,6 +26617,11 @@
 
   - version: '2.509'
     date: 2025-05-06
+    banner: >
+      Starting with Jenkins 2.509, the default Docker images ('2.509', 'latest', 'alpine', 'slim',
+      ...) use Java 21 unless specifically tagged with the <code>jdk17</code> string.
+      Refer to the <a href="https://github.com/jenkinsci/docker/releases/tag/2.509">Docker
+      2.509 changelog</a> or <a href="https://github.com/jenkinsci/docker/pull/2008">pull request for this update</a> for more details.
     changes:
       - type: major rfe
         category: major rfe

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26618,7 +26618,7 @@
   - version: '2.509'
     date: 2025-05-06
     banner: >
-      Starting with Jenkins 2.509, the default Docker images ('2.509', 'latest', 'alpine', 'slim',
+      Starting with Jenkins 2.509, the default Docker images (<code>2.509</code>, <code>latest</code>, <code>alpine</code>, <code>slim</code>,
       ...) use Java 21 unless specifically tagged with the <code>jdk17</code> string.
       Refer to the <a href="https://github.com/jenkinsci/docker/releases/tag/2.509">Docker
       2.509 changelog</a> or <a href="https://github.com/jenkinsci/docker/pull/2008">pull request for this update</a> for more details.


### PR DESCRIPTION
This PR adds a banner to the 2.509 weekly changelog to inform users that the docker images are now using Java 21 as the default JDK. It includes links to both the docker image changelog & the specific PR where this change took place

![Screenshot 2025-05-06 at 1 52 19 PM](https://github.com/user-attachments/assets/3cf5d584-acec-4bd3-b2c1-7bbfadfcce75)
