### PR TITLE
fix(download/mirrors) update instructions for mirror maintainers

### DIFF
--- a/content/download/mirrors.adoc
+++ b/content/download/mirrors.adoc
@@ -8,11 +8,11 @@
 :author: rtyler
 ---
 
-Jenkins packages and plugins are served by the web service https://get.jenkins.io (or its legacy alias mirrors.jenkins.io).
+Jenkins packages and plugins are served by the web service link:https://get.jenkins.io[get.jenkins.io] (or its legacy alias mirrors.jenkins.io).
 
-The web service https://get.jenkins.io relies on a network of mirror servers provided by generous sponsors of the Jenkins project all over the world.
-When a user download a plugin or a file, the web service https://get.jenkins.io redirects (transparently) the user to the closest mirror.
-The web service https://get.jenkins.io is based on the Open Source mirror redirector https://github.com/etix/mirrorbits.
+The web service link:https://get.jenkins.io[get.jenkins.io] relies on a network of mirror servers provided by generous sponsors of the Jenkins project all over the world.
+When a user download a plugin or a file, the web service link:https://get.jenkins.io[get.jenkins.io] redirects (transparently) the user to the closest mirror.
+The web service link:https://get.jenkins.io[get.jenkins.io] is based on the Open Source mirror redirector link:https://github.com/etix/mirrorbits[mirrorbits].
 
 The list of mirrors (and their locations) is available on the following page: link:https://get.jenkins.io/index.html?mirrorstats[mirror status page].
 
@@ -21,28 +21,28 @@ The list of mirrors (and their locations) is available on the following page: li
 Download mirror servers are always welcome to reduce the load on individual servers, to spread the bandwidth costs among multiple servers and to provide locations close to users.
 
 If you provide (or want to provide) a download mirror server, you'll have to fulfill the requirements below.
-We provide the link:https://github.com/jenkins-infra/helpdesk[GitHub "jenkins-infra" helpdesk] were you can open issues to add/change/delete a mirror or if you have any problem.
+We provide the link:https://github.com/jenkins-infra/helpdesk[GitHub "jenkins-infra" helpdesk] where you can open issues to add/change/delete a mirror or if you have any problem.
 
 
 Mirror requirements:
 
 * An HTTP server to serve files for the end users with:
-** A public IPv4 and IPv6 (we recommend both). You can have multiple IPs (see below).
+** A public IPv4 and IPv6 address (we recommend both). You can have multiple IPs (see below).
 ** A valid and resolvable public domain name pointing to your public IPs (we recommend `A` and `AAAA` DNS records). Multi-valued DNS records are valid if you have many IPs.
 ** Enforced HTTPS with a valid TLS certificate
 
