### PR TITLE
docs: fix deprecated references and broken examples in testing docs

### DIFF
--- a/content/doc/developer/testing/index.adoc
+++ b/content/doc/developer/testing/index.adoc
@@ -569,7 +569,6 @@ If you need a security realm for testing you can use a `MockAuthorizationStrateg
 ----
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.assertThrows;


### PR DESCRIPTION
Cleans up the testing documentation by removing deprecated Jenkins Wiki references and fixing correctness issues in code examples, including formatting and missing imports, so snippets are copy-paste usable.