### PR TITLE
Move configuration as code items to released in roadmap

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -256,7 +256,7 @@ categories:
     - name: "JCasC: Plugin compatibility"
       description: >
         Ensure wide support for Jenkins Configuration-as-Code in the Jenkins core and plugins.
-      status: current
+      status: released
       link: https://github.com/jenkinsci/configuration-as-code-plugin/issues/809
       labels:
       - feature
@@ -300,7 +300,7 @@ categories:
       description: >
         Evolution of plugin management capabilities in the Jenkins core and Docker images.
         It includes adoption of the new Plugin Management Tool in distributions, and support of advanced plugin definition formats like YAML.
-      status: near-term
+      status: released
       link: /projects/gsoc/2020/project-ideas/plugin-installation-manager-tool/
       labels:
       - feature


### PR DESCRIPTION
## Move configuration as code items to released in roadmap

Roadmap shows one project as current and the other as future, yet both are used in production in many Jenkins installations and are described in multiple locations.
