### PR TITLE
Show Overall/Manage as released in roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -266,7 +266,7 @@ categories:
       labels:
       - feature
     - name: 'JEP-223: Manage permissions'
-      status: preview
+      status: released
       link: https://github.com/jenkinsci/jep/tree/master/jep/223
       labels:
       - feature


### PR DESCRIPTION
## Show Overall/Manage as released in roadmap

The [2.555.1 changelog](https://www.jenkins.io/changelog/2.555.1/) shows that the permission is now a standard part of Jenkins
