### PR TITLE
Add note for outdated year in GSoC proposal template

### DIFF
--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -37,6 +37,7 @@ We cannot make any exception. Please:
 . Check out the link:/projects/gsoc/2026/project-ideas[GSoC 2026 Project ideas]
 . Select an interesting project idea or draft your own proposal.
 . Use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template] to write your project proposal.
+  If the template links to project ideas for an older year, use the link:/projects/gsoc/2026/project-ideas[GSoC 2026 project ideas] instead.
 . If you are not familiar with Jenkins, read the introductory info on the website and try using Jenkins with one of your previous projects.
 . Join the link:https://community.jenkins.io/c/contributing/gsoc/[Discourse communication channel].
 . Join the link:https://app.gitter.im/#/room/#jenkinsci_gsoc-sig:gitter.im[Jenkins GSoC Gitter Chat].
@@ -123,7 +124,9 @@ link:https://google.github.io/gsocguides/student/[Google Summer of Code Guide],
 specifically the link:https://google.github.io/gsocguides/student/writing-a-proposal#elements-of-a-quality-proposal[Elements of a Quality Proposal].
 
 Contributors need to use the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/[project proposal template]
-to write their proposals. Contributor proposals should not be confused with link:../proposing-project-ideas[project ideas].
+to write their proposals.
+If the template references project ideas for another year, use the link:/projects/gsoc/2026/project-ideas[GSoC 2026 project ideas] for the current program.
+Contributor proposals should not be confused with link:../proposing-project-ideas[project ideas].
 
 We strongly encourage contributors to engage with the mentors as early as
 possible. If you wait until the last few days to submit a proposal,

--- a/content/projects/gsoc/mentors.adoc
+++ b/content/projects/gsoc/mentors.adoc
@@ -175,6 +175,7 @@ This means that you need to:
 ** of course we appreciate if you help us find more mentors if you can
 * participate in the weekly public meeting
 * make sure the GSoC Contributors follow the process and that their application meets the requirements in the link:https://docs.google.com/document/d/1dIlPLXfLbFsvcaHFuwmH9_lSCVm9m6-SgNYTNAnSZpY/edit[template]
+  If the template links to project ideas for an older year, direct contributors to the link:/projects/gsoc/2026/project-ideas[GSoC 2026 project ideas].
 ** make sure the GSoC Contributors determine whether they are link:../contributors/#eligibility-steps[eligible]
 * if the GSoC Contributor proposes a genuine project idea in your area of interest or expertise, make sure it is presented and discussed in the community
 


### PR DESCRIPTION
### Summary
The Google Doc project proposal template occasionally links to an older year's project ideas. This PR adds a short note in both the contributors and mentors pages so readers know to use the current GSoC 2026 project ideas instead.

### Motivation / Issue
Closes #8858

### Changes Made
- `content/projects/gsoc/contributors.adoc` — added note under the "Use the project proposal template" step and in the "GSoC Contributor Proposals" section
- `content/projects/gsoc/mentors.adoc` — added note under the template bullet so mentors can redirect contributors

### Testing / Verification
- [x] `make check` passes with no errors (check-hard-coded-URL-references and check-filename pass; typos binary not available on Windows)
- [ ] `make generate` completes successfully
- [ ] `make run` — change visually verified at http://localhost:4242
- [x] AsciiDoc formatting follows one-sentence-per-line style