### PR TITLE
Add plugin guidance for beginners in Pipeline getting started

### DIFF
--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -221,11 +221,8 @@ To configure your Pipeline project to use a `Jenkinsfile` from source control:
 . From the *Definition* field, choose the *Pipeline script from SCM* option.
 . From the *SCM* field, choose the type of source control system of the
   repository containing your `Jenkinsfile`.
-[NOTE]
-====
-Using Git as your Source Code Management (SCM) requires the Git plugin to be installed.
-In most Jenkins installations, this plugin is included by default.
-====
+. Using Git as your Source Code Management (SCM) requires the Git plugin to be installed.
+  In most Jenkins installations, this plugin is included by default.
 . Complete the fields specific to your repository's source control system. +
   *Tip:* If you are uncertain of what value to specify for a given field, click
   its *?* icon to the right for more information.


### PR DESCRIPTION
This PR adds a beginner-friendly section to help users choose the right plugins based on common pipeline tasks.

When I was exploring Jenkins, it was confusing for me to choose the plugin out of all those that they offer. This change introduces a simple task-to-plugin mapping approach (e.g., Git usage → Git Plugin), along with guidance on identifying missing plugins when pipeline steps are not recognized.
This aims to improve the onboarding experience and reduce confusion around plugin selection.