### PR TITLE
Update Jenkins Project GPG key on `/download/verify` page

### DIFF
--- a/content/download/verify.adoc
+++ b/content/download/verify.adoc
@@ -45,7 +45,7 @@ Refer to link:https://www.ghacks.net/2018/04/16/how-to-verify-digital-signatures
 
 === Linux Package Repositories
 
-The long term support Linux package repositories for link:/doc/book/installing/linux/#debian-stable[Debian/Ubuntu], link:/doc/book/installing/linux/#red-hat-stable[Red Hat Enterprise Linux (and derivatives)], and link:/doc/book/installing/linux/#fedora-stable[Fedora Linux] have used the following GPG key since Jenkins 2.541.1:
+The long term support Linux package repositories for link:/doc/book/installing/linux/#debian-stable[Debian/Ubuntu], link:/doc/book/installing/linux/#red-hat-stable[Red Hat Enterprise Linux (and derivatives)], link:/doc/book/installing/linux/#fedora-stable[Fedora Linux], and openSUSE have used the following GPG key since Jenkins 2.541.1:
 
 [source]
 ----


### PR DESCRIPTION
This change updates the GPG key of https://www.jenkins.io/download/verify/#linux-package-repositories

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4922