### PR TITLE
Fix footnote reference for Groovy shebang line

### DIFF
--- a/content/doc/book/pipeline/getting-started.adoc
+++ b/content/doc/book/pipeline/getting-started.adoc
@@ -246,7 +246,7 @@ Groovy-like syntax, if your IDE is not correctly syntax highlighting your
 `Jenkinsfile`, try inserting the line `#!/usr/bin/env groovy` at the top of the
 `Jenkinsfile`,
 footnote:shebang[link:https://en.wikipedia.org/wiki/Shebang_(Unix)[Shebang (general definition)]]
-footnotegroovy_shebang:[link:http://groovy-lang.org/syntax.html#_shebang_line[Shebang line (Groovy syntax)]]
+footnote:groovy_shebang[link:http://groovy-lang.org/syntax.html#_shebang_line[Shebang line (Groovy syntax)]]
 which may rectify the issue.
 ====
 


### PR DESCRIPTION
Fixes this rendering issue
<img width="718" height="136" alt="image" src="https://github.com/user-attachments/assets/90df6dbf-f729-4aca-bcd2-622f8e474c5c" />
