### PR TITLE
docs: clarify authentication vs authorization in managing security section

### DIFF
--- a/content/doc/book/security/managing-security.adoc
+++ b/content/doc/book/security/managing-security.adoc
@@ -27,14 +27,9 @@ high-powered servers connected to the public internet. To safely support this
 wide spread of security and threat profiles, Jenkins offers many configuration
 options for enabling, editing, or disabling various security features.
 
-As of Jenkins 2.0, many of the security options were enabled by default to
-ensure that Jenkins environments remained secure unless an administrator
-explicitly disabled certain protections.
-
-This section will introduce the various security options available to a Jenkins
-administrator, explaining the protections offered, and trade-offs to disabling
-some of them.
-
+This section introduces the various security options available to Jenkins administrators,
+including authentication and authorization mechanisms, and explains the 
+protections offered and trade-offs when configuring them.
 
 == Enabling Security
 
@@ -59,7 +54,7 @@ image::security/configure-global-security.png["Security", role=center]
 
 Jenkins can use a TCP port to communicate with inbound (formerly known as “JNLP”) agents,
 such as Windows-based agents.
-As of Jenkins 2.0, by default this port is disabled.
+By default, this port is disabled.
 
 For administrators wishing to use inbound TCP agents, the two port options are:
 
@@ -79,16 +74,8 @@ Access Control is the primary mechanism for securing a Jenkins environment
 against unauthorized usage. Two facets of configuration are necessary for
 configuring Access Control in Jenkins:
 
-. A *Security Realm* which informs the Jenkins environment how and where to
-  pull user (or identity) information from. Also commonly known as "authentication."
-. *Authorization* configuration which informs the Jenkins environment as to
-  which users and/or groups can access which aspects of Jenkins, and to what
-  extent.
-
-
-Using both the Security Realm and Authorization configurations it is possible
-to configure very relaxed or very rigid authentication and authorization
-schemes in Jenkins.
+. A *Security Realm* defines how Jenkins authenticates users — that is, how user identities are verified (for example, via Jenkins’ own database, LDAP, or external systems).
+. *Authorization* defines what authenticated users are allowed to do within Jenkins, such as accessing jobs, configuring pipelines, or administering the system.
 
 Additionally, some plugins such as the
 plugin:role-strategy[Role-based Authorization Strategy]
@@ -217,6 +204,6 @@ See link:/doc/book/security/markup-formatter/[Markup Formatter].
 
 See link:/doc/book/security/csrf-protection[CSRF Protection].
 
-== Agent/Master Access Control
+== Agent → Controller Access Control
 
 See link:/doc/book/security/controller-isolation[Isolating the Controller from Builds].


### PR DESCRIPTION
Hi,

I’ve put together some updates for the "Managing Security" section, focusing on a few targeted improvements that were discussed in https://github.com/jenkins-infra/jenkins.io/pull/8376.

Here’s a quick rundown of what’s changed:

Cleaned up some outdated references to Jenkins 2.0 security behavior.

Added a bit more clarity between authentication and authorization.

Updated some of the older terminology (swapping Agent for Controller).

The idea was just to sharpen the language and make things more accurate without changing the overall structure. Let me know if you’d like me to tweak anything else!

Thanks.