### PR TITLE
Update 2015-11-01-adopt-a-plugin.adoc

### DIFF
--- a/content/blog/2015/2015-11-01-adopt-a-plugin.adoc
+++ b/content/blog/2015/2015-11-01-adopt-a-plugin.adoc
@@ -15,4 +15,4 @@ The major problem of course is that it's often difficult to tell whether a plugi
 
 To connect plugins that aren't actively maintained with potential maintainers, we recently implemented the "Adopt-a-plugin" initiative: We built a list of plugins that are up for "adoption", and display a prominent message on the plugins' wiki pages. Anyone interested in taking over as a plugin maintainer can then contact us, and we'll set you up.
 
-Are you interested in becoming a plugin maintainer? Maybe one of your favorite plugins isn't actively maintained right now. Check out the link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopt a Plugin page] for more details on this program, and a list of plugins that would benefit from your help.
+Are you interested in becoming a plugin maintainer? Maybe one of your favorite plugins isn't actively maintained right now, and you have a stalled PR that makes it better? Check out the link:/doc/developer/plugin-governance/adopt-a-plugin/[Adopt a Plugin page] for more details on this program, and a list of plugins that would benefit from your help.


### PR DESCRIPTION
As discussed on the Jenkins Summit (FOSDEM 2026) today, there is no ethical issue about adopting an unmaintained plugin to merge one's own PRs and make it better. Maybe one would stick around as a "real maintainer", maybe not; it would still be an improvement for the plugin, no stigma about that.

CC @MarkEWaite @daniel-beck 