### PR TITLE
fix: fix duplicate categories for 26105 in weekly.yml

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -31188,8 +31188,7 @@
         pr_title: Revert "Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky (#26863)"
         message: |-
           Revert "Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky".
-      - type: major rfe
-        category: major rfe
+      - type: rfe
         category: developer
         pull: 26105
         authors:


### PR DESCRIPTION
Remove duplicated categories for pull request 26105 to prevent weekly.yml file from being wiped by Changelog Drafter. 