### PR TITLE
Update URL to API token generation link name

### DIFF
--- a/content/doc/book/security/securing-jenkins.adoc
+++ b/content/doc/book/security/securing-jenkins.adoc
@@ -37,10 +37,10 @@ for authorization strategy. Or you might choose to let Jenkins run its own user
 database, and perform access control based on the permission/user matrix.
 
 
-* https://wiki.jenkins.io/display/JENKINS/Quick+and+Simple+Security[Quick and Simple Security] --- if you are running Jenkins like `java -jar jenkins.war` and only need a very simple setup
-* https://wiki.jenkins.io/display/JENKINS/Standard+Security+Setup[Standard Security Setup] --- discusses the most common setup of letting Jenkins run its own user database and do finer-grained access control
+* link:/doc/book/installing/war-file/[Quick and Simple Security] --- if you are running Jenkins like `java -jar jenkins.war` and only need a very simple setup
+* link:/doc/book/security/managing-security/[Standard Security Setup] --- discusses the most common setup of letting Jenkins run its own user database and do finer-grained access control
 * https://wiki.jenkins.io/display/JENKINS/Apache+frontend+for+security[Apache frontend for security] --- run Jenkins behind Apache and perform access control in Apache instead of Jenkins
-* https://wiki.jenkins.io/display/JENKINS/Authenticating+scripted+clients[Authenticating scripted clients] --- if you need to programmatically access security-enabled Jenkins web UI, use BASIC auth
-* https://wiki.jenkins.io/display/JENKINS/Matrix-based+security[Matrix-based security|Matrix-based security] --- Granting and denying finer-grained permissions
+* link:/doc/book/system-administration/authenticating-scripted-clients/[Authenticating scripted clients] --- if you need to programmatically access security-enabled Jenkins web UI, use BASIC auth
+* link:/doc/book/security/managing-security/#authorization[Matrix-based security] --- Granting and denying finer-grained permissions
 
 In addition to access control of users, link:../build-authorization[access control for builds] limits what builds can do, once started.

--- a/content/doc/book/system-administration/authenticating-scripted-clients.adoc
+++ b/content/doc/book/system-administration/authenticating-scripted-clients.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 To make scripted clients (such as wget) invoke operations that require
 authorization (such as scheduling a build), use HTTP BASIC
-authentication to specify the user name and the API token. 
+authentication to specify the user name and the API token.
 
 Earlier versions of Jenkins require you to specify your real password,
 and it is only available when your security realm is password-based (for
@@ -26,13 +26,13 @@ password is still supported, but it is not recommended
 because the risk of revealing password, and the human tendency to reuse
 the same password in different places.
 
-The API token is available in your personal configuration page. 
-Click your name on the top right corner on every page, 
-then click "Configure" to see your API token. 
-(The URL `+$root/me/configure+` is a good shortcut.) 
+The API token is available in your personal configuration page.
+Click your name on the top right corner on every page,
+then click "Security" to see your API token.
+(The URL `+$root/me/security+` is a good shortcut.)
 You can also change your API token from here.
 
-Note that Jenkins does not do any authorization negotiation. 
+Note that Jenkins does not do any authorization negotiation.
 i.e. it immediately returns a 403 (Forbidden) response instead
 of a 401 (Unauthorized) response, so make sure to send the authentication
 information from the first request (aka "preemptive authentication").
@@ -62,7 +62,7 @@ wget --auth-no-challenge \
 == Groovy script using cdancy/jenkins-rest
 
 The https://github.com/cdancy/jenkins-rest[cdancy/jenkins-rest client]
-greatly simplifies REST API access. 
+greatly simplifies REST API access.
 The following Groovy code shows how to authenticate to Jenkins and get some system info:
 
 [source,groovy]
@@ -82,11 +82,9 @@ println(client.api().systemApi().systemInfo())
 For additional information, see the
 https://github.com/cdancy/jenkins-rest/wiki[cdancy/jenkins-rest wiki].
 
-
-
 == Typescript script example using axios
 
-The following code shows how to create a job 
+The following code shows how to create a job
 [source,typescript]
 ----
 
@@ -118,13 +116,11 @@ getCrumb().then((response: any) => {
 });
 ----
 
-
 [[Authenticatingscriptedclients-PerlLWPexampleforascriptedclient]]
 == Perl LWP example for a scripted client
 
 The following Perl example uses the LWP module to start a Job via a
 "Trigger builds remotely" token:
-
 
 [source,perl]
 ----
@@ -162,7 +158,6 @@ else {
 }
 ----
 
-
 [[Authenticatingscriptedclients-Javaexamplewithhttpclient4.3.x]]
 == Java example with httpclient 4.3.x
 
@@ -191,12 +186,12 @@ import org.apache.http.util.EntityUtils;
 
 public class JenkinsScraper {
 
-    public String scrape(String urlString, String username, String password) 
+    public String scrape(String urlString, String username, String password)
         throws ClientProtocolException, IOException {
         URI uri = URI.create(urlString);
         HttpHost host = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(new AuthScope(uri.getHost(), uri.getPort()), 
+        credsProvider.setCredentials(new AuthScope(uri.getHost(), uri.getPort()),
             new UsernamePasswordCredentials(username, password));
         // Create AuthCache instance
         AuthCache authCache = new BasicAuthCache();

--- a/content/doc/developer/handling-requests/json.adoc
+++ b/content/doc/developer/handling-requests/json.adoc
@@ -236,8 +236,8 @@ Then, if you need a user and a token:
 
 For additional documentation on the token, please visit:
 
-* link:../../../book/system-administration/authenticating-scripted-clients[Authenticating scripted clients]
-* link:../../../book/security/csrf-protection[CSRF Protection]
+* link:/doc/book/system-administration/authenticating-scripted-clients[Authenticating scripted clients]
+* link:/doc/book/security/csrf-protection[CSRF Protection]
 
 And then send the POST request:
 [source,bash]


### PR DESCRIPTION
## Update URL to API token generation page

A user reported that the link to the API token generation page was incorrectly pointing the user to /me/configure when it should point them to /me/security.  Correct that link and update several locations that refer to the page.

- Replace redirecting wiki links with doc links
- Use /doc/book links instead of ../../../book/
- Update URL to API token generation page

## Testing done

* Checked each of the pages and the modified links to confirm that they continue to open the same final location page
