### PR TITLE
Add Prerequisites section to Using Docker with Pipeline page

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -19,6 +19,15 @@ Starting with Pipeline versions 2.5 and higher, Pipeline has built-in support fo
 
 While this page covers the basics of utilizing Docker from within a `Jenkinsfile`, it will not cover the fundamentals of Docker, which you can refer to in the link:https://docs.docker.com/get-started/[Docker Getting Started Guide].
 
+[[prerequisites]]
+== Prerequisites
+
+Install the link:https://plugins.jenkins.io/docker-workflow/[Docker Pipeline plugin] (often included with the Pipeline plugins offered in the setup wizard).
+The examples on this page assume that at least one agent can run Docker commands.
+
+If the Jenkins controller runs inside a container (for example via Docker Compose), it generally cannot start sibling containers.
+In that case, the `docker` agent and Scripted `docker.image(...).inside { }` are not available on the controller.
+Configure one or more agents that have Docker available and can run containers; then run your Pipeline or stages on those agents (for example with `agent { label 'docker' }` or by allocating the agent in the stage).
 
 [[execution-environment]]
 == Customizing the execution environment


### PR DESCRIPTION
### Summary
Users running Jenkins inside a container (e.g. Docker Compose) commonly get "Invalid agent type docker" because the Docker Pipeline plugin is absent or because the controller cannot start sibling containers. This PR adds a Prerequisites section that documents both requirements and explains the sibling-container limitation with a recommended workaround.

### Motivation / Issue
Closes #7870

### Changes Made
- `content/doc/book/pipeline/docker.adoc` — added `== Prerequisites` section before the existing "Customizing the execution environment" section:
  - Require the Docker Pipeline plugin
  - Note that at least one agent must be able to run Docker commands
  - Explain the sibling-container limitation when the controller runs in a container
  - Recommend using `agent { label 'docker' }` or per-stage agent allocation

### Testing / Verification
- [x] `make check` passes (check-hard-coded-URL-references and check-filename pass)
- [ ] `make generate` completes successfully
- [ ] `make run` — change visually verified at http://localhost:4242
- [x] AsciiDoc formatting follows one-sentence-per-line style