### PR TITLE
Remove office hours mention from JCasC page

### DIFF
--- a/content/projects/jcasc/index.adoc
+++ b/content/projects/jcasc/index.adoc
@@ -44,20 +44,7 @@ Fully working Jenkins controller with:
 * The link:https://github.com/jenkinsci/configuration-as-code-plugin[source code]
 * Feature requests, bugs and so on are currently tracked via the github link:https://github.com/jenkinsci/configuration-as-code-plugin/issues[issue tracker]
 
-=== Office Hours meeting
+[#CommunityBridge]
+==== Crowdfunding
 
-The purpose of JCasC Office Hours meeting is to discuss current issues but also short and long term future of the plugin
-
-==== Time and location
-The meeting takes place on Wednesdays, 9am (UTC+1) every two weeks. 
-
-Meetings will be announced at link:/event-calendar/[*Event Calendar*]
-
-Hangouts On Air is used to host and stream the meeting on link:https://www.youtube.com/channel/UC5JBtmoz7ePk-33ZHimGiDQ[*Jenkins Youtube channel*].
-Link to the actual meeting is always shared a few minutes before the meeting in the link:++https://app.gitter.im/#/room/#jenkinsci_configuration-as-code-plugin:gitter.im++[*configuration-as-code-plugin*] gitter channel
-
-link:https://docs.google.com/document/d/1Hm07Q1egWL6VVAqNgu27bcMnqNZhYJmXKRvknVw4Y84/edit?usp=sharing[*Minutes of Meeting*] are available for everyone interested
-
-==== CommunityBridge
-
-link:dev-tools[JCasC development tools improvement] is a funded CommunityBridge project to improve the experience of administrators and developers creating and maintaining JCasC YAML files. 
+The link:dev-tools[JCasC development tools improvement project] was funded in 2019 through link:https://crowdfunding.linuxfoundation.org/initiatives/jenkins[LFX Crowdfunding] (formerly CommunityBridge) to improve the experience of administrators and developers creating and maintaining JCasC YAML files.


### PR DESCRIPTION
## Remove office hours mention from JCasC page

Configuration as Code office hours have not been held for many years.
