### PR TITLE
feat(roadmap) update jenkins-infra tasks for June 2025

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -757,6 +757,13 @@ categories:
       status: near-term
       labels:
       - infrastructure
+    - name: "Move Configuration Management out of Puppet"
+      description: >
+        The Perforce Puppet project is now considered a strategic risk since February 2025. As such we should get rid of Puppet in favor of something else.
+      link: https://github.com/jenkins-infra/helpdesk/issues/4714
+      status: near-term
+      labels:
+      - infrastructure
   - name: Governance
     description: Initiatives targeting project governance, policies, funding, etc.
     link: /project

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -236,13 +236,6 @@ categories:
       link: https://issues.jenkins.io/browse/WEBSITE-742
       labels:
       - documentation
-    - name: Modernize mirror infrastructure
-      description: >
-        Improve and expand the mirror infrastructure to provide fast and reliable downloads to Jenkins users.
-      status: released
-      link: https://issues.jenkins.io/browse/INFRA-2516
-      labels:
-      - infrastructure
     - name: Non-inclusive terminology cleanup
       description: >
         In 2016, the Jenkins community decided to change the non-inclusive terminology within the project.
@@ -534,11 +527,6 @@ categories:
       Solutions and tools for Jenkins developers and contributors.
       User-focused developer tools, e.g. for Pipeline development, are listed in other sections.
     initiatives:
-    - name: Core release automation
-      status: preview
-      link: https://issues.jenkins.io/browse/INFRA-910
-      labels:
-      - infrastructure
     - name: Jenkins core BOM
       description: >
         This Bill of Materials lists libraries and versions supplied by the Jenkins core.
@@ -587,18 +575,10 @@ categories:
       link: https://groups.google.com/forum/#!searchin/jenkinsci-dev/dependabot%7Csort:date/jenkinsci-dev/XMllKuWLO_8/5hagrjApEgAJ
       labels:
       - tools
-    - name: "JEP-217: Infrastructure for Experimental Docker images"
-      description: >
-        Provide a storage for experimental Jenkins Docker images so that maintainers can build and deploy untrusted images
-        from ci.jenkins.io and other services.
-      status: near-term
-      link: https://github.com/jenkinsci/jep/blob/master/jep/217
-      labels:
-      - infrastructure
     - name: "JEP-229: Continuous Delivery of Jenkins Plugins"
       description: >
         Introduce a new system which would enable Jenkins plugin maintainers to add Continuous Delivery (CD) to their projects.
-      status: preview
+      status: released
       link: https://github.com/jenkinsci/jep/blob/master/jep/229
       labels:
       - tools

--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -719,39 +719,42 @@ categories:
       description: >
         Modernize or replace the accounts.jenkins.io LDAP account management system to improve security of our users and decrease the maintenance overhead.
       status: future
+      link: https://github.com/jenkins-infra/helpdesk/issues/2232
       labels:
       - infrastructure
     - name: "Modernize updates.jenkins.io to use mirrors"
       description: >
         Migration the "Update Center" updates.jenkins.io to use a mirror system in Azure + Cloudflare + OSUOSL: cheaper and highly available.
-      status: current
+      status: released
       link: https://github.com/jenkins-infra/helpdesk/issues/2649
       labels:
       - infrastructure
     - name: "Java 21 for all the infrastructure"
       description: >
         Provide JDK21 to developers and use Java 21 to run Jenkins to support the contributor efforts and to be the "tip of the spear" for the project.
-      status: current
+      status: released
       link: https://github.com/jenkins-infra/helpdesk/issues/4120
       labels:
       - infrastructure
-    - name: "Migrate ci.jenkins.io and agents to the AWS Sponsored Account"
+    - name: "Java 25 Preview for developers"
       description: >
-        AWS gave us 60k$ credits to use until 31 January 2025. Once we run out of Azure credits, we want to migrate ci.jenkins.io and its agents to AWS.
+        JDK25 GA is scheduled of 16 September 2025. We want to provide JDK25 Preview to developers on ci.jenkins.io to allow early testing.
+      status: preview
+      link: https://github.com/jenkins-infra/helpdesk/issues/4641
+      labels:
+      - infrastructure
+    - name: "Migrate ci.jenkins.io from Azure to the AWS Sponsored Account"
+      description: >
+        AWS gave us 90k$ credits to use until 31 January 2027. As we'll run out of sponsored Azure credits the 31 August 2025, we'll move ci.jenkins.io to AWS.
+      status: current
+      link: https://github.com/jenkins-infra/helpdesk/issues/4689
+      labels:
+      - infrastructure
+    - name: "Migrate pkg.origin.jenkins.io to our modern Azure infrastructure"
+      description: >
+        The VM pkg.origin.jenkins.io is a legacy machine running in a specific (CloudBees) account. We want it to move to Azure to decrease costs and modernize its components.
+      link: https://github.com/jenkins-infra/helpdesk/issues/3705
       status: near-term
-      labels:
-      - infrastructure
-    - name: "Migrate ci.jenkins.io and agents to the Azure Sponsored Account"
-      description: >
-        Migration of both controller and agent workloads from AWS/Azure to Azure in order consume the Azure donated credits
-      status: released
-      link: https://github.com/jenkins-infra/helpdesk/issues/3913
-      labels:
-      - infrastructure
-    - name: ci.jenkins.io as code
-      status: released
-      description: Define and maintain ci.jenkins.io configuration as code rather than through the user interface
-      link: https://github.com/jenkins-infra/jenkins-infra/blob/production/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
       labels:
       - infrastructure
   - name: Governance


### PR DESCRIPTION
This PR updates the Jenkins roadmap (https://www.jenkins.io/project/roadmap/) to ensure Jenkins Infrastructure main tasks ("EPIC"s?) are up to date as per the team discussions.

Preview:


<img width="1639" alt="Capture d’écran 2025-06-25 à 13 49 49" src="https://github.com/user-attachments/assets/a53258aa-ffb8-4eb1-b265-488635a730d4" />
