### PR TITLE
Add caveat about restarting Jenkins before reloading JCasC YAML

### DIFF
--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -152,6 +152,13 @@ before you check the modified YAML file into SCM,
 especially when making more substantive configuration changes.
 ====
 
+[CAUTION]
+====
+If you restart Jenkins before reloading the modified JCasC YAML file,
+Jenkins will overwrite your file changes with the current in-memory configuration values.
+Always click *Reload existing configuration* to apply your changes before restarting Jenkins.
+====
+
 When you have made and tested your desired changes,
 push the modified JCasC YAML file to your SCM.
 


### PR DESCRIPTION
## Description

This PR adds a caveat to the JCasC documentation warning users about the risk of restarting Jenkins before reloading a modified YAML configuration file.

## Changes Made

- Added a `CAUTION` block in the "Modifying the JCasC file" section
- The caveat warns that restarting Jenkins before reloading the modified YAML will overwrite file changes with in-memory values
- Instructs users to always click "Reload existing configuration" before restarting

## Technical Implementation

The caution block is placed immediately after the existing NOTE block about restarting Jenkins, providing clear guidance on the proper workflow:

1. Edit the YAML file
2. Click "Reload existing configuration" to apply changes
3. Only then restart Jenkins (if needed)

This prevents users from losing their configuration changes due to the restart overwriting the file.

## Testing

- [x] Documentation follows AsciiDoc syntax guidelines
- [x] Caution block is properly formatted
- [x] Placement is logical and easy to find
- [x] Message is clear and actionable

## Related Issue

Fixes #8295

## Impact

This documentation improvement will help users avoid a common mistake where configuration changes are lost due to restarting Jenkins before reloading the modified YAML file.
