### PR TITLE
Add "GitHub App Credentials" section

### DIFF
--- a/content/doc/book/security/securing-org-folders-and-multibranch-pipelines.adoc
+++ b/content/doc/book/security/securing-org-folders-and-multibranch-pipelines.adoc
@@ -75,10 +75,6 @@ Unfortunately, if your primary concern is to prevent users with SCM read/write a
 In some cases, you may be able to remove permissions from the credential to make it less powerful.
 For example, you may be able to remove webhook-related permissions from the credentials, which will prevent Jenkins from automatically managing webhooks, in favor of having an administrator configure webhooks manually.
 
-// TODO: Update and uncomment once https://github.com/jenkinsci/github-branch-source-plugin/pull/822 is released.
-////
 === Enhanced GitHub App Credentials
 
-If you are using GitHub Branch Source Plugin with GitHub App Credentials, the plugin offers various features as of version TODO that can be used to improve security.
-See TODO.
-////
+If you are using GitHub Branch Source Plugin with GitHub App Credentials, the plugin offers various features as of version 1844.v4a_9883d49126 that can be used to improve security.


### PR DESCRIPTION
[GitHub App Credentials  1844.v4a_9883d49126](https://github.com/jenkinsci/github-branch-source-plugin/releases/tag/1844.v4a_9883d49126) provides new options to GitHub App credentials.

Let's publish the information.
