### PR TITLE
Update CoC to v3

### DIFF
--- a/content/project/conduct.adoc
+++ b/content/project/conduct.adoc
@@ -6,7 +6,6 @@ section: conduct
 
 :toc:
 
-
 As community members, contributors and maintainers of this project,
 and in the interest of fostering an open and welcoming community,
 we commit to respect all people who participate in the community through reporting issues,
@@ -18,39 +17,49 @@ For more details about our cultural values, goals, philosophies, and structure, 
 
 == Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual identity
-and orientation.
+We pledge to make our community welcoming, safe, and equitable for all.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We are committed to fostering an environment that respects and promotes the dignity, rights,
+and contributions of all individuals, regardless of characteristics including race, ethnicity,
+caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender
+identity or expression, sexual orientation, language, philosophy or religion, national or social
+origin, socio-economic position, level of education, or other status. The same privileges of
+participation are extended to everyone who participates in good faith and in accordance with this Covenant.
 
-== Our Standards
+== Encouraged Behaviors
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior.
+We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
 
-Examples of unacceptable behavior include:
+* Respecting the **purpose of our community**, our activities, and our ways of gathering.
+* Engaging **kindly and honestly** with others.
+* Respecting **different viewpoints** and experiences.
+* **Taking responsibility** for our actions and contributions.
+* Gracefully giving and accepting **constructive feedback**.
+* Committing to **repairing harm** when it occurs.
+* Behaving in other ways that promote and sustain the **well-being of our community**.
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+== Restricted Behaviors
+
+We agree to restrict the following behaviors in our community.
+Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+* **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+* **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+* **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+* **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+* **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+* **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+* Behaving in other ways that **threaten the well-being** of our community.
+
+=== Other Restrictions
+
+* **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+* **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+* **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+* **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
 
 == Enforcement Responsibilities
 
@@ -84,6 +93,8 @@ It includes but not limited to:
 ** link:https://github.com/jenkinsci[jenkinsci]
 ** link:https://github.com/jenkinsci-cert[jenkinsci-cert]
 ** link:https://github.com/jenkins-infra[jenkins-infra]
+** link:https://github.com/jenkins-docs[jenkinsci-docs]
+** link:https://github.com/jenkinsci-transfer[jenkinsci-transfer]
 ** link:https://github.com/stapler[stapler]
 * Commits
 * Pull requests
@@ -95,9 +106,8 @@ Technical criticism is always appreciated. Keep it positive and constructive. Do
 
 ==== Websites
 
-Everything hosted under link:/[jenkins.io], link:https://jenkins-ci.org/[jenkins-ci.org] and their sub-domains such as:
+Everything hosted under link:/[jenkins.io] and their sub-domains such as:
 
-* link:/[jenkins.io]
 * link:https://issues.jenkins.io/[issues.jenkins.io]
 * link:https://stories.jenkins.io/[stories.jenkins.io]
 
@@ -107,7 +117,7 @@ All link:/mailing-lists[mailing lists] hosted on Google Groups and other platfor
 
 ==== Chats
 
-* All chats documented on the link:/chat[this page], e.g. IRC channels: `#jenkins`, `#jenkins-meeting`, `#jenkins-infra`, etc.
+* All chats documented on the link:/chat[this page].
 * Gitter channels within the link:https://app.gitter.im/#/room/#jenkins-ci:matrix.org[jenkinsci] space
 * Jenkins chats hosted by Linux Foundation and its subsidiaries including Continuous Delivery Foundation 
 
@@ -123,24 +133,19 @@ All link:/mailing-lists[mailing lists] hosted on Google Groups and other platfor
 Other Jenkins groups (such as conferences, meetups, and other unofficial forums) and local communities are encouraged to adopt this Code of Conduct.
 Those groups must provide their own moderators and/or reporting system.
 
-== Reporting
+== Reporting an Issue
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the link:/project/board[Jenkins board].
-If you feel somebody has breached this code, please send an email with the
-relevant information (links, etc) to `jenkinsci-board@googlegroups.com`.
+Tensions can occur between community members even when they are trying their best to collaborate.
+Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces
+encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, send an email with the relevant information (links, screenshots, etc.) to `jenkinsci-board@googlegroups.com`.
 This email list is only readable by the link:/project/board[Governance Board] members.
 The board may not have all of the necessary context and history,
 so it's better to describe the issue thoroughly.
 All complaints will be reviewed
 and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances.
-
-If you believe one of the board members has violated the code of conduct
-above, please email one of the other members of the Governance Board with the
-details (their emails are visible on the
-link:/project/board[Governance
-Board] page).
 
 If the desired resolution cannot be reached on the Jenkins community level,
 an issue can be escalated to the Continuous Delivery Foundation (CDF) by contacting the project team at `conduct@cd.foundation`.
