### PR TITLE
feat(installing/linux) specify the new GPG 2026 key and remove deprecated instructions

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -103,7 +103,7 @@ It can be installed from the link:https://pkg.jenkins.io/debian/[`debian` apt re
 [source,bash]
 ----
 sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
-  https://pkg.jenkins.io/debian/jenkins.io-2023.key
+  https://pkg.jenkins.io/debian/jenkins.io-2026.key
 echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc]" \
   https://pkg.jenkins.io/debian binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
@@ -159,7 +159,6 @@ It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
-sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the Jenkins package
 sudo dnf install fontconfig java-21-openjdk
@@ -178,7 +177,6 @@ It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum r
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat/jenkins.repo
-sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
 sudo dnf install fontconfig java-21-openjdk
@@ -260,7 +258,6 @@ It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat-stable/jenkins.repo
-sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
 sudo yum install fontconfig java-21-openjdk
@@ -279,7 +276,6 @@ It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum r
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
     https://pkg.jenkins.io/redhat/jenkins.repo
-sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2023.key
 sudo yum upgrade
 # Add required dependencies for the jenkins package
 sudo yum install fontconfig java-21-openjdk


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4922

This PR updates the Linux installation instructions in regard to the new Jenkins 2026 GPG key:

- On Debian/Ubuntu, update the filename for the new GPG key
- On Redhat/Fedora, remove the `rpm --import` command as the GPG key is automatically loaded by the package manager since 2.539 and 2.528.3