### PR TITLE
Fix typo: remove duplicate word in bug bounty announcement

### DIFF
--- a/content/_data/indexpage/carousel.yml
+++ b/content/_data/indexpage/carousel.yml
@@ -40,7 +40,7 @@
 # Jenkins Bug Bounty Program
 - :href: https://www.jenkins.io/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/
   :title: Announcing the new Jenkins Bug Bounty Program!
-  :intro: The European Commission (EC OSPO) has partnered with YesWeHack to launch bug bounty programs for several open source projects, including the the new Jenkins Bug Bounty Program!
+  :intro: The European Commission (EC OSPO) has partnered with YesWeHack to launch bug bounty programs for several open source projects, including the new Jenkins Bug Bounty Program!
   :image:
     :src: images/post-images/2025/12/yeswehack-jenkins.jpg
     :height: 285px


### PR DESCRIPTION
Fixed a duplicated word typo ("the the") in the homepage carousel announcement for the Bug Bounty program.

Testing done Text-only fix in carousel.yml
<img width="1254" height="558" alt="Screenshot 2026-02-07 at 11 12 03 PM" src="https://github.com/user-attachments/assets/a206080e-6f81-43da-a2f0-b0ddf65c2d20" />
