### PR TITLE
Create Celebrating-the-2025-Jenkins-Contributor-Award-Winners.adoc

### DIFF
--- a/content/blog/2025/06/25/Celebrating-the-2025-Jenkins-Contributor-Award-Winners.adoc
+++ b/content/blog/2025/06/25/Celebrating-the-2025-Jenkins-Contributor-Award-Winners.adoc
@@ -1,0 +1,47 @@
+---
+layout: post
+title: "🌟 Celebrating the 2025 Jenkins Contributor Award Winners"
+tags:
+- jenkins
+- community
+- awards
+- cdcon
+- cdf
+authors:
+- alyssat
+opengraph:
+  image: /images/post-images/2025/03/community-awards-2025-jenkins.png 
+discourse: true
+---
+At link://cd.foundation/cdcon-2025/[cdCon 2025 in Colorado] this week, we proudly recognized outstanding contributions within both the Continuous Delivery Foundation (CDF) and the Jenkins community. These awards celebrate exceptional ambassadors, contributors, documentation champions, and users who drive CI/CD excellence.
+
+*🎖️ Jenkins Project Honors*
+
+Jenkins presented three distinguished awards:
+
+* Jenkins Security MVP
+* Most Valuable Jenkins Contributor
+* Most Valuable Jenkins Advocate
+
+*🏅 Award Recipients*
+
+image:/images/avatars/janfaracik.jpg[image,width=99,height=99] *Most Valuable Contributor: link:https://github.com/janfaracik[Jan Faracik]*
+
+Jan has made tremendous contributions to the UI/UX front of the Jenkins project as the UI/UX SIG Lead, not just this year but throughout the years, and for helping to foster a collaborative environment especially in helping newcomers of the Jenkins ecosystem via code reviews.
+
+image:/images/post-images/2023/05/16/2023-05-16-jenkins-2023-award-winners/image3.png[image,width=99,height=99] *Security MVP: link:https://github.com/daniel-beck[Daniel Beck]*
+
+Daniel brought skills and thorough efforts to maintain and improve the security of Jenkins. His code reviews for Jenkins core are great examples of attention to detail and awareness of impact. He reviews security threats carefully and keeps himself current on recent security topics. He works well with release leads when delivering Jenkins security releases and works well with the Jenkins infrastructure team in many different areas.
+
+image:/images/post-images/2024/04/19/stefan-spieker.png[image,width=99,height=99] *Most Valuable Advocate: link:https://github.com/StefanSpieker[Stefan Spieker]*
+
+Stefan has made continuous efforts in advocating Jenkins in his company with excellent explanations and showcases. He organized Hacktoberfest, and encouraged other colleagues to contribute to Open Source, specifically Jenkins.  He speaks at conferences to advocate for Jenkins. He also wrote a successful book where he shared his insights on the open source and Jenkins.
+
+*📌 Closing Thoughts*
+
+These award winners exemplify the collaborative spirit that drives the Jenkins community forward. By spotlighting their achievements, we shine a light on security vigilance, code craftsmanship, educational outreach, and unwavering community support.
+
+Every nominee deserves a huge thank you and congratulations - your contributions are felt through the performance and reliability Jenkins provides users.
+
+Thank you to every voter, and participant who submitted nominations - your involvement continues to make Jenkins thrive.
+


### PR DESCRIPTION
This PR is to announce the Jenkins Contributor Award winners for 2025.  Please do not merge until Wednesday, 25 June, 9:05PM  UTC as this is the closing of CdCon where winners are announced.