### PR TITLE
docs: improve building section with prerequisites and troubleshooting

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -81,6 +81,34 @@ The key tool to convert source code into the site is the link:https://github.com
 
 Ensure you have GNU/Make and Curl and Docker available on your machine:
 
+Prerequisites
+
+If you do not have Docker installed, refer to the official installation guides:
+
+- https://docs.docker.com/get-docker/
+
+Ensure that Docker is running before executing any build commands.
+
+Additionally, verify that the required tools are available in your system:
+
+[source, bash]
+----
+make --version
+curl --version
+docker version
+----
+
+Troubleshooting
+
+If you encounter permission issues while running `make` commands, ensure that your working directory has the correct permissions:
+
+[source, bash]
+----
+chmod -R u+rw .
+----
+
+If Docker is installed but commands fail, make sure that Docker Desktop (or the Docker daemon) is running properly.
+
 * `make --version`
 * `curl --version`
 * `docker version`

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -100,12 +100,8 @@ docker version
 
 == Troubleshooting
 
-If you encounter permission issues while running `make` commands, ensure that your working directory has the correct permissions:
-
-[source, bash]
-----
-chmod -R u+rw .
-----
+If you encounter permission-related issues while running `make`, ensure that your working directory is owned by your current user and that files are writable.
+Avoid using broad permission changes unless you fully understand their impact.
 
 If Docker is installed but commands fail, make sure that Docker Desktop (or the Docker daemon) is running properly.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -79,17 +79,9 @@ This project uses GNU/Make and Docker to generate the fully statically link:http
 If you need to install Docker, utilize the instructions for link:https://docs.docker.com/engine/install/[Docker Engine] or link:https://docs.docker.com/desktop/[Docker Desktop] depending on your environment.
 The key tool to convert source code into the site is the link:https://github.com/awestruct/awestruct[Awestruct] static site generator, which is downloaded automatically as part of the build process.
 
-Ensure you have GNU/Make and Curl and Docker available on your machine:
+Ensure that GNU Make, Curl, and Docker are available on your machine.
 
-Prerequisites
-
-If you do not have Docker installed, refer to the official installation guides:
-
-- https://docs.docker.com/get-docker/
-
-Ensure you have GNU/Make, Curl, and Docker available on your machine.
-
-Prerequisites
+== Prerequisites
 
 If you do not have Docker installed, refer to the official installation guides:
 
@@ -106,7 +98,7 @@ curl --version
 docker version
 ----
 
-Troubleshooting
+== Troubleshooting
 
 If you encounter permission issues while running `make` commands, ensure that your working directory has the correct permissions:
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -85,7 +85,7 @@ Ensure that GNU Make, Curl, and Docker are available on your machine.
 
 If you do not have Docker installed, refer to the official installation guides:
 
-- https://docs.docker.com/get-docker/
+* https://docs.docker.com/get-docker/
 
 Ensure that Docker is running before executing any build commands.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -87,6 +87,14 @@ If you do not have Docker installed, refer to the official installation guides:
 
 - https://docs.docker.com/get-docker/
 
+Ensure you have GNU/Make, Curl, and Docker available on your machine.
+
+Prerequisites
+
+If you do not have Docker installed, refer to the official installation guides:
+
+- https://docs.docker.com/get-docker/
+
 Ensure that Docker is running before executing any build commands.
 
 Additionally, verify that the required tools are available in your system:
@@ -108,10 +116,6 @@ chmod -R u+rw .
 ----
 
 If Docker is installed but commands fail, make sure that Docker Desktop (or the Docker daemon) is running properly.
-
-* `make --version`
-* `curl --version`
-* `docker version`
 
 Docker must be version 17.04 or greater.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -100,10 +100,11 @@ docker version
 
 == Troubleshooting
 
-If you encounter permission-related issues while running `make`, ensure that your working directory is owned by your current user and that files are writable.
-Avoid using broad permission changes unless you fully understand their impact.
+If you encounter issues related to file access or unexpected behavior when running `make`, this may be caused by how Docker bind mounts handle file sharing between the host system and the container.
 
-If Docker is installed but commands fail, make sure that Docker Desktop (or the Docker daemon) is running properly.
+Refer to the official Docker documentation for details and known limitations:
+
+https://docs.docker.com/engine/storage/bind-mounts/#considerations-and-constraints
 
 Docker must be version 17.04 or greater.
 


### PR DESCRIPTION
Hi,

While exploring the repository as part of GSoC preparation, I noticed that the "Building" section could benefit from clearer prerequisites and troubleshooting guidance.

This PR:
- adds a prerequisites section with a Docker installation reference  
- includes verification steps for required tools  
- provides troubleshooting guidance for common permission and Docker issues  

These changes aim to improve the onboarding experience for new contributors.

This builds on the discussion in #7844.

Happy to refine further based on feedback.

Thanks.