### PR TITLE
Add scarf.sh tracking pixel as test for several authors

### DIFF
--- a/content/_data/authors/gounthar.adoc
+++ b/content/_data/authors/gounthar.adoc
@@ -10,3 +10,4 @@ He's been tinkering with continuous integration and continuous deployment since 
 He's passionate about embedded platforms, the ARM&RISC-V ecosystems, and Edge Computing.
 His main goal is to add FOSS projects and platforms to the ARM&RISC-V architectures, so that they become as link:https://twitter.com/jonmasters/status/1523041597683683328[boring] as X86_64. +
 He is also the creator of link:https://minijen.rocks/[miniJen], the smallest multi-cpu architectures Jenkins instance known to mankind.
+image:https://static.scarf.sh/a.png?x-pxid=e010adc8-3614-41ef-b7e8-2f42328e8962&page=authors-gounthar[]

--- a/content/_data/authors/kmartens27.adoc
+++ b/content/_data/authors/kmartens27.adoc
@@ -4,3 +4,4 @@ github: kmartens27
 ---
 
 Kevin Martens is part of the CloudBees Documentation team, helping with Jenkins documentation creation and maintenance.
+image:https://static.scarf.sh/a.png?x-pxid=e010adc8-3614-41ef-b7e8-2f42328e8962&page=authors-kmartens27[]

--- a/content/_data/authors/markewaite.adoc
+++ b/content/_data/authors/markewaite.adoc
@@ -10,3 +10,4 @@ Mark is a member of the link:/project/board/[Jenkins governing board], a long-ti
 // He is active in link:/sigs/[Jenkins special interest groups] including the link:/sigs/docs/[Docs SIG], link:/sigs/platform[Platform SIG], link:/sigs/ux[User Experience SIG], and link:/sigs/advocacy-and-outreach[Advocacy SIG].
 // He has mentored Google Summer of Code projects including link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance/[automatic git cache maintenance (2022)], link:/projects/gsoc/2021/projects/git-credentials-binding/[git credentials binding (2021)], and link:/projects/gsoc/2020/projects/git-plugin-performance/[git plugin performance improvements (2020)].
 He is one of the authors of the link:/doc/developer/tutorial-improve/["Improve a plugin"] tutorial.
+image:https://static.scarf.sh/a.png?x-pxid=e010adc8-3614-41ef-b7e8-2f42328e8962&page=authors-markewaite[]

--- a/content/_data/authors/stackscribe.adoc
+++ b/content/_data/authors/stackscribe.adoc
@@ -3,3 +3,4 @@ name: "Meg McRoberts"
 github: stackscribe
 ---
 Meg is an experienced technical writer and training author with career experience at Bell Labs, SCO, Trend Micro, and CloudBees.
+image:https://static.scarf.sh/a.png?x-pxid=e010adc8-3614-41ef-b7e8-2f42328e8962&page=authors-stackscribe[]


### PR DESCRIPTION
## Add scarf.sh tracking pixel as test for several authors

As discussed in Docs Office Hours 10 July 2025, the Linux Foundation has an agreement with scarf.sh for page tracking and download tracking.  We'd like to test drive this tracking through our fast.ly content delivery network to see if the data that is collected will help us understand page use.
