### PR TITLE
Update blog to include presentation link from GSoC page

### DIFF
--- a/content/blog/2025/07/24/2025-07-24-birajit-saikia-gsoc-midterm-update-blog-post.adoc
+++ b/content/blog/2025/07/24/2025-07-24-birajit-saikia-gsoc-midterm-update-blog-post.adoc
@@ -132,6 +132,11 @@ For me, the learning has been immense — not only in terms of technical depth, 
 
 Additional thanks to the Jenkins GSoC org admins for their support and for fostering such a collaborative open-source environment.
 
+=== Midterm Presentation
+
+We recently completed our midterm presentations, where I delivered a high-level overview of the work that has been completed so far and what the rest of the project timeline will look like.
+You can check out my presentation, as well as the others, link:/projects/gsoc/#gsoc-2025[on the Jenkins in Google Summer of Code] page.
+
 == Project Resources
 
 * link:https://github.com/jenkins-infra/docs.jenkins.io[Documentation Repository]


### PR DESCRIPTION
This PR is just a minor adjustment to @biru-codeastromer blog post so that it included a link to the GSoC page that now has a link to the presentations.