### PR TITLE
Add banner and other refinements to 2.574 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30843,7 +30843,74 @@
 
   - version: '2.574'
     date: 2026-07-21
+    banner: >
+      <p>
+      The <a href="https://plugins.jenkins.io/junit/">JUnit</a>, <a href="https://plugins.jenkins.io/mailer/">Mailer</a>, <a href="https://plugins.jenkins.io/matrix-auth/">Matrix Authorization Strategy</a>, <a href="https://plugins.jenkins.io/matrix-project/">Matrix Project</a>, and <a href="https://plugins.jenkins.io/antisamy-markup-formatter/">OWASP Markup Formatter</a> plugins are no longer bundled inside jenkins.war, reducing its download size by more than 20 MB.
+      This functionality was split out of Jenkins core into these plugins in 2014 (Jenkins 1.577) or earlier. Copies were bundled in the war since then so that instances upgrading from such old versions would keep working.
+      <p>
+      Most instances are not affected.
+      If these plugins are already installed (they are among the plugins suggested by the setup wizard), or your instance was installed or last upgraded at any point in the last decade, nothing changes.
+      <p>
+      You are only affected if you upgrade an instance directly from Jenkins 1.577 or earlier, or if you install plugins built against Jenkins (then Hudson) 1.577 or earlier without using the Jenkins plugin manager.
+      In those cases Jenkins can no longer install these plugins automatically from the war.
+      If the update center is reachable, install the plugins through the plugin manager as usual.
+      On instances without access to the update center, download the plugin files and place them in the plugins directory of the Jenkins home directory before starting the new version.
+      <p>
+      When upgrading an instance from Jenkins 1.577 or earlier, install these five plugins before starting the new Jenkins version.
+      Configuration that depends on them, such as matrix-based security, matrix (multi-configuration) jobs, JUnit test result publishing, email notification settings, and markup formatter settings, cannot be loaded without them. Jenkins may fail to start (for example, if matrix-based security is your authorization strategy), and configuration that fails to load may be discarded the next time the affected item is saved.
+      Alternatively, upgrade in two steps: first to an intermediate version that still bundles these plugins (any LTS release before this change), let Jenkins install them automatically, then upgrade to the current version.
     changes:
+      - type: rfe
+        category: rfe
+        pull: 27098
+        authors:
+          - timja
+        pr_title: Remove pre 2.0 detached plugins
+        references:
+          - url: https://plugins.jenkins.io/junit/
+            title: JUnit Plugin
+          - url: https://plugins.jenkins.io/mailer/
+            title: Mailer Plugin
+          - url: https://plugins.jenkins.io/matrix-auth/
+            title: Matrix Authorization Strategy Plugin
+          - url: https://plugins.jenkins.io/matrix-project/
+            title: Matrix Project Plugin
+          - url: https://plugins.jenkins.io/antisamy-markup-formatter/
+            title: OWASP Markup Formatter Plugin
+          - url: https://plugins.jenkins.io/junit/
+            title: JUnit Plugin
+          - url: https://github.com/jenkinsci/jenkins/issues/26914
+            title: issue 26914
+          - pull: 27098
+        message: |-
+          Stop bundling the JUnit, Mailer, Matrix Authorization Strategy, Matrix Project, and OWASP Markup Formatter plugins, reducing the size of <code>jenkins.war</code> by more than 20 MB.
+          Jenkins no longer installs these plugins automatically when upgrading from Jenkins 1.577 or earlier, or when a plugin built against such an old version is discovered.
+          If you are affected, install these plugins through the plugin manager.
+      - type: rfe
+        category: rfe
+        pull: 27100
+        authors:
+          - timja
+        pr_title: Remove comments from properties and jelly files in shipped war
+        message: |-
+          Reduce size of Jenkins war by removing comments from translation files.
+      - type: rfe
+        category: rfe
+        pull: 27099
+        authors:
+          - timja
+        pr_title: Reduce size of war by excluding unused BC jar
+        message: |-
+          Reduce size of Jenkins war by removing unused CLI dependency.
+      - type: rfe
+        category: rfe
+        pull: 27046
+        authors:
+          - janfaracik
+        pr_title: Standardise Jenkins branding during Sign in, Registration, and
+          About Jenkins
+        message: |-
+          Standardise Jenkins branding during Sign in, Registration, and About Jenkins
       - type: rfe
         category: internal
         pull: 27038
@@ -30868,31 +30935,6 @@
           Clarify "Restrict where builds can run" help with an <code>||</code> example and explicit note that wildcards/regex are unsupported
       - type: rfe
         category: rfe
