### PR TITLE
docs: improve contributing guide wording

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -75,7 +75,7 @@ When they are ready, you will push your changes to your fork and submit a PR fro
 
 == Building
 
-This project uses GNU/Make and Docker to generate the fully statically link:https://jenkins.io[jenkins.io] web site.
+This project uses GNU/Make and Docker to generate the fully static link:https://jenkins.io[jenkins.io] website.
 If you need to install Docker, utilize the instructions for link:https://docs.docker.com/engine/install/[Docker Engine] or link:https://docs.docker.com/desktop/[Docker Desktop] depending on your environment.
 The key tool to convert source code into the site is the link:https://github.com/awestruct/awestruct[Awestruct] static site generator, which is downloaded automatically as part of the build process.
 
@@ -123,11 +123,11 @@ This also downloads and regenerates external resources.
 * *clean* will remove all build output and dependencies in preparation for a full rebuild.
 * *prepare* will download external dependencies and resources necessary to build the site.
 As an optimization to make iterating on content locally more pleasant, dependencies and resources are not downloaded again unless the `clean` target is called first.
-The exception being `all`, which downloads and regenerates external resources (but not download dependencies because they are more bandwidth intensive).
+The exception is `all`, which downloads and regenerates external resources (but does not download dependencies because they are more bandwidth intensive).
 * *generate* will explicitly generate static website files.
 * *run* runs a live-reloading development server on link:http://localhost:4242/[localhost:4242].
 * *check* looks for typos.
-It is advised to use *check* to examine the documentation for typos and spelling mistakes before you submit a PR.
+Use *check* to examine the documentation for typos and spelling mistakes before you submit a PR.
 
 == Editing content
 


### PR DESCRIPTION
## Summary
This PR improves a few wording issues in CONTRIBUTING.adoc:

- clarifies the site build description
- improves the make target explanation
- simplifies the typo-check guidance

## Why
These small documentation updates improve readability and clarity.

## Testing
Not run. Documentation-only changes.