### PR TITLE
Fix the cd workflow URL

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -292,11 +292,11 @@ Due to technical limitations in GitHub Actions it is not possible to suppress th
 Actual releases will display a green check next to the *release* stage.
 +
 You can also trigger a deployment explicitly, if the current commit has a passing check from Jenkins.
-Visit https://github.com/jenkinsci/your-plugin/actions?query=workflow%3Acd and click Run workflow.
+Visit https://github.com/jenkinsci/your-plugin/actions/workflows/cd.yaml and click Run workflow.
 
 If you changed `cd.yaml` to only run on `workflow_dispatch`::
 You can trigger a release explicitly, if the current commit has a passing check from Jenkins.
-Visit https://github.com/jenkinsci/your-plugin/actions?query=workflow%3Acd and click Run workflow.
+Visit https://github.com/jenkinsci/your-plugin/actions/workflows/cd.yaml and click Run workflow.
 
 == Noting incompatible changes
 


### PR DESCRIPTION
The previous link didn't properly redirect to the cd workflow but to the All workflows page.