### PR TITLE
Add upgrade instructions to the Linux installation page

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -337,4 +337,16 @@ firewall-cmd --reload
 
 ====
 
+== Upgrading
+
+Upgrade Jenkins using your distribution's package manager so that the service and configuration stay consistent.
+Do not upgrade by replacing the `jenkins.war` file manually; that can leave the system in an inconsistent state.
+
+* Debian/Ubuntu: `sudo apt update && sudo apt upgrade jenkins` (or `jenkins-lts` if you use the LTS package).
+* Fedora: `sudo dnf upgrade jenkins` (or `jenkins-lts`).
+* Red Hat / CentOS: `sudo yum upgrade jenkins` (or `jenkins-lts`).
+
+After upgrading, restart the Jenkins service if it did not restart automatically (for example `sudo systemctl restart jenkins`).
+For broader system upgrades, follow your operating system's documentation.
+
 include::doc/book/installing/_setup-wizard.adoc[]


### PR DESCRIPTION
### Summary
The Linux installation page documented installation steps for Debian/Ubuntu, Fedora, and Red Hat/CentOS but provided no guidance on upgrading. Users who upgraded by replacing `jenkins.war` manually could leave the system in an inconsistent state.

### Motivation / Issue
Closes #5059

### Changes Made
- `content/doc/book/installing/linux.adoc`: Added a new `== Upgrading` section after the distribution-specific installation steps and before the setup wizard include.
  - States that upgrades must be done via the distribution package manager, not by replacing `jenkins.war`
  - Provides a one-line example for each supported distribution (Debian/Ubuntu `apt`, Fedora `dnf`, Red Hat/CentOS `yum`)
  - Notes that the service should be restarted if it did not restart automatically

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] `make run` — change visually verified at http://localhost:4242
- [ ] `make check-broken-links` passes (if links were added or changed)
- [ ] AsciiDoc formatting follows one-sentence-per-line style

### Notes for Reviewers
The section follows the one-sentence-per-line AsciiDoc convention used throughout the page and uses present tense throughout.