### PR TITLE
update broken link on `gsoc/contributors/` page

### DIFF
--- a/content/projects/gsoc/contributors.adoc
+++ b/content/projects/gsoc/contributors.adoc
@@ -84,7 +84,7 @@ such as how to write a sentence, and how to write a paragraph.
 The following links are suggestions to help you improve your communication skills:
 
 * link:http://guidetogrammar.org/grammar/index.htm[Guide to grammar & writing]
-* link:http://web.mit.edu/me-ugoffice/communication/technical-writing.pdf[Sentence structure of Technical Writing]
+* link:https://web.archive.org/web/20220401144317/https://web.mit.edu/me-ugoffice/communication/technical-writing.pdf[Sentence structure of Technical Writing]
 * link:https://www.youtube.com/watch?v=4dr5lN1jqRE[Learn English Grammar: The Sentence]
 * link:https://www.youtube.com/watch?v=0IFDuhdB2Hk[Writing Skills: The Paragraph]
 


### PR DESCRIPTION
This PR replaces the broken link on `gsoc/contributors/` with it's web archived version. 
broken link: https://web.mit.edu/me-ugoffice/communication/technical-writing.pdf
archived link: https://web.archive.org/web/20220401144317/https://web.mit.edu/me-ugoffice/communication/technical-writing.pdf

fixes #9025 