### PR TITLE
add Birajit as co-mentor to jenkins gsoc projects 2026

### DIFF
--- a/content/projects/gsoc/2026/project-ideas/continue-jenkins-docs-sites-retooling.adoc
+++ b/content/projects/gsoc/2026/project-ideas/continue-jenkins-docs-sites-retooling.adoc
@@ -14,6 +14,7 @@ skills:
 - Website retooling
 mentors:
 - "krisstern"
+- "biru-codeastromer"
 links:
   meetings: /projects/gsoc/#office-hours
   gitter: "jenkinsci_gsoc-sig:gitter.im"

--- a/content/projects/gsoc/2026/project-ideas/retool-jenkins-io-website-success-stories.adoc
+++ b/content/projects/gsoc/2026/project-ideas/retool-jenkins-io-website-success-stories.adoc
@@ -15,6 +15,7 @@ mentors:
 - "krisstern"
 - "iamrajiv"
 - "berviantoleo"
+- "biru-codeastromer"
 links:
   meetings: /projects/gsoc/#office-hours
   gitter: "jenkinsci_gsoc-sig:gitter.im"


### PR DESCRIPTION
Add Birajit as co-mentor to jenkins gsoc projects 2026


My weekly availability will depend on the nature of my internship this year (onsite or remote). However, I can reliably commit:

- 5–7 hours per week

- available after 8:00 PM IST (which corresponds to 14:30 UTC onwards)