### PR TITLE
Add warning about restarting Jenkins before reloading JCasC configuration

### DIFF
--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -144,6 +144,13 @@ jenkins:
 . Click the *Reload existing configuration* button to apply the changes
 . View the modified "System Message" on your dashboard
 
+[WARNING]
+====
+If you restart Jenkins before clicking *Reload existing configuration*,
+the in-memory configuration can overwrite your YAML file changes when the controller shuts down.
+Always click *Reload existing configuration* to apply your file changes before restarting Jenkins.
+====
+
 [NOTE]
 ====
 It is not necessary to restart Jenkins to apply the JCasC changes,


### PR DESCRIPTION
### Summary
When a user edits the JCasC YAML file and then restarts Jenkins without first clicking "Reload existing configuration", the in-memory configuration can overwrite the file edits on shutdown. This data-loss scenario is not documented. Adding a WARNING block makes the risk explicit.

### Motivation / Issue
Closes #8295

### Changes Made
- `content/doc/book/managing/casc.adoc`: Added a `[WARNING]` admonition immediately after step 5 ("Click the *Reload existing configuration* button") in the "Modifying the JCasC file" procedure. The warning explains that restarting before reloading can overwrite YAML file changes with the in-memory configuration, and recommends always reloading before restarting.

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] `make run` — warning block rendered correctly at http://localhost:4242/doc/book/managing/casc/
- [ ] AsciiDoc formatting follows one-sentence-per-line style

### Notes for Reviewers
The WARNING block uses standard AsciiDoc admonition syntax consistent with existing admonitions on this page. It is placed immediately after the step that triggers the risk, and before the existing NOTE, so readers encounter it at exactly the right moment.