### PR TITLE
Fix grammar: subject-verb agreement in tutorial docs

### DIFF
--- a/content/doc/tutorials/build-a-java-app-with-maven.adoc
+++ b/content/doc/tutorials/build-a-java-app-with-maven.adoc
@@ -207,7 +207,7 @@ Within the `simple-java-maven-app` directory, run the commands:
 .. `git push` to push your changes to your forked repository on GitHub, so it can be picked up by Jenkins.
 
 . In Jenkins, go back to *Dashboard* if necessary, then *Maven Tutorial* and launch another build thanks to *Build Now*.
-. After a while, a new column *Test* appear in the *Stage View*.
+. After a while, a new column *Test* appears in the *Stage View*.
 
 [.boxshadow]
 image:tutorials/maven/test-stage-added.png[alt="Test stage runs successfully",width=100%]

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -232,7 +232,7 @@ and finally +
 `git push` to push your changes to your forked repository on GitHub, so it can be picked up by Jenkins.
 
 . In Jenkins, go back to *Dashboard* if necessary, then *simple-node-js-react-npm-app* and launch another build thanks to *Build Now*.
-. After a while, a new column *Test* appear in the *Stage View*.
+. After a while, a new column *Test* appears in the *Stage View*.
 
 [.boxshadow]
 image:tutorials/node/test-stage.png[alt="Test stage",width=100%]


### PR DESCRIPTION
## Summary
- Fix "a new column *Test* appear" → "appears" (subject-verb agreement)
- Affected files: `build-a-java-app-with-maven.adoc` and `build-a-node-js-and-react-app-with-npm.adoc`
- Note: instances using "you should see...appear" (bare infinitive) are grammatically correct and left unchanged

## Test plan
- [ ] Verify rendered documentation reads correctly