-        pull: 27100
-        authors:
-          - timja
-        pr_title: Remove comments from properties and jelly files in shipped war
-        message: |-
-          Reduce size of Jenkins war by removing comments from translation files.
-      - type: rfe
-        category: rfe
-        pull: 27098
-        authors:
-          - timja
-        pr_title: Remove pre 2.0 detached plugins
-        message: |-
-          Stop bundling the [JUnit](https://plugins.jenkins.io/junit/), [Mailer](https://plugins.jenkins.io/mailer/), [Matrix Authorization Strategy](https://plugins.jenkins.io/matrixauth/), [Matrix Project](https://plugins.jenkins.io/matrixproject/), and [OWASP Markup Formatter](https://plugins.jenkins.io/antisamymarkupformatter/) plugins, reducing the size of <code>jenkins.war</code> by more than 20 MB. Jenkins no longer installs these plugins automatically when upgrading from Jenkins 1.577 or earlier, or when a plugin built against such an old version is discovered. If you are affected, install these plugins through the plugin manager.
-      - type: rfe
-        category: rfe
-        pull: 27046
-        authors:
-          - janfaracik
-        pr_title: Standardise Jenkins branding during Sign in, Registration, and
-          About Jenkins
-        message: |-
-          Standardise Jenkins branding during Sign in, Registration, and About Jenkins
-      - type: rfe
-        category: rfe
         pull: 4904
         authors:
           - takashiharano
@@ -30901,21 +30943,14 @@
           Add Japanese translations for user configuration screen
       - type: rfe
         category: rfe
-        pull: 27099
-        authors:
-          - timja
-        pr_title: Reduce size of war by excluding unused BC jar
-        message: |-
-          Reduce size of war by removing unused CLI dependency.
-      - type: rfe
-        category: rfe
         pull: 26833
         authors:
           - annplatoworld
         pr_title: Make remember-me token validity configurable via system 
           property
         message: |-
-          Allow administrators to configure the rememberme ("Keep me signed in") cookie validity with the <code>hudson.security.TokenBasedRememberMeServices2.tokenValidity</code> system property capped 1 year.
+          Allow administrators to configure the remember-me ("Keep me signed in") cookie validity with the <code>hudson.security.TokenBasedRememberMeServices2.tokenValidity</code> system property.
+          The validity period is limited to 1 year.
       - type: rfe
         category: rfe
         pull: 27048
@@ -30925,7 +30960,16 @@
         pr_title: "[JENKINS-75134] Clarify unclear Spanish translation for 'Unprotected
           URLs' blurb"
         message: |-
-          humanreadable text
+          Clarify unclear Spanish translation for 'Unprotected URLs'.
+      - type: bug
+        category: bug
+        pull: 27094
+        authors:
+          - mawinter69
+        pr_title: Fix NPE after Jenkins restart when UpstreamCause is a Pipeline
+          job
+        message: |-
+          Avoid null pointer exception showing the upstream cause of a job that was triggered by the <code>build</code> step in a pipeline prior to a Jenkins restart (regression in 2.558).
       - type: bug
         category: regression
         pull: 27113
@@ -30943,15 +30987,6 @@
         pr_title: Fix PackedMap.values() returning keys instead of values
         message: |-
           Fix <code>PackedMap.values()</code> returning keys instead of values.
-      - type: bug
-        category: bug
-        pull: 27094
-        authors:
-          - mawinter69
-        pr_title: Fix NPE after Jenkins restart when UpstreamCause is a Pipeline
-          job
-        message: |-
-          Avoid null pointer exception showing the upstream cause of a job that was triggered by the <code>build</code> step in a pipeline prior to a Jenkins restart (regression in 2.558).
       - type: bug
         category: bug
         pull: 27090


### PR DESCRIPTION
## Add banner and other refinements to 2.574 changelog

Banner uses the upgrade guide text from pull request:

* https://github.com/jenkinsci/jenkins/pull/27098

Replace the "-" characters that are removed by changelog generator.  Noted in issue:

* https://github.com/jenkinsci/core-changelog-generator/issues/32

Repaired the changelog entry for the Spanish translation improvement

Reordered entries in a sequence that seemed logical to me.

## Testing done

* Reviewed the changelog from the generated site for accuracy and clarity
* Confirmed the hyperlinks work as expected

## Screenshot

<img width="1064" height="1211" alt="screencapture-mark-pc2-markwaite-net-4242-changelog-2-574-2026-07-21-04_35_45-edit" src="https://github.com/user-attachments/assets/5346e39b-3d00-4682-8447-e0203353bd89" />

