### PR TITLE
Fix formatting of 2.516 changelog entry

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -27069,9 +27069,9 @@
           - basil
         pr_title: "[JENKINS-75683] re-introduce actions for Jenkins with custom action.jelly"
         message: |-
-          <code>RootActions</code> that used custom rendering (<code>action.jelly</code>) are once again visible in the header and behave appropriately.
-          <code>RootActions</code> that use jelly to show/hide are correctly hidden in the header
-          <code>RootActions</code> with sub tasks now show the subtasks as a dropdown when in the correct context
+          Any <code>RootAction</code> that used custom rendering (<code>action.jelly</code>) is once again visible in the header and behaves appropriately.
+          Any <code>RootAction</code> that uses jelly to show/hide is correctly hidden in the header.
+          Any <code>RootAction</code> with sub tasks now shows the subtasks as a dropdown when in the correct context.
       - type: bug
         category: bug
         pull: 10754


### PR DESCRIPTION
This PR is to fix the formatting of one of the 2.516 changelog entries that had inconsistent formatting. Just a small change to include the "s" within the code formatting of the `RootActions` text.