### PR TITLE
Add separate entry for jbcrypt library removal

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26652,7 +26652,16 @@
         message: |-
           Jenkins' own user database no longer accepts new passwords longer than supported by bcrypt (72 bytes).
           Users with longer passwords are advised to change their password.
-          If you are using the Active Directory plugin, make sure to update to version 2.40 at the same time as updating Jenkins.
+      - type: rfe
+        category: rfe
+        pull: 10604
+        issue: 75533
+        authors:
+          - daniel-beck
+        pr_title: "[JENKINS-75533] Remove jbcrypt mindrot, use Spring Security instead"
+        message: |-
+          Remove jbcrypt library.
+          If you're using Active Directory plugin, make sure to update to version 2.40 at the same time as updating Jenkins.
       - type: bug
         category: bug
         pull: 10555


### PR DESCRIPTION
This PR is to update the 2.509 changelog with a separate entry for the jbcrypt library removal. Previously, just the message was updated, whereas it should be highlighted more specifically.