### PR TITLE
Inject Open Graph description into security advisory pages by default

### DIFF
--- a/content/_layouts/advisory.html.haml
+++ b/content/_layouts/advisory.html.haml
@@ -7,6 +7,10 @@ notitle: true
 :ruby
   require 'asciidoctor'
 
+  page.description = page.title + " - vulnerabilities and fixes for Jenkins and plugins."
+  page.opengraph ||= {}
+  page.opengraph[:image] = "images/logo-title-opengraph.png"
+
   plugins = page.issues.collect { |issue| issue.plugins }.flatten.uniq.keep_if { |p| p }.sort { |x,y| (site._generated[:update_center].plugins[x.name]&.title&.downcase || x.name&.downcase) <=> (site._generated[:update_center].plugins[y.name]&.title&.downcase || y.name&.downcase) }
   credits = page.issues.reduce({}) do |issues, issue|
     if issue.has_key?("reporter")


### PR DESCRIPTION
### Summary
Security advisory pages had no `page.description` set, so social media link previews showed a generic Jenkins description instead of anything advisory-specific. This PR sets `page.description` in the advisory layout so the existing `frame.html.haml` `og:description` and `twitter:description` meta tags render a useful value.

### Motivation / Issue
Closes #4349

### Changes Made
- `content/_layouts/advisory.html.haml` — inside the existing `:ruby` block, set:
  - `page.description` to `page.title + " - vulnerabilities and fixes for Jenkins and plugins."` so social previews show the advisory title
  - `page.opengraph[:image]` to the standard site logo (same value `frame.html.haml` defaults to, making the intent explicit)

### Testing / Verification
- [x] `make check` passes (check-hard-coded-URL-references and check-filename pass)
- [ ] `make generate` completes successfully
- [ ] `make run` — visually verify that sharing an advisory URL produces the advisory title in the og:description meta tag
- [ ] No regressions on adjacent advisory pages

### Notes for Reviewers
`frame.html.haml` already handles `og:title`, `og:description`, `og:image`, and `twitter:*` meta tags using `page.description` and `page.opengraph[:image]` — no new template code is required.