### PR TITLE
feat(roadmap) update jenkins-infra roadmap tasks

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -723,10 +723,17 @@ categories:
       link: https://github.com/jenkins-infra/helpdesk/issues/4641
       labels:
       - infrastructure
+    - name: "Java 25 GA for developers"
+      description: >
+        JDK25 GA is scheduled of 16 September 2025. We provided a preview version to developers on ci.jenkins.io: we should provide the GA version with automatic updates once released.
+      status: near-term
+      # link: https://github.com/jenkins-infra/helpdesk/issues/4641
+      labels:
+      - infrastructure
     - name: "Migrate ci.jenkins.io from Azure to the AWS Sponsored Account"
       description: >
         AWS gave us 90k$ credits to use until 31 January 2027. As we'll run out of sponsored Azure credits the 31 August 2025, we'll move ci.jenkins.io to AWS.
-      status: current
+      status: released
       link: https://github.com/jenkins-infra/helpdesk/issues/4689
       labels:
       - infrastructure
@@ -734,7 +741,15 @@ categories:
       description: >
         The VM pkg.origin.jenkins.io is a legacy machine running in a specific (CloudBees) account. We want it to move to Azure to decrease costs and modernize its components.
       link: https://github.com/jenkins-infra/helpdesk/issues/3705
-      status: near-term
+      status: current
+      labels:
+      - infrastructure
+    - name: "Add support for Windows 2025"
+      description: >
+        Windows 2025 Server is the current (and most recent) LTS line. As per https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info, it has been released since November 2024 and will be supported until November 2029.
+        It should be used as the default for Windows agents in the Jenkins infrastructure.
+      link: https://github.com/jenkins-infra/helpdesk/issues/4791
+      status: current
       labels:
       - infrastructure
     - name: "Move Configuration Management out of Puppet"


### PR DESCRIPTION
- ci.jenkins.io has been migrated since 2 month, including the cleanup (Azure subscription, etc.)
- Current main priority is pkg.origin.jenkins.io VM
- Added Windows 2025 and JDK25 GA