### PR TITLE
Update 2025-09-03 security advisory

### DIFF
--- a/content/security/advisory/2025-09-03.adoc
+++ b/content/security/advisory/2025-09-03.adoc
@@ -11,7 +11,7 @@ issues:
     severity: Medium
     vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
   description: |-
-    PLUGIN_NAME 6.3.2 and earlier allows specifying the experimental `amazon-s3` protocol for use with the bundled JGit library.
+    PLUGIN_NAME 6.3.2 and earlier, except 6.1.4 and 6.2.1, allows specifying the experimental `amazon-s3` protocol for use with the bundled JGit library.
     This protocol authenticates against Amazon S3 based on contents of the file whose path is provided as the authority part of the URL (`amazon-s3://path-to-file@bucketname/folder`).
 
     While use of this protocol in PLUGIN_NAME to perform any actions always fails due to a bug in the plugin, error messages can be used to determine whether the specified file path exists on the controller.


### PR DESCRIPTION
There is two backports of the SECURITY-3590 fix of git-client that were created today.

I'm updating the advisory description to represent that. 

See also https://github.com/jenkins-infra/update-center2/pull/887