### PR TITLE
Update wording to "Use this node as much as possible" to match UI (fi…

### DIFF
--- a/content/doc/book/managing/system-configuration.adoc
+++ b/content/doc/book/managing/system-configuration.adoc
@@ -117,7 +117,7 @@ Labels can be assigned in the agent configuration settings.
 This section defines how jobs are assigned to agents.
 Options include:
 
-* **Utilize this node as much as possible**: Jobs will be assigned to this node whenever possible.
+* **Use this node as much as possible**: Jobs will be assigned to this node whenever possible.
 * **Only build jobs with label expressions matching this node**: Jobs will only be assigned if their label matches.
 
 === Quiet period


### PR DESCRIPTION
This pull request updates the documentation wording in the “Managing Jenkins > Configuring the System” section to match the current Jenkins user interface. The sentence:

"Utilize this node as much as possible"

has been changed to:

"Use this node as much as possible"

This improves consistency between the documentation and the Jenkins UI, making the instructions clearer and more helpful for users.

Reference
Closes [#8286](https://github.com/jenkins-infra/jenkins.io/issues/8286)