### PR TITLE
Document drop of Java 17 in java policy

### DIFF
--- a/content/doc/book/platform-information/support-policy-java.adoc
+++ b/content/doc/book/platform-information/support-policy-java.adoc
@@ -11,6 +11,7 @@ The following Java versions are required to run Jenkins:
 
 |===
 |Supported Java versions|Long term support (LTS) release|Weekly release
+|Java 21 or Java 25 |2.541.1 (January 2026) |2.545 (January 2026)
 |Java 17, Java 21, or Java 25 |N/A |2.534 (October 2025)
 |Java 17 or Java 21|2.479.1 (October 2024) |2.463 (June 2024)
 |Java 11, Java 17, or Java 21|2.426.1 (November 2023) |2.419 (August 2023)


### PR DESCRIPTION
The change proposed updates our supported Java policy matching the Jenkins versions where drop support of Java 17.