### PR TITLE
Mention bug bounty program on main security page

### DIFF
--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -47,7 +47,7 @@ We provide issue reporting guidelines and an overview of our process on link:rep
 If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
 `jenkinsci-cert@googlegroups.com`
 
-NOTE: From late 2025 to late 2026, a bug bountry program accepts reports of security vulnerabilities in Jenkins core, components, and some plugins.
+NOTE: From late 2025 to late 2026, a bug bounty program accepts reports of security vulnerabilities in Jenkins core, components, and some plugins.
 For more details please see link:/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/[the announcement blog post] and link:https://yeswehack.com/programs/jenkins-bug-bounty-program/[the program on YesWeHack].
 
 IMPORTANT: Do not contact the Jenkins security team asking us for compliance documents, certifications, or to fill out a questionnaire.


### PR DESCRIPTION
Amends https://github.com/jenkins-infra/jenkins.io/pull/8612. Gives reporters a better chance to discover this.

> <img width="969" height="431" alt="image" src="https://github.com/user-attachments/assets/78e99483-40b6-4c8f-a1d6-a5d1b8bd2168" />
