### PR TITLE
chore: add PR template to jenkins.io repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,64 @@
+<!-- Comment:
+A great PR typically begins with the line below.
+Replace XXXX with the numeric part of the issue ID from https://github.com/jenkins-infra/jenkins.io/issues.
+If this PR was created following a discussion on Gitter or with a Jenkins maintainer and no GitHub issue exists, you may skip this line.
+-->
+
+Fixes #XXXX <!-- optional -->
+
+<!-- Comment:
+If the issue is not fully described in [jenkins.io github issue tracker](https://github.com/jenkins-infra/jenkins.io/issues) , please provide additional context here.
+
+Significant content or structural changes should be tracked via a GitHub issue.
+-->
+
+### Changes proposed
+
+<!-- Comment:
+Provide a clear description of what changes are being made and why.
+For documentation changes, explain what content was added, modified, or removed.
+-->
+
+### Testing done
+
+<!-- Comment:
+For documentation changes, describe how you verified the changes (e.g., built the site locally, checked rendering).
+For infrastructure changes, describe what testing was performed.
+For content changes to UI/UX, show the preview of how the changes looks.
+-->
+
+### Proposed documentation updates
+
+<!-- Comment:
+List the documentation changes in human-readable form.
+For examples, see: https://www.jenkins.io/doc/developer/documentation/
+
+Write in the imperative mood; e.g., "Add section about X" rather than "Added section about X".
+-->
+
+### Submitter checklist
+
+- [ ] Related GitHub issue is linked or explained
+- [ ] Documentation updates are included and use the imperative mood
+- [ ] Site was built and previewed locally or via Netlify
+- [ ] For infrastructure changes, testing details are provided or explained
+- [ ] For UI/UX content, screenshots or visual validation are included
+
+### Desired reviewers
+
+@mention
+
+<!-- Comment:
+Tag specific SIG members, mentors, or maintainers who should review this.
+
+If you need an accelerated review process by the community, mention @PersonX. (PersonX is/are the person/persons who needs to review this PR soon)
+-->
+
+Before the changes are marked as `ready-for-merge`:
+
+### Maintainer checklist
+
+- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
+- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
+- [ ] Documentation updates in the pull request title and/or **Proposed documentation updates** are accurate and in the imperative mood.
+- [ ] There is no pending requested changes by any maintainer.


### PR DESCRIPTION
Changes 

- added pr template to our repo 
- now it have similar pr template to that of jenkins-core repo