### PR TITLE
Node: track .node-version and scripts/node via packer-images; split manifests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,3 +15,5 @@ If you're interested in contributing to the site, please see our
 link:https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc[Contributing document]
 
 Documentation for Jenkins website maintenance is in the https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#maintainer-guide[maintainers guidelines].
+ 
+NOTE: This project uses specific Ruby and Node.js versions defined in `.ruby-version` and `.node-version`. These files are kept in sync with our CI environment via Updatecli.

--- a/updatecli/updatecli.d/node-documentation.yaml
+++ b/updatecli/updatecli.d/node-documentation.yaml
@@ -1,0 +1,179 @@
+---
+name: Bumps the node docker images versions
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  nodeLatestLTSVersionFromJson:
+    name: Get value from json
+    kind: json
+    spec:
+      file: https://nodejs.org/dist/index.json
+      key: .(lts!=false).version
+    transformers:
+      - trimprefix: "v"
+
+  # Using the githubrelease allows us to retrieve the changelog information
+  # It will fail if the version mentioned by appVersion does not have an equivalent published
+  # GitHub release
+  nodeLatestVersion:
+    kind: githubrelease
+    name: Get latest nodejs version
+    dependson:
+      - nodeLatestLTSVersionFromJson
+    spec:
+      owner: "nodejs"
+      repository: "node"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+        pattern: '{{ source "nodeLatestLTSVersionFromJson" }}'
+    transformers:
+      - trimprefix: "v"
+  alpineLatestVersion:
+    kind: githubrelease
+    name: "Get the latest Alpine Linux version"
+    spec:
+      owner: "alpinelinux"
+      repository: "aports" # Its release process follows Alpine's
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+        pattern: "~3"
+    transformers:
+      - findsubmatch:
+          pattern: >-
+            v(.*)(\.\d+)
+          captureindex: 1
+
+conditions:
+  testNodeArg:
+    name: "Does the 'Hello World!' tutorial have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/pipeline/tour/hello-world.adoc
+      matchpattern: >-
+        .*agent.*docker.*image.*node:.*
+  testNodeInAgentsDocumentation:
+    name: "Does the 'Defining execution environments' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/pipeline/tour/agents.adoc
+      matchpattern: >-
+        .*docker.*image.*node:.*
+  testNodeInStyleGuideDocumentation:
+    name: "Does the 'Jenkins Documentation Style Guide' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: STYLEGUIDE.adoc
+      matchpattern: >-
+        .*docker.*image.*node:.*
+  testNodeInUsingDockerWithPipelineDocumentation:
+    name: "Does the 'Using Docker with Pipeline' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/book/pipeline/docker.adoc
+      matchpattern: >-
+        .*image.*node:.*
+  testNodeAlpineImagePublished:
+    name: "Test node:<latest_version>-alpine<latest-version> docker image tag"
+    kind: dockerimage
+    disablesourceinput: true
+    spec:
+      image: "node"
+      tag: '{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
+
+targets:
+  updateHelloWorldTutorialNodePipeline:
+    name: "Update the value of the node docker image for pipelines in the 'Hello World!' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/pipeline/tour/hello-world.adoc
+      matchpattern: >-
+        (.*agent.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateHelloWorldTutorialNodeScripted:
+    name: "Update the value of the node docker image for scripts in the 'Hello World!' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/pipeline/tour/hello-world.adoc
+      matchpattern: >-
+        (.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateAgentsDocumentation:
+    name: "Update the value of the node docker image in the 'Defining execution environments' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/pipeline/tour/agents.adoc
+      matchpattern: >-
+        (.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateStyleGuideDocumentation:
+    name: "Update the value of the node docker image in the 'Jenkins Documentation Style Guide' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: STYLEGUIDE.adoc
+      matchpattern: >-
+        (.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateUsingDockerWithPipelineDocumentation:
+    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/book/pipeline/docker.adoc
+      matchpattern: >-
+        (.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateUsingDockerWithPipelineDocumentationDockerExample:
+    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/book/pipeline/docker.adoc
+      matchpattern: >-
+        (FROM )node:(.*)(.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Bump node LTS version to {{ source "nodeLatestLTSVersionFromJson" }} (alpine {{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }})'
+    spec:
+      labels:
+        - dependencies
+
+

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bumps the node docker images versions
+name: Bump NodeJS version (docker image) to follow packer-image infra version
 
 scms:
   default:
@@ -14,179 +14,62 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  nodeLatestLTSVersionFromJson:
-    name: Get value from json
-    kind: json
+  getDeployedPackerImageVersion:
+    kind: file
+    name: Retrieve the current version of the Packer images used in production
     spec:
-      file: https://nodejs.org/dist/index.json
-      key: .(lts!=false).version
-    transformers:
-      - trimprefix: "v"
-
-  # Using the githubrelease allows us to retrieve the changelog information
-  # It will fail if the version mentioned by appVersion does not have an equivalent published
-  # GitHub release
-  nodeLatestVersion:
-    kind: githubrelease
-    name: Get latest nodejs version
-    dependson:
-      - nodeLatestLTSVersionFromJson
-    spec:
-      owner: "nodejs"
-      repository: "node"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: semver
-        pattern: '{{ source "nodeLatestLTSVersionFromJson" }}'
-    transformers:
-      - trimprefix: "v"
-  alpineLatestVersion:
-    kind: githubrelease
-    name: "Get the latest Alpine Linux version"
-    spec:
-      owner: "alpinelinux"
-      repository: "aports" # Its release process follows Alpine's
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: semver
-        pattern: "~3"
+      file: https://raw.githubusercontent.com/jenkins-infra/kubernetes-management/refs/heads/main/config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: 'galleryImageVersion:\s"(.*)"'
     transformers:
       - findsubmatch:
-          pattern: >-
-            v(.*)(\.\d+)
+          pattern: 'galleryImageVersion:\s"(.*)"'
+          captureindex: 1
+  getNodeVersionFromPackerImages:
+    kind: file
+    name: Get the NodeJS version set in packer-images
+    dependson:
+      - getDeployedPackerImageVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getDeployedPackerImageVersion" }}/provisioning/tools-versions.yml
+      matchpattern: 'node.*_version:\s(.*)'
+    transformers:
+      - findsubmatch:
+          pattern: 'node.*_version:\s(.*)'
           captureindex: 1
 
 conditions:
-  testNodeArg:
-    name: "Does the 'Hello World!' tutorial have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/pipeline/tour/hello-world.adoc
-      matchpattern: >-
-        .*agent.*docker.*image.*node:.*
-  testNodeInAgentsDocumentation:
-    name: "Does the 'Defining execution environments' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/pipeline/tour/agents.adoc
-      matchpattern: >-
-        .*docker.*image.*node:.*
-  testNodeInStyleGuideDocumentation:
-    name: "Does the 'Jenkins Documentation Style Guide' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: STYLEGUIDE.adoc
-      matchpattern: >-
-        .*docker.*image.*node:.*
-  testNodeInUsingDockerWithPipelineDocumentation:
-    name: "Does the 'Using Docker with Pipeline' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/book/pipeline/docker.adoc
-      matchpattern: >-
-        .*image.*node:.*
-  testNodeAlpineImagePublished:
-    name: "Test node:<latest_version>-alpine<latest-version> docker image tag"
+  checkDockerImagePublished:
+    name: Test node:{{ source "getNodeVersionFromPackerImages" }} docker image tag
+    sourceid: getNodeVersionFromPackerImages
     kind: dockerimage
-    disablesourceinput: true
     spec:
       image: "node"
-      tag: '{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
+      ## Tag from source
 
 targets:
-  updateHelloWorldTutorialNodePipeline:
-    name: "Update the value of the node docker image for pipelines in the 'Hello World!' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/pipeline/tour/hello-world.adoc
-      matchpattern: >-
-        (.*agent.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateHelloWorldTutorialNodeScripted:
-    name: "Update the value of the node docker image for scripts in the 'Hello World!' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/pipeline/tour/hello-world.adoc
-      matchpattern: >-
-        (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateAgentsDocumentation:
-    name: "Update the value of the node docker image in the 'Defining execution environments' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/pipeline/tour/agents.adoc
-      matchpattern: >-
-        (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateStyleGuideDocumentation:
-    name: "Update the value of the node docker image in the 'Jenkins Documentation Style Guide' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: STYLEGUIDE.adoc
-      matchpattern: >-
-        (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateUsingDockerWithPipelineDocumentation:
-    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/book/pipeline/docker.adoc
-      matchpattern: >-
-        (.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateUsingDockerWithPipelineDocumentationDockerExample:
-    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/book/pipeline/docker.adoc
-      matchpattern: >-
-        (FROM )node:(.*)(.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
   setNodeImageVersion:
     name: "Bump Node Image version in scripts/node"
     kind: file
-    sourceid: nodeLatestLTSVersionFromJson
+    sourceid: getNodeVersionFromPackerImages
     spec:
       file: scripts/node
       matchpattern: 'CONTAINER_NAME=node:.*'
-      replacepattern: 'CONTAINER_NAME=node:{{ source "nodeLatestLTSVersionFromJson" }}'
+      replacepattern: 'CONTAINER_NAME=node:{{ source "getNodeVersionFromPackerImages" }}'
     scmid: default
   setNodeVersionFile:
     name: "Bump Node version in .node-version"
     kind: file
-    sourceid: nodeLatestLTSVersionFromJson
+    sourceid: getNodeVersionFromPackerImages
     spec:
       file: .node-version
     scmid: default
+
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: 'Bump node LTS version to {{ source "nodeLatestLTSVersionFromJson" }} (alpine {{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }})'
+    title: Bump Node version to {{ source "getNodeVersionFromPackerImages" }} to match packer-images in production
     spec:
       labels:
         - dependencies
+        - nodejs


### PR DESCRIPTION
1. Add `setNodeVersionFile` target to `sync .node-version` from packer-images
2. Add `setNodeImageVersion` target to sync scripts/node container tag
3. Split manifests: infra-tracking `node.yaml` and docs `node-documentation.yaml`
4. Add `README` note referencing `.ruby-version` and `.node-version`

Fixes #8515 (PR 2)