### PR TITLE
Convert changelog message fragment into a link

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30703,8 +30703,14 @@
         authors:
           - daniel-beck
         pr_title: Prohibit deserialization of Object fields by default
+        references:
+          - url: /redirect/safe-object-field/
+            title: Learn more
+          - url: https://github.com/jenkinsci/jenkins/issues/26914
+            title: issue 26914
+          - pull: 26915
         message: |-
-          Prohibit the deserialization of <code>Object</code> fields by default. Learn more: link:/redirect/safeobjectfield/
+          Prohibit the deserialization of <code>Object</code> fields by default.
       - type: rfe
         category: rfe
         pull: 26997


### PR DESCRIPTION
## Convert changelog message fragment into a link

The message fragment needs manual intervention to insert the link into the changelog

## Testing done

* Confirmed that the page renders as expected in local environment
* Confirmed that the link works as expected in local environment

## Before the change

<img width="934" height="386" alt="before-the-change" src="https://github.com/user-attachments/assets/4c5d2ef8-9289-4262-9d86-06491eadfa3d" />

## After the change

<img width="920" height="386" alt="after-the-change" src="https://github.com/user-attachments/assets/64146ed0-430b-4695-924a-5b25637ce01b" />
