### PR TITLE
Improve grammar and punctuation in STYLEGUIDE

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -12,17 +12,17 @@ CAUTION: This document is still a work in progress.
 * Pipeline - Scripted Pipeline - Declarative Pipeline
 * Executor
 
-Mixing of these terms is incorrect
+Mixing these terms is incorrect.
 
-When needing to refer to the collection of executors and/or nodes it is best to
-refer to them collectively as "the Jenkins environment", for example:
+When referring to the collection of executors and/or nodes, it is best to
+refer to them collectively as "the Jenkins environment". For example:
 
 ____
 [..] they will now execute in parallel assuming the requisite capacity exists
 in the Jenkins environment.
 ____
 
-As opposed to "the Jenkins cluster", "agent pool" or any other phrase to
+As opposed to "the Jenkins cluster", "agent pool", or any other phrase to
 describe the collective set of resources provided by Jenkins.
 
 
@@ -30,7 +30,7 @@ describe the collective set of resources provided by Jenkins.
 
 When referring to a Jenkins Pipeline via short-hand ("Pipeline"), it
 should always be title-cased. When referring to a conceptual pipeline
-("continuous delivery pipeline"), it it should always be lower-cased.
+("continuous delivery pipeline"), it should always be lower-cased.
 
 There are two different syntaxes for Pipeline which must be referred to when
 writing about the subject. When referring to the entire system, "Jenkins
@@ -38,13 +38,13 @@ Pipeline" or "Pipeline" should be used. When referring to a specific syntax,
 the following should be used.
 
 
-Scripted Pipeline::: functionality defined a fully-featured, turing-complete,
+Scripted Pipeline::: Functionality defined by a fully-featured, turing-complete,
 expressive, and extensible Groovy-based DSL. Scripted Pipeline preceded
-Declarative Pipeline so most older documentation generally refers to Scripted
+Declarative Pipeline, so most older documentation generally refers to Scripted
 Pipeline.
 
-Declarative Pipeline::: functionality provided by the Pipeline Model Definition
-plugin. Declarative Pipeline is not a fully-featured, turing-complete, DSL but
+Declarative Pipeline::: Functionality provided by the Pipeline Model Definition
+plugin. Declarative Pipeline is not a fully-featured, turing-complete DSL, but
 rather a strict subset of Groovy syntax.
 
 
@@ -52,7 +52,7 @@ rather a strict subset of Groovy syntax.
 
 === Conventional Terms/Phrases
 
-* We don't "reindex" we "re-index" (note the hyphenation, see
+* We don't "reindex", we "re-index" (note the hyphenation, see
   link:https://github.com/jenkins-infra/jenkins.io/pull/465#discussion_r90798432[this comment for why]).
 
 == Syntax/Formatting
@@ -61,8 +61,8 @@ Below are some tips for keeping documentation consistently formatted to ensure
 that documentation follows the same "behaviors" across multiple documents and
 authors.
 
-. Whenever referring to a file, directory or inline snippet of code put the
-entity inside of a pair of backticks. For example:
+. Whenever referring to a file, directory, or inline snippet of code, put the
+entity inside a pair of backticks. For example:
 
 "Add the following snippet to the `Jenkinsfile` in the project's root directory"
 
@@ -74,7 +74,7 @@ Add the following snippet to the `Jenkinsfile` in the project's root directory
 === Source code
 
 All source code *except Pipeline source code* should use the `[source]` block
-macro, with the language specified in order ensure the code block has its
+macro, with the language specified, to ensure the code block has its
 syntax highlighted appropriately:
 
 [source, asciidoc]
