### PR TITLE
update contributor summit for 2025 info

### DIFF
--- a/content/events/contributor-summit/index.adoc
+++ b/content/events/contributor-summit/index.adoc
@@ -21,18 +21,18 @@ description: >
 The Jenkins Contributor Summit brings together current and future contributors to the Jenkins project.
 It brings together community members to learn, meet, and help shape the future of Jenkins.
 
-== Next Summit: Brussels (Feb 2, 2024)
+== Next Summit: Brussels (January 31, 2025)
 
 We are happy to announce that we will hold a **Jenkins Contributor Summit** in Brussels prior to FOSDEM. 
 
 link:https://fosdem.org/2024/[FOSDEM] is a free event for software developers to meet, share ideas, and collaborate. 
 Every year, thousands of developers of free and open-source software from all over the world gather at the event in Brussels. 
-For the 2024 event, FOSDEM will occur between February 3 - 4, the first weekend of February.
+For the 2025 event, FOSDEM will occur between February 1 - 2, the first weekend of February.
 
 
 === Key Dates:
-* **Jenkins Contributor Summit:** Friday 2 February 2024
-* **FOSDEM:** Saturday 3 and Sunday 4 February 2024
+* **Jenkins Contributor Summit:** Friday 31 January 2025
+* **FOSDEM:** Saturday 1 and Sunday 2 February 2025
 
 === Location:
 * link:https://www.betacowork.com/[_Betacowork_], located at _4 Rue des Pères Blancs, 1040 Brussels, Belgium_


### PR DESCRIPTION
Small update to make sure the contributor summit page reflects the 2025 event.