### PR TITLE
Restore '-' that is deleted by changelog generator

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30606,7 +30606,7 @@
           - Aarav-Singh2007
         pr_title: Update operating system end of life data
         message: |-
-          Display operating system end of life messages when we are within 6 months of the end of life for Alpine Linux 3.213.24, CentOS Stream 910, Debian 13, Fedora 4244, Red Hat Enterprise Linux 10, Rocky Linux 10, and Ubuntu 26.04. Correct the end of life date for Fedora 41.
+          Display operating system end of life messages when we are within 6 months of the end of life for Alpine Linux 3.21 - 3.24, CentOS Stream 9 - 10, Debian 13, Fedora 42 - 44, Red Hat Enterprise Linux 10, Rocky Linux 10, and Ubuntu 26.04. Correct the end of life date for Fedora 41.
       - type: rfe
         category: rfe
         pull: 26614
@@ -30641,7 +30641,7 @@
           - janfaracik
         pr_title: '[JENKINS-73906] Fix weird animation artifact when clicking "Apply"'
         message: |-
-          [JENKINS73906] Fix weird animation artifact when clicking "Apply"
+          Fix weird animation artifact when clicking "Apply".
       - type: bug
         category: bug
         pull: 26981


### PR DESCRIPTION
## Restore '-' that is deleted by changelog generator

The changelog messages for 'Update operating system end of life data' and 'Fix weird animation artifact' were more difficult to read because the changelog generator removed the '-' character.

Issue is:

* https://github.com/jenkinsci/core-changelog-generator/issues/32

### Testing done

* Built the site and confirmed the page is correct
