### PR TITLE
Document `setTimeout` and `setInterval`

### DIFF
--- a/content/doc/developer/security/csp.adoc
+++ b/content/doc/developer/security/csp.adoc
@@ -34,6 +34,9 @@ You can easily identify them through their use of single quotes inside the doubl
 Use of `eval`::
 Check for the use of `eval` inside any JS resource files (potentially after applying fixes for the previously listed issues).
 This will break without `'unsafe-eval'` in the `script-src` CSP directive.
+Use of `setTimeout` and `setInterval` with string arguments::
+Check for the use of `setTimeout` and `setInterval` where the first argument is a string.
+This will break without `'unsafe-eval'` in the `script-src` CSP directive.
 Use of `FormApply#applyResponse`::
 This method expects as the argument a JavaScript snippet to be executed.
 Resources loaded from other domains::
@@ -185,6 +188,19 @@ Then your code can invoke the callback like this:
 let callbackName = 'foo';
 /* invoke it with arguments */
 window[callbackName](args);
+
+=== `setTimeout` and `setInterval` with string arguments
+
+The first argument to `setTimeout` and `setInterval` should be a function, not a string.
+The following snippets show the correct usage.
+
+[source, javascript]
+/* If you don't need to pass arguments to the function: */
+setTimeout(functionName, 1000);
+/* Or, more generally: */
+setTimeout(function() {
+  // do something
+}, 1000);
 
 === `FormApply#applyResponse` calls
 


### PR DESCRIPTION
Somehow we had missed this before.

Related:
https://github.com/daniel-beck/csp-scanner/pull/19
https://github.com/jenkinsci/extra-columns-plugin/pull/91
https://github.com/jenkinsci/dashboard-view-plugin/pull/436

There are a few others, but these are the big ones.