### PR TITLE
Note 2.553.1 as a fix version for 2026-03-18 security advisory

### DIFF
--- a/content/security/advisory/2026-03-18.adoc
+++ b/content/security/advisory/2026-03-18.adoc
@@ -5,7 +5,7 @@ kind: core and plugin
 core:
   lts:
     previous: 2.541.2
-    fixed: 2.541.3
+    fixed: 2.541.3 or 2.553.1
   weekly:
     previous: '2.554'
     fixed: '2.555'
@@ -27,7 +27,7 @@ issues:
     A number of features and plugins use the affected functionality, most prominently the "Archive the artifacts" post-build action, and the `archiveArtifacts` and `archive` Pipeline steps, when using the standard artifact manager (i.e., archiving artifacts on the controller file system).
     This allows attackers with Item/Configure permission, or able to control agent processes, to exploit this vulnerability.
 
-    Jenkins 2.555, LTS 2.541.3 refuses to extract files from `.tar` and `.tar.gz` archives whose real path is outside the target directory, and prevents extraction through symbolic links in the path or at the target location.
+    Jenkins 2.555, LTS 2.541.3, and LTS 2.553.1 refuses to extract files from `.tar` and `.tar.gz` archives whose real path is outside the target directory, and prevents extraction through symbolic links in the path or at the target location.
 
     NOTE: This vulnerability has been reported through the link:/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/[Jenkins Bug Bounty Program sponsored by the European Commission].
 - id: SECURITY-3674
@@ -63,7 +63,7 @@ issues:
 
     If the anonymous user has no permissions, attackers can execute the `who-am-i` CLI command, obtaining limited information about the anonymous user in Jenkins.
 
-    Jenkins 2.555, LTS 2.541.3 uses the configured Jenkins URL (from _Manage Jenkins » System_) rather than HTTP request headers to compute the expected origin for comparison, and refuses CLI WebSocket connections if they don't match or the Jenkins URL is not configured.
+    Jenkins 2.555, LTS 2.541.3, and LTS 2.553.1 uses the configured Jenkins URL (from _Manage Jenkins » System_) rather than HTTP request headers to compute the expected origin for comparison, and refuses CLI WebSocket connections if they don't match or the Jenkins URL is not configured.
 
     In case of problems with this fix, you can revert to the previous behavior by setting the link:/doc/book/managing/system-properties/#hudson-cli-cliaction-accept_url_from_request[Java system property `hudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST`] to `true`.
 


### PR DESCRIPTION
Reducing user confusion about version numbers.

Based on security-advisory-2026-03-18-2.553.1

On hold until LTS RC. Can be merged between then and LTS release.