### PR TITLE
docs: avoid hardcoded archetype version in plugin tutorial

### DIFF
--- a/content/doc/developer/tutorial/create.adoc
+++ b/content/doc/developer/tutorial/create.adoc
@@ -67,7 +67,7 @@ version: 1.0-SNAPSHOT
 
 ----
 <1> Enter the number for the `hello-world-plugin` archetype, *4* in this case.
-<2> This tutorial is based on version 1.30 of the *hello-world-plugin* archetype, so enter *29* to select it.
+<2> Select the latest available version of the *hello-world-plugin* archetype.
 <3> `groupId` uniquely identifies your project across all projects.
     A group ID should follow Java's package name rules.
     This means it starts with a reversed domain name.


### PR DESCRIPTION
while reviewing the Jenkins plugin tutorial from a clean local environment, I noticed that the instructions rely on a hardcoded archetype version and index number.
the `hello-world-plugin` archetype has continued to evolve since then, and index-based selection is inherently unstable as new versions are released. 

Following the tutorial today can therefore be confusing or misleading for new contributors.

This change updates the tutorial to instruct contributors to select the latest available version of the `hello-world-plugin` archetype, avoiding outdated templates nd reducing onboarding friction.