### PR TITLE
Added information and links for pipeline step error handling

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -960,8 +960,8 @@ An alternative way of handling this, which preserves the early-exit behavior of 
 
 ==== Error-handling steps
 
-Jenkins Pipelines provide dedicated steps for flexible error handling, allowing you to control how your pipeline responds to errors and warnings.
-These steps help you surface errors and warnings clearly in Jenkins, giving you control over whether the pipeline fails, continues, or simply reports a warning.
+Jenkins Pipelines provide dedicated steps for flexible error handling, allowing you to control how your Pipeline responds to errors and warnings.
+These steps help you surface errors and warnings clearly in Jenkins, giving you control over whether the Pipeline fails, continues, or simply reports a warning.
 For more information, refer to:
 
 * link:/doc/pipeline/steps/workflow-basic-steps/#catcherror-catch-error-and-set-build-result-to-failure[catchError]

--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -958,6 +958,16 @@ This approach, while valid, means the following stages need to check `currentBui
 
 An alternative way of handling this, which preserves the early-exit behavior of failures in Pipeline, while still giving `junit` the chance to capture test reports, is to use a series of `try`/`finally` blocks:
 
+==== Error-handling steps
+
+Jenkins Pipelines provide dedicated steps for flexible error handling, allowing you to control how your pipeline responds to errors and warnings.
+These steps help you surface errors and warnings clearly in Jenkins, giving you control over whether the pipeline fails, continues, or simply reports a warning.
+For more information, refer to:
+
+* link:/doc/pipeline/steps/workflow-basic-steps/#catcherror-catch-error-and-set-build-result-to-failure[catchError]
+* link:/doc/pipeline/steps/workflow-basic-steps/#error-error-signal[error]
+* link:/doc/pipeline/steps/workflow-basic-steps/#unstable-set-stage-result-to-unstable[unstable]
+* link:/doc/pipeline/steps/workflow-basic-steps/#warnerror-catch-error-and-set-build-and-stage-result-to-unstable[warnError]
 
 === Using multiple agents
 


### PR DESCRIPTION
This PR adds a new error handling section with links to the Pipeline: Basic Steps plugin, for more information about the `catchError`, `error`, `unstable`, and `warnError` steps.