### PR TITLE
fix: replace links to https://jenkinsistheway.io/ by https://stories.jenkins.io/

### DIFF
--- a/content/_data/adopters/D4Science.adoc
+++ b/content/_data/adopters/D4Science.adoc
@@ -1,6 +1,6 @@
 ---
 name: "D4Science"
 url: https://www.d4science.org/
-detailsUrl: https://jenkinsistheway.io/case-studies/d4science-amps-up-their-scientific-research-platform-with-ci-cd-powered-by-jenkins/
+detailsUrl: https://stories.jenkins.io/case-studies/d4science-amps-up-their-scientific-research-platform-with-ci-cd-powered-by-jenkins/
 detailsLinkText: User Story
 ---

--- a/content/blog/2020/10/2020-10-20-Cross-Industry-DevOps-3-Firms-Get-It-Right-with-Jenkins.adoc
+++ b/content/blog/2020/10/2020-10-20-Cross-Industry-DevOps-3-Firms-Get-It-Right-with-Jenkins.adoc
@@ -40,7 +40,7 @@ _“What was critical to our success was the stability of Jenkins and a signific
 
 _With this implementation, Jenkins allows more than would be manually possible. It flawlessly updates our staging environments, blocks commits based on the SonarQube analysis, and provides us with near-instant feedback on merge requests.”_
 
-Learn how Wright Medical supports a growing dev team by switching to an agile DevOps process that allows for automatic daily releases — versus weekly manual builds. Best of all, it’s letting the developers focus on building great code rather than infrastructure. link:https://jenkinsistheway.io/user-story/to-focus-on-your-code/[The full Jenkins / Wright Medical story is here!]
+Learn how Wright Medical supports a growing dev team by switching to an agile DevOps process that allows for automatic daily releases — versus weekly manual builds. Best of all, it’s letting the developers focus on building great code rather than infrastructure. link:https://stories.jenkins.io/user-story/to-focus-on-your-code/[The full Jenkins / Wright Medical story is here!]
 
 === What are you building?
 

--- a/content/blog/2020/12/2020-12-05-3-Cases-Jenkins-Success-stories-from-the-community.adoc
+++ b/content/blog/2020/12/2020-12-05-3-Cases-Jenkins-Success-stories-from-the-community.adoc
@@ -12,7 +12,7 @@ Back in April, when we started canvassing the Jenkins community for user stories
 
 Some Jenkins users had a much more complex story to tell, whether it was about getting upper management to buy-in, keeping developers happy, or simply making sure pipelines weren't just bottlenecks in disguise. 
 
-Here are a handful of link:https://jenkinsistheway.io/case-studies/[Jenkins Case Studies] we've published in the past few months, with many more on the way!
+Here are a handful of link:https://stories.jenkins.io/case-studies/[Jenkins Case Studies] we've published in the past few months, with many more on the way!
 
 == Case Study #1: D4Science
 
@@ -24,7 +24,7 @@ Of course, they had to build and release their software framework (gCube) in a w
 
 Using Jenkins, they created an innovative approach to software delivery: a continuous integration/continuous delivery (CI/CD) pipeline, scalable, easy to maintain, and upgradable at a minimal cost.  
 
-Discover how D4Science empowers e-Science and virtual research communities with software released via Jenkins. link:https://jenkinsistheway.io/case-studies/d4science-amps-up-their-scientific-research-platform-with-ci-cd-powered-by-jenkins/[Read the Jenkins case study featuring D4Science here!]
+Discover how D4Science empowers e-Science and virtual research communities with software released via Jenkins. link:https://stories.jenkins.io/case-studies/d4science-amps-up-their-scientific-research-platform-with-ci-cd-powered-by-jenkins/[Read the Jenkins case study featuring D4Science here!]
 
 == Case Study #2: Gainsight
 
@@ -36,7 +36,7 @@ That's why the engineering team at Gainsight approached the customer experience 
 
 The result was a flexible DevSecOps infrastructure, 95% of which is scalable with code. And the cost of infrastructure costs was 40% less. That provides Gainsight with ease of collaboration, keener operational insight, and — because builds are 30% faster — the ability to stay a step ahead of the competition.
 
