### PR TITLE
chore(renovate) remove tracking of the jenkinsciinfra/builder image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,12 +36,6 @@
       "datasourceTemplate": "github-releases"
     },
     {
-      "fileMatch": ["Jenkinsfile_k8s"],
-      "matchStrings": ["image: \"jenkinsciinfra/builder:(?<currentValue>.*?)\"\n"],
-      "depNameTemplate": "jenkinsciinfra/builder",
-      "datasourceTemplate": "docker"
-    },
-    {
       "fileMatch": ["content/_layouts/frame.html.haml"],
       "matchStrings": ["lit@(?<currentValue>.*?)/"],
       "depNameTemplate": "lit",


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4867