### PR TITLE
Add banner to 2.579 changelog for Commons Lang 2 and Windows Server 2019

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -31157,8 +31157,39 @@
     changes: []
   - version: '2.579'
     date: 2026-08-23
+    banner: >
+      <strong>Apache Commons Lang 2 removed from Jenkins core</strong>
+      <p>The Apache Commons Lang 2.6 library has been removed from Jenkins core.
+      The Apache project last released Commons Lang 2.6 on January 16, 2011.
+      The 2.x line is no longer maintained and includes known vulnerabilities that trigger software content analysis security scanners.
+      <p>Many Jenkins plugins previously relied on Jenkins core to provide this library rather than declaring it as their own dependency.
+      New releases have been published for most affected plugins that now provide their own dependency or otherwise no longer require Apache Commons Lang 2.
+      Pull requests have been submitted for other plugins so that they no longer require Apache Commons Lang 2.
+      Plugin that used Apache Commons Lang 2 are listed in the <a href="https://docs.google.com/spreadsheets/d/1dM2Sa90n-O47T3bWMqVyOJlaSyYALZqJLIZkg1_-Wk0/edit?usp=sharing">tracking spreadsheet</a>.
+      <p>Before upgrading Jenkins, upgrade your installed plugins to their most recent releases.
+      In particular, make sure that plugins that previously depended on Commons Lang 2 have been updated.
+      An outdated plugin may fail to load or may not function correctly after upgrading Jenkins because the Apache Commons Lang 2 classes are no longer provided by Jenkins core.
+      <p>Jenkins plugin developers should ensure that plugins do not rely on Commons Lang 2 being provided by Jenkins core.
+      The Jenkins plugin <a href="https://github.com/jenkinsci/plugin-pom/pull/1338">build tooling</a> can help prevent new dependencies on Commons Lang 2.
+      <p><strong>Windows Server 2019 agent container images dropped</strong>
+      <p>Container images (<code>jenkins/inbound-agent</code> and <code>jenkins/ssh-agent</code>) are no longer provided for Windows Server 2019.
+      Users with Windows Server 2019 container agents may either:
+      <ul>
+      <li>Upgrade to Windows Server 2022</li>
+      <li>Upgrade to Windows Server 2025</li>
+      <li>Build their own agent container image for Windows Server 2019</li>
+      </ul>
     changes:
-      - type: rfe
+      - type: major bug
+        category: major bug
+        pull: 27265
+        authors:
+          - gbhat618
+        pr_title: Revert "Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky (#26863)"
+        message: |-
+          Revert "Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky".
+      - type: major rfe
+        category: major rfe
         category: developer
         pull: 26105
         authors:
@@ -31169,15 +31200,6 @@
         pr_title: Removes commons-lang:2.6 from core
         message: |-
           Remove Apache Commons Lang 2 library.
-      - type: major rfe
-        category: major rfe
-        pull: 26863
-        authors:
-          - janfaracik
-        pr_title: Standardise experimental Jenkins pages, make the side panel 
-          independently scrollable + make the build bar sticky
-        message: |-
-          Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky
       - type: rfe
         category: rfe
         pull: 26595
@@ -31197,7 +31219,7 @@
         pr_title: Retrying renamedTo operation up to 5 times because it randomly
           fails …
         message: |-
-          Made tool installations more tolerant for slow file systems.
+          Make tool installations more tolerant of slow file systems.
       - type: bug
         category: bug
         pull: 26467
@@ -31207,7 +31229,7 @@
         pr_title: Fix incorrect Unicode escape decoding in 
           QuotedStringTokenizer.unquote
         message: |-
-          Fix decoding of quoted Unicode escape sequences in label parsing
+          Fix decoding of quoted Unicode escape sequences in label parsing.
       - type: bug
         category: bug
         pull: 27228
@@ -31217,7 +31239,7 @@
         pr_title: Show only accessible links in sidepanel for new manage Jenkins
           UI
         message: |-
-          Show only accessible links in sidepanel for new manage Jenkins UI
+          Show only accessible links in sidepanel for new manage Jenkins UI.
       - type: bug
         category: bug
         pull: 27201


### PR DESCRIPTION
## Add banner to 2.579 changelog for Commons Lang 2 and Windows Server 2019

Refer to the 2.568.3 upgrade guide for similar comments for Windows Server 2019 agent container images.

* https://github.com/jenkins-infra/jenkins.io/pull/9367

Refer to the Apache Commons Lang 2.6 pull request for its upgrade guide:

* https://github.com/jenkinsci/jenkins/pull/26105

## Testing done

* Confirmed that the page looks as expected with `make run`

## Screenshot

<img width="1074" height="1167" alt="screencapture-mark-pc2-markwaite-net-4242-changelog-2-579-2026-08-25-06_47_26-edit" src="https://github.com/user-attachments/assets/4bfd737a-0e63-43ef-a201-c92060aea276" />
