### PR TITLE
Minor formatting improvement in restart stage section

### DIFF
--- a/content/doc/book/pipeline/running-pipelines.adoc
+++ b/content/doc/book/pipeline/running-pipelines.adoc
@@ -77,7 +77,7 @@ image::pipeline/pipeline-restart-stages-blue-ocean.png[alt = "Jenkins pipeline v
 
 include::doc/book/blueocean/_blue-ocean-status.adoc[]
 
-==== Preserving `stash`es for Use with Restarted Stages
+==== Preserving `stashes` for Use with Restarted Stages
 
 Normally, when you run the `stash` step in your Pipeline, the resulting stash of artifacts is cleared when the
 Pipeline completes, regardless of the result of the Pipeline. Since `stash` artifacts aren't accessible outside of the


### PR DESCRIPTION
### Summary

This pull request makes a small documentation improvement to the **"Restart from Stage"** section in the Pipeline book.

The original section title included `'stash'es`, which may appear visually awkward or confusing when rendered. To improve readability and consistency with other code-related terms, it has been changed to use backticks and pluralized as `stashes`.

### Before
Preserving 'stash'es for Use with Restarted Stages

### After
Preserving `stashes` for Use with Restarted Stages

No other content was changed. This is a minor formatting update to improve clarity. Thanks for reviewing!