### PR TITLE
Fix incorrect git command in tutorials: git stage -> git add

### DIFF
--- a/content/doc/tutorials/build-a-dotnet-web-app-with-jenkins.adoc
+++ b/content/doc/tutorials/build-a-dotnet-web-app-with-jenkins.adoc
@@ -205,7 +205,7 @@ The link:/doc/book/pipeline/syntax/#post[`post`] section's `always` condition th
 . Save your edited `Jenkinsfile` and commit it to your local `simple-dotnet-web-app` Git repository.
 Within the `simple-dotnet-web-app` directory, run the commands:
 +
-.. `git stage .`
+.. `git add .`
 .. `git commit -m "Add 'Test' stage"`
 .. `git push` to push your changes to your forked repository on GitHub, so it can be picked up by Jenkins.
 
@@ -297,7 +297,7 @@ pipeline {
 
 . Save your updated `Jenkinsfile` and commit it to your local `simple-dotnet-web-app` Git repository.
 +
-.. `git stage .`
+.. `git add .`
 .. `git commit -m "Add 'Deliver' stage"`
 .. `git push` to push your changes to your forked repository on GitHub, so it can be picked up by Jenkins.
 

--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -202,7 +202,7 @@ The link:/doc/book/pipeline/syntax/#post[`post`] section's `always` condition th
 . Save your edited `Jenkinsfile` and commit it to your local `simple-java-maven-app` Git repository.
 Within the `simple-java-maven-app` directory, run the commands:
 +
-.. `git stage .`
+.. `git add .`
 .. `git commit -m "Add 'Test' stage"`
 .. `git push` to push your changes to your forked repository on GitHub, so it can be picked up by Jenkins.
 
@@ -279,7 +279,7 @@ It is generally good practice to keep your Pipeline code, such as your `Jenkinsf
 Maintaining your Pipeline code is easier this way.
 . Save your updated `Jenkinsfile` and commit it to your local `simple-java-maven-app` Git repository.
 +
-.. `git stage .`
+.. `git add .`
 .. `git commit -m "Add 'Deliver' stage"`
 .. `git push` to push your changes to your forked repository on GitHub, so it can be picked up by Jenkins.
 


### PR DESCRIPTION
## Summary
- Replace `git stage .` with the correct `git add .` command in tutorial documentation
- Affected files: `build-a-java-app-with-maven.adoc` and `build-a-dotnet-web-app-with-jenkins.adoc`
- `git stage` is not a standard git command; `git add` is the correct command for staging changes

## Test plan
- [ ] Verify the rendered documentation shows the correct `git add .` command
- [ ] Confirm no other tutorial files reference `git stage`

