### PR TITLE
Update mirrors.adoc to fix rsync syntax error

### DIFF
--- a/content/download/mirrors.adoc
+++ b/content/download/mirrors.adoc
@@ -59,7 +59,7 @@ Mirror requirements (click for details on each requirement):
 ----
 curl --silent --show-error --location --remote-name https://archives.jenkins.io/rsync-jenkins-mirrors.filter
 # It's a ~3.1 Mb text file with ~47650 lines
-rsync --times --delete-during --delete-excluded --prune-empty-dirs --include-from=./rsync-jenkins-mirrors.filter # ...
+rsync -a --times --delete-during --delete-excluded --prune-empty-dirs --include-from=./rsync-jenkins-mirrors.filter # ...
 ----
 
 ### A rsync server to allow regular scans of your mirror


### PR DESCRIPTION
rsync: --delete does not work without --recursive (-r) or --dirs (-d).
rsync error: syntax or usage error (code 1) at main.c(1795) [client=3.2.7]