### PR TITLE
Replace 'humanreadable text' with PR description in 2.573 changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30776,7 +30776,7 @@
         pr_title: "[JENKINS-69789] Address review feedback for password complexity
           rule"
         message: |-
-          Move password complexity rule classes from <code>hudson.security</code> to <code>jenkins.security</code> package
+          Move password complexity rule classes from <code>hudson.security</code> to <code>jenkins.security</code> package.
       - type: rfe
         category: rfe
         pull: 27048
@@ -30786,7 +30786,7 @@
         pr_title: "[JENKINS-75134] Clarify unclear Spanish translation for 'Unprotected
           URLs' blurb"
         message: |-
-          humanreadable text
+          Clarify unclear Spanish translation for 'Unprotected URLs'.
       - type: major rfe
         category: rfe
         pull: 23904


### PR DESCRIPTION
## Replace 'humanreadable text' with PR description in 2.573 changelog

Minor update to 2.573 changelog.

## Before screenshot

<img width="1064" height="375" alt="before-the-change" src="https://github.com/user-attachments/assets/71f42b49-ab22-413e-afce-931d1c0e5498" />

## After screenshot

<img width="1064" height="378" alt="after-the-change" src="https://github.com/user-attachments/assets/80a4eead-0577-4be2-98b8-978f1c56dbab" />
