### PR TITLE
Increase border-radius of thank-you note boxes to 8px

### DIFF
--- a/content/css/jenkins.css
+++ b/content/css/jenkins.css
@@ -1621,7 +1621,7 @@ ion-icon.report {
 
 .thank-you-box {
   padding: 24px;
-  border-radius: 3px;
+  border-radius: 8px;
   max-width: fit-content;
   height: fit-content;
   background-color: rgb(218, 209, 198, 0.3);


### PR DESCRIPTION
### Summary
The `.thank-you-box` CSS class used `border-radius: 3px`, making corners appear nearly sharp. Increasing the value to `8px` gives the thank-you notes on the landing page and download page clearly rounded corners.

### Motivation / Issue
Closes #8849

### Changes Made
- `content/css/jenkins.css`: Changed `.thank-you-box { border-radius: 3px }` to `border-radius: 8px`.
  The `.thank-you-box` class is shared by the `thank-you-note.html.haml` partial rendered on both the landing page and the download page, so both pages are updated with this single change.

### Testing / Verification
- [ ] `make generate` completes successfully
- [ ] `make run` — thank-you note rounded corners verified on http://localhost:4242 and http://localhost:4242/download/
- [ ] No regressions on adjacent pages
- [ ] No console errors

### Notes for Reviewers
Change is scoped to the existing `.thank-you-box` selector; no global CSS bleed. The value `8px` is consistent with the `border-radius: 8px` already used on `.author-card` and other card components on the site.