### PR TITLE
Clarify Docker Pipeline plugin requirements and containerized Jenkins limitations

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -19,6 +19,28 @@ Starting with Pipeline versions 2.5 and higher, Pipeline has built-in support fo
 
 While this page covers the basics of utilizing Docker from within a `Jenkinsfile`, it will not cover the fundamentals of Docker, which you can refer to in the link:https://docs.docker.com/get-started/[Docker Getting Started Guide].
 
+== Prerequisites
+
+To use Docker with Pipeline, you need:
+
+* The link:https://plugins.jenkins.io/docker-workflow/[Docker Pipeline plugin] installed on your Jenkins instance.
+This plugin is included in the suggested plugins during the Jenkins setup wizard.
+* A Jenkins agent with Docker installed and the Docker daemon running.
+
+[IMPORTANT]
+====
+If you are running Jenkins inside a Docker container (for example, using Docker Compose), the examples using `agent { docker { ... } }` will not work by default.
+When the Jenkins controller runs inside a container, it is generally a bad security practice to allow that controller to start additional containers directly.
+
+To use Docker-based agents when Jenkins runs in a container, you must:
+
+* Configure one or more Jenkins agents that have Docker installed and can run containers, OR
+* Use Docker-in-Docker (DinD) with appropriate security considerations, OR
+* Mount the Docker socket from the host into the Jenkins container (not recommended for production due to security risks)
+
+For more information, see the link:../../managing/nodes/[Managing Nodes] documentation.
+====
+
 
 [[execution-environment]]
 == Customizing the execution environment


### PR DESCRIPTION
## Description

This PR clarifies the requirements for using Docker with Jenkins Pipeline and addresses the common issue where users running Jenkins in a container encounter errors when trying to use the `docker` agent type.

## Changes Made

- Added a **Prerequisites** section at the beginning of the document explaining:
  - Docker Pipeline plugin is required (included in setup wizard)
  - Docker must be installed and running on Jenkins agents
  
- Added an **IMPORTANT** note warning users about limitations when Jenkins runs inside a container:
  - Explains why `agent { docker { ... } }` doesn't work by default in containerized Jenkins
  - Describes the security concerns with running Docker-in-Docker
  - Provides three alternative approaches for using Docker-based agents
  - Links to Managing Nodes documentation for more information

## Technical Implementation

The changes address the issue reported in #7870 where users running Jenkins via Docker Compose receive the error:
```
Invalid agent type "docker" specified. Must be one of [any, label, none]
```

This error occurs because:
1. The Docker Pipeline plugin may not be installed
2. When Jenkins runs in a container, it cannot directly start sibling containers without special configuration

The documentation now clearly explains these requirements upfront, preventing confusion and providing guidance for different deployment scenarios.

## Testing

- [x] Documentation follows AsciiDoc syntax guidelines
- [x] Prerequisites section is clear and actionable
- [x] IMPORTANT note is prominently placed and easy to understand
- [x] Alternative approaches are provided for containerized Jenkins
- [x] Links to relevant documentation are included

## Related Issue

Fixes #7870

## Impact

This documentation improvement will help users:
- Understand the plugin requirements before attempting to use Docker with Pipeline
- Avoid the common error when running Jenkins in a container
- Choose the appropriate approach for their deployment scenario
- Set up Docker-based agents correctly based on their environment
