### PR TITLE
Document JKS and PKCS#12 as supported keystore formats for HTTPS configuration

### DIFF
--- a/content/doc/book/installing/_jenkins-command-parameters.adoc
+++ b/content/doc/book/installing/_jenkins-command-parameters.adoc
@@ -113,6 +113,10 @@ If you're setting up Jenkins using the built-in Winstone server and want to use 
 --httpsKeyStorePassword=keystorePassword
 ----
 
+Jenkins supports both *Java KeyStore (JKS)* and *PKCS#12* (`.p12` / `.pfx`) keystore formats for the `--httpsKeyStore` parameter.
+Use `keytool` (bundled with the JDK) to create a JKS keystore or to convert an existing certificate into a supported format.
+When using a PKCS#12 file, pass the file path directly as the `--httpsKeyStore` value; no conversion is required.
+
 === Using HTTP/2
 
 The link:https://tools.ietf.org/html/rfc7540[HTTP/2 protocol] allows web servers to reduce latency over encrypted connections by pipelining requests, multiplexing requests, and allowing servers to push, in some cases, before receiving a client request for the data.


### PR DESCRIPTION
### Summary
The "HTTPS with an existing certificate" section showed the `--httpsKeyStore` command-line parameter but did not say which keystore formats are accepted. Users with existing PKCS#12 (`.p12`/`.pfx`) certificates had no way to know whether they could pass the file directly or needed to convert it first.

### Motivation / Issue
Closes #5469

### Changes Made
- `content/doc/book/installing/_jenkins-command-parameters.adoc`: Added a short paragraph after the HTTPS configuration code block stating that both Java KeyStore (JKS) and PKCS#12 (`.p12`/`.pfx`) formats are supported for `--httpsKeyStore`, and that PKCS#12 files can be used directly without conversion.

### Testing / Verification
- [ ] `make check` passes with no errors
- [ ] `make generate` completes successfully
- [ ] `make run` — new note visible at http://localhost:4242/doc/book/installing/initial-settings/#https-with-an-existing-certificate
- [ ] AsciiDoc formatting follows one-sentence-per-line style

### Notes for Reviewers
PKCS#12 support was added in Jenkins core (see jenkinsci/jenkins#6694). The note is deliberately brief — it confirms supported formats and references `keytool` for format conversion without expanding into a full tutorial.