### PR TITLE
docs: explain Maven -am and -pl flags in IntelliJ build guide

### DIFF
--- a/content/doc/developer/building/intellij.adoc
+++ b/content/doc/developer/building/intellij.adoc
@@ -70,6 +70,13 @@ Now we want to build Jenkins. Run the following: (This will prepare the jenkins.
  mvn -am -pl war,bom -DskipTests -Dspotbugs.skip clean install
 ----
 
+[NOTE]
+====
+The `-pl` (project list) option limits the build to the specified modules instead of building the entire repository.
+When used together with `-am` (also make), Maven will automatically build any required dependent modules needed by the selected projects.
+This helps keep local builds focused and avoids unnecessary full builds when working on Jenkins.
+====
+
 This may take a little time. If everything works well, you should get a successful build result like below:
 
 image::/images/developer/building/intellij/build1.png[]


### PR DESCRIPTION
while validating the IntelliJ build instructions, I noticed that the recommended Maven command
uses the `-am` and `-pl` flags without explaining their purpose

This change adds a short note clarifying how these flags affect multi-module builds, helping
contributors understand why they are used and avoid unnecessary full builds.
