### PR TITLE
Add non-empty link to instance identity plugin

### DIFF
--- a/content/_data/changelogs/weekly.yml
+++ b/content/_data/changelogs/weekly.yml
@@ -31077,7 +31077,7 @@
       <a href="https://plugins.jenkins.io/javax-activation-api/">JavaBeans Activation
       Framework (JAF) API</a>,
       <a href="https://plugins.jenkins.io/javax-mail-api/">JavaMail API</a>, and
-      <a href="">Instance Identity plugins</a> are no longer bundled inside jenkins.war,
+      <a href="https://plugins.jenkins.io/instance-identity/">Instance Identity plugins</a> are no longer bundled inside jenkins.war,
       reducing its download size by more than 20 MB.
       This functionality was split out of Jenkins core into these plugins between
       2016 and 2022 (Jenkins 2.16 through 2.356).


### PR DESCRIPTION
## Add non-empty link to instance identity plugin

Banner on weekly changelog has links to all the other plugins, just not the instance identity plugin.

Corrects pull request:

* https://github.com/jenkins-infra/jenkins.io/pull/9328
