### PR TITLE
Revise archetypes version

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -31,50 +31,26 @@ mvn -U archetype:generate -Dfilter=io.jenkins.archetypes:
 This command will let you generate one of several project archetypes related to Jenkins.
 In this tutorial we're going to use the `hello-world` archetype, so select the most recent version of that archetype:
 
+For an exhaustive list of archetypes versions see link:https://repo.maven.apache.org/maven2/io/jenkins/archetypes/archetypes-parent/[the central repository].
+
 // https://asciidoctor.org/docs/user-manual/#applying-substitutions
 [source,subs="verbatim,quotes"]
 ----
 mvn -U archetype:generate -Dfilter=io.jenkins.archetypes:
-…
+...
 Choose archetype:
 1: remote -> io.jenkins.archetypes:empty-plugin (Skeleton of a Jenkins plugin with a POM and an empty source tree.)
 2: remote -> io.jenkins.archetypes:global-configuration-plugin (Skeleton of a Jenkins plugin with a POM and an example piece of global configuration.)
 3: remote -> io.jenkins.archetypes:global-shared-library (Uses the Jenkins Pipeline Unit mock library to test the usage of a Global Shared Library)
 4: remote -> io.jenkins.archetypes:hello-world-plugin (Skeleton of a Jenkins plugin with a POM and an example build step.)
 5: remote -> io.jenkins.archetypes:scripted-pipeline (Uses the Jenkins Pipeline Unit mock library to test the logic inside a Pipeline script.)
+6: remote -> io.jenkins.archetypes:theme-plugin (The skeleton of a Jenkins theme plugin)
 Choose a number or apply filter (format: [groupId:]artifactId, case sensitive contains): : *4* // <1>
 Choose io.jenkins.archetypes:hello-world-plugin version:
-1: 1.1
-2: 1.2
-3: 1.3
-4: 1.4
-5: 1.5
-6: 1.6
-7: 1.7
-8: 1.8
-9: 1.9
-10: 1.10
-11: 1.11
-12: 1.12
-13: 1.13
-14: 1.14
-15: 1.15
-16: 1.16
-17: 1.17
-18: 1.19
-19: 1.20
-20: 1.21
-21: 1.22
-22: 1.23
-23: 1.24
-24: 1.25
-25: 1.26
-26: 1.27
-27: 1.28
-28: 1.29
-29: 1.30
+...
+35: 1.35
 
-Choose a number: 29: *29* // <2>
+Choose a number: 35: *35* // <2>
 …
 [INFO] Using property: groupId = unused // <3>
 [INFO] Using property: package = io.jenkins.plugins.sample


### PR DESCRIPTION
The change proposed reduces the non-exhaustive list of archetype versions, providing the latest one only, which starters want to use, making the page a bit more clearer.

I've left a comment where an exhaustive list of versions can be obtained, in case someone is interested in that.