### PR TITLE
docs(nginx): preserve upstream keepalive connections while supporting websockets

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -37,9 +37,12 @@ upstream jenkins {
   server 127.0.0.1:8080; # jenkins ip and port
 }
 
-# Required for Jenkins websocket agents and HTTP keepalive support
+# Required for Jenkins websocket agents and HTTP keepalive support.
 # Setting '' to '' clears the Connection header for non-WebSocket traffic,
 # allowing upstream keepalive connections (e.g., keepalive 32) to function.
+# References:
+# - https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
+# - https://nginx.org/en/docs/http/websocket.html
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' '';
@@ -109,6 +112,9 @@ server {
 
 This assumes that you run Jenkins on port 8080.
 Remember to create the folder /var/log/nginx/jenkins.
+
+NOTE: The `$connection_upgrade` map sets the `Connection` header to `upgrade` for WebSocket requests, while clearing the header (setting it to `""`) for non-WebSocket traffic.
+Clearing the `Connection` header is required to preserve upstream HTTP keepalive connections (such as `keepalive 32;`), as documented in the link:https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive[NGINX upstream keepalive documentation] and link:https://nginx.org/en/docs/http/websocket.html[NGINX WebSocket proxying documentation].
 
 Make sure you do not end the `proxy_pass` value with a slash, as it will cause problems like those described in link:https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/16[this discussion].
 

--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -37,10 +37,12 @@ upstream jenkins {
   server 127.0.0.1:8080; # jenkins ip and port
 }
 
-# Required for Jenkins websocket agents
+# Required for Jenkins websocket agents and HTTP keepalive support
+# Setting '' to '' clears the Connection header for non-WebSocket traffic,
+# allowing upstream keepalive connections (e.g., keepalive 32) to function.
 map $http_upgrade $connection_upgrade {
   default upgrade;
-  '' close;
+  '' '';
 }
 
 server {


### PR DESCRIPTION
Fixes #4905 

### Summary
Resolves issue #4905 where the example Nginx reverse proxy configuration causes upstream HTTP keepalives (`keepalive 32;`) to be disabled for non-WebSocket traffic.

### Problem
In the existing configuration, the `$connection_upgrade` map maps empty `$http_upgrade` headers to `'close'`:

```nginx
map $http_upgrade $connection_upgrade {
  default upgrade;
  '' close;
}
```

For standard browser and REST API requests, `$http_upgrade` is not present (empty), so Nginx was passing `Connection: close` to the upstream Jenkins instance. This prevented the upstream `keepalive 32;` connection pool from being utilized for regular web traffic.

### Solution & References
Mapping `''` to `''` resolves this conflict:

**[NGINX `proxy_set_header` documentation](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header)**:
   > *"If the value of a header field is an empty string then this field will not be passed to a proxied server:"*
Setting `'' '';` evaluates `$connection_upgrade` to an empty string for non-WebSocket traffic, instructing NGINX to omit the `Connection` header rather than passing `Connection: close`.

**[NGINX upstream `keepalive` documentation](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive)**:
> *"For HTTP, the `proxy_http_version` directive should be set to "1.1" and the "Connection" header field should be cleared:*
> ```nginx
> proxy_http_version 1.1;
> proxy_set_header Connection "";
> ```
Clearing the `Connection` header is the documented requirement for HTTP/1.1 upstream keepalive connections to function.

**Behavior**:
- **WebSocket traffic (agents/CLI)**: `$http_upgrade` is present -> `$connection_upgrade` is `'upgrade'` -> `Connection: upgrade` is sent.
- **Normal HTTP traffic**: `$http_upgrade` is empty -> `$connection_upgrade` is `''` -> `Connection` header is omitted, preserving HTTP/1.1 persistent keepalive connections.