### PR TITLE
Improve IDE configuration documentation completeness

### DIFF
--- a/content/doc/developer/development-environment/ide-configuration.adoc
+++ b/content/doc/developer/development-environment/ide-configuration.adoc
@@ -3,7 +3,7 @@ layout: developersection
 title: IDE Configuration
 references:
 - url: https://wiki.jenkins.io/display/JENKINS/Developing+with+JRebel
-  title: Developing with JRebel # TODO find someone who can write actual documentation for this
+  title: Developing with JRebel (external wiki; plugin enables hot reload of Java classes without full restarts)
 ---
 
 == IntelliJ IDEA
@@ -20,11 +20,12 @@ This plugin has the following features:
 * "Go to stapler view" to jump from a Java class to its views (Cmd/Ctrl+Shift+P)
 * Select a string expression, then "Refactor" > "i18n for Stapler" to create a message resource
 
-== Netbeans
+== NetBeans
 The previously referenced NetBeans plugin is no longer available.
+For Java and Maven support, use the built-in NetBeans tooling and run the plugin with `mvn hpi:run` from the project root.
 
 == Visual Studio Code
-See: https://code.visualstudio.com/docs/languages/java for useful extensions
+See link:https://code.visualstudio.com/docs/languages/java[Visual Studio Code Java documentation] for recommended extensions (e.g. Extension Pack for Java, Debugger for Java).
 
 Create the following 2 files in your project:
 


### PR DESCRIPTION
### Summary
Fills in the thin IDE configuration page: replaces a TODO in the JRebel reference, fixes the NetBeans capitalisation, adds a one-sentence usage note for NetBeans, and converts the bare VS Code URL into a proper AsciiDoc link with extension recommendations.

### Motivation / Issue
Closes #8781

### Changes Made
- `content/doc/developer/development-environment/ide-configuration.adoc`
  - JRebel front-matter title: replaced `# TODO` comment with a short description
  - `== Netbeans` → `== NetBeans` (correct capitalisation)
  - NetBeans section: added one sentence about using built-in tooling and `mvn hpi:run`
  - VS Code section: converted bare URL to `link:...[...]` with descriptive anchor text and extension mentions

### Testing / Verification
- [x] `make check` passes (check-hard-coded-URL-references and check-filename pass)
- [ ] `make generate` completes successfully
- [ ] `make run` — change visually verified at http://localhost:4242
- [x] AsciiDoc formatting follows one-sentence-per-line style