### PR TITLE
docs: add lts 2.568.2 changelog and upgrade guide

### DIFF
--- a/content/_data/changelogs/lts.yml
+++ b/content/_data/changelogs/lts.yml
@@ -14591,202 +14591,244 @@
     <li>Build their own image</li>
     </ol>
   changes: # compared to lts_baseline 2.555 - extracted from the RC commit(s)
-    - type: rfe
-      category: rfe
-      pull: 26904
-      authors:
-        - renovate
-      pr_title: Update spring security to v7.1.0
-      references:
-        - url: https://github.com/spring-projects/spring-security/releases/tag/7.1.0
-          title: Spring Security 7.1.0 release notes
-        - url: https://github.com/spring-projects/spring-security/releases/tag/7.0.6
-          title: Spring Security 7.0.6 release notes
-        - pull: 26904
-      message: |-
-        Update Spring Security from 7.0.5 to 7.1.0.
-    - type: rfe
-      category: rfe
-      pull: 26896
-      authors:
-        - renovate
-      pr_title: Update spring core to v7.0.8
-      references:
-        - url: https://github.com/spring-projects/spring-framework/releases/tag/v7.0.8
-          title: Spring Framework 7.0.8 release notes
-        - pull: 26896
-      message: |-
-        Update Spring Framework from 7.0.7 to 7.0.8.
-    - type: bug
-      category: regression
-      pull: 26937
-      authors:
-        - amarkdotdev
-      pr_title: 'fix(ui): re-enable Add button when hetero-list item is deleted'
-      message: |-
-        Re-enable the "Add" button immediately when an item is deleted from a full list (regression in 2.536).
-    - type: bug
-      category: regression
-      pull: 26893
-      authors:
-        - janfaracik
-      pr_title: Fix unexpected bluish scrollbar background
-      message: |-
-        Fix blue tinted scrollbar.
-    - type: bug
-      category: regression
-      pull: 26884
-      authors:
-        - Anexus5919
-        - MarkEWaite
-      pr_title: Fix combobox and autocomplete dropdown selection beyond the
-        first item
-      message: |-
-        Fix the combobox suggestion list flashing and closing immediately when the field is clicked.
-    - type: rfe
-      category: rfe
-      pull: 26989
-      authors:
-        - Kevin-CB
-      pr_title: Update bundled script-security to 1402.1405
-      message: |-
-        Update bundled Script Security Plugin from 1402.v94c9ce464861 to 1402.1405.vc96e74964250.
-    - type: rfe
-      category: rfe
-      pull: 26883
-      authors:
-        - jtnord
-      pr_title: disabling sticky elements for a magic cookie
-      message: |-
-        Disable sticky elements when the <code>disableStickyPositioning</code> HTTP cookie is enabled (used in acceptance tests).
+  - type: rfe
+    category: rfe
+    pull: 26904
+    authors:
+      - renovate
+    pr_title: Update spring security to v7.1.0
+    references:
+      - url: https://github.com/spring-projects/spring-security/releases/tag/7.1.0
+        title: Spring Security 7.1.0 release notes
+      - url: https://github.com/spring-projects/spring-security/releases/tag/7.0.6
+        title: Spring Security 7.0.6 release notes
+      - pull: 26904
+    message: |-
+      Update Spring Security from 7.0.5 to 7.1.0.
+  - type: rfe
+    category: rfe
+    pull: 26896
+    authors:
+      - renovate
+    pr_title: Update spring core to v7.0.8
+    references:
+      - url: https://github.com/spring-projects/spring-framework/releases/tag/v7.0.8
+        title: Spring Framework 7.0.8 release notes
+      - pull: 26896
+    message: |-
+      Update Spring Framework from 7.0.7 to 7.0.8.
+  - type: bug
+    category: regression
+    pull: 26937
+    authors:
+      - amarkdotdev
+    pr_title: 'fix(ui): re-enable Add button when hetero-list item is deleted'
+    message: |-
+      Re-enable the "Add" button immediately when an item is deleted from a full list (regression in 2.536).
+  - type: bug
+    category: regression
+    pull: 26893
+    authors:
+      - janfaracik
+    pr_title: Fix unexpected bluish scrollbar background
+    message: |-
+      Fix blue tinted scrollbar.
+  - type: bug
+    category: regression
+    pull: 26884
+    authors:
+      - Anexus5919
+      - MarkEWaite
+    pr_title: Fix combobox and autocomplete dropdown selection beyond the
+      first item
+    message: |-
+      Fix the combobox suggestion list flashing and closing immediately when the field is clicked.
+  - type: rfe
+    category: rfe
+    pull: 26989
+    authors:
+      - Kevin-CB
+    pr_title: Update bundled script-security to 1402.1405
+    message: |-
+      Update bundled Script Security Plugin from 1402.v94c9ce464861 to 1402.1405.vc96e74964250.
+  - type: rfe
+    category: rfe
+    pull: 26883
+    authors:
+      - jtnord
+    pr_title: disabling sticky elements for a magic cookie
+    message: |-
+      Disable sticky elements when the <code>disableStickyPositioning</code> HTTP cookie is enabled (used in acceptance tests).
 
   lts_changes: # compared to lts_predecessor 2.555.3 (selected by personal review)
