### PR TITLE
Format weekly changelog banner to match automation

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30374,10 +30374,13 @@
   - version: '2.569'
     date: 2026-06-15
     banner: >
-      <strong>Windows 2019 controller images</strong> have been dropped from this release, and the next LTS release line will not include them either.
-      For users who must use Windows for their controller and are stuck on Windows 2019, the workaround is either to:
+      <strong>Windows 2019 controller images</strong> have been dropped from this
+      release, and the next LTS release line will not include them either.
+      For users who must use Windows for their controller and are stuck on Windows
+      2019, the workaround is either to:
       <ol>
-      <li>Install Jenkins controller via the MSI available via the "Windows" links on <a href="https://www.jenkins.io/download/">https://www.jenkins.io/download/</a></li>
+      <li>Install Jenkins controller via the MSI available via the "Windows" links
+      on <a href="https://www.jenkins.io/download/">https://www.jenkins.io/download/</a></li>
       <li>Build their own image</li>
       </ol>
     changes:


### PR DESCRIPTION
##Format weekly changelog banner to match automation

Changelog content formatting is not sensitive to line breaks.  Let's make the changelog formatting consistent with the automation to reduce the differences shown in the automated changelog for the weekly release.