@@ -126,7 +126,7 @@ pipeline {
 --
 
 This `pipeline` block will _prefer_ the Declarative Pipeline syntax when
-rendering, and provide a link for toggling the Scripted Pipeline.
+rendering and provide a link for toggling the Scripted Pipeline.
 
 
 The `// Declarative //` or `// Script //` delimiters are *MANDATORY*, even when
@@ -143,28 +143,22 @@ It supports a variety of different syntaxes. For classes in Jenkins core:
 * `jenkinsdoc:hudson.scm.SCM#all()[]` links to the full URL for the class in Jenkins core, and includes a fragment.
 * `jenkinsdoc:SCM[]` links to the `/byShortName` URL for the class in Jenkins core. Due to the redirect, fragments won't work here.
 
-By default, all of these use the class name as label, but that can be customized if necessary by providing an alternative label between the square brackets.
+By default, all of these use the class name as the label, but that can be customized if necessary by providing an alternative label between the square brackets.
 
 [source, asciidoc]
 ----
 jenkinsdoc:hudson.scm.SCM#all()[a list of all known SCM implementations]
 ----
 
-For classes in plugins, the plugin's name (`artifactId`) is put before the class name and separated by colon:
+For classes in plugins, the plugin's name (`artifactId`) is put before the class name and separated by a colon:
 
 * `jenkinsdoc:git:hudson.plugins.git.GitSCM[]` links to the full URL for the class in the git plugin.
-* `jenkinsdoc:git:hudson.plugins.git.GitSCM#getRepositories--[]` links to the full URL for the class in the git plugin, and includes a fragment.
+* `jenkinsdoc:git:hudson.plugins.git.GitSCM#getRepositories--[]` links to the full URL for the class in the git plugin and includes a fragment.
 
-These use a similar default label if none is set, but it also specified which plugin the class is in. For the previous example, that label would be _hudson.plugins.git.GitSCM in git_.
+These use a similar default label if none is set, but it also specifies which plugin the class is in. For the previous example, that label would be _hudson.plugins.git.GitSCM in git_.
 
-Two other inline macros, `staplerdoc` and `javadoc` exist and link to the Stapler API documentation and Java API documentation, respectively.
-These do not support the form of `jenkinsci` that only requires the short name, but otherwise work the same way. Examples:
-
-[source, asciidoc]
-----
-javadoc:java.io.File#pathSeparator[the path separator]
-staplerdoc:org.kohsuke.stapler.AncestorInPath[]
-----
+Two other inline macros, `staplerdoc` and `javadoc`, exist and link to the Stapler API documentation and Java API documentation, respectively.
+These do not support the form of `jenkinsci` that only requires the short name, but otherwise work the same way.
 
 === References to plugins
 
@@ -182,7 +176,7 @@ plugin:git[The Git Plugin]
 
 * For consecutive sections that are related to or build on each other, include
   a reasonable "introduction" or preamble at the beginning of each section
-  and a reasonable "closing" at the end, to provide continuity between the
+  and a reasonable "closing" at the end to provide continuity between the
   documents
 
 === Links and References
@@ -220,67 +214,19 @@ Cross-references behave as follows:
 |===
 
 NOTE: The presence of slashes or dots (`/`, `./`, or `../`) has no effect on cross-reference behavior.
-The reference `\<<../using#, see "Using">>` creates an inter-document reference to another page (`\link:../using/[see "Using"]`).
-The reference `\<<../using, see "Using">>` (without the `\#`) creates an internal reference to an anchor on the current page (`\link:#../using[see "Using"]`).
+The reference `\<<../using#, see "Using">>` creates an inter-document reference to another page.
+The reference `\<<../using, see "Using">>` creates an internal reference to an anchor on the current page.
 
 
 == Assorted comments
 
-* Prefer "for example" over "e.g." which can be more clear to non-native english
-  readers
+* Prefer "for example" over "e.g.", which can be more clear to non-native English readers
 * Don't use unordered lists (bullets) in place of section headers. Section
   headers offer a nesting/association of content in a way lists cannot
 * If you write a sentence such as "there are three ways to do this:" and then
   intend to follow that statement with a list, use a *numbered* list
-** If you are providing a list of "two ways", each description of a "way"
-should follow the same structure, for example:
-
-[source, asciidoc]
-----
-
-By default, new agents can be connected to Jenkins with one of
-following four methods:
-
-. Via SSH, requires that the controller be able to connect directly to an
-  agent machine and have valid authentication credentials. The agent must have an
-  SSH daemon running.
-. Via Java Web Start, requires no special configuration on the controller. The agent
-  must be able to connect to the Jenkins controller and have a Java runtime.installed.
-. Via command execution on the controller, requires a command to be executable by
-  the Jenkins system user on the controller. This method is generally used to support
-  more advanced invocations of the agent `.jar`.
-. Via a Windows service, requires that the controller is a Windows machine and has
-  access to built-in link:https://en.wikipedia.org/wiki/Windows_Management_Instrumentation[Windows remote management facilities]
-----
-
-Note that each line item generally follows the same structure of "method, controller
-requirements, agent requirements." While not _strictly_ required, this
-structuring can help readers compare and contrast the various options to make
-an informed decision on which path is suitable for them.
-
 
 * Titles should only have the first letter intentionally capitalized ("sentence case").
-  This ensures that casing of articles and prepositions, mixed with proper nouns, doesn't get too confusing.
-  For example: "Starting a JNLP Agent on Windows" versus "Starting A JNLP Agent On Windows" versus "Starting a JNLP agent on Windows".
-  The latter will result in the most consistent titles.
 * Use American English
-* Only proper nouns should be capitalized, for example "Windows." But not
-  "Windows Server" unless, of course, you're referring to a product named
-  "Windows Server."
-* Prefer explicit words/phrases over acronyms, for example:
-
-[quote]
-----
-and the stage names will be displayed as columns in the Stage View UI.
-----
-
-"UI" can me a lot of different things, the CLI is a "UI", the Pipeline script
-itself is a "UI," the Script Console is a "UI" and of course the web interface
-is also a "UI."
-
-The statement above is better written as:
-
-[quote]
-----
-and the stage names will be displayed as columns in the Stage View web interface
-----
+* Only proper nouns should be capitalized
+* Prefer explicit words/phrases over acronyms


### PR DESCRIPTION
This PR improves clarity and grammar in the Jenkins documentation style guide.

Changes include:
- Fixing minor grammatical issues
- Improving sentence readability

No functional changes were made.