### PR TITLE
Make Embedded Video Iframe Responsive in Mobile View and avoid overflow

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1616,3 +1616,4 @@ center > iframe {
 .blog-content iframe {
   max-width: 100%;
 }
+


### PR DESCRIPTION
Fixes #8479 
I have gone through almost all of the iframes in this repo and the fix can be seen on 
1. https://www.jenkins.io/solutions/embedded/
2. https://www.jenkins.io/solutions/ruby/
3. https://www.jenkins.io/solutions/pipeline/
4. https://www.jenkins.io/projects/gsoc/2018/remoting-over-message-bus/.
5. https://www.jenkins.io/zh/blog/2015/12/02/hacksgiving-left-overs/
6. https://www.jenkins.io/blog/2011/10/17/andrew-bayer-discusses-jenkins-with-tim-obrien/
7. https://www.jenkins.io/blog/2019/10/21/thinking-about-jenkins-security/
8. https://www.jenkins.io/blog/2019/10/24/jenkins-performance-avoiding-pitfalls/
9. https://www.jenkins.io/blog/2011/04/04/the-final-two-run-off-vote-for-the-new-jenkins-logo/
10. https://www.jenkins.io/blog/2011/03/21/the-polls-are-open-for-the-jenkins-logo-contest/

The issue has now been resolved by applying a responsive styling fix directly in the main.css file, ensuring consistent iframe behavior across all devices and preventing similar issues in the future.