### PR TITLE
Format Jenkins 2.579 changelog banner to match automated formatting

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -31161,18 +31161,30 @@
       <strong>Apache Commons Lang 2 removed from Jenkins core</strong>
       <p>The Apache Commons Lang 2.6 library has been removed from Jenkins core.
       The Apache project last released Commons Lang 2.6 on January 16, 2011.
-      The 2.x line is no longer maintained and includes known vulnerabilities that trigger software content analysis security scanners.
-      <p>Many Jenkins plugins previously relied on Jenkins core to provide this library rather than declaring it as their own dependency.
-      New releases have been published for most affected plugins that now provide their own dependency or otherwise no longer require Apache Commons Lang 2.
-      Pull requests have been submitted for other plugins so that they no longer require Apache Commons Lang 2.
-      Plugin that used Apache Commons Lang 2 are listed in the <a href="https://docs.google.com/spreadsheets/d/1dM2Sa90n-O47T3bWMqVyOJlaSyYALZqJLIZkg1_-Wk0/edit?usp=sharing">tracking spreadsheet</a>.
-      <p>Before upgrading Jenkins, upgrade your installed plugins to their most recent releases.
-      In particular, make sure that plugins that previously depended on Commons Lang 2 have been updated.
-      An outdated plugin may fail to load or may not function correctly after upgrading Jenkins because the Apache Commons Lang 2 classes are no longer provided by Jenkins core.
-      <p>Jenkins plugin developers should ensure that plugins do not rely on Commons Lang 2 being provided by Jenkins core.
-      The Jenkins plugin <a href="https://github.com/jenkinsci/plugin-pom/pull/1338">build tooling</a> can help prevent new dependencies on Commons Lang 2.
+      The 2.x line is no longer maintained and includes known vulnerabilities that
+      trigger software content analysis security scanners.
+      <p>Many Jenkins plugins previously relied on Jenkins core to provide this library
+      rather than declaring it as their own dependency.
+      New releases have been published for most affected plugins that now provide
+      their own dependency or otherwise no longer require Apache Commons Lang 2.
+      Pull requests have been submitted for other plugins so that they no longer require
+      Apache Commons Lang 2.
+      Plugin that used Apache Commons Lang 2 are listed in the <a href="https://docs.google.com/spreadsheets/d/1dM2Sa90n-O47T3bWMqVyOJlaSyYALZqJLIZkg1_-Wk0/edit?usp=sharing">tracking
+      spreadsheet</a>.
+      <p>Before upgrading Jenkins, upgrade your installed plugins to their most recent
+      releases.
+      In particular, make sure that plugins that previously depended on Commons Lang
+      2 have been updated.
+      An outdated plugin may fail to load or may not function correctly after upgrading
+      Jenkins because the Apache Commons Lang 2 classes are no longer provided by
+      Jenkins core.
+      <p>Jenkins plugin developers should ensure that plugins do not rely on Commons
+      Lang 2 being provided by Jenkins core.
+      The Jenkins plugin <a href="https://github.com/jenkinsci/plugin-pom/pull/1338">build
+      tooling</a> can help prevent new dependencies on Commons Lang 2.
       <p><strong>Windows Server 2019 agent container images dropped</strong>
-      <p>Container images (<code>jenkins/inbound-agent</code> and <code>jenkins/ssh-agent</code>) are no longer provided for Windows Server 2019.
+      <p>Container images (<code>jenkins/inbound-agent</code> and <code>jenkins/ssh-agent</code>)
+      are no longer provided for Windows Server 2019.
       Users with Windows Server 2019 container agents may either:
       <ul>
       <li>Upgrade to Windows Server 2022</li>
@@ -31185,7 +31197,8 @@
         pull: 27265
         authors:
           - gbhat618
-        pr_title: Revert "Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky (#26863)"
+        pr_title: Revert "Standardise experimental Jenkins pages, make the side 
+          panel independently scrollable + make the build bar sticky (#26863)"
         message: |-
           Revert "Standardise experimental Jenkins pages, make the side panel independently scrollable + make the build bar sticky".
       - type: rfe


### PR DESCRIPTION
## Format Jenkins 2.579 banner to match automated formatting

The original banner text was formatted as sentence per line.  The automated formatter wraps in order to avoid long lines.
