### PR TITLE
Update 2.512 packaging entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -26856,8 +26856,9 @@
         category: rfe
         authors:
           - slide
+        pr_title: "Add Powershell script to update registry information after war update"
         references:
-          - URL: https://github.com/jenkinsci/packaging/pull/494
+          - url: https://github.com/jenkinsci/packaging/pull/494
             title: Packaging PR 494
         message: |-
           Add Powershell script to Windows installer to update registry information after WAR update.


### PR DESCRIPTION
This PR is to update the packaging entry for the 2.512 changelog so that the reference/URL works as expected. Currently it is only showing as white text instead of a clickable link.