### PR TITLE
docs: clarify Docker Pipeline plugin requirement

### DIFF
--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -15,7 +15,7 @@ endif::[]
 = Using Docker with Pipeline
 
 Many organizations use link:https://www.docker.com[Docker] to unify their build and test environments across machines, and to provide an efficient mechanism for deploying applications.
-Starting with Pipeline versions 2.5 and higher, Pipeline has built-in support for interacting with Docker from within a `Jenkinsfile`.
+Pipeline can interact with Docker from within a `Jenkinsfile` when the Pipeline plugin and the Docker Pipeline plugin are installed.
 
 While this page covers the basics of utilizing Docker from within a `Jenkinsfile`, it will not cover the fundamentals of Docker, which you can refer to in the link:https://docs.docker.com/get-started/[Docker Getting Started Guide].
 

--- a/content/doc/book/pipeline/docker.adoc
+++ b/content/doc/book/pipeline/docker.adoc
@@ -27,6 +27,12 @@ Pipeline is designed to easily use link:https://docs.docker.com/[Docker] images 
 Meaning that a user can define the tools required for their Pipeline, without having to manually configure agents.
 Any tool that can be link:https://hub.docker.com[packaged in a Docker container] can be used with ease, by making only minor edits to a `Jenkinsfile`.
 
+[NOTE]
+====
+The examples on this page require the plugin:docker-workflow[*Docker Pipeline*] plugin.
+Without that plugin, Jenkins cannot use the `docker` agent type in Declarative Pipeline or the `docker.image(...).inside {}` steps in Scripted Pipeline.
+====
+
 [pipeline]
 ----
 // Declarative //


### PR DESCRIPTION
## Summary
This PR clarifies the plugin requirement for the Docker Pipeline examples.

- adds a note that the examples require the Docker Pipeline plugin
- explains why the `docker` agent type is unavailable without that plugin
- covers both Declarative and Scripted Pipeline examples

## Why
This addresses confusion reported in the linked issue and makes the prerequisite more visible to readers.

Closes #7870