### PR TITLE
Fix reference to SECURITY-3657

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30265,7 +30265,7 @@
           - MarkEWaite
         pr_title: Limit SECURITY-3657 fix to controller JVM
         message: |-
-          Limit the SECURITY3657 security fix by default to the controller JVM due to reported problems extracting some stashes involving symbolic links on agents.
+          Limit the SECURITY-3657 security fix by default to the controller JVM due to reported problems extracting some stashes involving symbolic links on agents.
       - type: bug
         category: bug
         pull: 26700


### PR DESCRIPTION
Unsure where this is coming from, I never changed https://github.com/jenkinsci/jenkins/pull/26709#issue-4335348439. Are we removing formatting improperly?