### PR TITLE
Add back Active Directory upgrade instruction for 2.509 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26652,6 +26652,7 @@
         message: |-
           Jenkins' own user database no longer accepts new passwords longer than supported by bcrypt (72 bytes).
           Users with longer passwords are advised to change their password.
+          If you're using Active Directory plugin, make sure to update to version 2.40 at the same time as updating Jenkins.
       - type: bug
         category: bug
         pull: 10555

--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26652,7 +26652,7 @@
         message: |-
           Jenkins' own user database no longer accepts new passwords longer than supported by bcrypt (72 bytes).
           Users with longer passwords are advised to change their password.
-          If you're using Active Directory plugin, make sure to update to version 2.40 at the same time as updating Jenkins.
+          If you are using the Active Directory plugin, make sure to update to version 2.40 at the same time as updating Jenkins.
       - type: bug
         category: bug
         pull: 10555


### PR DESCRIPTION
This PR adds back a line for the jbcrypt/spring security entry of the 2.509 changelog.