### PR TITLE
Update Managing Security documentation

### DIFF
--- a/content/doc/book/security/managing-security.adoc
+++ b/content/doc/book/security/managing-security.adoc
@@ -27,53 +27,23 @@ high-powered servers connected to the public internet. To safely support this
 wide spread of security and threat profiles, Jenkins offers many configuration
 options for enabling, editing, or disabling various security features.
 
-As of Jenkins 2.0, many of the security options were enabled by default to
-ensure that Jenkins environments remained secure unless an administrator
-explicitly disabled certain protections.
-
 This section will introduce the various security options available to a Jenkins
 administrator, explaining the protections offered, and trade-offs to disabling
 some of them.
 
 
-== Enabling Security
+== Configuring Security
 
-Beginning with Jenkins 2.214 and Jenkins LTS 2.222.1, the "Enable Security" checkbox has been removed.
-Jenkins own user database is used as the default security realm.
+Jenkins is installed with some basic security provisions. Users can log in with a username and password in order to perform operations not available to anonymous users. By default, logged-in users have full access to all Jenkins functionality and are managed using the "Jenkins own user database" security realm. The default configuration also includes protections against many common threats.
 
-In versions before Jenkins 2.214 and Jenkins LTS 2.222.1, when the *Enable Security* checkbox is checked,
-users can log in with a username and password in order to
-perform operations not available to anonymous users. Which operations require
-users to log in depends on the chosen authorization strategy and its configuration;
-by default anonymous users have no permissions, and logged in users have full
-control. The "Enable Security" checkbox should *always* be enabled for any non-local (test) Jenkins
-environment.
-
-The "Security" section of the web UI allows a Jenkins administrator to
+The "Configure Global Security" section of the web UI allows a Jenkins administrator to
 enable, configure, or disable key security features which apply to the entire
 Jenkins environment.
 
 image::security/configure-global-security.png["Security", role=center]
 
-=== TCP Port
 
-Jenkins can use a TCP port to communicate with inbound (formerly known as “JNLP”) agents,
-such as Windows-based agents.
-As of Jenkins 2.0, by default this port is disabled.
-
-For administrators wishing to use inbound TCP agents, the two port options are:
-
-
-. *Random*: The TCP port is chosen at random to avoid collisions on the Jenkins <<../glossary#controller,controller>>.
-  The downside to randomized ports is that they are chosen during the boot of the Jenkins controller,
-  making it difficult to manage firewall rules allowing TCP traffic.
-. *Fixed*: The port is chosen by the Jenkins administrator and is consistent across reboots of the Jenkins controller.
-  This makes it easier to manage firewall rules allowing TCP-based agents to connect to the controller.
-
-As of Jenkins 2.217, inbound agents may instead be configured to use WebSocket transport to connect to Jenkins.
-In this case no extra TCP port need be enabled and no special security configuration is needed.
-
-=== Access Control
+=== Authentication
 
 Access Control is the primary mechanism for securing a Jenkins environment
 against unauthorized usage. Two facets of configuration are necessary for
@@ -211,6 +181,24 @@ granted to "kohsuke", "developers", "administrators", "authenticated", and
 === Markup Formatter
 
 See link:/doc/book/security/markup-formatter/[Markup Formatter].
+
+=== TCP Port
+
+Jenkins can use a TCP port to communicate with inbound (formerly known as “JNLP”) agents,
+such as Windows-based agents.
+As of Jenkins 2.0, by default this port is disabled.
+
+For administrators wishing to use inbound TCP agents, the two port options are:
+
+
+. *Random*: The TCP port is chosen at random to avoid collisions on the Jenkins <<../glossary#controller,controller>>.
+  The downside to randomized ports is that they are chosen during the boot of the Jenkins controller,
+  making it difficult to manage firewall rules allowing TCP traffic.
+. *Fixed*: The port is chosen by the Jenkins administrator and is consistent across reboots of the Jenkins controller.
+  This makes it easier to manage firewall rules allowing TCP-based agents to connect to the controller.
+
+As of Jenkins 2.217, inbound agents may instead be configured to use WebSocket transport to connect to Jenkins.
+In this case no extra TCP port need be enabled and no special security configuration is needed.
 
 
 == CSRF Protection


### PR DESCRIPTION
## Description

Updates the Managing Security documentation as requested in #8374.

- Removes outdated Jenkins 2.0 history from the introduction
- Renames "Enabling Security" to "Configuring Security"
- Updates the security introduction
- Renames "Access Control" to "Authentication"
- Updates the "Configure Global Security" wording
- Reorders the security configuration sections

Closes #8374