### PR TITLE
feat(2.541.1) change GPG key to 2026 and use new packaging URLs (unified RPM, pkg.jenkins.io and get.jenkins.io)

### DIFF
--- a/content/_partials/legacy/download.html.haml
+++ b/content/_partials/legacy/download.html.haml
@@ -23,7 +23,7 @@
             Java Web Archive (.war)
           %dd
             %div
-              %a{:href => 'http://mirrors.jenkins-ci.org/war/latest/jenkins.war'}
+              %a{:href => 'http://get.jenkins.io/war/latest/jenkins.war'}
                 %strong
                   Latest:
                   = site.jenkins.latest
@@ -31,26 +31,26 @@
               %a{:href => '/changelog'}
                 changelog
               |
-              %a{:href => 'http://mirrors.jenkins-ci.org/war/'}
+              %a{:href => 'http://get.jenkins.io/war/'}
                 past releases
 
           %dt Native packages
           %dd.release-block-platforms
             %div
               %img{:src => "/images/os/win_other.png"}
-                %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/windows/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-windows-installer')"} Windows
+                %a.release-block-soft{:href => "http://get.jenkins.io/windows/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-windows-installer')"} Windows
             %div
               %img{:src => "/images/os/ubuntu.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/debian/"} Ubuntu/Debian
+                %a.release-block-soft{:href => "http://pkg.jenkins.io/debian/"} Ubuntu/Debian
             %div
               %img{:src => "/images/os/redhat.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/redhat/"} Red Hat/Fedora/Alma/Rocky/CentOS
+                %a.release-block-soft{:href => "http://pkg.jenkins.io/rpm/"} Red Hat/Fedora/Alma/Rocky/CentOS
             %div
               %img{:src => "/images/os/os_macosx.png"}
-                %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/osx/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-os-x-installer')"} Mac OS X
+                %a.release-block-soft{:href => "http://get.jenkins.io/osx/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-os-x-installer')"} Mac OS X
             %div
               %img{:src => "/images/os/opensuse.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/opensuse/"} openSUSE
+                %a.release-block-soft{:href => "http://pkg.jenkins.io/rpm/"} openSUSE
             %div
               %img{:src => "/sites/default/files/images/freebsd.png"}
                 %a.release-block-soft{:href => "https://www.freshports.org/devel/jenkins"} FreeBSD
@@ -70,14 +70,14 @@
           %dt Java Web Archive (.war)
           %dd{:style => "margin-bottom:1em"}
             %div
-              %a{:href => "http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war"}
+              %a{:href => "http://get.jenkins.io/war-stable/latest/jenkins.war"}
                 %strong
                   Older but stable:
                   = site.jenkins.stable
             .release-block-small{:style => "text-align:right"}
               %a.release-block-soft{:href => "/changelog-stable"} changelog
               |
-              %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/war-stable/"} past releases
+              %a.release-block-soft{:href => "http://get.jenkins.io/war-stable/"} past releases
               |
               %a.release-block-soft{:href => "/stable-rc"} RC
             %br/
@@ -88,19 +88,19 @@
           %dd.release-block-platforms
             %div
               %img{:src => "/images/os/win_other.png"}
-                %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/windows-stable/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-windows-installer#stable')"} Windows
+                %a.release-block-soft{:href => "http://get.jenkins.io/windows-stable/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-windows-installer#stable')"} Windows
             %div
               %img{:src => "/images/os/ubuntu.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/debian-stable/"} Ubuntu/Debian
+                %a.release-block-soft{:href => "http://pkg.jenkins.io/debian-stable/"} Ubuntu/Debian
             %div
               %img{:src => "/images/os/redhat.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/redhat-stable/"} Red Hat/Fedora/Alma/Rocky/CentOS
+                %a.release-block-soft{:href => "http://pkg.jenkins.io/rpm-stable/"} Red Hat/Fedora/Alma/Rocky/CentOS
             %div
               %img{:src => "/images/os/os_macosx.png"}
