### PR TITLE
Fix final blog demo video autoplay

### DIFF
--- a/content/blog/2026/09/11/2026-09-11-arjun-713-final-blog.adoc
+++ b/content/blog/2026/09/11/2026-09-11-arjun-713-final-blog.adoc
@@ -113,7 +113,7 @@ image::/images/post-images/2026/09/11/arjun-713-build-failure-diagnosis-flow.png
 This feature made me think much more carefully about what data should reach an LLM in the first place, rather than simply sending everything and expecting the model to handle it.
 
 ++++
-<iframe width="100%" height="500" src="https://drive.google.com/file/d/1Yo-JW-HOgwG6baV3XVvtbg64cV_ca26j/preview" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe width="100%" height="500" src="https://www.youtube.com/embed/I1QG1lBp7No?autoplay=1&mute=1" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 ++++
 
 === Third-Party LLM Provider Support


### PR DESCRIPTION
The Google Drive Video link was not supported for autoplay in https://www.jenkins.io/blog/2026/09/11/arjun-713-final-blog/ . 

Replaced the drive video with a youtube iframe.

Resolves #9404 