### PR TITLE
Remove reference to friend of Jenkins

### DIFF
--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -60,10 +60,6 @@ If you announce your or your company's donation in social media, reach out to th
 The Jenkins governance board is also responsible for recognizing big donations.
 There is no formal process for that, please contact the link:/project/board/[Jenkins Governance Board].
 
-== Friend of Jenkins
-
-Before May 15th 2021, the Jenkins project would send a special "Friend of Jenkins" plugin to contributors who donate 25 USD or more. This setup not only went against our design of an open source project, but it didn't adequately acknowledge the thanks we wanted to give people. We are working on redefining this program. Please refer to link:https://groups.google.com/u/1/g/jenkinsci-dev/c/bIgDEM2E7hY[this thread] for the details.
-
 == Donations to sub-projects and plugins
 
 This page describes donations to the Jenkins project in general.


### PR DESCRIPTION
## Remove reference to friend of Jenkins

Friend of Jenkins program is not returning to the project

https://github.com/jenkins-infra/helpdesk/issues/2013#issuecomment-2988983012 prompted this deletion.  No reason to retain that section in the donation page.
