### PR TITLE
Use SARIF format for typos checking in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,8 @@ content/doc/pipeline/steps/allAscii/params/*.adoc
 content/doc/developer/extensions/*.adoc
 
 # ignore files from typo check
-checkstyle.xml
+typos.sarif
 typos
-typos-checkstyle
 
 # unknown
 /.sass-cache/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node('docker&&linux') {
         */
         if (!infra.isTrusted() && env.BRANCH_NAME != null) {
             sh 'make check'
-            recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')],
+            recordIssues(tools: [sarif(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')],
                          qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]])
         }
     }

--- a/scripts/check-typos
+++ b/scripts/check-typos
@@ -4,23 +4,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TYPOS_VERSION=v1.31.2
-
-if [[ -v CI ]] ; then
-    if [[ $OSTYPE == darwin* ]] ; then
-        echo "CI mode for Mac OS has not been implemented!"
-        exit 1
-    fi
-    curl --disable --silent --show-error --location "https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xzf - ./typos
-    curl --disable --silent --show-error --location https://github.com/halkeye/typos-json-to-checkstyle/releases/download/v0.1.1/typos-checkstyle-v0.1.1-x86_64 > typos-checkstyle
-    chmod +x typos-checkstyle
-    ./typos --format json | ./typos-checkstyle - > checkstyle.xml || true
-    exit
-fi
+TYPOS_VERSION=v1.33.1
 
 if [[ $OSTYPE == darwin* ]] ; then
     curl --disable --silent --show-error --location "https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-x86_64-apple-darwin.tar.gz" | tar xzf - ./typos
 else
     curl --disable --silent --show-error --location "https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xzf - ./typos
 fi
-./typos
+if [[ -v CI ]] ; then
+    ./typos --format sarif > typos.sarif || true
+else
+    ./typos
+fi


### PR DESCRIPTION
The typos package now supports SARIF format out of the box, so converting to checkstyle is not needed.