### PR TITLE
Fix deprecated "IRC" link text in developer tutorial extend.adoc

### DIFF
--- a/content/doc/developer/tutorial/extend.adoc
+++ b/content/doc/developer/tutorial/extend.adoc
@@ -254,4 +254,4 @@ Congratulations, you've successfully created and substantially extended a Jenkin
 
 == Troubleshooting
 
-NOTE: Anything not working for you? Ask for help in link:/chat[IRC] or link:/mailing-lists[on the jenkinsci-dev mailing list].
+NOTE: Anything not working for you? Ask for help in link:/chat[chat] or link:/mailing-lists[on the jenkinsci-dev mailing list].


### PR DESCRIPTION
The Troubleshooting section in extend.adoc linked to /chat but labeled it as "IRC". The /chat page covers all Jenkins chat platforms not just IRC. Also, the IRC bridge has been deprecated in favor of Gitter/Matrix.
The other tutorial pages (create.adoc, run.adoc) already use link:/chat[chat] — this fix makes extend.adoc consistent with them.
Changes :-  - NOTE: Anything not working for you? Ask for help in link:/chat[IRC] or link:/mailing-lists[on the jenkinsci-dev mailing list].
                    + NOTE: Anything not working for you? Ask for help in link:/chat[chat] or link:/mailing-lists[on the jenkinsci-dev mailing list].
