### PR TITLE
Noting special character of bumps to version in lib wrapper plugin

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -242,6 +242,9 @@ Use the `revision` property for the `<dependency>` declaration to ensure they al
 </dependency>
 ----
 
+Remember that changes to this property mean that the wrapped component has been updated, which would typically be a significant change that deserves an appropriate release-triggering label (`developer`, `enhancement`, or `bug`).
+You may wish to edit your Dependabot configuration to automatically apply `developer` rather than `dependencies` for bumps to this special dependency.
+
 === Enable CD Permissions
 
 Enable the continuous delivery flag in link:https://github.com/jenkins-infra/repository-permissions-updater/[repository permission updater] (RPU) for your plugin by filing a pull request adding to `permissions/plugin-xxx.yml`:


### PR DESCRIPTION
https://github.com/jenkinsci/jackson2-api-plugin/pull/284#issuecomment-2900938681 Better yet would be to suggest a concrete example of such YAML config, but in the meantime it would be nice to at least note it.