### PR TITLE
docs: document Java 21 requirement for IntelliJ jenkins build

### DIFF
--- a/content/doc/developer/building/intellij.adoc
+++ b/content/doc/developer/building/intellij.adoc
@@ -26,7 +26,7 @@ Index:
 ** Install IntelliJ using the link:https://www.jetbrains.com/help/idea/installation-guide.html[Installation guide]. 
 ** The minimum Apache Maven version for Jenkins development is 3.9.6.
 Refer to link:https://www.jetbrains.com/help/idea/troubleshooting-common-maven-issues.html[Troubleshooting common Maven issues] if needed.
-** Java 21 or newer is required to build Jenkins core.
+** Java 21 or newer is required to build recent Jenkins and plugin versions.
 The build enforces this requirement and will fail when using older Java versions.
 ** Fork from the link:https://github.com/jenkinsci/jenkins[Jenkins core source code]. 
 ** Clone the forked repository to your machine.


### PR DESCRIPTION
while following the IntelliJ build instructions in this guide on a local Ubuntu environment, I encountered enforced build failures due to missing toolchain requirements

The documented steps were first attempted using the distribution-provided Maven, which failed due to Jenkins’ enforced minimum Maven version. After upgrading Maven to a suported `3.9.x` release, the build failed again with a Maven Enforcer error indicating that Java 21 or newer is required.

these requirements are enforced by the Jenkins build itself, but are not currently stated in this guide. 

This change documents the required Java version alongside the existing Maven requirement and removes a stale IntelliJ version reference, helping contributors avoid immediate build failures when following the instructions.
