### PR TITLE
Link infra helpdesk on support page

### DIFF
--- a/content/support.adoc
+++ b/content/support.adoc
@@ -60,6 +60,12 @@ For demonstrable bug reports and feature requests:
 * link:/participate/report-issue/[How to report an issue] - Guidelines for effective issue reporting
 * link:https://issues.jenkins.io/[Jenkins Issue Tracker] - Report bugs or request features
 
+=== Infrastructure Helpdesk
+
+For problems related to Jenkins project infrastructure (e.g., the jenkins.io website, plugins.jenkins.io, issues.jenkins.io, etc.):
+
+* link:https://github.com/jenkins-infra/helpdesk/[Jenkins Infra Helpdesk on GitHub] - Open a new issue to report problems with Jenkins project infrastructure
+
 == Commercial Support Options
 
 While Jenkins is an open source project, several companies offer commercial support services including:


### PR DESCRIPTION
Make helpdesk more discoverable. Right now it's only really linked from "Report Issue" and the governance doc (???).

The rest of the page is already in violation of sentence case titles specified in https://github.com/jenkins-infra/jenkins.io/blob/master/STYLEGUIDE.adoc#assorted-comments, so I made the new title consistent with that.