### PR TITLE
fix: adjust compress images config

### DIFF
--- a/.github/workflows/compress-images.yaml
+++ b/.github/workflows/compress-images.yaml
@@ -47,7 +47,7 @@ jobs:
           pngQuality: '80' # default value
           webpQuality: '85' # default value
           avifQuality: '75' # default value
-          minPctChange: '10' # default = '5'
+          minPctChange: '20' # default = '5'
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
           compressOnly: ${{ github.event_name != 'pull_request' }}
       - name: Create Pull Request


### PR DESCRIPTION
## Tasks completed

* Adjusted compress images config so that compression only happens if minimum percentage change is 20, currently we are using the default value of 5
* Added other default config to indicate their explicit value for better control later on