### PR TITLE
Move multi-platform Docker images into 'released' column

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -469,7 +469,7 @@ categories:
       labels:
       - feature
     - name: Multi-platform Docker images
-      status: preview
+      status: released
       link: https://issue-redirect.jenkins.io/issue/52785
       labels:
       - feature


### PR DESCRIPTION
## Move multi-platform Docker images into 'released' column

We've had multi-platform for many years

Includes ARM, s390x, ppc64le

Recently added RISC-V
