### PR TITLE
Add CloudRaft as a Jenkins support option

### DIFF
--- a/content/support.adoc
+++ b/content/support.adoc
@@ -80,6 +80,7 @@ NOTE: The Jenkins project does not endorse specific vendors. Users should perfor
 
 
 ** link:https://www.cloudbees.com/[CloudBees] offers a commercial derivate of Jenkins with support and training options.
+** link:https://www.cloudraft.io/cicd-consulting-support[CloudRaft] offers Jenkins support, consulting and migration services.
 ** link:https://www.feathersoft.com/jenkins-development-service/[Feathersoft] offers Jenkins development and consulting services for Jenkins.
 ** link:https://www.infracloud.io/jenkins-consulting-support/[InfraCloud] offers support and consulting services for Jenkins.
 ** link:https://www.stackgenie.io/jenkins-automation-services/[StackGenie] offers support, hosting and consulting services for Jenkins.


### PR DESCRIPTION
I would like to add our business as support provider for Jenkins. We are currently helping customers with Jenkins CI optimization, support and consulting. 