@@ -156,67 +161,39 @@ Handling of violations will be done in private and the affected people will be n
 In the majority of cases there will not be a public announcement of the resolution,
 unless the Governance Board deems it necessary to announce the resolution in public.
 
-=== 1. Correction
+=== 1. Warning
 
-If the severity of the violation is mild enough, the board will notify the community member that their conduct is not acceptable and needs to change.
+1. Event: A violation involving a single incident or series of incidents.
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+2. Consequence: A private, written warning from the Community Moderators.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+3. Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
 
-=== 2. Warning
+=== 2. Temporarily Limited Activities
 
-If the severity of the violation is serious enough,
-the board will issue an official warning to the community member.
+1. Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+2. Consequence: A private, written warning with a time-limited cooldown period designed to underscore
+the seriousness of the situation and give the community members involved time to process the incident.
+The cooldown period may be limited to particular communication channels or interactions with particular community members.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a _Probation_ or _Ban_.
+=== 3. Temporary Suspension
 
-=== 3. Probation
+1. Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
 
-// oleg_nenashev: It merges statements of "3. Temporary ban" in Contributor Covenant 2.0
-// + original statements of the Probation period in Jenkins CoC 2016
+2. Consequence: A private written warning with conditions for return from suspension.
+In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
 
-If the severity of the violation is serious or reprimands are not effective,
-the board will ask the community member to "take a break" 
-and to step
-away from the community for a period of time.
-The intent of this is to send a clear signal to the community member that their
-conduct is unacceptable, de-escalate the situation for everyone who are
-affected, and ask the community member to reflect on their behaviors.
+3. Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+=== 4. Permanent Ban
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time
-(chats, mailing lists, pull requests, issues, events, etc.).
-No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a ban.
+1. Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
 
-=== 4. Ban
+2. Consequence: Access to all community spaces, tools, and communication channels is removed.
+In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
 
-//oleg_nenashev: There is a deviation from Contributor Covenant 2.0 which recommends a Permanent Ban.
-// Jenkins Code of Conduct in the 2016 edition offered a way to restore accounts after 12 months in the case of explusion,
-// and it is retained in this edition
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+3. Repair: There is no possible repair in cases of this severity.
 // Addition to Contributor Covenant 2.0 begins here
 The individual will be expelled from the Jenkins community.
 After 12 months they may appeal to the board for the ban to be lifted.
@@ -230,19 +207,23 @@ The ban will include but is not limited to:
 *  Banning them from social media and meetup groups
 *  Banning them from participating in Community-organized events
 
+This enforcement ladder is intended as a guideline.
+It does not limit the ability of the Jenkins governance board to use their discretion and judgment, in keeping with the best interests of our community.
+
 == Attribution
 
-This Code of Conduct is adapted from the link:https://www.contributor-covenant.org/[Contributor Covenant],
-version 2.1, available at
-https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at link:https://www.contributor-covenant.org/version/3/0/[Contributor Covenant v3.0].
 
-Community Impact Guidelines were inspired by link:https://github.com/mozilla/diversity[Mozilla's code of conduct
-enforcement ladder].
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit link:https://creativecommons.org/licenses/by-sa/4.0/[CC BY-SA 4.0].
 
-For answers to common questions about the adapted code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+For answers to common questions, see the link:https://www.contributor-covenant.org/faq[FAQ]. Translations are available at link:https://www.contributor-covenant.org/translations[translations]. Additional resources can be found at link:https://www.contributor-covenant.org/resources[resources]. The enforcement ladder was inspired by the work of Mozilla’s code of conduct team (link:https://github.com/mozilla/inclusion[GitHub]).
 
 == Version history
 
+* **Apr 07, 2025** - Major update to version link:https://github.com/EthicalSource/contributor_covenant/blob/dc57d29b3a15d81e51538fee940dada061ef2a7c/content/version/3/0/code_of_conduct.md[3.0]  of the Code of Conduct. Notable changes:
+** Removed outdated IRC channel scopes
+** Removed outdated way to contact the board
+** Added additional GitHub organizations to the scope
 * **Aug 23, 2023** - Minor update of the Code of Conduct adding translations to the footer and incorporating the link:https://github.com/EthicalSource/contributor_covenant/releases/tag/2.1[2.1] update.
 * **Jul 02, 2020** - Major update of the Code of Conduct.
   It was approved the project governance meeting on Jul 01


### PR DESCRIPTION
The contributor covenant has released a new version of the CoC. The change proposed adopts https://github.com/EthicalSource/contributor_covenant/blob/dc57d29b3a15d81e51538fee940dada061ef2a7c/content/version/3/0/code_of_conduct.md, similar to https://github.com/jenkins-infra/jenkins.io/pull/6632 I filed 3 years ago.