### PR TITLE
Fix: task-identifier attribute substitution in output block

### DIFF
--- a/content/doc/developer/tutorial-improve/_create-a-pull-request.adoc
+++ b/content/doc/developer/tutorial-improve/_create-a-pull-request.adoc
@@ -21,6 +21,8 @@ Push the change to GitHub:
 ----
 git push origin --set-upstream {task-identifier}
 ----
+
+[source,bash,subs="attributes+"]
 ----
 Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
 remote:


### PR DESCRIPTION
Closes [#9216](https://github.com/jenkins-infra/jenkins.io/issues/9216)

## Root Cause
The output listing block in `_create-a-pull-request.adoc` did not enable attribute substitutions, which caused `{task-identifier}` to be rendered as plain text when closely enclosed inside single quotes (`'{task-identifier}'`) within listing blocks. 

This occurs because modern Asciidoctor parsing rules prioritize character-constrained formatting boundaries, interpreting the single quotes as inline text emphasis (italics) markers. 

## Resolution
Added `[source,bash,subs="attributes+"]` just before the affected listing block. This renders `{task-identifier}` consistently.