### PR TITLE
feat: Add reading time estimate to blog post layout

### DIFF
--- a/content/_layouts/post.html.haml
+++ b/content/_layouts/post.html.haml
@@ -26,6 +26,11 @@ section: blog
     - if page.date
       = page.date.strftime('%B %-d, %Y')
 
+    - words = content.to_s.split.size
+    - reading_time = (words / 200.0).ceil
+
+    %span ⏱︎ #{reading_time} min read
+
     %div.app-social-media-buttons__container.share-buttons__container
       %span
         Share


### PR DESCRIPTION
This PR adds a read time (estimation) to the blog posts. This PR particularly focused on adding a feature to the blog post i.e. read-time estimation

### Screenshot
<img width="1904" height="906" alt="image" src="https://github.com/user-attachments/assets/60217036-62ac-4b9c-9f20-0fe5b2feb092" />
<img width="1901" height="898" alt="image" src="https://github.com/user-attachments/assets/6748a3b3-47eb-4d0e-b5d8-26e596f60657" />

### Logic
it's working on a very simple logic 
```
reading_time = (words / 200.0).ceil
```
### Additional
I wanted to use new `jio-read-time-estimation` component for this PR, but Blog post pages are server-rendered using HAML (Ruby), so since the content is available at build time, the reading time is computed on the server instead of using a client-side component.
