### PR TITLE
Clarify which Jira component these categories map to

### DIFF
--- a/content/security/reporting.adoc
+++ b/content/security/reporting.adoc
@@ -28,10 +28,15 @@ NOTE: We are currently running a Bug Bounty Program (November 2025 – November 
 
 Please report issues present in the following components:
 
-* Jenkins, including installers and Docker images published by the Jenkins project
-* Jenkins plugins published by the Jenkins project (listed on https://plugins.jenkins.io/[plugins.jenkins.io] and/or hosted in https://github.com/jenkinsci[the jenkinsci GitHub organization])
-* Additional components published by the Jenkins project for general use, such as Docker images for Jenkins agents
-* Jenkins infrastructure projects, such as link:/[jenkins.io] or more generally the repositories hosted in the https://github.com/jenkins-infra[jenkins-infra GitHub organization]
+* Jenkins, including installers and Docker images published by the Jenkins project.
+  In Jira, use the `core` or `packaging` component, as applicable.
+* Jenkins plugins published by the Jenkins project (listed on https://plugins.jenkins.io/[plugins.jenkins.io] and/or hosted in https://github.com/jenkinsci[the jenkinsci GitHub organization]).
+  In Jira, use the `specific-plugin` component and specify the plugin name or ID in the issue summary.
+  Please do not bundle issues in multiple plugins into a single issue, as this prevents assigning the issue to the correct maintainer.
+* Additional components published by the Jenkins project for general use, such as Docker images for Jenkins agents.
+  In Jira, use the `other` component.
+* Jenkins infrastructure projects, such as link:/[jenkins.io] or more generally the repositories hosted in the https://github.com/jenkins-infra[jenkins-infra GitHub organization].
+  In Jira, use the `infra` component.
 
 
 The following components are out of scope:


### PR DESCRIPTION
Someone recently informed us they were unable to figure out how to report a plugin issue in Jira, because there was no component for it.

This hopefully makes that clearer.

There is one other component, `multiple-plugins`, but it's probably never the correct choice for someone external to the team.