### PR TITLE
Remove EOL commits google group

### DIFF
--- a/content/mailing-lists/index.html.haml
+++ b/content/mailing-lists/index.html.haml
@@ -25,9 +25,6 @@ title: Mailing Lists
 
 = partial(group, :name => "jenkinsci-advisories")
 
-= partial(group, :name => "jenkinsci-commits",
-  :description => "Automated core and plugin commit notifications.")
-
 %h2 Special Interest Groups Mailing Lists
 
 - sigs = site.pages.select { |p| p.source_path =~ /\/content\/sigs\/[^\/]+\/index.adoc/ }


### PR DESCRIPTION
The change proposed removes the dead commits mailing list: https://groups.google.com/g/jenkinsci-commits

Given it's been dead for over a year and nobody asked about it, it's safe to assume that nobody uses the list anymore.
Let's remove it and focus on the active content.