### PR TITLE
Update CSP incompatibility list

### DIFF
--- a/content/doc/book/security/csp.adoc
+++ b/content/doc/book/security/csp.adoc
@@ -97,24 +97,21 @@ This section highlights plugins that provide functionality that is inherently re
 Individual plugins may implement workarounds or additional configuration options to mitigate these restrictions, but as of November 2025, some functionality in some configurations is affected.
 If you use these plugins, plugin:csp[Content Security Policy Plugin] 2.x can be used to customize the CSP directives enforced on a Jenkins controller for many of these cases.
 
+plugin:anything-goes-formatter[Anything Goes Formatter]::
+This plugin allows users to specify arbitrary HTML, CSS, and JavaScript in description fields across the Jenkins UI.
+Administrators must ensure that the provided (and trusted) descriptions are compatible with the CSP directives enforced on their Jenkins controller.
 plugin:badge[Badge]::
 This plugin allows build badges to include images from external URLs.
 Administrators are advised to allow specific, known safe domains for the `img-src` directive.
 Compatibility discussion is in https://github.com/jenkinsci/badge-plugin/issues/316[#316].
-plugin:customizable-header[Customizable Header]::
-This plugin allows administrators to specify image URLs for the Jenkins header.
-Administrators must ensure that the provided URLs are compatible with the CSP directives enforced on their Jenkins controller.
-Compatibility efforts are tracked in https://github.com/jenkinsci/customizable-header-plugin/issues/280[#280].
 plugin:login-theme[Login Theme]::
 This plugin allows administrators to specify arbitrary snippets of HTML, CSS, and JavaScript to customize the login page.
 Administrators must ensure that the provided snippets are compatible with the CSP directives enforced on their Jenkins controller.
+Compatibility discussion is in https://github.com/jenkinsci/login-theme-plugin/issues/161[#161].
 plugin:simple-theme-plugin[Simple Theme]::
 This plugin allows administrators to specify arbitrary URLs for JavaScript files to customize the Jenkins UI.
 Administrators must ensure that the provided URLs are compatible with the CSP directives enforced on their Jenkins controller.
-Compatibility efforts are tracked in https://github.com/jenkinsci/simple-theme-plugin/issues/280[#280].
-// Hypothetically this matters, in practice probably not. Such plugins just need to allow-list their theme URLs.
-// plugin:theme-manager[Theme Manager]::
-// Theme implementations may specify paths to CSS files outside of Jenkins, which is prohibited by CSP by default.
+Compatibility discussion is in https://github.com/jenkinsci/simple-theme-plugin/issues/280[#280].
 
 
 ==== Notable plugins with known incompatibilities
@@ -131,14 +128,10 @@ plugin:artifactory[Artifactory]::
 https://github.com/jfrog/jenkins-artifactory-plugin/pull/952#issuecomment-3401172294[This plugin is abandoned].
 Installations requiring this plugin cannot enforce CSP protection without breaking its functionality.
 plugin:build-pipeline-plugin[Build Pipeline]::
-This plugin is looking for new maintainers.
+This plugin is looking for new maintainers and has unresolved security vulnerabilities.
 Installations requiring this plugin cannot enforce CSP protection without breaking its functionality.
 plugin:dashboard-view[Dashboard View]::
 The plugin does not periodically reload agent information in the "Agent statistics" portlet (https://github.com/jenkinsci/dashboard-view-plugin/issues/435[#435]).
-plugin:gitlab-plugin[GitLab]::
-The user interface does not correctly update after selecting "Generate" or "Clear" for the "Secret token" (https://github.com/jenkinsci/gitlab-plugin/issues/1837[#1837]).
-// Ignore monitoring plugin, as the affected functionality is currently broken anyway.
-// Ignore allure-jenkins-plugin, as the problem is that it's too permissive, not that it's broken.
 
 [#identifying]
 === Identifying incompatibilities in your setup


### PR DESCRIPTION
* Add https://plugins.jenkins.io/anything-goes-formatter/ as an inherently incompatible plugin.
* Remove https://plugins.jenkins.io/customizable-header/ from the list of inherently incompatible plugins, it just load images (and there's an open PR with the fix).
* Remove GitLab Plugin after https://github.com/jenkinsci/gitlab-plugin/releases/tag/gitlab-plugin-1.9.11
* Clean up some comments
