### PR TITLE
Clarify Jenkinsfile secret interpolation guidance

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -737,9 +737,8 @@ pipeline {
     stages {
         stage('Example') {
             steps {
-                sh /* WRONG: GString interpolates the secret */ """
-                    set +x
-                    curl -H 'Authorization: Bearer ${API_TOKEN}' https://example.com/data
+                /* WRONG */
+                    sh "curl -H 'Authorization: Bearer ${API_TOKEN}' https://example.com"
                 """
             }
         }


### PR DESCRIPTION
Fixes [#8407](https://github.com/jenkins-infra/jenkins.io/issues/8407).

Clarifies the “Interpolation of sensitive environment variables” section in jenkinsfile.adoc to explain that the real risk is Groovy GStrings interpolating secrets into sh/bat commands. Updates the examples to show a bad pattern (GString interpolation of a token) and a good pattern (literal command string where the shell expands $API_TOKEN), and notes that any approach avoiding Groovy interpolation of secrets is safe.