### PR TITLE
docs: clarify required Java version during installation

### DIFF
--- a/content/doc/book/installing/_installation_requirements.adoc
+++ b/content/doc/book/installing/_installation_requirements.adoc
@@ -25,7 +25,8 @@ Comprehensive hardware recommendations:
 
 Software requirements:
 
-* Java 21 or later: see the link:/doc/book/platform-information/support-policy-java/[Java Requirements] page* Web browser: see the link:/doc/administration/requirements/web-browsers/[Web Browser Compatibility] page
+* Java 21 or later: see the link:/doc/book/platform-information/support-policy-java/[Java Requirements] page
+* Web browser: see the link:/doc/administration/requirements/web-browsers/[Web Browser Compatibility] page
 * For Windows operating system: link:/doc/administration/requirements/windows/[Windows Support Policy]
 * For Linux operating system: link:/doc/book/platform-information/support-policy-linux/[Linux Support Policy]
 * For servlet containers: link:/doc/book/platform-information/support-policy-servlet-containers/[Servlet Container Support Policy]

--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -91,7 +91,6 @@ The installation process checks for Java on your machine and prefills the dialog
 If the needed Java version is not installed on your machine, you will be prompted to install it.
 Once your Java home directory has been selected, click on *Next* to continue.
 
-
 image:tutorials/windows-select-jdk-installation.png[alt="Select Java Home Directory",width=80%]
 
 Step 6: Custom setup::


### PR DESCRIPTION
Fixes #7905

### What does this PR do?
Adds a short note clarifying the required Java version during the Windows Jenkins installation step to prevent setup issues.

### Why is this change needed?
Recent Jenkins versions require Java 21 or newer. Making this explicit helps first-time users avoid misconfiguration.

### Testing
Documentation-only change.
