### PR TITLE
Document jenkins.security.JettySameSiteCookieSetup.sameSiteDefault

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1938,6 +1938,17 @@ properties:
   description: |
     When set to `true`, disable `Basic` authentication with username and password (rather than API token).
 
+- name: jenkins.security.JettySameSiteCookieSetup.sameSiteDefault
+  tags:
+  - escape hatch
+  - security
+  - tuning
+  def: |
+    Lax
+  # since: 2.51x TODO https://github.com/jenkinsci/jenkins/pull/10630
+  description: |
+    When running in Jetty (usually with `java -jar jenkins.war`), this allows customizing the value of the `SameSite` attribute of cookies set by Jenkins.
+
 - name: jenkins.security.ManagePermission
   tags:
   - feature

--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -1945,7 +1945,7 @@ properties:
   - tuning
   def: |
     Lax
-  # since: 2.51x TODO https://github.com/jenkinsci/jenkins/pull/10630
+  # since: 2.513
   description: |
     When running in Jetty (usually with `java -jar jenkins.war`), this allows customizing the value of the `SameSite` attribute of cookies set by Jenkins.
 


### PR DESCRIPTION
This PR is to document [jenkinsci/jenkins#10630](https://github.com/jenkinsci/jenkins/pull/10630) as originally submitted in https://github.com/jenkins-infra/jenkins.io/pull/8124 by @daniel-beck. Since that PR was merged too early and reverted, this plans to replace the documentation once the associated PR in jenkinsci is merged.