### PR TITLE
Remove the related links section from support page

### DIFF
--- a/content/support.adoc
+++ b/content/support.adoc
@@ -4,7 +4,6 @@ title: "Support"
 section: support
 tags:
   - support
-  - community
   - help
 description: >
   This page provides information about support options for Jenkins


### PR DESCRIPTION
## Remove the related links section from support page

The related links are not of interest to most readers of the support page.

### Before Screenshot

<img width="1736" height="957" alt="screencapture-mark-pc2-markwaite-net-4242-support-2025-08-26-11_31_08" src="https://github.com/user-attachments/assets/c212dbae-2cf3-41f1-a56e-40899953ab83" />

### After Screenshot

<img width="1672" height="964" alt="screencapture-mark-pc2-markwaite-net-4242-support-2025-08-26-11_31_23" src="https://github.com/user-attachments/assets/06685358-2354-44a5-a19a-28c78b11e41c" />
