### PR TITLE
Clarify CDF and Jenkins project involvement in meetups

### DIFF
--- a/content/projects/jam/index.adoc
+++ b/content/projects/jam/index.adoc
@@ -12,7 +12,7 @@ tags:
 CI/CD Meetups and Jenkins Area Meetups (JAMs) are local meetups intended to bring CI/CD users and contributors together for socializing and learning.
 These are organized by local community members who have a passion for sharing experiences about new CI/CD concepts, patterns and tools.
 All topics about Jenkins are welcome: using Jenkins, case studies, success and war stories, development and the community.
-We invite everyone who is interested in other CI/CD projects such as Spinnaker, Tekton, and JayeX to join our network.
+We invite everyone who is interested in other CI/CD projects such as link:https://cdevents.dev/[CDEvents], link:https://jayex.io/[JayeX], link:https://ortelius.io/[Ortelius], link:https://screwdriver.cd/[Screwdriver], and link:https://spinnaker.io/[Spinnaker] to join our network.
 
 JAMs and CI/CD Meetups receive support from the link:https://cd.foundation/[Continuous Delivery Foundation] and many local sponsors.
 
@@ -50,11 +50,9 @@ If you would like to organize an online event, please see the link:/events/onlin
 
 CI/CD and Jenkins Meetups receive support from the link:https://cd.foundation/[Continuous Delivery Foundation] via swag (stickers, etc), promotion, and help bootstrapping and operating the meetup group.
 
-* Swag - We will send you cool swags (stickers, t-shirts, etc) to share with members
 * Promote - We give every CDF Meetup and JAM social media love via Twitter, blog posts, Facebook, newsletter, and post on the link:https://cd.foundation/events/list/[events calendar].
 * CI/CD Expertise - We will help you to schedule a project expert as the key speaker at your meetup, or provide you with presentation materials.
-* Outreach - We will assist in reaching out to your local community for food/venue sponsorship.
-* Support specific to JAMs - As CDF will manage the operational aspect of JAMs and CI/CD meetups, the link:/sigs/advocacy-and-outreach/[Advocacy & Outreach SIG] is a channel to provide guidance/advice to new JAM organizers if needed. See the contacts on the linked page.
+* Support specific to JAMs - The link:/sigs/advocacy-and-outreach/[Advocacy & Outreach SIG] is a channel to provide guidance/advice to new JAM organizers if needed. See the contacts on the linked page.
 
 === Best Practices
 


### PR DESCRIPTION
## Clarify CDF and Jenkins project involvement in meetups

Revise the list of interested projects to include all CDF projects.

Remove the offer to ship swag, since the CDF store no longer exists and the Jenkins project no longer has a swag sponsor of its own.

Remove the reference to CDF managing the operational aspect of meetups, since that is no longer a responsibility of the CDF.

CC: @StefanSpieker 