### PR TITLE
chore(updatecli) fix manifest for deprecated syntax or infrastructure

### DIFF
--- a/updatecli/updatecli.d/node-documentation.yaml
+++ b/updatecli/updatecli.d/node-documentation.yaml
@@ -175,5 +175,3 @@ actions:
     spec:
       labels:
         - dependencies
-
-

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -15,15 +15,11 @@ scms:
 
 sources:
   getDeployedPackerImageVersion:
-    kind: file
+    kind: yaml
     name: Retrieve the current version of the Packer images used in production
     spec:
-      file: https://raw.githubusercontent.com/jenkins-infra/kubernetes-management/refs/heads/main/config/jenkins_infra.ci.jenkins.io.yaml
-      matchpattern: 'galleryImageVersion:\s"(.*)"'
-    transformers:
-      - findsubmatch:
-          pattern: 'galleryImageVersion:\s"(.*)"'
-          captureindex: 1
+      file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/refs/heads/production/hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
   getNodeVersionFromPackerImages:
     kind: file
     name: Get the NodeJS version set in packer-images

--- a/updatecli/updatecli.d/ruby.yaml
+++ b/updatecli/updatecli.d/ruby.yaml
@@ -15,15 +15,11 @@ scms:
 
 sources:
   getDeployedPackerImageVersion:
-    kind: file
+    kind: yaml
     name: Retrieve the current version of the Packer images used in production
     spec:
-      file: https://raw.githubusercontent.com/jenkins-infra/kubernetes-management/refs/heads/main/config/jenkins_infra.ci.jenkins.io.yaml
-      matchpattern: 'galleryImageVersion:\s"(.*)"'
-    transformers:
-      - findsubmatch:
-          pattern: 'galleryImageVersion:\s"(.*)"'
-          captureindex: 1
+      file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/refs/heads/production/hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
   getRubyVersionFromPackerImages:
     kind: file
     name: Get the latest Maven version set in packer-images


### PR DESCRIPTION
Sources of the `node` and `ruby` were broken due to https://github.com/jenkins-infra/helpdesk/issues/5091.

This issues fixes it by getting the correct information from ci.jenkins.io source if truth (and use YAML engine instead of tedious regexp).

~Also a nit: pin JSON engine to `dasel/v2` as per the `WARNING` logs~ (reverted as it breaks a manifest: not a nit and requires subsequent PR)