### PR TITLE
Create 2.528.1 changelog and upgrade guide

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -13554,6 +13554,252 @@
     message: |-
       Position the <strong>Save</strong> and <strong>Apply</strong> buttons for views under the header instead of over it.
 
+- version: "2.528.1"
+  date: 2025-10-15
+  lts_predecessor: "2.516.3"
+  lts_baseline: "2.528"
+  changes: # compared to lts_baseline 2.528 - extracted from the RC commit(s)
+  
+  - type: bug
+    category: bug
+    pull: 11087
+    issue: 76135
+    authors:
+      - jtnord
+    pr_title: "[JENKINS-76135] work around eclipse compiler bug"
+    message: |-
+      Remove Eclipse modifier class to ensure code compiles as expected.
+  - type: bug
+    category: bug
+    pull: 11070
+    issue: 76114
+    authors:
+      - jeromepochat
+    pr_title: "[JENKINS-76114] Bring back the All/None/Suggested buttons in the plugin configuration wizard"
+    message: |-
+      Fix <strong>All/None/Suggested</strong> buttons visibility in plugin setup wizard.
+  - type: bug
+    category: bug
+    pull: 11059
+    issue: 76002
+    authors:
+      - jeromepochat
+    pr_title: "[JENKINS-76002] Apply number instead of string comparison"
+    message: |-
+      Fix number comparison in min/max form validator.
+
+  lts_changes: # compared to lts_predecessor 2.516.3 (selected by personal review)
+
+  - type: major rfe
+    category: rfe
+    authors:
+      - janfaracik
+    references:
+      - pull: 10814
+      - pull: 10806
+      - pull: 10853
+      - pull: 10901
+      - pull: 10913
+    pr_title: "Refine header, app bar, and side panel alignment"
+    message: |-
+      Updates to various UI elements.
+      Refine the header, app bar, and side pannel.
+      Refine colors, borders, and buttons.
+      Use secondary text color for dropdowns.
+  - type: rfe
+    category: rfe
+    authors:
+      - dukhlov
+      - jasssonpet
+      - StefanSpieker
+    references:
+      - pull: 11025
+      - pull: 10835
+      - pull: 10943
+    pr_title: Adds Polish translations
+    message: |-
+      Add Polish localization.
+      Adjust Bulgarian localization spacing.
+      Add German localization for Global Build Discarder.
+  - type: rfe
+    category: rfe
+    pull: 10979
+    authors:
+      - dukhlov
+    pr_title: Move common caching class loading functionality to the 
+      separate class
+    message: |-
+      Improve <code>UberClassLoader</code> class caching.
+  - type: rfe
+    category: rfe
+    pull: 10945
+    authors:
+      - mawinter69
+    pr_title: Make shutdown and safe-restart messages theme aware
+    message: |-
+      Apply the current theme color palette to shutdown and safe-restart messages.
+  - type: rfe
+    category: rfe
+    pull: 10997
+    issue: 76028
+    authors:
+      - dukhlov
+    pr_title: "[JENKINS-76028] Add NavigableMap support for CopyOnWriteMap.Tree"
+    message: |-
+      Expose <code>NavigableMap</code> interface from the <code>CopyOnWrite.Tree</code> map.
+      Optimise the <code>AbstractLazyLoadRunMap.search()</code> method.
+  - type: rfe
+    category: rfe
+    pull: 10946
+    issue: 75986
+    authors:
+      - dukhlov
+    pr_title: "[JENKINS-75986] Refactor `BuildReferenceMapAdapter`"
+    message: |-
+      Refactor <code>BuildReferenceMapAdapter</code> to improve code re-usage.
+  - type: rfe
+    category: rfe
+    pull: 10926
+    authors:
+      - jglick
+    pr_title: Deprecate `UserIdMapper` and just use an HMAC
+    message: |-
+      Pick a new name format for subdirectories of <code>$JENKINS_HOME/users/</code>.
+      Stop creating redundant <code>$JENKINS_HOME/users/users.xml</code>.
+  - type: rfe
+    category: rfe
+    pull: 10855
+    authors:
+      - jglick
+    pr_title: "`AdministrativeMonitorsDecorator` cleanup; `ManageJenkinsAction.getBadge`
+      optimization"
+    message: |-
+      Minor performance optimization for administrative monitors badge display.
+  - type: rfe
+    category: rfe
+    pull: 10752
+    authors:
+      - daniel-beck
+      - MarkEWaite
+    pr_title: Remove `/extensionList/` URL
+    message: |-
+      Remove the <code>/extensionList/</code> HTTP endpoint and related telemetry.
+      Users of the Timestamper plugin should update to version 1.29 or newer.
+  - type: rfe
+    category: rfe
+    pull: 10807
+    authors:
+      - janfaracik
+      - krisstern
+    pr_title: Refine User page
+    message: |-
+      Refine <strong>User</strong> page UI.
+  - type: rfe
+    category: rfe
+    pull: 10839
+    authors:
+      - janfaracik
+    pr_title: Refine Console URL Provider UI
+    message: |-
+      Refine the Console URL Provider UI.
+  - type: rfe
+    category: rfe
+    pull: 10941
+    authors:
+      - mawinter69
+    pr_title: show parameters of a run with readOnlyMode
+    message: |-
+      Show parameters of a run in read-only mode.
+  - type: rfe
+    category: rfe
+    pull: 10803
+    issue: 75851
+    authors:
+      - scherler
+    pr_title: "[JENKINS-75851] implement a dropdown indicator"
+    message: |-
+      Breadcrumbs now have a visual indicator and are compatible with accessibility guidelines.
+  - type: rfe
+    category: rfe
+    pull: 10927
+    authors:
+      - jglick
+    pr_title: Avoid printing stack trace for `ClosedChannelException` in 
+      agent launch log
+    message: |-
+      Reduce agent launch log stack trace noise for <code>ClosedChannelException</code>s.
+  - type: rfe
+    category: rfe
+    pull: 10788
+    authors:
+      - olamy
+    pr_title: "Remove net.i2p.crypto:eddsa which is not supported anymore and
+      use support of EdDSA natively provided now by Apache Mina via Bouncycastle"
+    message: |-
+      SSH cli now uses support of EdDSA natively provided by Apache Mina via Bouncycastle.
+  - type: bug
+    category: bug
+    pull: 11039
+    authors:
+      - gbhat618
+    pr_title: "Initialize `transport` at the beginning of `opened`"
+    message: |-
+      Fix a race condition in WebSocket agent connection initialization.
+  - type: bug
+    category: bug
+    pull: 10954
+    authors:
+      - jglick
+    pr_title: Better error response from `doBuildWithParameters`
+    message: |-
+      Create friendlier HTTP response for an attempt to <code>buildWithParameters</code> a disabled or nonparameterized job.
+  - type: bug
+    category: bug
+    pull: 10965
+    issue: 75991
+    authors:
+      - stephane-chazelas
+    pr_title: "[JENKINS-75991] Fix name of reason query parameter in online help
+          for quietDown"
+    message: |-
+      Fix incorrect parameter name in <code>quietDown</code> API online help.
+  - type: bug
+    category: bug
+    pull: 10881
+    authors:
+      - lewisbirks
+    pr_title: Fix word breaking in pre tags and help classes
+    message: |-
+      Correct <code>word-wrap</code> and <code>word-break</code> CSS properties to use supported values.
+  - type: bug
+    category: bug
+    pull: 10863
+    authors:
+      - jglick
+    pr_title: Avoid warning about `labelAtomSet` during `Slave.readResolve`
+    message: |-
+      Stop printing an incorrect message from <code>Slave.warnPlugin</code>.
+  - type: bug
+    category: bug
+    pull: 10390
+    issue: 75252
+    authors:
+      - singghh
+      - krisstern
+      - MarkEWaite
+    pr_title: "JENKINS-75252: Remove pointer-events:none from .jenkins-menu-dropdown-chevron"
+    message: |-
+      Enable the chevron button in job tables by removing <code>pointerevents:none</code> from its CSS styling.
+  - type: bug
+    category: bug
+    pull: 10756
+    authors:
+      - Vlatombe
+    pr_title: When a pending item lost its executor, it should be 
+      rescheduled
+    message: |-
+      Avoid queue items being lost if the node disconnects at a bad time during allocation.
+
 # DO NOT EDIT THIS FILE DIRECTLY
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS
 # MALFORMED FILE CONTENTS WILL BREAK THE SITE BUILD

--- a/content/_data/upgrades/2-528-1.adoc
+++ b/content/_data/upgrades/2-528-1.adoc
@@ -1,0 +1,7 @@
+==== Configuration as code entry for 'myViewsTabBar' is deprecated.
+
+As of 2.528.1, the configuration as code entry for 'myViewsTabBar' has been deprecated.
+In its place, a new user property has been introduced that makes it possible for a user to override what is configured for the global dashboard or a folder.
+This will be seen as the Views Tab Bar in Jenkins UI.
+Instead of the 'myViewsTabBar', users can now select one of the implementations of 'ViewsTabBar' to be used for the My Views dashboard.
+The default view on the *My Views* configuration is a selectable option instead of checking if the user enters a valid view name.


### PR DESCRIPTION
This PR is to create the changelog & upgrade guide for 2.528.1. The upgrade guide only contains 1 entry at this time based on the Jenkins github issues list. It has been compared to the already released changelogs to prevent any duplicate entries. Screenshots will be added later once I have been able to run a proper build locally.