### PR TITLE
Add core-components-jira-migration.adoc redirection

### DIFF
--- a/content/redirect/core-components-jira-migration.adoc
+++ b/content/redirect/core-components-jira-migration.adoc
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_url: https://github.com/jenkinsci/jenkins/issues/11301
+---


### PR DESCRIPTION
This PR adds a redirection so the link https://jenkins.io/redirect/core-components-jira-migration in automated Jira bulk comments (like for ex [this one](https://issues.jenkins.io/browse/JENKINS-67651?focusedId=459079&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-459079)) doesn't return a "not found" error.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4870