### PR TITLE
Use ':Z' option to bind mount Docker volumes on SELinux

### DIFF
--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -4,7 +4,15 @@
 # https://github.com/jenkins-infra/jenkins.io/pull/1129
 if [[ "$(docker version -f {{.Server.Version}})" =~ ^1[7-9]\. ]]; then
     DELEGATED=:delegated
-fi;
+fi
+
+# When using SELinux, bind mounted Docker volumes need the ":Z" option
+# https://github.com/jenkinsci/acceptance-test-harness/pull/2032 has more details
+if [ -x /usr/bin/sestatus ]; then
+    if /usr/bin/sestatus | grep -q 'status:.*enabled'; then
+        DELEGATED=:Z
+    fi
+fi
 
 # allow scripts to be passed special argument that triggers a docker pull
 # without this images can get stale and out of sync from CI system


### PR DESCRIPTION
## Use ':Z' option to bind mount Docker volumes on SELinux

[ATH PR 2032](https://github.com/jenkinsci/acceptance-test-harness/pull/2032) shares what Basil Crow learned about bind mounts on Docker containers using Fedora Linux.

Fedora Linux SELinux requires the ":Z" option when bind-mounting local volumes into the container.

### Testing done:

Confirmed that `make run` fails on Fedora Linux 42 before this change and passes after this change.

Confirmed that `make run` succeeds on Ubuntu Linux in both cases.
