### PR TITLE
docs: fix grammar and example errors in user documentation

### DIFF
--- a/content/doc/book/using/executor-starvation.adoc
+++ b/content/doc/book/using/executor-starvation.adoc
@@ -15,8 +15,8 @@ exactly why it is not building, but the common symptoms are as follows:
     agent, but the agent is offline. Go to
     \http://server/jenkins/computer/AGENTNAME to understand why, and
     bring it back online. Or better yet, use labels and do not tie
-    builds to specific agents, so that a single offline agents will not
-    prevent your builds from starving.
+    builds to specific agents, so that a single offline agent will not
+    cause build starvation.
 2.  **Waiting for an available executor on an agent**: your build needs
     to run on a particular agent, but the agent is already fully busy
     building other things, and your build is waiting for "too long"

--- a/content/doc/book/using/using-jmeter-with-jenkins.adoc
+++ b/content/doc/book/using/using-jmeter-with-jenkins.adoc
@@ -39,7 +39,7 @@ It can also be used to simulate a heavy load on a server, group of servers, netw
 
 == Jenkins Installation
 
-The Jenkins docs has a page to help with the link:/doc/book/installing/[Jenkins installation process.].
+The Jenkins docs have a page to help with the link:/doc/book/installing/[Jenkins installation process.].
 This guide uses the .jar installation.
 Refer to the link:/doc/pipeline/tour/getting-started/[guided tour page] if you want to use .jar as well.
 Both installation methods produce the same results.
@@ -113,7 +113,7 @@ Select the *View Results in Table* option.
 +
 image:jmeter/jmeter-07.png[Save and run test plan]
 . To save the test plan, select the Save (disk) icon in the upper left side of the screen or go to *File > Save*, and enter a name for the test plan with a .jmx extension.
-For example: `jenkins.io.jml`.
+For example: `jenkins.io.jmx`.
 
 Run the test and view the table results.
 


### PR DESCRIPTION
This PR fixes a couple of objective issues in user-facing documentation, including grammar errors and an incorrect JMeter file extension in examples.