### PR TITLE
Update version from 2.575 to 2.576 in changelog

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -31054,7 +31054,7 @@
   # pull: 27149 (PR title: Lock file maintenance)
   # pull: 27150 (PR title: Update dependency sass to v1.102.0)
 
-  - version: '2.575'
+  - version: '2.576'
     date: 2026-08-05
     changes:
       - type: security


### PR DESCRIPTION
Closes https://github.com/jenkinsci/jenkins/issues/27203

Currently: https://www.jenkins.io/changelog/
> <img width="1073" height="380" alt="image" src="https://github.com/user-attachments/assets/8ee867c8-6318-471d-9c25-812ab56f0c4a" />

Ref:
- https://github.com/jenkinsci/jenkins/issues/27203
