### PR TITLE
docs: fix typo Temurin in lts note

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -13812,7 +13812,7 @@
       - url: https://github.com/jenkinsci/docker/pull/2109
         title: Docker pull request 2109
       - url: https://adoptium.net/en-GB/temurin/release-notes?version=21
-        title: Temuring JDK21 release notes
+        title: Temurin JDK21 release notes
     message: |-
       Update JDK21 from <code>21.0.8+9</code> to <code>21.0.9+10</code>.
   - type: rfe


### PR DESCRIPTION
<img width="500" height="225" alt="스크린샷 2026-01-13 오후 6 59 41" src="https://github.com/user-attachments/assets/e15c38e3-87ee-40ef-9aaa-d60c95926a1d" />

It’s a relatively recent version, but I’m fixing a typo.
`temuring` -> `temurin`