### PR TITLE
Fixes #8781-Remove TODO and improve IDE configuration documentation reference 

### DIFF
--- a/content/doc/developer/development-environment/ide-configuration.adoc
+++ b/content/doc/developer/development-environment/ide-configuration.adoc
@@ -3,7 +3,7 @@ layout: developersection
 title: IDE Configuration
 references:
 - url: https://wiki.jenkins.io/display/JENKINS/Developing+with+JRebel
-  title: Developing with JRebel # TODO find someone who can write actual documentation for this
+  title: Developing with JRebel
 ---
 
 == IntelliJ IDEA
@@ -11,6 +11,9 @@ references:
 link:https://plugins.jetbrains.com/plugin/1885-jenkins-development-support/[Jenkins Development Support] (source code https://github.com/jenkinsci/idea-stapler-plugin)
 
 This IDEA plugin makes it easy to develop Jenkins and its plugins on IntelliJ IDEA
+
+Developers who want faster reload cycles during plugin development may also consider tools like JRebel.
+See the reference section above for additional information.
 
 This plugin has the following features:
 


### PR DESCRIPTION
### Improve IDE configuration documentation

Removes the TODO comment from the JRebel reference in `ide-configuration.adoc` and slightly clarifies the IDE configuration documentation.

Fixes #8781
