### PR TITLE
Update dependabot.yml URL to specific tag version

### DIFF
--- a/content/doc/developer/publishing/releasing-cd.adoc
+++ b/content/doc/developer/publishing/releasing-cd.adoc
@@ -102,7 +102,7 @@ If you did not yet have such a file, create it now:
 
 [source,shell]
 ----
-curl --silent --show-error --location --output .github/dependabot.yml https://raw.githubusercontent.com/jenkinsci/archetypes/master/common-files/.github/dependabot.yml
+curl --silent --show-error --location --output .github/dependabot.yml https://raw.githubusercontent.com/jenkinsci/archetypes/refs/tags/archetypes-1.34/common-files/.github/dependabot.yml
 ----
 
 === Update Maven POM and Config


### PR DESCRIPTION
dependabot.yml was removed from master in https://github.com/jenkinsci/archetypes/pull/886. 

Keep the instructions to use dependabot for now, but with a link that works.