### PR TITLE
Replace jira:27035 with jira:JENKINS-27035 for use with new jira macro

### DIFF
--- a/content/blog/2018/09/2018-09-10-scaling-network-connections.adoc
+++ b/content/blog/2018/09/2018-09-10-scaling-network-connections.adoc
@@ -21,7 +21,7 @@ that allows a controller to orchestrate agent activity and receive build results
 Techniques such as tuning the agent launcher can improve service,
 but qualitative change can only come from fundamentally reworking what gets transmitted and how.
 
-In March, jira:27035[] introduced a framework for inspecting the traffic on a Remoting channel at a high level.
+In March, jira:JENKINS-27035[] introduced a framework for inspecting the traffic on a Remoting channel at a high level.
 Previously, developers could only use generic low-level tools such as Wireshark,
 which cannot identify the precise piece of Jenkins code responsible for traffic.
 


### PR DESCRIPTION
## Replace jira:27035 with jira:JENKINS-27035 for use with new jira macro

This is the only location in the jenkins.io website that uses `jira:nnnnn`. Let's switch it to `jira:JENKINS-nnnnn` to adapt to the [issue redirector](https://github.com/jenkins-infra/docker-issue-redirect) as described in its [documentation](https://github.com/jenkins-infra/docker-issue-redirect#api).

An updated jira macro using the issue-redirect service is in pull request:

* https://github.com/jenkins-infra/asciidoctor-jenkins-extensions/pull/73

That updated macro replaces a URL of the form:

* `%(https://issues.jenkins.io/browse/#{issueId})`

with a URL of the form:

* `%(https://issue-redirect.jenkins.io/#{issueId})`

However, that new form assumes that the issueId is `JENKINS-27035`.  It does not redirect correctly if the issue ID is `27035`.

The following URL does not redirect:

* https://issue-redirect.jenkins.io/27035

The following URL works as expected:

* https://issue-redirect.jenkins.io/JENKINS-27035

CC: @lemeurherve

### Testing done

* Confirmed that the page link works the same [before](https://www.jenkins.io/blog/2018/09/10/scaling-network-connections/) the change and [after](https://deploy-preview-9212--jenkins-io-site-pr.netlify.app/blog/2018/09/10/scaling-network-connections/) the change