### PR TITLE
Add Job/ExtendedRead and Agent/ExtendedRead to the permissions reference page

### DIFF
--- a/content/doc/book/security/access-control/permissions.adoc
+++ b/content/doc/book/security/access-control/permissions.adoc
@@ -133,6 +133,11 @@ This permission allows users to delete existing agents.
 Agent/Disconnect::
 This permission allows users to disconnect agents or mark agents as temporarily offline.
 
+Agent/ExtendedRead::
+This permission grants read-only access to agent configuration pages.
+It is enabled by installing the plugin:extended-read-permission[Extended Read Permission] plugin.
+It is intended for use together with _Overall/SystemRead_ to provide a fully read-only view of the Jenkins configuration.
+
 === _Job_ Permissions
 
 Though these permissions use the word "Job" in their name,
@@ -160,6 +165,13 @@ Without it they would get a 404 error and wouldn't be able to discover project n
 +
 This permission is only useful if anonymous users have _Overall/Read_ permission, but not _Job/Read_.
 It is implied by _Job/Read_.
+
+Job/ExtendedRead::
+This permission grants read-only access to job configuration pages.
+It is enabled by installing the plugin:extended-read-permission[Extended Read Permission] plugin.
+It is intended for use together with _Overall/SystemRead_ to provide a fully read-only view of the Jenkins configuration.
++
+This permission is implied by _Job/Configure_.
 
 Job/Move::
 Required to move a job from one folder (or Jenkins root) to another.


### PR DESCRIPTION
### Summary
The permissions reference page was missing `Job/ExtendedRead` and `Agent/ExtendedRead`, two optional permissions introduced by the Extended Read Permission plugin for providing read-only access to job and agent configuration. These were only documented in a 2020 blog post, not on the canonical permissions page that users consult.

### Motivation / Issue
Closes #8344

### Changes Made
- `content/doc/book/security/access-control/permissions.adoc`:
  - Added `Agent/ExtendedRead` entry under the *Agent Permissions* section (after `Agent/Disconnect`), describing its scope and that it requires the Extended Read Permission plugin.
  - Added `Job/ExtendedRead` entry under the *Job Permissions* section (after `Job/Discover`), with the same description pattern, plus a note that it is implied by `Job/Configure`.

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] `make run` — new permission entries verified at http://localhost:4242/doc/book/security/access-control/permissions/
- [ ] AsciiDoc formatting follows one-sentence-per-line style

### Notes for Reviewers
The permissions were introduced as part of the read-only Jenkins feature (JEP-224, Jenkins 2.222). Both entries follow the definition list (`::`-prefixed) style used by every other permission on this page. The `+` continuation for `Job/ExtendedRead` uses the same pattern as `Job/Discover` for the implied-by note.