### PR TITLE
Split JENKINS-76075 entry into two entries

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -28040,12 +28040,20 @@
         issue: 76075
         authors:
           - dukhlov
-          - 'TODO: Dmytro Ukhlov (dukhlov@csod.com)'
         pr_title: "[JENKINS-76075]: Optimise BuildReferenceMapAdapter and LogRotator:
           defer reference resolution"
         message: |-
           Optimize build lazy loading during iteration via RunMap.entrySet() and RunMap.keySet().
-           Optimize LogRotator build iteration using RunMap.entrySet().
+      - type: rfe
+        category: internal
+        pull: 11038
+        issue: 76075
+        authors:
+          - dukhlov
+        pr_title: "[JENKINS-76075]: Optimise BuildReferenceMapAdapter and LogRotator:
+          defer reference resolution"
+        message: |-
+          Optimize LogRotator build iteration using RunMap.entrySet().
       - type: rfe
         category: rfe
         pull: 11065


### PR DESCRIPTION
## Split JENKINS-76075 entry into two entries

Author of the change had used two entries.  We should honor that in the changelog.

Refer to pull request:

* https://github.com/jenkinsci/jenkins/pull/11038

Bug report [JENKINS-76075](https://issues.jenkins.io/browse/JENKINS-76075)
