### PR TITLE
Remove WEBSITE-662 references

### DIFF
--- a/content/participate/how-to-guides.adoc
+++ b/content/participate/how-to-guides.adoc
@@ -8,9 +8,6 @@ tags:
   - contributing
 ---
 
-NOTE: This page is under development, there will be more content added soon.
-See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
-
 === How-To Guidelines
 
 ==== How to report a bug, request an improvement, or propose a new feature
@@ -20,4 +17,3 @@ See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions ar
 ==== How To Track an issue
 
 - link:/participate/track-issue[Track an issue]
-

--- a/content/participate/test.adoc
+++ b/content/participate/test.adoc
@@ -8,15 +8,13 @@ tags:
   - contributing
 ---
 
-NOTE: This page is under development, there will be more content added soon.
-See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions are welcome!
-
 === Automated Testing
 
 ==== Jenkins Code
- - https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md#testing-changes[Unit Tests and Integration Tests]
- 
- - https://github.com/jenkinsci/acceptance-test-harness/blob/master/README.md[Acceptance Test Harness]
+
+- https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md#testing-changes[Unit Tests and Integration Tests]
+
+- https://github.com/jenkinsci/acceptance-test-harness/blob/master/README.md[Acceptance Test Harness]
 
 ==== Jenkins Plugins
 
@@ -32,13 +30,12 @@ See the jira:WEBSITE-662[] EPIC for tasks related to this page, contributions ar
 
 ==== Jenkins Code
 
-- Pull Requests - link:https://ci.jenkins.io/job/Core/job/jenkins/view/change-requests/[https://ci.jenkins.io/job/Core/job/jenkins/view/change-requests/]
+- Pull Requests - link:https://ci.jenkins.io/job/Core/job/jenkins/view/change-requests/[ci.jenkins.io]
 
 - Weekly Release - link:/download/[weekly downloads]
-
-- Quarterly Long Term Support Release Candidate - link:http://mirrors.jenkins.io/war-stable-rc/[http://mirrors.jenkins.io/war-stable-rc/]
 
 - Quarterly Long Term Support Release - link:/download/[LTS downloads]
 
 ==== Jenkins Plugins
+
 - Pull request builds from link:https://ci.jenkins.io/job/Plugins/[ci.jenkins.io]


### PR DESCRIPTION
## Remove WEBSITE-662 references

The [WEBSITE-662](https://issues.jenkins.io/browse/WEBSITE-662) epic has been archived.  The work that was intended to be completed in that epic was completed in 2023.

The "updated soon" entries do not make sense any longer.
