### PR TITLE
Remove the unused paragraph marker recently added

### DIFF
--- a/content/doc/developer/index.html.haml
+++ b/content/doc/developer/index.html.haml
@@ -17,34 +17,33 @@ noanchors: true
 %h3
   Avoid some common mistakes
 
-%p
-  %ul
-    %li
-      %strong Do
-      %ul
-        %li
-          Use the repository pull request template
-        %li
-          Read the repository contributing guide
-        %li
-          Maintain the pull request until it is merged.
-          Respond constructively to reviewer feedback and automated reviews.
-          Ideally, respond to post-merge bug reports
-        %li
-          Respect each other's time.
-          Many people contribute in their spare time
-        %li
-          Prefer small pull requests
-    %li
-      %strong Do not
-      %ul
-        %li
-          Reformat lines that are not part of your feature or fix within your pull request
-        %li
-          Commit unrelated files.
-          Separate improvements should be separate pull requests
-        %li
-          Apply your own standards (code structure or formatting, Maven plugins) that do not align with existing practices in the repository
+%ul
+  %li
+    %strong Do
+    %ul
+      %li
+        Use the repository pull request template
+      %li
+        Read the repository contributing guide
+      %li
+        Maintain the pull request until it is merged.
+        Respond constructively to reviewer feedback and automated reviews.
+        Ideally, respond to post-merge bug reports
+      %li
+        Respect each other's time.
+        Many people contribute in their spare time
+      %li
+        Prefer small pull requests
+  %li
+    %strong Do not
+    %ul
+      %li
+        Reformat lines that are not part of your feature or fix within your pull request
+      %li
+        Commit unrelated files.
+        Separate improvements should be separate pull requests
+      %li
+        Apply your own standards (code structure or formatting, Maven plugins) that do not align with existing practices in the repository
 
 .row
   .col-xl-6


### PR DESCRIPTION
## Remove the unused paragraph marker recently added

I didn't realize that the paragraph tag is not expected to contain unordered lists.  I've made that mistake for years and had never detected that the browser was adapting to my incorrect markup.  Special thanks to GitHub Copilot for identifying the incorrect HTML markup.
