### PR TITLE
Remove incorrect comment in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,14 +30,6 @@ node('docker&&linux') {
 
     stage('Checkout source') {
         /*
-        * For a standalone workflow script, we would use the `git` step
-        *
-        *
-        * git url: 'git://github.com/jenkinsci/jenkins.io',
-        *     branch: 'master'
-        */
-
-        /*
         * Represents the SCM configuration in a "Workflow from SCM" project build. Use checkout
         * scm to check out sources matching Jenkinsfile with the SCM details from
         * the build that is executing this Jenkinsfile.


### PR DESCRIPTION
## Remove incorrect comment in Jenkinsfile

For a standalone Pipeline script, we should still use checkout scm, but provide necessary arguments.
