### PR TITLE
Clarify docker agent short form vs args parameter in Pipeline Syntax docs

### DIFF
--- a/content/doc/book/pipeline/syntax.adoc
+++ b/content/doc/book/pipeline/syntax.adoc
@@ -161,9 +161,10 @@ For example: `agent { label 'my-label1 && my-label2' }` or `agent { label 'my-la
 
 node:: `agent { node { label 'labelName' } }` behaves the same as `agent { label 'labelName' }`, but `node` allows for additional options (such as `customWorkspace`).
 
-docker:: Execute the Pipeline, or stage, with the given container which will be dynamically provisioned on a <<../glossary#node, node>> pre-configured to accept Docker-based Pipelines, or on a node matching the optionally defined `label` parameter. 
+docker:: Execute the Pipeline, or stage, with the given container which will be dynamically provisioned on a <<../glossary#node, node>> pre-configured to accept Docker-based Pipelines, or on a node matching the optionally defined `label` parameter.
 `docker` also optionally accepts an `args` parameter which may contain arguments to pass directly to a `docker run` invocation, and an `alwaysPull` option, which will force a `docker pull` even if the image name is already present.
-For example: `agent { docker 'maven:3.9.3-eclipse-temurin-17' }` or
+Simple form: `agent { docker 'maven:3.9.3-eclipse-temurin-17' }`.
+To pass options to `docker run`, use the `args` parameter in a `docker` block:
 +
 [source,groovy]
 ----


### PR DESCRIPTION
### Summary
The `docker` agent section showed a block example but the intro text ended mid-sentence ("...or"), making it unclear how the short-form string syntax related to the `args` parameter block form. This PR explicitly labels both usage patterns.

### Motivation / Issue
Closes #5134

### Changes Made
- `content/doc/book/pipeline/syntax.adoc` — rewrote the two intro lines for the `docker` agent:
  - Added `Simple form: \`agent { docker '...' }\`.` to show the string shorthand
  - Added `To pass options to \`docker run\`, use the \`args\` parameter in a \`docker\` block:` as the lead-in to the existing block example

### Testing / Verification
- [x] `make check` passes (check-hard-coded-URL-references and check-filename pass)
- [ ] `make generate` completes successfully
- [ ] `make run` — change visually verified at http://localhost:4242
- [x] AsciiDoc formatting follows one-sentence-per-line style