-    - type: rfe
-      category: rfe
-      pull: 26535
-      authors:
-        - mawinter69
-      pr_title: Use a dialog to add/edit the description of jobs, builds,
-        views, ...
-      message: |-
-        Use a dialog to add and edit the description of jobs, builds, views, computers, and more.
-    - type: rfe
-      category: rfe
-      pull: 26514
-      authors:
-        - janfaracik
-      pr_title: Refine dialogs
-      message: |-
-        Refine appearance of dialogs.
-    - type: rfe
-      category: rfe
-      pull: 26679
-      authors:
-        - janfaracik
-      pr_title: Refine Manage Jenkins' System page content
-      message: |-
-        Refine the 'System' page of Manage Jenkins.
-    - type: rfe
-      category: rfe
-      pull: 26475
-      authors:
-        - janfaracik
-        - timja
-      pr_title: Refine the 'Users' Manage Jenkins page
-      message: |-
-        Refine the 'Users' page of Manage Jenkins.
-    - type: rfe
-      category: rfe
-      pull: 26417
-      authors:
-        - mawinter69
-        - janfaracik
-        - timja
-      pr_title: Refine how administrative monitors are displayed
-      message: |-
-        Refine how administrative monitors are displayed.
-    - type: rfe
-      category: rfe
-      pull: 26392
-      authors:
-        - mawinter69
-      pr_title: Deduplicate build causes in queue tooltip and build overview
-      message: |-
-        Deduplicate build causes in queue tooltip and build overview.
-    - type: rfe
-      category: rfe
-      pull: 26797
-      authors:
-        - sghill
-      pr_title: Improve `Queue.maintain` performance by introducing cache for
-        `Util.isOverridden`
-      references:
-        - url: https://github.com/jenkinsci/jenkins/issues/26796
-          title: "issue 26796"
-        - pull: 26797
-      message: |-
-        Reduce agent creation time during high usage.
-    - type: rfe
-      category: rfe
-      pull: 26597
-      authors:
-        - bennettzhu1
-      pr_title: Add streamLoadedBuilds method to avoid full map copy in
-        getEstimatedDurationCandidates
-      message: |-
-        Improve queue maintenance performance for jobs with large build histories.
-    - type: rfe
-      category: rfe
-      authors:
-        - lemeurherve
-        - dduportal
-      pr_title: "add Windows Server 2025 image"
-      references:
-        - url: https://github.com/jenkinsci/docker/pull/2369
-          title: "pull 2369"
-      message: |-
-        Add Windows Server 2025 container image for the Jenkins controller.
-    - type: bug
-      category: bug
-      pull: 26564
-      authors:
-        - mawinter69
-      pr_title: Ensure constant number of td in queue widget
-      message: |-
-        Ensure cancel button for queued jobs doesn't move when other badges are present.
-    - type: bug
-      category: bug
-      pull: 26598
-      authors:
-        - janfaracik
-      pr_title: Remove lines from log recorder page
-      message: |-
-        Remove lines from log recorder page.
-    - type: bug
-      category: bug
-      pull: 26574
-      authors:
-        - Anexus5919
-      pr_title: 'fix: prevent long parameter values from overflowing the parameters
-        dialog'
-      message: |-
-        Wrap long, unbroken strings correctly within the maximum width of the dialog.
-    - type: bug
-      category: regression
-      pull: 26727
-      authors:
-        - Anexus5919
-      pr_title: Restore job name in run console and changes page titles
-      message: |-
-        Restore the job name in the page title on the build console and changes pages.
-    - type: bug
-      category: bug
-      pull: 26721
-      authors:
-        - mawinter69
-      pr_title: Ensure urls in widgets loaded via ajax are correct
-      message: |-
-        Ensure urls in widgets loaded via ajax are correct.
+  - type: rfe
+    category: rfe
+    pull: 26535
+    authors:
+      - mawinter69
+    pr_title: Use a dialog to add/edit the description of jobs, builds,
+      views, ...
+    message: |-
+      Use a dialog to add and edit the description of jobs, builds, views, computers, and more.
+  - type: rfe
+    category: rfe
+    pull: 26514
+    authors:
+      - janfaracik
+    pr_title: Refine dialogs
+    message: |-
+      Refine appearance of dialogs.
+  - type: rfe
+    category: rfe
+    pull: 26679
+    authors:
+      - janfaracik
+    pr_title: Refine Manage Jenkins' System page content
+    message: |-
+      Refine the 'System' page of Manage Jenkins.
+  - type: rfe
+    category: rfe
+    pull: 26475
+    authors:
+      - janfaracik
+      - timja
+    pr_title: Refine the 'Users' Manage Jenkins page
+    message: |-
+      Refine the 'Users' page of Manage Jenkins.
+  - type: rfe
+    category: rfe
+    pull: 26417
+    authors:
+      - mawinter69
+      - janfaracik
+      - timja
+    pr_title: Refine how administrative monitors are displayed
+    message: |-
+      Refine how administrative monitors are displayed.
+  - type: rfe
+    category: rfe
+    pull: 26392
+    authors:
+      - mawinter69
+    pr_title: Deduplicate build causes in queue tooltip and build overview
+    message: |-
+      Deduplicate build causes in queue tooltip and build overview.
+  - type: rfe
+    category: rfe
+    pull: 26797
+    authors:
+      - sghill
+    pr_title: Improve `Queue.maintain` performance by introducing cache for
+      `Util.isOverridden`
+    references:
+      - url: https://github.com/jenkinsci/jenkins/issues/26796
+        title: "issue 26796"
+      - pull: 26797
+    message: |-
+      Reduce agent creation time during high usage.
+  - type: rfe
+    category: rfe
+    pull: 26597
+    authors:
+      - bennettzhu1
+    pr_title: Add streamLoadedBuilds method to avoid full map copy in
+      getEstimatedDurationCandidates
+    message: |-
+      Improve queue maintenance performance for jobs with large build histories.
+  - type: rfe
+    category: rfe
+    authors:
+      - lemeurherve
+      - dduportal
+    pr_title: "add Windows Server 2025 image"
+    references:
+      - url: https://github.com/jenkinsci/docker/pull/2369
+        title: "pull 2369"
+    message: |-
+      Add Windows Server 2025 container image for the Jenkins controller.
+  - type: bug
+    category: bug
+    pull: 26564
+    authors:
+      - mawinter69
+    pr_title: Ensure constant number of td in queue widget
+    message: |-
+      Ensure cancel button for queued jobs doesn't move when other badges are present.
+  - type: bug
+    category: bug
+    pull: 26598
+    authors:
+      - janfaracik
+    pr_title: Remove lines from log recorder page
+    message: |-
+      Remove lines from log recorder page.
+  - type: bug
+    category: bug
+    pull: 26574
+    authors:
+      - Anexus5919
+    pr_title: 'fix: prevent long parameter values from overflowing the parameters
+      dialog'
+    message: |-
+      Wrap long, unbroken strings correctly within the maximum width of the dialog.
+  - type: bug
+    category: regression
+    pull: 26727
+    authors:
+      - Anexus5919
+    pr_title: Restore job name in run console and changes page titles
+    message: |-
+      Restore the job name in the page title on the build console and changes pages.
+  - type: bug
+    category: bug
+    pull: 26721
+    authors:
+      - mawinter69
+    pr_title: Ensure urls in widgets loaded via ajax are correct
+    message: |-
+      Ensure urls in widgets loaded via ajax are correct.
+
+- version: "2.568.2"
+  date: 2026-08-05
+  changes:
+  - type: bug
+    category: bug
+    pull: 27094
+    authors:
+      - mawinter69
+    pr_title: Fix NPE after Jenkins restart when UpstreamCause is a Pipeline
+      job
+    references:
+      - url: https://github.com/jenkinsci/jenkins/issues/26633
+        title: "issue 26633"
+      - pull: 27094
+    message: |-
+      Avoid null pointer exception showing the upstream cause of a job that was triggered by the <code>build</code> step in a pipeline prior to a Jenkins restart (regression in 2.558).
+  - type: bug
+    category: bug
+    pull: 27002
+    authors:
+      - janfaracik
+    pr_title: '[JENKINS-73906] Fix weird animation artifact when clicking "Apply"'
+    references:
+      - url: https://github.com/jenkinsci/jenkins/issues/16570
+        title: "issue 16570"
+      - pull: 27002
+    message: |-
+      Fix weird animation artifact when clicking "Apply".
+  - type: bug
+    category: bug
+    pull: 26554
+    authors:
+      - ridemountainpig
+      - MarkEWaite
+    pr_title: Fix build history tooltip being clipped by overflow hidden
+    references:
+      - url: https://github.com/jenkinsci/jenkins/issues/27000
+        title: "issue 27000"
+      - pull: 26554
+    message: |-
+      Fix build history tooltip being clipped by overflow hidden.
 
 # DO NOT EDIT THIS FILE DIRECTLY
 # ALL CHANGES MUST GO THROUGH PULL REQUESTS

--- a/content/_data/upgrades/2-568-2.adoc
+++ b/content/_data/upgrades/2-568-2.adoc
@@ -1,0 +1,1 @@
+No notable changes requiring upgrade notes.


### PR DESCRIPTION
### Tasks completed
1. Added LTS 2.568.2 Changelog and Upgrade Guide
2. Properly indent the contents for the LTS 2.568.1 Changelog

### Image of the LTS 2.568.2 Changelog
<img width="2862" height="2320" alt="screencapture-localhost-4242-changelog-2-568-2-2026-07-20-22_59_07" src="https://github.com/user-attachments/assets/78f310e0-f54d-44ac-8bd4-2d219e9035e7" />

### Image of the LTS 2.568.2 Upgrade Guide
<img width="2862" height="2578" alt="screencapture-localhost-4242-doc-upgrade-guide-2-568-2026-07-20-22_59_25" src="https://github.com/user-attachments/assets/69921caf-4da0-42b7-8b6e-c4fa9496a4b0" />
