### PR TITLE
Add election announcement to jumbotron

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -1,4 +1,18 @@
 ---
+# Jenkins 2025 Elections Announcement
+- :href: /blog/2025/08/08/board-officer-election-announcement/
+  :title: Jenkins 2025 Governance board elections
+  :intro: The Jenkins 2025 board and officer elections are happening now.
+    From August 8 - September 22, you can submit nominations for 2 governance board positions
+    and all officer positions.
+    You can find all necessary information regarding the nomination process and timelines in our blog post.
+  :image:
+    :src: /images/governance/elections/2025/2025-announcement-opengraph.svg
+    :height: 285px
+  :call_to_action:
+    :text: Jenkins election announcement.
+    :href: /blog/2025/08/08/board-officer-election-announcement/
+
 # Jenkins redesigned header and UI
 - :href: /blog/2025/07/24/redesigning-jenkins-part-two/
   :title: Redesigned Jenkins header and UI


### PR DESCRIPTION
This PR is to add the 2025 election announcement to the Jumbotron so that it informs anyone going to jenkins.io that it is election season once again.