### PR TITLE
Update docs to use Java 21 instead of Java 17

### DIFF
--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -288,7 +288,7 @@ NOTE: The following steps are written for *Amazon Linux 2*. If you're using *Ama
 +
 [source,bash]
 ----
-[ec2-user ~]$ sudo yum install java-17-amazon-corretto -y
+[ec2-user ~]$ sudo yum install java-21-amazon-corretto -y
 ----
 
 . Install Jenkins:


### PR DESCRIPTION
This PR updates documentation references from Java 17 to Java 21:

 - content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc updated to use Java 21.