### PR TITLE
Jenkins 2.541.1 is the LTS for Java 17, 21, and 25

### DIFF
--- a/content/doc/book/platform-information/support-policy-java.adoc
+++ b/content/doc/book/platform-information/support-policy-java.adoc
@@ -12,7 +12,7 @@ The following Java versions are required to run Jenkins:
 |===
 |Supported Java versions|Long term support (LTS) release|Weekly release
 |Java 21 or Java 25 |N/A |2.545 (January 2026)
-|Java 17, Java 21, or Java 25 |2.451.1 (January 2026) |2.534 (October 2025)
+|Java 17, Java 21, or Java 25 |2.541.1 (January 2026) |2.534 (October 2025)
 |Java 17 or Java 21|2.479.1 (October 2024) |2.463 (June 2024)
 |Java 11, Java 17, or Java 21|2.426.1 (November 2023) |2.419 (August 2023)
 |Java 11 or Java 17|2.361.1 (September 2022)|2.357 (June 2022)


### PR DESCRIPTION
## Jenkins 2.541.1 is the LTS for Java 17, 21, and 25

Version string was incorrectly listed as 2.451.1 in the [Java support policy](https://www.jenkins.io/doc/book/platform-information/support-policy-java/).

First reported on [community.jenkins.io](https://community.jenkins.io/t/did-you-notice-that-the-latest-lts-versions-on-the-two-pages-are-different/36097)