### PR TITLE
docs(nginx): add unix domain socket configuration guide

### DIFF
--- a/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
+++ b/content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc
@@ -173,3 +173,152 @@ Caused by: java.io.IOException: Premature EOF
     at java.io.DataInputStream.readInt(DataInputStream.java:387)
     at hudson.cli.PlainCLIProtocol$EitherSide$Reader.run(PlainCLIProtocol.java:111)
 ----
+
+== Unix Domain Sockets
+
+Nginx can be configured to proxy requests to Jenkins over a Unix domain socket instead of a TCP port.
+This approach enhances security by eliminating network exposure of Jenkins, and is particularly useful when Jenkins and Nginx run on the same host.
+
+NOTE: Unix domain socket support for Jenkins requires a systemd-based installation (for example, Linux package installations).
+This configuration is not applicable to Jenkins WAR or the official Jenkins Docker image, as they do not rely on systemd.
+
+=== Configure Jenkins for Unix Domain Sockets
+
+First, configure Jenkins to listen on a Unix domain socket instead of a TCP port.
+
+This section applies only to Jenkins installations managed by systemd (for example, Linux package installations).
+For Jenkins WAR or Docker-based installations, refer to the Jenkins initial configuration documentation.
+
+Edit the Jenkins systemd service to disable TCP and enable a Unix socket:
+
+[source,bash]
+----
+systemctl edit jenkins
+----
+
+Add the following override:
+
+[source,ini]
+----
+[Service]
+Environment="JENKINS_PORT=-1"
+Environment="JENKINS_UNIX_DOMAIN_PATH=/run/jenkins/jenkins.socket"
+----
+
+Reload and restart Jenkins:
+
+[source,bash]
+----
+systemctl daemon-reload
+systemctl restart jenkins
+----
+
+Verify the socket exists:
+
+[source,bash]
+----
+ls -l /run/jenkins/jenkins.socket
+----
+
+=== Configure Nginx for Unix Domain Socket
+
+In the Nginx configuration, configure the `upstream` block to point to the Unix domain socket instead of a TCP port:
+
+[source]
+----
+upstream jenkins {
+  keepalive 32; # keepalive connections
+  server unix:/run/jenkins/jenkins.socket;
+}
+
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+server {
+  listen          80;       # Listen on port 80 for IPv4 requests
+
+  server_name     jenkins.example.com;  # replace 'jenkins.example.com' with your server domain name
+
+  # this is the jenkins web root directory
+  # (mentioned in the output of "systemctl cat jenkins")
+  root            /var/run/jenkins/war/;
+
+  access_log      /var/log/nginx/jenkins.access.log;
+  error_log       /var/log/nginx/jenkins.error.log;
+
+  # pass through headers from Jenkins that Nginx considers invalid
+  ignore_invalid_headers off;
+
+  location ~ "^/static/[0-9a-fA-F]{8}\/(.*)$" {
+    # rewrite all static files into requests to the root
+    # E.g /static/12345678/css/something.css will become /css/something.css
+    rewrite "^/static/[0-9a-fA-F]{8}\/(.*)" /$1 last;
+  }
+
+  location /userContent {
+    # have nginx handle all the static requests to userContent folder
+    # files here are very unlikely to change
+    root /var/lib/jenkins/;
+    if (!-f $request_filename){
+      # this will check that the file exists locally,
+      # otherwise it will send the request to jenkins
+      rewrite (.*) /$1 last;
+      break;
+    }
+    sendfile on;
+  }
+
+  location / {
+      sendfile off;
+      proxy_pass         http://jenkins;
+      proxy_redirect     default;
+      proxy_http_version 1.1;
+
+      # Required for Jenkins websocket agents
+      proxy_set_header   Connection        $connection_upgrade;
+      proxy_set_header   Upgrade           $http_upgrade;
+
+      proxy_set_header   Host              $host;
+      proxy_set_header   X-Real-IP         $remote_addr;
+      proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Proto $scheme;
+      proxy_max_temp_file_size 0;
+
+      # this is the maximum upload size
+      client_max_body_size       10m;
+      client_body_buffer_size    128k;
+
+      proxy_connect_timeout      90;
+      proxy_send_timeout         90;
+      proxy_read_timeout         90;
+      proxy_request_buffering    off; # Required for HTTP CLI commands
+  }
+}
+----
+
+The primary difference from the TCP configuration is the `server` directive in the `upstream` block, which points to `unix:/run/jenkins/jenkins.socket` instead of `127.0.0.1:8080`.
+
+=== Permissions
+
+Ensure Nginx has permission to access the Jenkins Unix socket.
+The socket is created with the `jenkins` user and group permissions.
+Add the Nginx user to the `jenkins` group to grant socket access:
+
+On Debian / Ubuntu systems:
+
+[source,bash]
+----
+usermod -aG jenkins www-data
+systemctl restart nginx
+----
+
+On RHEL / AlmaLinux / Rocky Linux systems:
+
+[source,bash]
+----
+usermod -aG jenkins nginx
+systemctl restart nginx
+----
+


### PR DESCRIPTION
Fixes #6891

### Summary

Adds documentation for configuring Nginx as a reverse proxy for Jenkins using Unix domain sockets instead of TCP loopback (`127.0.0.1:8080`).

Following the packaging update in [jenkinsci/packaging#442](https://github.com/jenkinsci/packaging/pull/442) that added Unix domain socket support, this completes the reverse proxy documentation for Nginx, matching the precedents established in:
- [PR #7970](https://github.com/jenkins-infra/jenkins.io/pull/7970) (Apache UDS support)
- [PR #8685](https://github.com/jenkins-infra/jenkins.io/pull/8685) (HAProxy UDS support)
### Changes

- Added `== Unix Domain Sockets` section to `content/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/reverse-proxy-configuration-nginx.adoc`:
-  **Prerequisites**: Clarified that Unix domain socket support requires systemd package installations.
-  **Jenkins Configuration**: Explained how to override `JENKINS_PORT=-1` and `JENKINS_UNIX_DOMAIN_PATH=/run/jenkins/jenkins.socket` via `systemctl edit jenkins`.
-   **Nginx Configuration**: Provided an example configuration using `server unix:/run/jenkins/jenkins.socket;` in the `upstream` block.
-   **Permissions**: Documented required socket group access for Nginx service accounts (`www-data` on Debian/Ubuntu, `nginx` on RHEL/derivatives).