-* A storage of at least 300Gb to to store ~1 year of files served by the HTTP server:
-** As a data point, the "reference" download server, which is https://archives.jenkins.io, uses around ~600Gb with **all** of the files.
-** 300Gb of data is enough to provide artifacts published for 1 year (recommended time window). You may clean artifacts older than 1 year (provided by the archives.jenkins.io).
+* A storage of at least 300Gb to store ~1 year of files served by the HTTP server:
+** As a data point, the "reference" download server, which is link:https://archives.jenkins.io[archives.jenkins.io], uses around ~600Gb with **all** of the files.
+** 300Gb of data is enough to provide artifacts published for 1 year (recommended time window). You may clean artifacts older than 1 year (provided by link:https://archives.jenkins.io[archives.jenkins.io]).
 
-* A rsync or FTP server to allow https://get.jenkins.io to scan your mirror regularly:
+* A rsync or FTP server to allow link:https://get.jenkins.io[get.jenkins.io] to scan your mirror regularly:
 ** Should serve the same data as the HTTP server
-** You can restrict inbound requests using IPs: we provide an API endpoint at https://reports.jenkins.io/infrastructure/v2/index.json with our rsync/ftp outbound scanning IPs.
+** You can restrict inbound requests using an IP allowlist, we provide an API endpoint at link:https://reports.jenkins.io/infrastructure/v2/index.json[reports.jenkins.io/infrastructure/v2/index.json] with our rsync/ftp outbound IPs.
 *** Check the JSON list at `"get.jenkins.io".outbound_ips[]`
 *** Our scanning IPs do not change often (once a year usually) but we update the JSON daily in case of any change
 
 * A rsync routine to keep your data up to date:
-** The data source is rsync://archives.jenkins.io without authentication but we need your outbound IPs to restrict access.
+** The data source is `rsync://archives.jenkins.io` without authentication but we need your outbound IPs to restrict access.
 ** We recommend a (differential) data update at least hourly
 ** The file can be deleted if they are more than 1 year old to avoid filling your disks, unless you have at least 600 Gb of data available
 
@@ -50,6 +50,6 @@ Mirror requirements:
 ** If you wish for us to keep this email privately, please send it to jenkins-infra-team@googlegroups.com
 
 * The outbound IP(s) used by your rsync server to update data (so we can apply restrictions)
-** We store these IPs in https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json
+** We store these IPs in link:https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json[get-jenkins-io-data.json]
 ** You can open a Pull Request on this file to add/change your outbound IPs (even if your mirror is not up to date yet)
 ** Alternatively you can email them to us at jenkins-infra-team@googlegroups.com or share with us an API endpoint where we can retrieve the IPs regularly

--- a/content/download/mirrors.adoc
+++ b/content/download/mirrors.adoc
@@ -11,14 +11,14 @@
 Jenkins packages and plugins are served by the web service link:https://get.jenkins.io[get.jenkins.io] (or its legacy alias mirrors.jenkins.io).
 
 The web service link:https://get.jenkins.io[get.jenkins.io] relies on a network of mirror servers provided by generous sponsors of the Jenkins project all over the world.
-When a user download a plugin or a file, the web service link:https://get.jenkins.io[get.jenkins.io] redirects (transparently) the user to the closest mirror.
+When a user downloads a plugin or a file, the web service link:https://get.jenkins.io[get.jenkins.io] redirects (transparently) the user to the closest mirror.
 The web service link:https://get.jenkins.io[get.jenkins.io] is based on the Open Source mirror redirector link:https://github.com/etix/mirrorbits[mirrorbits].
 
 The list of mirrors (and their locations) is available on the following page: link:https://get.jenkins.io/index.html?mirrorstats[mirror status page].
 
 ## How to Help the Jenkins Project by Running a Mirror?
 
-Download mirror servers are always welcome to reduce the load on individual servers, to spread the bandwidth costs among multiple servers and to provide locations close to users.
+Download mirror servers are always welcome to reduce the load on individual servers, to spread the bandwidth costs among multiple servers, and to provide locations close to users.
 
 If you provide (or want to provide) a download mirror server, you'll have to fulfill the requirements below.
 We provide the link:https://github.com/jenkins-infra/helpdesk[GitHub "jenkins-infra" helpdesk] where you can open issues to add/change/delete a mirror or if you have any problem.
@@ -51,15 +51,15 @@ Mirror requirements (click for details on each requirement):
 ### A rsync client routine to keep your data up to date from our reference server
 
 * The data source is `rsync://archives.jenkins.io` without authentication but we need your outbound IPs to restrict access.
-* We recommend a (differential) data update at least hourly
-* The file can be deleted if they are more than 1 year old to avoid filling your disks, unless you have at least 600 Gb of data available
+* We recommend a (differential) data update at least hourly.
+* The file can be deleted if they are more than 1 year old to avoid filling your disks, unless you have at least 600 Gb of data available.
 
 ### A rsync server to allow regular scans of your mirror
 
 * Should serve the same data as the HTTP server
 * You can restrict inbound requests using IPs: we provide an API endpoint at link:https://reports.jenkins.io/infrastructure/v2/index.json[reports.jenkins.io/infrastructure/v2/index.json] with our rsync/ftp outbound IPs.
 ** Check the JSON list at `"get.jenkins.io".outbound_ips[]`
-** Our scanning IPs do not change often (once a year usually) but we update the JSON daily in case of any change
+** Our scanning IPs do not change often (once a year usually) but we update the JSON daily in case of any change.
 
 ### A mirror administrator email if we need to contact you
 
@@ -73,6 +73,6 @@ We provide a public rsync without authentication on `rsync://archives.jenkins.io
 
 As such, we need your outbound IPs used by your rsync client routine.
 
-We store these IPs in link:https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json[get-jenkins-io-data.json]: you can open a Pull Request on this file to add/change your outbound IPs (even if your mirror is not up to date yet).
+We store these IPs in link:https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json[get-jenkins-io-data.json]: you can open a pull request on this file to add/change your outbound IPs (even if your mirror is not up to date yet).
 
-Alternatively you can email them to us at mailto:jenkins-infra-team@googlegroups.com[`jenkins-infra-team@googlegroups.com`] or share with us an API endpoint where we can retrieve the IPs regularly.
+Alternatively, you can email them to us at mailto:jenkins-infra-team@googlegroups.com[`jenkins-infra-team@googlegroups.com`] or share an API endpoint with us where we can retrieve the IPs regularly.

--- a/content/download/mirrors.adoc
+++ b/content/download/mirrors.adoc
@@ -23,33 +23,56 @@ Download mirror servers are always welcome to reduce the load on individual serv
 If you provide (or want to provide) a download mirror server, you'll have to fulfill the requirements below.
 We provide the link:https://github.com/jenkins-infra/helpdesk[GitHub "jenkins-infra" helpdesk] where you can open issues to add/change/delete a mirror or if you have any problem.
 
+Mirror requirements (click for details on each requirement):
 
-Mirror requirements:
+* <<An HTTP server to serve files for the end users>>
 
-* An HTTP server to serve files for the end users with:
-** A public IPv4 and IPv6 address (we recommend both). You can have multiple IPs (see below).
-** A valid and resolvable public domain name pointing to your public IPs (we recommend `A` and `AAAA` DNS records). Multi-valued DNS records are valid if you have many IPs.
-** Enforced HTTPS with a valid TLS certificate
+* <<A storage of at least 300Gb to store ~1 year of files served by the HTTP server>>
 
-* A storage of at least 300Gb to store ~1 year of files served by the HTTP server:
-** As a data point, the "reference" download server, which is link:https://archives.jenkins.io[archives.jenkins.io], uses around ~600Gb with **all** of the files.
-** 300Gb of data is enough to provide artifacts published for 1 year (recommended time window). You may clean artifacts older than 1 year (provided by link:https://archives.jenkins.io[archives.jenkins.io]).
+* <<A rsync client routine to keep your data up to date from our reference server>>
 
-* A rsync or FTP server to allow link:https://get.jenkins.io[get.jenkins.io] to scan your mirror regularly:
-** Should serve the same data as the HTTP server
-** You can restrict inbound requests using an IP allowlist, we provide an API endpoint at link:https://reports.jenkins.io/infrastructure/v2/index.json[reports.jenkins.io/infrastructure/v2/index.json] with our rsync/ftp outbound IPs.
-*** Check the JSON list at `"get.jenkins.io".outbound_ips[]`
-*** Our scanning IPs do not change often (once a year usually) but we update the JSON daily in case of any change
+* <<A rsync server to allow regular scans of your mirror>>
 
-* A rsync routine to keep your data up to date:
-** The data source is `rsync://archives.jenkins.io` without authentication but we need your outbound IPs to restrict access.
-** We recommend a (differential) data update at least hourly
-** The file can be deleted if they are more than 1 year old to avoid filling your disks, unless you have at least 600 Gb of data available
+* <<A mirror administrator email if we need to contact you>>
 
-* A contact email if we need to reach out to the mirror's administrators for advertising configuration change or errors reported by users.
-** If you wish for us to keep this email privately, please send it to jenkins-infra-team@googlegroups.com
+* <<The outbound IP(s) used by your rsync client routine>>
 
-* The outbound IP(s) used by your rsync server to update data (so we can apply restrictions)
-** We store these IPs in link:https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json[get-jenkins-io-data.json]
-** You can open a Pull Request on this file to add/change your outbound IPs (even if your mirror is not up to date yet)
-** Alternatively you can email them to us at jenkins-infra-team@googlegroups.com or share with us an API endpoint where we can retrieve the IPs regularly
+### An HTTP server to serve files for the end users
+
+* A public IPv4 and IPv6 (we recommend both). You can have multiple IPs (see below).
+* A valid and resolvable public domain name pointing to your public IPs (we recommend `A` and `AAAA` DNS records). Multi-valued DNS records are valid if you have many IPs.
+* Enforced HTTPS with a valid TLS certificate
+
+### A storage of at least 300Gb to store ~1 year of files served by the HTTP server
+
+* As a data point, the "reference" download server, which is link:https://archives.jenkins.io[archives.jenkins.io], uses around ~600Gb with **all** of the files.
+* 300Gb of data is enough to provide artifacts published for 1 year (recommended time window). You may clean artifacts older than 1 year (provided by link:https://archives.jenkins.io[archives.jenkins.io]).
+
+### A rsync client routine to keep your data up to date from our reference server
+
+* The data source is `rsync://archives.jenkins.io` without authentication but we need your outbound IPs to restrict access.
+* We recommend a (differential) data update at least hourly
+* The file can be deleted if they are more than 1 year old to avoid filling your disks, unless you have at least 600 Gb of data available
+
+### A rsync server to allow regular scans of your mirror
+
+* Should serve the same data as the HTTP server
+* You can restrict inbound requests using IPs: we provide an API endpoint at link:https://reports.jenkins.io/infrastructure/v2/index.json[reports.jenkins.io/infrastructure/v2/index.json] with our rsync/ftp outbound IPs.
+** Check the JSON list at `"get.jenkins.io".outbound_ips[]`
+** Our scanning IPs do not change often (once a year usually) but we update the JSON daily in case of any change
+
+### A mirror administrator email if we need to contact you
+
+When we need to reach out to the mirror's administrators (for advertising configuration change or report errors) an email is needed.
+
+If you wish for us to keep this email private, please send it to our mailto:jenkins-infra-team@googlegroups.com[`jenkins-infra-team@googlegroups.com` Mailing List].
+
+### The outbound IP(s) used by your rsync client routine
+
+We provide a public rsync without authentication on `rsync://archives.jenkins.io` for mirrors to update their data but we need to restrict it to only mirrors.
+
+As such, we need your outbound IPs used by your rsync client routine.
+
+We store these IPs in link:https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json[get-jenkins-io-data.json]: you can open a Pull Request on this file to add/change your outbound IPs (even if your mirror is not up to date yet).
+
+Alternatively you can email them to us at mailto:jenkins-infra-team@googlegroups.com[`jenkins-infra-team@googlegroups.com`] or share with us an API endpoint where we can retrieve the IPs regularly.

--- a/content/download/mirrors.adoc
+++ b/content/download/mirrors.adoc
@@ -7,15 +7,49 @@
 - infrastructure
 :author: rtyler
 ---
-## Releases
 
-Currently releases are mirrored to the locations documented on the link:https://get.jenkins.io/index.html?mirrorstats[mirror status page].
+Jenkins packages and plugins are served by the web service https://get.jenkins.io (or its legacy alias mirrors.jenkins.io).
 
-### Running a mirror
+The web service https://get.jenkins.io relies on a network of mirror servers provided by generous sponsors of the Jenkins project all over the world.
+When a user download a plugin or a file, the web service https://get.jenkins.io redirects (transparently) the user to the closest mirror.
+The web service https://get.jenkins.io is based on the Open Source mirror redirector https://github.com/etix/mirrorbits.
 
-More mirrors are certainly welcome.
-Jenkins is mirrored by the link:https://osuosl.org/services/hosting/details[Oregon State University Open Source Lab (OSUOSL)] and by servers hosted by donors in the United States, Europe, China, Singapore, and Japan.
-Worldwide mirrors reduce the load on individual servers, spread the bandwidth costs among multiple servers, and improve download performance for users.
+The list of mirrors (and their locations) is available on the following page: link:https://get.jenkins.io/index.html?mirrorstats[mirror status page].
 
-If you're interested in running a public mirror, open an issue in the link:https://github.com/jenkins-infra/helpdesk[Jenkins infra help desk] and we can discuss space and bandwidth requirements.
-Mirrors on the Indian subcontinent, in South America, Russia and in Africa would be great additions to the Jenkins mirrors.
+## How to Help the Jenkins Project by Running a Mirror?
+
+Download mirror servers are always welcome to reduce the load on individual servers, to spread the bandwidth costs among multiple servers and to provide locations close to users.
+
+If you provide (or want to provide) a download mirror server, you'll have to fulfill the requirements below.
+We provide the link:https://github.com/jenkins-infra/helpdesk[GitHub "jenkins-infra" helpdesk] were you can open issues to add/change/delete a mirror or if you have any problem.
+
+
+Mirror requirements:
+
+* An HTTP server to serve files for the end users with:
+** A public IPv4 and IPv6 (we recommend both). You can have multiple IPs (see below).
+** A valid and resolvable public domain name pointing to your public IPs (we recommend `A` and `AAAA` DNS records). Multi-valued DNS records are valid if you have many IPs.
+** Enforced HTTPS with a valid TLS certificate
+
+* A storage of at least 300Gb to to store ~1 year of files served by the HTTP server:
+** As a data point, the "reference" download server, which is https://archives.jenkins.io, uses around ~600Gb with **all** of the files.
+** 300Gb of data is enough to provide artifacts published for 1 year (recommended time window). You may clean artifacts older than 1 year (provided by the archives.jenkins.io).
+
+* A rsync or FTP server to allow https://get.jenkins.io to scan your mirror regularly:
+** Should serve the same data as the HTTP server
+** You can restrict inbound requests using IPs: we provide an API endpoint at https://reports.jenkins.io/infrastructure/v2/index.json with our rsync/ftp outbound scanning IPs.
+*** Check the JSON list at `"get.jenkins.io".outbound_ips[]`
+*** Our scanning IPs do not change often (once a year usually) but we update the JSON daily in case of any change
+
+* A rsync routine to keep your data up to date:
+** The data source is rsync://archives.jenkins.io without authentication but we need your outbound IPs to restrict access.
+** We recommend a (differential) data update at least hourly
+** The file can be deleted if they are more than 1 year old to avoid filling your disks, unless you have at least 600 Gb of data available
+
+* A contact email if we need to reach out to the mirror's administrators for advertising configuration change or errors reported by users.
+** If you wish for us to keep this email privately, please send it to jenkins-infra-team@googlegroups.com
+
+* The outbound IP(s) used by your rsync server to update data (so we can apply restrictions)
+** We store these IPs in https://github.com/jenkins-infra/infra-reports/blob/main/jenkins-infra-data/get-jenkins-io-data.json
+** You can open a Pull Request on this file to add/change your outbound IPs (even if your mirror is not up to date yet)
+** Alternatively you can email them to us at jenkins-infra-team@googlegroups.com or share with us an API endpoint where we can retrieve the IPs regularly


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2953

Context: With https://github.com/jenkins-infra/helpdesk/issues/4681 and https://github.com/jenkins-infra/helpdesk/issues/4653, it is mandatory to provide a single source of truth to mirror maintainer so they can keep their setup up to date.

This PR provides such documentation on the existing page https://www.jenkins.io/download/mirrors/ as described in https://github.com/jenkins-infra/helpdesk/issues/2953.

Using www.jenkins.io for this information ensure we get enough visibility for future mirror maintainers.