### PR TITLE
Add 2.577 banner for removal of more bundled plugins

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -30339,7 +30339,7 @@
   # pull: 26830 (PR title: Update stapler.version to v2088)
 
   - version: '2.567'
-    date: 2026-05-30
+    date: 2026-06-02
     changes:
       - type: bug
         category: bug
@@ -30372,7 +30372,7 @@
             title: security advisory
 
   - version: '2.569'
-    date: 2026-06-15
+    date: 2026-06-16
     banner: >
       <strong>Windows 2019 controller images</strong> have been dropped from this
       release, and the next LTS release line will not include them either.
@@ -30597,7 +30597,7 @@
   # pull: 26973 (PR title: Update babel monorepo to v8.0.2)
 
   - version: '2.571'
-    date: 2026-06-29
+    date: 2026-06-30
     changes:
       - type: rfe
         category: rfe
@@ -30669,7 +30669,7 @@
   # pull: 26998 (PR title: Update dawidd6/action-send-mail action to v18)
 
   - version: '2.572'
-    date: 2026-07-06
+    date: 2026-07-07
     changes:
       - type: rfe
         category: rfe
@@ -31064,7 +31064,27 @@
             title: security advisory
 
   - version: '2.577'
-    date: 2026-08-10
+    date: 2026-08-11
+    banner: >
+      <p>
+      The <a href="https://plugins.jenkins.io/bouncycastle-api/">bouncycastle API</a>,
+      <a href="https://plugins.jenkins.io/command-launcher/">Command Agent Launcher</a>,
+      <a href="https://plugins.jenkins.io/jdk-tool/">Oracle Java SE Development Kit Installer</a>,
+      <a href="https://plugins.jenkins.io/jaxb/">JAXB</a>,
+      <a href="https://plugins.jenkins.io/trilead-api/">Trilead API</a>,
+      <a href="https://plugins.jenkins.io/sshd/">SSH server</a>,
+      <a href="https://plugins.jenkins.io/javax-activation-api/">JavaBeans Activation Framework (JAF) API</a>,
+      <a href="https://plugins.jenkins.io/javax-mail-api/">JavaMail API</a>, and
+      <a href="">Instance Identity plugins</a> are no longer bundled inside jenkins.war, reducing its download size by more than 20 MB.
+      This functionality was split out of Jenkins core into these plugins between 2016 and 2022 (Jenkins 2.16 through 2.356).
+      Copies were bundled in the war since then so that instances upgrading from such old versions, or plugins built against them, would keep working.
+      <p>
+      Most instances are not affected.
+      If the update center is reachable, Jenkins resolves and installs these plugins automatically over the network whenever something needs them, the same way it would for any other missing dependency, regardless of which Jenkins version you're running.
+      <p>
+      You are only affected if your instance has no access to the update center.
+      In that case, upgrading core past one of the versions above, or installing a plugin built against an old baseline, can no longer pull these plugins in automatically.
+      Download the plugin files from the update center and place them in the plugins directory of the Jenkins home directory before starting the new version, or before installing the plugin that needs them.
     changes:
       - type: rfe
         category: developer
@@ -31091,7 +31111,7 @@
           - timja
         pr_title: Remove remaining detached-plugin bundling from jenkins.war
         message: |-
-          Stop bundling the [bouncycastle API](https://plugins.jenkins.io/bouncycastleapi/), [Command Agent Launcher](https://plugins.jenkins.io/commandlauncher/), [Oracle Java SE Development Kit Installer](https://plugins.jenkins.io/jdktool/), [JAXB](https://plugins.jenkins.io/jaxb/), [Trilead API](https://plugins.jenkins.io/trileadapi/), [SSH server](https://plugins.jenkins.io/sshd/), [JavaBeans Activation Framework (JAF) API](https://plugins.jenkins.io/javaxactivationapi/), [JavaMail API](https://plugins.jenkins.io/javaxmailapi/), and [Instance Identity](https://plugins.jenkins.io/instanceidentity/) plugins, reducing the size of <code>jenkins.war</code> by more than 20 MB. Jenkins no longer installs these plugins automatically when upgrading from Jenkins 2.356 or earlier, or when a plugin built against such an old version is discovered. If you are affected, install these plugins through the plugin manager.
+          Stop bundling the bouncycastle API, Command Agent Launcher, Oracle Java SE Development Kit Installer, JAXB, Trilead API, SSH server, JavaBeans Activation Framework (JAF) API, JavaMail API, and Instance Identity plugins, reducing the size of <code>jenkins.war</code> by more than 20 MB. Jenkins no longer installs these plugins automatically when upgrading from Jenkins 2.356 or earlier, or when a plugin built against such an old version is discovered. If you are affected, install these plugins through the plugin manager.
 
   # pull: 27029 (PR title: Fix hover area overlap for console and upstream hyperlinks)
   # pull: 27152 (PR title: Update dependency com.puppycrawl.tools:checkstyle to v13.9.0)


### PR DESCRIPTION
## Add 2.577 banner for removal of more bundled plugins

Follows the same pattern that we used for Jenkins 2.574.  The banner includes the proposed text for the LTS upgrade guide.

Also corrects the release dates of several recent releases.

<img width="1219" height="888" alt="Screenshot 2026-08-11 043237" src="https://github.com/user-attachments/assets/19fc599b-509b-4932-97ca-cd6474ce3f7f" />