-                %a.release-block-soft{:href => "http://mirrors.jenkins-ci.org/osx-stable/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-os-x-installer#stable')"} Mac OS X
+                %a.release-block-soft{:href => "http://get.jenkins.io/osx-stable/latest", :onclick => "return downloadWithThanks('/content/thank-you-downloading-os-x-installer#stable')"} Mac OS X
             %div
               %img{:src => "/images/os/opensuse.png"}
-                %a.release-block-soft{:href => "http://pkg.jenkins-ci.org/opensuse-stable/"} openSUSE
+                %a.release-block-soft{:href => "http://pkg.jenkins.io/rpm-stable/"} openSUSE
             %div
               %img{:src => "/sites/default/files/images/freebsd.png"}
                 %a.release-block-soft{:href => "https://www.freshports.org/devel/jenkins-lts"} FreeBSD

--- a/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
+++ b/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
@@ -51,16 +51,16 @@ echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
 
 Update Red Hat compatible operating systems (Red Hat Enterprise Linux, Alma Linux, CentOS, Fedora, Oracle Linux, Rocky Linux, Scientific Linux, etc.) with the command:
 
-// .Red Hat/CentOS LTS release
-// [source,bash]
-// ----
-// sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-// ----
+.Red Hat/CentOS LTS release
+[source,bash]
+----
+sudo rpm --import https://pkg.jenkins.io/rpm-stable/jenkins.io-2026.key
+----
 
 .Red Hat/CentOS weekly release
 [source,bash]
 ----
-sudo rpm --import https://pkg.jenkins.io/redhat/jenkins.io-2026.key
+sudo rpm --import https://pkg.jenkins.io/rpm/jenkins.io-2026.key
 ----
 
 == Frequently Asked Questions

--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -71,7 +71,7 @@ If Jenkins is installed first and Java is added later, the Jenkins service may f
 jenkins: failed to find a valid Java installation
 ----
 
-Installing Java first ensures the environment is fully initialized and avoids this issue.  
+Installing Java first ensures the environment is fully initialized and avoids this issue.
 After completing the Java installation, continue with the Jenkins installation steps below.
 ====
 
@@ -85,7 +85,7 @@ It can be installed from the link:https://pkg.jenkins.io/debian-stable/[`debian-
 [source,bash]
 ----
 sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
-  https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
+  https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key
 echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc]" \
   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
