### PR TITLE
docs: update Blue Ocean deprecation note

### DIFF
--- a/content/doc/book/blueocean/_blue-ocean-status.adoc
+++ b/content/doc/book/blueocean/_blue-ocean-status.adoc
@@ -5,8 +5,8 @@ This file is only meant to be included as a snippet in other documents.
 [NOTE]
 .Blue Ocean status
 ====
-Blue Ocean will be deprecated in July 2026.
-It will not receive further security fixes or functionality updates.
+Blue Ocean is deprecated as of July 2026.
+It will not receive further functionality updates and will receive only selective fixes for significant security issues or functional defects.
 
 ifdef::pipeline-visualization-admonition[]
 The link:https://plugins.jenkins.io/pipeline-graph-view/[Pipeline Graph View plugin] is actively maintained and provides the most crucial features of Blue Ocean.


### PR DESCRIPTION
## Summary
This PR updates the Blue Ocean status note.

- changes the note to reflect Blue Ocean deprecation as of July 2026
- clarifies that only selective fixes are expected after deprecation
- keeps the existing links to recommended alternatives

## Why
This aligns the status note with the current deprecation guidance described in the linked issue.

Closes #9038