### PR TITLE
docs: clarify Java prerequisite for Windows installation

### DIFF
--- a/content/doc/book/installing/windows.adoc
+++ b/content/doc/book/installing/windows.adoc
@@ -87,6 +87,9 @@ Then, click on *Next*.
 
 image:tutorials/windows-select-port.png[alt="Jenkins Select Port",width=80%]
 
+NOTE: Jenkins requires a supported Java version to be installed *before* running the Windows installer.
+The installer verifies an existing Java installation but does not install Java itself.
+
 Step 5: Select Java home directory::
 
 The installation process checks for Java on your machine and prefills the dialog with the Java home directory.


### PR DESCRIPTION
This change clarifies that a supported Java version must be installed before running the Jenkins Windows installer.

While the installer verifies an existing Java installation and pre-fills the Java home directory, it does not install Java itself. Making this explicit aligns the Windows insstallation guide with the Linux documentation and helps avoid confusion during initial setup.