@@ -153,12 +153,12 @@ You can install Jenkins through `dnf`. You need to add the Jenkins repository fr
 
 [#long-term-support-release-2]
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
-It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
+It can be installed from the link:https://pkg.jenkins.io/rpm-stable/[`rpm-stable`] yum repository.
 
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
-    https://pkg.jenkins.io/redhat-stable/jenkins.repo
+    https://pkg.jenkins.io/rpm-stable/jenkins.repo
 sudo dnf upgrade
 # Add required dependencies for the Jenkins package
 sudo dnf install fontconfig java-21-openjdk
@@ -171,12 +171,12 @@ sudo systemctl daemon-reload
 
 [#weekly-release-2]
 A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
-It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum repository.
+It can be installed from the link:https://pkg.jenkins.io/rpm/[`rpm`] yum repository.
 
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
-    https://pkg.jenkins.io/redhat/jenkins.repo
+    https://pkg.jenkins.io/rpm/jenkins.repo
 sudo dnf upgrade
 # Add required dependencies for the jenkins package
 sudo dnf install fontconfig java-21-openjdk
@@ -252,12 +252,12 @@ You need to choose either the Jenkins Long Term Support release or the Jenkins w
 
 [#long-term-support-release-3]
 A link:/download/lts/[LTS (Long-Term Support) release] is chosen every 12 weeks from the stream of regular releases as the stable release for that time period.
-It can be installed from the link:https://pkg.jenkins.io/redhat-stable/[`redhat-stable`] yum repository.
+It can be installed from the link:https://pkg.jenkins.io/rpm-stable/[`rpm-stable`] yum repository.
 
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
-    https://pkg.jenkins.io/redhat-stable/jenkins.repo
+    https://pkg.jenkins.io/rpm-stable/jenkins.repo
 sudo yum upgrade
 # Add required dependencies for the jenkins package
 sudo yum install fontconfig java-21-openjdk
@@ -270,12 +270,12 @@ sudo systemctl daemon-reload
 
 [#weekly-release-3]
 A new release is produced weekly to deliver bug fixes and features to users and plugin developers.
-It can be installed from the link:https://pkg.jenkins.io/redhat/[`redhat`] yum repository.
+It can be installed from the link:https://pkg.jenkins.io/rpm/[`rpm`] yum repository.
 
 [source,bash]
 ----
 sudo wget -O /etc/yum.repos.d/jenkins.repo \
-    https://pkg.jenkins.io/redhat/jenkins.repo
+    https://pkg.jenkins.io/rpm/jenkins.repo
 sudo yum upgrade
 # Add required dependencies for the jenkins package
 sudo yum install fontconfig java-21-openjdk

--- a/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
+++ b/content/doc/tutorials/tutorial-for-installing-jenkins-on-AWS.adoc
@@ -269,14 +269,14 @@ NOTE: The following steps are written for *Amazon Linux 2*. If you're using *Ama
 [source,bash]
 ----
 [ec2-user ~]$ sudo wget -O /etc/yum.repos.d/jenkins.repo \
-    https://pkg.jenkins.io/redhat-stable/jenkins.repo
+    https://pkg.jenkins.io/rpm-stable/jenkins.repo
 ----
 
 . Import a key file from Jenkins-CI to enable installation from the package:
 +
 [source,bash]
 ----
-[ec2-user ~]$ sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
+[ec2-user ~]$ sudo rpm --import https://pkg.jenkins.io/rpm-stable/jenkins.io-2026.key
 ----
 +
 [source,bash]
@@ -437,7 +437,7 @@ NOTE: If you already generated a `.ppk` file in AWS (by selecting the PuTTY-comp
 
 . From the *Start* menu, select *All Programs* > *PuTTY* > *PuTTY*.
 . In the *Category* pane, select *Session*, and complete the following fields:
-.. In *Host Name*, enter **`ec2-user@public_dns_name`**. 
+.. In *Host Name*, enter **`ec2-user@public_dns_name`**.
    Make sure to replace `public_dns_name` with the actual public DNS of your instance.
 +
 IMPORTANT: You must prefix the public DNS name with `ec2-user@` to successfully connect to the instance.
@@ -460,5 +460,5 @@ image::tutorials/AWS/putty_select_key_pair.png[Selecting and opening a new PuTTY
 * **PEM Keys**: Used by OpenSSH and other SSH clients. These are text-based files that start with `-----BEGIN RSA PRIVATE KEY-----`.
 * **PPK Keys**: Used by PuTTY. These are binary files and are not compatible with OpenSSH without conversion.
 
-For more detailed instructions, refer to the official AWS documentation: 
+For more detailed instructions, refer to the official AWS documentation:
 link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-linux-inst-from-windows.html[Connecting to Your Linux Instance from Windows Using PuTTY].

--- a/content/download/index.html.haml
+++ b/content/download/index.html.haml
@@ -98,7 +98,7 @@ title: Download and deploy
     },
     {
         "image": "opensuse",
-        "href": "https://pkg.jenkins.io/opensuse-stable/",
+        "href": "https://pkg.jenkins.io/rpm-stable/",
         "title": "openSUSE"
     },
     {
@@ -160,7 +160,7 @@ title: Download and deploy
     },
     {
         "image": "opensuse",
-        "href": "https://pkg.jenkins.io/opensuse/",
+        "href": "https://pkg.jenkins.io/rpm/",
         "title": "openSUSE"
     },
     {

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -4,18 +4,18 @@ map $http_accept_language $lang {
 }
 
 server {
-  listen       80;
+  listen 80;
   server_name _ localhost;
 
-  root   /usr/share/nginx/html;
+  root /usr/share/nginx/html;
 
   location / {
-      index  index.html index.htm;
-      add_header Vary "Accept-Language";
-      # Language setting
-      if ($lang) {
-        rewrite ^/$ https://www.jenkins.io/$lang$1;
-      }
+    index index.html index.htm;
+    add_header Vary "Accept-Language";
+    # Language setting
+    if ($lang) {
+      rewrite ^/$ https://www.jenkins.io/$lang$1;
+    }
   }
 
   add_header X-Frame-Options "DENY";
@@ -30,25 +30,28 @@ server {
     add_header Cache-Control "public";
   }
 
-  error_page  404              /404/index.html;
+  error_page 404 /404/index.html;
 
   # redirect server error pages to the static page /50x.html
   #
-  error_page   500 502 503 504  /50x.html;
+  error_page 500 502 503 504 /50x.html;
   location = /50x.html {
-      root   /usr/share/nginx/html;
+    root /usr/share/nginx/html;
   }
 
   # compatibility with old package repository locations
-  rewrite ^/redhat/(.*) https://pkg.jenkins.io/redhat/$1 permanent;
-  rewrite ^/opensuse/(.*) https://pkg.jenkins.io/opensuse/$1 permanent;
+  rewrite ^/redhat/(.*) https://pkg.jenkins.io/rpm/$1 permanent;
+  rewrite ^/redhat-stable/(.*) https://pkg.jenkins.io/rpm-stable/$1 permanent;
+  rewrite ^/opensuse/(.*) https://pkg.jenkins.io/rpm/$1 permanent;
+  rewrite ^/opensuse-stable/(.*) https://pkg.jenkins.io/rpm-stable/$1 permanent;
   rewrite ^/debian/(.*) https://pkg.jenkins.io/debian/$1 permanent;
+  rewrite ^/debian-stable/(.*) https://pkg.jenkins.io/debian-stable/$1 permanent;
 
   # convenient short URLs
-  rewrite ^/issue/(.+)          https://issues.jenkins.io/browse/JENKINS-$1 permanent;
-  rewrite ^/commit/core/(.+)    https://github.com/jenkinsci/jenkins/commit/$1 permanent;
-  rewrite ^/commit/(.+)/(.+)    https://github.com/jenkinsci/$1/commit/$2 permanent;
-  rewrite ^/pull/(.+)/([0-9]+)  https://github.com/jenkinsci/$1/pull/$2 permanent;
+  rewrite ^/issue/(.+) https://issues.jenkins.io/browse/JENKINS-$1 permanent;
+  rewrite ^/commit/core/(.+) https://github.com/jenkinsci/jenkins/commit/$1 permanent;
+  rewrite ^/commit/(.+)/(.+) https://github.com/jenkinsci/$1/commit/$2 permanent;
+  rewrite ^/pull/(.+)/([0-9]+) https://github.com/jenkinsci/$1/pull/$2 permanent;
 
   rewrite ^/maven-site/hudson-core /maven-site/jenkins-core permanent;
 
@@ -58,41 +61,40 @@ server {
   # Probably not needed but, rating code moved a while ago
   rewrite ^/rate/(.*) https://rating.jenkins.io/$1 permanent;
   rewrite ^/census/(.*) https://census.jenkins.io/$1 permanent;
-  rewrite ^/jenkins-ci.org.key$ https://pkg.jenkins.io/redhat/jenkins.io-2023.key permanent;
+  rewrite ^/jenkins-ci.org.key$ https://pkg.jenkins.io/rpm/jenkins.io-2026.key permanent;
 
   # permalinks
   # - this one is referenced from 1.395.1 "sign post" release
-  rewrite ^/why$            https://www.jenkins.io/ permanent;
+  rewrite ^/why$ https://www.jenkins.io/ permanent;
   # baked in the help file to create account on Oracle for JDK downloads
-  rewrite ^/oracleAccountSignup$    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
+  rewrite ^/oracleAccountSignup$ http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
   # to the donation page
-  rewrite ^/donate$        https://www.jenkins.io/donate/ permanent;
+  rewrite ^/donate$ https://www.jenkins.io/donate/ permanent;
   # CLA links used in the CLA forms
-  rewrite ^/license$        https://www.jenkins.io/project/governance/#GovernanceDocument-cla permanent;
-  rewrite ^/licenses$        https://www.jenkins.io/project/governance/#GovernanceDocument-cla permanent;
+  rewrite ^/license$ https://www.jenkins.io/project/governance/#GovernanceDocument-cla permanent;
+  rewrite ^/licenses$ https://www.jenkins.io/project/governance/#GovernanceDocument-cla permanent;
   # used to advertise the project meeting
-  rewrite ^/meetings/$        https://www.jenkins.io/project/governance-meeting/ permanent;
+  rewrite ^/meetings/$ https://www.jenkins.io/project/governance-meeting/ permanent;
   # used from friends of Jenkins plugin to link to the thank you page
-  rewrite ^/friend$        https://www.jenkins.io/donate/ permanent;
+  rewrite ^/friend$ https://www.jenkins.io/donate/ permanent;
   # used by Gradle JPI plugin to include fragment
-  rewrite ^/gradle-jpi-plugin/latest$    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install permanent;
+  rewrite ^/gradle-jpi-plugin/latest$ https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install permanent;
   # used when encouraging people to subscribe to security advisories
-  rewrite ^/advisories$        https://www.jenkins.io/security/ permanent;
+  rewrite ^/advisories$ https://www.jenkins.io/security/ permanent;
   # used in slides and handouts to refer to survey
-  rewrite ^/survey$        http://s.zoomerang.com/s/JenkinsSurvey permanent;
+  rewrite ^/survey$ http://s.zoomerang.com/s/JenkinsSurvey permanent;
   # used by RekeySecretAdminMonitor in Jenkins
-  rewrite ^/rekey$            https://www.jenkins.io/security/advisory/2013-01-04/re-keying/ permanent;
+  rewrite ^/rekey$ https://www.jenkins.io/security/advisory/2013-01-04/re-keying/ permanent;
   # persistent Google hangout link
-  rewrite ^/hangout$        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38 permanent;
+  rewrite ^/hangout$ https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38 permanent;
   # .16.203.43 repo.jenkins-ci.org
-  rewrite ^/pull-request-greeting$    https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories permanent;
+  rewrite ^/pull-request-greeting$ https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories permanent;
   # Mailer plugin uses this to redirect to Javamail jenkinsio page
-  rewrite ^/javamail-properties$   https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description permanent;
+  rewrite ^/javamail-properties$ https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description permanent;
   # baked in jenkins.war 1.587 / 1.580.1
-  rewrite ^/security-144$          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control permanent;
+  rewrite ^/security-144$ https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control permanent;
   # baked in 1.600 easter egg
-  rewrite ^/100k$                  https://www.jenkins.io/content/jenkins-celebration-day-february-26 permanent;
+  rewrite ^/100k$ https://www.jenkins.io/content/jenkins-celebration-day-february-26 permanent;
   rewrite ^/jep/([0-9]+) https://github.com/jenkinsci/jep/blob/master/jep/$1/README.adoc permanent;
   rewrite ^/iep/([0-9]+) https://github.com/jenkins-infra/iep/blob/master/iep/$1/README.adoc permanent;
 }
-


### PR DESCRIPTION
⚠️ Do not merge this PR until 2.541.1 packages have been successfully delivered (same as https://github.com/jenkins-infra/kubernetes-management/pull/7424)! ⚠️ 

This PR updates the www.jenkins.io to integrate recent packaging changes delivered in the Jenkins stable line with 2.541.1 on 21 January 2026:

- Update the GPG key used for signing all packages (except Windows) from 2023 to 2026.
  - See https://github.com/jenkins-infra/helpdesk/issues/4922 for details
- Update the packaging URL to point to the correct `*.jenkins.io` domains (pkg.jenkins.io for Linux packages and get.jenkins.io for WAR/MSI)
  - See https://github.com/jenkins-infra/helpdesk/issues/3705 for details
- Update the Linux RPM URLs to point to the new unified RPMs
  - See https://github.com/jenkins-infra/helpdesk/issues/4924 for details

Associated changelog / upgrade guide for the stable line can be found at https://github.com/jenkins-infra/jenkins.io/pull/8690