### PR TITLE
Fix incorrect guidance that agent JVM must match controller JVM version

### DIFF
--- a/content/doc/book/platform-information/upgrade-java-to-11.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-11.adoc
@@ -58,8 +58,9 @@ However, if you manage your plugins outside Jenkins, for example using a `plugin
 
 == JVM version on agents
 
-All agents must be running on the same JVM version as the controller due to how controllers and agents communicate.
-If you're upgrading your Jenkins controller to run on Java 11, you must upgrade the JVM on your agents.
+Agents must run a JVM that meets the minimum Java version required by the version of Jenkins running on the controller.
+Agents do not need to run the same major Java version as the controller, but running the same major version reduces the risk of serialization incompatibilities between the controller and the agent.
+If you are upgrading your Jenkins controller to run on Java 11, upgrade the JVM on any agents still running on Java 8.
 
 You can validate the version of each agent with the plugin:versioncolumn[Versions Node Monitors] plugin.
 This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins instance.

--- a/content/doc/book/platform-information/upgrade-java-to-17.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-17.adoc
@@ -41,8 +41,9 @@ Refer to link:/participate/report-issue/#issue-reporting[our issue reporting doc
 
 == JVM version on agents
 
-All agents must be running on the same JVM version as the controller, due to how controllers and agents communicate.
-If you're upgrading your Jenkins controller to run on Java 17, you must upgrade the JVM on your agents.
+Agents must run a JVM that meets the minimum Java version required by the version of Jenkins running on the controller.
+Agents do not need to run the same major Java version as the controller, but running the same major version reduces the risk of serialization incompatibilities between the controller and the agent.
+If you are upgrading your Jenkins controller to run on Java 17, upgrade the JVM on any agents running below the minimum required Java version.
 
 Validating the version of each agent can be done with the plugin:versioncolumn[Versions Node Monitors] plugin.
 This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins controller.

--- a/content/doc/book/platform-information/upgrade-java-to-21.adoc
+++ b/content/doc/book/platform-information/upgrade-java-to-21.adoc
@@ -29,10 +29,10 @@ To verify the Java version currently used in your agent:
 . Select an agent name from the *Build Executor Status* widget and then select *System Information*.
 . Locate the `java.runtime.version` and reveal the hidden value to display the current Java version.
 
-The `checkNodes` script determines what version of Java is running the controller process, along with the version of the agent that's associated with that controller.
-The script then checks the version of Java that is on the agent.
-When these values are returned, `OK` means that the agent Java version matches the controller Java version.
-Otherwise, the result displays the expected Java version and the version found instead.
+The `checkNodes` script determines what version of Java is running the controller process, along with the version of Java on each connected agent.
+When the agent Java version matches the controller Java version, the result shows `OK`.
+Otherwise, the result displays the controller Java version and the version found on the agent.
+Use this script to identify agents that may need a Java upgrade.
 
 To run the `checkNodes` script:
 
@@ -122,8 +122,9 @@ Refer to link:/participate/report-issue/#issue-reporting[our issue reporting doc
 
 === JVM version on agents
 
-Due to how controllers and agents communicate, all agents must run on the same JVM version as the controller.
-If you're upgrading your Jenkins controller to run on Java 21, you must upgrade the JVM on your agents.
+Agents must run a JVM that meets the minimum Java version required by the version of Jenkins running on the controller.
+Agents do not need to run the same major Java version as the controller, but running the same major version reduces the risk of serialization incompatibilities between the controller and the agent.
+If you are upgrading your Jenkins controller to run on Java 21, upgrade the JVM on any agents running below the minimum required Java version.
 
 Validating the version of each agent can be done with the plugin:versioncolumn[Versions Node Monitors] plugin.
 This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins controller.


### PR DESCRIPTION
### Summary
Three Java upgrade guides incorrectly stated that agents *must run the same JVM version* as the controller. This is inaccurate: agents only need to satisfy the minimum Java version required by the running Jenkins version. They do not need to match the controller's exact major version, though running the same major version reduces serialization risks.

### Motivation / Issue
Closes #8691

### Changes Made
- `content/doc/book/platform-information/upgrade-java-to-11.adoc`: Updated the "JVM version on agents" section to replace "must run the same JVM version" with the correct minimum-version requirement language.
- `content/doc/book/platform-information/upgrade-java-to-17.adoc`: Same correction applied.
- `content/doc/book/platform-information/upgrade-java-to-21.adoc`: Same correction applied. Also clarified the description of the `checkNodes` diagnostic script, which checks version parity but whose output does not imply agents are required to match exactly.

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] `make run` — updated sections verified at http://localhost:4242/doc/book/platform-information/upgrade-java-to-11/
- [ ] AsciiDoc formatting follows one-sentence-per-line style

### Notes for Reviewers
The fix is based on the analysis in issue #8691 by @daniel-beck (Jenkins maintainer) and the CloudBees CI documentation. The added note about same-major-version being recommended reflects the nuanced comment by @jtnord in the issue thread about serialization risks.