### PR TITLE
docs: add decision guide for Jenkins testing approaches

### DIFF
--- a/content/doc/developer/plugin-development/dependencies-and-class-loading.adoc
+++ b/content/doc/developer/plugin-development/dependencies-and-class-loading.adoc
@@ -476,12 +476,22 @@ This system has no effect on accesses using `java.lang.reflect`.
 
 ## `JenkinsRule` vs. `acceptance-test-harness` class loading
 
-There are three main categories of automated test used in Jenkins:
+For a broader overview of Jenkins testing approaches, see the link:/doc/developer/testing/[testing documentation].
 
-* Unit tests, including mocking frameworks such as PowerMock.
-* Functional tests based on the `JenkinsRule` API defined in `jenkins-test-harness`.
-* Acceptance tests located in the `acceptance-test-harness` repository.
+There are several categories of automated tests in Jenkins, each with different class loading characteristics:
 
+* Unit tests
+  Do not start Jenkins and use the test classpath directly.
+
+* Functional tests (JenkinsRule)
+  Start Jenkins within the same JVM, which may hide some class loading issues.
+
+* Integration tests (RealJenkinsRule)
+  Start Jenkins in a separate JVM, providing more realistic class loading behavior.
+
+* Acceptance tests (acceptance-test-harness)
+  Run Jenkins externally and interact via a browser, closely matching production behavior.
+  
 These have different levels of fidelity to the class loading behavior of plugin code running in production Jenkins servers.
 Unit tests simply pick up the Java classpath (java.class.path) defined by Maven’s `test` scope.
 

--- a/content/doc/developer/plugin-development/dependencies-and-class-loading.adoc
+++ b/content/doc/developer/plugin-development/dependencies-and-class-loading.adoc
@@ -480,17 +480,13 @@ For a broader overview of Jenkins testing approaches, see the link:/doc/develope
 
 There are several categories of automated tests in Jenkins, each with different class loading characteristics:
 
-* Unit tests
-  Do not start Jenkins and use the test classpath directly.
+* *Unit tests*: Do not start Jenkins and use the test classpath directly.
 
-* Functional tests (JenkinsRule)
-  Start Jenkins within the same JVM, which may hide some class loading issues.
+* *Functional tests (JenkinsRule)*: Start Jenkins within the same JVM, which may hide some class loading issues.
 
-* Integration tests (RealJenkinsRule)
-  Start Jenkins in a separate JVM, providing more realistic class loading behavior.
+* *Integration tests (RealJenkinsRule)*: Start Jenkins in a separate JVM, providing more realistic class loading behavior.
 
-* Acceptance tests (acceptance-test-harness)
-  Run Jenkins externally and interact via a browser, closely matching production behavior.
+* *Acceptance tests (acceptance-test-harness)*: Run Jenkins externally and interact via a browser, closely matching production behavior.
   
 These have different levels of fidelity to the class loading behavior of plugin code running in production Jenkins servers.
 Unit tests simply pick up the Java classpath (java.class.path) defined by Maven’s `test` scope.


### PR DESCRIPTION
Add a comparison table in the JenkinsRule vs acceptance-test-harness section to help contributors choose the appropriate testing approach.

The existing documentation explains these tools but lacks a quick, scannable guide. This change improves clarity and reduces decision friction for new contributors.

No existing content modified; only a non-breaking addition.