### PR TITLE
Add Windows Server 2025 container to 2.568.1 changelog

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -14735,6 +14735,17 @@
         getEstimatedDurationCandidates
       message: |-
         Improve queue maintenance performance for jobs with large build histories.
+    - type: rfe
+      category: rfe
+      authors:
+        - lemeurherve
+        - dduportal
+      pr_title: "add Windows Server 2025 image"
+      references:
+        - url: https://github.com/jenkinsci/docker/pull/2369
+          title: "pull 2369"
+      message: |-
+        Add Windows Server 2025 container image for the Jenkins controller.
     - type: bug
       category: bug
       pull: 26564


### PR DESCRIPTION
## Add Windows Server 2025 container to 2.568.1 changelog

Added with pull request:

* https://github.com/jenkinsci/docker/pull/2369
