### PR TITLE
fix broken AsciiDoc block under Simple Health Check

### DIFF
--- a/content/blog/2026/02/06/2026-02-06-tuning-java-settings-for-higher-performance.adoc
+++ b/content/blog/2026/02/06/2026-02-06-tuning-java-settings-for-higher-performance.adoc
@@ -130,19 +130,24 @@ Once deployed, monitor these metrics to validate your settings are working:
   * Check `/proc/<pid>/environ` (Linux) or `ps` output to confirm `JAVA_OPTS` are set
 
 **Simple Health Check**::
-  Enable basic logging:
-  [source,bash]
-  ----
-  JAVA_OPTS="
-    -XX:+UseG1GC
-    -XX:MaxRAMPercentage=60.0
-    -XX:InitialRAMPercentage=20.0
-    -XX:+PrintGCDetails
-    -XX:+PrintGCDateStamps
-    -Xloggc:/var/log/jenkins/gc.log
-  "
-  ----
-  Monitor `gc.log` for unexpected pause times or full GC events.
++
+--
+Enable basic logging:
+
+[source,bash]
+----
+JAVA_OPTS="
+  -XX:+UseG1GC
+  -XX:MaxRAMPercentage=60.0
+  -XX:InitialRAMPercentage=20.0
+  -XX:+PrintGCDetails
+  -XX:+PrintGCDateStamps
+  -Xloggc:/var/log/jenkins/gc.log
+"
+----
+
+Monitor `gc.log` for unexpected pause times or full GC events.
+--
 
 == Quick Rules of Thumb
 


### PR DESCRIPTION
fix rendering of the `Simple Health Check` section
wrap the content in an open block so the source block renders correctly inside the description list.

## Before this pull request

<img width="1037" height="952" alt="before-pull-request" src="https://github.com/user-attachments/assets/c987ca6a-328e-4136-9c52-d6374bed92f2" />

## After this pull request

<img width="1037" height="952" alt="after-pull-request" src="https://github.com/user-attachments/assets/c5766468-580b-4ccd-b1d8-1f55848d184a" />
