### PR TITLE
Temporarily hide the LTS signing key upgrade instructions

### DIFF
--- a/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
+++ b/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
@@ -27,15 +27,15 @@ Administrators of Linux systems *must* install the new signing keys on their Lin
 
 Update Debian compatible operating systems (Debian, Ubuntu, Linux Mint Debian Edition, etc.) with the command:
 
-.Debian/Ubuntu LTS release
-[source,bash]
-----
-curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key | sudo tee \
-  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
-  /etc/apt/sources.list.d/jenkins.list > /dev/null
-----
+// .Debian/Ubuntu LTS release
+// [source,bash]
+// ----
+// curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key | sudo tee \
+//   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+// echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+//   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+//   /etc/apt/sources.list.d/jenkins.list > /dev/null
+// ----
 
 .Debian/Ubuntu weekly release
 [source,bash]
@@ -51,11 +51,11 @@ echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
 
 Update Red Hat compatible operating systems (Red Hat Enterprise Linux, Alma Linux, CentOS, Fedora, Oracle Linux, Rocky Linux, Scientific Linux, etc.) with the command:
 
-.Red Hat/CentOS LTS release
-[source,bash]
-----
-sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-----
+// .Red Hat/CentOS LTS release
+// [source,bash]
+// ----
+// sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
+// ----
 
 .Red Hat/CentOS weekly release
 [source,bash]


### PR DESCRIPTION
## Temporarily hide the LTS signing key upgrade instructions

Refer to the pull request:

* https://github.com/jenkins-infra/release/pull/829

The [comment](https://github.com/jenkins-infra/release/pull/829#issuecomment-3697509016) includes the details.
