### PR TITLE
Place major enhancement at the top of the changelog page

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -31086,15 +31086,6 @@
       In that case, upgrading core past one of the versions above, or installing a plugin built against an old baseline, can no longer pull these plugins in automatically.
       Download the plugin files from the update center and place them in the plugins directory of the Jenkins home directory before starting the new version, or before installing the plugin that needs them.
     changes:
-      - type: rfe
-        category: developer
-        pull: 27165
-        authors:
-          - thswlsqls
-        pr_title: Correct Javadoc for QuotedStringTokenizer.quote(String) to 
-          reflect unconditional quoting
-        message: |-
-          Correct Javadoc for <code>QuotedStringTokenizer.quote(String)</code> to reflect its unconditional quoting
       - type: major rfe
         category: major rfe
         pull: 26863
@@ -31111,7 +31102,9 @@
           - timja
         pr_title: Remove remaining detached-plugin bundling from jenkins.war
         message: |-
-          Stop bundling the bouncycastle API, Command Agent Launcher, Oracle Java SE Development Kit Installer, JAXB, Trilead API, SSH server, JavaBeans Activation Framework (JAF) API, JavaMail API, and Instance Identity plugins, reducing the size of <code>jenkins.war</code> by more than 20 MB. Jenkins no longer installs these plugins automatically when upgrading from Jenkins 2.356 or earlier, or when a plugin built against such an old version is discovered. If you are affected, install these plugins through the plugin manager.
+          Stop bundling the bouncycastle API, Command Agent Launcher, Oracle Java SE Development Kit Installer, JAXB, Trilead API, SSH server, JavaBeans Activation Framework (JAF) API, JavaMail API, and Instance Identity plugins, reducing the size of <code>jenkins.war</code> by more than 20 MB.
+          Jenkins no longer installs these plugins automatically when upgrading from Jenkins 2.356 or earlier, or when a plugin built against such an old version is discovered.
+          If you are affected, install these plugins through the plugin manager.
 
   # pull: 27029 (PR title: Fix hover area overlap for console and upstream hyperlinks)
   # pull: 27152 (PR title: Update dependency com.puppycrawl.tools:checkstyle to v13.9.0)
@@ -31119,6 +31112,7 @@
   # pull: 27161 (PR title: Add more to quick-build, remove cleaning node_modules)
   # pull: 27162 (PR title: List annotation processors explicitly)
   # pull: 27163 (PR title: Enable build caching using develocity)
+  # pull: 27165 (PR title: Correct Javadoc for QuotedStringTokenizer.quote(String) to reflect unconditional quoting)
   # pull: 27169 (PR title: Update dependency com.github.eirslett:frontend-maven-plugin to v2.0.2)
   # pull: 27170 (PR title: Update dependency commons-codec:commons-codec to v1.22.1)
   # pull: 27171 (PR title: Update dependency postcss to v8.5.25 - autoclosed)


### PR DESCRIPTION
## Place major enhancement at the top of the changelog page

Also removes the Javadoc entry, since that is not visible to users.
