### PR TITLE
fix: add missing section tag in upgrade-java-to-11 doc

### DIFF
--- a/content/doc/book/platform-information/upgrade-java-to-11.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-11.adoc
@@ -29,10 +29,11 @@ If you need to upgrade Jenkins, as well as the JVM, we recommend you:
 TIP: We recommend that you use the package manager of your system (such as `apt` or `yum`).
 . Validate the upgrade to confirm that all plugins and jobs are loaded.
 . Upgrade the required plugins.
-Refer to <<Upgrading Plugins>> for further information.
+Refer to <<upgrading-plugins,Upgrading Plugins>> for further information.
 
 Starting with Jenkins releases 2.357 and LTS 2.361.1, Java 11 or Java 17 is required.
 
+[[upgrading-plugins]]
 == Upgrade Plugins
 
 When upgrading the Java version for Jenkins and the JVM, it is important to upgrade all plugins that support Java 11.


### PR DESCRIPTION
Fixes #8774 

Added missing section tag for in-doc section referencing in "content/doc/book/platform-information/upgrade-java-to-11.adoc". 