### PR TITLE
docs: fix duplicated text and broken formatting in report-issue.adoc

### DIFF
--- a/content/participate/report-issue.adoc
+++ b/content/participate/report-issue.adoc
@@ -43,15 +43,11 @@ This can help you find solutions if it's actually e.g. a configuration
 problem, or point you to earlier reports in case you're not the first
 one experiencing this problem. You can search the issue tracker, or use web search.
 https://stackoverflow.com/tags/jenkins[Stack Overflow] may also be a
-good place to search. Any results will often point you to earlier issue
-reports if it's really a bug. You can then _watch them_ and _vote for
-https://stackoverflow.com/tags/jenkins[Stack Overflow] may also be a
-good place to search.
-Any results will often point you to earlier issue reports if it's really a bug.
-You can then _subscribe_ and _up vote_ (thumbs up reaction) to the issue.
+good place to search. Any results will often point you to earlier issue reports if it's really a bug.
+You can then _watch them_, _subscribe_, and _up vote_ (thumbs up reaction) to the issue.
 Voting helps us determine the impact of bugs and prioritize them.
 If you have doubts that the problem you're experiencing is the exact same one as you found, and prefer to file a new issue, be sure to mention the one(s) you found in the description.
-issue (and mention the one(s) you found in the description)._
+issue (and mention the one(s) you found in the description).
 * *Make sure that the problem actually is with Jenkins*. If your build
 seems to fail for no reason, try to build your project outside Jenkins,
 but in the same general environment (e.g. same machine, same user


### PR DESCRIPTION
This PR fixes duplicated sentences and broken AsciiDoc emphasis
in the “Before reporting a bug” section of `report-issue.adoc`.

The change restores the intended formatting and removes repetition
without altering meaning or structure.