### PR TITLE
docs: polish up Remote Access API documentation

### DIFF
--- a/content/doc/book/using/remote-access-api.adoc
+++ b/content/doc/book/using/remote-access-api.adoc
@@ -6,11 +6,11 @@ title: Remote Access API
 
 Jenkins provides machine-consumable remote access API to its
 functionalities. 
-Currently, it provides data in two primary formats:
+Currently, it provides data in three flavors:
 
 . XML
 . JSON with JSONP support
-. Wrapper libraries are also available for Python.
+. Python-compatible JSON variant
 
 Remote access API is offered in a REST-like style. 
 That is, there is no single entry point for all features, 


### PR DESCRIPTION
This PR fixes a few objective issues in the Remote Access API documentation:

- Corrects an incorrect description that listed Python as a data format alongside XML and JSON
- Fixes an unidiomatic hyperlink phrase ("`here`")
- Corrects a minor typo ("`depthvalue`")

No behavioral or structural changes are introduced.