### PR TITLE
Update info about new signing keys for discoverability

### DIFF
--- a/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
+++ b/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
@@ -76,7 +76,7 @@ Sample messages from the operating system may look like:
 Reading package lists... Done
 W: GPG error: https://pkg.jenkins.io/debian-stable binary/ Release:
     The following signatures couldn't be verified because the public key is not available:
-        NO_PUBKEY 5BA31D57EF5975CA
+        NO_PUBKEY 7198F4B714ABFC68
 E: The repository 'https://pkg.jenkins.io/debian-stable binary/ Release' is not signed.
 N: Updating from such a repository can't be done securely, and is therefore disabled by default.
 N: See apt-secure(8) manpage for repository creation and user configuration details.


### PR DESCRIPTION
The actual error message mentions the new key that is missing, not the old key which is still present. Updating the document to reflect this should make it easier for people to find when searching for the text of the error message.