### PR TITLE
chore: uses 'npm ci' instead of 'npm install' to ensure reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV FONTS_DIR=/usr/src/jenkinsio/build/_site/css/fonts
 COPY Makefile package* ./
 COPY scripts ./scripts
 
-RUN npm install
+RUN npm ci
 RUN make assets
 
 FROM ruby:3.4.8 AS builder

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -22,9 +22,9 @@ pipeline {
   }
 
   stages {
-    stage('NPM Install') {
+    stage('NPM Dependencies') {
       steps {
-        sh 'npm install'
+        sh 'npm ci'
       }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(BUILD_DIR)/ruby: Gemfile Gemfile.lock scripts/ruby vendor/gems | $(OUTPUT_DIR)
 # If the dev deletes node_modules independent of other changes, the build reinstalls it.
 $(BUILD_DIR)/node: package.json package-lock.json scripts/node node_modules | $(OUTPUT_DIR)
 	./scripts/node pull
-	./scripts/node npm install
+	./scripts/node npm ci
 	@touch $(BUILD_DIR)/node
 
 assets: $(BUILD_DIR)/assets

--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -109,7 +109,7 @@ Script* syntax. For example:
 node {
     stage('Build') {
       // Install dependencies
-      sh 'npm install'
+      sh 'npm ci'
     }
 }
 
@@ -118,7 +118,7 @@ pipeline {
     agent { docker { image 'node:24.16.0-alpine3.23' } }
     stages {
 	stage('Build') {
-	    sh 'npm install'
+	    sh 'npm ci'
 	}
     }
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5119