### PR TITLE
Do not drop Java 17 support from 2.541.1

### DIFF
--- a/content/doc/book/platform-information/support-policy-java.adoc
+++ b/content/doc/book/platform-information/support-policy-java.adoc
@@ -11,8 +11,8 @@ The following Java versions are required to run Jenkins:
 
 |===
 |Supported Java versions|Long term support (LTS) release|Weekly release
-|Java 21 or Java 25 |2.541.1 (January 2026) |2.545 (January 2026)
-|Java 17, Java 21, or Java 25 |N/A |2.534 (October 2025)
+|Java 21 or Java 25 |N/A |2.545 (January 2026)
+|Java 17, Java 21, or Java 25 |2.451.1 (January 2026) |2.534 (October 2025)
 |Java 17 or Java 21|2.479.1 (October 2024) |2.463 (June 2024)
 |Java 11, Java 17, or Java 21|2.426.1 (November 2023) |2.419 (August 2023)
 |Java 11 or Java 17|2.361.1 (September 2022)|2.357 (June 2022)


### PR DESCRIPTION
## Do not drop Java 17 support from 2.541.1

Reasons why I think we should support Java 17 in Jenkins 2.541.1:

* We have consistently provided at least one transition LTS release that serves as a bridge version supporting 3 Java releases
* We have never backported a Java removal because we want it to be well used in weekly releases before we change it for LTS users
* Our administrative monitor says that we'll drop support on or after March 31, 2026
* Enterprise users will be surprised that our administrative monitor said that we would drop support for Java 17 on or after March 31, 2026, yet now we're dropping support for Java 17 in January 2026

@NotMyFault , this amends your pull request:

* https://github.com/jenkins-infra/jenkins.io/pull/8675

This is also related to the Jenkins 2.541.1 backporting pull request:

* https://github.com/jenkinsci/jenkins/pull/26070

This is also related to the issue report:

* https://github.com/jenkinsci/jenkins/issues/26039

### Highlight screenshot of the new page (after this pull request)

<img width="1192" height="955" alt="screencapture-mark-pc2-markwaite-net-4242-doc-book-platform-information-support-policy-java-2026-01-05-20_09_53-edit (1)" src="https://github.com/user-attachments/assets/ef57ccdb-3ab0-4fc3-90d0-f00c489052d8" />

### Screenshot of the current page (before this pull request)

<img width="1192" height="1018" alt="screencapture-jenkins-io-doc-book-platform-information-support-policy-java-2026-01-05-20_21_23-edit" src="https://github.com/user-attachments/assets/4eda8c76-db91-474d-937a-9e694d69241d" />
