### PR TITLE
Fix typos and formatting in architecting-for-scale documentation

### DIFF
--- a/content/doc/book/scaling/architecting-for-scale.adoc
+++ b/content/doc/book/scaling/architecting-for-scale.adoc
@@ -308,7 +308,7 @@ The 3 most common forms of stratifying development by controllers is:
 ** No way to visualize the complete flow across controllers
 ** Outage of a controller will block flow of all products
 
-3. **Group controllers by product lines** - When a group of products, with one only critical product in each group, gets its own Jenkins controllers.
+3. **Group controllers by product lines** - When a group of products, with only one critical product in each group, gets its own Jenkins controller.
 
 * **Pros**
 ** Entire flows can be visualized because all steps are on one controller


### PR DESCRIPTION
- Fix missing word: 'the number of that need' → 'the number of jobs that need'
This pull request makes minor corrections to the documentation in `content/doc/book/scaling/architecting-for-scale.adoc`, primarily addressing typos and clarifying phrasing.

Documentation corrections:

* Fixed typo in the section about Jenkins controller start-up time by changing "the number of that need to be rendered" to "the number of jobs that need to be rendered".
* Clarified phrasing in the controller grouping strategy by correcting "with on only critical product" to "with one only critical product" and improved the description of controller downtime impact.
* Corrected spelling of "componetizing" to "componentizing" in the section on continuous delivery factors.
- Fix missing space: 'The_.jar_' → 'The _.jar_'
- Fix typo: 'with on only critical product' → 'with one only critical product'
- Fix broken sentence: 'downtime on only affects' → 'downtime to only'
- Fix typo: 'componetizing' → 'componentizing'