### PR TITLE
fix: birajit blog post project links to latest project page 

### DIFF
--- a/content/_data/authors/biru-codeastromer.adoc
+++ b/content/_data/authors/biru-codeastromer.adoc
@@ -6,5 +6,5 @@ linkedin: birajit-saikia-08125030a
 ---
 Birajit is currently pursuing a B.Tech in Computer Science and Engineering with a specialization in Artificial Intelligence and Machine Learning at Newton School of Technology (NST), Pune, India.
 With a strong passion for software development, web development, technical documentation, and DevOps, Birajit has been an active contributor to the Jenkins community since November 2024.
-In 2025, he was selected as a Google Summer of Code (GSoC) contributor for the Jenkins project, working on link:projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/[Complete build retooling of jenkins.io].
+In 2025, he was selected as a Google Summer of Code (GSoC) contributor for the Jenkins project, working on link:/projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/[Complete build retooling of jenkins.io].
 Beyond his technical pursuits, Birajit enjoys playing cricket and experimenting with new recipes in the kitchen.

--- a/content/_data/authors/biru-codeastromer.adoc
+++ b/content/_data/authors/biru-codeastromer.adoc
@@ -6,5 +6,5 @@ linkedin: birajit-saikia-08125030a
 ---
 Birajit is currently pursuing a B.Tech in Computer Science and Engineering with a specialization in Artificial Intelligence and Machine Learning at Newton School of Technology (NST), Pune, India.
 With a strong passion for software development, web development, technical documentation, and DevOps, Birajit has been an active contributor to the Jenkins community since November 2024.
-In 2025, he was selected as a Google Summer of Code (GSoC) contributor for the Jenkins project, working on link:/projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling/[Complete build retooling of jenkins.io].
+In 2025, he was selected as a Google Summer of Code (GSoC) contributor for the Jenkins project, working on link:projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/[Complete build retooling of jenkins.io].
 Beyond his technical pursuits, Birajit enjoys playing cricket and experimenting with new recipes in the kitchen.

--- a/content/blog/2025/06/03/2025-06-03-birajit-saikia-gsoc-community-bonding-blog-post.adoc
+++ b/content/blog/2025/06/03/2025-06-03-birajit-saikia-gsoc-community-bonding-blog-post.adoc
@@ -22,7 +22,7 @@ image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=
 
 Hello everyone! 
 
-I'm Birajit Saikia, and I’m thrilled to be a Google Summer of Code 2025 contributor with Jenkins. This summer, I’ll be working on the link:projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/[Complete Build Retooling of jenkins.io] project, which focuses on modernizing and reorganizing the Jenkins documentation infrastructure and updating the tech stack with UI/UX changes.
+I'm Birajit Saikia, and I’m thrilled to be a Google Summer of Code 2025 contributor with Jenkins. This summer, I’ll be working on the link:/projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/[Complete Build Retooling of jenkins.io] project, which focuses on modernizing and reorganizing the Jenkins documentation infrastructure and updating the tech stack with UI/UX changes.
 
 == Project Description
 

--- a/content/blog/2025/06/03/2025-06-03-birajit-saikia-gsoc-community-bonding-blog-post.adoc
+++ b/content/blog/2025/06/03/2025-06-03-birajit-saikia-gsoc-community-bonding-blog-post.adoc
@@ -22,7 +22,7 @@ image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=
 
 Hello everyone! 
 
-I'm Birajit Saikia, and I’m thrilled to be a Google Summer of Code 2025 contributor with Jenkins. This summer, I’ll be working on the "Complete Build Retooling of jenkins.io" project, which focuses on modernizing and reorganizing the Jenkins documentation infrastructure and updating the tech stack with UI/UX changes.
+I'm Birajit Saikia, and I’m thrilled to be a Google Summer of Code 2025 contributor with Jenkins. This summer, I’ll be working on the link:projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/[Complete Build Retooling of jenkins.io] project, which focuses on modernizing and reorganizing the Jenkins documentation infrastructure and updating the tech stack with UI/UX changes.
 
 == Project Description
 


### PR DESCRIPTION
Updated my blog post project to new project page link instead of the old project idea page .