### PR TITLE
Remove WIP status from developer documentation and fix minor issues

### DIFF
--- a/content/doc/developer/FIPS-140/index.adoc
+++ b/content/doc/developer/FIPS-140/index.adoc
@@ -1,12 +1,12 @@
 ---
 layout: developerchapter
 summary: FIPS-140 for developers
-wip: true
+wip: false
 title: FIPS-140 for developers
 references:
 - url: https://github.com/jenkinsci/jep/blob/master/jep/237/README.adoc
   title: JEP-237 FIPS-140 support for Jenkins
-- url: hhttps://csrc.nist.gov/pubs/fips/140-2/upd2/final
+- url: https://csrc.nist.gov/pubs/fips/140-2/upd2/final
   title: FIPS-140-2 Security Requirements for Cryptographic Modules
 ---
 
@@ -45,4 +45,4 @@ Therefore it is important that this guidance is applied to all libraries used by
 
 Care must be taken when obtaining / creating a link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/KeyStore.html[`java.security.KeyStore`].
 The majority of ``Keystore``s provided by stock JDKs are not FIPS-140 compliant and the one that is can not be used to store keys only certificates.
-A FIPS-140 compliant `KeyStore` provider would need to be provided by the JVM, as the name of this can not be known at compile time, any code that requires to create a keystore should assume that this has been configured as the default type and use `KeyStore.getInstance(KeyStore.getDefaultType())` to obtain an new instance.
+A FIPS-140 compliant `KeyStore` provider would need to be provided by the JVM, as the name of this can not be known at compile time, any code that requires creating a keystore should assume that this has been configured as the default type and use `KeyStore.getInstance(KeyStore.getDefaultType())` to obtain an new instance.


### PR DESCRIPTION
### Description
The Developer Guide page is currently marked as Work in Progress (WIP) despite containing substantial content.

### Changes Made
- Removed WIP status from the FIPS-140 developer documentation page
- Fixed a broken URL (hhttps → https)
- Improved minor grammatical wording

### Reason
The WIP label may mislead users into thinking the documentation is incomplete, whereas it already provides useful information. Removing it improves user trust and documentation quality.