### PR TITLE
fix: urls of `gsoc projects`

### DIFF
--- a/content/projects/gsoc/2026/projects/jenkins-email-notifications-using-outlook-smtp-with-oath.adoc
+++ b/content/projects/gsoc/2026/projects/jenkins-email-notifications-using-outlook-smtp-with-oath.adoc
@@ -14,7 +14,7 @@ mentors:
 - "krisstern"
 links:
   idea: /projects/gsoc/2026/project-ideas/jenkins-email-notifications-using-outlook-smtp-with-oath
-  meetings: "/projects/gsoc/2026/projects/project-ideas/jenkins-email-notifications-using-outlook-smtp-with-oath/#office-hours"
+  meetings: "/projects/gsoc/2026/projects/jenkins-email-notifications-using-outlook-smtp-with-oath/#office-hours"
 ---
 
 == Abstract

--- a/content/projects/gsoc/2026/projects/plugin-modernizer-stats-visualization.adoc
+++ b/content/projects/gsoc/2026/projects/plugin-modernizer-stats-visualization.adoc
@@ -14,8 +14,8 @@ mentors:
 - "krisstern"
 - "CodexRaunak"
 links:
-  idea: /projects/gsoc/2026/plugin-modernizer-stats-visualization
-  meetings: "/projects/gsoc/2026/projects/project-ideas/plugin-modernizer-stats-visualization/#office-hours"
+  idea: /projects/gsoc/2026/project-ideas/plugin-modernizer-stats-visualization
+  meetings: "/projects/gsoc/2026/projects/plugin-modernizer-stats-visualization/#office-hours"
 ---
 
 === Abstract

--- a/content/projects/gsoc/2026/projects/retool-jenkins-io-website-success-stories.adoc
+++ b/content/projects/gsoc/2026/projects/retool-jenkins-io-website-success-stories.adoc
@@ -14,8 +14,8 @@ mentors:
 - "chamodshehanka"
 - "krisstern"
 links:
-  idea: /projects/gsoc/2026/plugin-modernizer-stats-visualization
-  meetings: "/projects/gsoc/2026/projects/project-ideas/plugin-modernizer-stats-visualization/#office-hours"
+  idea: /projects/gsoc/2026/project-ideas/retool-jenkins-io-website-success-stories
+  meetings: "/projects/gsoc/2026/projects/retool-jenkins-io-website-success-stories/#office-hours"
 ---
 
 == Abstract


### PR DESCRIPTION
Some urls were giving 404 not found in gsoc projects (2026)
For stories project, it had the url of plugin-modernizer project.