### PR TITLE
Remove Docker image changes polling from roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -144,14 +144,6 @@ categories:
       link: /projects/gsoc/2020/project-ideas/automatic-spec-generator-for-jenkins-rest-api/
       labels:
       - feature
-    - name: "Docker: image changes polling and security scans"
-      status: future
-      description: >
-        Create a new Jenkins plugin to automate polling of image changes and security scans.
-      link: /projects/gsoc/2020/project-ideas/docker-registries-polling-plugin/
-      labels:
-      - feature
-      - security
   - name: End user experience and interface
     description: Initiatives focused on improving the Jenkins user interface and user experience
     link: /sigs/ux


### PR DESCRIPTION
## Remove Docker image changes polling from roadmap

Image change detection is a standard part of Renovate and Dependabot. This Google Summer of Code 2020 project idea should be removed from the Jenkins roadmap.
