### PR TITLE
Removes instruction to create an INFRA Jenkins JIRA ticket for wiki links

### DIFF
--- a/content/doc/developer/publishing/wiki-page.adoc
+++ b/content/doc/developer/publishing/wiki-page.adoc
@@ -62,7 +62,6 @@ If you cannot identify migrated pages, this creates a major technical obstacle i
 . Check that the images are not outdated.
 ** A lot of UI changes have occurred, and wiki pages often contain out-of-date images (images that contain keywords like Hudson will need to be replaced).
 . Commit changes, push them to your fork and create a pull request against the plugin repository.
-. Once the pull request is merged, create an `INFRA` Jenkins JIRA ticket to replace the content on Wiki by a link to the new jenkins.io locations.
 
 [[configuring-wiki-redirects]]
 === Configuring Wiki Redirects


### PR DESCRIPTION
INFRA Jenkins JIRA has been migrated to Github issues in repository [jenkins-infra/helpdesk](https://github.com/jenkins-infra/helpdesk/issues).

There is now a section Configuring Wiki Redirects instructing the developer to do it themselves.

https://github.com/jenkins-infra/jenkins.io/pull/8644