### PR TITLE
Update Uplink access request link in documentation

### DIFF
--- a/content/doc/developer/telemetry/index.adoc
+++ b/content/doc/developer/telemetry/index.adoc
@@ -37,7 +37,7 @@ To trigger telemetry submission, you can call `ExtensionList.lookupSingleton(jen
 
 === Uplink Access
 
-Request access to https://uplink.jenkins.io/[Uplink] in the INFRA Jira project.
+Request access to https://uplink.jenkins.io/[Uplink] in https://github.com/jenkins-infra/helpdesk/issues[the Jenkins Infrastructure help desk].
 This should best be done before the telemetry change is released or even merged, as the collected data and other parameters will be reviewed (if the telemetry collection is in a plugin).
 
 === Backporting (Jenkins core)


### PR DESCRIPTION
This change replaces the mention of the INFRA Jira project, migrated to the helpdesk repo since a few years.