### PR TITLE
Update scheduling information for security advisories

### DIFF
--- a/content/security/scheduling.adoc
+++ b/content/security/scheduling.adoc
@@ -21,7 +21,7 @@ We typically publish between four and eight advisories of this kind every year.
 
 The publication dates of these security advisories is tied to the link:/download/lts/[Jenkins LTS schedule]:
 They are usually published on Wednesdays, which corresponds to the scheduled regular release day for Jenkins LTS releases.
-In the case of the Jenkins weekly release line, the security update will be an additional mid-week release between regular releases typically scheduled for release on weekends.
+In the case of the Jenkins weekly release line, the security update will replace the regular release and occur on the same day LTS security release (typically a Wednesday).
 
 link:/security/for-administrators/#pre-announcements[Pre-announcements] for these security advisories will be published several days in advance, sometimes up to a week.
 


### PR DESCRIPTION
Clarified the timing of Jenkins weekly security updates as the page was contradictory.

@daniel-beck pointed out https://github.com/jenkinsci/jenkins/pull/23873#issuecomment-3602371905 that the security releases happen in Wednesday but the weeklies happen on Tuesdays.  This doc was inconsistent stating that the security release on a weekly was both in addition to the regular weekly and replaces it.  

This updates the part that said it was in addition to so that it matches the current flow.