### PR TITLE
Document slower response times

### DIFF
--- a/content/security/for-maintainers.adoc
+++ b/content/security/for-maintainers.adoc
@@ -113,6 +113,9 @@ The following is a rough approximation of the typical recommended lifecycle of a
   The source code is pushed to the public GitHub repository.
   The issue in the issue tracker is closed.
 
+WARNING: Due to an increased number of reports since early 2026, processing of reports and followup messages is currently delayed.
+Please allow additional time for the security team to respond to your messages, and do not send multiple messages about the same issue.
+
 
 // TODO == Deciding For or Against Staging
 

--- a/content/security/index.adoc
+++ b/content/security/index.adoc
@@ -47,6 +47,8 @@ We provide issue reporting guidelines and an overview of our process on link:rep
 If you are unable to report using our issue tracker, you can also send your report to the private Jenkins Security Team mailing list:
 `jenkinsci-cert@googlegroups.com`
 
+WARNING: Due to an increased number of reports since early 2026, processing of reports is currently delayed.
+
 NOTE: From late 2025 to late 2026, a bug bounty program accepts reports of security vulnerabilities in Jenkins core, components, and some plugins.
 For more details please see link:/blog/2025/12/10/jenkins-bug-bounty-program-yeswehack-european-commission/[the announcement blog post] and link:https://yeswehack.com/programs/jenkins-bug-bounty-program/[the program on YesWeHack].
 

--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -105,6 +105,11 @@ The following behaviors/issues are not vulnerabilities in Jenkins project infras
 Once reported, the Jenkins security team will perform an evaluation of the issue to determine affected components and whether the report is a valid security vulnerability.
 We endeavour to respond to all reports within three working days (Mon-Fri), with typical response times within one working day.
 
+[WARNING]
+====
+Due to an increased number of reports since early 2026, processing of reports is currently delayed. We endeavour to respond within a week if your report concerns Jenkins core, core components, or plugins installed on 10+% of Jenkins controllers as reported on plugins.jenkins.io, within two weeks for plugins installed on 1-10% of controllers, and within four weeks for plugins installed on <1% of controllers.
+====
+
 Please note that we may choose to reject issues as security vulnerabilities while still tracking them in the SECURITY project.
 In those cases, the issue type will be changed accordingly.
 
@@ -130,10 +135,23 @@ Please let us know in advance if your issue report is subject to a coordinated d
 This allows us to schedule the fix well in advance and ensure a high quality of the fix.
 For example, Jenkins core is on a monthly release cadence with several weeks of testing for each release, so we would like to know well in advance when a fix is due.
 
+[WARNING]
+====
+Due to an increased number of reports since early 2026, processing of reports is currently delayed.
+We aim to honor coordinated disclosure deadlines no shorter than the following:
+
+* For core, core components, and plugins installed on 10+% of Jenkins controllers as reported on plugins.jenkins.io: 90 days.
+* For plugins installed on 1-10% of controllers: 120 days.
+* For plugins installed on <1% of controllers: 180 days.
+
+Thanks for your understanding.
+====
 
 == Attribution Policy
 
 Reporters who privately disclosed security vulnerabilities may request to be credited in our security advisories.
+We will only credit the first reporter of an issue by default.
+Additional reporters may be credited at our discretion, e.g., if they contribute substantial new information.
 
 Attribution text (e.g., name, affiliation, GitHub or social media user name) must:
 
@@ -144,8 +162,6 @@ URLs or email addresses can be included, but will not be hyperlinked.
 
 We reserve the right to edit or reject any attribution.
 
-As an exception to the above, if a vulnerability is reported through a bug bounty program, we will only credit the first reporter of the issue.
-Additional reporters may be credited at our discretion, e.g., if they contribute substantial new information.
 
 == Bug bounty / Reward / Gift
 


### PR DESCRIPTION
We received more reports in the last 60 days than in either of the previous years (>5x increase), and it's not slowing down. This is consistent with reporting elsewhere about additional load generated by LLM-empowered reporters. This is consistent with us also receiving several issues reported multiple times.

This PR:

* declares new (hopefully temporary) slow response times for initial messages, maintainer assistance,
* pre-emptively rejects the usual coordinated disclosure deadline of 90 days for niche plugins, and
* makes not crediting reporters of duplicates the default policy (with an exception if substantial new information is provided).