### PR TITLE
feat: add Jenkins Bug Bounty Program to homepage carousel

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -40,7 +40,7 @@
 # Jenkins Bug Bounty Program
 - :href: https://www.jenkins.io/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/
   :title: Announcing the new Jenkins Bug Bounty Program!
-  :intro: It is with great pleasure that we announce the new Jenkins Bug Bounty Program! The European Commission (EC OSPO) has partnered with YesWeHack to launch bug bounty programs for several open source projects..
+  :intro: The European Commission (EC OSPO) has partnered with YesWeHack to launch bug bounty programs for several open source projects, including the the new Jenkins Bug Bounty Program!
   :image:
     :src: images/post-images/2025/12/yeswehack-jenkins.jpg
     :height: 285px


### PR DESCRIPTION
Added a new homepage carousel slide promoting the Jenkins Bug Bounty Program

## Changes made
- Adds new slide promoting Bug Bounty Program
- Links to announcement blog post
- Positioned after DevOps Dozen Award  slide for visibility

## Testing
-  Verified carousel displays correctly
-  Confirmed all links work properly
-  Tested responsive design on different screen sizes

## Screenshots
<img width="1049" height="338" alt="Screenshot 2026-01-23 at 1 28 04 PM" src="https://github.com/user-attachments/assets/0624945f-5bca-4969-b33a-8e0823fe2c76" />



Fixes #8648
