### PR TITLE
feat:add content to c/c++ solution page

### DIFF
--- a/content/solutions/c.adoc
+++ b/content/solutions/c.adoc
@@ -3,3 +3,46 @@ layout: solution
 title: "Jenkins and C/C++"
 ---
 
+Jenkins provides robust support for C and C++ projects, enabling efficient continuous integration and delivery pipelines for system software, embedded applications, and performance-critical solutions.
+
+== Building C/C++ Projects
+
+Jenkins integrates seamlessly with all major C/C++ build systems:
+
+* **Make/Ninja**: Execute builds through shell steps
+* **CMake**: Use the plugin:cmakebuilder[CMake Plugin] for configured builds
+* **Autotools**: Run `./configure` scripts with environment customization
+* **Cross-compilation**: Manage toolchains with plugin:custom-tools-plugin[Custom Tools Plugin]
+
+== Testing and Analysis
+
+* **Unit Testing**: Process results from Google Test, Catch2, and CppUnit with plugin:xunit[xUnit Plugin]
+* **Static Analysis**: Integrate Clang-Tidy, Cppcheck with plugin:warnings-ng[Warnings Next Generation Plugin]
+* **Code Coverage**: Generate reports using gcov and plugin:coverage[Cobertura Plugin]
+
+== Cross-Platform Support
+
+Jenkins supports matrix builds for multiple platforms (Linux, Windows, macOS) with consistent toolchains and environments.
+
+== Embedded Development
+
+Special considerations for firmware projects:
+
+* Hardware resource management with plugin:throttle-concurrents[Throttle Concurrent Builds Plugin]
+* Build reliability with plugin:build-timeout[Build Timeout Plugin]
+* Device flashing automation
+
+== Resources
+
+* link:https://www.jenkins.io/doc/tutorials/build-a-cpp-app-with-jenkins/[Build a C++ app with Jenkins tutorial]
+* link:https://github.com/jenkinsci/cmakebuilder-plugin[CMake Plugin documentation]
+
+== Presentations
+
+++++
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/FHPtchw-eHA" frameborder="0" allowfullscreen></iframe>
+</center>
+++++
+
+*Continuous Integration in C++* by TheCherno

--- a/content/solutions/c.adoc
+++ b/content/solutions/c.adoc
@@ -34,7 +34,7 @@ Special considerations for firmware projects:
 
 == Resources
 
-* link:https://www.jenkins.io/doc/tutorials/build-a-cpp-app-with-jenkins/[Build a C++ app with Jenkins tutorial]
+* link:/doc/tutorials/build-a-cpp-app-with-jenkins/[Build a C++ app with Jenkins tutorial]
 * link:https://github.com/jenkinsci/cmakebuilder-plugin[CMake Plugin documentation]
 
 == Presentations

--- a/content/solutions/c.adoc
+++ b/content/solutions/c.adoc
@@ -44,5 +44,4 @@ Special considerations for firmware projects:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/FHPtchw-eHA" frameborder="0" allowfullscreen></iframe>
 </center>
 ++++
-
 *Continuous Integration in C++* by TheCherno


### PR DESCRIPTION
All other pages has a content in their pages except c/c++. 
I have added some important resources and content to it . 
I have checked the links.