### PR TITLE
Add caveat about Jenkins restart behavior with JCasC

### DIFF
--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -152,6 +152,15 @@ before you check the modified YAML file into SCM,
 especially when making more substantive configuration changes.
 ====
 
+[CAUTION]
+====
+When Jenkins restarts, it automatically reads and applies the JCasC YAML file during startup.
+If you have made configuration changes through the Jenkins UI but have not yet exported or saved them to the YAML file,
+those in-memory changes will be lost when Jenkins restarts, as the system will reload the configuration from the YAML file.
+Always click *Reload existing configuration* to apply YAML file changes before restarting,
+or use *View Configuration* and *Download Configuration* to export UI changes to your YAML file before restarting Jenkins.
+====
+
 When you have made and tested your desired changes,
 push the modified JCasC YAML file to your SCM.
 


### PR DESCRIPTION
This PR adds a caveat to the JCasC documentation to clarify the behavior when restarting Jenkins, addressing issue #8295.

### Problem

Users were experiencing confusion when they modified Jenkins configuration through the UI and then restarted Jenkins, only to find their changes were lost. The existing documentation didn't explicitly warn that restarting Jenkins before exporting/saving UI changes to the YAML file would result in those in-memory changes being overwritten by the YAML file contents.

### Changes Made

Added a **CAUTION** block to the "Modifying the JCasC file" section that explains:

1. When Jenkins restarts, it automatically reads and applies the JCasC YAML file during startup
2. Any in-memory configuration changes made through the UI but not saved to the YAML file will be lost upon restart
3. Users should either:
   - Click *Reload existing configuration* to apply YAML file changes before restarting, or
   - Use *View Configuration* and *Download Configuration* to export UI changes to the YAML file before restarting Jenkins

### Location

The caveat is placed immediately after the existing NOTE block in the "Modifying the JCasC file" section, making it visible to users who are learning about the configuration reload process.

### Testing

- Verified AsciiDoc formatting is correct
- Confirmed the CAUTION block appears in the appropriate context
- Ensured the warning is clear and actionable

Fixes #8295