### PR TITLE
Show Remoting over WebSockets as released in the roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -261,7 +261,7 @@ categories:
       labels:
       - feature
     - name: 'JEP-222: Remoting over WebSockets'
-      status: preview
+      status: released
       link: https://github.com/jenkinsci/jep/tree/master/jep/222
       labels:
       - feature


### PR DESCRIPTION
## Show Remoting over WebSockets as released in the roadmap

Released several years ago.  Used in production by many users
