### PR TITLE
docs: fix duplicated wording in STYLEGUIDE

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -30,7 +30,7 @@ describe the collective set of resources provided by Jenkins.
 
 When referring to a Jenkins Pipeline via short-hand ("Pipeline"), it
 should always be title-cased. When referring to a conceptual pipeline
-("continuous delivery pipeline"), it it should always be lower-cased.
+("continuous delivery pipeline"), it should always be lower-cased.
 
 There are two different syntaxes for Pipeline which must be referred to when
 writing about the subject. When referring to the entire system, "Jenkins


### PR DESCRIPTION
## Summary

Fix duplicated wording in STYLEGUIDE.adoc.

## Testing

Documentation-only change.