### PR TITLE
fix(weekly 2.537 changelog) add missing item around RPM packaging

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -28617,6 +28617,15 @@
 
   - version: '2.537'
     date: 2025-11-18
+    banner: >
+      Starting with Jenkins 2.537, RedHat and openSUSE have the same RPM packages from the same unified repository at <a href="https://pkg.jenkins.io/rpm/">https://pkg.jenkins.io/rpm/</a>.
+      Users with an already installed prior version are transparently redirected when refreshing their repositories: <a href="https://pkg.jenkins.io/redhat/">https://pkg.jenkins.io/redhat/</a> and <a href="https://pkg.jenkins.io/opensuse/">https://pkg.jenkins.io/opensuse/</a> both redirect to the new URL.
+      <br /><br />
+      The old repositories are retained and allow to install older versions (<2.537) by using the following URLs: <a href="https://pkg.jenkins.io/redhat-legacy/">https://pkg.jenkins.io/redhat-legacy/</a> for RedHat distributions and <a href="https://pkg.jenkins.io/opensuse-legacy/">https://pkg.jenkins.io/opensuse-legacy/</a> for openSUSE distributions.
+      <br /><br />
+      Note for openSUSE users: the System V initialization scripts are removed for openSUSE installations (details in <a href="https://www.jenkins.io/blog/2022/03/25/systemd-migration/">https://www.jenkins.io/blog/2022/03/25/systemd-migration/</a>).
+      <br /><br />
+      ⚠️ There is a known bug introduced for openSUSE users: the <code>autorefresh</code> feature of the zypper repository is disabled and requires a `zypper refresh` command.
     changes:
       - type: rfe
         category: rfe
@@ -28661,13 +28670,8 @@
           - url: https://www.jenkins.io/blog/2022/03/25/systemd-migration/
             title: Linux install packages migrated from System V init to systemd
         message: |-
-          RedHat and openSUSE packages are unified into the same RPM packaging with a brand new URL: https://pkg.jenkins.io/rpm/.
-          Current users are transparently redirected to the new URL when refreshing their repositories: https://pkg.jenkins.io/redhat/ and https://pkg.jenkins.io/opensuse/ both redirect to https://pkg.jenkins.io/rpm/.
-          The old repositories are retained and allow to install older versions (<2.537) by using the repository URL https://pkg.jenkins.io/redhat-legacy/ for RedHat distributions and https://pkg.jenkins.io/opensuse-legacy/ for openSUSE distributions.
-          Note for openSUSE users: this RPM "unification" brought a few changes to installations:
-            - System V initialization scripts are removed for openSUSE installations (details in https://www.jenkins.io/blog/2022/03/25/systemd-migration/).
-            - Users with a custom log directory no longer have a <code>logrotate(8)</code> configuration out-of-the-box.
-            - Autorefresh of the zypper repository is disabled and require a `zypper refresh` command. This sounds like an unexpected bug and should be fixed in 2.539.
+          RedHat and openSUSE packages are unified into the same RPM packaging with a brand new URL: <a href="https://pkg.jenkins.io/rpm/">https://pkg.jenkins.io/rpm/</a>.
+          System V initialization scripts are removed for openSUSE installations
 
 
   # pull: 11250 (PR title: Update dependency org.glassfish.tyrus.bundles:tyrus-standalone-client-jdk to v2.2.1)


### PR DESCRIPTION
The weekly release 2.537 includes a packaging change (https://github.com/jenkinsci/packaging/pull/430) which we have not documented because I integrated on the infra late in the planning.

This PR adds required elements in the changelog following the issue https://issues.jenkins.io/browse/JENKINS-76296 opened by a user.