### PR TITLE
docs: improve development environment overview and taglibs context

### DIFF
--- a/content/doc/developer/development-environment/index.adoc
+++ b/content/doc/developer/development-environment/index.adoc
@@ -4,4 +4,6 @@ layout: developerchapter
 summary: Preparing your development environment for Jenkins core and plugin development
 ---
 
-This chapter will give an overview about what you need to know about preparing your development environment for Jenkins core and plugin development
+This chapter provides an overview of how to prepare a development environment for Jenkins core and plugin development.
+
+It introduces the tools, configuration, and concepts commonly used when developing Jenkins and Jenkins plugins.

--- a/content/doc/developer/development-environment/taglibs.adoc
+++ b/content/doc/developer/development-environment/taglibs.adoc
@@ -3,6 +3,8 @@ layout: developersection
 title: Taglibs
 ---
  
+Jelly is the XML-based templating engine used to define views and UI components in Jenkins. This page provides references to Jenkins tag libraries that are commonly used when developing Jenkins core and plugins.
+
 Documentation for jelly tag libraries is published in the following places:
 
 - link:https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html[Core]


### PR DESCRIPTION
Improves the Development Environment landing page (`index.adoc`) by adding a clearer overview, and adds brief context to the Taglibs page (`taglibs.adoc`) so readers understand what it covers before jumping into links.