### PR TITLE
Fix typo on JENKINS-75834 description

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -27567,7 +27567,7 @@
           - MarkEWaite
         pr_title: "[JENKINS-75834] limit the functionality to a specific reference"
         message: |-
-          Only hide the dropdown on the breadcumbs, not on other menus.
+          Only hide the dropdown on the breadcrumbs, not on other menus.
 
   # pull: 10811 (PR title: Allow up to 15 seconds for agent reconnect)
   # pull: 10812 (PR title: Update dependency io.jenkins.plugins:design-library to v401)


### PR DESCRIPTION
Fixing a small typo, identified while running `make check`.

Before:

```
make check
scripts/check-hard-coded-URL-references
scripts/check-typos
error: `breadcumbs` should be `breadcrumbs`
  --> ./content/_data/changelogs/weekly.yml:27570:41
      |
27570 |           Only hide the dropdown on the breadcumbs, not on other menus.
      |                                         ^^^^^^^^^^
      |
make: *** [Makefile:123: check] Error 2
```

After: 
```
make check
scripts/check-hard-coded-URL-references
scripts/check-typos
```