### PR TITLE
Add some details to the attribution policy

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -133,8 +133,16 @@ For example, Jenkins core is on a monthly release cadence with several weeks of 
 
 == Attribution Policy
 
-We will credit reporters who informed us in private about security vulnerabilities in security advisories.
-// TODO more detail
+Reporters who privately disclosed security vulnerabilities may request to be credited in our security advisories.
+
+Attribution text (e.g., name, affiliation, GitHub or social media user name) must:
+
+* Not include any formatting, including line breaks.
+* Not exceed 100 characters in length, per individual reporter.
+
+URLs or email addresses can be included, but will not be hyperlinked.
+
+We reserve the right to edit or reject any attribution.
 
 As an exception to the above, if a vulnerability is reported through a bug bounty program, we will only credit the first reporter of the issue.
 Additional reporters may be credited at our discretion, e.g., if they contribute substantial new information.


### PR DESCRIPTION
We've recently had reporters requesting formatted or overly long attributions, so let's clarify that this isn't happening.