### PR TITLE
docs: recommend git-filter-repo for plugin extraction

### DIFF
--- a/content/doc/developer/plugin-development/split-plugin-from-core.adoc
+++ b/content/doc/developer/plugin-development/split-plugin-from-core.adoc
@@ -27,7 +27,7 @@ video::vGJtbgghYO8[youtube, width=852, height=480, start=480]
 If there are, you have some refactoring ahead of you, and this is where it gets hairy.
 * Split the code into a new repository with history intact.
 +
-The Git project recommends using `git-filter-repo` for repository rewriting tasks.
+The Git project link:https://git-scm.com/docs/git-filter-branch#_warning[recommends] using link:https://github.com/newren/git-filter-repo/[`git-filter-repo`] for repository rewriting tasks.
 +
 For example:
 +
@@ -36,7 +36,7 @@ For example:
 git filter-repo --path core/src/main/java/org/example/
 ----
 +
-NOTE: `git-filter-repo` is distributed separately from Git and may require manual installation.
+NOTE: `git-filter-repo` is distributed separately from Git.
 See the link:https://github.com/newren/git-filter-repo[git-filter-repo documentation] for installation instructions and additional examples.
 +
 If possible, make sure translated commits mention the original commit hash.

--- a/content/doc/developer/plugin-development/split-plugin-from-core.adoc
+++ b/content/doc/developer/plugin-development/split-plugin-from-core.adoc
@@ -26,7 +26,19 @@ video::vGJtbgghYO8[youtube, width=852, height=480, start=480]
 * Try temporarily deleting all the classes you propose to split, and do a clean build to verify that there are not unwanted usages from elsewhere in core.
 If there are, you have some refactoring ahead of you, and this is where it gets hairy.
 * Split the code into a new repository with history intact.
-`git-filter-branch` can work, though it is not easy to use.
++
+The Git project recommends using `git-filter-repo` for repository rewriting tasks.
++
+For example:
++
+[source,bash]
+----
+git filter-repo --path core/src/main/java/org/example/
+----
++
+NOTE: `git-filter-repo` is distributed separately from Git and may require manual installation.
+See the link:https://github.com/newren/git-filter-repo[git-filter-repo documentation] for installation instructions and additional examples.
++
 If possible, make sure translated commits mention the original commit hash.
 * Do a 1.0 release of the new plugin, with the baseline set to the last weekly prior to your split.
 Ideally you would actually use the `-SNAPSHOT` version from the current core but Maven release rules will forbid this.


### PR DESCRIPTION
Updates the plugin extraction guide to recommend `git-filter-repo` for repository rewriting tasks, along with a small example command and a reference to the [official Git documentation](https://git-scm.com/docs/git-filter-branch), which recommends `git-filter-repo` as an alternative to `git-filter-branch`.