### PR TITLE
Update Dockerfile to use uppercase 'AS' in multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.1 as node
+FROM node:22.22.1 AS node
 ENV USE_LOCAL_NODE=true
 
 WORKDIR /usr/src/jenkinsio/build/_site/
@@ -11,7 +11,7 @@ COPY scripts ./scripts
 RUN npm install
 RUN make assets
 
-FROM ruby:3.4.7 as builder
+FROM ruby:3.4.7 AS builder
 ENV USE_LOCAL_RUBY=true
 
 # throw errors if Gemfile has been modified since Gemfile.lock


### PR DESCRIPTION
Replaced the lowercase deprecated 'as' with 'AS' in Dockerfile 'From' instructions for multi-stage builds aliases, as per docker best practices and the dockerfile refrences (https://docs.docker.com/reference/dockerfile/#from).

changes:-
- Line 1: FROM node:22.22.1 as node → FROM node:22.22.1 AS node
- Line 14: FROM ruby:3.4.7 as builder → FROM ruby:3.4.7 AS builder

test:-Docker build completes successfully with the updated syntax and removed the warns like WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)