### PR TITLE
Move Firefox ESR to level 2 support

### DIFF
--- a/content/doc/book/platform-information/support-policy-web-browsers.adoc
+++ b/content/doc/book/platform-information/support-policy-web-browsers.adoc
@@ -34,8 +34,8 @@ browsers.
 |Other versions
 
 |Mozilla Firefox
-|Latest regular release/patch;
-|Version N-1, latest patch
+|Latest regular release/patch
+|Version N-1, latest patch;
 Latest https://www.mozilla.org/en-US/firefox/organizations/[ESR] release
 |Other versions 
 

--- a/content/doc/book/platform-information/support-policy-web-browsers.adoc
+++ b/content/doc/book/platform-information/support-policy-web-browsers.adoc
@@ -35,8 +35,8 @@ browsers.
 
 |Mozilla Firefox
 |Latest regular release/patch;
-Latest https://www.mozilla.org/en-US/firefox/organizations/[ESR] release
 |Version N-1, latest patch
+Latest https://www.mozilla.org/en-US/firefox/organizations/[ESR] release
 |Other versions 
 
 |Microsoft Edge


### PR DESCRIPTION
Preview: https://deploy-preview-8191--jenkins-io-site-pr.netlify.app/doc/book/platform-information/support-policy-web-browsers/

We don't support any other long term browsers.

The world has moved on from fixed point in time browsers like Internet Explorer and Firefox ESR. In my experience most corporations are using Edge or Chrome these days.

The current ESR version is nearly 2 years old at this point and missing features that Firefox has had for a long time.

-----

The usage of ESR appears to be extremely low as we shipped a feature [breaking color](https://github.com/jenkinsci/jenkins/pull/10078) in it 5 months ago (which has progressed through an entire LTS line) and only had 1 user report about it.

-----

I think level 2 is ok for this, in the example of broken colour its still functional just visually degraded.