### PR TITLE
Remove metadata field for consistent link rendering across GSoC projects pages

### DIFF
--- a/content/projects/gsoc/2025/projects/ai-powered-chatbot-for-quick-access-to-jenkins-resources.adoc
+++ b/content/projects/gsoc/2025/projects/ai-powered-chatbot-for-quick-access-to-jenkins-resources.adoc
@@ -15,7 +15,6 @@ mentors:
 - "gounthar"
 - "berviantoleo"
 links:
-  gitter: "https://gitter.im/jenkinsci/gsoc-sig"
   draft: https://docs.google.com/document/d/1DvDh-RlonpM13OyNyrB1fm44ldn6VFbkvnqXa10sBIY/
   idea: /projects/gsoc/2025/project-ideas/ai-powered-chatbot-for-quick-access-to-jenkins-resources
   meetings: "/projects/gsoc/2025/projects/ai-powered-chatbot-for-quick-access-to-jenkins-resources/#office-hours"

--- a/content/projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling.adoc
+++ b/content/projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling.adoc
@@ -15,7 +15,6 @@ mentors:
 - "kmartens27"
 - "iamrajiv"
 links:
-  gitter: "https://gitter.im/jenkinsci/gsoc-sig"
   draft: https://summerofcode.withgoogle.com/media/user/77e3b8323a5f/proposal/gAAAAABn9W4OrTJ_TFxHvMSVoAsMxEQFsDnw-raoBHX5qmzCUiYYmACJ80DxLSRc9UNXdwuH7DwOS6I319_A7sPSKTmcEDDzicG_eVIUhwy60yPthGdsDFs=.pdf
   idea: /projects/gsoc/2025/project-ideas/complete-alternative-jenkins-io-build-retooling
   meetings: "/projects/gsoc/2025/projects/complete-alternative-jenkins-io-build-retooling/#office-hours"

--- a/content/projects/gsoc/2025/projects/domain-specific-LLM-based-on-jenkins-usage-using-ci-jenkins-io-data.adoc
+++ b/content/projects/gsoc/2025/projects/domain-specific-LLM-based-on-jenkins-usage-using-ci-jenkins-io-data.adoc
@@ -16,7 +16,6 @@ mentors:
 - "shivaylamba"
 - "cnu1812"
 links:
-  gitter: "https://gitter.im/jenkinsci/gsoc-sig"
   draft: https://summerofcode.withgoogle.com/media/user/83c42dc69127/proposal/gAAAAABn9W4OhHfosVyfiKg6uwMV18FtcJXFjG_3kMQRbCJI13zX1zp5nvv1CDKlNz6VwI4p7uTMVeEudl18IRJnbrpmy37Wr7KllROp8RHb1nYnDul6MC4=.pdf
   idea: /projects/gsoc/2025/project-ideas/domain-specific-LLM-based-on-jenkins-usage-using-ci-jenkins-io-data
   meetings: "/projects/gsoc/2025/projects/domain-specific-LLM-based-on-jenkins-usage-using-ci-jenkins-io-data/#office-hours"

--- a/content/projects/gsoc/2025/projects/improving-tekton-client-plugin.adoc
+++ b/content/projects/gsoc/2025/projects/improving-tekton-client-plugin.adoc
@@ -14,7 +14,6 @@ mentors:
 - "krisstern"
 - "gounthar"
 links:
-  gitter: "https://gitter.im/jenkinsci/gsoc-sig"
   draft: https://summerofcode.withgoogle.com/media/user/8f6f4971e5f7/proposal/gAAAAABn9W4O6_0DRDxMhmvH5qJq4-iH0a-anroB2tNIXpmBUqnzR9yENTV7o-MZf-GWEi1mveGTsGKa2eLguljaHIU89IvoXgKQoYCLCDCEdQs0kL4YrXY=.pdf
   idea: /projects/gsoc/2025/project-ideas/improving-tekton-client-plugin
   meetings: "/projects/gsoc/2025/projects/improving-tekton-client-plugin/#office-hours"


### PR DESCRIPTION
### Description -

This PR removes the `gitter:` field from the frontmatter of GSoC 2025 project pages that currently include it, aligning them structurally with other project pages like “Improving Plugin Modernizer” which do not use this metadata key.

### Reason -

The `gitter:` field triggers an automatic badge-based rendering on the frontend, which is currently resulting in a broken image icon due to a failed badge load. 



### Before 

<img width="322" height="210" alt="Screenshot 2025-07-14 at 2 09 08 AM" src="https://github.com/user-attachments/assets/dad8dcc8-295f-4093-bcde-06575edd6797" />


### After 

<img width="363" height="217" alt="Screenshot 2025-07-14 at 2 09 18 AM" src="https://github.com/user-attachments/assets/8da507c5-ce18-4d47-aaf3-e86ebcfc7c8a" />


### Preview

<img width="1512" height="901" alt="Screenshot 2025-07-14 at 2 20 29 AM" src="https://github.com/user-attachments/assets/c6a2a65e-aa2f-4716-a207-e8da6839b3fe" />

