### PR TITLE
Add a support page

### DIFF
--- a/content/support.adoc
+++ b/content/support.adoc
@@ -1,0 +1,82 @@
+---
+layout: project
+title: "Support"
+section: support
+tags:
+  - support
+  - community
+  - help
+description: >
+  This page provides information about support options for Jenkins
+  and explains how to get help from the Jenkins community.
+---
+
+== Jenkins Support
+
+Jenkins is an open source automation server with a vibrant community of users and contributors. 
+As an open source project, Jenkins offers community-based support through various channels.
+
+=== Support Expectations
+
+As an open source project, Jenkins operates on a community-based support model:
+
+* **Community-driven support**: Help comes from fellow Jenkins users and contributors, not paid support staff
+* **Best-effort basis**: Support is provided by volunteers on their own time
+* **Self-service oriented**: The community provides extensive documentation and resources for self-help
+* **No guaranteed response times**: Response times depend on volunteer availability and issue complexity
+
+=== Community Support Channels
+
+==== Documentation and Resources
+
+The Jenkins project provides extensive self-help resources and should be your first stop for information:
+
+* link:/doc/book/[User Documentation] - Comprehensive user guides and tutorials
+* link:/doc/pipeline/[Pipeline Documentation] - Documentation for Jenkins Pipeline
+* link:/solutions/[Solution Pages] - Common use case solutions
+* link:/doc/developer/[Developer Documentation] - Information for those extending Jenkins
+
+==== Discussion Forum
+
+Our community forums are the primary place to get help for Jenkins usage questions:
+
+* link:https://community.jenkins.io/[community.jenkins.io] - Ask questions, share knowledge, and engage with other Jenkins users
+* link:/mailing-lists/[Jenkins Mailing Lists] - Various mailing lists for users, developers, and specific interest groups
+
+Many Jenkins questions are answered on Stack Overflow (however, these are mostly older questions):
+
+* link:https://stackoverflow.com/questions/tagged/jenkins[Jenkins questions on Stack Overflow]
+* link:https://stackoverflow.com/questions/tagged/jenkins-pipeline[Jenkins Pipeline questions on Stack Overflow]
+
+==== Chat Platforms
+
+For real-time discussions and quick questions:
+
+* link:/chat/[Jenkins Chat] - Connect via Gitter, IRC, or Slack channels
+
+==== Issue Tracking
+
+For demonstrable bug reports and feature requests:
+
+* link:https://issues.jenkins.io/[Jenkins Issue Tracker] - Report bugs or request features
+* link:/participate/report-issue/[How to report an issue] - Guidelines for effective issue reporting
+
+=== Commercial Support Options
+
+While Jenkins is an open source project, several companies offer commercial support services including:
+
+* **Consulting services** from CI/CD specialists
+* **Enterprise support contracts** from companies specializing in Jenkins
+* **Training and certification** programs
+* **Managed Jenkins services** and cloud offerings
+
+==== Commercial Support Providers
+
+NOTE: The Jenkins project does not endorse specific vendors. Users should perform due diligence when selecting commercial support options.
+
+
+** link:https://www.cloudbees.com/[CloudBees] offers a commercial derivate of Jenkins with support and training options.
+** link:https://www.feathersoft.com/jenkins-development-service/[Feathersoft] offers Jenkins development and consulting services for Jenkins.
+** link:https://www.infracloud.io/jenkins-consulting-support/[InfraCloud] offers support and consulting services for Jenkins.
+** link:https://www.itmethods.com/jenkins/[ITMethods] provides managed Jenkins services and support.
+** link:https://www.stackgenie.io/jenkins-automation-services/[StackGenie] offers support, hosting and consulting services for Jenkins.


### PR DESCRIPTION
there was no single place to find how to get support. Various parts are included elsewhere, but this attempts to pull bits into a consise page that is expected to be linked from the header.

It is expected that the page is navigable directory from the header so that it is prominent for users.