### PR TITLE
Add missing ExtendedRead permissions documentation

### DIFF
--- a/content/doc/book/security/access-control/permissions.adoc
+++ b/content/doc/book/security/access-control/permissions.adoc
@@ -133,6 +133,16 @@ This permission allows users to delete existing agents.
 Agent/Disconnect::
 This permission allows users to disconnect agents or mark agents as temporarily offline.
 
+Agent/ExtendedRead::
+This permission grants read-only access to agent configurations.
+Users with this permission can view agent configuration pages but cannot modify them.
+This is useful for debugging build issues without granting full administrative access.
++
+This permission requires the plugin:extended-read-permission[Extended Read Permission] plugin to be installed.
+It was introduced in Jenkins 2.238 with UI support.
++
+Learn more in the link:/blog/2020/05/25/read-only-jenkins-announcement/[Read-only Jenkins announcement].
+
 === _Job_ Permissions
 
 Though these permissions use the word "Job" in their name,
@@ -160,6 +170,16 @@ Without it they would get a 404 error and wouldn't be able to discover project n
 +
 This permission is only useful if anonymous users have _Overall/Read_ permission, but not _Job/Read_.
 It is implied by _Job/Read_.
+
+Job/ExtendedRead::
+This permission grants read-only access to job configurations.
+Users with this permission can view job configuration pages but cannot modify them.
+This is useful for users who need to understand job configurations for debugging purposes without having the ability to change them.
++
+This permission requires the plugin:extended-read-permission[Extended Read Permission] plugin to be installed.
+The permission existed since 2009, but UI support was added as part of the read-only Jenkins feature.
++
+Learn more in the link:/blog/2020/05/25/read-only-jenkins-announcement/[Read-only Jenkins announcement].
 
 Job/Move::
 Required to move a job from one folder (or Jenkins root) to another.


### PR DESCRIPTION
## Description

This PR adds documentation for the missing `Job/ExtendedRead` and `Agent/ExtendedRead` permissions that were introduced as part of the read-only Jenkins feature but were not documented on the permissions page.

## Changes Made

- Added `Agent/ExtendedRead` permission documentation to the Agent Permissions section
- Added `Job/ExtendedRead` permission documentation to the Job Permissions section
- Both entries include:
  - Description of what the permission grants
  - Use case explanation
  - Plugin requirement (Extended Read Permission plugin)
  - Historical context (when introduced/UI support added)
  - Link to the read-only Jenkins announcement blog post

## Technical Implementation

The permissions are documented following the existing format used for other permissions in the file:

- **Job/ExtendedRead**: Grants read-only access to job configurations, useful for debugging without modification rights. Existed since 2009 but UI support was added later.

- **Agent/ExtendedRead**: Grants read-only access to agent configurations, introduced in Jenkins 2.238 with UI support.

Both permissions are part of the read-only Jenkins feature (JEP-224) and require the Extended Read Permission plugin.

## Testing

- [x] Documentation follows AsciiDoc syntax guidelines
- [x] Formatting is consistent with existing permission entries
- [x] Links to blog post and plugin are correct
- [x] Information is accurate based on the source blog post

## Related Issue

Fixes #8344

## References

- [Read-only Jenkins announcement blog post](https://www.jenkins.io/blog/2020/05/25/read-only-jenkins-announcement/)
- [JEP-224: Readonly system configuration](https://github.com/jenkinsci/jep/blob/master/jep/224/README.adoc)
- [Extended Read Permission plugin](https://plugins.jenkins.io/extended-read-permission/)

## Impact

This documentation update helps users understand and properly configure the ExtendedRead permissions for implementing read-only access to Jenkins configurations, which is especially useful for Jenkins instances managed as code.
