### PR TITLE
a11y: restore visible focus state for pagination page switcher

### DIFF
--- a/content/stylesheets/components/_pagination.scss
+++ b/content/stylesheets/components/_pagination.scss
@@ -15,7 +15,8 @@
     align-items: center;
     justify-content: center;
 
-    &:first-child, &:last-child {
+    &:first-child,
+    &:last-child {
       position: absolute;
       top: 0;
       bottom: 0;
@@ -79,7 +80,9 @@
 
   select {
     appearance: none;
-    outline: none;
+    &:focus-visible {
+      outline: 2px solid var(--color);
+    }
     border: none;
     margin: 0;
     padding: 0.45rem 1.55rem 0.45rem 0.85rem;


### PR DESCRIPTION
## Summary

Restore visible keyboard focus styling for the pagination page switcher select element.

## Changes

- Added a `:focus-visible` outline style for the page switcher select
- Preserved browser default focus behavior while improving keyboard focus visibility
- Aligned focus styling with existing accessibility patterns used in the repository

## Why

The page switcher select element did not provide a clear visible focus indicator for keyboard navigation users.

## Testing

Frontend/CSS-only change. Reviewed for consistency with existing `:focus-visible` styles used in the repository.