### PR TITLE
Fix GitHub capitalization in report-issue.adoc

### DIFF
--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -19,7 +19,7 @@ If you need assistance or have general questions, post on the https://community.
 First, *identify the location of the issue*.
 Are you reporting an issue in Jenkins itself or one of its plugins? 
 We document all the issues in Jenkins on link:https://github.com/jenkinsci/jenkins/issues[GitHub].
-Plugins may use Jira or Github for issue tracking, see <<Howtoreportanissue-Creatingtheissue,Creating the Issue>> for details.
+Plugins may use Jira or GitHub for issue tracking, see <<Howtoreportanissue-Creatingtheissue,Creating the Issue>> for details.
 If you are reporting an issue with the jenkins.io site, please create an issue in our link:https://github.com/jenkins-infra/jenkins.io/issues[GitHub issue tracker].
 
 After that, determine what kind of issue it is. There are three main types:
@@ -96,7 +96,7 @@ However *if the issue you're reporting is in one of Jenkins' plugins*, you'll ha
 * Click the *Report an issue* link in the *Links* section on the right side of the
 plugin page.
 ** After selecting the link, if you end up on Jira follow the instructions on link:/participate/report-issue/#reporting-issue-on-jira[Reporting an Issue in Jira].
-** After selecting the link, if you end up on Github follow the instructions on link:/participate/report-issue/#reporting-issue-on-github[Reporting an Issue on Github].
+** After selecting the link, if you end up on GitHub follow the instructions on link:/participate/report-issue/#reporting-issue-on-github[Reporting an Issue on GitHub].
 
 
 === Reporting an issue on Jira
@@ -107,7 +107,7 @@ https://issues.jenkins.io/secure/Dashboard.jspa[the Jira home page].
 * For *Project* select:
 ** _Jenkins_ for general issues with plugins that use Jira for issue tracking,
 ** _Security Issues_ if you want to report a security issue privately
-* For _Infrastructure_, if you're reporting a bug with link:/projects/infrastructure/[a Jenkins service run by the Jenkins project], open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on Github].
+* For _Infrastructure_, if you're reporting a bug with link:/projects/infrastructure/[a Jenkins service run by the Jenkins project], open an issue in the https://github.com/jenkins-infra/helpdesk/issues/new/choose[dedicated helpdesk on GitHub].
 * Enter a short but meaningful description of your problem as *Summary*.
 * For *Priority*, see
 https://issues.jenkins.io/secure/ShowConstantsHelp.jspa?decorator=popup#PriorityLevels[here]
@@ -118,20 +118,20 @@ severe problem otherwise.
 * Leave the *Assignee* field to automatic.
 
 === Reporting an issue on GitHub 
-You need to have a Github account. 
+You need to have a GitHub account. 
 link:https://docs.github.com/en/get-started/onboarding/getting-started-with-your-github-account[Register an account] if you haven't already.
 
-* If you are redirected to the Github issue tracker from the link:https://plugins.jenkins.io/[Plugin Site], you will see something like this:
+* If you are redirected to the GitHub issue tracker from the link:https://plugins.jenkins.io/[Plugin Site], you will see something like this:
 +
 [.boxshadow]
-image:/images/participate/github-issues.png[alt="Github Issue Page",width=80%]
+image:/images/participate/github-issues.png[alt="GitHub Issue Page",width=80%]
 
 * Select *Get started* next to the type of issue you'd like to open.
 +
 [.boxshadow]
 image:/images/participate/get-started.png[alt="Get Started Button",width=40%,align="center"]
 
-* After that, fill in the details of the issue according to the Github issue template provided for each type of issue.
+* After that, fill in the details of the issue according to the GitHub issue template provided for each type of issue.
 * Don't forget to subscribe to the issue so you'll get notifications regarding any updates on the issue.
 [[Howtoreportanissue-WhatinformationtoprovideforEnvironmentandDescription]]
 


### PR DESCRIPTION
This PR updates the capitalization of “GitHub” in `report-issue.adoc` to match the official product branding.

The change improves consistency without altering content or structure.