### PR TITLE
docs: reduce redundant text in post-installation setup wizard

### DIFF
--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -173,8 +173,6 @@ This would install Jenkins into D:\Jenkins, use the Java runtime from C:\Program
 
 After downloading, installing and running Jenkins, the post-installation setup wizard begins.
 
-This setup wizard takes you through a few quick "one-off" steps to unlock Jenkins, customize it with plugins and create the first administrator user through which you can continue accessing Jenkins.
-
 
 === Unlocking Jenkins
 


### PR DESCRIPTION
This change removes a redundant introductory paragraph in the
“Post-installation setup wizard” section of the Windows installation guide (`windows.adoc`).

The removed text duplicated information already conveyed by the section
structure. Removing it reduces verbosity without affecting clarity.