-Read why Gainsight's lead DevOps engineer, Prudviraj Pentakota, says "Jenkins is the epicenter of DevSecOps in our organization." link:https://jenkinsistheway.io/case-studies/jenkins-case-study-gainsight/[Get the full story here.]
+Read why Gainsight's lead DevOps engineer, Prudviraj Pentakota, says "Jenkins is the epicenter of DevSecOps in our organization." link:https://stories.jenkins.io/case-studies/jenkins-case-study-gainsight/[Get the full story here.]
 
 == Case Study #3: Avoris Travel
 
@@ -48,7 +48,7 @@ Also unique to Avoris is a discreet machining technology that enables agents to 
 
 "Our infrastructure is very important because we have to be online to meet customer demand anywhere in the world," said Alejandro Alvarez Vazquez, Sysadmin, Avoris Travel. "Our CI/CD platform is used by 200 people. The services that we build and deploy are used by thousands of potential clients and by our network of 675 own agencies located in Spain and Portugal." 
 
-link:https://jenkinsistheway.io/case-studies/jenkins-case-study-avoris-travel/[Read the case study] to learn how the flexibility of Jenkins plugins helped Avoris reduce build times by over 50% and became a go-to, scalable infrastructure supporting 675 agencies and over 2.8 million international consumers.
+link:https://stories.jenkins.io/case-studies/jenkins-case-study-avoris-travel/[Read the case study] to learn how the flexibility of Jenkins plugins helped Avoris reduce build times by over 50% and became a go-to, scalable infrastructure supporting 675 agencies and over 2.8 million international consumers.
 
 === What’s your story?
 We want to know what you're building with Jenkins and would love to post your case study on our link:https://stories.jenkins.io/["Jenkins Is The Way"] website, a global showcase of how developers and engineers build, deploy, and automate great stuff with Jenkins.

--- a/content/blog/2021/01/2021-01-26-new-ebook-build-deploy-and-automate-great-stuff-with-jenkins.adoc
+++ b/content/blog/2021/01/2021-01-26-new-ebook-build-deploy-and-automate-great-stuff-with-jenkins.adoc
@@ -32,9 +32,9 @@ To date, we have nearly 60 user stories, a handful of case studies, and some new
 You shared how using Jenkins has helped make your builds faster, your pipelines more secure, and your developers and software engineers happier.
 In essence, Jenkins Is The Way showcases how Jenkins has made it a whole lot easier to do the work you do every day.
 
-We've now gathered some of those stories in our first https://jenkinsistheway.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf[Jenkins Is The Way ebook], covering various challenges and solutions from six different industries: Aerospace, Education, Finance, Insurance, Retail, and Travel.
+We've now gathered some of those stories in our first https://stories.jenkins.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf[Jenkins Is The Way ebook], covering various challenges and solutions from six different industries: Aerospace, Education, Finance, Insurance, Retail, and Travel.
 
-image:/images/post-images/jenkins-is-the-way/ebook-cover.png[role="right", height=320, link="https://jenkinsistheway.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf"]
+image:/images/post-images/jenkins-is-the-way/ebook-cover.png[role="right", height=320, link="https://stories.jenkins.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf"]
 
 You'll read about innovations from *KP Labs* in Poland and *Preply* in Ukraine.
 You'll discover how automation helped *Avoris* out of Spain & Portugal and *Tymit* in the United Kingdom.
@@ -49,7 +49,7 @@ Your engineering time and resources are too valuable to be spent re-inventing th
 
 Jenkins' vast array of plugins and pre-built solutions will have you automating more than you ever imagined.
 So, get inspired to build great stuff with Jenkins.
-And, please https://jenkinsistheway.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf[share this ebook] with your network.
+And, please https://stories.jenkins.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf[share this ebook] with your network.
 
 == Share your story!
 

