### PR TITLE
Restore LTS signing key instructions in blog post

### DIFF
--- a/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
+++ b/content/blog/2025/12/23/2025-12-23-repository-signing-keys-changing.adoc
@@ -27,15 +27,15 @@ Administrators of Linux systems *must* install the new signing keys on their Lin
 
 Update Debian compatible operating systems (Debian, Ubuntu, Linux Mint Debian Edition, etc.) with the command:
 
-// .Debian/Ubuntu LTS release
-// [source,bash]
-// ----
-// curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key | sudo tee \
-//   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-// echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-//   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
-//   /etc/apt/sources.list.d/jenkins.list > /dev/null
-// ----
+.Debian/Ubuntu LTS release
+[source,bash]
+----
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
+----
 
 .Debian/Ubuntu weekly release
 [source,bash]


### PR DESCRIPTION
## Restore LTS signing instructions in blog post

Enable LTS upgrade instructions for Debian based distributions now that Jenkins 2.541.1 has released.

Testing done:

* Confirmed with a Debian 12 system that the instructions work as expected.
  * 2026 signing key is added
  * Package is added to apt sources
  * Jenkins 2.541.1 is offered to the administrator that can be installed

Reported in community post:

* https://community.jenkins.io/t/new-linux-repository-signing-keys-for-jenkins-2-543-and-2-541-1/35979/2

This reverts commit ed57d2f66c2ef2c57deb5fae6815d82a93bea3c8.
