### PR TITLE
Add jcasc warning

### DIFF
--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -121,6 +121,7 @@ before you make any modifications to the file.
 
 == Modifying the JCasC file
 
+CAUTION: If Jenkins is restarted before the updated Configuration as Code (JCasC) YAML file is reloaded, the in-memory configuration may overwrite the changes in the file. Always reload the configuration after editing the YAML file.
 To modify the JCasC YAML file,
 use the text editor of your choice to edit the file
 that is listed on the *Manage Jenkins >> Configuration as Code* UI page.

--- a/content/support.adoc
+++ b/content/support.adoc
@@ -82,4 +82,5 @@ NOTE: The Jenkins project does not endorse specific vendors. Users should perfor
 ** link:https://www.cloudbees.com/[CloudBees] offers a commercial derivate of Jenkins with support and training options.
 ** link:https://www.feathersoft.com/jenkins-development-service/[Feathersoft] offers Jenkins development and consulting services for Jenkins.
 ** link:https://www.infracloud.io/jenkins-consulting-support/[InfraCloud] offers support and consulting services for Jenkins.
+** link:https://www.itmethods.com/jenkins/[ITMethods] provides managed Jenkins services and support.
 ** link:https://www.stackgenie.io/jenkins-automation-services/[StackGenie] offers support, hosting and consulting services for Jenkins.

--- a/content/support.adoc
+++ b/content/support.adoc
@@ -82,5 +82,4 @@ NOTE: The Jenkins project does not endorse specific vendors. Users should perfor
 ** link:https://www.cloudbees.com/[CloudBees] offers a commercial derivate of Jenkins with support and training options.
 ** link:https://www.feathersoft.com/jenkins-development-service/[Feathersoft] offers Jenkins development and consulting services for Jenkins.
 ** link:https://www.infracloud.io/jenkins-consulting-support/[InfraCloud] offers support and consulting services for Jenkins.
-** link:https://www.itmethods.com/jenkins/[ITMethods] provides managed Jenkins services and support.
 ** link:https://www.stackgenie.io/jenkins-automation-services/[StackGenie] offers support, hosting and consulting services for Jenkins.


### PR DESCRIPTION
Fixes  #8295 

### Add warning about restarting Jenkins before reloading JCasC YAML configuration

This PR adds a caution note to the **Modifying the JCasC file** section of the documentation.

Restarting Jenkins before reloading the updated Configuration as Code (JCasC) YAML file may cause the in-memory configuration to overwrite the changes on disk.

This clarification helps prevent accidental configuration loss.
