### PR TITLE
Update funding urls

### DIFF
--- a/content/donate.adoc
+++ b/content/donate.adoc
@@ -11,7 +11,7 @@ We will appreciate any contributions to the Jenkins: code, documentation, etc.
 If you have no opportunity to contribute your time, we also appreciate donations of money and equipment.
 
 You can donate here:
-image:/images/governance/funding/lfx_crowdfunding.png[Donate via LFX Crowdfunding, link="https://crowdfunding.lfx.linuxfoundation.org/projects/jenkins", role=center, height=48]
+image:/images/governance/funding/lfx_crowdfunding.png[Donate via LFX Crowdfunding, link="https://crowdfunding.linuxfoundation.org/initiatives/jenkins", role=center, height=48]
 
 == Why donate?
 
@@ -37,7 +37,7 @@ even small contributions can make a real difference for the project and its user
 
 == Donations through LFX Crowdfunding
 
-image:/images/governance/funding/lfx_crowdfunding.png[Donate via LFX Crowdfunding, link="https://crowdfunding.lfx.linuxfoundation.org/projects/jenkins", role=center, height=48]
+image:/images/governance/funding/lfx_crowdfunding.png[Donate via LFX Crowdfunding, link="https://crowdfunding.linuxfoundation.org/initiatives/jenkins", role=center, height=48]
 
 The Jenkins project https://funding.communitybridge.org/projects/jenkins[has an account] on the LFX Crowdfunding platform.
 It provides support for donations by individuals and by organizations, including anonymous donations.


### PR DESCRIPTION
LFX Crowdfunding received a major overhaul, causing existing project URLs to break as expected.
The change proposed fixes the broken URLs on the funding page.