### PR TITLE
Use correct link syntax in 2.516.1 upgrade guide

### DIFF
--- a/content/_data/upgrades/2-516-1.adoc
+++ b/content/_data/upgrades/2-516-1.adoc
@@ -32,7 +32,7 @@ New jobs no longer create an empty `legacyIds` marker file in the builds directo
 Existing `legacyIds` files are deleted upon upgrade to reduce inode usage.
 
 No action is required when upgrading from a version prior to 2.516.1.
-On the first startup after upgrading, you will see an info log: `hudson.model.Job#onLoad: Deleting legacyIds file in /.../JENKINS_HOME/jobs/my-job/builds. See [JENKINS-75465](https://issue-redirect.jenkins.io/issue/75465) for more information.`.
+On the first startup after upgrading, you will see an info log: `hudson.model.Job#onLoad: Deleting legacyIds file in /.../JENKINS_HOME/jobs/my-job/builds. See jira:JENKINS-75465[] for more information.`.
 
 However, if you decide to downgrade after upgrading, you should manually create the `legacyIds` file in the builds directory to prevent a potential slow startup.
 This is because the older version will perform migration checks when the file is missing.


### PR DESCRIPTION
## Use correct link syntax in 2.516.1 upgrade guide

Was using markdown syntax, but the file is asciidoc.
