### PR TITLE
Remove lapsed domain

### DIFF
--- a/content/_data/authors/rtyler.adoc
+++ b/content/_data/authors/rtyler.adoc
@@ -2,7 +2,6 @@
 name: "R. Tyler Croy"
 twitter: agentdero
 github: rtyler
-blog: 'http://unethicalblogger.com'
 ---
 
 R&#46; Tyler Croy has been part of the Jenkins project for the past seven years.


### PR DESCRIPTION
He now blogs at brokenco.de, but let's leave it up to him whether to point there from jenkins.io.