### PR TITLE
Improve homepage feature copy and sponsor section messaging

### DIFF
--- a/content/index.html.haml
+++ b/content/index.html.haml
@@ -4,21 +4,16 @@ title: Jenkins
 blogrollup: true
 homepage: true
 ---
-
 :ruby
   # Images should all be between 300 and 350 pixels wide, and no more than 180px tall
-
   supporters = site.indexpage[:supporters]
   slides = site.indexpage[:carousel]
-
 = partial('downloadbanner.html.haml')
-
 -# Carousel
 = partial('projectcarousel.html.haml',
   :background => '#000000',
   :background_image => {:src => expand_link('images/cdf/cdf-background-wide.jpg')},
   :slides => slides)
-
 #feature-list-segment.segment
   .container
     .row.chunks.features.uniform-height
@@ -26,63 +21,57 @@ homepage: true
         .box.cicd
           %ion-icon{:name=>"git-pull-request-outline"}
           %h5
-            Continuous Integration and Continuous Delivery
+            From commit to production
           %p
-            As an extensible automation server, Jenkins can be used as a simple
-            CI server or turned into the continuous delivery hub for any project.
-
-
+            Jenkins supports everything from simple CI jobs to complete
+            delivery pipelines, helping teams automate builds, tests,
+            and releases.
       .col-md-6.col-lg-4
         .box.install
           %ion-icon{:name=>"download-outline"}
           %h5
-            Easy installation
+            Up and running quickly
           %p
-            Jenkins is a self-contained Java-based program, ready to run
-            out-of-the-box, with packages for Windows, Linux, macOS and other
-            Unix-like operating systems.
-
+            Install Jenkins on Windows, Linux, macOS, and other
+            Unix-like systems with ready-to-use packages and a smooth
+            setup experience.
       .col-md-6.col-lg-4
         .box.settings
           %ion-icon{:name=>"options-outline"}
           %h5
-            Easy configuration
+            Easy to configure
           %p
-            Jenkins can be easily set up and configured via its web interface,
-            which includes on-the-fly error checks and built-in help.
-
+            Jenkins can be configured through a web interface with
+            built-in guidance, on-the-fly validation, and helpful
+            error checks.
       .col-md-6.col-lg-4
         .box.ecosystem
           %ion-icon{:name=>"apps-outline"}
           %h5
-            Plugins
+            Works with your existing tools
           %p
-            With hundreds of plugins in the Update Center, Jenkins integrates
-            with practically every tool in the continuous integration and
-            continuous delivery toolchain.
-
+            Hundreds of plugins integrate Jenkins with source control,
+            build tools, test frameworks, cloud platforms, and
+            deployment workflows already used by your team.
       .col-md-6.col-lg-4
         .box.extend
           %ion-icon{:name=>"extension-puzzle-outline"}
           %h5
-            Extensible
+            Extend to fit your workflow
           %p
-            Jenkins can be extended via its plugin architecture, providing
-            nearly infinite possibilities for what Jenkins can do.
-
+            The plugin architecture makes it easy to adapt Jenkins to
+            almost any process, toolchain, or team requirement.
       .col-md-6.col-lg-4
         .box.distributed
           %ion-icon{:name=>"git-network-outline"}
           %h5
-            Distributed
+            Distributed and scalable
           %p
-            Jenkins can easily distribute work across multiple machines,
-            helping drive builds, tests and deployments across multiple
-            platforms faster.
+            Run builds, tests, and deployments across multiple machines
+            and platforms to keep pipelines fast as your workload grows.
 .container
   .section
     = partial('video.html.haml')
-
 .container
   .section
     = partial('blogs.html.haml')
@@ -91,24 +80,19 @@ homepage: true
     #sponsorsblock.section
       .sponsors
         %p
-          We thank the following organizations for their major commitments to
-          support the Jenkins project.
-
+          These organizations provide major support for the Jenkins
+          project, and we are grateful for their continued commitment.
         %ul
-
           - supporters.select{|sponsor| sponsor[:logo]}.each do |sponsor|
             %li
               %a{:href => sponsor[:url]}
                 = File.read("content/images/sponsors/#{sponsor[:logo]}")
-
       .supporters
         %p
-          We thank the following organizations for their support of the Jenkins
-          project through free and/or open source licensing programs.
-
+          We also appreciate the organizations that support Jenkins
+          through free and open source licensing programs.
         %ul
           - supporters.reject{|supporter| supporter[:logo]}.each do |supporter|
             %li
               %a{:href => supporter[:url]}= supporter[:name]
-
 = partial('thank-you-note.html.haml')


### PR DESCRIPTION
Refreshed the homepage content to make it easier to scan and more welcoming for first-time visitors.

- Updated feature card titles to better reflect how people use Jenkins in practice
- Simplified and shortened descriptions for quicker reading
- Reworked the plugins and extensibility section to make it clearer and easier to understand
- Tweaked the sponsor messaging to better highlight the community-driven nature of the project
- No changes were made to the existing Haml or Ruby logic