### PR TITLE
fix: yaml links in kubernetes page

### DIFF
--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -103,7 +103,7 @@ To bind a ClusterRole to all the namespaces in our cluster, we use a ClusterRole
 +
 [source,bash]
 ----
-kubectl apply -f jenkins-02-sa.yaml
+kubectl apply -f jenkins-02-sa.yaml 
 ----
 
 === Install Jenkins

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -103,7 +103,7 @@ To bind a ClusterRole to all the namespaces in our cluster, we use a ClusterRole
 +
 [source,bash]
 ----
-kubectl apply -f jenkins-02-sa.yaml 
+kubectl apply -f jenkins-02-sa.yaml
 ----
 
 === Install Jenkins

--- a/content/doc/book/installing/_kubernetes.adoc
+++ b/content/doc/book/installing/_kubernetes.adoc
@@ -43,12 +43,12 @@ We choose to use the `/data` directory. This directory will contain our Jenkins 
 
 *We will create a volume which is called jenkins-pv:*
 
-. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-01-volume.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkinsHelm-01-volume.yaml] into a YAML formatted file called `jenkinsHelm-01-volume.yaml`.
+. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-01-volume.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkins-01-volume.yaml] into a YAML formatted file called `jenkins-01-volume.yaml`.
 . Run the following command to apply the spec:
 +
 [source,bash]
 ----
-kubectl apply -f jenkinsHelm-01-volume.yaml
+kubectl apply -f jenkins-01-volume.yaml
 ----
 
 NOTE: It’s worth noting that, in the above spec, hostPath uses the /data/jenkins-volume/ of your node to emulate network-attached storage.
@@ -96,14 +96,14 @@ A RoleBinding may reference any Role in the same namespace.
 Alternatively, a RoleBinding can reference a ClusterRole and bind that ClusterRole to the namespace of the RoleBinding.
 To bind a ClusterRole to all the namespaces in our cluster, we use a ClusterRoleBinding.
 
-. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkinsHelm-02-sa.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkinsHelm-02-sa.yaml] into a YAML formatted file called
-`jenkinsHelm-02-sa.yaml`.
+. Paste the content from link:https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/doc/tutorials/kubernetes/installing-jenkins-on-kubernetes/jenkins-02-sa.yaml[https://raw.githubusercontent.com/installing-jenkins-on-kubernetes/jenkins-02-sa.yaml] into a YAML formatted file called
+`jenkins-02-sa.yaml`.
 +
 . Run the following command to apply the spec:
 +
 [source,bash]
 ----
-kubectl apply -f jenkinsHelm-02-sa.yaml
+kubectl apply -f jenkins-02-sa.yaml
 ----
 
 === Install Jenkins


### PR DESCRIPTION
Description: 
The issue has been discussed in the Jenkins discourse channel via [this](https://community.jenkins.io/t/links-on-site-install-jenkins-on-kubernetes-not-working/31131) 

This PR updates the documentation to point to the correct official YAML files for Jenkins on Kubernetes installation.



I verified the links are working now .