### PR TITLE
Fix nginx config: use empty Connection header for non-WebSocket requests to preserve keepalives

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -40,7 +40,7 @@ upstream jenkins {
 # Required for Jenkins websocket agents
 map $http_upgrade $connection_upgrade {
   default upgrade;
-  '' close;
+  '' "";  # Clear Connection header for non-WebSocket requests to preserve keepalives
 }
 
 server {


### PR DESCRIPTION
### Summary
The nginx reverse proxy example configured a `map` that set `Connection: close` for all non-WebSocket HTTP requests. This silently disabled keepalive connections between nginx and the Jenkins upstream for every normal browser request, negating the `keepalive 32` setting on the `upstream` block. Changing the empty-Upgrade case to `""` (empty string) instead of `close` clears the Connection header for regular requests, preserving upstream keepalives while WebSocket upgrades continue to work correctly.

### Motivation / Issue
Closes #4905

### Changes Made
- `content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc`:
  - Changed `'' close;` to `'' "";  # Clear Connection header for non-WebSocket requests to preserve keepalives` in the `$connection_upgrade` map.

### Technical explanation
The `$connection_upgrade` variable is set to `upgrade` when an `Upgrade` request header is present (WebSocket), and to `close` when it is absent. For non-WebSocket requests `Connection: close` is forwarded to Jenkins, which signals the upstream to close the connection after each response — defeating `keepalive 32`. Setting the value to `""` means nginx does not forward a `Connection` header for regular requests, allowing the upstream connection to remain persistent.

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] Nginx syntax check passes: `nginx -t`
- [ ] WebSocket agents still connect correctly after the change
- [ ] HTTP keepalive connections to Jenkins upstream are maintained for regular browser requests

### Notes for Reviewers
This is a behavioural fix to the nginx configuration snippet; it does not break WebSocket support. The nginx documentation and the referenced Stack Overflow answers in the issue confirm this approach. The inline comment explains the intent for future readers.