### PR TITLE
Update 2025 Community Awards carousel slide

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -11,10 +11,10 @@
     :href: /blog/2024/10/04/content-security-policy-grant/
 
 # Jenkins 2025 Community Awards Open
-- :href: /blog/2025/03/18/jenkins-contributor-awards-2025-nomination-is-open/
+- :href: /blog/2025/05/15/jenkins-contributor-awards-cast-your-vote/
   :title: Jenkins 2025 Community Awards
   :intro: Vote for the Jenkins 2025 Community Awards!
-    Voting opened on April 22 and closes on June 5, 2025.
+    Voting opened on April 22 and closes on June 16, 2025.
   :image:
     :src: /images/post-images/2025/03/community-awards-2025-jenkins.png
     :height: 285px


### PR DESCRIPTION
This PR is to update the Community Awards slide on the carousel to point to the latest blog post (announcing voting is open) and update the voting period dates to match the updated voting period.