### PR TITLE
Fix incorrect description of the built-in node on the Managing Nodes page

### DIFF
--- a/content/doc/book/managing/nodes.adoc
+++ b/content/doc/book/managing/nodes.adoc
@@ -31,17 +31,17 @@ Files written when a Pipeline executes are written to the filesystem on the cont
 
 Nodes::
 
-Nodes are the "machines" on which build agents run. 
-Jenkins monitors each attached node for disk space, free temp space, free swap, clock time/sync, and response time. 
+Nodes are computing resources on which Jenkins runs builds.
+Jenkins monitors each node for disk space, free temp space, free swap, clock time/sync, and response time.
 A node is taken offline if any of these values go outside the configured threshold.
-Jenkins supports two types of nodes:
-* *agents* (described below)
-* *built-in node*
-** The built-in node is a node that exists within the controller process. 
-It is possible to use agents and the build-in node to run tasks. 
-However, running tasks on the built-in node is discouraged for security, performance, and scalability reasons. 
-The number of executors configured for the node determines the node's ability to run tasks. 
-Set the number of executors to 0 to disable running tasks on the built-in node.
+Jenkins has two types of nodes:
+
+* *Built-in node*: a node that exists inside the controller process itself.
+The built-in node is not an agent; it runs within the controller.
+Running builds on the built-in node is discouraged for security, performance, and scalability reasons.
+Set the number of executors on the built-in node to 0 to prevent it from running builds.
+* *Agents* (described below): separate processes that connect to the controller and run builds on its behalf.
+All agents are nodes, but the built-in node is not an agent.
 
 Agents::
 


### PR DESCRIPTION
### Summary
The "Nodes" definition block in the Managing Nodes page contained conceptual errors about the relationship between nodes, the built-in node, and agents — along with a typo ("build-in" instead of "built-in"). The section implied the built-in node was a machine for agents, which is inaccurate. The rewrite accurately describes both node types and clarifies that the built-in node is not an agent.

### Motivation / Issue
Closes #5776

### Changes Made
- `content/doc/book/managing/nodes.adoc`: Rewrote the `Nodes::` definition list entry to:
  - Correct the description ("machines on which build agents run" → "computing resources on which Jenkins runs builds")
  - Describe the built-in node accurately as a node inside the controller process, not an agent
  - Fix the typo "build-in" → "built-in"
  - Add the clarifying statement "All agents are nodes, but the built-in node is not an agent"
  - List both node types (built-in node and agents) as explicit bullet points for clarity

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] `make run` — updated Nodes section verified at http://localhost:4242/doc/book/managing/nodes/
- [ ] AsciiDoc formatting follows one-sentence-per-line style

### Notes for Reviewers
The rewrite is faithful to the conceptual correction described by @daniel-beck in issue #5776: "The built-in node is a node inside the controller process, hence the name. It can have executors, but it is not an agent. All agents are nodes, but not all nodes are agents."