### PR TITLE
Fix typo in "Using a Jenkinsfile" page

### DIFF
--- a/content/doc/book/pipeline/jenkinsfile.adoc
+++ b/content/doc/book/pipeline/jenkinsfile.adoc
@@ -654,11 +654,11 @@ node {
   withCredentials([string(credentialsId: 'mytoken', variable: 'TOKEN')]) {
     sh /* WRONG! */ """
       set +x
-      curl -H 'Token: $TOKEN' https://some.api/
+      curl -H "Token: $TOKEN" https://some.api/
     """
     sh /* CORRECT */ '''
       set +x
-      curl -H 'Token: $TOKEN' https://some.api/
+      curl -H "Token: $TOKEN" https://some.api/
     '''
   }
 }


### PR DESCRIPTION
`sh` will not escape variables in arguments surrounded by single-quotes. Double-quotes have to be used instead.