### PR TITLE
feat(roadmap/infrastructure) update items for May 2026

### DIFF
--- a/content/_data/roadmap/roadmap.yml
+++ b/content/_data/roadmap/roadmap.yml
@@ -603,22 +603,8 @@ categories:
     - name: "Modernize accounts.jenkins.io"
       description: >
         Modernize or replace the accounts.jenkins.io LDAP account management system to improve security of our users and decrease the maintenance overhead.
-      status: near-term
+      status: future
       link: https://github.com/jenkins-infra/helpdesk/issues/2232
-      labels:
-      - infrastructure
-    - name: "Java 25 GA for developers"
-      description: >
-        JDK25 GA is scheduled of 16 September 2025. We provided a preview version to developers on ci.jenkins.io: we should provide the GA version with automatic updates once released.
-      status: released
-      link: https://github.com/jenkins-infra/helpdesk/issues/4641
-      labels:
-      - infrastructure
-    - name: "Migrate pkg.origin.jenkins.io to our modern Azure infrastructure"
-      description: >
-        The VM pkg.origin.jenkins.io is a legacy machine running in a specific (CloudBees) account. We want it to move to Azure to decrease costs and modernize its components.
-      link: https://github.com/jenkins-infra/helpdesk/issues/3705
-      status: released
       labels:
       - infrastructure
     - name: "Add support for Windows 2025"
@@ -626,7 +612,7 @@ categories:
         Windows 2025 Server is the current (and most recent) LTS line. As per https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info, it has been released since November 2024 and will be supported until November 2029.
         It should be used as the default for Windows agents in the Jenkins infrastructure.
       link: https://github.com/jenkins-infra/helpdesk/issues/4791
-      status: preview
+      status: released
       labels:
       - infrastructure
     - name: "Switch Jenkins Infrastructure to JDK25"
@@ -634,7 +620,7 @@ categories:
         JDK25 is the current LTS java version and Jenkins community is working towards a full support.
         Jenkins Infrastructure should be one of the first end to end user of JDK25 to run controller and agents.
       link: https://github.com/jenkins-infra/helpdesk/issues/4941
-      status: current
+      status: released
       labels:
       - infrastructure
     - name: "Move Configuration Management out of Puppet"
@@ -642,6 +628,20 @@ categories:
         The Perforce Puppet project is now considered a strategic risk since February 2025. As such we should get rid of Puppet in favor of something else.
       link: https://github.com/jenkins-infra/helpdesk/issues/4714
       status: current
+      labels:
+      - infrastructure
+    - name: "Sign Jenkins MSI Package with the Linux Foundation Certificate"
+      description: >
+        The Digitcert certificate paid by the Jenkins project in 2023 expires in May 2026. The Linux Foundation allows us to sign our MSI installer using their own certificate system like the Node.JS project.
+      link: https://github.com/jenkins-infra/helpdesk/issues/4923
+      status: preview
+      labels:
+      - infrastructure
+    - name: "Resume and automate Jenkins statistics collection"
+      description: >
+        The data presented in stats.jenkins.io has not been updated since 1 year. We should resume this statistics collection and automate it.
+      link: https://github.com/jenkins-infra/helpdesk/issues/4666
+      status: near-term
       labels:
       - infrastructure
   - name: Governance


### PR DESCRIPTION
This update was due since 2 months at least. Sorry for the delay!

- Removes the "Java 25 GA for developers" and "Migrate pkg.origin.jenkins.io to our modern Azure infrastructure" items (it's been many months since we delivered them).
- Move "Switch Jenkins Infrastructure to JDK25" to "released" (done in February when I was in paternity leave, by Jay and Herve with the help of Mark and Tim).

- Adding:
  - the "MSI signing" item, which is already used for weekly. As such I've put it in "preview" state.
  - "Resume and automate Jenkins statistics collection" in "near-term"

- Move accounts.jenkins.io back to the future (Great Scott!).



----


Notes:

- I chose not to add items regarding the infrastructure funding. Even though we spend quite the effort on it, it does not feel right to have items in the roadmap for this. If there are any objection, I'll add an item (no strong opinion)
- The "Tombstone Puppet" item is kept as current since we started to work on Ansible