### PR TITLE
Fix formatting errors in 2.556 weekly changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -29669,7 +29669,7 @@
         authors:
           - renovate[bot]
           - MarkEWaite
-        pr_title: Update dependency
+        pr_title: Update dependency 
           org.springframework.security:spring-security-bom to v7
         message: |-
           Upgrade to Spring Security 7.
@@ -29678,7 +29678,7 @@
         pull: 11292
         authors:
           - renovate[bot]
-        pr_title: Update dependency org.springframework:spring-framework-bom to
+        pr_title: Update dependency org.springframework:spring-framework-bom to 
           v7
         message: |-
           Upgrade to Spring Framework 7.
@@ -29705,7 +29705,7 @@
         authors:
           - janfaracik
           - timja
-        pr_title: Introduce experimental API for adding actions to experimental
+        pr_title: Introduce experimental API for adding actions to experimental 
           Run UI
         message: |-
           Introduce experimental API for adding actions to experimental Run UI.
@@ -29724,7 +29724,7 @@
         authors:
           - Pindi-Srilasya
           - MarkEWaite
-        pr_title: Describe BASE+EXTRA syntax in help for global environment
+        pr_title: Describe BASE+EXTRA syntax in help for global environment 
           variables
         message: |-
           Explain prepending additional values to environment variables with BASE+EXTRA in the online help for nodes.


### PR DESCRIPTION
## Fix formatting errors in 2.556 weekly changelog

My manual edits of the 2.556 weekly changelog removed the trailing spaces from several entries.  The trailing spaces are added again by the automated changelog generator.  Corrects the 2.556 changelog so that the automated changelog generator is not modifying it.
