### PR TITLE
Add correct presentation link

### DIFF
--- a/content/blog/2025/07/24/2025-07-24-giovanni-vaccarino-gsoc-midterm-post.adoc
+++ b/content/blog/2025/07/24/2025-07-24-giovanni-vaccarino-gsoc-midterm-post.adoc
@@ -50,7 +50,7 @@ Also, a big shout-out to the Jenkins org admins *Kris Stern*, *Bruno Verachten*,
 
 == Midterm Presentation
 
-We've recently completed the GSoC midterm presentation for the project, where I walked through the current status, key features and future plans. If you are interested in a more detailed overview, you can check out the recording https://youtube.com/add-presentation-link[here].
+We've recently completed the GSoC midterm presentation for the project, where I walked through the current status, key features and future plans. If you are interested in a more detailed overview, you can check out the recording https://www.youtube.com/watch?v=serD66DmEeU&t=845s[here].
 
 == Want to Track the Project?
 


### PR DESCRIPTION
This PR follows #8294, by adding the correct youtube midterm presentation link, since previously it was linked to a non-existent youtube page.