### PR TITLE
Remove broken Hacktoberfest project board link

### DIFF
--- a/content/events/hacktoberfest.adoc
+++ b/content/events/hacktoberfest.adoc
@@ -82,7 +82,7 @@ who have committed to assist contributors and to provide quick turnaround in pul
   Additionally, we invite new and experienced Jenkins developers to help improve the link:/doc/developer/[developer documentation].
   If you want to learn a Jenkins development topic and share your new knowledge with others, or want to help someone else learn, you're welcome to contribute here.
 
-  link:https://github.com/jenkins-infra/jenkins.io/projects/3[Board], https://app.gitter.im/#/room/#jenkins/docs:matrix.org[chat]
+  https://app.gitter.im/#/room/#jenkins/docs:matrix.org[chat]
 
 | link:https://github.com/jenkinsci/jenkins[Jenkins Core]
 | Java, +


### PR DESCRIPTION
This pull request makes a minor update to the Hacktoberfest event documentation. The change removes a link to a project board, leaving only the chat link for contributors to use.

* Removed the link to the GitHub project board, simplifying contributor guidance and focusing communication on the Gitter chat.The GitHub Classic Projects link (jenkins-infra/jenkins.io/projects/3) no longer exists as GitHub has removed Classic Projects. Removed the broken Board link from the featured projects table.