--- a/content/blog/2021/06/2021-06-10-jenkins-is-the-way-ebook-2.adoc
+++ b/content/blog/2021/06/2021-06-10-jenkins-is-the-way-ebook-2.adoc
@@ -21,7 +21,7 @@ image:/images/post-images/jenkins-is-the-way/ebook/ebook2_front.png["Jenkins Is 
 
 A little over a year ago, we launched JenkinsIsTheWay.io, a website whose sole purpose is to share Jenkins user stories with the developers and engineers in our community.  Over a hundred of you have already link:https://stories.jenkins.io[shared your innovations], and they just keep coming.  It comes as no surprise that many of the submitted stories are from IT consultants and software developers around the world building next-generation DevOps and CI/CD platforms to fuel the modernization of enterprise companies far and wide.
 
-That’s why we’ve dedicated link:https://jenkinsistheway.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[our latest eBook] to focus on Jenkins users in the global Information Technology sector.  We shine the spotlight on these developers and engineers who have solved unique software development and DevOps challenges by turning to the leading open source automation server.  From powering large enterprises needing a better way to manage their inventory to innovative tech firms looking to advance technologies and healthcare initiatives during a pandemic, you’ll read about how teams everywhere solved their unique challenges — with the help of Jenkins. 
+That’s why we’ve dedicated link:https://stories.jenkins.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[our latest eBook] to focus on Jenkins users in the global Information Technology sector.  We shine the spotlight on these developers and engineers who have solved unique software development and DevOps challenges by turning to the leading open source automation server.  From powering large enterprises needing a better way to manage their inventory to innovative tech firms looking to advance technologies and healthcare initiatives during a pandemic, you’ll read about how teams everywhere solved their unique challenges — with the help of Jenkins. 
 
 === Jenkins is the Way to…
 
@@ -42,18 +42,18 @@ While we all fondly think of Jenkins as a modest butler who has empowered develo
 
 For our Jenkins users, that means results — significant, measurable results with a common theme.  Using Jenkins has enabled you — the user — to help the businesses you serve save money, spin up software faster, and automate processes.  In doing so, you've freed up developers and engineers from countless hours of mundane tasks.  Thanks to Jenkins, you’re empowering entire IT teams to innovate, focus on what they love to do and, ultimately, build great stuff.
 
-Of course, we devote much of our link:https://jenkinsistheway.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[latest eBook] to those victories.  Results like how RedHat’s link:https://stories.jenkins.io/user-story/to-build-and-release-faster/[releases are 5x faster] thanks to Jenkins.  The fact that DevOps problem tickets were link:https://stories.jenkins.io/user-story/to-automate-everything/[reduced by over 90%] for Electronic Health Solutions.  And why the CTO at Cloudologia was link:https://stories.jenkins.io/user-story/to-experiments-and-eternity/[psyched to share] that — with a Jenkins at the helm — they were able to shorten onboarding for deployment & build release cycles from one week to a single day.
+Of course, we devote much of our link:https://stories.jenkins.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[latest eBook] to those victories.  Results like how RedHat’s link:https://stories.jenkins.io/user-story/to-build-and-release-faster/[releases are 5x faster] thanks to Jenkins.  The fact that DevOps problem tickets were link:https://stories.jenkins.io/user-story/to-automate-everything/[reduced by over 90%] for Electronic Health Solutions.  And why the CTO at Cloudologia was link:https://stories.jenkins.io/user-story/to-experiments-and-eternity/[psyched to share] that — with a Jenkins at the helm — they were able to shorten onboarding for deployment & build release cycles from one week to a single day.
 
 === Share Your User Story, Too!
 
-I am proud to share another common theme from the users who have submitted their story:  you turn to our community for collaboration, guidance, and advice.  A community of a million strong and growing, link:https://jenkinsistheway.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[this eBook] and link:https://stories.jenkins.io/[stories.jenkins.io] are other ways to provide you with the insight and lessons learned by developers and engineers, like you, to innovate and build next-generation technologies for companies of all sizes.
+I am proud to share another common theme from the users who have submitted their story:  you turn to our community for collaboration, guidance, and advice.  A community of a million strong and growing, link:https://stories.jenkins.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[this eBook] and link:https://stories.jenkins.io/[stories.jenkins.io] are other ways to provide you with the insight and lessons learned by developers and engineers, like you, to innovate and build next-generation technologies for companies of all sizes.
 
 When you're ready to tell your story, we're prepared to help you share it.  link:https://www.surveymonkey.com/r/JenkinsIsTheWay[Fill out our short questionnaire], and we'll send you our Jenkins Is The Way T-shirt as a thank you once it’s published! 
 
 === Links
 
-* link:https://jenkinsistheway.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[Jenkins IsThe Way. IT User Story eBook, chapter 2] 
-* link:https://jenkinsistheway.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf[Jenkins IsThe Way. IT User Story eBook, chapter 1] 
+* link:https://stories.jenkins.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf[Jenkins IsThe Way. IT User Story eBook, chapter 2] 
+* link:https://stories.jenkins.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf[Jenkins IsThe Way. IT User Story eBook, chapter 1] 
 * link:https://stories.jenkins.io/[Visit Jenkins Is The Way]
 * link:https://www.surveymonkey.com/r/JenkinsIsTheWay[Share Your User Story]
 

--- a/content/blog/2021/09/2021-09-22-fortune-500-real-world-results.adoc
+++ b/content/blog/2021/09/2021-09-22-fortune-500-real-world-results.adoc
@@ -24,14 +24,14 @@ With over 200,000 installations to date, Jenkins remains the most widely used op
 And story after story, we hear what a critical role Jenkins plays in building robust, secure CI/CD pipelines.
 
 So it comes as no surprise that in many of the back (and remote) offices of Fortune 500 companies, developers are turning to Jenkins to help make their lives easier with automation while also giving their engineers more time to innovate.
-With this in mind, I invite you to read the link:https://jenkinsistheway.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf[latest ebook] focused on the behind-the-scenes development activities underway in large-scale enterprises.
+With this in mind, I invite you to read the link:https://stories.jenkins.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf[latest ebook] focused on the behind-the-scenes development activities underway in large-scale enterprises.
 
 == Jenkins led
 
 Learn how companies like link:https://stories.jenkins.io/user-story/to-faster-product-release/[IBM] continue to innovate their software prowess while confidently relying on their custom-built CI/CD pipelines.
 You'll also read how Jenkins became the ultimate collaboration tool for thousands of link:https://stories.jenkins.io/user-story/to-produce-ultra-modern-and-sophisticated-electronic-devices/[Apple] developers.
 And we don't just shine the spotlight on tech companies.
-In link:https://jenkinsistheway.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf[this ebook], Jenkins users span multiple industries across the enterprise.
+In link:https://stories.jenkins.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf[this ebook], Jenkins users span multiple industries across the enterprise.
 
 You'll read how Jenkins made it possible to standardize multidisciplinary team procedures so Roche engineers can create innovative healthcare applications with confidence.
 We also dive into how Telstra's software team was able to automate the build cycle - across 100,000 microservices - to accelerate the creation of world-class communication tools.
@@ -79,6 +79,6 @@ Fill out our short questionnaire, and we'll send you our Jenkins Is The Way T-sh
 
 == Links
 
-* Download link:https://jenkinsistheway.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf[Fortune 500 User Story eBook]
+* Download link:https://stories.jenkins.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf[Fortune 500 User Story eBook]
 * Visit link:https://stories.jenkins.io/[JenkinsIsTheWay]
 * link:https://www.surveymonkey.com/r/JenkinsIsTheWay[Share your story]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4709

This PR is a simple "search and replace" of all occurrences of `https://jenkinsistheway.io/` by `https://stories.jenkins.io/`.

The following links are now OK (HTTP/200):

- https://stories.jenkins.io/
- https://stories.jenkins.io/user-story/to-automate-everything/
- https://stories.jenkins.io/user-story/to-experiments-and-eternity/

However the following links are still "Not Found" (HTTP/404) and I have no idea if they should be kept "as it", changed (as part of this PR), removed or other (cc @kmartens27 as docs SIG leader and @alyssat @gounthar as Developer evangelists)?

- https://stories.jenkins.io/case-studies/d4science-amps-up-their-scientific-research-platform-with-ci-cd-powered-by-jenkins/
- https://stories.jenkins.io/case-studies/
- https://stories.jenkins.io/case-studies/d4science-amps-up-their-scientific-research-platform-with-ci-cd-powered-by-jenkins/
- https://stories.jenkins.io/case-studies/jenkins-case-study-avoris-travel/
- https://stories.jenkins.io/case-studies/jenkins-case-study-gainsight/
- https://stories.jenkins.io/user-story/to-focus-on-your-code/
- https://stories.jenkins.io/wp-content/uploads/2021/01/Jenkins-User-Story-Industry-focused-ebook-2020.pdf
- https://stories.jenkins.io/wp-content/uploads/2021/03/2021-Jenkins-User-Story-IT-focused-ebook.pdf
- https://stories.jenkins.io/wp-content/uploads/2021/07/2021-Jenkins-Is-The-Way-in-the-Fortune-500-ebook.pdf