### PR TITLE
Update jumbotron with Jenkins redesign

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,4 +1,16 @@
 ---
+# Jenkins redesigned header and UI
+- :href: /blog/2025/07/24/redesigning-jenkins-part-two/
+  :title: Redesigned Jenkins header and UI
+  :intro: Jenkins' UI has been redesigned and updated for a more modern look and feel.
+    Read more about the background and various changes in Jan Faracik's blog post.
+  :image:
+    :src: /images/post-images/2025/07/24/redesigning-jenkins-part-two.png
+    :height: 320px
+  :call_to_action:
+    :text: Read here
+    :href: /blog/2025/07/24/redesigning-jenkins-part-two/
+
 # Jenkins 2025 Community Awards Open
 - :href: /blog/2025/06/25/Celebrating-the-2025-Jenkins-Contributor-Award-Winners/
   :title: Jenkins 2025 Community Awards
@@ -11,19 +23,6 @@
   :call_to_action:
     :text: Read more about the awards and winners in our blog.
     :href: /blog/2025/06/25/Celebrating-the-2025-Jenkins-Contributor-Award-Winners/
-
-# Alpha Omega Grant
-- :href: /blog/2024/10/04/content-security-policy-grant/
-  :title: Alpha Omega Foundation Content Security Policy Grant
-  :intro: Alpha Omega Foundation has provided a grant to Jenkins to improve the implementation of Content Security Policy.
-    Read more about what this means for the Jenkins project.
-  :image:
-    :src: /images/post-images/2024/10/04/content-security-policy-grant.png
-    :height: 320px
-  :call_to_action:
-    :text: More info
-    :href: /blog/2024/10/04/content-security-policy-grant/
-
 
 # Jenkins 2024 DevOps Dozen Award
 - :href: https://devopsdozen.com/devops-dozen-2024-community-award-winners/


### PR DESCRIPTION
This PR is to update the jumbotron to remove the Alpha/Omega grant and add the Jenkins redesign with Jan's blog post.