### PR TITLE
docs: clarify JCasC reload before restart

### DIFF
--- a/content/doc/book/managing/casc.adoc
+++ b/content/doc/book/managing/casc.adoc
@@ -146,10 +146,9 @@ jenkins:
 
 [NOTE]
 ====
-It is not necessary to restart Jenkins to apply the JCasC changes,
-although you should try to restart Jenkins with the modifications
-before you check the modified YAML file into SCM,
-especially when making more substantive configuration changes.
+It is not necessary to restart Jenkins to apply JCasC changes.
+After you modify the YAML file, reload the existing configuration before restarting Jenkins.
+If you restart Jenkins first, the in-memory configuration may overwrite the changes you made in the YAML file.
 ====
 
 When you have made and tested your desired changes,


### PR DESCRIPTION
## Summary
This PR updates the JCasC documentation to clarify the reload flow after editing the YAML file.

- explains that a restart is not required to apply JCasC changes
- adds guidance to reload the existing configuration before restarting Jenkins
- notes that restarting first may overwrite YAML changes with in-memory configuration

## Why
This addresses confusion in the current documentation and documents the caveat described in the linked issue.

Closes #8295