### PR TITLE
Fix typos

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -27488,7 +27488,7 @@
           - timja
         pr_title: "[JENKINS-75853] - Remove active look of hamburger button"
         message: |-
-          Improve UI of secondardy actions in the header.
+          Improve UI of secondary actions in the header.
       - type: bug
         category: bug
         pull: 10390

--- a/content/_partials/changelog-old.html
+++ b/content/_partials/changelog-old.html
@@ -3893,7 +3893,7 @@
     Matrix project's parent can be now tied to labels/agents.
     (<a href="https://issues.jenkins.io/browse/JENKINS-7825">issue 7825</a>)
   <li class=bug>
-    Clean up fingerprint records that correspond to the deleted build recods
+    Clean up fingerprint records that correspond to the deleted build records
     (<a href="https://issues.jenkins.io/browse/JENKINS-18417">issue 18417</a>)
   <li class=bug>
     Fixed "Comparison method violates its general contract" error in BuildTrigger.execute
@@ -13238,7 +13238,7 @@
 <h3>What's new in 1.95 (03-31-2007)</h3>
 <ul>
   <li>Performance improvement in the controller/agent communication.
-  <li>Fixed JavaScript errors that occurs when there's no entries for repetable form fields
+  <li>Fixed JavaScript errors that occurs when there's no entries for repeatable form fields
       (typically during the fresh install.)
   <li>Hudson now warns the lack of MAVEN2_HOME configuration upfront when job is being configured,
       instead of reporting a failure at the build time.

--- a/content/_partials/changelog-stable.html
+++ b/content/_partials/changelog-stable.html
@@ -1538,7 +1538,7 @@ If your SSH agents fail to start and you have the plugin install the JRE to run 
     Cannot create a custom logger matching any namespace
     (<a href='https://issues.jenkins.io/browse/JENKINS-17983'>issue 17983</a>)
   <li class='bug'>
-    Clean up fingerprint records that correspond to the deleted build recods
+    Clean up fingerprint records that correspond to the deleted build records
     (<a href='https://issues.jenkins.io/browse/JENKINS-18417'>issue 18417</a>)
   <li class='bug'>
     "projects tied to node" shows unrelated maven module jobs


### PR DESCRIPTION
Discovered while running `make check`:

```
make check
scripts/check-hard-coded-URL-references
scripts/check-typos
error: `recods` should be `records`, `recodes`
  --> ./content/_partials/changelog-old.html:3896:71
     |
3896 |     Clean up fingerprint records that correspond to the deleted build recods
     |                                                                       ^^^^^^
     |
error: `repetable` should be `repeatable`, `reputable`
  --> ./content/_partials/changelog-old.html:13241:71
      |
13241 |   <li>Fixed JavaScript errors that occurs when there's no entries for repetable form fields
      |                                                                       ^^^^^^^^^
      |
error: `recods` should be `records`, `recodes`
  --> ./content/_partials/changelog-stable.html:1541:71
     |
1541 |     Clean up fingerprint records that correspond to the deleted build recods
     |                                                                       ^^^^^^
     |
error: `secondardy` should be `secondary`
  --> ./content/_data/changelogs/weekly.yml:27491:25
      |
27491 |           Improve UI of secondardy actions in the header.
      |                         ^^^^^^^^^^
      |
make: *** [Makefile:123: check] Error 2
```

For the two `recods` occurences, I guess I should also update the BEE ticket: https://issues.jenkins.io/browse/JENKINS-18417