### PR TITLE
Specify maven-release-plugin 3.1.1 in security fix staging instructions

### DIFF
--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -268,7 +268,7 @@ It's a good practice to run `mvn clean verify` now, even when there are no merge
 For Maven-based plugins that are usually released manually using `mvn release:prepare release:perform`, use the following command to stage the plugin release.
 `REPONAME` is a placeholder for the name of the Maven staging repository that is provided by the Jenkins security team.
 
-`mvn -DstagingRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/REPONAME -DpushChanges=false -DlocalCheckout=true org.apache.maven.plugins:maven-release-plugin:3.0.0:prepare org.apache.maven.plugins:maven-release-plugin:3.0.0:stage`
+`mvn -DstagingRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/REPONAME -DpushChanges=false -DlocalCheckout=true org.apache.maven.plugins:maven-release-plugin:3.1.1:prepare org.apache.maven.plugins:maven-release-plugin:3.1.1:stage`
 
 WARNING: The staging repository name (`REPONAME`) is _never_ a GitHub URL or GitHub repository name.
 


### PR DESCRIPTION
3.0.0 is several years old at this point (March '23), so update to something a little more recent (July '24).

3.1.1 is the last version I could confirm working while Spotless is active. 3.2.0+ fail and require workarounds: https://github.com/jenkinsci/plugin-pom/issues/1417

Instructions untested, I guess we'll learn whether this works the next time we stage.