### PR TITLE
Include crumbIssuer configuration as code change in upgrade guide

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -14353,6 +14353,16 @@
 
   - type: rfe
     category: rfe
+    pull: 25918
+    authors:
+      - daniel-beck
+      - MarkEWaite
+    pr_title: Remove IP address from DefaultCrumbIssuer
+    message: |-
+      Show a warning to administrators who set the <code>hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID</code> flag, informing them of the further reduced safety, and the option's planned future removal.
+
+  - type: rfe
+    category: rfe
     pull: 26034
     authors:
       - strangelookingnerd

--- a/content/_data/upgrades/2-555-1.adoc
+++ b/content/_data/upgrades/2-555-1.adoc
@@ -61,3 +61,30 @@ java --add-opens java.base/java.lang=ALL-UNNAMED --add-
 opens=java.base/java.lang.reflect=ALL-UNNAMED -jar agent.jar -url
 http://localhost:9090/ -secret <secret> -name inbound -workDir <workdir>
 ----
+
+==== Removing IP address from DefaultCrumbIssuer
+
+The IP address is no longer included in the default crumb issuer that provides https://en.wikipedia.org/wiki/Cross-site_request_forgery[Cross-Site Request Forgery] (CSRF or XSRF) protection.
+Jenkins already uses the session ID to compute CSRF crumbs.
+Using the session id to compute the crumb makes usage of the client ip unnecessary.
+
+Jenkins administrators that use configuration as code should remove the `crumbIssuer` section from their configuration before upgrading to Jenkins 2.555.1.
+
+```yaml
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+```
+
+By default, the plugin:configuration-as-code[Configuration as Code Plugin] cancels Jenkins startup when a deprecated section is detected.
+If the `crumbIssuer` section is in a Jenkins 2.555.1 global configuration, Jenkins 2.555.1 will cancel startup and process no jobs.
+That is the intentional behavior of the plugin so that administrators detect and apply configuration changes immediately.
+
+The Configuration as Code Plugin can warn when deprecated configuration elements are found instead of canceling startup.
+Warning on deprecated configuration elements may not handle all configuration changes.
+If an administrator wants a warning for configuration as code deprecations instead of canceling startup, they can add the following to their configuration as code global configuration:
+
+```yaml
+configuration-as-code:
+  deprecated: warn
+```


### PR DESCRIPTION
## Include crumbIssuer configuration as code change in upgrade guide

A Jenkins user noted that they had to remove the crumbIssuer configuration as code entry as part of their upgrade to Jenkins 2.555.1.  Since we've documented configuration as code changes for Jenkins core in previous upgrade guides, it makes sense to also document this change.

Configuration as code instructions are a modified copty of the instructions in:

* https://www.jenkins.io/doc/upgrade-guide/2.492/#removing-configurability-of-jenkins-agent-protocols-list

I chose those as the base instead of choosing:

* https://www.jenkins.io/doc/upgrade-guide/2.516/#views-tab-now-configurable-per-user
* https://www.jenkins.io/doc/upgrade-guide/2.528/#configuration-as-code-entry-for-myviewstabbar-is-deprecated
* https://www.jenkins.io/doc/upgrade-guide/2.440/#replace-diskspacemonitor-with-diskspace-in-configuration-as-code

## Testing done

* Confirmed that the two modified pages look correct


Fixes #9060
