### PR TITLE
Update carousel for 2025 community award winners

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,4 +1,17 @@
 ---
+# Jenkins 2025 Community Awards Open
+- :href: /blog/2025/06/25/Celebrating-the-2025-Jenkins-Contributor-Award-Winners/
+  :title: Jenkins 2025 Community Awards
+  :intro: The Jenkins 2025 Community Awards winners have been announced!
+    Congratulations to all the winners and thank you for all of your contributions.
+    Thanks to the community for voting and making this possible.
+  :image:
+    :src: /images/post-images/2025/03/community-awards-2025-jenkins.png
+    :height: 285px
+  :call_to_action:
+    :text: Read more about the awards and winners in our blog.
+    :href: /blog/2025/06/25/Celebrating-the-2025-Jenkins-Contributor-Award-Winners/
+
 # Alpha Omega Grant
 - :href: /blog/2024/10/04/content-security-policy-grant/
   :title: Alpha Omega Foundation Content Security Policy Grant
@@ -11,17 +24,6 @@
     :text: More info
     :href: /blog/2024/10/04/content-security-policy-grant/
 
-# Jenkins 2025 Community Awards Open
-- :href: /blog/2025/05/15/jenkins-contributor-awards-cast-your-vote/
-  :title: Jenkins 2025 Community Awards
-  :intro: Vote for the Jenkins 2025 Community Awards!
-    Voting opened on April 22 and closes on June 16, 2025.
-  :image:
-    :src: /images/post-images/2025/03/community-awards-2025-jenkins.png
-    :height: 285px
-  :call_to_action:
-    :text: Make your voice heard by voting through this Google form.
-    :href: https://forms.gle/TjFR6kgYoasrUrFF9
 
 # Jenkins 2024 DevOps Dozen Award
 - :href: https://devopsdozen.com/devops-dozen-2024-community-award-winners/


### PR DESCRIPTION
This PR is to update the carousel/jumbotron for the 2025 Community Award winners blog post, as well as updating the order of what appears.