### PR TITLE
docs: improve IDE configuration accuracy and cross-platform clarity

### DIFF
--- a/content/doc/developer/development-environment/ide-configuration.adoc
+++ b/content/doc/developer/development-environment/ide-configuration.adoc
@@ -14,21 +14,21 @@ This IDEA plugin makes it easy to develop Jenkins and its plugins on IntelliJ ID
 
 This plugin has the following features:
 
-* Cmd+B navigation from the Jelly tags to their definitions
+* Cmd/Ctrl+B navigation from the Jelly tags to their definitions
 * Error checks and auto completion on attributes and elements of taglibs
 * Syntax error checks on JEXL expressions
-* "Go to stapler view" to jump from a Java class to its views (Cmd+Shift+P)
+* "Go to stapler view" to jump from a Java class to its views (Cmd/Ctrl+Shift+P)
 * Select a string expression, then "Refactor" > "i18n for Stapler" to create a message resource
 
 == Netbeans
-http://plugins.netbeans.org/plugin/43938/?show=true
+The previously referenced NetBeans plugin is no longer available.
 
 == Visual Studio Code
 See: https://code.visualstudio.com/docs/languages/java for useful extensions
 
 Create the following 2 files in your project:
 
-`~/.vscode/tasks.json`:
+`.vscode/tasks.json`:
 [source, json]
 ----
 {
@@ -57,7 +57,7 @@ Create the following 2 files in your project:
 }
 ----
 
-`~/.vscode/launch.json`:
+`.vscode/launch.json`:
 [source, json]
 ----
 {


### PR DESCRIPTION
Fixes a outdated NetBeans reference, corrects VS Code configuration paths, and clarifies cross-platform IntelliJ IDEA shortcuts in the IDE configuration documentation.