### PR TITLE
Update markewaite biography and SIG memberships

### DIFF
--- a/content/_data/authors/markewaite.adoc
+++ b/content/_data/authors/markewaite.adoc
@@ -6,8 +6,5 @@ irc: markewaite
 linkedin: markwaite
 ---
 
-Mark is a member of the link:/project/board/[Jenkins governing board], a long-time Jenkins user and contributor, a core maintainer, and maintainer of the plugin:git[git plugin], the plugin:git-client[git client plugin], the plugin:platformlabeler[platform labeler plugin], the plugin:embeddable-build-status[embeddable build status plugin], and several others.
-// He is active in link:/sigs/[Jenkins special interest groups] including the link:/sigs/docs/[Docs SIG], link:/sigs/platform[Platform SIG], link:/sigs/ux[User Experience SIG], and link:/sigs/advocacy-and-outreach[Advocacy SIG].
-// He has mentored Google Summer of Code projects including link:/projects/gsoc/2022/projects/automatic-git-cache-maintenance/[automatic git cache maintenance (2022)], link:/projects/gsoc/2021/projects/git-credentials-binding/[git credentials binding (2021)], and link:/projects/gsoc/2020/projects/git-plugin-performance/[git plugin performance improvements (2020)].
+Mark is a Jenkins user and contributor, a core maintainer, and maintainer of the plugin:git[git plugin], the plugin:git-client[git client plugin], and several others.
 He is one of the authors of the link:/doc/developer/tutorial-improve/["Improve a plugin"] tutorial.
-image:https://static.scarf.sh/a.png?x-pxid=e010adc8-3614-41ef-b7e8-2f42328e8962&page=authors-markewaite[]

--- a/content/sigs/advocacy-and-outreach/index.adoc
+++ b/content/sigs/advocacy-and-outreach/index.adoc
@@ -14,10 +14,10 @@ tags:
   - events
 
 leads:
-- "alyssat"
-- "markewaite"
+- "stefan_spieker"
 participants:
-- "jmMeessen"
+- "alyssat"
+- "gounthar"
 - "krisstern"
 
 links:

--- a/content/sigs/docs/index.adoc
+++ b/content/sigs/docs/index.adoc
@@ -11,13 +11,12 @@ tags:
   - docs_sig
   - documentation
 leads:
-- "kmartens27"
-- "markewaite"
+- "krisstern"
 participants:
 - "gounthar"
-- "krisstern"
-- "vandit1604"
 - "stackscribe"
+- "markewaite"
+- "kmartens27"
 
 links:
   gitter: "jenkins/docs:matrix.org"

--- a/content/sigs/gsoc/index.adoc
+++ b/content/sigs/gsoc/index.adoc
@@ -9,12 +9,10 @@ opengraph:
 tags:
   - gsoc
 leads:
-- "alyssat"
-- "jmMeessen"
 - "krisstern"
 participants:
-- "kwhetstone"
-- "markewaite"
+- "alyssat"
+- "gounthar"
 links:
   gitter: "jenkinsci_gsoc-sig:gitter.im"
   forum: "gsoc"


### PR DESCRIPTION
## Update markewaite biography and SIG memberships

No longer a member of the Jenkins Governance Board and not active in several of the SIGs.
