### PR TITLE
docs: separate Java install commands and expected output for clarity

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -56,9 +56,9 @@ If the installation was successful, you should see an output similar to the foll
 
 [source,bash]
 ----
-openjdk version "21.0.3" 2024-04-16
-OpenJDK Runtime Environment (build 21.0.3+11-Debian-2)
-OpenJDK 64-Bit Server VM (build 21.0.3+11-Debian-2, mixed mode, sharing)
+openjdk 21.0.8 2025-07-15
+OpenJDK Runtime Environment (build 21.0.8+9-Debian-1)
+OpenJDK 64-Bit Server VM (build 21.0.8+9-Debian-1, mixed mode, sharing)
 ----
 
 [NOTE]


### PR DESCRIPTION
**What I changed**
Separated the OpenJDK installation commands and the expected `java -version` output into two code blocks, following the same style used elsewhere in the Jenkins installation guide.

**Why**
Previously, the expected output was part of the same `[source,bash]` block as the commands. When users click the “copy” button, they inadvertently copy the output too, which can cause confusion or errors when pasting into the terminal.

**Example**
Before:
    (commands and expected output mixed in one block)
After:
    Commands and expected output are now in separate blocks, consistent with other examples like the `systemctl status jenkins` section.
