### PR TITLE
Fix: Corrected 404 broken link for Bug Bounty Program

### DIFF
--- a/content/blog/2026/03/2026-03-02-contributor-summit.adoc
+++ b/content/blog/2026/03/2026-03-02-contributor-summit.adoc
@@ -58,7 +58,7 @@ There will be a separate blog post covering the officer updates in more detail, 
 An important aspect worth highlighting is the sponsorship support from the European Commission.
 The funding, managed by YesWeHack as part of a structured Bug Bounty program, strengthens the security posture of Jenkins in a very concrete way.
 This kind of institutional support demonstrates that open source infrastructure like Jenkins is recognized as critical digital infrastructure.
-If you missed the blog post about the Bug Bounty program, you can find it here: link:https://www.jenkins.io/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/[Introducing the Jenkins Bug Bounty Program].
+If you missed the blog post about the Bug Bounty program, you can find it here: link:/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/[Introducing the Jenkins Bug Bounty Program].
 A big thanks also to the security team for their ongoing efforts in this area and securing nice shirts for all contributors.
 
 == SIG Updates and Technical Direction


### PR DESCRIPTION
Updated the link to point to the correct December 2025 blog post.