### PR TITLE
Add Microsoft SmartScreen disclaimer to 2.562 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30104,6 +30104,15 @@
 
   - version: '2.562'
     date: 2026-04-27
+    banner: >
+      The <strong>Jenkins MSI installer</strong> is now signed by "LF Open Source, LLC" using the Microsoft Artifact Signing Service.
+      The change causes the Edge browser on Windows to report that the file is not commonly downloaded.
+      Users need to select "Keep anyway" to download the installer.
+      <br/>
+      When running the <strong>Jenkins MSI installer</strong> with the new signature, Windows SmartScreen reports "Microsoft Defender SmartScreen prevented an unrecognized app from starting. Running this app might put your PC at risk.".
+      Users need to select "More info" to advance to the next screen and then select "Run anyway".
+      <br/>
+      The Microsoft <a href="https://learn.microsoft.com/en-ca/answers/questions/5861981/blocked-by-windows-defender-smartscreen">support forum</a> says that Microsoft SmartScreen will stop prompting users once there are enough installations to increase its reputation score.
     changes:
       - type: rfe
         category: rfe


### PR DESCRIPTION
## Add Microsoft SmartScreen disclaimer to 2.562 changelog

Microsoft SmartScreen warns Jenkins administrators on Windows that the MSI is an unrecognized app.  Describe how to resolve that complaint.

Jenkins core issue:

* https://github.com/jenkinsci/jenkins/issues/26716

A later update will be provided that adds a blog post.  When the blog post is available, this entry will be updated to include a link to the blog post.

The MSI signing certificate update is discussed in infra help desk:

* https://github.com/jenkins-infra/helpdesk/issues/4923

Page looks like this:

<img width="1053" height="436" alt="screencapture-mark-pc2-markwaite-net-4242-changelog-2-562-2026-04-28-09_18_30-edit" src="https://github.com/user-attachments/assets/46299ae4-01b1-4bdd-a5f2-01771d75d264" />
