### PR TITLE
Update Jenkins Docker image to use JDK17 instead of JDK21

### DIFF
--- a/content/doc/book/installing/_docker.adoc
+++ b/content/doc/book/installing/_docker.adoc
@@ -76,7 +76,7 @@ docker run --name jenkins-docker --rm --detach \
 +
 [source,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk21
+FROM FROM jenkins/jenkins:{jenkins-stable}-jdk17
 USER root
 RUN apt-get update && apt-get install -y lsb-release ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
@@ -190,7 +190,7 @@ docker run --name jenkins-docker --rm --detach ^
 +
 [source,dockerfile,subs="attributes+"]
 ----
-FROM jenkins/jenkins:{jenkins-stable}-jdk21
+FROM FROM jenkins/jenkins:{jenkins-stable}-jdk17
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \


### PR DESCRIPTION
This PR updates the Jenkins Docker image reference from JDK21 to JDK17 in the documentation for both macOS/Linux and Windows sections.

This ensures compatibility with environments where JDK21 is not yet supported and prevents potential runtime issues during Jenkins setup via Docker.

No functional code changes were made; this is a documentation-only update.