### PR TITLE
Update and improve Overall/Manage permission documentation

### DIFF
--- a/content/doc/book/managing/system-properties.adoc
+++ b/content/doc/book/managing/system-properties.adoc
@@ -2083,12 +2083,14 @@ properties:
   tags:
   - feature
   - security
+  - obsolete
   def: |
     `false`
   since: 2.222
   description: |
     Enable the optional Overall/Manage permission that allows limited access to administrative features suitable for a hosted Jenkins environment.
     See https://github.com/jenkinsci/jep/tree/master/jep/223[JEP-223].
+    Has no effect since Jenkins 2.542, when the permission was enabled by default.
 
 - name: jenkins.security.ResourceDomainRootAction.allowAuthenticatedUser
   tags:

--- a/content/doc/book/security/access-control/permissions.adoc
+++ b/content/doc/book/security/access-control/permissions.adoc
@@ -88,6 +88,25 @@ Lack of necessary permission checks constitutes a security vulnerability.
 While these are expected to be resolved in a timely manner, this may be worth considering when deciding who to grant _Overall/Read_ permission to.
 ====
 
+[#manage]
+==== Access granted with Overall/Manage
+
+_Overall/Administer_ (next section) is a very high level of permission:
+Between administrative tools like the script console and the ability to install plugins, there are no limits to what administrators can do.
+
+_Overall/Manage_ grants permission to access and modify a subset of administrative options.
+Users with this permission are able to perform some administrative tasks.
+Options generally considered critical to the security of Jenkins are not available to these users.
+
+While this permission does not _imply_ (i.e., automatically grant) any other permissions, features accessible to users with this permission may involve data usually protected by other permissions.
+For example, users with _Overall/Manage_ permission may be able to configure the credentials a specific feature in Jenkins uses to access other systems, even though they won't be able to view the credentials themselves without _Credentials/View_ permission.
+
+Learn more in jep:223[].
+
+NOTE: This permission was added in Jenkins 2.222 and became enabled by default (i.e., can be assigned without installing a plugin) in Jenkins 2.542.
+Before Jenkins 2.542, this permission could be enabled by setting link:/doc/book/managing/system-properties/#jenkins-security-managepermission[the system property `jenkins.security.ManagePermission` to `true`] or installing the plugin:manage-permission[Overall/Manage permission enabler] plugin.
+Some features, especially those provided by plugins, may not yet support this permission.
+
 
 [#administer]
 ==== Access granted with Overall/Administer
@@ -235,23 +254,6 @@ Learn more in jep:224[].
 NOTE: This permission was added in Jenkins 2.222.
 Some features, especially those provided by plugins, may not yet support this permission.
 
-
-=== Access granted with Overall/Manage
-
-_Overall/Administer_ (described below) is a very high level of permission:
-Between administrative tools like the script console and the ability to install plugins, there are no limits to what administrators can do.
-
-_Overall/Manage_ grants permission to access and modify a subset of administrative options.
-Users with this permission are able to perform some administrative tasks.
-Options generally considered critical to the security of Jenkins are not available to these users.
-
-This permission can be enabled by setting link:/doc/book/managing/system-properties/#jenkins-security-managepermission[the system property `jenkins.security.ManagePermission` to `true`] or installing the plugin:manage-permission[Overall/Manage permission enabler] plugin.
-
-Learn more in jep:223[].
-
-NOTE: This permission was added in Jenkins 2.222.
-Some features, especially those provided by plugins, may not yet support this permission.
-
 == Obsolete Permissions
 
 The following three permissions are obsolete since Jenkins 2.222:
@@ -266,6 +268,6 @@ By default, these permissions were _implied_ by the Overall/Administer permissio
 
 This model has been retired.
 While these permissions still exist, they're no longer used by Jenkins core and related features have been removed, e.g., uploading plugins or using the script console just requires Overall/Administer permission now.
+Less security-sensitive features can now often be used with the _Overall/Manage_ permission, which is now enabled by default and can be granted without granting _Overall/Administer_.
 
-For more fine-grained access to the global configuration, the permissions _Overall/Manage_ and _Overall/SystemRead_ can optionally be enabled.
-
+For even more fine-grained access to the global configuration, the _Overall/SystemRead_ permission can optionally be enabled.


### PR DESCRIPTION
Adapt to https://github.com/jenkinsci/jenkins/pull/23873 and also clarify/define the scope of this permission: We got a bunch of reports claiming vulnerabilities of various kinds. For this permission to make sense, be explicit that indirectly getting access to information or being able to change things that would be protected by another permission is expected, not unlike Job/Configure is good enough to get credentials listed on job config forms, even without Credentials/View.

Fix https://github.com/jenkins-infra/jenkins.io/issues/9066