### PR TITLE
Page recognizing past officers and board members published

### DIFF
--- a/content/project/board.html.haml
+++ b/content/project/board.html.haml
@@ -68,3 +68,6 @@ structure the following individuals have been empowered with executive authority
   %li
     %a{:href => expand_link("/blog/2019/11/08/board-elections/")}
       2019 Board elections
+  %li
+    %a{:href => expand_link("/project/past-board")}
+      Past Board Members and Officers

--- a/content/project/past-board.html.haml
+++ b/content/project/past-board.html.haml
@@ -19,13 +19,15 @@ tags:
     ["markewaite", "2021/12/03", "2023/12/02"],
   ]
   past_officers = [
-    ["Release", "olivergondza", "2019/12/03", "2020/12/02"],
-    ["Security", "daniel-beck", "2019/12/03", "2021/12/02"],
+    ["Release", "olivergondza", "2016/03/30", "2020/12/02"],
+    ["Security", "daniel-beck", "2016/12/07", "2021/12/02"],
     ["Infrastructure", "olblak", "2019/12/03", "2021/12/02"],
-    ["Documentation", "markewaite", "2019/12/03", "2021/12/02"],
-    ["Events", "markyjackson-taulia", "2020/12/03", "2021/12/02"],
+    ["Documentation", "markewaite", "2019/12/03", "2022/12/02"],
+    ["Documentation", "kmartens27", "2022/12/03", "2025/12/02"],
+    ["Events", "markyjackson-taulia", "2020/12/03", "2021/03/09"],
     ["Events", "oleg_nenashev", "2021/03/10", "2021/12/02"],
-    ["Events", "alyssat", "2019/12/03", "2022/12/02"],
+    ["Events", "alyssat", "2016/12/03", "2020/12/02"],
+    ["Events", "alyssat", "2021/12/03", "2025/12/02"],
   ]
 
 %h2

--- a/content/project/past-board.html.haml
+++ b/content/project/past-board.html.haml
@@ -1,0 +1,54 @@
+---
+layout: simplepage
+title: "Past Jenkins Board and Officers"
+section: project
+tags:
+  - governance
+  - board
+---
+
+:ruby
+  past_board_members = [
+    ["rtyler", "2011", "2020/12/03"],
+    ["uhafner", "2019/12/03", "2021/12/02"],
+    ["slide_o_mix", "2019/12/03", "2021/12/02"],
+    ["ewelinawilkosz", "2020/03/10", "2022/12/02"],
+    ["halkeye", "2020/12/03", "2022/12/02"],
+    ["markyjackson-taulia", "2020/12/03", "2022/12/02"],
+    ["oleg_nenashev", "2019/12/03", "2023/12/02"],
+    ["markewaite", "2021/12/03", "2023/12/02"],
+  ]
+  past_officers = [
+    ["Release", "olivergondza", "2019/12/03", "2020/12/02"],
+    ["Security", "daniel-beck", "2019/12/03", "2021/12/02"],
+    ["Infrastructure", "olblak", "2019/12/03", "2021/12/02"],
+    ["Documentation", "markewaite", "2019/12/03", "2021/12/02"],
+    ["Events", "markyjackson-taulia", "2020/12/03", "2021/12/02"],
+    ["Events", "oleg_nenashev", "2021/03/10", "2021/12/02"],
+    ["Events", "alyssat", "2019/12/03", "2022/12/02"],
+  ]
+
+%h2
+  Founder
+
+%p
+  Kohsuke Kawaguchi is the creator of Jenkins and the project founder. He served on the Jenkins Governance Board from its inception until 2020.
+
+%div.app-authors
+  = partial("community-role-holder.html.haml", :author => "kohsuke", :term_begin => "2004", :term_end => "2020/01/31")
+
+%h2
+  Past board members
+
+%div.app-authors
+  - past_board_members.each do |member_id, term_begin, term_end|
+    = partial("community-role-holder.html.haml", :author => member_id, :term_begin => term_begin, :term_end => term_end)
+
+%h2
+  Past officers
+
+%div.app-authors
+  - past_officers.each do |officer_type, member_id, term_begin, term_end|
+    %h3
+      = officer_type
+    = partial("community-role-holder.html.haml", :author => member_id, :term_begin => term_begin, :term_end => term_end)


### PR DESCRIPTION
Fixes #9290 
### **Changes made:-**
In `/project/board `
new link added at the very bottom under the References section
<img width="1010" height="821" alt="image" src="https://github.com/user-attachments/assets/5e45322a-be09-4aed-8f0d-e5792f73213d" />
 Clicking that link takes you to the new page is created (`/project/past-board`), which contains the actual list of past members and acknowledges Kohsuke as the founder.