### PR TITLE
Improve Java prerequisite visibility in Linux install docs (#8968)

### DIFF
--- a/content/doc/book/installing/linux.adoc
+++ b/content/doc/book/installing/linux.adoc
@@ -19,6 +19,20 @@ Jenkins installers are available for several Linux distributions.
 * <<Fedora>>
 * <<red-hat-centos,Red Hat Enterprise Linux and derivatives>>
 
+== Prerequisites
+
+Before installing Jenkins, ensure the following requirement is met:
+
+* *Java 17 or Java 21* (LTS) is required to run Jenkins.
+* Check your installed Java version:
+
+[source,bash]
+----
+java -version
+----
+
+If Java is not installed on the system, install it using your package manager.
+
 include::doc/book/installing/_installation_requirements.adoc[]
 
 == Debian/Ubuntu


### PR DESCRIPTION
## Summary
This PR improves the visibility of Java requirements on the installation documentation pages.

## What was changed
- Added a clear "Prerequisites" section at the top of `linux.adoc`
- Highlighted Java LTS versions required to run Jenkins
- Added Java verification command (`java -version`)

## Why?
Issue #8968 raised concerns that Java installation instructions appear too low on the page, causing confusion for beginners. This update makes the Java requirement immediately visible.

## Related Issue
Fixes #8968